### PR TITLE
docs(sidebar): ensure content is not obscured due to new focus styling

### DIFF
--- a/src/components/accordion/accordion-test.stories.tsx
+++ b/src/components/accordion/accordion-test.stories.tsx
@@ -63,9 +63,9 @@ export const Default = ({ ...args }) => (
       ...args,
     }}
   >
-    <div>Content</div>
-    <div>Content</div>
-    <div>Content</div>
+    <Box mt={2}>Content</Box>
+    <Box>Content</Box>
+    <Box>Content</Box>
   </Accordion>
 );
 
@@ -85,9 +85,9 @@ export const Grouped = () => (
     </Accordion>
     <Accordion title="Third Accordion" onChange={action("expansionToggled")}>
       <Box p={2}>
-        <div>Content</div>
-        <div>Content</div>
-        <div>Content</div>
+        <Box mt={2}>Content</Box>
+        <Box>Content</Box>
+        <Box>Content</Box>
       </Box>
     </Accordion>
   </AccordionGroup>
@@ -117,9 +117,9 @@ export const AccordionComponent = ({ ...props }) => {
       width="100%"
       {...props}
     >
-      <div>Content</div>
-      <div>Content</div>
-      <div>Content</div>
+      <Box mt={2}>Content</Box>
+      <Box>Content</Box>
+      <Box>Content</Box>
     </Accordion>
   );
 };
@@ -164,19 +164,15 @@ export const AccordionGroupWithError = () => {
   });
 
   return (
-    <div
-      style={{
-        marginTop: "16px",
-      }}
-    >
+    <Box mt="16px">
       <AccordionGroup>
         <Accordion title="Heading" error={errors.one}>
-          <div style={{ padding: "8px" }}>
+          <Box p="8px">
             <Checkbox label="Add error" error={!!errors.one} />
-          </div>
+          </Box>
         </Accordion>
       </AccordionGroup>
-    </div>
+    </Box>
   );
 };
 
@@ -186,19 +182,15 @@ export const AccordionGroupWithWarning = () => {
   });
 
   return (
-    <div
-      style={{
-        marginTop: "16px",
-      }}
-    >
+    <Box mt="16px">
       <AccordionGroup>
         <Accordion title="Heading" warning={warnings.one}>
-          <div style={{ padding: "8px" }}>
+          <Box p="8px">
             <Checkbox label="Add warning" warning={!!warnings.one} />
-          </div>
+          </Box>
         </Accordion>
       </AccordionGroup>
-    </div>
+    </Box>
   );
 };
 
@@ -208,19 +200,15 @@ export const AccordionGroupWithInfo = () => {
   });
 
   return (
-    <div
-      style={{
-        marginTop: "16px",
-      }}
-    >
+    <Box mt="16px">
       <AccordionGroup>
         <Accordion title="Heading" info={infos.one}>
-          <div style={{ padding: "8px" }}>
+          <Box p="8px">
             <Checkbox label="Add info" info={!!infos.one} />
-          </div>
+          </Box>
         </Accordion>
       </AccordionGroup>
-    </div>
+    </Box>
   );
 };
 
@@ -238,7 +226,7 @@ export const AccordionGroupComponent = () => {
         </Box>
       </Accordion>
       <Accordion title="Third Accordion" onChange={() => {}} width="100%">
-        <div>Content</div>
+        <Box>Content</Box>
       </Accordion>
     </AccordionGroup>
   );
@@ -268,7 +256,7 @@ export const DynamicContent = () => {
       </Button>
       <Accordion title="Title" defaultExpanded>
         {Array.from(Array(contentCount).keys()).map((value) => (
-          <div key={value}>Content</div>
+          <Box key={value}>Content</Box>
         ))}
       </Accordion>
     </>
@@ -279,9 +267,9 @@ export const DynamicContent = () => {
 export const AccordionDefault = ({ ...props }) => {
   return (
     <Accordion title="Heading" {...props}>
-      <div>Content</div>
-      <div>Content</div>
-      <div>Content</div>
+      <Box mt={2}>Content</Box>
+      <Box>Content</Box>
+      <Box>Content</Box>
     </Accordion>
   );
 };
@@ -302,7 +290,7 @@ export const AccordionWithBoxAndDifferentPaddings = () => {
             This is example content inside of the Box component with gray
             background
           </Box>
-          <div>
+          <Box>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla in
             ornare neque. Maecenas pellentesque et erat tincidunt mollis. Etiam
             diam nisi, elementum efficitur ipsum et, imperdiet iaculis ligula.
@@ -314,7 +302,7 @@ export const AccordionWithBoxAndDifferentPaddings = () => {
             ac molestie ante dapibus. Ut molestie auctor turpis, quis ultrices
             ante aliquet eu. Aenean et condimentum arcu, non malesuada elit.
             Cras a magna vestibulum, semper tortor id, molestie eros.
-          </div>
+          </Box>
         </Box>
       </Accordion>
       <Accordion
@@ -330,7 +318,7 @@ export const AccordionWithBoxAndDifferentPaddings = () => {
             This is example content inside of the Box component with gray
             background
           </Box>
-          <div>
+          <Box>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla in
             ornare neque. Maecenas pellentesque et erat tincidunt mollis. Etiam
             diam nisi, elementum efficitur ipsum et, imperdiet iaculis ligula.
@@ -342,7 +330,7 @@ export const AccordionWithBoxAndDifferentPaddings = () => {
             ac molestie ante dapibus. Ut molestie auctor turpis, quis ultrices
             ante aliquet eu. Aenean et condimentum arcu, non malesuada elit.
             Cras a magna vestibulum, semper tortor id, molestie eros.
-          </div>
+          </Box>
         </Box>
       </Accordion>
     </Box>
@@ -351,11 +339,7 @@ export const AccordionWithBoxAndDifferentPaddings = () => {
 
 export const AccordionOpeningButton = () => {
   return (
-    <div
-      style={{
-        margin: "8px",
-      }}
-    >
+    <Box m="8px">
       <Accordion
         title="More info"
         openTitle="Less info"
@@ -366,9 +350,9 @@ export const AccordionOpeningButton = () => {
         buttonWidth="200px"
         error="hello"
       >
-        <div>Content</div>
-        <div>Content</div>
-        <div>Content</div>
+        <Box mt={2}>Content</Box>
+        <Box>Content</Box>
+        <Box>Content</Box>
       </Accordion>
       <br />
       <Accordion
@@ -380,9 +364,9 @@ export const AccordionOpeningButton = () => {
         buttonHeading
         buttonWidth="200px"
       >
-        <div>Content</div>
-        <div>Content</div>
-        <div>Content</div>
+        <Box mt={2}>Content</Box>
+        <Box>Content</Box>
+        <Box>Content</Box>
       </Accordion>
       <br />
       <Accordion
@@ -396,9 +380,9 @@ export const AccordionOpeningButton = () => {
         }}
         buttonWidth="96px"
       >
-        <div>Content</div>
-        <div>Content</div>
-        <div>Content</div>
+        <Box mt={2}>Content</Box>
+        <Box>Content</Box>
+        <Box>Content</Box>
       </Accordion>
       <br />
       <Accordion
@@ -413,11 +397,11 @@ export const AccordionOpeningButton = () => {
           px: 1,
         }}
       >
-        <div>Content</div>
-        <div>Content</div>
-        <div>Content</div>
+        <Box mt={2}>Content</Box>
+        <Box>Content</Box>
+        <Box>Content</Box>
       </Accordion>
-    </div>
+    </Box>
   );
 };
 
@@ -436,9 +420,9 @@ export const AccordionGroupDefault = () => {
       </Accordion>
       <Accordion title="Third Accordion">
         <Box p={2}>
-          <div>Content</div>
-          <div>Content</div>
-          <div>Content</div>
+          <Box mt={2}>Content</Box>
+          <Box>Content</Box>
+          <Box>Content</Box>
         </Box>
       </Accordion>
     </AccordionGroup>
@@ -493,11 +477,7 @@ export const AccordionGroupValidation = () => {
           warning={warnings.one}
           info={infos.one}
         >
-          <div
-            style={{
-              padding: "8px",
-            }}
-          >
+          <Box p="8px">
             <Checkbox
               label="Add error"
               error={!!errors.one}
@@ -516,7 +496,7 @@ export const AccordionGroupValidation = () => {
               info={!!infos.one}
               onChange={() => handleChange("one", infos, setInfos, "info")}
             />
-          </div>
+          </Box>
         </Accordion>
         <Accordion
           title="Heading"
@@ -532,11 +512,7 @@ export const AccordionGroupValidation = () => {
           warning={warnings.two}
           info={infos.two}
         >
-          <div
-            style={{
-              padding: "8px",
-            }}
-          >
+          <Box p="8px">
             <Checkbox
               label="Add error"
               error={!!errors.two}
@@ -555,7 +531,7 @@ export const AccordionGroupValidation = () => {
               info={!!infos.two}
               onChange={() => handleChange("two", infos, setInfos, "info")}
             />
-          </div>
+          </Box>
         </Accordion>
         <Accordion
           title="Heading"
@@ -571,11 +547,7 @@ export const AccordionGroupValidation = () => {
           warning={warnings.three}
           info={infos.three}
         >
-          <div
-            style={{
-              padding: "8px",
-            }}
-          >
+          <Box p="8px">
             <Checkbox
               label="Add error"
               error={!!errors.three}
@@ -594,7 +566,7 @@ export const AccordionGroupValidation = () => {
               info={!!infos.three}
               onChange={() => handleChange("three", infos, setInfos, "info")}
             />
-          </div>
+          </Box>
         </Accordion>
       </AccordionGroup>
     </Box>

--- a/src/components/accordion/accordion.stories.tsx
+++ b/src/components/accordion/accordion.stories.tsx
@@ -23,9 +23,9 @@ type Validations = keyof ValidationObject;
 export const AccordionDefault: ComponentStory<typeof Accordion> = () => {
   return (
     <Accordion title="Heading">
-      <div>Content</div>
-      <div>Content</div>
-      <div>Content</div>
+      <Box mt={2}>Content</Box>
+      <Box>Content</Box>
+      <Box>Content</Box>
     </Accordion>
   );
 };
@@ -35,9 +35,9 @@ export const WithDisableContentPadding: ComponentStory<
 > = () => {
   return (
     <Accordion disableContentPadding title="Heading">
-      <div>Content</div>
-      <div>Content</div>
-      <div>Content</div>
+      <Box mt={2}>Content</Box>
+      <Box>Content</Box>
+      <Box>Content</Box>
     </Accordion>
   );
 };
@@ -45,9 +45,9 @@ export const WithDisableContentPadding: ComponentStory<
 export const Transparent: ComponentStory<typeof Accordion> = () => {
   return (
     <Accordion scheme="transparent" title="Heading">
-      <div>Content</div>
-      <div>Content</div>
-      <div>Content</div>
+      <Box mt={2}>Content</Box>
+      <Box>Content</Box>
+      <Box>Content</Box>
     </Accordion>
   );
 };
@@ -55,9 +55,9 @@ export const Transparent: ComponentStory<typeof Accordion> = () => {
 export const Small: ComponentStory<typeof Accordion> = () => {
   return (
     <Accordion size="small" title="Heading">
-      <div>Content</div>
-      <div>Content</div>
-      <div>Content</div>
+      <Box mt={2}>Content</Box>
+      <Box>Content</Box>
+      <Box>Content</Box>
     </Accordion>
   );
 };
@@ -65,9 +65,9 @@ export const Small: ComponentStory<typeof Accordion> = () => {
 export const Subtitle: ComponentStory<typeof Accordion> = () => {
   return (
     <Accordion subTitle="Sub title" title="Heading">
-      <div>Content</div>
-      <div>Content</div>
-      <div>Content</div>
+      <Box mt={2}>Content</Box>
+      <Box>Content</Box>
+      <Box>Content</Box>
     </Accordion>
   );
 };
@@ -75,9 +75,9 @@ export const Subtitle: ComponentStory<typeof Accordion> = () => {
 export const Fullborder: ComponentStory<typeof Accordion> = () => {
   return (
     <Accordion borders="full" title="Heading">
-      <div>Content</div>
-      <div>Content</div>
-      <div>Content</div>
+      <Box mt={2}>Content</Box>
+      <Box>Content</Box>
+      <Box>Content</Box>
     </Accordion>
   );
 };
@@ -85,9 +85,9 @@ export const Fullborder: ComponentStory<typeof Accordion> = () => {
 export const LeftAlignedIcon: ComponentStory<typeof Accordion> = () => {
   return (
     <Accordion iconAlign="left" title="Heading">
-      <div>Content</div>
-      <div>Content</div>
-      <div>Content</div>
+      <Box mt={2}>Content</Box>
+      <Box>Content</Box>
+      <Box>Content</Box>
     </Accordion>
   );
 };
@@ -95,9 +95,9 @@ export const LeftAlignedIcon: ComponentStory<typeof Accordion> = () => {
 export const DifferentWidth: ComponentStory<typeof Accordion> = () => {
   return (
     <Accordion width="500px" title="Heading">
-      <div>Content</div>
-      <div>Content</div>
-      <div>Content</div>
+      <Box mt={2}>Content</Box>
+      <Box>Content</Box>
+      <Box>Content</Box>
     </Accordion>
   );
 };
@@ -108,25 +108,25 @@ export const WithDifferentPaddingAndMargin: ComponentStory<
   return (
     <>
       <Accordion m={0} p={0} title="Accordion">
-        <div>content</div>
+        <Box mt={2}>content</Box>
       </Accordion>
       <Accordion m={1} p={1} title="Accordion">
-        <div>content</div>
+        <Box mt={2}>content</Box>
       </Accordion>
       <Accordion m={2} p={2} title="Accordion">
-        <div>content</div>
+        <Box mt={2}>content</Box>
       </Accordion>
       <Accordion m={3} p={3} title="Accordion">
-        <div>content</div>
+        <Box mt={2}>content</Box>
       </Accordion>
       <Accordion m={4} p={4} title="Accordion">
-        <div>content</div>
+        <Box mt={2}>content</Box>
       </Accordion>
       <Accordion m={5} p={5} title="Accordion">
-        <div>content</div>
+        <Box mt={2}>content</Box>
       </Accordion>
       <Accordion m={6} p={6} title="Accordion">
-        <div>content</div>
+        <Box mt={2}>content</Box>
       </Accordion>
     </>
   );
@@ -138,25 +138,25 @@ export const WithDifferentPaddingAndMarginInAccordionTitle: ComponentStory<
   return (
     <>
       <Accordion headerSpacing={{ p: 0 }} title="Accordion">
-        <div>content</div>
+        <Box mt={2}>content</Box>
       </Accordion>
       <Accordion headerSpacing={{ p: 1 }} title="Accordion">
-        <div>content</div>
+        <Box mt={2}>content</Box>
       </Accordion>
       <Accordion headerSpacing={{ p: 2 }} title="Accordion">
-        <div>content</div>
+        <Box mt={2}>content</Box>
       </Accordion>
       <Accordion headerSpacing={{ p: 3 }} title="Accordion">
-        <div>content</div>
+        <Box mt={2}>content</Box>
       </Accordion>
       <Accordion headerSpacing={{ p: 4 }} title="Accordion">
-        <div>content</div>
+        <Box mt={2}>content</Box>
       </Accordion>
       <Accordion headerSpacing={{ p: 5 }} title="Accordion">
-        <div>content</div>
+        <Box mt={2}>content</Box>
       </Accordion>
       <Accordion headerSpacing={{ p: 6 }} title="Accordion">
-        <div>content</div>
+        <Box mt={2}>content</Box>
       </Accordion>
     </>
   );
@@ -182,7 +182,7 @@ export const WithBoxComponentAndDifferentPaddings: ComponentStory<
             This is example content inside of the Box component with gray
             background
           </Box>
-          <div>
+          <Box>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla in
             ornare neque. Maecenas pellentesque et erat tincidunt mollis. Etiam
             diam nisi, elementum efficitur ipsum et, imperdiet iaculis ligula.
@@ -194,7 +194,7 @@ export const WithBoxComponentAndDifferentPaddings: ComponentStory<
             ac molestie ante dapibus. Ut molestie auctor turpis, quis ultrices
             ante aliquet eu. Aenean et condimentum arcu, non malesuada elit.
             Cras a magna vestibulum, semper tortor id, molestie eros.
-          </div>
+          </Box>
         </Box>
       </Accordion>
       <Accordion
@@ -208,7 +208,7 @@ export const WithBoxComponentAndDifferentPaddings: ComponentStory<
             This is example content inside of the Box component with gray
             background
           </Box>
-          <div>
+          <Box>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla in
             ornare neque. Maecenas pellentesque et erat tincidunt mollis. Etiam
             diam nisi, elementum efficitur ipsum et, imperdiet iaculis ligula.
@@ -220,7 +220,7 @@ export const WithBoxComponentAndDifferentPaddings: ComponentStory<
             ac molestie ante dapibus. Ut molestie auctor turpis, quis ultrices
             ante aliquet eu. Aenean et condimentum arcu, non malesuada elit.
             Cras a magna vestibulum, semper tortor id, molestie eros.
-          </div>
+          </Box>
         </Box>
       </Accordion>
       <Accordion
@@ -233,7 +233,7 @@ export const WithBoxComponentAndDifferentPaddings: ComponentStory<
             This is example content inside of the Box component with gray
             background
           </Box>
-          <div>
+          <Box>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla in
             ornare neque. Maecenas pellentesque et erat tincidunt mollis. Etiam
             diam nisi, elementum efficitur ipsum et, imperdiet iaculis ligula.
@@ -245,7 +245,7 @@ export const WithBoxComponentAndDifferentPaddings: ComponentStory<
             ac molestie ante dapibus. Ut molestie auctor turpis, quis ultrices
             ante aliquet eu. Aenean et condimentum arcu, non malesuada elit.
             Cras a magna vestibulum, semper tortor id, molestie eros.
-          </div>
+          </Box>
         </Box>
       </Accordion>
       <Accordion
@@ -258,7 +258,7 @@ export const WithBoxComponentAndDifferentPaddings: ComponentStory<
             This is example content inside of the Box component with gray
             background
           </Box>
-          <div>
+          <Box>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla in
             ornare neque. Maecenas pellentesque et erat tincidunt mollis. Etiam
             diam nisi, elementum efficitur ipsum et, imperdiet iaculis ligula.
@@ -270,7 +270,7 @@ export const WithBoxComponentAndDifferentPaddings: ComponentStory<
             ac molestie ante dapibus. Ut molestie auctor turpis, quis ultrices
             ante aliquet eu. Aenean et condimentum arcu, non malesuada elit.
             Cras a magna vestibulum, semper tortor id, molestie eros.
-          </div>
+          </Box>
         </Box>
       </Accordion>
     </>
@@ -279,7 +279,7 @@ export const WithBoxComponentAndDifferentPaddings: ComponentStory<
 
 export const OpeningButton: ComponentStory<typeof Accordion> = () => {
   return (
-    <div style={{ margin: "8px" }}>
+    <Box m="8px">
       <Accordion
         title="More info"
         openTitle="Less info"
@@ -290,9 +290,9 @@ export const OpeningButton: ComponentStory<typeof Accordion> = () => {
         buttonWidth="200px"
         error="hello"
       >
-        <div>Content</div>
-        <div>Content</div>
-        <div>Content</div>
+        <Box mt={2}>Content</Box>
+        <Box>Content</Box>
+        <Box>Content</Box>
       </Accordion>
       <br />
       <Accordion
@@ -304,9 +304,9 @@ export const OpeningButton: ComponentStory<typeof Accordion> = () => {
         buttonHeading
         buttonWidth="200px"
       >
-        <div>Content</div>
-        <div>Content</div>
-        <div>Content</div>
+        <Box mt={2}>Content</Box>
+        <Box>Content</Box>
+        <Box>Content</Box>
       </Accordion>
       <br />
       <Accordion
@@ -318,9 +318,9 @@ export const OpeningButton: ComponentStory<typeof Accordion> = () => {
         headerSpacing={{ px: 0 }}
         buttonWidth="96px"
       >
-        <div>Content</div>
-        <div>Content</div>
-        <div>Content</div>
+        <Box mt={2}>Content</Box>
+        <Box>Content</Box>
+        <Box>Content</Box>
       </Accordion>
       <br />
       <Accordion
@@ -333,11 +333,11 @@ export const OpeningButton: ComponentStory<typeof Accordion> = () => {
         buttonWidth="120px"
         headerSpacing={{ px: 1 }}
       >
-        <div>Content</div>
-        <div>Content</div>
-        <div>Content</div>
+        <Box mt={2}>Content</Box>
+        <Box>Content</Box>
+        <Box>Content</Box>
       </Accordion>
-    </div>
+    </Box>
   );
 };
 
@@ -356,9 +356,9 @@ export const Grouped: ComponentStory<typeof Accordion> = () => {
       </Accordion>
       <Accordion title="Third Accordion">
         <Box p={2}>
-          <div>Content</div>
-          <div>Content</div>
-          <div>Content</div>
+          <Box>Content</Box>
+          <Box>Content</Box>
+          <Box>Content</Box>
         </Box>
       </Accordion>
     </AccordionGroup>
@@ -397,7 +397,7 @@ export const WithValidationIcon: ComponentStory<typeof Accordion> = () => {
     setter((previous) => ({ ...previous, [id]: update }));
   };
   return (
-    <div style={{ marginTop: "16px" }}>
+    <Box mt="16px">
       <AccordionGroup>
         <Accordion
           title="Heading"
@@ -412,7 +412,7 @@ export const WithValidationIcon: ComponentStory<typeof Accordion> = () => {
           warning={warnings.one}
           info={infos.one}
         >
-          <div style={{ padding: "8px" }}>
+          <Box p="8px">
             <Checkbox
               label="Add error"
               error={!!errors.one}
@@ -431,7 +431,7 @@ export const WithValidationIcon: ComponentStory<typeof Accordion> = () => {
               info={!!infos.one}
               onChange={() => handleChange("one", infos, setInfos, "info")}
             />
-          </div>
+          </Box>
         </Accordion>
         <Accordion
           title="Heading"
@@ -447,7 +447,7 @@ export const WithValidationIcon: ComponentStory<typeof Accordion> = () => {
           warning={warnings.two}
           info={infos.two}
         >
-          <div style={{ padding: "8px" }}>
+          <Box p="8px">
             <Checkbox
               label="Add error"
               error={!!errors.two}
@@ -466,7 +466,7 @@ export const WithValidationIcon: ComponentStory<typeof Accordion> = () => {
               info={!!infos.two}
               onChange={() => handleChange("two", infos, setInfos, "info")}
             />
-          </div>
+          </Box>
         </Accordion>
         <Accordion
           title="Heading"
@@ -482,7 +482,7 @@ export const WithValidationIcon: ComponentStory<typeof Accordion> = () => {
           warning={warnings.three}
           info={infos.three}
         >
-          <div style={{ padding: "8px" }}>
+          <Box p="8px">
             <Checkbox
               label="Add error"
               error={!!errors.three}
@@ -501,10 +501,10 @@ export const WithValidationIcon: ComponentStory<typeof Accordion> = () => {
               info={!!infos.three}
               onChange={() => handleChange("three", infos, setInfos, "info")}
             />
-          </div>
+          </Box>
         </Accordion>
       </AccordionGroup>
-    </div>
+    </Box>
   );
 };
 
@@ -525,9 +525,11 @@ export const WithDynamicContent: ComponentStory<typeof Accordion> = () => {
       <Button onClick={() => modifyContentCount(-1)} ml={2}>
         Remove content
       </Button>
-      <Accordion title="Title">
+      <Accordion mt={2} title="Title">
         {Array.from(Array(contentCount).keys()).map((value) => (
-          <div key={value}>Content</div>
+          <Box key={value} mt={2}>
+            Content
+          </Box>
         ))}
       </Accordion>
     </>
@@ -535,8 +537,15 @@ export const WithDynamicContent: ComponentStory<typeof Accordion> = () => {
 };
 
 export const WithDefinitionList: ComponentStory<typeof Accordion> = () => {
+  const [isOpen, setOpen] = useState(true);
   return (
-    <Accordion title="Heading" expanded>
+    <Accordion
+      title="Heading"
+      onChange={() => {
+        setOpen(!isOpen);
+      }}
+      expanded={isOpen}
+    >
       <Dl>
         <Dt>Drink</Dt>
         <Dd>Coffee</Dd>

--- a/src/components/sidebar/sidebar-test.stories.tsx
+++ b/src/components/sidebar/sidebar-test.stories.tsx
@@ -77,13 +77,13 @@ export const Default = (args: Partial<SidebarProps>) => {
     <>
       <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
       <Sidebar {...args} aria-label="sidebar" open={isOpen} onCancel={onCancel}>
-        <div>
+        <Box mb={2}>
           <Button buttonType="primary">Test</Button>
           <Button buttonType="secondary" ml={2}>
             Last
           </Button>
-        </div>
-        <div style={{ marginBottom: 3000 }}>Main content</div>
+        </Box>
+        <Box mb="3000px">Main content</Box>
       </Sidebar>
     </>
   );
@@ -107,19 +107,13 @@ export const SidebarComponent = (props: Partial<SidebarProps>) => {
         size="medium"
         {...props}
       >
-        <div>
+        <Box mb={2}>
           <Button buttonType="primary">Test</Button>
           <Button buttonType="secondary" ml={2}>
             Last
           </Button>
-        </div>
-        <div
-          style={{
-            marginBottom: 3000,
-          }}
-        >
-          Main content
-        </div>
+        </Box>
+        <Box mb="3000px">Main content</Box>
       </Sidebar>
     </>
   );
@@ -178,13 +172,13 @@ export const SidebarComponentFocusable = (props: Partial<SidebarProps>) => {
         focusableSelectors={CUSTOM_SELECTOR}
         {...props}
       >
-        <div className="focusable-container">
+        <Box className="focusable-container">
           <Textbox label="First Name" />
-        </div>
-        <div>
+        </Box>
+        <Box>
           <Textbox label="Surname" />
-        </div>
-        <div className="focusable-container">
+        </Box>
+        <Box className="focusable-container">
           <Button
             buttonType="primary"
             data-element="open-toast"
@@ -192,7 +186,7 @@ export const SidebarComponentFocusable = (props: Partial<SidebarProps>) => {
           >
             Show toast
           </Button>
-        </div>
+        </Box>
       </Sidebar>
       <Toast
         open={isToastOpen}

--- a/src/components/sidebar/sidebar.stories.tsx
+++ b/src/components/sidebar/sidebar.stories.tsx
@@ -7,6 +7,7 @@ import Typography from "../typography";
 import Form from "../form";
 import Toast from "../toast";
 import Textbox from "../textbox";
+import Box from "../box";
 
 import isChromatic from "../../../.storybook/isChromatic";
 
@@ -22,12 +23,12 @@ export const DefaultStory: ComponentStory<typeof Sidebar> = () => {
         open={isOpen}
         onCancel={() => setIsOpen(false)}
       >
-        <div>
+        <Box mb={2}>
           <Button buttonType="primary">Test</Button>
           <Button buttonType="secondary" ml={2}>
             Last
           </Button>
-        </div>
+        </Box>
         Main Content
       </Sidebar>
     </>
@@ -42,12 +43,12 @@ export const CustomPaddingAroundContent: ComponentStory<
     <>
       <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
       <Sidebar open={isOpen} onCancel={() => setIsOpen(false)} p={0}>
-        <div>
+        <Box mb={2}>
           <Button buttonType="primary">Test</Button>
           <Button buttonType="secondary" ml={2}>
             Last
           </Button>
-        </div>
+        </Box>
         Main Content
       </Sidebar>
     </>
@@ -64,12 +65,12 @@ export const WithHeader: ComponentStory<typeof Sidebar> = () => {
         onCancel={() => setIsOpen(false)}
         header={<Typography variant="h3">Sidebar header</Typography>}
       >
-        <div>
+        <Box mb={2}>
           <Button buttonType="primary">Test</Button>
           <Button buttonType="secondary" ml={2}>
             Last
           </Button>
-        </div>
+        </Box>
         Main Content
       </Sidebar>
     </>
@@ -86,13 +87,13 @@ export const WithScroll: ComponentStory<typeof Sidebar> = () => {
         onCancel={() => setIsOpen(false)}
         header={<Typography variant="h3">Sidebar header</Typography>}
       >
-        <div>
+        <Box mb={2}>
           <Button buttonType="primary">Test</Button>
           <Button buttonType="secondary" ml={2}>
             Last
           </Button>
-        </div>
-        <div style={{ marginBottom: 3000 }}>Long content</div>
+        </Box>
+        <Box mb="3000px">Long content</Box>
       </Sidebar>
     </>
   );
@@ -260,12 +261,12 @@ export const CustomWidth: ComponentStory<typeof Sidebar> = () => {
         onCancel={() => setIsOpen(false)}
         width="25%"
       >
-        <div>
+        <Box mb={2}>
           <Button buttonType="primary">Test</Button>
           <Button buttonType="secondary" ml={2}>
             Last
           </Button>
-        </div>
+        </Box>
         Main Content
       </Sidebar>
     </>


### PR DESCRIPTION
### Proposed behaviour

![Screenshot 2023-09-23 at 20 25 56](https://github.com/Sage/carbon/assets/56251247/abd0e6df-c42b-4ce4-b88c-0cc31b2c8532)

![Screenshot 2023-09-23 at 20 48 46](https://github.com/Sage/carbon/assets/56251247/6a50593d-d23a-4fdf-a269-3654bd0009df)

### Current behaviour

![Screenshot 2023-09-23 at 20 26 26](https://github.com/Sage/carbon/assets/56251247/a92ca951-608b-4bec-8465-08ef258c6021)

![Screenshot 2023-09-23 at 20 49 07](https://github.com/Sage/carbon/assets/56251247/5d40341c-0799-41fa-9032-11039f5515b8)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Content should not be obscured by the new focus styling in any `Sidebar` examples.
Content should not be obscured by the new focus styling in any `Accordion` examples.
