### PR TITLE
docs(dialog): update explanation on refocusing

### DIFF
--- a/src/components/dialog/dialog.stories.mdx
+++ b/src/components/dialog/dialog.stories.mdx
@@ -92,21 +92,21 @@ For situations where content cannot be rendered immediately, such as content dep
 
 Note in the previous example, the first `Textbox` in the loaded content has autofocus, which is recommended so assistive technology users are informed of the updated content.
 
-Alternatively, focus can be programmatically moved back to the `Dialog` to inform assistive technology users of a content change:
+Alternatively, focus can be programmatically moved back to the `Dialog` if the title or subtitle has been updated as part of a content change. Most screen readers will then announce the new title indicating to users that the dialog has changed:
 
 <Canvas>
   <Story
-    name="refocusing dialog after content change"
+    name="refocusing dialog using ref handle"
     story={stories.UsingHandle}
   />
 </Canvas>
 
-A custom ref handle can be forwarded to the `Dialog` component:
+To achieve this, a custom ref handle can be forwarded to the `Dialog` component:
 
 ```tsx
 const dialogHandle = useRef<DialogHandle>(null);
 return (
-  <Dialog ref={dialogHandle}>
+  <Dialog title="Thank you for your feedback" ref={dialogHandle}>
     Your feedback helps us continually improve our software.
   </Dialog>
 );
@@ -120,8 +120,8 @@ dialogHandle.current?.focus();
 
 ### Overriding the content padding
 
-Using the `contentPadding` prop will enable the padding of the `Dialog` content to be overriden, the example below has
-set the padding to 0. Please see the [table below](#props) for more iformation about the values accepted by this prop.
+Using the `contentPadding` prop will enable the padding of the `Dialog` content to be overridden, the example below has
+set the padding to 0. Please see the [table below](#props) for more information about the values accepted by this prop.
 
 <Canvas>
   <Story


### PR DESCRIPTION
### Proposed behaviour

- Fix typos in docs 
- Reword explanation regarding refocusing dialogs, to avoid ambiguity.

### Current behaviour

- Explanation of refocusing dialogs is misleading

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [] Related issues linked in commit messages if required
- [] Screenshots are included in the PR if useful
- [] All themes are supported if required
- [] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
