### PR TITLE
fix: remove resize observer error

### DIFF
--- a/cypress/components/global-header/global-header.cy.tsx
+++ b/cypress/components/global-header/global-header.cy.tsx
@@ -1,7 +1,10 @@
 /* eslint-disable jest/valid-expect, jest/valid-expect-in-promise */
 import React from "react";
 import GlobalHeader from "../../../src/components/global-header";
-import { FullMenuExample } from "../../../src/components/global-header/global-header-test.stories";
+import {
+  FullMenuExample,
+  GlobalHeaderWithErrorHandler,
+} from "../../../src/components/global-header/global-header-test.stories";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
 
 import carbonLogo from "../../../logo/carbon-logo.png";
@@ -9,6 +12,12 @@ import navigationBar from "../../locators/navigation-bar";
 import { globalHeader, globalHeaderLogo } from "../../locators/global-header";
 
 context("Testing Global Header component", () => {
+  it("should not cause a ResizeObserver-related error to occur", () => {
+    CypressMountWithProviders(<GlobalHeaderWithErrorHandler />);
+    cy.wait(500);
+    cy.get("#error-div").should("have.text", "");
+  });
+
   it("should check that z-index of component is greater than that of NavigationBar", () => {
     CypressMountWithProviders(<FullMenuExample />);
     globalHeader().invoke("css", "zIndex").as("globalHeaderZIndex");

--- a/cypress/components/menu/menu.cy.tsx
+++ b/cypress/components/menu/menu.cy.tsx
@@ -63,6 +63,7 @@ import {
   MenuDividerComponent,
   InGlobalHeaderStory,
 } from "../../../src/components/menu/menu-test.stories";
+import { NavigationBarWithSubmenuAndChangingHeight } from "../../../src/components/navigation-bar/navigation-bar-test.stories";
 
 const span = "span";
 const div = "div";
@@ -1960,7 +1961,7 @@ context("Testing Menu component", () => {
     });
   });
 
-  describe("when inside a GlobalHeader", () => {
+  describe("when inside a Navigation Bar", () => {
     it("all the content of a long submenu can be accessed with the keyboard while remaining visible", () => {
       CypressMountWithProviders(<InGlobalHeaderStory />);
 
@@ -1976,6 +1977,33 @@ context("Testing Menu component", () => {
       cy.focused().should("contain", "Foo 20");
       cy.checkInViewport(
         '[data-component="submenu-wrapper"] ul > li:nth-child(20)'
+      );
+    });
+
+    it("all the content of a long submenu can be accessed with the keyboard while remaining visible if the navbar height changes", () => {
+      CypressMountWithProviders(<NavigationBarWithSubmenuAndChangingHeight />);
+
+      cy.viewport(1000, 500);
+
+      menuComponent(1).trigger("keydown", keyCode("downarrow"));
+      submenuItem(1).should("have.length", 21);
+
+      // navigate to "change height" item and press it
+      for (let i = 0; i < 3; i++) {
+        cy.focused().trigger("keydown", keyCode("downarrow"));
+      }
+      cy.focused().trigger("keydown", keyCode("Enter"));
+
+      // reopen menu and scroll to bottom with keyboard
+      cy.wait(100);
+      menuComponent(1).trigger("keydown", keyCode("downarrow"));
+
+      for (let i = 0; i < 21; i++) {
+        cy.focused().trigger("keydown", keyCode("downarrow"));
+      }
+
+      cy.checkInViewport(
+        '[data-component="submenu-wrapper"] ul > li:nth-child(21)'
       );
     });
   });

--- a/src/components/global-header/global-header-test.stories.tsx
+++ b/src/components/global-header/global-header-test.stories.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 
-import GlobalHeader from "./global-header.component";
+import GlobalHeader, { GlobalHeaderProps } from "./global-header.component";
 import { Menu, MenuItem, MenuDivider } from "../menu";
 import VerticalDivider from "../vertical-divider";
 import NavigationBar from "../navigation-bar";
@@ -96,3 +96,23 @@ export const FullMenuExample = () => (
     </NavigationBar>
   </>
 );
+
+export const GlobalHeaderWithErrorHandler = ({
+  ...props
+}: GlobalHeaderProps) => {
+  const [error, setError] = useState("");
+  useEffect(() => {
+    const handleError = (e: ErrorEvent) => {
+      setError(e.message);
+    };
+    window.addEventListener("error", handleError);
+
+    return () => window.removeEventListener("error", handleError);
+  });
+  return (
+    <>
+      <GlobalHeader {...props} />
+      <div id="error-div">{error}</div>
+    </>
+  );
+};

--- a/src/components/global-header/global-header.spec.tsx
+++ b/src/components/global-header/global-header.spec.tsx
@@ -1,24 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 import GlobalHeader, { GlobalHeaderProps } from "./global-header.component";
-import Logger from "../../__internal__/utils/logger";
-
-// mock Logger.deprecate so that no console warnings occur while running the tests
-const loggerSpy = jest.spyOn(Logger, "deprecate");
 
 function renderer(props?: GlobalHeaderProps) {
   return render(<GlobalHeader {...props}>foobar</GlobalHeader>);
 }
 
 describe("Global Header", () => {
-  beforeAll(() => {
-    loggerSpy.mockImplementation(() => {});
-  });
-
-  afterAll(() => {
-    loggerSpy.mockRestore();
-  });
-
   it("should be visible with correct accessible name", () => {
     renderer();
     expect(screen.getByRole("navigation")).toHaveAccessibleName(

--- a/src/components/navigation-bar/components.test-pw.tsx
+++ b/src/components/navigation-bar/components.test-pw.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { ComponentStory } from "@storybook/react";
 import NavigationBar, { NavigationBarProps } from ".";
 import { Menu, MenuDivider, MenuItem } from "../menu";
@@ -217,4 +217,24 @@ export const Fixed: ComponentStory<typeof NavigationBar> = () => (
 Fixed.parameters = {
   docs: { inlineStories: false, iframeHeight: 200 },
   themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const NavigationBarWithErrorHandler = ({
+  ...props
+}: NavigationBarProps) => {
+  const [error, setError] = useState("");
+  useEffect(() => {
+    const handleError = (e: ErrorEvent) => {
+      setError(e.message);
+    };
+    window.addEventListener("error", handleError);
+
+    return () => window.removeEventListener("error", handleError);
+  });
+  return (
+    <>
+      <NavigationBar {...props} />
+      <div id="error-div">{error}</div>
+    </>
+  );
 };

--- a/src/components/navigation-bar/fixed-navigation-bar-context.spec.tsx
+++ b/src/components/navigation-bar/fixed-navigation-bar-context.spec.tsx
@@ -14,15 +14,13 @@ const ConsumerComponent = () => {
 };
 
 const mockNavbarElement = { offsetHeight: 40 } as HTMLElement;
+const navbarRef = { current: mockNavbarElement };
 
 const MockComponent = (
-  props: Omit<FixedNavigationBarContextProviderProps, "navbarElement">
+  props: Omit<FixedNavigationBarContextProviderProps, "navbarRef">
 ) => {
   return (
-    <FixedNavigationBarContextProvider
-      navbarElement={mockNavbarElement}
-      {...props}
-    >
+    <FixedNavigationBarContextProvider navbarRef={navbarRef} {...props}>
       <ConsumerComponent />
     </FixedNavigationBarContextProvider>
   );

--- a/src/components/navigation-bar/fixed-navigation-bar.context.tsx
+++ b/src/components/navigation-bar/fixed-navigation-bar.context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useCallback } from "react";
+import React, { createContext, useState, useCallback, useEffect } from "react";
 import useResizeObserver from "../../hooks/__internal__/useResizeObserver/useResizeObserver";
 import { NavigationBarProps } from ".";
 
@@ -15,7 +15,7 @@ export interface FixedNavigationBarContextProviderProps
     NavigationBarProps,
     "position" | "orientation" | "offset" | "children"
   > {
-  navbarElement: HTMLElement | null;
+  navbarRef: React.RefObject<HTMLElement>;
 }
 
 export const FixedNavigationBarContextProvider = ({
@@ -23,16 +23,22 @@ export const FixedNavigationBarContextProvider = ({
   orientation,
   offset,
   children,
-  navbarElement,
+  navbarRef,
 }: FixedNavigationBarContextProviderProps) => {
-  const [navbarHeight, setNavbarHeight] = useState(navbarElement?.offsetHeight);
-
-  const updateHeight = useCallback(
-    () => setNavbarHeight(navbarElement?.offsetHeight),
-    [navbarElement]
+  const [navbarHeight, setNavbarHeight] = useState(
+    navbarRef.current?.offsetHeight
   );
 
-  useResizeObserver({ current: navbarElement }, updateHeight);
+  const updateHeight = useCallback(
+    () => setNavbarHeight(navbarRef.current?.offsetHeight),
+    [navbarRef]
+  );
+
+  useEffect(() => {
+    updateHeight();
+  }, [updateHeight]);
+
+  useResizeObserver(navbarRef, updateHeight);
 
   let submenuMaxHeight;
 

--- a/src/components/navigation-bar/navigation-bar-test.stories.tsx
+++ b/src/components/navigation-bar/navigation-bar-test.stories.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useRef } from "react";
 import NavigationBar, { NavigationBarProps } from ".";
+import { Menu, MenuItem } from "../menu";
 
 export default {
   title: "Navigation Bar/Test",
-  includeStories: ["DefaultStory"],
+  includeStories: ["DefaultStory", "NavigationBarWithSubmenuAndChangingHeight"],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -24,4 +25,46 @@ DefaultStory.args = {
   ariaLabel: undefined,
   position: undefined,
   offset: "0",
+};
+
+export const NavigationBarWithSubmenuAndChangingHeight = () => {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const toggleHeight = () => {
+    const navbarElement = wrapperRef.current?.querySelector("nav");
+    if (navbarElement) {
+      navbarElement.style.height =
+        navbarElement.style.height === "100px" ? "40px" : "100px";
+    }
+  };
+  return (
+    <div ref={wrapperRef}>
+      <NavigationBar position="fixed" orientation="top">
+        <Menu menuType="dark">
+          <MenuItem submenu="I'm long" clickToOpen>
+            <MenuItem onClick={() => {}}>Foo 1</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 2</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 3</MenuItem>
+            <MenuItem onClick={toggleHeight}>Change Height!</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 4</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 5</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 6</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 7</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 8</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 9</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 10</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 11</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 12</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 13</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 14</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 15</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 16</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 17</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 18</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 19</MenuItem>
+            <MenuItem onClick={() => {}}>Foo 20</MenuItem>
+          </MenuItem>
+        </Menu>
+      </NavigationBar>
+    </div>
+  );
 };

--- a/src/components/navigation-bar/navigation-bar.component.tsx
+++ b/src/components/navigation-bar/navigation-bar.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef } from "react";
 import { PaddingProps, FlexboxProps } from "styled-system";
 import StyledNavigationBar from "./navigation-bar.style";
 import { FixedNavigationBarContextProvider } from "./fixed-navigation-bar.context";
@@ -32,35 +32,35 @@ export const NavigationBar = ({
   children,
   ariaLabel,
   position,
-  offset = "0",
+  offset = "0px",
   orientation,
   isGlobal,
   ...props
 }: NavigationBarProps): JSX.Element => {
-  const [navbarElement, setNavbarElement] = useState<HTMLElement | null>(null);
+  const navbarRef = useRef(null);
 
   return (
-    <StyledNavigationBar
-      role="navigation"
-      data-component={isGlobal ? "global-header" : "navigation-bar"}
-      aria-label={isGlobal ? "Global Header" : ariaLabel}
-      navigationType={isGlobal ? "black" : navigationType}
+    <FixedNavigationBarContextProvider
       orientation={isGlobal ? "top" : orientation}
       offset={isGlobal ? "0px" : offset}
       position={isGlobal ? "fixed" : position}
-      {...props}
-      isGlobal={isGlobal}
-      ref={setNavbarElement}
+      navbarRef={navbarRef}
     >
-      <FixedNavigationBarContextProvider
+      <StyledNavigationBar
+        role="navigation"
+        data-component={isGlobal ? "global-header" : "navigation-bar"}
+        aria-label={isGlobal ? "Global Header" : ariaLabel}
+        navigationType={isGlobal ? "black" : navigationType}
         orientation={isGlobal ? "top" : orientation}
         offset={isGlobal ? "0px" : offset}
         position={isGlobal ? "fixed" : position}
-        navbarElement={navbarElement}
+        {...props}
+        isGlobal={isGlobal}
+        ref={navbarRef}
       >
         {!isLoading && children}
-      </FixedNavigationBarContextProvider>
-    </StyledNavigationBar>
+      </StyledNavigationBar>
+    </FixedNavigationBarContextProvider>
   );
 };
 

--- a/src/components/navigation-bar/navigation-bar.pw.tsx
+++ b/src/components/navigation-bar/navigation-bar.pw.tsx
@@ -15,6 +15,7 @@ import {
   ContentMaxWidthBox,
   Sticky,
   Fixed,
+  NavigationBarWithErrorHandler,
 } from "./components.test-pw";
 
 import navigationBar from "../../../playwright/components/navigation-bar";
@@ -32,6 +33,15 @@ const variants = [
 const offsetVal = [25, 100, -100];
 
 test.describe("Test props for NavigationBar component", () => {
+  test("should not cause a ResizeObserver-related error to occur", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<NavigationBarWithErrorHandler />);
+
+    await expect(page.locator("#error-div")).toContainText("");
+  });
+
   specialCharacters.forEach((childrenValue) => {
     test(`should render with ${childrenValue} as a children`, async ({
       mount,

--- a/src/components/navigation-bar/navigation-bar.spec.tsx
+++ b/src/components/navigation-bar/navigation-bar.spec.tsx
@@ -52,7 +52,9 @@ describe("NavigationBar", () => {
       </NavigationBar>
     );
 
-    expect(wrapper.prop("data-component")).toBe("navigation-bar");
+    expect(wrapper.find(StyledNavigationBar).prop("data-component")).toBe(
+      "navigation-bar"
+    );
   });
 
   it("should provide ariaLabel correctly", () => {
@@ -62,7 +64,9 @@ describe("NavigationBar", () => {
       </NavigationBar>
     );
 
-    expect(wrapper.prop("aria-label")).toBe("my aria label");
+    expect(wrapper.find(StyledNavigationBar).prop("aria-label")).toBe(
+      "my aria label"
+    );
   });
 
   it("should render `light` scheme as default", () => {
@@ -72,7 +76,9 @@ describe("NavigationBar", () => {
       </NavigationBar>
     );
 
-    expect(wrapper.props().navigationType).toBe("light");
+    expect(wrapper.find(StyledNavigationBar).props().navigationType).toBe(
+      "light"
+    );
   });
 
   it("should render correct styles in `light` scheme", () => {
@@ -190,7 +196,7 @@ describe("NavigationBar", () => {
       assertStyleMatch(
         {
           position: `${position}`,
-          [orientation]: offset || "0",
+          [orientation]: offset || "0px",
           ...(position === "fixed" && {
             width: "100%",
             boxSizing: "border-box",


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

NavigationBar and GlobalHeader, when rendered, should not throw ResizeObserver errors.

Fix https://github.com/Sage/carbon/issues/6259

### Current behaviour

An error is thrown: "ResizeObserver loop completed with undelivered notifications" (precise wording varies between browsers but it always mentions ResizeObserver).

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Cypress automation tests added or updated if required
- [X] Playwright automation tests added or updated if required
- [X] Storybook added or updated if required
- [X] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required
- [X] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
The error is only seen in the console on Safari - so please check all our stories for GlobalHeader and NavigationBar in the Safari browser: they should throw an ResizeObserver-related error in the console when run on master, but not on this branch.

For testing other browsers, uses this sandbox https://codesandbox.io/s/tender-stallman-mz9tz7?file=/src/App.tsx which catches the error and logs it to the console. (This is similar to what happens in Sage MFE environments, where there is a window `error` handler which pops up an intrusive error iframe in development, and logs to an external service in production, causing the logs to be spammed with this warning as it happens whenever any users uses any products with a NavigationBar!).

Also check the testing instructions for this older PR, and ensure that nothing has regressed from that fix https://github.com/Sage/carbon/pull/6141


<!-- Add CodeSandbox here -->
