### PR TITLE
fix(menu-item): address aria role accessibility error with icon only menu items - FE-6055

### DIFF
--- a/src/components/link/link.component.tsx
+++ b/src/components/link/link.component.tsx
@@ -49,6 +49,8 @@ export interface LinkProps extends StyledLinkProps, React.AriaAttributes {
   rel?: string;
   /** @ignore @private internal prop to be set when no href or onClick passed */
   placeholderTabIndex?: boolean;
+  /** @ignore @private internal prop to be set when no aria-label should be specified */
+  removeAriaLabelOnIcon?: boolean;
 }
 
 export const Link = React.forwardRef<
@@ -75,6 +77,7 @@ export const Link = React.forwardRef<
       variant = "default",
       isDarkBackground,
       placeholderTabIndex,
+      removeAriaLabelOnIcon,
       ...rest
     }: LinkProps,
     ref
@@ -109,7 +112,7 @@ export const Link = React.forwardRef<
           type={icon}
           bgSize="extra-small"
           disabled={disabled}
-          ariaLabel={ariaLabel}
+          ariaLabel={removeAriaLabelOnIcon ? undefined : ariaLabel}
           tooltipMessage={tooltipMessage}
           tooltipPosition={tooltipPosition}
         />

--- a/src/components/link/link.spec.tsx
+++ b/src/components/link/link.spec.tsx
@@ -293,6 +293,19 @@ describe("Link", () => {
         expect(anchor.getAttribute("aria-label")).toEqual("test");
       });
     });
+
+    describe("when removeAriaLabelOnIcon is true", () => {
+      it("should set aria-label as undefined on icon", () => {
+        wrapper = renderLink({
+          onClick: () => null,
+          icon: "home",
+          "aria-label": "test",
+          removeAriaLabelOnIcon: true,
+        });
+
+        expect(wrapper.find(Icon).props().ariaLabel).toBe(undefined);
+      });
+    });
   });
 
   describe("'negative' variant", () => {

--- a/src/components/menu/menu-item/menu-item.component.tsx
+++ b/src/components/menu/menu-item/menu-item.component.tsx
@@ -242,6 +242,7 @@ export const MenuItem = ({
     rel,
     onClick,
     icon,
+    removeAriaLabelOnIcon: true,
     selected,
     variant,
     onKeyDown: !inFullscreenView ? handleKeyDown : undefined,

--- a/src/components/menu/menu-item/menu-item.spec.tsx
+++ b/src/components/menu/menu-item/menu-item.spec.tsx
@@ -748,9 +748,10 @@ describe("MenuItem", () => {
       expect(wrapper.find(StyledIcon).exists()).toBe(true);
     });
 
-    it("add aria-label when it is set", () => {
+    it("add aria-label to Link and Icon aria-label to be undefined when it is set on menu item", () => {
       wrapper = mount(<MenuItem icon="settings" ariaLabel="Settings" />);
-      expect(wrapper.find(Icon).props().ariaLabel).toBe("Settings");
+      expect(wrapper.find(Link).props().ariaLabel).toBe("Settings");
+      expect(wrapper.find(Icon).props().ariaLabel).toBe(undefined);
     });
 
     it("give error when `aria-label` is not set and menu item has no child text", () => {


### PR DESCRIPTION
`Elements must only use allowed ARIA attributes` error was occurring in an example of Menu with icon only menu items. This was due to the aria-label being specified on the anchor element and also the underlying span element of the icon itself.

fixes #6175
fixes #4986

### Proposed behaviour

Address "Elements must only use allowed ARIA attributes" warning on `with icon` Menu story.

### Current behaviour

`with icon` Menu story has an accessibility error of "Elements must only use allowed ARIA attributes".

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- `with icon` Story should have no accessibility errors. 
- Should be no regression of features or screenreader behaviour in `menu-item`, `link` and `icon`.