### PR TITLE
fix(switch): fix alignment issue with component when no new validation is applied

### DIFF
--- a/src/components/switch/switch.component.tsx
+++ b/src/components/switch/switch.component.tsx
@@ -214,16 +214,20 @@ export const Switch = React.forwardRef(
       ...rest,
     };
 
+    const applyValidation = error || warning;
+
     return (
       <>
         {validationRedesignOptIn ? (
           <StyledSwitch {...switchStylePropsForNewValidation}>
             <Label>
-              {label}
-              {labelHelp && <StyledHintText>{labelHelp}</StyledHintText>}
+              <Box mb={labelHelp ? 0 : 1}>
+                {label}
+                {labelHelp && <StyledHintText>{labelHelp}</StyledHintText>}
+              </Box>
               <Box position="relative">
                 <ValidationMessage error={error} warning={warning} />
-                {(error || warning) && (
+                {applyValidation && (
                   <ErrorBorder warning={!!(!error && warning)} />
                 )}
                 <CheckableInput {...inputPropsForNewValidation}>

--- a/src/components/switch/switch.spec.tsx
+++ b/src/components/switch/switch.spec.tsx
@@ -24,6 +24,7 @@ import Tooltip from "../tooltip";
 import StyledHelp from "../help/help.style";
 import Logger from "../../__internal__/utils/logger";
 import CarbonProvider from "../../components/carbon-provider";
+import Box from "../../components/box/box.component";
 
 jest.mock("../../__internal__/utils/logger");
 
@@ -601,6 +602,62 @@ describe("Switch", () => {
               : "var(--colorsSemanticNegative500)",
         },
         wrapper.find(ErrorBorder)
+      );
+    });
+
+    it("applies correct styling to label with labelHelp with validations", () => {
+      wrapper = renderWithCarbonProvider({
+        warning: "message",
+        label: "Label",
+        labelHelp: "Label help",
+      });
+
+      assertStyleMatch(
+        {
+          marginBottom: `var(--spacing000)`,
+        },
+        wrapper.find(Box)
+      );
+    });
+
+    it("applies correct styling to label without labelHelp with validations", () => {
+      wrapper = renderWithCarbonProvider({
+        error: "message",
+        label: "Label",
+      });
+
+      assertStyleMatch(
+        {
+          marginBottom: `var(--spacing100)`,
+        },
+        wrapper.find(Box)
+      );
+    });
+
+    it("applies correct styling to label with labelHelp and no validations", () => {
+      wrapper = renderWithCarbonProvider({
+        label: "Label",
+        labelHelp: "Label help",
+      });
+
+      assertStyleMatch(
+        {
+          marginBottom: `var(--spacing000)`,
+        },
+        wrapper.find(Box)
+      );
+    });
+
+    it("applies correct styling to label without labelHelp and no validations", () => {
+      wrapper = renderWithCarbonProvider({
+        label: "Label",
+      });
+
+      assertStyleMatch(
+        {
+          marginBottom: `var(--spacing100)`,
+        },
+        wrapper.find(Box)
       );
     });
   });


### PR DESCRIPTION
A bug is present whereby when the new validation style is used and no hint text or validation message is passed to the component, the label appears to be misaligned

fixes #6303

### Proposed behaviour

![Screenshot 2023-11-01 at 13 32 14](https://github.com/Sage/carbon/assets/56251247/1e7ed930-9287-4bb8-b724-b05de8b05d63)

### Current behaviour

![Screenshot 2023-09-23 at 18 14 34](https://github.com/Sage/carbon/assets/56251247/b43015ff-be8a-464e-91e3-3ef38df5ac41)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

There should be no other styling regressions to Switch in the new or old style validations.
