### PR TITLE
feat(toast, message): update component to align with Design System - FE-5775

### DIFF
--- a/cypress/components/toast/toast.cy.tsx
+++ b/cypress/components/toast/toast.cy.tsx
@@ -12,9 +12,10 @@ const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testData = CHARACTERS.STANDARD;
 const colorTypes = [
   "rgb(203, 55, 74)",
-  "rgb(51, 91, 112)",
+  "rgb(0, 96, 167)",
   "rgb(0, 138, 33)",
   "rgb(239, 103, 0)",
+  "rgb(51, 91, 112)",
 ];
 
 context("Testing Toast component", () => {
@@ -84,6 +85,8 @@ context("Testing Toast component", () => {
       [TOAST_COLORS[1], colorTypes[1]],
       [TOAST_COLORS[2], colorTypes[2]],
       [TOAST_COLORS[3], colorTypes[3]],
+      [TOAST_COLORS[4], colorTypes[4]],
+      [TOAST_COLORS[5], colorTypes[1]],
     ] as [ToastProps["variant"], string][])(
       "should render Toast component with %s variant",
       (variant, color) => {
@@ -187,6 +190,15 @@ context("Testing Toast component", () => {
         .focus()
         .should("have.css", "outline", "rgb(255, 188, 25) solid 3px");
     });
+
+    it.each(["left", "center", "right"] as ToastProps["align"][])(
+      "should render Toast component with align prop set to %s",
+      (align) => {
+        CypressMountWithProviders(<ToastComponent align={align} />);
+
+        toastComponent().should("have.css", "justify-content", align);
+      }
+    );
   });
 
   describe("check events for Toast component", () => {

--- a/src/components/message/message-test.stories.tsx
+++ b/src/components/message/message-test.stories.tsx
@@ -14,7 +14,7 @@ export default {
   },
   argTypes: {
     variant: {
-      options: ["info", "error", "success", "warning"],
+      options: ["info", "error", "success", "warning", "neutral"],
       control: {
         type: "select",
       },

--- a/src/components/message/message.component.tsx
+++ b/src/components/message/message.component.tsx
@@ -10,7 +10,12 @@ import IconButton from "../icon-button";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import useLocale from "../../hooks/__internal__/useLocale";
 
-export type MessageVariant = "error" | "info" | "success" | "warning";
+export type MessageVariant =
+  | "error"
+  | "info"
+  | "success"
+  | "warning"
+  | "neutral";
 
 export interface MessageProps extends MarginProps {
   /** set content to component */

--- a/src/components/message/message.pw.tsx
+++ b/src/components/message/message.pw.tsx
@@ -27,10 +27,11 @@ const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 test.describe("Tests for Message component properties", () => {
   ([
-    ["info", "rgb(51, 91, 112)"],
+    ["info", "rgb(0, 96, 167)"],
     ["error", VALIDATION.ERROR],
     ["success", "rgb(0, 138, 33)"],
     ["warning", VALIDATION.WARNING],
+    ["neutral", "rgb(51, 91, 112)"],
   ] as [MessageProps["variant"], string][]).forEach(
     ([variant, backgroundColor]) => {
       test(`should check ${variant} as variant for Message components`, async ({

--- a/src/components/message/message.spec.tsx
+++ b/src/components/message/message.spec.tsx
@@ -24,9 +24,10 @@ const wrappingComponent = (props: { children: React.ReactNode }) => (
 
 const messageVariants = {
   error: "var(--colorsSemanticNegative500)",
-  info: "var(--colorsSemanticNeutral500)",
+  info: "var(--colorsSemanticInfo500)",
   success: "var(--colorsSemanticPositive500)",
   warning: "var(--colorsSemanticCaution500)",
+  neutral: "var(--colorsSemanticNeutral500)",
 } as const;
 
 function getCloseButtonLabel(wrapper: ShallowWrapper | ReactWrapper) {

--- a/src/components/message/message.stories.mdx
+++ b/src/components/message/message.stories.mdx
@@ -63,6 +63,12 @@ When the `showCloseIcon` is `false` the close icon will not be rendered, and pad
   <Story name="showCloseIcon" story={stories.ShowCloseIcon} />
 </Canvas>
 
+### Neutral
+
+<Canvas>
+  <Story name="neutral" story={stories.Neutral} />
+</Canvas>
+
 ### Error
 
 <Canvas>

--- a/src/components/message/message.stories.tsx
+++ b/src/components/message/message.stories.tsx
@@ -73,6 +73,22 @@ export const Warning: ComponentStory<typeof Message> = () => {
   );
 };
 
+export const Neutral: ComponentStory<typeof Message> = () => {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <>
+      {!isOpen && <Button onClick={() => setIsOpen(true)}>Open Message</Button>}
+      <Message
+        open={isOpen}
+        onDismiss={() => setIsOpen(false)}
+        variant="neutral"
+      >
+        Some custom message
+      </Message>
+    </>
+  );
+};
+
 export const WithRichContent: ComponentStory<typeof Message> = () => {
   const [isOpen, setIsOpen] = useState(true);
   return (

--- a/src/components/message/message.style.ts
+++ b/src/components/message/message.style.ts
@@ -7,9 +7,10 @@ import { MessageVariant } from "./message.component";
 
 const messageVariants = {
   error: "var(--colorsSemanticNegative500)",
-  info: "var(--colorsSemanticNeutral500)",
+  info: "var(--colorsSemanticInfo500)",
   success: "var(--colorsSemanticPositive500)",
   warning: "var(--colorsSemanticCaution500)",
+  neutral: "var(--colorsSemanticNeutral500)",
 };
 
 type MessageStyleProps = {

--- a/src/components/message/type-icon/__snapshots__/type-icon.spec.tsx.snap
+++ b/src/components/message/type-icon/__snapshots__/type-icon.spec.tsx.snap
@@ -77,6 +77,77 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
+  background-color: var(--colorsSemanticInfo500);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 100%;
+  min-width: 30px;
+  text-align: center;
+}
+
+.c0 span:before {
+  color: var(--colorsUtilityYang100);
+}
+
+.c1 {
+  position: relative;
+  color: var(--colorsYin090);
+  background-color: transparent;
+  vertical-align: middle;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 24px;
+  width: 24px;
+}
+
+.c1::before {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-family: CarbonIcons;
+  content: "\\e92a";
+  font-style: normal;
+  font-weight: normal;
+  vertical-align: middle;
+  font-size: var(--sizing250);
+  line-height: var(--sizing250);
+  display: block;
+}
+
+<div
+  className="c0"
+>
+  <span
+    className="c1"
+    data-component="icon"
+    data-element="info"
+    fontSize="small"
+    type="info"
+  />
+</div>
+`;
+
+exports[`TypeIcon when rendered with no additional props should match the snapshot for neutral 1`] = `
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   background-color: var(--colorsSemanticNeutral500);
   display: -webkit-box;
   display: -webkit-flex;
@@ -191,7 +262,7 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-family: CarbonIcons;
-  content: "\\e950";
+  content: "\\e993";
   font-style: normal;
   font-weight: normal;
   vertical-align: middle;
@@ -206,9 +277,9 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
   <span
     className="c1"
     data-component="icon"
-    data-element="tick"
+    data-element="tick_circle"
     fontSize="small"
-    type="tick"
+    type="tick_circle"
   />
 </div>
 `;
@@ -290,7 +361,7 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
   -webkit-box-align: center;
   -ms-flex-align: center;
   align-items: center;
-  background-color: var(--colorsSemanticNeutral500);
+  background-color: var(--colorsSemanticInfo500);
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -310,7 +381,7 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
 }
 
 .c0 span:before {
-  color: var(--colorsSemanticNeutral500);
+  color: var(--colorsSemanticInfo500);
 }
 
 .c1 {
@@ -490,7 +561,7 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   font-family: CarbonIcons;
-  content: "\\e950";
+  content: "\\e993";
   font-style: normal;
   font-weight: normal;
   vertical-align: middle;
@@ -505,9 +576,9 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
   <span
     className="c1"
     data-component="icon"
-    data-element="tick"
+    data-element="tick_circle"
     fontSize="small"
-    type="tick"
+    type="tick_circle"
   />
 </div>
 `;
@@ -584,6 +655,82 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
     data-element="warning"
     fontSize="small"
     type="warning"
+  />
+</div>
+`;
+
+exports[`TypeIcon when transparent prop is set to true applies white background and the type icon with the proper style applied 5`] = `
+.c0 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  background-color: var(--colorsSemanticNeutral500);
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  line-height: 100%;
+  min-width: 30px;
+  text-align: center;
+  background-color: transparent;
+}
+
+.c0 span:before {
+  color: var(--colorsUtilityYang100);
+}
+
+.c0 span:before {
+  color: var(--colorsSemanticNeutral500);
+}
+
+.c1 {
+  position: relative;
+  color: var(--colorsYin090);
+  background-color: transparent;
+  vertical-align: middle;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  height: 24px;
+  width: 24px;
+}
+
+.c1::before {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-family: CarbonIcons;
+  content: "\\e92a";
+  font-style: normal;
+  font-weight: normal;
+  vertical-align: middle;
+  font-size: var(--sizing250);
+  line-height: var(--sizing250);
+  display: block;
+}
+
+<div
+  className="c0"
+>
+  <span
+    className="c1"
+    data-component="icon"
+    data-element="info"
+    fontSize="small"
+    type="info"
   />
 </div>
 `;

--- a/src/components/message/type-icon/type-icon.component.tsx
+++ b/src/components/message/type-icon/type-icon.component.tsx
@@ -12,9 +12,14 @@ export interface TypeIconProps {
 }
 
 const TypeIcon = ({ variant = "info", transparent = false }: TypeIconProps) => {
+  function iconToRender() {
+    if (variant === "neutral") return "info";
+    if (variant === "success") return "tick_circle";
+    return variant;
+  }
   return (
     <TypeIconStyle variant={variant} transparent={transparent}>
-      <Icon type={variant} />
+      <Icon type={iconToRender()} />
     </TypeIconStyle>
   );
 };

--- a/src/components/message/type-icon/type-icon.spec.tsx
+++ b/src/components/message/type-icon/type-icon.spec.tsx
@@ -9,7 +9,7 @@ function render(props?: TypeIconProps) {
   return TestRenderer.create(<TypeIcon {...props} />);
 }
 
-const messages = ["info", "error", "success", "warning"] as const;
+const messages = ["info", "error", "success", "warning", "neutral"] as const;
 
 describe("TypeIcon", () => {
   describe("default props", () => {

--- a/src/components/message/type-icon/type-icon.style.ts
+++ b/src/components/message/type-icon/type-icon.style.ts
@@ -4,9 +4,11 @@ import { MessageVariant } from "../message.component";
 
 const messageVariants = {
   error: "var(--colorsSemanticNegative500)",
-  info: "var(--colorsSemanticNeutral500)",
+  info: "var(--colorsSemanticInfo500)",
   success: "var(--colorsSemanticPositive500)",
   warning: "var(--colorsSemanticCaution500)",
+  neutral: "var(--colorsSemanticNeutral500)",
+  notification: "var(--colorsSemanticInfo500)",
 };
 
 type TypeIconStyleProps = {

--- a/src/components/toast/toast.config.ts
+++ b/src/components/toast/toast.config.ts
@@ -1,2 +1,9 @@
 // eslint-disable-next-line import/prefer-default-export
-export const TOAST_COLORS = ["error", "info", "success", "warning"];
+export const TOAST_COLORS = [
+  "error",
+  "info",
+  "success",
+  "warning",
+  "neutral",
+  "notification",
+];

--- a/src/components/toast/toast.stories.mdx
+++ b/src/components/toast/toast.stories.mdx
@@ -76,10 +76,34 @@ Toast variant is `success` by default
   <Story name="default" story={stories.Default} />
 </Canvas>
 
+### Align - Left
+
+<Canvas>
+  <Story name="align left aligned" story={stories.AlignedLeft} />
+</Canvas>
+
+### Align - Center
+
+<Canvas>
+  <Story name="align center aligned" story={stories.AlignedCenter} />
+</Canvas>
+
+### Align - Right
+
+<Canvas>
+  <Story name="align right aligned" story={stories.AlignedRight} />
+</Canvas>
+
 ### Info
 
 <Canvas>
   <Story name="info" story={stories.Info} />
+</Canvas>
+
+### Neutral
+
+<Canvas>
+  <Story name="neutral" story={stories.Neutral} />
 </Canvas>
 
 ### Error
@@ -101,6 +125,12 @@ The "isCenter" and "maxWidth" props will be ignored in this variant.
 
 <Canvas>
   <Story name="notice" story={stories.Notice} />
+</Canvas>
+
+### Notification
+
+<Canvas>
+  <Story name="notification" story={stories.Notification} />
 </Canvas>
 
 ### Variant Left Aligned

--- a/src/components/toast/toast.stories.tsx
+++ b/src/components/toast/toast.stories.tsx
@@ -70,6 +70,32 @@ export const Info = () => {
   );
 };
 
+export const Neutral = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleToggle = () => {
+    if (!isOpen) {
+      window.scrollTo(0, 0);
+    }
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div id="wrapper-variant-neutral">
+      <StyledButton
+        id="button-variant-neutral"
+        key="button"
+        onClick={handleToggle}
+        isOpen={isOpen}
+      >
+        Toggle - Preview is: {isOpen ? "ON" : "OFF"}
+      </StyledButton>
+      <Toast variant="neutral" id="toast-variant-neutral" open={isOpen}>
+        My Neutral Toast
+      </Toast>
+    </div>
+  );
+};
+
 export const Error = () => {
   const [isOpen, setIsOpen] = useState(false);
   const handleToggle = () => {
@@ -159,6 +185,32 @@ export const Notice = () => {
   );
 };
 
+export const Notification = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleToggle = () => {
+    if (!isOpen) {
+      window.scrollTo(0, 0);
+    }
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div id="wrapper-notification">
+      <StyledButton
+        id="button-notification"
+        key="button"
+        onClick={handleToggle}
+        isOpen={isOpen}
+      >
+        Toggle - Preview is: {isOpen ? "ON" : "OFF"}
+      </StyledButton>
+      <Toast id="toast-notification" variant="notification" open={isOpen}>
+        My message
+      </Toast>
+    </div>
+  );
+};
+
 export const LeftAligned = () => {
   const [isOpen, setIsOpen] = useState(false);
   const onDismissClick = () => {
@@ -184,6 +236,114 @@ export const LeftAligned = () => {
       <Toast
         variant="warning"
         id="toast-left-aligned"
+        open={isOpen}
+        onDismiss={onDismissClick}
+        isCenter={false}
+      >
+        My text
+      </Toast>
+    </div>
+  );
+};
+
+export const AlignedLeft = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const onDismissClick = () => {
+    setIsOpen(!isOpen);
+  };
+  const handleToggle = () => {
+    if (!isOpen) {
+      window.scrollTo(0, 0);
+    }
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div id="wrapper-left-aligned">
+      <StyledButton
+        id="button-left-aligned"
+        key="button"
+        onClick={handleToggle}
+        isOpen={isOpen}
+      >
+        Toggle - Preview is: {isOpen ? "ON" : "OFF"}
+      </StyledButton>
+      <Toast
+        align="left"
+        variant="warning"
+        id="toast-left-aligned"
+        open={isOpen}
+        onDismiss={onDismissClick}
+        isCenter={false}
+      >
+        My text
+      </Toast>
+    </div>
+  );
+};
+
+export const AlignedCenter = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const onDismissClick = () => {
+    setIsOpen(!isOpen);
+  };
+  const handleToggle = () => {
+    if (!isOpen) {
+      window.scrollTo(0, 0);
+    }
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div id="wrapper-center-aligned">
+      <StyledButton
+        id="button-center-aligned"
+        key="button"
+        onClick={handleToggle}
+        isOpen={isOpen}
+      >
+        Toggle - Preview is: {isOpen ? "ON" : "OFF"}
+      </StyledButton>
+      <Toast
+        align="center"
+        variant="warning"
+        id="toast-center-aligned"
+        open={isOpen}
+        onDismiss={onDismissClick}
+        isCenter={false}
+      >
+        My text
+      </Toast>
+    </div>
+  );
+};
+
+export const AlignedRight = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const onDismissClick = () => {
+    setIsOpen(!isOpen);
+  };
+  const handleToggle = () => {
+    if (!isOpen) {
+      window.scrollTo(0, 0);
+    }
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div id="wrapper-right-aligned">
+      <StyledButton
+        id="button-right-aligned"
+        key="button"
+        onClick={handleToggle}
+        isOpen={isOpen}
+      >
+        Toggle - Preview is: {isOpen ? "ON" : "OFF"}
+      </StyledButton>
+      <Toast
+        align="right"
+        variant="warning"
+        id="toast-right-aligned"
         open={isOpen}
         onDismiss={onDismissClick}
         isCenter={false}

--- a/src/components/toast/toast.style.ts
+++ b/src/components/toast/toast.style.ts
@@ -9,10 +9,11 @@ import baseTheme from "../../style/themes/base";
 import StyledIcon from "../icon/icon.style";
 
 const StyledPortal = styled(Portal)<{
+  align?: "left" | "center" | "right";
   isCenter?: boolean;
   isNotice?: boolean;
 }>`
-  ${({ theme, isCenter, isNotice }) => css`
+  ${({ theme, isCenter, isNotice, align }) => css`
     position: fixed;
     top: 0;
 
@@ -21,6 +22,25 @@ const StyledPortal = styled(Portal)<{
     ${isCenter &&
     css`
       margin-left: 50%;
+      transform: translateX(-50%);
+    `}
+
+    ${align === "left" &&
+    css`
+      left: 12%;
+      transform: translateX(-50%);
+    `}
+
+    ${align === "center" &&
+    css`
+      margin-left: 50%;
+      transform: translateX(-50%);
+    `}
+
+    ${align === "right" &&
+    css`
+      display: flex;
+      right: 0;
       transform: translateX(-50%);
     `}
 
@@ -40,18 +60,25 @@ StyledPortal.defaultProps = {
 const animationName = ".toast";
 const alternativeAnimationName = ".toast-alternative";
 const ToastStyle = styled(MessageStyle)<{
+  align?: "left" | "center" | "right";
   maxWidth?: string;
   isCenter?: boolean;
   isNotice?: boolean;
+  isNotification?: boolean;
 }>`
-  ${({ maxWidth, isCenter }) => css`
+  ${({ maxWidth, isCenter, align, isNotification }) => css`
     box-shadow: 0 10px 30px 0 rgba(0, 20, 29, 0.1),
       0 30px 60px 0 rgba(0, 20, 29, 0.1);
     line-height: 22px;
     margin-top: 30px;
     max-width: ${!maxWidth ? "300px" : maxWidth};
     position: relative;
-    margin-right: ${isCenter ? "auto" : "30px"};
+    margin-right: ${isCenter || align === "right" ? "auto" : "30px"};
+
+    ${isNotification &&
+    css`
+      border: 1px solid var(--colorsSemanticInfo500);
+    `}
   `}
 
   :focus {
@@ -148,9 +175,20 @@ const ToastContentStyle = styled(MessageContentStyle)<{
 `;
 
 const ToastWrapper = styled.div<{
+  align?: "left" | "center" | "right";
   isCenter?: boolean;
   isNotice?: boolean;
 }>`
+  ${({ align }) =>
+    align &&
+    css`
+      position: relative;
+      width: auto;
+      height: auto;
+      justify-content: ${align};
+      display: flex;
+    `}
+
   ${({ isCenter }) =>
     isCenter &&
     css`


### PR DESCRIPTION
### Proposed behaviour

Toast: 
- Update Toast with new variants and colours.
- Introduced a new `notification` variant.
- Introduced a new `align` prop that will supersede the current `isCenter` prop.
- Deprecation warning applied to the `isCenter` prop.

Message:
- Update Message with new variants and colours.
- Update success variant icon to `tick_circle`.

### Current behaviour

- No `notification` variant.
- No `align` prop.
- `isCenter` prop is still recommended for positioning the component.
- Message no doesn't align with the DS.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

<!-- How can a reviewer test this PR? -->

- Deprecation warning should only appear in the console once.
- Test the new stories created for `align` prop example.
- Test that the new `notification` toast example matches the designs provided in the ticket.
- No other styling regressions to any other variants of `Toast`.
- `isCenter` prop should still work as previously too.
