### PR TITLE
fix(flat-table): ensure tabindex is set on clickable elements when table has pager and loading state FE-6194

### DIFF
--- a/cypress/components/flat-table/flat-table.cy.tsx
+++ b/cypress/components/flat-table/flat-table.cy.tsx
@@ -2274,6 +2274,88 @@ context("Tests for Flat Table component", () => {
       flatTableBodyRowByPosition(5).should("be.focused");
     });
 
+    it("should set tabIndex 0 on the first row when after the loading state has finished", () => {
+      CypressMountWithProviders(<stories.KeyboardNavigationWithPagination />);
+      cy.wait(300);
+
+      cy.get("body").tab();
+
+      cy.focused().tab();
+      flatTableBodyRowByPosition(0).then(checkNewFocusStyling);
+      cy.focused().tab();
+      flatTableBodyRowByPosition(0).should("not.be.focused");
+      flatTableBodyRowByPosition(1).should("not.be.focused");
+      flatTableBodyRowByPosition(2).should("not.be.focused");
+      flatTableBodyRowByPosition(3).should("not.be.focused");
+      flatTablePageSelectNext().click();
+      cy.wait(300);
+      cy.get("body").tab();
+
+      cy.focused().tab();
+      flatTableBodyRowByPosition(0).then(checkNewFocusStyling);
+    });
+
+    it("should set the tabIndex on the highlighted row when the loading state has finished", () => {
+      CypressMountWithProviders(
+        <stories.KeyboardNavigationWithPagination highlighted />
+      );
+      cy.wait(300);
+
+      cy.get("body").tab();
+
+      cy.focused().tab();
+      flatTableBodyRowByPosition(0).should("not.be.focused");
+      flatTableBodyRowByPosition(2).then(checkNewFocusStyling);
+      cy.focused().tab();
+      flatTableBodyRowByPosition(3).should("not.be.focused");
+      flatTablePageSelectNext().click();
+      cy.wait(300);
+      cy.get("body").tab();
+
+      cy.focused().tab();
+      flatTableBodyRowByPosition(0).then(checkNewFocusStyling);
+    });
+
+    it("should set the tabIndex on the highlighted row when the loading state has finished and remove it when row is no longer highlighted", () => {
+      CypressMountWithProviders(
+        <stories.HighlightedRowWithLoadingState expandableArea="wholeRow" />
+      );
+      cy.wait(300);
+
+      cy.get("body").tab();
+
+      cy.focused().tab();
+      flatTableBodyRowByPosition(0).should("not.be.focused");
+      flatTableBodyRowByPosition(2).should("be.focused");
+      cy.focused().tab();
+      flatTableBodyRowByPosition(3).should("not.be.focused");
+      flatTableBodyRowByPosition(2).click();
+      cy.get("body").tab();
+
+      cy.focused().tab();
+      flatTableBodyRowByPosition(0).should("be.focused");
+    });
+
+    it("should set the tabIndex on the first cell in a highlighted row when the loading state has finished and remove it when row is no longer highlighted", () => {
+      CypressMountWithProviders(
+        <stories.HighlightedRowWithLoadingState expandableArea="firstColumn" />
+      );
+      cy.wait(300);
+
+      cy.get("body").tab();
+
+      cy.focused().tab();
+      flatTableCell(0).should("not.be.focused");
+      flatTableCell(8).should("be.focused");
+      cy.focused().tab();
+      flatTableCell(12).should("not.be.focused");
+      flatTableCell(8).click();
+      cy.get("body").tab();
+
+      cy.focused().tab();
+      flatTableCell(0).should("be.focused");
+    });
+
     it("should render Flat Table with action popover in a cell opened by mouse", () => {
       CypressMountWithProviders(
         <stories.FlatTableAllSubrowSelectableComponent />

--- a/src/components/flat-table/__internal__/index.ts
+++ b/src/components/flat-table/__internal__/index.ts
@@ -1,2 +1,2 @@
-export { default as useCalculateStickyCells } from "./use-calculate-sticky-cells";
+export { default as useTableCell } from "./use-table-cell";
 export { default as buildPositionMap } from "./build-position-map";

--- a/src/components/flat-table/__internal__/use-table-cell.ts
+++ b/src/components/flat-table/__internal__/use-table-cell.ts
@@ -1,7 +1,10 @@
-import { useContext } from "react";
+import { useContext, useEffect, useState } from "react";
 import FlatTableRowContext from "../flat-table-row/__internal__/flat-table-row-context";
+import { FlatTableThemeContext } from "../flat-table.component";
 
 export default (id: string) => {
+  const { getTabStopElementId } = useContext(FlatTableThemeContext);
+  const [tabIndex, setTabIndex] = useState(-1);
   const {
     expandable,
     firstCellId,
@@ -10,6 +13,8 @@ export default (id: string) => {
     rightPositions,
     onClick,
     onKeyDown,
+    highlighted,
+    selected,
   } = useContext(FlatTableRowContext);
 
   const leftPosition = leftPositions[id];
@@ -18,6 +23,16 @@ export default (id: string) => {
     leftPosition !== undefined || rightPosition !== undefined;
   const isFirstCell = id === firstCellId;
   const isExpandableCell = expandable && isFirstCell && firstColumnExpandable;
+
+  useEffect(() => {
+    const tabstopTimer = setTimeout(() => {
+      setTabIndex(isExpandableCell && getTabStopElementId() === id ? 0 : -1);
+    }, 0);
+
+    return () => {
+      clearTimeout(tabstopTimer);
+    };
+  }, [getTabStopElementId, isExpandableCell, id]);
 
   return {
     expandable,
@@ -28,5 +43,8 @@ export default (id: string) => {
     onKeyDown,
     isFirstCell,
     isExpandableCell,
+    tabIndex,
+    isInHighlightedRow: highlighted,
+    isInSelectedRow: selected,
   };
 };

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.component.tsx
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.component.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useEffect, useContext } from "react";
+import React, { useRef } from "react";
 import { PaddingProps } from "styled-system";
 import { TableBorderSize, TableCellAlign } from "..";
 
@@ -7,9 +7,8 @@ import {
   StyledCellContent,
 } from "./flat-table-cell.style";
 import Icon from "../../icon";
-import { FlatTableThemeContext } from "../flat-table.component";
 import guid from "../../../__internal__/utils/helpers/guid";
-import useCalculateStickyCells from "../__internal__/use-calculate-sticky-cells";
+import useTableCell from "../__internal__/use-table-cell";
 
 export interface FlatTableCellProps extends PaddingProps {
   /** Content alignment */
@@ -46,10 +45,8 @@ export const FlatTableCell = ({
   id,
   ...rest
 }: FlatTableCellProps) => {
-  const ref = useRef<HTMLTableCellElement>(null);
   const internalId = useRef(id || guid());
-  const [tabIndex, setTabIndex] = useState(-1);
-  const { selectedId } = useContext(FlatTableThemeContext);
+
   const {
     leftPosition,
     rightPosition,
@@ -59,11 +56,10 @@ export const FlatTableCell = ({
     isFirstCell,
     isExpandableCell,
     makeCellSticky,
-  } = useCalculateStickyCells(internalId.current);
-
-  useEffect(() => {
-    setTabIndex(isExpandableCell && selectedId === internalId.current ? 0 : -1);
-  }, [selectedId, isExpandableCell]);
+    isInHighlightedRow,
+    isInSelectedRow,
+    tabIndex,
+  } = useTableCell(internalId.current);
 
   return (
     <StyledFlatTableCell
@@ -71,7 +67,6 @@ export const FlatTableCell = ({
       rightPosition={rightPosition}
       makeCellSticky={makeCellSticky}
       className={makeCellSticky ? "isSticky" : undefined}
-      ref={ref}
       align={align}
       data-element="flat-table-cell"
       pl={pl}
@@ -83,6 +78,8 @@ export const FlatTableCell = ({
       expandable={expandable}
       {...(colspan !== undefined && { colSpan: Number(colspan) })}
       {...(rowspan !== undefined && { rowSpan: Number(rowspan) })}
+      data-selected={isInSelectedRow && isExpandableCell}
+      data-highlighted={isInHighlightedRow && isExpandableCell}
       {...rest}
       id={internalId.current}
     >

--- a/src/components/flat-table/flat-table-header/flat-table-header.component.tsx
+++ b/src/components/flat-table/flat-table-header/flat-table-header.component.tsx
@@ -5,7 +5,7 @@ import { TableBorderSize, TableCellAlign } from "..";
 import StyledFlatTableHeader from "./flat-table-header.style";
 import { FlatTableThemeContext } from "../flat-table.component";
 import guid from "../../../__internal__/utils/helpers/guid";
-import useCalculateStickyCells from "../__internal__/use-calculate-sticky-cells";
+import useTableCell from "../__internal__/use-table-cell";
 
 export interface FlatTableHeaderProps extends PaddingProps {
   /** Content alignment */
@@ -42,11 +42,9 @@ export const FlatTableHeader = ({
   const ref = useRef<HTMLTableCellElement>(null);
   const internalId = useRef(id || guid());
   const { colorTheme } = useContext(FlatTableThemeContext);
-  const {
-    leftPosition,
-    rightPosition,
-    makeCellSticky,
-  } = useCalculateStickyCells(internalId.current);
+  const { leftPosition, rightPosition, makeCellSticky } = useTableCell(
+    internalId.current
+  );
 
   return (
     <StyledFlatTableHeader

--- a/src/components/flat-table/flat-table-header/flat-table-header.spec.tsx
+++ b/src/components/flat-table/flat-table-header/flat-table-header.spec.tsx
@@ -63,7 +63,7 @@ describe("FlatTableHeader", () => {
       (colorTheme) => {
         const wrapper = mount(
           <FlatTableThemeContext.Provider
-            value={{ colorTheme, setSelectedId: jest.fn }}
+            value={{ colorTheme, getTabStopElementId: () => "" }}
           >
             <table>
               <thead>

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.tsx
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useContext,
-  useState,
-  useRef,
-  useEffect,
-} from "react";
+import React, { useCallback, useRef } from "react";
 import { PaddingProps } from "styled-system";
 import { TableBorderSize, TableCellAlign } from "..";
 
@@ -13,12 +7,11 @@ import {
   StyledFlatTableRowHeader,
   StyledFlatTableRowHeaderContent,
 } from "./flat-table-row-header.style";
-import { FlatTableThemeContext } from "../flat-table.component";
 import guid from "../../../__internal__/utils/helpers/guid";
 import tagComponent, {
   TagProps,
 } from "../../../__internal__/utils/helpers/tags/tags";
-import useCalculateStickyCells from "../__internal__/use-calculate-sticky-cells";
+import useTableCell from "../__internal__/use-table-cell";
 
 export interface FlatTableRowHeaderProps extends PaddingProps, TagProps {
   /** Content alignment */
@@ -60,8 +53,6 @@ export const FlatTableRowHeader = ({
   ...rest
 }: FlatTableRowHeaderProps) => {
   const internalId = useRef(id || guid());
-  const [tabIndex, setTabIndex] = useState(-1);
-  const { selectedId } = useContext(FlatTableThemeContext);
 
   const {
     leftPosition,
@@ -71,11 +62,10 @@ export const FlatTableRowHeader = ({
     onKeyDown,
     isFirstCell,
     isExpandableCell,
-  } = useCalculateStickyCells(internalId.current);
-
-  useEffect(() => {
-    setTabIndex(isExpandableCell && selectedId === internalId.current ? 0 : -1);
-  }, [selectedId, isExpandableCell]);
+    tabIndex,
+    isInHighlightedRow,
+    isInSelectedRow,
+  } = useTableCell(internalId.current);
 
   const handleOnClick = useCallback(
     (ev: React.MouseEvent<HTMLElement>) => {
@@ -115,6 +105,8 @@ export const FlatTableRowHeader = ({
       stickyAlignment={stickyAlignment}
       {...(colspan !== undefined && { colSpan: Number(colspan) })}
       {...(rowspan !== undefined && { rowSpan: Number(rowspan) })}
+      data-selected={isInSelectedRow && isExpandableCell}
+      data-highlighted={isInHighlightedRow && isExpandableCell}
       {...rest}
       id={internalId.current}
     >

--- a/src/components/flat-table/flat-table-row/__internal__/flat-table-row-context.tsx
+++ b/src/components/flat-table/flat-table-row/__internal__/flat-table-row-context.tsx
@@ -8,6 +8,8 @@ export interface FlatTableRowContextProps {
   leftPositions: Record<string, number>;
   rightPositions: Record<string, number>;
   firstColumnExpandable?: boolean;
+  highlighted?: boolean;
+  selected?: boolean;
 }
 
 export default createContext<FlatTableRowContextProps>({

--- a/src/components/flat-table/flat-table-row/flat-table-row.component.tsx
+++ b/src/components/flat-table/flat-table-row/flat-table-row.component.tsx
@@ -188,7 +188,7 @@ export const FlatTableRow = React.forwardRef<
       `Do not render a right hand side \`${FlatTableRowHeader.displayName}\` before left hand side \`${FlatTableRowHeader.displayName}\``
     );
 
-    const { colorTheme, size, setSelectedId, selectedId } = useContext(
+    const { colorTheme, size, getTabStopElementId } = useContext(
       FlatTableThemeContext
     );
     const { isInSidebar } = useContext(DrawerSidebarContext);
@@ -250,14 +250,8 @@ export const FlatTableRow = React.forwardRef<
     }, [expanded]);
 
     useEffect(() => {
-      if (highlighted || selected) {
-        setSelectedId(internalId.current);
-      }
-    }, [highlighted, selected, setSelectedId]);
-
-    useEffect(() => {
-      setTabIndex(selectedId === internalId.current ? 0 : -1);
-    }, [selectedId]);
+      setTabIndex(getTabStopElementId() === internalId.current ? 0 : -1);
+    }, [getTabStopElementId]);
 
     const { isSubRow, firstRowId, addRow, removeRow } = useContext(
       SubRowContext
@@ -297,6 +291,8 @@ export const FlatTableRow = React.forwardRef<
         draggable={draggable}
         totalChildren={cellsArray.length}
         id={internalId.current}
+        data-selected={selected && expandableArea === "wholeRow"}
+        data-highlighted={highlighted && expandableArea === "wholeRow"}
         {...interactiveRowProps}
         {...rest}
       >
@@ -309,6 +305,8 @@ export const FlatTableRow = React.forwardRef<
             firstColumnExpandable,
             onKeyDown: handleCellKeyDown,
             onClick: () => toggleExpanded(),
+            highlighted,
+            selected,
           }}
         >
           {children}

--- a/src/components/flat-table/flat-table-row/flat-table-row.spec.tsx
+++ b/src/components/flat-table/flat-table-row/flat-table-row.spec.tsx
@@ -1352,7 +1352,7 @@ describe("FlatTableRow", () => {
       it("should add the correct padding to child row cells", () => {
         const wrapper = mount(
           <FlatTableThemeContext.Provider
-            value={{ size: "compact", setSelectedId: jest.fn }}
+            value={{ size: "compact", getTabStopElementId: () => "" }}
           >
             <table>
               <tbody>

--- a/src/components/flat-table/flat-table-test.stories.tsx
+++ b/src/components/flat-table/flat-table-test.stories.tsx
@@ -3350,3 +3350,218 @@ export const SubRowsAsAComponentStory = () => {
     </FlatTable>
   );
 };
+
+export const KeyboardNavigationWithPagination = (
+  props: Partial<FlatTableProps> & { highlighted?: boolean }
+) => {
+  const { highlighted, ...rest } = props;
+  const rows = [
+    <FlatTableRow onClick={() => {}} key="0">
+      <FlatTableCell>John Doe</FlatTableCell>
+      <FlatTableCell>London</FlatTableCell>
+      <FlatTableCell>Single</FlatTableCell>
+      <FlatTableCell>0</FlatTableCell>
+    </FlatTableRow>,
+    <FlatTableRow onClick={() => {}} key="1">
+      <FlatTableCell>Jane Doe</FlatTableCell>
+      <FlatTableCell>York</FlatTableCell>
+      <FlatTableCell>Married</FlatTableCell>
+      <FlatTableCell>2</FlatTableCell>
+    </FlatTableRow>,
+    <FlatTableRow highlighted={highlighted} onClick={() => {}} key="2">
+      <FlatTableCell>John Smith</FlatTableCell>
+      <FlatTableCell>Edinburgh</FlatTableCell>
+      <FlatTableCell>Single</FlatTableCell>
+      <FlatTableCell>1</FlatTableCell>
+    </FlatTableRow>,
+    <FlatTableRow onClick={() => {}} key="3">
+      <FlatTableCell>Jane Smith</FlatTableCell>
+      <FlatTableCell>Newcastle</FlatTableCell>
+      <FlatTableCell>Married</FlatTableCell>
+      <FlatTableCell>5</FlatTableCell>
+    </FlatTableRow>,
+    <FlatTableRow onClick={() => {}} key="4">
+      <FlatTableCell>Liz Anya</FlatTableCell>
+      <FlatTableCell>Stoke</FlatTableCell>
+      <FlatTableCell>Single</FlatTableCell>
+      <FlatTableCell>2</FlatTableCell>
+    </FlatTableRow>,
+    <FlatTableRow onClick={() => {}} key="5">
+      <FlatTableCell>Karl Ickbred</FlatTableCell>
+      <FlatTableCell>Newcastle</FlatTableCell>
+      <FlatTableCell>Single</FlatTableCell>
+      <FlatTableCell>0</FlatTableCell>
+    </FlatTableRow>,
+  ];
+
+  const [recordsRange, setRecordsRange] = useState({
+    start: 0,
+    end: 5,
+  });
+  const [update, setUpdate] = React.useState(false);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const renderRows = () => {
+    const { start, end } = recordsRange;
+    if (start < 0) return rows;
+    if (end > rows.length) return rows.slice(start, rows.length);
+    return rows.slice(start, end);
+  };
+
+  const handlePagination = (newPage: number, newPageSize: number) => {
+    const start = (newPage - 1) * newPageSize;
+    const end = start + newPageSize;
+    setRecordsRange({
+      start,
+      end,
+    });
+    setCurrentPage(newPage);
+  };
+
+  React.useEffect(() => {
+    setTimeout(() => setUpdate(true), 300);
+  }, [update]);
+
+  React.useEffect(() => {
+    setUpdate(false);
+  }, [currentPage]);
+
+  const loading = (
+    <>
+      <FlatTableRow>
+        <FlatTableCell colspan={4}>Loading State</FlatTableCell>
+      </FlatTableRow>
+    </>
+  );
+
+  return (
+    <div
+      style={{
+        height: "200px",
+        marginBottom: "16px",
+      }}
+    >
+      <FlatTable
+        footer={
+          <Pager
+            totalRecords={rows.length}
+            showPageSizeSelection
+            pageSize={5}
+            currentPage={currentPage}
+            onPagination={(next, size) => handlePagination(next, size)}
+            pageSizeSelectionOptions={[
+              {
+                id: "1",
+                name: 1,
+              },
+              {
+                id: "5",
+                name: 5,
+              },
+            ]}
+          />
+        }
+        {...rest}
+      >
+        <FlatTableHead>
+          <FlatTableRow>
+            <FlatTableHeader>Name</FlatTableHeader>
+            <FlatTableHeader width={180}>Location</FlatTableHeader>
+            <FlatTableHeader width={150}>Relationship Status</FlatTableHeader>
+            <FlatTableHeader width={100}>Dependents</FlatTableHeader>
+          </FlatTableRow>
+        </FlatTableHead>
+        <FlatTableBody>{update ? renderRows() : loading}</FlatTableBody>
+      </FlatTable>
+    </div>
+  );
+};
+
+export const HighlightedRowWithLoadingState = (
+  props: Partial<FlatTableProps> & {
+    expandableArea: "wholeRow" | "firstColumn";
+  }
+) => {
+  const { expandableArea, ...rest } = props;
+  const [highlighted, setHighlighted] = useState(true);
+  const rows = (
+    <>
+      <FlatTableRow
+        onClick={() => {}}
+        expandable
+        expandableArea={expandableArea}
+      >
+        <FlatTableCell>John Doe</FlatTableCell>
+        <FlatTableCell>London</FlatTableCell>
+        <FlatTableCell>Single</FlatTableCell>
+        <FlatTableCell>0</FlatTableCell>
+      </FlatTableRow>
+      <FlatTableRow
+        onClick={() => {}}
+        expandable
+        expandableArea={expandableArea}
+      >
+        <FlatTableCell>Jane Doe</FlatTableCell>
+        <FlatTableCell>York</FlatTableCell>
+        <FlatTableCell>Married</FlatTableCell>
+        <FlatTableCell>2</FlatTableCell>
+      </FlatTableRow>
+      <FlatTableRow
+        highlighted={highlighted}
+        onClick={() => setHighlighted((p) => !p)}
+        expandable
+        expandableArea={expandableArea}
+      >
+        <FlatTableCell>John Smith</FlatTableCell>
+        <FlatTableCell>Edinburgh</FlatTableCell>
+        <FlatTableCell>Single</FlatTableCell>
+        <FlatTableCell>1</FlatTableCell>
+      </FlatTableRow>
+      <FlatTableRow
+        onClick={() => {}}
+        expandable
+        expandableArea={expandableArea}
+      >
+        <FlatTableCell>Jane Smith</FlatTableCell>
+        <FlatTableCell>Newcastle</FlatTableCell>
+        <FlatTableCell>Married</FlatTableCell>
+        <FlatTableCell>5</FlatTableCell>
+      </FlatTableRow>
+    </>
+  );
+
+  const [update, setUpdate] = React.useState(false);
+
+  React.useEffect(() => {
+    setTimeout(() => setUpdate(true), 300);
+  }, [update]);
+
+  const loading = (
+    <>
+      <FlatTableRow>
+        <FlatTableCell colspan={4}>Loading State</FlatTableCell>
+      </FlatTableRow>
+    </>
+  );
+
+  return (
+    <div
+      style={{
+        height: "200px",
+        marginBottom: "16px",
+      }}
+    >
+      <FlatTable {...rest}>
+        <FlatTableHead>
+          <FlatTableRow>
+            <FlatTableHeader>Name</FlatTableHeader>
+            <FlatTableHeader width={180}>Location</FlatTableHeader>
+            <FlatTableHeader width={150}>Relationship Status</FlatTableHeader>
+            <FlatTableHeader width={100}>Dependents</FlatTableHeader>
+          </FlatTableRow>
+        </FlatTableHead>
+        <FlatTableBody>{update ? rows : loading}</FlatTableBody>
+      </FlatTable>
+    </div>
+  );
+};

--- a/src/components/flat-table/flat-table.spec.tsx
+++ b/src/components/flat-table/flat-table.spec.tsx
@@ -1050,6 +1050,48 @@ describe("FlatTable", () => {
         });
       });
 
+      it("should tabindex to 0 on the first cell in a highlighted row", async () => {
+        rtlRender(
+          <FlatTable>
+            <FlatTableBody>
+              <FlatTableRow expandableArea="firstColumn" expandable>
+                <FlatTableCell data-testid="one">one</FlatTableCell>
+                <FlatTableCell>two</FlatTableCell>
+              </FlatTableRow>
+              <FlatTableRow highlighted expandableArea="firstColumn" expandable>
+                <FlatTableCell data-testid="two">three</FlatTableCell>
+                <FlatTableCell>four</FlatTableCell>
+              </FlatTableRow>
+            </FlatTableBody>
+          </FlatTable>
+        );
+        await waitFor(() => {
+          expect(screen.getByTestId("one").getAttribute("tabindex")).toBe("-1");
+          expect(screen.getByTestId("two").getAttribute("tabindex")).toBe("0");
+        });
+      });
+
+      it("should tabindex to 0 on the first cell in a selected row", async () => {
+        rtlRender(
+          <FlatTable>
+            <FlatTableBody>
+              <FlatTableRow expandableArea="firstColumn" expandable>
+                <FlatTableCell data-testid="one">one</FlatTableCell>
+                <FlatTableCell>two</FlatTableCell>
+              </FlatTableRow>
+              <FlatTableRow selected expandableArea="firstColumn" expandable>
+                <FlatTableCell data-testid="two">three</FlatTableCell>
+                <FlatTableCell>four</FlatTableCell>
+              </FlatTableRow>
+            </FlatTableBody>
+          </FlatTable>
+        );
+        await waitFor(() => {
+          expect(screen.getByTestId("one").getAttribute("tabindex")).toBe("-1");
+          expect(screen.getByTestId("two").getAttribute("tabindex")).toBe("0");
+        });
+      });
+
       it("should set the first row header's tabindex to 0", async () => {
         rtlRender(
           <FlatTable>
@@ -1072,6 +1114,56 @@ describe("FlatTable", () => {
         await waitFor(() => {
           expect(screen.getByTestId("one").getAttribute("tabindex")).toBe("0");
           expect(screen.getByTestId("two").getAttribute("tabindex")).toBe("-1");
+        });
+      });
+
+      it("should tabindex to 0 on the first row header in a highlighted row", async () => {
+        rtlRender(
+          <FlatTable>
+            <FlatTableBody>
+              <FlatTableRow expandableArea="firstColumn" expandable>
+                <FlatTableRowHeader data-testid="one" id="one">
+                  one
+                </FlatTableRowHeader>
+                <FlatTableCell id="two">two</FlatTableCell>
+              </FlatTableRow>
+              <FlatTableRow highlighted expandableArea="firstColumn" expandable>
+                <FlatTableRowHeader data-testid="two" id="three">
+                  three
+                </FlatTableRowHeader>
+                <FlatTableCell id="four">four</FlatTableCell>
+              </FlatTableRow>
+            </FlatTableBody>
+          </FlatTable>
+        );
+        await waitFor(() => {
+          expect(screen.getByTestId("one").getAttribute("tabindex")).toBe("-1");
+          expect(screen.getByTestId("two").getAttribute("tabindex")).toBe("0");
+        });
+      });
+
+      it("should tabindex to 0 on the first row header in a selected row", async () => {
+        rtlRender(
+          <FlatTable>
+            <FlatTableBody>
+              <FlatTableRow expandableArea="firstColumn" expandable>
+                <FlatTableRowHeader data-testid="one" id="one">
+                  one
+                </FlatTableRowHeader>
+                <FlatTableCell id="two">two</FlatTableCell>
+              </FlatTableRow>
+              <FlatTableRow selected expandableArea="firstColumn" expandable>
+                <FlatTableRowHeader data-testid="two" id="three">
+                  three
+                </FlatTableRowHeader>
+                <FlatTableCell id="four">four</FlatTableCell>
+              </FlatTableRow>
+            </FlatTableBody>
+          </FlatTable>
+        );
+        await waitFor(() => {
+          expect(screen.getByTestId("one").getAttribute("tabindex")).toBe("-1");
+          expect(screen.getByTestId("two").getAttribute("tabindex")).toBe("0");
         });
       });
 


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Updates component to handle loading states and pagination to ensure tab stop is put on correct row.
Ensure tab index is placed on correct cell when first column is expandable and is in selected or highlighted row

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Tab index is not updated on first/ highlighted/ selected row when there is a loading state and pagination is used
When first column is expandable and part of the a highlighted/ selected row the tab index is set incorrectly

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
https://codesandbox.io/s/rough-paper-nmdxzk?file=/src/App.js
(may be easier to run locally so you can trigger the loading state by refreshing page etc)

Ensure first row/ cell is focused when tabbing or that the the row/ cell in the highlighted/ selected row is when tabbing. Ensure row/ cell can be focused after pagination via tabbing etc

