### PR TITLE
docs(link-preview): ensure props table renders 

### DIFF
--- a/src/components/link-preview/link-preview.stories.mdx
+++ b/src/components/link-preview/link-preview.stories.mdx
@@ -1,4 +1,5 @@
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 import LinkPreview from ".";
 import * as stories from "./link-preview.stories.tsx";


### PR DESCRIPTION
fixes #6313

### Proposed behaviour

Ensure prop table renders for component

### Current behaviour

No prop table currently renders

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Prop table should be rendered for `Link-Preview` component
