### PR TITLE
fix(menu-fullscreen): ensure menu has aria properties required for accessible dialogs

### DIFF
--- a/cypress/components/menu/menu.cy.tsx
+++ b/cypress/components/menu/menu.cy.tsx
@@ -1177,17 +1177,21 @@ context("Testing Menu component", () => {
       menuItem().should("not.be.focused");
     });
 
-    it.each([
-      ["open", true, "be.visible"],
-      ["closed", false, "not.be.visible"],
-    ])(
-      "should verify that Menu Fullscreen is %s when isOpen prop is %s",
-      (value, boolVal, state) => {
-        CypressMountWithProviders(<MenuComponentFullScreen isOpen={boolVal} />);
+    it("Menu Fullscreen dialog should exist when isOpen prop is true", () => {
+      CypressMountWithProviders(
+        <MenuComponentFullScreen isOpen>Content</MenuComponentFullScreen>
+      );
+      getComponent("menu-fullscreen").should("exist");
+    });
 
-        getComponent("menu-fullscreen").should(state);
-      }
-    );
+    it("Menu Fullscreen dialog does not exist when isOpen prop is false", () => {
+      CypressMountWithProviders(
+        <MenuComponentFullScreen isOpen={false}>
+          Content
+        </MenuComponentFullScreen>
+      );
+      getComponent("menu-fullscreen").should("not.exist");
+    });
 
     it("should verify that Menu Fullscreen has no effect on the tab order when isOpen prop is false", () => {
       CypressMountWithProviders(<ClosedMenuFullScreenWithButtons />);
@@ -1197,24 +1201,6 @@ context("Testing Menu component", () => {
       cy.tab();
       cy.get("#button-2").should("be.focused");
     });
-
-    it.each([
-      ["left", -1200, 1200],
-      ["right", 1200, -1200],
-    ] as [MenuFullscreenProps["startPosition"], number, number][])(
-      "should verify that Menu Fullscreen start position is %s",
-      (side, left, right) => {
-        CypressMountWithProviders(
-          <MenuComponentFullScreen startPosition={side} />
-        );
-        getComponent("menu-fullscreen").should("have.css", "left", `${left}px`);
-        getComponent("menu-fullscreen").should(
-          "have.css",
-          "right",
-          `${right}px`
-        );
-      }
-    );
 
     it("should focus the next menu item on tab press when the current item has a Search input with searchButton but no value", () => {
       CypressMountWithProviders(

--- a/src/components/menu/menu-full-screen/menu-full-screen.component.tsx
+++ b/src/components/menu/menu-full-screen/menu-full-screen.component.tsx
@@ -13,9 +13,8 @@ import IconButton from "../../icon-button";
 import Icon from "../../icon";
 import Portal from "../../portal";
 import MenuDivider from "../menu-divider/menu-divider.component";
-import tagComponent, {
-  TagProps,
-} from "../../../__internal__/utils/helpers/tags";
+import type { TagProps } from "../../../__internal__/utils/helpers/tags";
+import useLocale from "../../../hooks/__internal__/useLocale";
 
 export interface MenuFullscreenProps extends TagProps {
   /** The child elements to render */
@@ -31,16 +30,18 @@ export interface MenuFullscreenProps extends TagProps {
 }
 
 export const MenuFullscreen = ({
+  "data-element": dataElement,
+  "data-role": dataRole,
   children,
   isOpen,
   startPosition = "left",
   onClose,
-  ...rest
 }: MenuFullscreenProps) => {
   const menuWrapperRef = useRef<HTMLDivElement>(null);
   const menuContentRef = useRef<HTMLUListElement>(null);
   const { menuType } = useContext(MenuContext);
   const isDarkVariant = ["dark", "black"].includes(menuType);
+  const locale = useLocale();
 
   const handleKeyDown = (ev: React.KeyboardEvent<HTMLElement>) => {
     /* istanbul ignore else */
@@ -50,7 +51,7 @@ export const MenuFullscreen = ({
 
     if (Events.isTabKey(ev) && !Events.isShiftKey(ev)) {
       const search = menuWrapperRef.current?.querySelector(
-        '[data-component="search"'
+        '[data-component="search"]'
       );
       const searchInput = search?.querySelector("input");
       const searchButton = search?.querySelector("button");
@@ -98,13 +99,14 @@ export const MenuFullscreen = ({
       <Portal>
         <FocusTrap wrapperRef={menuWrapperRef} isOpen={isOpen}>
           <StyledMenuFullscreen
+            data-component="menu-fullscreen"
+            data-element={dataElement}
+            data-role={dataRole}
             ref={menuWrapperRef}
             isOpen={isOpen}
             menuType={menuType}
             startPosition={startPosition}
             onKeyDown={handleKeyDown}
-            {...rest}
-            {...tagComponent("menu-fullscreen", rest)}
           >
             <StyledMenuFullscreenHeader
               isOpen={isOpen}
@@ -112,7 +114,7 @@ export const MenuFullscreen = ({
               startPosition={startPosition}
             >
               <IconButton
-                aria-label="menu fullscreen close button"
+                aria-label={locale.menuFullscreen.ariaLabels.closeButton()}
                 onClick={onClose}
                 data-element="close"
               >

--- a/src/components/menu/menu-full-screen/menu-full-screen.spec.tsx
+++ b/src/components/menu/menu-full-screen/menu-full-screen.spec.tsx
@@ -7,7 +7,6 @@ import MenuFullscreen, { MenuFullscreenProps } from ".";
 import MenuDivider from "../menu-divider/menu-divider.component";
 import MenuContext, { MenuType } from "../menu.context";
 import StyledIcon from "../../icon/icon.style";
-import IconButton from "../../icon-button";
 import {
   StyledMenuFullscreen,
   StyledMenuFullscreenHeader,
@@ -358,14 +357,14 @@ describe("MenuFullscreen", () => {
 
   describe("onClose", () => {
     it("calls the onClose callback when close icon button is clicked", () => {
-      render({ isOpen: true }).find(IconButton).simulate("click");
+      wrapper = render({ isOpen: true });
+      wrapper.find("button[aria-label='Close']").simulate("click");
       expect(onClose).toHaveBeenCalled();
     });
 
     it("calls the onClose callback when escape key pressed", () => {
-      simulate.keydown.pressEscape(
-        render({ isOpen: true }).find(StyledMenuFullscreen)
-      );
+      wrapper = render({ isOpen: true });
+      simulate.keydown.pressEscape(wrapper.find(StyledMenuFullscreen));
       expect(onClose).toHaveBeenCalled();
     });
   });

--- a/src/components/menu/menu-full-screen/menu-full-screen.spec.tsx
+++ b/src/components/menu/menu-full-screen/menu-full-screen.spec.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from "react";
-import { mount, ReactWrapper } from "enzyme";
+import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 
+import MenuFullscreen from ".";
 import { MenuItem } from "..";
-import MenuFullscreen, { MenuFullscreenProps } from ".";
 import MenuDivider from "../menu-divider/menu-divider.component";
-import MenuContext, { MenuType } from "../menu.context";
+import MenuContext, { MenuContextProps } from "../menu.context";
+
 import StyledIcon from "../../icon/icon.style";
 import {
   StyledMenuFullscreen,
@@ -20,7 +21,8 @@ import {
   simulate,
   testStyledSystemPadding,
 } from "../../../__spec_helper__/test-utils";
-import { baseTheme } from "../../../style/themes";
+import CarbonProvider from "../../carbon-provider";
+import { sageTheme } from "../../../style/themes";
 import { StyledMenuItem } from "../menu.style";
 import menuConfigVariants from "../menu.config";
 import Logger from "../../../__internal__/utils/logger";
@@ -28,68 +30,32 @@ import Logger from "../../../__internal__/utils/logger";
 // mock Logger.deprecate so that Typography (used for the alert dialog's heading) doesn't trigger a warning while running the tests
 const loggerSpy = jest.spyOn(Logger, "deprecate");
 
-const onClose = jest.fn();
-const onClick = jest.fn();
-
-const TestMenu = ({
-  startPosition,
-  isOpen,
-}: Pick<MenuFullscreenProps, "startPosition" | "isOpen">) => (
-  <MenuFullscreen
-    startPosition={startPosition}
-    isOpen={isOpen}
-    onClose={onClose}
-    data-element="bar"
-    data-role="baz"
-  >
-    <MenuItem maxWidth="200px" href="#">
-      Menu Item One
-    </MenuItem>
-    <MenuItem maxWidth="200px" onClick={onClick} submenu="Menu Item Two">
-      <MenuItem maxWidth="200px" href="#">
-        Submenu Item One
-      </MenuItem>
-      <MenuItem maxWidth="200px" href="#">
-        Submenu Item Two
-      </MenuItem>
-    </MenuItem>
-    <MenuItem maxWidth="200px" href="#">
-      Menu Item Three
-    </MenuItem>
-    <MenuItem maxWidth="200px" href="#">
-      Menu Item Four
-    </MenuItem>
-    <MenuItem maxWidth="200px" submenu="Menu Item Five">
-      <MenuItem maxWidth="200px" href="#">
-        Submenu Item One
-      </MenuItem>
-      <MenuItem maxWidth="200px" href="#">
-        Submenu Item Two
-      </MenuItem>
-    </MenuItem>
-    <MenuItem maxWidth="200px" href="#">
-      Menu Item Six
-    </MenuItem>
-  </MenuFullscreen>
-);
-
-const render = ({
-  menuType = "light",
-  ...props
-}: { menuType?: MenuType } & Partial<MenuFullscreenProps>) => {
-  return mount(
-    <MenuContext.Provider
-      value={{
-        menuType,
-        openSubmenuId: null,
-        inMenu: true,
-        setOpenSubmenuId: () => {},
-      }}
-    >
-      <TestMenu {...props} />
-    </MenuContext.Provider>
-  );
-};
+function customMount(
+  ui: React.ReactElement,
+  {
+    menuType = "light",
+    openSubmenuId = null,
+    inMenu = true,
+    setOpenSubmenuId = () => {},
+  }: Partial<MenuContextProps> = {}
+) {
+  return mount(ui, {
+    wrappingComponent: ({ children }: { children: React.ReactNode }) => (
+      <CarbonProvider validationRedesignOptIn theme={sageTheme}>
+        <MenuContext.Provider
+          value={{
+            menuType,
+            openSubmenuId,
+            inMenu,
+            setOpenSubmenuId,
+          }}
+        >
+          {children}
+        </MenuContext.Provider>
+      </CarbonProvider>
+    ),
+  });
+}
 
 const MockMenuWithSearch = ({
   isOpen,
@@ -118,25 +84,16 @@ const MockMenuWithSearch = ({
   );
 };
 
-const MockMenuWithFalsyValues = ({ isOpen }: { isOpen?: boolean }) => {
-  const showMenuItem = false;
-  return mount(
-    <MenuFullscreen isOpen={isOpen} onClose={() => {}}>
-      <MenuItem maxWidth="200px">Submenu Item One</MenuItem>
-      {false && <MenuItem href="#">Product Item One</MenuItem>}
-      {showMenuItem ? <MenuItem href="#">Product Item Two</MenuItem> : null}
-    </MenuFullscreen>
-  );
-};
-
 const UpdatingSubmenu = () => {
   const [counter, setCounter] = useState(0);
+
   useEffect(() => {
     const interval = setInterval(() => {
       setCounter((prev) => (prev >= 2 ? prev : prev + 1));
     }, 2000);
     return () => clearInterval(interval);
   }, []);
+
   return (
     <MenuItem submenu={`submenu 2 - count ${counter}`}>
       <MenuItem>Item One </MenuItem>
@@ -147,20 +104,22 @@ const UpdatingSubmenu = () => {
 
 const MockFullScreenMenuWithUpdatingItems = () => {
   const [extraItem, setExtraItem] = useState(false);
+
   useEffect(() => {
     const timeout = setTimeout(() => {
       setExtraItem(true);
     }, 5000);
     return () => clearTimeout(timeout);
   }, []);
+
   return (
     <MenuFullscreen onClose={() => {}} isOpen>
-      {extraItem ? (
+      {extraItem && (
         <MenuItem submenu="extra submenu">
           <MenuItem>Item One </MenuItem>
           <MenuItem>Item Two </MenuItem>
         </MenuItem>
-      ) : null}
+      )}
       <MenuItem submenu="submenu 1">
         <MenuItem>Item One </MenuItem>
         <MenuItem>Item Two </MenuItem>
@@ -171,256 +130,254 @@ const MockFullScreenMenuWithUpdatingItems = () => {
 };
 
 describe("MenuFullscreen", () => {
-  let wrapper: ReactWrapper;
-
   beforeAll(() => {
     loggerSpy.mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // clean up DOM due to used React portals
+    window.document.body.innerHTML = "";
   });
 
   afterAll(() => {
     loggerSpy.mockRestore();
   });
 
-  beforeEach(() => {
-    wrapper = render({});
-  });
+  it("root container has correct component, element and role data tags", () => {
+    const wrapper = customMount(
+      <MenuFullscreen
+        data-element="bar"
+        data-role="baz"
+        isOpen
+        onClose={() => {}}
+      >
+        <MenuItem href="#">Item one</MenuItem>
+      </MenuFullscreen>
+    );
+    expect(
+      wrapper
+        .find(StyledMenuFullscreen)
+        .getDOMNode()
+        .getAttribute("data-component")
+    ).toEqual("menu-fullscreen");
 
-  describe("tags on component", () => {
-    it("includes correct component, element and role data tags", () => {
-      expect(
-        wrapper
-          .find(StyledMenuFullscreen)
-          .getDOMNode()
-          .getAttribute("data-component")
-      ).toEqual("menu-fullscreen");
+    expect(
+      wrapper
+        .find(StyledMenuFullscreen)
+        .getDOMNode()
+        .getAttribute("data-element")
+    ).toEqual("bar");
 
-      expect(
-        wrapper
-          .find(StyledMenuFullscreen)
-          .getDOMNode()
-          .getAttribute("data-element")
-      ).toEqual("bar");
-
-      expect(
-        wrapper
-          .find(StyledMenuFullscreen)
-          .getDOMNode()
-          .getAttribute("data-role")
-      ).toEqual("baz");
-    });
+    expect(
+      wrapper.find(StyledMenuFullscreen).getDOMNode().getAttribute("data-role")
+    ).toEqual("baz");
   });
 
   it("should render children correctly", () => {
-    expect(wrapper.find(MenuItem).length).toEqual(10);
-    expect(wrapper.find(MenuDivider).length).toEqual(5);
+    const wrapper = customMount(
+      <MenuFullscreen isOpen onClose={() => {}}>
+        <MenuItem href="#">Item one</MenuItem>
+        <MenuItem href="#">Item two</MenuItem>
+      </MenuFullscreen>
+    );
+    expect(wrapper.find(MenuItem).length).toEqual(2);
+    expect(wrapper.find(MenuDivider).length).toEqual(1);
   });
 
-  it("should set any maxWidth values passed to items to undefined", () => {
-    const items = wrapper.find(StyledMenuItem);
-    items.forEach((item) => {
-      assertStyleMatch(
-        {
-          maxWidth: undefined,
-        },
-        item
+  it("if a child item has maxWidth prop set, component overrides it and sets it to undefined", () => {
+    const wrapper = customMount(
+      <MenuFullscreen isOpen onClose={() => {}}>
+        <MenuItem href="#" maxWidth="200px">
+          Item one
+        </MenuItem>
+      </MenuFullscreen>
+    );
+
+    assertStyleMatch(
+      {
+        maxWidth: undefined,
+      },
+      wrapper.find(StyledMenuItem)
+    );
+  });
+
+  it("renders with correct style rules", () => {
+    const wrapper = customMount(
+      <MenuFullscreen isOpen onClose={() => {}}>
+        <MenuItem href="#">Item one</MenuItem>
+      </MenuFullscreen>
+    );
+
+    assertStyleMatch(
+      {
+        position: "fixed",
+        top: "0",
+        bottom: "0",
+        zIndex: "5000",
+      },
+      wrapper.find(StyledMenuFullscreen)
+    );
+
+    assertStyleMatch(
+      {
+        position: "absolute",
+        zIndex: "1",
+        right: "16px",
+        top: "8px",
+      },
+      wrapper.find(StyledMenuFullscreenHeader),
+      { modifier: `${StyledIconButton}` }
+    );
+  });
+
+  it.each(["light", "white", "dark", "black"] as const)(
+    "renders %s MenuFullscreen with correct background colour",
+    (menuType) => {
+      const wrapper = customMount(
+        <MenuFullscreen isOpen onClose={() => {}}>
+          <MenuItem href="#">Item one</MenuItem>
+        </MenuFullscreen>,
+        { menuType }
       );
-    });
-  });
 
-  describe("styling", () => {
-    it.each<MenuType>(["light", "white", "dark", "black"])(
-      "matches the expected as default",
-      (menuType) => {
-        wrapper = render({ menuType });
-        assertStyleMatch(
-          {
-            position: "fixed",
-            top: "0",
-            bottom: "0",
-            backgroundColor: menuConfigVariants[menuType].background,
-            zIndex: `${baseTheme.zIndex.fullScreenModal}`,
-            visibility: "hidden",
-            left: "-100%",
-            transition: "all 0.3s ease",
-          },
-          wrapper.find(StyledMenuFullscreen)
-        );
-
-        ["a", "button", "div"].forEach((el) => {
-          assertStyleMatch(
-            {
-              fontSize: "16px",
-            },
-            wrapper.find(StyledMenuFullscreen),
-            { modifier: el }
-          );
-        });
-
-        assertStyleMatch(
-          {
-            position: "absolute",
-            zIndex: "1",
-            right: "16px",
-            top: "8px",
-          },
-          wrapper.find(StyledMenuFullscreenHeader),
-          { modifier: `${StyledIconButton}` }
-        );
-
-        assertStyleMatch(
-          {
-            paddingTop: "var(--spacing200)",
-            paddingBottom: "var(--spacing200)",
-          },
-          wrapper.find(StyledMenuItem)
-        );
-      }
-    );
-
-    describe.each<MenuType>(["light", "white", "dark", "black"])(
-      "applies the expected styling when `menuType` is %s",
-      (menuType) => {
-        beforeEach(() => {
-          wrapper = render({ menuType });
-        });
-
-        it("renders a correct item background", () => {
-          assertStyleMatch(
-            {
-              backgroundColor:
-                menuConfigVariants[menuType].submenuItemBackground,
-            },
-            wrapper.find(StyledMenuFullscreenHeader)
-          );
-        });
-
-        it("renders a correct icon color", () => {
-          const iconColors = {
-            light: "var(--colorsYin090)",
-            dark: "var(--colorsYang100)",
-            white: "var(--colorsYin090)",
-            black: "var(--colorsYang100)",
-          };
-
-          assertStyleMatch(
-            {
-              color: iconColors[menuType],
-            },
-            wrapper.find(StyledIcon)
-          );
-        });
-      }
-    );
-
-    it("applies the expected styling when `isOpen` is true", () => {
-      wrapper = render({ isOpen: true });
       assertStyleMatch(
         {
-          visibility: "visible",
-          left: "0",
+          backgroundColor: menuConfigVariants[menuType].background,
+        },
+        wrapper.find(StyledMenuFullscreen)
+      );
+    }
+  );
+
+  it.each([
+    ["light", "var(--colorsYin090)"],
+    ["dark", "var(--colorsYang100)"],
+    ["white", "var(--colorsYin090)"],
+    ["black", "var(--colorsYang100)"],
+  ] as const)(
+    "renders close button icon with correct color within a %s menu",
+    (menuType, color) => {
+      const wrapper = customMount(
+        <MenuFullscreen isOpen onClose={() => {}}>
+          <MenuItem href="#">Item one</MenuItem>
+        </MenuFullscreen>,
+        { menuType }
+      );
+      assertStyleMatch({ color }, wrapper.find(StyledIcon));
+    }
+  );
+
+  it.each([
+    [true, "visible", "0"],
+    [false, "hidden", "-100%"],
+  ])(
+    "when isOpen prop is %s, applies correct styles",
+    (isOpen, visibility, leftPosition) => {
+      const wrapper = customMount(
+        <MenuFullscreen isOpen={isOpen} onClose={() => {}}>
+          <MenuItem href="#">Item one</MenuItem>
+        </MenuFullscreen>
+      );
+      assertStyleMatch(
+        {
+          visibility,
+          left: leftPosition,
           transition: "all 0.3s ease",
         },
         wrapper.find(StyledMenuFullscreen)
       );
-    });
+    }
+  );
 
-    it("applies the expected styling when `startPosition` is 'right'", () => {
-      wrapper = render({ isOpen: true, startPosition: "right" });
-      assertStyleMatch(
-        {
-          visibility: "visible",
-          right: "0",
-          transition: "all 0.3s ease",
-        },
-        wrapper.find(StyledMenuFullscreen)
-      );
-    });
-
-    testStyledSystemPadding(
-      (props) => (
-        <MenuContext.Provider
-          value={{
-            menuType: "light",
-            openSubmenuId: null,
-            inFullscreenView: true,
-            inMenu: true,
-            setOpenSubmenuId: () => {},
-          }}
-        >
-          <MenuItem {...props}>Foo</MenuItem>
-        </MenuContext.Provider>
-      ),
-      { pt: "10px", pb: "10px" },
-      (component) => component.find(StyledMenuItem)
+  it("applies the expected styling when `startPosition` is 'right'", () => {
+    const wrapper = customMount(
+      <MenuFullscreen startPosition="right" isOpen onClose={() => {}}>
+        <MenuItem href="#">Item one</MenuItem>
+      </MenuFullscreen>
+    );
+    assertStyleMatch(
+      { visibility: "visible", right: "0" },
+      wrapper.find(StyledMenuFullscreen)
     );
   });
+
+  testStyledSystemPadding(
+    (props) => (
+      <MenuContext.Provider
+        value={{
+          menuType: "light",
+          openSubmenuId: null,
+          inFullscreenView: true,
+          inMenu: true,
+          setOpenSubmenuId: () => {},
+        }}
+      >
+        <MenuItem {...props}>Foo</MenuItem>
+      </MenuContext.Provider>
+    ),
+    { pt: "10px", pb: "10px" },
+    (component) => component.find(StyledMenuItem)
+  );
 
   describe("onClose", () => {
     it("calls the onClose callback when close icon button is clicked", () => {
-      wrapper = render({ isOpen: true });
+      const onClose = jest.fn();
+      const wrapper = customMount(
+        <MenuFullscreen isOpen onClose={onClose}>
+          <MenuItem href="#">Item one</MenuItem>
+        </MenuFullscreen>
+      );
       wrapper.find("button[aria-label='Close']").simulate("click");
-      expect(onClose).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalledTimes(1);
     });
 
     it("calls the onClose callback when escape key pressed", () => {
-      wrapper = render({ isOpen: true });
+      const onClose = jest.fn();
+      const wrapper = customMount(
+        <MenuFullscreen isOpen onClose={onClose}>
+          <MenuItem href="#">Item one</MenuItem>
+        </MenuFullscreen>
+      );
       simulate.keydown.pressEscape(wrapper.find(StyledMenuFullscreen));
-      expect(onClose).toHaveBeenCalled();
-    });
-  });
-
-  describe("onClick", () => {
-    it("calls the onClick callback when menu item is clicked", () => {
-      const menuItem = render({ isOpen: true })
-        .find(MenuItem)
-        .at(1)
-        .find("button");
-      menuItem.simulate("click");
-      expect(onClick).toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("focus behaviour", () => {
-    it("focuses the menu wrapper on open of menu", () => {
-      wrapper = mount(<TestMenu />);
+    it("when menu is opened, its root container is focused", () => {
+      const wrapper = customMount(
+        <MenuFullscreen isOpen={false} onClose={() => {}}>
+          <MenuItem href="#">Item one</MenuItem>
+        </MenuFullscreen>
+      );
+
       wrapper.setProps({ isOpen: true });
-      const element = wrapper.find(StyledMenuFullscreen).getDOMNode();
-      const startEvent = new Event("transitionstart", {
-        bubbles: true,
-        cancelable: true,
-      });
-      const endEvent = new Event("transitionend", {
-        bubbles: true,
-        cancelable: true,
-      });
-      element.dispatchEvent(startEvent);
-      element.dispatchEvent(endEvent);
+      const menu = wrapper.find(StyledMenuFullscreen).getDOMNode();
+      menu.dispatchEvent(
+        new Event("transitionstart", {
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      menu.dispatchEvent(
+        new Event("transitionend", {
+          bubbles: true,
+          cancelable: true,
+        })
+      );
 
       expect(wrapper.find(StyledMenuFullscreen)).toBeFocused();
     });
 
     describe("when pressing tab key without shift", () => {
       it("does not prevent the browser default behaviour when no Search input with searchButton and no value is rendered", () => {
-        const container = document.createElement("div");
-        container.id = "enzymeContainer";
-        document.body.appendChild(container);
         const preventDefault = jest.fn();
-        wrapper = mount(<TestMenu />, {
-          attachTo: document.getElementById("enzymeContainer"),
-        });
-        wrapper.setProps({ isOpen: true });
 
-        const element = wrapper.find(StyledMenuFullscreen).getDOMNode();
-        const startEvent = new Event("transitionstart", {
-          bubbles: true,
-          cancelable: true,
-        });
-        const endEvent = new Event("transitionend", {
-          bubbles: true,
-          cancelable: true,
-        });
-        element.dispatchEvent(startEvent);
-        element.dispatchEvent(endEvent);
+        const wrapper = customMount(
+          <MenuFullscreen isOpen onClose={() => {}}>
+            <MenuItem href="#">Item one</MenuItem>
+          </MenuFullscreen>
+        );
 
         wrapper.find(StyledMenuFullscreen).prop("onKeyDown")({
           key: "Tab",
@@ -436,30 +393,12 @@ describe("MenuFullscreen", () => {
           preventDefault,
         });
         expect(preventDefault).not.toHaveBeenCalled();
-        wrapper.unmount();
       });
 
       it("prevents the browser default behaviour when Search input with searchButton and no value rendered", () => {
-        const container = document.createElement("div");
-        container.id = "enzymeContainer";
-        document.body.appendChild(container);
         const preventDefault = jest.fn();
-        wrapper = mount(<MockMenuWithSearch />, {
-          attachTo: document.getElementById("enzymeContainer"),
-        });
-        wrapper.setProps({ isOpen: true });
-        const element = wrapper.find(StyledMenuFullscreen).getDOMNode();
-        const startEvent = new Event("transitionstart", {
-          bubbles: true,
-          cancelable: true,
-        });
-        const endEvent = new Event("transitionend", {
-          bubbles: true,
-          cancelable: true,
-        });
-        element.dispatchEvent(startEvent);
-        element.dispatchEvent(endEvent);
-        wrapper.setProps({ focusInput: true });
+
+        const wrapper = customMount(<MockMenuWithSearch isOpen focusInput />);
 
         expect(wrapper.find(StyledSearch).find("input")).toBeFocused();
         expect(wrapper.find(StyledSearchButton).exists()).toBe(true);
@@ -469,46 +408,74 @@ describe("MenuFullscreen", () => {
         });
         expect(preventDefault).toHaveBeenCalled();
         expect(wrapper.find(StyledMenuItem).last().find("a")).toBeFocused();
-        wrapper.unmount();
       });
     });
   });
 
-  describe("when clicking outside a submenu", () => {
-    it("the app does not crash", () => {
-      wrapper = mount(<TestMenu isOpen />);
+  it("when clicking outside a submenu, the app does not crash", () => {
+    const wrapper = customMount(
+      <MenuFullscreen isOpen onClose={() => {}}>
+        <MenuItem onClick={() => {}} submenu="My submenu">
+          <MenuItem href="#">Item One</MenuItem>
+          <MenuItem href="#">Item Two</MenuItem>
+        </MenuItem>
+      </MenuFullscreen>
+    );
 
-      const clickOutsideSubmenu = () =>
-        act(() => {
-          wrapper
-            .find(StyledMenuItem)
-            .at(0)
-            .getDOMNode()
-            .dispatchEvent(new MouseEvent("click", { bubbles: true }));
-        });
+    const clickOutsideSubmenu = () =>
+      act(() => {
+        wrapper
+          .find(StyledMenuItem)
+          .at(0)
+          .getDOMNode()
+          .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
 
-      expect(clickOutsideSubmenu).not.toThrow();
-    });
+    expect(clickOutsideSubmenu).not.toThrow();
   });
 
-  describe("Menu Divider", () => {
-    it("should not render a divider when menu contains a falsy values", () => {
-      wrapper = MockMenuWithFalsyValues({ isOpen: true });
-      expect(wrapper.find(MenuDivider).exists()).toBe(false);
-    });
+  it("when clicking on a submenu with an onClick prop, the passed onClick callback is called", () => {
+    const onClick = jest.fn();
+    const wrapper = customMount(
+      <MenuFullscreen isOpen onClose={() => {}}>
+        <MenuItem onClick={onClick} submenu="My submenu">
+          <MenuItem href="#">Item One</MenuItem>
+          <MenuItem href="#">Item Two</MenuItem>
+        </MenuItem>
+      </MenuFullscreen>
+    );
+    const submenu = wrapper.find(MenuItem).at(0).find("button");
+
+    submenu.simulate("click");
+
+    expect(onClick).toBeCalledTimes(1);
+  });
+
+  it("should not render a divider when menu contains a falsy values", () => {
+    const wrapper = customMount(
+      <MenuFullscreen isOpen onClose={() => {}}>
+        <MenuItem href="#">Product Item One</MenuItem>
+        {false && <MenuItem href="#">Product Item Two</MenuItem>}
+      </MenuFullscreen>
+    );
+    expect(wrapper.find(MenuDivider).exists()).toBeFalsy();
   });
 
   describe("keys of children", () => {
     it("should maintain the state of any child items if items are added or removed", () => {
       jest.useFakeTimers();
-      wrapper = mount(<MockFullScreenMenuWithUpdatingItems />);
+
+      const wrapper = customMount(<MockFullScreenMenuWithUpdatingItems />);
+
       act(() => {
         jest.advanceTimersByTime(5000);
       });
       wrapper.update();
+
       expect(wrapper.find(MenuItem).at(6).getDOMNode().textContent).toContain(
         "count 2"
       );
+
       jest.useRealTimers();
     });
   });

--- a/src/components/menu/menu-full-screen/menu-full-screen.style.ts
+++ b/src/components/menu/menu-full-screen/menu-full-screen.style.ts
@@ -34,7 +34,7 @@ const StyledMenuFullscreen = styled.div<StyledMenuFullScreenProps>`
     font-size: 16px;
   }
 
-  ${({ isOpen, menuType, startPosition, theme }) => css`
+  ${({ menuType, theme }) => css`
     background-color: ${menuConfigVariants[menuType].background};
     z-index: ${theme.zIndex.fullScreenModal};
 
@@ -84,20 +84,6 @@ const StyledMenuFullscreen = styled.div<StyledMenuFullScreenProps>`
         }
       }
     }
-
-    ${isOpen &&
-    css`
-      visibility: visible;
-      ${startPosition}: 0;
-      transition: all 0.3s ease;
-    `}
-
-    ${!isOpen &&
-    css`
-      visibility: hidden;
-      ${startPosition}: -100%;
-      transition: all 0.3s ease;
-    `}
   `}
 
   ${StyledBox} {

--- a/src/components/menu/menu.stories.mdx
+++ b/src/components/menu/menu.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 import { useState } from "react";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 import {
   Menu,
   MenuItem,
@@ -223,3 +224,19 @@ as such any `maxWidth` value passed will not be set when they are children of `M
 ### MenuFullscreen
 
 <ArgsTable of={MenuFullscreen} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "menuFullscreen.ariaLabels.closeButton",
+      description: "Aria label for the MenuFullscreen's close button",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
+/>

--- a/src/components/modal/modal.component.tsx
+++ b/src/components/modal/modal.component.tsx
@@ -37,6 +37,8 @@ export interface ModalProps extends TagProps {
   timeout?: number;
   /** Manually override the internal modal stacking order to set this as top */
   topModalOverride?: boolean;
+  /** Set how the modal should be animated when opened and closed */
+  transitionName?: "fade" | "slide-from-left" | "slide-from-right";
 }
 
 const Modal = ({
@@ -48,6 +50,7 @@ const Modal = ({
   enableBackgroundUI = false,
   timeout = 300,
   topModalOverride,
+  transitionName = "fade",
   ...rest
 }: ModalProps) => {
   const ref = useRef<HTMLDivElement>(null);
@@ -96,34 +99,17 @@ const Modal = ({
     topModalOverride,
   });
 
-  let background;
-  let content;
-
-  if (open) {
-    background = !enableBackgroundUI ? (
-      <StyledModalBackground
-        ref={backgroundNodeRef}
-        data-element="modal-background"
-        transitionName="modal-background"
-        transitionTime={timeout}
-      />
-    ) : null;
-
-    content = children;
-  }
-
   return (
     <Portal>
       <StyledModal
         data-state={open ? "open" : "closed"}
-        transitionName="modal"
         transitionTime={timeout}
         topModalOverride={topModalOverride}
         ref={ref}
         {...rest}
       >
         <TransitionGroup>
-          {background && (
+          {open && !enableBackgroundUI && (
             <CSSTransition
               nodeRef={backgroundNodeRef}
               key="modal"
@@ -133,16 +119,20 @@ const Modal = ({
               onEntered={() => setAnimationComplete(true)}
               onExiting={() => setAnimationComplete(false)}
             >
-              {background}
+              <StyledModalBackground
+                ref={backgroundNodeRef}
+                data-element="modal-background"
+                transitionTime={timeout}
+              />
             </CSSTransition>
           )}
         </TransitionGroup>
         <TransitionGroup>
-          {content && (
+          {open && (
             <CSSTransition
               nodeRef={contentNodeRef}
               appear
-              classNames="modal"
+              classNames={transitionName}
               timeout={timeout}
             >
               <ModalContext.Provider
@@ -152,7 +142,7 @@ const Modal = ({
                   isInModal: true,
                 }}
               >
-                <div ref={contentNodeRef}>{content}</div>
+                <div ref={contentNodeRef}>{children}</div>
               </ModalContext.Provider>
             </CSSTransition>
           )}

--- a/src/components/modal/modal.style.ts
+++ b/src/components/modal/modal.style.ts
@@ -4,7 +4,6 @@ import baseTheme from "../../style/themes/base";
 const backgroundOpacity = "0.6";
 
 type TransitionProps = {
-  transitionName: string;
   transitionTime: number;
 };
 
@@ -17,22 +16,23 @@ const StyledModalBackground = styled.div<TransitionProps>`
   right: 0;
   top: 0;
 
-  ${({ transitionName, transitionTime }) => css`
-    &.${transitionName}-enter, .${transitionName}-appear {
+  ${({ transitionTime }) => css`
+    &.modal-background-enter,
+    .modal-background-appear {
       opacity: 0;
     }
 
-    &.${transitionName}-enter.${transitionName}-enter-active,
-      &.${transitionName}-appear.${transitionName}-appear-active {
+    &.modal-background-enter.modal-background-enter-active,
+    &.modal-background-appear.modal-background-appear-active {
       opacity: ${backgroundOpacity};
       transition: opacity ${transitionTime}ms ease-out;
     }
 
-    &.${transitionName}-exit {
+    &.modal-background-exit {
       opacity: ${backgroundOpacity};
     }
 
-    &.${transitionName}-exit.${transitionName}-exit-active {
+    &.modal-background-exit.modal-background-exit-active {
       opacity: 0;
       transition: opacity ${transitionTime}ms 100ms ease-out;
     }
@@ -43,27 +43,78 @@ const StyledModal = styled.div<
   TransitionProps & { topModalOverride?: boolean }
 >`
   position: absolute;
+  height: 100vh;
+  width: 100%;
   z-index: ${({ theme, topModalOverride }) =>
     `${topModalOverride ? theme.zIndex.notification : theme.zIndex.modal}`};
 
-  ${({ transitionName, transitionTime }) => css`
-    .${transitionName}-enter, .${transitionName}-appear {
+  ${({ transitionTime }) => css`
+    .fade-enter,
+    .fade-appear {
       opacity: 0;
     }
 
-    .${transitionName}-enter.${transitionName}-enter-active,
-      .${transitionName}-appear.${transitionName}-appear-active {
+    .fade-enter.fade-enter-active,
+    .fade-appear.fade-appear-active {
       opacity: 1;
       transition: all ${transitionTime}ms 100ms ease-out;
     }
 
-    .${transitionName}-exit {
+    .fade-exit {
       opacity: 1;
     }
 
-    .${transitionName}-exit.${transitionName}-exit-active {
+    .fade-exit.fade-exit-active {
       opacity: 0;
       transition: all ${transitionTime}ms ease-out;
+    }
+
+    .slide-from-left-enter {
+      visibility: hidden;
+      position: absolute;
+      left: -100%;
+    }
+
+    .slide-from-left-enter.slide-from-left-enter-active {
+      visibility: visible;
+      left: 0;
+      transition: all ${transitionTime}ms ease;
+    }
+
+    .slide-from-left-exit {
+      visibility: visible;
+      position: relative;
+      left: 0;
+    }
+
+    .slide-from-left-exit.slide-from-left-exit-active {
+      visibility: hidden;
+      left: -100%;
+      transition: all ${transitionTime}ms ease;
+    }
+
+    .slide-from-right-enter {
+      visibility: hidden;
+      position: absolute;
+      left: 100%;
+    }
+
+    .slide-from-right-enter.slide-from-right-enter-active {
+      visibility: visible;
+      left: 0;
+      transition: all ${transitionTime}ms ease;
+    }
+
+    .slide-from-right-exit {
+      visibility: visible;
+      position: relative;
+      left: 0;
+    }
+
+    .slide-from-right-exit.slide-from-right-exit-active {
+      visibility: hidden;
+      left: 100%;
+      transition: all ${transitionTime}ms ease;
     }
   `}
 `;

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -99,6 +99,9 @@ const enGB: Locale = {
   loader: {
     loading: () => "Loading",
   },
+  menuFullscreen: {
+    ariaLabels: { closeButton: () => "Close" },
+  },
   message: {
     closeButtonAriaLabel: () => "Close",
   },

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -74,6 +74,11 @@ interface Locale {
   loader: {
     loading: () => string;
   };
+  menuFullscreen: {
+    ariaLabels: {
+      closeButton: () => string;
+    };
+  };
   message: {
     closeButtonAriaLabel: () => string;
   };

--- a/src/locales/pl-pl.ts
+++ b/src/locales/pl-pl.ts
@@ -158,6 +158,11 @@ const plPL: Locale = {
   loader: {
     loading: () => "Ładowanie",
   },
+  menuFullscreen: {
+    ariaLabels: {
+      closeButton: () => "Zamknij",
+    },
+  },
   message: {
     closeButtonAriaLabel: () => "Zamknij",
   },


### PR DESCRIPTION
closes #5631

### Proposed behaviour

For `MenuFullscreen`:

- Add translation key for the opened menu's close button.
- Add `aria-label` prop to control `aria-label` attribute on root container.
- Ensure opened menu has all [the necessary ARIA attributes set to be classified as a modal](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/#wai-ariaroles,states,andproperties), these are `aria-label`, `aria-modal` and `role`.
- Set `aria-modal` attribute on the menu's root container when it is open and is the topmost modal on the page.
- Refactor test code

### Current behaviour

- `MenuFullscreen`, when opened, does not have an ARIA role of dialog, nor the `aria-modal` attribute set.
- No translation support for any of the `aria-label`s in the component's markup

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Using Safari with macOS VoiceOver, Chrome with NVDA and Firefox with NVDA. Please do the following:

1. Do npm start. Once storybook is loaded, open the `fullscreen view` story in canvas mode in a new tab
2. Start screen reader
3. Ensure the width of the viewport is less than 1200px
4. Open menu with the keyboard
5. Verify screen reader announces the `aria-label` of the menu and it is a dialog with content.

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

[Link to codesandbox showing broken behaviour](https://codesandbox.io/s/menu-fullscreen-aria-properties-t3hpc4?file=/src/App.js)
