### PR TITLE
fix(link): refactor styles to remove focus-within due to issues with JSDOM FE-6217

### DIFF
--- a/cypress/components/menu/menu.cy.tsx
+++ b/cypress/components/menu/menu.cy.tsx
@@ -84,8 +84,10 @@ context("Testing Menu component", () => {
       innerMenu(positionOfElement("third"), span).click({ multiple: true });
       cy.focused().tab();
       cy.focused().should("contain", "Item Submenu Three");
+      cy.focused().parent().should("have.css", "box-shadow", "none");
       cy.focused().tab();
       cy.focused().should("contain", "Item Submenu Four");
+      cy.focused().parent().should("have.css", "box-shadow", "none");
     });
 
     it("should verify a submenu can be navigated using keyboard down arrow after an item was clicked", () => {

--- a/src/components/card/card-footer/__snapshots__/card-footer.spec.tsx.snap
+++ b/src/components/card/card-footer/__snapshots__/card-footer.spec.tsx.snap
@@ -120,21 +120,6 @@ exports[`CardFooter matches expected styling when it contains non-interactive co
 
 .c1 a,
 .c1 button {
-  outline: none;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  border-bottom-left-radius: var(--borderRadius000);
-  border-bottom-right-radius: var(--borderRadius000);
-}
-
-.c1:focus-within {
-  box-shadow: 0 4px 0 0 var(--colorsUtilityYin090);
-  border-bottom-left-radius: var(--borderRadius025);
-  border-bottom-right-radius: var(--borderRadius025);
-}
-
-.c1 a,
-.c1 button {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
@@ -181,6 +166,8 @@ exports[`CardFooter matches expected styling when it contains non-interactive co
   >
     <a
       href="https://carbon.sage.com/"
+      onBlur={[Function]}
+      onFocus={[Function]}
       onKeyDown={[Function]}
     >
       <span

--- a/src/components/link/__snapshots__/link.spec.tsx.snap
+++ b/src/components/link/__snapshots__/link.spec.tsx.snap
@@ -5,6 +5,7 @@ exports[`Link renders as expected 1`] = `
   data-component="link"
   disabled={false}
   hasContent={true}
+  hasFocus={false}
   iconAlign="left"
   isMenuItem={false}
   theme="[ theme object ]"
@@ -12,6 +13,8 @@ exports[`Link renders as expected 1`] = `
 >
   <a
     href="www.foo.com"
+    onBlur={[Function]}
+    onFocus={[Function]}
     onKeyDown={[Function]}
   >
     <styled.span>

--- a/src/components/link/link-test.stories.tsx
+++ b/src/components/link/link-test.stories.tsx
@@ -15,7 +15,7 @@ export default {
   },
   argTypes: {
     icon: {
-      options: ["", ICONS],
+      options: ["", ...ICONS],
       control: {
         type: "select",
       },

--- a/src/components/link/link.component.tsx
+++ b/src/components/link/link.component.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from "react";
+import React, { useContext, useMemo, useState } from "react";
 
 import Icon, { IconType } from "../icon";
 import MenuContext from "../menu/menu.context";
@@ -82,6 +82,7 @@ export const Link = React.forwardRef<
     }: LinkProps,
     ref
   ) => {
+    const [hasFocus, setHasFocus] = useState(false);
     const l = useLocale();
     const { inMenu } = useContext(MenuContext);
     const handleOnKeyDown = (
@@ -141,6 +142,8 @@ export const Link = React.forwardRef<
       rel,
       "aria-label": ariaLabel,
       ...ariaProps,
+      onFocus: () => setHasFocus(true),
+      onBlur: () => setHasFocus(false),
     };
 
     const buttonProps = {
@@ -160,7 +163,6 @@ export const Link = React.forwardRef<
           ? {
               ...componentProps,
               ...buttonProps,
-              placeholderTabIndex,
             }
           : {
               ...componentProps,
@@ -192,6 +194,7 @@ export const Link = React.forwardRef<
         isMenuItem={inMenu}
         {...tagComponent("link", rest)}
         {...(isSkipLink && { "data-element": "skip-link" })}
+        hasFocus={hasFocus}
       >
         {createLinkBasedOnType()}
       </StyledLink>

--- a/src/components/link/link.style.ts
+++ b/src/components/link/link.style.ts
@@ -14,6 +14,7 @@ export interface StyledLinkProps {
   isDarkBackground?: boolean;
   /** Allows link styling to be updated for light or dark backgrounds */
   variant?: Variants;
+  hasFocus?: boolean;
 }
 interface PrivateStyledLinkProps {
   hasContent: boolean;
@@ -80,6 +81,7 @@ const StyledLink = styled.span<StyledLinkProps & PrivateStyledLinkProps>`
     variant,
     isDarkBackground,
     isMenuItem,
+    hasFocus,
   }) => {
     const colorMapKey = isDarkBackground ? "dark" : "light";
     const { color, hoverColor, disabledColor } = colorMap[colorMapKey](variant);
@@ -155,23 +157,6 @@ const StyledLink = styled.span<StyledLinkProps & PrivateStyledLinkProps>`
             }
           `}
         }
-
-        ${!disabled &&
-        !theme.focusRedesignOptOut &&
-        css`
-          a,
-          button {
-            outline: none;
-            text-decoration: none;
-            border-bottom-left-radius: var(--borderRadius000);
-            border-bottom-right-radius: var(--borderRadius000);
-          }
-          &:focus-within {
-            box-shadow: 0 4px 0 0 var(--colorsUtilityYin090);
-            border-bottom-left-radius: var(--borderRadius025);
-            border-bottom-right-radius: var(--borderRadius025);
-          }
-        `}
       `}
 
       a,
@@ -215,6 +200,23 @@ const StyledLink = styled.span<StyledLinkProps & PrivateStyledLinkProps>`
           }
         `}
       }
+
+      ${!isSkipLink &&
+      !disabled &&
+      !theme.focusRedesignOptOut &&
+      hasFocus &&
+      css`
+        a,
+        button {
+          outline: none;
+          text-decoration: none;
+          border-bottom-left-radius: var(--borderRadius000);
+          border-bottom-right-radius: var(--borderRadius000);
+        }
+        box-shadow: 0 4px 0 0 var(--colorsUtilityYin090);
+        border-bottom-left-radius: var(--borderRadius025);
+        border-bottom-right-radius: var(--borderRadius025);
+      `}
 
       button {
         background-color: transparent;

--- a/src/components/menu/menu-item/menu-item.style.ts
+++ b/src/components/menu/menu-item/menu-item.style.ts
@@ -34,19 +34,6 @@ interface StyledMenuItemWrapperProps
   hasInput?: boolean;
 }
 
-const overrideLinkFocusStyling = (fullScreenView?: boolean) => `
-  &:focus-within {
-    box-shadow: none;
-    a {
-      background-color: ${
-        fullScreenView
-          ? "var(--colorsComponentsMenuAutumnStandard600)"
-          : "transparent"
-      };
-    }
-  }
-`;
-
 const oldFocusStyling = `
   box-shadow: inset 0 0 0 var(--borderWidth300) var(--colorsSemanticFocus500);
 `;
@@ -81,19 +68,13 @@ const StyledMenuItemWrapper = styled.a.attrs({
     font-weight: 700;
     height: 40px;
     position: relative;
-
-    && {
-      :focus-within > a, > button {
-        background-color: transparent;
-      }
-    }
+    box-shadow: none;
 
     a,
     button {
       cursor: pointer;
     }
 
-      ${overrideLinkFocusStyling(inFullscreenView)}
       a:focus,
       button:focus {
         ${({ theme }) =>


### PR DESCRIPTION
fix #6320

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Refactor new focus styling for `Link` to avoid `focus-within` as it creates issues when running tests in JSDOM.
Ensures `text-decoration` is `none` when new focus styling applied
Fixes test story `icon` dropdown

![image](https://github.com/Sage/carbon/assets/44157880/33a4b2b6-8148-4f3d-9d43-a1b733efac18)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
New focus styling uses `focus-within`
`text-decoration` is `underline` when new focus styling applied
Test story `icon` dropdown is broken

![image](https://github.com/Sage/carbon/assets/44157880/0f7e88b2-7c58-49fe-9b35-a292a1a95f98)


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] Unit tests added or updated if required
- [x] Storybook added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
