### PR TITLE
feat(dialog): expose focus method of root dom node via a ref handle (FE-6176)

### DIFF
--- a/src/components/dialog/dialog.pw.tsx
+++ b/src/components/dialog/dialog.pw.tsx
@@ -13,11 +13,12 @@ import {
   DefaultStory,
   Editable,
   WithHelp,
-  DynamicContent,
+  LoadingContent,
   FocusingADifferentFirstElement,
   OverridingContentPadding,
   OtherFocusableContainers,
   Responsive,
+  UsingHandle,
 } from "./dialog.stories";
 
 import toastComponent from "../../../playwright/components/toast";
@@ -537,11 +538,11 @@ test.describe("Testing Dialog component properties", () => {
         await checkAccessibility(page);
       });
 
-      test("DynamicContent story should pass accessiblity checks", async ({
+      test("LoadingContent story should pass accessibility checks", async ({
         mount,
         page,
       }) => {
-        await mount(<DynamicContent />);
+        await mount(<LoadingContent />);
 
         const openDialogButton = page
           .getByRole("button")
@@ -623,6 +624,24 @@ test.describe("Testing Dialog component properties", () => {
           .getByRole("button")
           .filter({ hasText: "Open Dialog" });
         await openDialogButton.click();
+
+        await checkAccessibility(page);
+      });
+
+      test("UsingHandle story should pass accessibility checks", async ({
+        mount,
+        page,
+      }) => {
+        await mount(<UsingHandle />);
+
+        await page
+          .getByRole("button")
+          .filter({ hasText: "Open Dialog" })
+          .click();
+
+        await checkAccessibility(page);
+
+        await page.getByRole("button").filter({ hasText: "Submit" }).click();
 
         await checkAccessibility(page);
       });

--- a/src/components/dialog/dialog.spec.tsx
+++ b/src/components/dialog/dialog.spec.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { mount, ReactWrapper } from "enzyme";
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
+
+import Dialog from ".";
 
 import { space } from "../../style/themes/base/base-theme.config";
 import guid from "../../__internal__/utils/helpers/guid";
 import useResizeObserver from "../../hooks/__internal__/useResizeObserver";
-import Dialog, { DialogProps } from "./dialog.component";
 import {
   StyledDialog,
   StyledDialogTitle,
@@ -25,7 +26,6 @@ import {
 } from "../../__spec_helper__/test-utils";
 import Form from "../form";
 import { StyledFormContent, StyledFormFooter } from "../form/form.style";
-import IconButton from "../icon-button";
 import Help from "../help";
 import CarbonProvider from "../carbon-provider";
 import Logger from "../../__internal__/utils/logger";
@@ -40,12 +40,27 @@ const useResizeObserverMock = useResizeObserver as jest.MockedFunction<
   typeof useResizeObserver
 >;
 
+function enzymeMount(ui: React.ReactElement, document = globalThis.document) {
+  if (document.body.innerHTML.length >= 1) {
+    throw new Error(
+      "Found DOM to be non-empty before mounting. Please make sure to call cleanup() after each test."
+    );
+  }
+
+  const container = document.createElement("div");
+  container.setAttribute("id", "enzymeContainer");
+  document.body.appendChild(container);
+  return mount(ui, { attachTo: container });
+}
+
+function cleanup(document = globalThis.document) {
+  document.body.innerHTML = "";
+}
+
 describe("Dialog", () => {
   let onCancel: jest.Mock;
   let addEventListenerSpy: jest.SpyInstance;
   let removeEventListenerSpy: jest.SpyInstance;
-
-  let wrapper: ReactWrapper<DialogProps>;
 
   beforeAll(() => {
     loggerSpy.mockImplementation(() => {});
@@ -61,6 +76,7 @@ describe("Dialog", () => {
 
   afterEach(() => {
     onCancel.mockClear();
+    cleanup();
   });
 
   describe("event listeners", () => {
@@ -75,7 +91,7 @@ describe("Dialog", () => {
     });
 
     it("binds the key event listener to the document on mount", () => {
-      wrapper = mount(
+      enzymeMount(
         <Dialog open>
           <div />
         </Dialog>
@@ -87,7 +103,7 @@ describe("Dialog", () => {
     });
 
     it("does not bind if component is not open on mount", () => {
-      wrapper = mount(
+      enzymeMount(
         <Dialog open={false}>
           <div />
         </Dialog>
@@ -99,7 +115,7 @@ describe("Dialog", () => {
     });
 
     it("removes the event listener if modal was open on unmount", () => {
-      wrapper = mount(
+      const wrapper = enzymeMount(
         <Dialog open>
           <div />
         </Dialog>
@@ -112,7 +128,7 @@ describe("Dialog", () => {
     });
 
     it("does not remove the event listener if it was not in use on unmount", () => {
-      wrapper = mount(
+      const wrapper = enzymeMount(
         <Dialog open={false}>
           <div />
         </Dialog>
@@ -125,7 +141,7 @@ describe("Dialog", () => {
     });
 
     it("adds event listeners on modal open", () => {
-      wrapper = mount(
+      const wrapper = enzymeMount(
         <Dialog open={false}>
           <div />
         </Dialog>
@@ -139,7 +155,7 @@ describe("Dialog", () => {
     });
 
     it("removes event listeners on modal close", () => {
-      wrapper = mount(
+      const wrapper = enzymeMount(
         <Dialog open>
           <div />
         </Dialog>
@@ -154,7 +170,7 @@ describe("Dialog", () => {
 
   it("renders when a child is undefined", () => {
     expect(() => {
-      mount(
+      enzymeMount(
         <Dialog
           onCancel={() => {}}
           open
@@ -185,7 +201,7 @@ describe("Dialog", () => {
 
     describe("when dialog is lower than 20px", () => {
       it("sets top position to the correct value on open", () => {
-        wrapper = mount(
+        const wrapper = enzymeMount(
           <Dialog open>
             <div />
           </Dialog>
@@ -196,7 +212,7 @@ describe("Dialog", () => {
       });
 
       it("sets top position to the correct value on resize", () => {
-        wrapper = mount(
+        const wrapper = enzymeMount(
           <Dialog open>
             <div />
           </Dialog>
@@ -234,7 +250,7 @@ describe("Dialog", () => {
               } as DOMRect)
           );
 
-        wrapper = mount(
+        const wrapper = enzymeMount(
           <Dialog open>
             <div />
           </Dialog>
@@ -246,7 +262,7 @@ describe("Dialog", () => {
       });
 
       it("sets top position to 20px on resize", () => {
-        wrapper = mount(
+        const wrapper = enzymeMount(
           <Dialog open>
             <div />
           </Dialog>
@@ -284,7 +300,7 @@ describe("Dialog", () => {
               } as DOMRect)
           );
 
-        wrapper = mount(
+        const wrapper = enzymeMount(
           <Dialog open>
             <div />
           </Dialog>
@@ -296,7 +312,7 @@ describe("Dialog", () => {
       });
 
       it("sets left position to 0px on resize", () => {
-        wrapper = mount(
+        const wrapper = enzymeMount(
           <Dialog open>
             <div />
           </Dialog>
@@ -325,9 +341,9 @@ describe("Dialog", () => {
   });
 
   describe("dialog headers", () => {
-    describe("when a props title or subtitle is passed", () => {
+    describe("when title and subtitle props are passed", () => {
       it("sets a dialog headers", () => {
-        wrapper = mount(
+        const wrapper = enzymeMount(
           <Dialog
             onCancel={onCancel}
             open
@@ -342,7 +358,7 @@ describe("Dialog", () => {
       });
     });
 
-    describe("when jsx is passed as title prop value", () => {
+    describe("when jsx is passed to title prop", () => {
       it("Heading component is not used", () => {
         const TitleComponent = () => (
           <div>
@@ -351,7 +367,7 @@ describe("Dialog", () => {
           </div>
         );
 
-        wrapper = mount(
+        const wrapper = enzymeMount(
           <Dialog onCancel={onCancel} open title={<TitleComponent />} />
         );
 
@@ -362,17 +378,17 @@ describe("Dialog", () => {
       });
     });
 
-    describe("when a props title is not passed", () => {
+    describe("when title prop is not passed", () => {
       it("title is not rendered", () => {
-        wrapper = mount(<Dialog onCancel={onCancel} open />);
+        const wrapper = enzymeMount(<Dialog onCancel={onCancel} open />);
         expect(wrapper.find(StyledDialogTitle).exists()).toBe(false);
         expect(wrapper.find(Heading).exists()).toBe(false);
       });
     });
 
-    describe("when prop help is passed", () => {
+    describe("when help prop is passed", () => {
       it("should render Help component", () => {
-        wrapper = mount(
+        const wrapper = enzymeMount(
           <Dialog open title="This is test title" help="this is help text" />
         );
 
@@ -383,45 +399,39 @@ describe("Dialog", () => {
 
   describe("render", () => {
     describe("when dialog is open", () => {
-      beforeEach(() => {
-        wrapper = mount(
-          <Dialog
-            open
-            title="Test"
-            subtitle="Test"
-            size="small"
-            className="foo"
-            onCancel={onCancel}
-            height="500"
-            role="dialog"
-            data-element="bar"
-            data-role="baz"
-          >
-            <Button>Button</Button>
-            <Button>Button</Button>
-          </Dialog>
-        );
-      });
+      const TestDialog = () => (
+        <Dialog
+          open
+          title="Test"
+          subtitle="Test"
+          size="small"
+          className="foo"
+          onCancel={onCancel}
+          height="500"
+          role="dialog"
+        >
+          <Button>Button</Button>
+          <Button>Button</Button>
+        </Dialog>
+      );
 
-      it("has the correct content, tags, elements etc", () => {
-        expect(wrapper.props()["data-element"]).toEqual("bar");
-        expect(wrapper.props()["data-role"]).toEqual("baz");
-        expect((wrapper.props().children as JSX.Element[]).length).toEqual(2);
-      });
-
-      it("closes when the exit icon is click", () => {
-        wrapper.find(IconButton).first().simulate("click");
+      it("closes when the close button is clicked", () => {
+        const wrapper = enzymeMount(<TestDialog />);
+        wrapper.find("button[data-element='close']").simulate("click");
         expect(onCancel).toHaveBeenCalled();
       });
 
-      it("closes when exit icon is focused and Enter key is pressed", () => {
-        const icon = wrapper.find(IconButton).first();
+      it("closes when close button is focused and Enter key is pressed", () => {
+        const wrapper = enzymeMount(<TestDialog />);
+        const icon = wrapper.find("button[data-element='close']");
         icon.simulate("keyDown", { key: "Enter" });
         expect(onCancel).toHaveBeenCalled();
       });
 
-      it("does not close when exit icon is focused any other key is pressed", () => {
-        const icon = wrapper.find(IconButton).first();
+      it("does not close when close button is focused Enter key is not pressed", () => {
+        const wrapper = enzymeMount(<TestDialog />);
+
+        const icon = wrapper.find("button[data-element='close']");
         icon.simulate("keyDown", { key: "a" });
         expect(onCancel).not.toHaveBeenCalled();
       });
@@ -429,7 +439,9 @@ describe("Dialog", () => {
 
     describe("when dialog is closed", () => {
       it("only renders a parent div with mainClasses attached", () => {
-        wrapper = mount(<Dialog open={false} onCancel={onCancel} />);
+        const wrapper = enzymeMount(
+          <Dialog open={false} onCancel={onCancel} />
+        );
 
         expect(wrapper.find(".carbon-dialog").at(0).length).toEqual(1);
         expect(wrapper.find(".carbon-dialog__dialog").length).toEqual(0);
@@ -437,74 +449,62 @@ describe("Dialog", () => {
     });
   });
 
-  describe("a11y", () => {
-    beforeEach(() => {
-      wrapper = mount(
-        <Dialog
-          onCancel={() => {}}
-          open
-          subtitle="Test"
-          title="Test"
-          role="dialog"
-        />
-      );
-    });
-
-    describe("when title or subtitle are not set", () => {
-      it(`does not render aria-labelledby pointing at the title element or
+  describe("when title or subtitle are not passed", () => {
+    it(`does not render aria-labelledby pointing at the title element or
       an aria-describedby attribute pointing at the subtitle element`, () => {
-        wrapper = mount(<Dialog onCancel={() => {}} open />);
-
-        expect(
-          wrapper.find('[aria-describedby="carbon-dialog-subtitle"]').length
-        ).toEqual(0);
-        expect(
-          wrapper.find('[aria-labelledby="carbon-dialog-title"]').length
-        ).toEqual(0);
-      });
-    });
-
-    it("should have aria-modal attribute on the dialog container", () => {
-      onCancel = jest.fn();
-      wrapper = mount(
-        <CarbonProvider>
-          <Dialog
-            onCancel={onCancel}
-            className="foo"
-            open
-            title="my title"
-            subtitle="my subtitle"
-          >
-            <Button>Button</Button>
-            <Button>Button</Button>
-          </Dialog>
-        </CarbonProvider>
-      );
+      const wrapper = enzymeMount(<Dialog onCancel={() => {}} open />);
 
       expect(
-        wrapper.find(StyledDialog).getDOMNode().getAttribute("aria-modal")
-      ).toBe("true");
-
-      wrapper.unmount();
+        wrapper.find('[aria-describedby="carbon-dialog-subtitle"]').length
+      ).toEqual(0);
+      expect(
+        wrapper.find('[aria-labelledby="carbon-dialog-title"]').length
+      ).toEqual(0);
     });
   });
 
-  describe("when topMargin is passed to the StyledDialog", () => {
-    it("should set correct max-height on StyledDialog", () => {
-      assertStyleMatch(
-        {
-          maxHeight: "calc(100vh - 30px)",
-        },
-        mount(<StyledDialog topMargin={30} />)
-      );
-    });
+  it("should have aria-modal attribute on the dialog container", () => {
+    onCancel = jest.fn();
+
+    const wrapper = enzymeMount(
+      <CarbonProvider>
+        <Dialog
+          onCancel={onCancel}
+          className="foo"
+          open
+          title="my title"
+          subtitle="my subtitle"
+        >
+          <Button>Button</Button>
+          <Button>Button</Button>
+        </Dialog>
+      </CarbonProvider>
+    );
+
+    expect(
+      wrapper.find(StyledDialog).getDOMNode().getAttribute("aria-modal")
+    ).toBe("true");
+  });
+
+  it("should have correct max-height", () => {
+    const wrapper = enzymeMount(
+      <Dialog open title="My dialog" subtitle="subtitle">
+        Content
+      </Dialog>
+    );
+    assertStyleMatch(
+      {
+        maxHeight: "calc(100vh - 20px)",
+      },
+      wrapper.find(StyledDialog)
+    );
   });
 
   describe.each(["400", "400px"])(
     "when height is passed to the Dialog",
     (height) => {
       it("have proper value passed as height css rule", () => {
-        wrapper = mount(<Dialog open height={height} />);
+        const wrapper = enzymeMount(<Dialog open height={height} />);
 
         assertStyleMatch(
           {
@@ -517,18 +517,19 @@ describe("Dialog", () => {
   );
 
   describe("when showCloseIcon prop is true", () => {
-    it("StyledDialogTitle should have padding-right: 85px", () => {
-      wrapper = mount(<Dialog title="Heading" open />);
+    it("dialog title should have padding-right: 85px", () => {
+      const wrapper = enzymeMount(<Dialog title="Heading" open />);
 
-      const DialogTitle = wrapper.find(StyledDialogTitle);
-
-      assertStyleMatch({ paddingRight: "85px" }, DialogTitle);
+      assertStyleMatch(
+        { paddingRight: "85px" },
+        wrapper.find(StyledDialogTitle)
+      );
     });
   });
 
   describe("when the Form child has a sticky footer", () => {
     it("does not set overflow styling", () => {
-      wrapper = mount(
+      const wrapper = enzymeMount(
         <Dialog open>
           <Form stickyFooter />
         </Dialog>
@@ -542,7 +543,7 @@ describe("Dialog", () => {
 
   describe("when the Form child does not have a sticky footer", () => {
     it("sets overflow styling", () => {
-      wrapper = mount(
+      const wrapper = enzymeMount(
         <Dialog open>
           <Form />
         </Dialog>
@@ -557,13 +558,15 @@ describe("Dialog", () => {
 
   describe("when auto focus disabled", () => {
     it("should not focus the first element by default", () => {
-      mount(
+      const wrapper = enzymeMount(
         <Dialog open disableAutoFocus>
-          <input type="text" />
+          <input data-role="test-input" type="text" />
         </Dialog>
       );
 
-      const firstFocusableElement = document.querySelector("input");
+      const firstFocusableElement = wrapper
+        .find("input[data-role='test-input']")
+        .getDOMNode();
       expect(document.activeElement).not.toBe(firstFocusableElement);
     });
   });
@@ -574,7 +577,7 @@ describe("Dialog", () => {
         (guid as jest.MockedFunction<typeof guid>).mockImplementation(
           () => "foo"
         );
-        wrapper = mount(<Dialog open title="Test" />);
+        const wrapper = enzymeMount(<Dialog open title="Test" />);
 
         expect(
           wrapper
@@ -591,7 +594,7 @@ describe("Dialog", () => {
           () => "baz"
         );
 
-        wrapper = mount(<Dialog open subtitle="Test" />);
+        const wrapper = enzymeMount(<Dialog open subtitle="Test" />);
 
         expect(
           wrapper
@@ -606,7 +609,7 @@ describe("Dialog", () => {
       it("then the container should have the same aria-labelledby attribute", () => {
         const titleId = "foo";
 
-        wrapper = mount(
+        const wrapper = enzymeMount(
           <Dialog
             aria-labelledby={titleId}
             open
@@ -626,7 +629,7 @@ describe("Dialog", () => {
     describe("when the role prop is specified", () => {
       it("then the container should have the same role attribute", () => {
         const dialogRole = "foo";
-        wrapper = mount(<Dialog open role={dialogRole} />);
+        const wrapper = enzymeMount(<Dialog open role={dialogRole} />);
         expect(
           wrapper.find("[data-element='dialog']").first().prop("role")
         ).toBe(dialogRole);
@@ -636,7 +639,7 @@ describe("Dialog", () => {
     describe("when the aria-label prop is specified", () => {
       it("then the container should have the same aria-label attribute", () => {
         const label = "foo";
-        wrapper = mount(<Dialog open aria-label={label} />);
+        const wrapper = enzymeMount(<Dialog open aria-label={label} />);
         expect(
           wrapper.find("[data-element='dialog']").first().prop("aria-label")
         ).toBe(label);
@@ -703,15 +706,15 @@ describe("Dialog", () => {
         describe.each(["p", "py", "px"] as const)(
           "to the `%s` property",
           (prop) => {
-            beforeEach(() => {
-              wrapper = mount(
-                <Dialog open contentPadding={{ [prop]: value }}>
-                  <Form />
-                </Dialog>
-              );
-            });
+            const TestDialog = () => (
+              <Dialog open contentPadding={{ [prop]: value }}>
+                <Form />
+              </Dialog>
+            );
 
             it("applies the expected values to the DialogStyle and Form elements", () => {
+              const wrapper = enzymeMount(<TestDialog />);
+
               assertStyleMatch(
                 {
                   marginLeft: getFormSpacing(value, "left", prop, true),
@@ -744,6 +747,8 @@ describe("Dialog", () => {
             });
 
             it("applies the expected values to the DialogContentStyle and DialogInnerContentStyle elements", () => {
+              const wrapper = enzymeMount(<TestDialog />);
+
               assertStyleMatch(
                 {
                   padding: getDialogContentPadding(value, prop === "p", true),
@@ -772,6 +777,12 @@ describe("Dialog", () => {
   });
 
   it("applies the expected border radius to the main container and footer elements", () => {
+    const wrapper = enzymeMount(
+      <Dialog open title="My dialog" subtitle="subtitle">
+        Content
+      </Dialog>
+    );
+
     assertStyleMatch(
       {
         borderRadius: "var(--borderRadius200)",

--- a/src/components/dialog/dialog.stories.mdx
+++ b/src/components/dialog/dialog.stories.mdx
@@ -20,9 +20,9 @@ import * as stories from "./dialog.stories.tsx";
 <a
   target="_blank"
   href="https://zeroheight.com/2ccf2b601/p/497e21-dialog/b/310ef2"
-  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+  style={{ color: "#007E45", fontWeight: "bold", textDecoration: "underline" }}
 >
-  Product Design System component 
+  Product Design System component
 </a>
 
 A dialog box overlaid on top of any page.
@@ -67,12 +67,6 @@ When mixing editable and non-editable content, you can use the <LinkTo kind="Box
   <Story name="with help" story={stories.WithHelp} />
 </Canvas>
 
-### With dynamic content
-
-<Canvas>
-  <Story name="dynamic content" story={stories.DynamicContent} />
-</Canvas>
-
 ### Overriding the first focused element
 
 By default, when a dialog is opened it will automatically focus the first element within its children that can be focussed.
@@ -87,6 +81,42 @@ and setting the `autoFocus` on the element you wish to be focused instead (click
     story={stories.FocusingADifferentFirstElement}
   />
 </Canvas>
+
+### Loading content
+
+For situations where content cannot be rendered immediately, such as content dependent on data from an external API, conditional rendering and the `Loader` component can be used to create a loading pattern:
+
+<Canvas>
+  <Story name="loading content" story={stories.LoadingContent} />
+</Canvas>
+
+Note in the previous example, the first `Textbox` in the loaded content has autofocus, which is recommended so assistive technology users are informed of the updated content.
+
+Alternatively, focus can be programmatically moved back to the `Dialog` to inform assistive technology users of a content change:
+
+<Canvas>
+  <Story
+    name="refocusing dialog after content change"
+    story={stories.UsingHandle}
+  />
+</Canvas>
+
+A custom ref handle can be forwarded to the `Dialog` component:
+
+```tsx
+const dialogHandle = useRef<DialogHandle>(null);
+return (
+  <Dialog ref={dialogHandle}>
+    Your feedback helps us continually improve our software.
+  </Dialog>
+);
+```
+
+which exposes the `focus()` method of `Dialog`'s root DOM node:
+
+```ts
+dialogHandle.current?.focus();
+```
 
 ### Overriding the content padding
 

--- a/src/components/dialog/dialog.stories.tsx
+++ b/src/components/dialog/dialog.stories.tsx
@@ -2,9 +2,11 @@ import React, { useRef, useState } from "react";
 import { StoryFn } from "@storybook/react";
 import isChromatic from "../../../.storybook/isChromatic";
 
+import Dialog from ".";
+import type { DialogHandle } from ".";
+
 import Box from "../box";
 import Button from "../button";
-import Dialog from "./dialog.component";
 import Form from "../form";
 import Typography from "../typography";
 import Textbox from "../textbox";
@@ -12,6 +14,8 @@ import Fieldset from "../fieldset";
 import { RadioButton, RadioButtonGroup } from "../radio-button";
 import Loader from "../loader";
 import Toast from "../toast";
+import Textarea from "../textarea";
+import CarbonProvider from "../carbon-provider";
 import useMediaQuery from "../../hooks/useMediaQuery";
 
 const defaultOpenState = isChromatic();
@@ -168,7 +172,7 @@ export const WithHelp: StoryFn = () => {
   );
 };
 
-export const DynamicContent: StoryFn = () => {
+export const LoadingContent: StoryFn = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isOpen, setIsOpen] = useState(defaultOpenState);
 
@@ -193,7 +197,7 @@ export const DynamicContent: StoryFn = () => {
           <Loader isActive isInsideButton={false} size="small" />
         ) : (
           <>
-            <Textbox label="Textbox 1" labelInline />
+            <Textbox label="Textbox 1" labelInline autoFocus />
             <Textbox label="Textbox 2" labelInline />
             <Textbox label="Textbox 3" labelInline />
             <Textbox label="Textbox 4" labelInline />
@@ -206,7 +210,7 @@ export const DynamicContent: StoryFn = () => {
     </>
   );
 };
-DynamicContent.parameters = { chromatic: { disableSnapshot: true } };
+LoadingContent.parameters = { chromatic: { disableSnapshot: true } };
 
 export const FocusingADifferentFirstElement: StoryFn = () => {
   const [isOpenOne, setIsOpenOne] = useState(false);
@@ -434,4 +438,47 @@ Responsive.parameters = {
   chromatic: {
     viewports: [1500, 900],
   },
+};
+
+export const UsingHandle = () => {
+  const dialogHandle = useRef<DialogHandle>(null);
+
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  function handleSubmit(ev: React.FormEvent<HTMLFormElement>) {
+    ev.preventDefault();
+    setIsSubmitted(true);
+    dialogHandle.current?.focus();
+  }
+
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
+      <Dialog
+        open={isOpen}
+        onCancel={() => setIsOpen(false)}
+        title={isSubmitted ? "Thank you for your feedback." : "Give feedback"}
+        showCloseIcon
+        ref={dialogHandle}
+      >
+        {isSubmitted ? (
+          <Typography>
+            Your feedback helps us continually improve our software.
+          </Typography>
+        ) : (
+          <Form
+            stickyFooter
+            saveButton={<Button type="submit">Submit</Button>}
+            onSubmit={handleSubmit}
+          >
+            <Textarea
+              label="What would you like to tell us?"
+              characterLimit={1000}
+            />
+          </Form>
+        )}
+      </Dialog>
+    </CarbonProvider>
+  );
 };

--- a/src/components/dialog/index.ts
+++ b/src/components/dialog/index.ts
@@ -1,3 +1,4 @@
 export { default } from "./dialog.component";
 export type { DialogProps } from "./dialog.component";
+export type { DialogHandle } from "./dialog.component";
 export type { DialogSizes } from "./dialog.config";


### PR DESCRIPTION
addresses #6250

### Proposed behaviour

- Allow ability for consumers to forward a ref handle to `Dialog`, which exposes the component's root DOM node `focus()` method:

```tsx
import Dialog from "carbon-react/lib/components/dialog";
import type { DialogHandle } from "carbon-react/lib/components/dialog";

const MyComponent = () => {
     const dialogHandle = useRef<DialogHandle>(null);

     return (
         <Dialog ref={dialogHandle}>
             <Button onClick={() => dialogHandle.current?.focus()}>
                  Refocus on dialog
             </Button>
         </Dialog>
     );
};
``` 

- Update `Dialog` tests to address DOM elements, particularly those used by React Portals, that were not cleaned-up after tests

### Current behaviour

Currently, there is no way to programmatically refocus on the `Dialog`'s root DOM node. This functionality is required for cases where the content inside the `Dialog` is dynamically updated and screen reader users need to be informed about this change.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

The purposed changes only exposes the `focus()` method of `Dialog`'s root DOM node, as opposed to the whole DOM node. This has been done to intentionally prevent unnecessary access to the other methods of the root DOM node, as providing access to these methods could make support more difficult. 

### Testing instructions

Using Safari with macOS VoiceOver, Chrome with NVDA and Firefox with NVDA. Please do the following:

1. Do `npm start`. Once storybook is loaded, go to the following URL in the browser: 
```
http://localhost:9001/iframe.html?args=&id=dialog--using-handle&viewMode=story
```
2. Start screen reader
3. Open the dialog, then navigate with the keyboard to the submit button and submit form. This should update the dialog's content.
4. Verify screen reader announces the new content after form submission.
