### PR TITLE
fix(textarea, textbox): display icon when component is disabled or readOnly

### DIFF
--- a/cypress/components/date/date.cy.tsx
+++ b/cypress/components/date/date.cy.tsx
@@ -527,6 +527,34 @@ context("Test for DateInput component", () => {
         .parent()
         .should("have.css", "max-width", "100%");
     });
+
+    it("should render Date with disabled prop", () => {
+      CypressMountWithProviders(<DateInputCustom disabled />);
+
+      dateInput().should("be.disabled").and("have.attr", "disabled");
+    });
+
+    it("should render Date icon with disabled style", () => {
+      CypressMountWithProviders(<DateInputCustom disabled />);
+
+      dateIcon()
+        .should("be.visible")
+        .and("have.css", "color", "rgba(0, 0, 0, 0.3)");
+    });
+
+    it("should render Date with read only prop", () => {
+      CypressMountWithProviders(<DateInputCustom readOnly />);
+
+      dateInput().should("have.attr", "readOnly");
+    });
+
+    it("should render Date icon with read only style", () => {
+      CypressMountWithProviders(<DateInputCustom readOnly />);
+
+      dateIcon()
+        .should("be.visible")
+        .and("have.css", "color", "rgba(0, 0, 0, 0.3)");
+    });
   });
 
   it("should check the pickerProps prop", () => {

--- a/cypress/components/select/filterable-select/filterable-select.cy.tsx
+++ b/cypress/components/select/filterable-select/filterable-select.cy.tsx
@@ -201,12 +201,28 @@ context("Tests for FilterableSelect component", () => {
         .and("have.attr", "disabled");
     });
 
+    it("should render FilterableSelect icon with disabled style", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent disabled />);
+
+      dropdownButton()
+        .should("be.visible")
+        .and("have.css", "color", "rgba(0, 0, 0, 0.3)");
+    });
+
     it("should render FilterableSelect as read only", () => {
       CypressMountWithProviders(<stories.FilterableSelectComponent readOnly />);
 
       commonDataElementInputPreview().should("have.attr", "readOnly");
       selectInput().click();
       selectListWrapper().should("not.be.visible");
+    });
+
+    it("should render FilterableSelect icon with read only style", () => {
+      CypressMountWithProviders(<stories.FilterableSelectComponent readOnly />);
+
+      dropdownButton()
+        .should("be.visible")
+        .and("have.css", "color", "rgba(0, 0, 0, 0.3)");
     });
 
     it.each([

--- a/cypress/components/select/multi-select/multi-select.cy.tsx
+++ b/cypress/components/select/multi-select/multi-select.cy.tsx
@@ -212,12 +212,28 @@ context("Tests for MultiSelect component", () => {
         .and("have.attr", "disabled");
     });
 
+    it("should render MultiSelect icon with disabled style", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent disabled />);
+
+      dropdownButton()
+        .should("be.visible")
+        .and("have.css", "color", "rgba(0, 0, 0, 0.3)");
+    });
+
     it("should render MultiSelect as read only", () => {
       CypressMountWithProviders(<stories.MultiSelectComponent readOnly />);
 
       commonDataElementInputPreview().should("have.attr", "readOnly");
       selectInput().click();
       selectListWrapper().should("not.be.visible");
+    });
+
+    it("should render MultiSelect icon with read only style", () => {
+      CypressMountWithProviders(<stories.MultiSelectComponent readOnly />);
+
+      dropdownButton()
+        .should("be.visible")
+        .and("have.css", "color", "rgba(0, 0, 0, 0.3)");
     });
 
     it.each([

--- a/cypress/components/select/simple-select/simple-select.cy.tsx
+++ b/cypress/components/select/simple-select/simple-select.cy.tsx
@@ -175,6 +175,14 @@ context("Tests for SimpleSelect component", () => {
         .and("have.attr", "disabled");
     });
 
+    it("should render SimpleSelect icon with disabled style", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent disabled />);
+
+      dropdownButton()
+        .should("be.visible")
+        .and("have.css", "color", "rgba(0, 0, 0, 0.3)");
+    });
+
     it("should render SimpleSelect as read only", () => {
       CypressMountWithProviders(<stories.SimpleSelectComponent readOnly />);
 
@@ -182,6 +190,14 @@ context("Tests for SimpleSelect component", () => {
       commonDataElementInputPreview().should("have.attr", "readOnly");
       selectText().should("have.attr", "aria-hidden", "true");
       selectListWrapper().should("not.be.visible");
+    });
+
+    it("should render SimpleSelect icon with read only style", () => {
+      CypressMountWithProviders(<stories.SimpleSelectComponent readOnly />);
+
+      dropdownButton()
+        .should("be.visible")
+        .and("have.css", "color", "rgba(0, 0, 0, 0.3)");
     });
 
     it("should render SimpleSelect as transparent", () => {

--- a/cypress/components/textarea/textarea.cy.tsx
+++ b/cypress/components/textarea/textarea.cy.tsx
@@ -307,6 +307,15 @@ context("Tests for Textarea component", () => {
       textareaChildren().should("be.disabled").and("have.attr", "disabled");
     });
 
+    it("should render Textarea icon with disabled style", () => {
+      CypressMountWithProviders(<TextareaComponent disabled inputIcon="bin" />);
+
+      textarea()
+        .find(ICON)
+        .should("be.visible")
+        .and("have.css", "color", "rgba(0, 0, 0, 0.3)");
+    });
+
     it.each(testData)(
       "should render Textarea with placeholder prop set to %s",
       (placeholder) => {
@@ -362,6 +371,15 @@ context("Tests for Textarea component", () => {
       CypressMountWithProviders(<TextareaComponent readOnly />);
 
       textareaChildren().and("have.attr", "readOnly");
+    });
+
+    it("should render Textarea icon with readOnly style", () => {
+      CypressMountWithProviders(<TextareaComponent readOnly inputIcon="bin" />);
+
+      textarea()
+        .find(ICON)
+        .should("be.visible")
+        .and("have.css", "color", "rgba(0, 0, 0, 0.3)");
     });
 
     it.each(["error", "warning", "info"])(

--- a/cypress/components/textbox/textbox.cy.tsx
+++ b/cypress/components/textbox/textbox.cy.tsx
@@ -363,6 +363,17 @@ context("Tests for Textbox component", () => {
       textboxInput().should("be.disabled").and("have.attr", "disabled");
     });
 
+    it("should render Textbox icon with disabled style", () => {
+      CypressMountWithProviders(
+        <stories.TextboxComponent disabled inputIcon="bin" />
+      );
+
+      textbox()
+        .find(ICON)
+        .should("be.visible")
+        .and("have.css", "color", "rgba(0, 0, 0, 0.3)");
+    });
+
     it.each(testData)(
       "should render Textbox with placeholder prop set to %s",
       (placeholder) => {
@@ -418,6 +429,17 @@ context("Tests for Textbox component", () => {
       CypressMountWithProviders(<stories.TextboxComponent readOnly />);
 
       textboxInput().and("have.attr", "readOnly");
+    });
+
+    it("should render Textbox icon with readOnly style", () => {
+      CypressMountWithProviders(
+        <stories.TextboxComponent readOnly inputIcon="bin" />
+      );
+
+      textbox()
+        .find(ICON)
+        .should("be.visible")
+        .and("have.css", "color", "rgba(0, 0, 0, 0.3)");
     });
 
     it.each(["error", "warning", "info"])(

--- a/src/__internal__/input-icon-toggle/input-icon-toggle.component.tsx
+++ b/src/__internal__/input-icon-toggle/input-icon-toggle.component.tsx
@@ -75,7 +75,7 @@ const InputIconToggle = ({
     );
   }
 
-  if (type && !(disabled || readOnly)) {
+  if (type) {
     return (
       <InputIconToggleStyle
         size={size}
@@ -85,8 +85,10 @@ const InputIconToggle = ({
         onMouseDown={onMouseDown}
         tabIndex={iconTabIndex}
         data-element="input-icon-toggle"
+        disabled={disabled}
+        readOnly={readOnly}
       >
-        <Icon type={type} />
+        <Icon disabled={disabled || readOnly} type={type} />
       </InputIconToggleStyle>
     );
   }

--- a/src/__internal__/input-icon-toggle/input-icon-toggle.spec.tsx
+++ b/src/__internal__/input-icon-toggle/input-icon-toggle.spec.tsx
@@ -17,14 +17,6 @@ function renderInputIconToggle(props: InputIconToggleProps) {
 }
 
 describe("InputIconToggle", () => {
-  describe("when initiated with the disabled prop set to true", () => {
-    it("does not render anything", () => {
-      const wrapper = shallow(renderInputIconToggle({ disabled: true }));
-
-      expect(wrapper.isEmptyRender()).toBeTruthy();
-    });
-  });
-
   describe("tooltip positioning", () => {
     const testCases: [InputIconToggleProps["align"], string][] = [
       ["left", "right"],
@@ -64,7 +56,7 @@ describe("InputIconToggle", () => {
         });
 
         describe("with disabled prop", () => {
-          it("does not render an icon", () => {
+          it("does render an icon", () => {
             const wrapper = mount(
               renderInputIconToggle({
                 [validationProp]: "Message",
@@ -73,7 +65,7 @@ describe("InputIconToggle", () => {
               })
             );
             expect(wrapper.find(ValidationIcon).exists()).toBe(false);
-            expect(wrapper.find(Icon).exists()).toBe(false);
+            expect(wrapper.find(Icon).exists()).toBe(true);
           });
         });
 
@@ -86,8 +78,8 @@ describe("InputIconToggle", () => {
                 readOnly: true,
               })
             );
-            const validationIcon = wrapper.find(ValidationIcon);
-            expect(validationIcon.exists()).toBe(true);
+            expect(wrapper.find(ValidationIcon).exists()).toBe(true);
+            expect(wrapper.find(Icon).exists()).toBe(false);
           });
         });
       });
@@ -154,18 +146,33 @@ describe("InputIconToggle", () => {
     }
   );
 
-  describe("does not render input icon", () => {
+  describe("renders input icon", () => {
     it("when disabled prop is true", () => {
       const wrapper = mount(
         renderInputIconToggle({ inputIcon: "dropdown", disabled: true })
       );
-      expect(wrapper.find(Icon).exists()).toBe(false);
+      expect(wrapper.find(Icon).exists()).toBe(true);
+      expect(wrapper.find(Icon).prop("disabled")).toBe(true);
+      assertStyleMatch(
+        {
+          cursor: "not-allowed",
+        },
+        wrapper.find(InputIconToggleStyle)
+      );
     });
     it("when readOnly prop is true", () => {
       const wrapper = mount(
         renderInputIconToggle({ inputIcon: "dropdown", readOnly: true })
       );
-      expect(wrapper.find(Icon).exists()).toBe(false);
+
+      expect(wrapper.find(Icon).exists()).toBe(true);
+      expect(wrapper.find(Icon).prop("disabled")).toBe(true);
+      assertStyleMatch(
+        {
+          cursor: "default",
+        },
+        wrapper.find(InputIconToggleStyle)
+      );
     });
   });
 

--- a/src/__internal__/input-icon-toggle/input-icon-toggle.style.ts
+++ b/src/__internal__/input-icon-toggle/input-icon-toggle.style.ts
@@ -9,6 +9,8 @@ const oldFocusStyling = `
 
 export interface InputIconToggleStyleProps extends ValidationProps {
   size?: "small" | "medium" | "large";
+  disabled?: boolean;
+  readOnly?: boolean;
   onClick?: (
     event:
       | React.MouseEvent<HTMLSpanElement>
@@ -36,6 +38,18 @@ const InputIconToggleStyle = styled.span.attrs(
   ${({ size = "medium" }) => css`
     width: ${sizes[size].height};
   `}
+
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      cursor: not-allowed;
+    `}
+  
+  ${({ readOnly }) =>
+    readOnly &&
+    css`
+      cursor: default;
+    `}
 
   ${({ theme }) =>
     `


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
![Screenshot 2023-10-20 at 13 22 39](https://github.com/Sage/carbon/assets/78361608/c8646fc9-9f6e-4073-b307-5fbd43bc9416)
![Screenshot 2023-10-20 at 13 22 46](https://github.com/Sage/carbon/assets/78361608/23bc5252-f119-410c-b461-797078bc063d)


When the `inputIcon` prop is passed and `disabled` or `readOnly` are true, the input icon is properly rendered with the expected styling and cursor behaviour.


### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
![Screenshot 2023-10-20 at 13 21 52](https://github.com/Sage/carbon/assets/78361608/11b6c5b5-8819-4b34-8520-27bdd4ffb9e7)
![Screenshot 2023-10-20 at 13 21 58](https://github.com/Sage/carbon/assets/78361608/12704f78-017d-4ccd-b230-f9dbea9a84f4)


When the `inputIcon` prop is passed and `disabled` or `readOnly` are true the input icon is not rendered in the DOM.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
