### PR TITLE
chore: remove qa as owners of unit test files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,15 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
-*                  @Sage/carbon
+*                        @Sage/carbon
 
 # The Carbon Dev team are responsible for reviewing Pull Requests
 # that contain any change modifying JS, JSX, TS or TSX files
-*.js               @Sage/carbon-dev
-*.ts               @Sage/carbon-dev
+*.js                     @Sage/carbon-dev
+*.ts                     @Sage/carbon-dev
 
 # The Carbon QA team are responsible for reviewing Pull Requests
-# that contain any change modifying spec and test.js files 
-# or anything in the cypress directory
-*.spec.*                 @Sage/carbon-qa
+# that contain any changes to files within the cypress and 
+# playwright directories or any test files relating to them 
 *.cy.*                   @Sage/carbon-qa
 *.pw.tsx                 @Sage/carbon-qa
 *.test-pw.tsx            @Sage/carbon-qa
@@ -20,4 +19,4 @@ cypress.config.ts        @Sage/carbon-qa
 playwright-ct.config.ts  @Sage/carbon-qa
 
 # Codeowners file changes must be approved by a Carbon Admin.
-.github/CODEOWNERS @Sage/carbon-admin
+.github/CODEOWNERS       @Sage/carbon-admin


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Carbon dev own unit (spec) test files

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Carbon QA own unit (spec) test files

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
