### PR TITLE
chore(playwright): increase timeout for github actions workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   playwright-react:
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.34.0-jammy
@@ -78,7 +78,7 @@ jobs:
               "context": "Playwright tests",
               "description": "workflow completed successfully."
             }'
-          
+
       - name: Report status - failed
         if: always() && failure()
         run: |

--- a/cypress/components/flat-table/flat-table.cy.tsx
+++ b/cypress/components/flat-table/flat-table.cy.tsx
@@ -2201,7 +2201,8 @@ context("Tests for Flat Table component", () => {
       }
     );
 
-    it("should navigate the first column of cells with down arrow key press when expandableArea is set to 'firstColumn'", () => {
+    // TODO: Skipping due to flakey behaviour. Investigate as part of FE-6231
+    it.skip("should navigate the first column of cells with down arrow key press when expandableArea is set to 'firstColumn'", () => {
       CypressMountWithProviders(
         <stories.FlatTableFirstColExpandableComponent />
       );


### PR DESCRIPTION
### Proposed behaviour

- Increase timeout for Playwright workflow from 20mins to 30mins.
- Skip flaking `FlatTable` cypress test, note to investigate in a separate ticket

### Current behaviour

- Currently, some PRs have failing Playwright tests, due to workflow timing out.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

[Playwright seems to recommend 60 minutes for GitHub Actions workflows](https://playwright.dev/docs/ci-intro). However, it would be ideal to first ensure tests are written to not encourage flakiness, as well as explore parallelisation options.
