### PR TITLE
Playwright events

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -65,3 +65,29 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 3
+
+      - name: Report status - success
+        if: always() && success()
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
+            -d '{
+              "state": "success",
+              "context": "Workflow Status",
+              "description": "Playwright tests workflow completed successfully."
+            }'
+          
+      - name: Report status - failed
+        if: always() && failure()
+        run: |
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
+            -d '{
+              "state": "failure",
+              "context": "Workflow Status",
+              "description": "Playwright tests workflow failed."
+            }'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -75,8 +75,8 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
             -d '{
               "state": "success",
-              "context": "Workflow Status",
-              "description": "Playwright tests workflow completed successfully."
+              "context": "Playwright tests",
+              "description": "workflow completed successfully."
             }'
           
       - name: Report status - failed
@@ -88,6 +88,6 @@ jobs:
             https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.sha }} \
             -d '{
               "state": "failure",
-              "context": "Workflow Status",
-              "description": "Playwright tests workflow failed."
+              "context": Playwright tests",
+              "description": "workflow failed."
             }'

--- a/playwright/support/helper.ts
+++ b/playwright/support/helper.ts
@@ -91,3 +91,34 @@ export const checkDialogIsNotInDOM = async (page: Page) => {
   await checkElementIsNotInDOM(page, OPEN_MODAL);
   await checkElementIsInDOM(page, CLOSED_MODAL);
 };
+
+/**
+ * Asserts if an element has event was calledOnce
+ * @param callbackData an array with callback data
+ * @param eventName {string} event name
+ * @example await expectEventWasCalledOnce(messages, "onClick");
+ */
+export const expectEventWasCalledOnce = async (
+  callbackData: string[],
+  eventName: string
+) => {
+  const count = JSON.stringify(callbackData.length);
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const callbackName = JSON.stringify(callbackData[0]._reactName);
+  expect(count).toBe("1");
+  expect(callbackName).toBe(`"${eventName}"`);
+};
+
+/**
+ * Asserts that event was NOT called
+ * @param callbackData an array with callback data
+ * @example await expectEventWasNotCalled(messages);
+ */
+export const expectEventWasNotCalled = async (callbackData: string[]) => {
+  const count = JSON.stringify(callbackData.length);
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  expect(count).toBe("0");
+  expect(callbackData).toEqual([]);
+};

--- a/src/components/badge/badge.pw.tsx
+++ b/src/components/badge/badge.pw.tsx
@@ -5,7 +5,10 @@ import {
   badgeCounter,
   badgeCrossIcon,
 } from "../../../playwright/components/badge/index";
-import { checkAccessibility } from "../../../playwright/support/helper";
+import {
+  checkAccessibility,
+  expectEventWasCalledOnce,
+} from "../../../playwright/support/helper";
 import { CHARACTERS } from "../../../playwright/support/constants";
 import BadgeComponent from "./components.test-pw";
 
@@ -81,20 +84,22 @@ test.describe("should render Badge component", () => {
     mount,
     page,
   }) => {
-    let hasOnClickBeenCalledCount = 0;
+    const messages: string[] = [];
 
     await mount(
       <BadgeComponent
         counter={5}
-        onClick={() => {
-          hasOnClickBeenCalledCount += 1;
+        onClick={(data) => {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          messages.push(data);
         }}
       />
     );
 
     const badgeToClick = badge(page);
     await badgeToClick.click();
-    expect(hasOnClickBeenCalledCount).toBe(1);
+    await expectEventWasCalledOnce(messages, "onClick");
   });
 
   test("should render with expected border radius styling", async ({

--- a/src/components/breadcrumbs/breadcrumbs.pw.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.pw.tsx
@@ -6,7 +6,11 @@ import {
   crumbAtIndex,
 } from "../../../playwright/components/breadcrumbs/index";
 import { Default, DefaultCrumb } from "./components.test-pw";
-import { checkAccessibility } from "../../../playwright/support/helper";
+import {
+  checkAccessibility,
+  expectEventWasNotCalled,
+  expectEventWasCalledOnce,
+} from "../../../playwright/support/helper";
 import { CHARACTERS } from "../../../playwright/support/constants";
 
 test.describe("should render Breadcrumbs component", async () => {
@@ -116,30 +120,37 @@ test("should call the onClick callback when clicked", async ({
   mount,
   page,
 }) => {
-  let hasOnClickBeenCalledCount = 0;
+  const messages: string[] = [];
+
   await mount(
     <DefaultCrumb
-      onClick={() => {
-        hasOnClickBeenCalledCount += 1;
+      onClick={(data) => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        messages.push(data);
       }}
     />
   );
 
   const crumbToClick = crumbAtIndex(page, 0);
   await crumbToClick.click();
-  expect(hasOnClickBeenCalledCount).toBe(1);
+
+  await expectEventWasCalledOnce(messages, "onClick");
 });
 
 test("should not set the onClick or href props when isCurrent is true", async ({
   mount,
   page,
 }) => {
-  let hasOnClickBeenCalledCount = 0;
+  const messages: string[] = [];
+
   await mount(
     <DefaultCrumb
       href={CHARACTERS.STANDARD}
-      onClick={() => {
-        hasOnClickBeenCalledCount += 1;
+      onClick={(data) => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        messages.push(data);
       }}
       isCurrent
     />
@@ -147,8 +158,8 @@ test("should not set the onClick or href props when isCurrent is true", async ({
 
   const crumbToClick = crumbAtIndex(page, 0);
   await crumbToClick.click();
-  expect(hasOnClickBeenCalledCount).toBeFalsy();
 
+  await expectEventWasNotCalled(messages);
   await expect(crumbToClick.locator("a")).not.toHaveAttribute("href", "/");
 });
 


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
- add reporting statuses back to github
<img width="444" alt="Screenshot 2023-08-09 at 15 12 16" src="https://github.com/Sage/carbon/assets/34001198/c067c816-0642-47cf-86d3-ad475e279424">

- add helper for events 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
- no reporting statuses back to github
- no helper for events 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

### Testing instructions

- [ ] check if all tests still pass
- [ ] check if the `Playwright tests workflow completed successfully.` appears in checks below the PR
- [ ] check the newly added helper functions for events
