### PR TITLE
fix(multi-action-button): update styling to ensure corrext spacing when child buttons have icons

### DIFF
--- a/src/components/multi-action-button/__snapshots__/multi-action-button.spec.tsx.snap
+++ b/src/components/multi-action-button/__snapshots__/multi-action-button.spec.tsx.snap
@@ -334,11 +334,6 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
   margin: 0 -1px;
 }
 
-.c14 .c3 {
-  margin-left: 0;
-  left: 8px;
-}
-
 .c14 .c1 {
   border: 1px solid var(--colorsActionMajorTransparent);
   display: -webkit-box;

--- a/src/components/multi-action-button/multi-action-button.stories.mdx
+++ b/src/components/multi-action-button/multi-action-button.stories.mdx
@@ -97,6 +97,15 @@ Subtext only works when `size` is `large`
   />
 </Canvas>
 
+## When children buttons render icons
+
+<Canvas>
+  <Story
+    name="when children buttons render icons"
+    story={stories.WithChildrenButtonsWithIcons}
+  />
+</Canvas>
+
 ## Props
 
 ### MultiActionButton

--- a/src/components/multi-action-button/multi-action-button.stories.tsx
+++ b/src/components/multi-action-button/multi-action-button.stories.tsx
@@ -153,3 +153,30 @@ export const InOverflowHiddenContainer = () => {
 InOverflowHiddenContainer.parameters = {
   chromatic: { disableSnapshot: true },
 };
+
+export const WithChildrenButtonsWithIcons: ComponentStory<
+  typeof MultiActionButton
+> = () => (
+  <>
+    {(["before", "after"] as const).map((iconPosition) => (
+      <MultiActionButton
+        align={iconPosition === "before" ? "left" : "right"}
+        text="Multi Action Button"
+      >
+        <Button iconPosition={iconPosition} iconType="add">
+          Child Button 1
+        </Button>
+        <Button iconPosition={iconPosition} iconType="upload">
+          Child Button 2
+        </Button>
+        <Button iconPosition={iconPosition} iconType="clock">
+          Child Button 3
+        </Button>
+      </MultiActionButton>
+    ))}
+  </>
+);
+
+WithChildrenButtonsWithIcons.parameters = {
+  chromatic: { disableSnapshot: true },
+};

--- a/src/components/multi-action-button/multi-action-button.style.ts
+++ b/src/components/multi-action-button/multi-action-button.style.ts
@@ -89,11 +89,6 @@ const StyledButtonChildrenContainer = styled.div<StyledButtonChildrenContainerPr
     box-shadow: var(--boxShadow100);
     border-radius: var(--borderRadius100);
 
-    ${StyledIcon} {
-      margin-left: 0;
-      left: 8px;
-    }
-
     ${borderRadiusStyling}
 
     ${StyledButton} {


### PR DESCRIPTION
fix #6214

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Removes styling that targets icons in child buttons and applies 8px of left position. This ensures that the spacing between button text and icon matches DS.

![image](https://github.com/Sage/carbon/assets/44157880/c9662267-03a4-4c6b-aa7e-eff50c3907e9)
![image](https://github.com/Sage/carbon/assets/44157880/dbc82aa1-9c90-40ca-9426-5eb3bbb2cab7)


### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
--> 
Incorrect spacing when child buttons have icons

![image](https://github.com/Sage/carbon/assets/44157880/8af74b04-b882-4897-9a90-511b731b9467)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] Unit tests added or updated if required
- [x] Storybook added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
