### PR TITLE
feat(typography): add a prop to support text that is for screen readers only

### DIFF
--- a/cypress/components/typography/typography.cy.tsx
+++ b/cypress/components/typography/typography.cy.tsx
@@ -277,6 +277,23 @@ context("Tests for Typography component", () => {
           .and(`${assertion}.css`, "text-overflow", "ellipsis");
       }
     );
+
+    it("should display as visually hidden when screenReaderOnly prop is enabled", () => {
+      CypressMountWithProviders(
+        <Typography variant="h1" screenReaderOnly>
+          {testCypress}
+        </Typography>
+      );
+      cy.get("h1")
+        .should("have.text", testCypress)
+        .and("have.css", "border", "0px none rgba(0, 0, 0, 0.9)")
+        .and("have.css", "height", "1px")
+        .and("have.css", "margin", "-1px")
+        .and("have.css", "overflow", "hidden")
+        .and("have.css", "padding", "0px")
+        .and("have.css", "position", "absolute")
+        .and("have.css", "width", "1px");
+    });
   });
 
   describe("should check accessibility for Typography component", () => {
@@ -288,6 +305,12 @@ context("Tests for Typography component", () => {
 
     it("should check accessibility for Typography component TruncateStory", () => {
       CypressMountWithProviders(<stories.TruncateStory />);
+
+      cy.checkAccessibility();
+    });
+
+    it("should check accessibility for Typography component ScreenReaderOnlyStory", () => {
+      CypressMountWithProviders(<stories.ScreenReaderOnlyStory />);
 
       cy.checkAccessibility();
     });

--- a/src/components/typography/typography.component.tsx
+++ b/src/components/typography/typography.component.tsx
@@ -71,6 +71,9 @@ export interface TypographyProps extends SpaceProps, TagProps {
   opacity?: string | number;
   /** @private @ignore */
   className?: string;
+  /** Set whether it will be visually hidden
+   * NOTE: This is for screen readers only and will make a lot of the other props redundant */
+  screenReaderOnly?: boolean;
 }
 
 export const Typography = ({
@@ -95,6 +98,7 @@ export const Typography = ({
   opacity,
   children,
   className,
+  screenReaderOnly,
   ...rest
 }: TypographyProps) => {
   return (
@@ -118,6 +122,7 @@ export const Typography = ({
       bg={bg}
       opacity={opacity}
       className={className}
+      screenReaderOnly={screenReaderOnly}
       {...tagComponent(dataComponent, rest)}
       {...filterStyledSystemMarginProps(rest)}
       {...filterStyledSystemPaddingProps(rest)}

--- a/src/components/typography/typography.spec.tsx
+++ b/src/components/typography/typography.spec.tsx
@@ -603,6 +603,27 @@ describe("Typography", () => {
         wrapper.find(Typography)
       );
     });
+
+    it("sets to visually hidden when screenReaderOnly prop is true", () => {
+      const wrapper = mount(
+        <ThemeProvider theme={mintTheme}>
+          <Typography screenReaderOnly>FooBar</Typography>
+        </ThemeProvider>
+      );
+      assertStyleMatch(
+        {
+          border: "0",
+          height: "1px",
+          margin: "-1px",
+          overflow: "hidden",
+          padding: "0",
+          position: "absolute",
+          width: "1px",
+          whiteSpace: "nowrap",
+        },
+        wrapper.find(Typography)
+      );
+    });
   });
 
   testStyledSystemSpacing((props) => <Typography {...props} />);

--- a/src/components/typography/typography.stories.mdx
+++ b/src/components/typography/typography.stories.mdx
@@ -61,6 +61,14 @@ This prop will only work with block level elements, so ensure `display="block"` 
 | brilliantGreenShade38 | ✅               | ✅             | Positive text      |
 | errorRed              | ✅               | ✅             | Negative text      |
 
+## Screen reader only text
+
+The `screenReaderOnly` prop is a boolean prop that will make the Typography component visually hidden and only available for screen readers.
+
+<Canvas>
+  <Story name="screenReaderOnly" story={stories.ScreenReaderOnlyStory} />
+</Canvas>
+
 ## Props
 
 <StyledSystemProps of={Typography} noHeader spacing />

--- a/src/components/typography/typography.stories.tsx
+++ b/src/components/typography/typography.stories.tsx
@@ -113,3 +113,16 @@ export const TruncateStory: ComponentStory<typeof Fragment> = () => (
   </>
 );
 TruncateStory.parameters = { info: { disable: true } };
+
+export const ScreenReaderOnlyStory: ComponentStory<typeof Fragment> = () => (
+  <>
+    <Typography>
+      This is regular text, that can be seen, but under it is visually hidden
+      text. Check the source to see it or use a screen reader.
+    </Typography>
+    <Typography screenReaderOnly>
+      This text is visually hidden and will only be read out by a screen reader.
+    </Typography>
+  </>
+);
+ScreenReaderOnlyStory.parameters = { info: { disable: true } };

--- a/src/components/typography/typography.style.ts
+++ b/src/components/typography/typography.style.ts
@@ -3,6 +3,7 @@ import { space } from "styled-system";
 import styledColor from "../../style/utils/color";
 import baseTheme from "../../style/themes/base";
 import { TypographyProps, VariantTypes } from "./typography.component";
+import visuallyHidden from "../../style/utils/visually-hidden";
 
 const getAs = (variant?: VariantTypes) => {
   switch (variant) {
@@ -160,6 +161,7 @@ const StyledTypography = styled.span.attrs(
     wordWrap,
     textOverflow,
     truncate,
+    screenReaderOnly,
   }) => css`
     font-style: normal;
     font-size: ${size};
@@ -176,6 +178,7 @@ const StyledTypography = styled.span.attrs(
     css`
       overflow: hidden;
     `};
+    ${screenReaderOnly && visuallyHidden}
     ${variant === "sup" && "vertical-align: super;"};
     ${variant === "sub" && "vertical-align: sub;"};
     ${display && `display: ${display};`};


### PR DESCRIPTION
### Proposed behaviour

Add a new prop to the Typography component that will allow consumers to visually hide text for the purpose of screen readers.

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

This is a new feature so currently there is no support for this

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Adding the prop `screenReaderOnly` will enable the visually hidden behaviour

<!-- How can a reviewer test this PR? -->

The following CodeSandbox shows the new prop in operation:

<!-- Add CodeSandbox here -->
https://codesandbox.io/s/carbon-quickstart-forked-7xhg4n
