### PR TITLE
fix: set rootDir to src in tsconfig

### DIFF
--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.stories.*", "src/**/*.spec.*"]
+  "compilerOptions": {
+    "rootDir": "./src/",
+  },
+  "exclude": ["src/**/*.stories.*", "src/**/*.spec.*", "./src/**/*.pw.ts*", "./src/**/*.test-pw.ts*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,5 @@
     "target": "es6"
   },
   "include": ["./src/global.d.ts", "./src/**/*.ts*"],
-  "exclude": ["./node_modules", "./cypress", "./cypress.config.ts"]
+  "exclude": ["./node_modules", "./cypress", "./cypress.config.ts", "./playwright", "./playwright-ct.config.ts"]
 }


### PR DESCRIPTION
The `build:types` script ran as part of the release process is broken as it outputs the `.d.ts` files inside `src` directories in the output folders. On investigation, this has happened because of the addition of `.ts` files inside the new `playwright` folder which are not excluded from the ts build and which cause tsc to default the `rootDir` compiler option to the root directory, rather than the `src` folder as it needs to be. To fix this, `rootDir` has been explicitly set to `./src/` in the build config, as well as the playwright ts files being excluded (without that tsc throws errors about trying to build files outside of `rootDir`). To avoid breaking the local `type-check` script which still needs to typecheck the playwright ts files, the new config has only been added inside the `tsconfig-build.json`.

### Proposed behaviour

`npm run precompile` should output `.d.ts` files alongside the corresponding `.js` files in the appropriate subdirectories of the output folders (`/lib/` and `/esm/`), as can be seen from the file structure of a working NPM release https://www.npmjs.com/package/carbon-react/v/119.10.0?activeTab=code . There should also be no `playwright` folder in the build output.

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

There is a separate `src` directory inside each output folder, and this contains just the `.d.ts` files (in normal folder structure). The `.js` files are still in the normal place, but TS intellisense (etc) is broken for consumers because there are no type declaration files alongside them (see broken structure here https://www.npmjs.com/package/carbon-react/v/119.10.1?activeTab=code).

A `playwright` folder is also found in the top level of these output directories.

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Cypress automation tests added or updated if required
- [X] Playwright automation tests added or updated if required
- [X] Storybook added or updated if required
- [X] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required
- [X] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

Run `npm run precompile` from the root directory (after first deleting the local `lib` and `esm` folders, if present), and ensure the build succeeds with no errors, and the correct directory structure is found in the two output directories.

Also try introducing TS errors into the playwright ts files (esp in the `playwright` directory) and ensuring these are picked up by `npm run type-check`, as a sanity check that local type-checking is not excluding files it shouldn't be. (Feel free to do any more tests along these lines that you can think of!)

<!-- Add CodeSandbox here -->
