### PR TITLE
fix(popover-container): ensure that component is closed when Esc key is pressed - FE-6072

### DIFF
--- a/cypress/components/popover-container/popover-container.cy.tsx
+++ b/cypress/components/popover-container/popover-container.cy.tsx
@@ -20,7 +20,7 @@ import {
 } from "../../locators/popover-container/index";
 import { selectListText, selectText } from "../../locators/select/index";
 import CypressMountWithProviders from "../../support/component-helper/cypress-mount";
-import { keyCode } from "../../support/helper";
+import { keyCode, pressESCKey } from "../../support/helper";
 import { CHARACTERS } from "../../support/component-helper/constants";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
@@ -280,12 +280,41 @@ context("Test for Popover Container component", () => {
       }
     );
 
+    it("should close Popover Container using escape keyboard key", () => {
+      CypressMountWithProviders(
+        <PopoverContainer title="Cypress is awesome">Contents</PopoverContainer>
+      );
+
+      popoverSettingsIcon().click();
+      pressESCKey();
+      popoverContainerContent().should("not.exist");
+    });
+
     it("should not close Popover Container when an option is selected from Select component inside", () => {
       CypressMountWithProviders(<PopoverContainerWithSelect />);
       popoverSettingsIcon().click();
       selectText().click();
       selectListText("green").click();
       popoverContainerContent().should("be.visible");
+    });
+
+    it("should not close Popover Container when the escape key is pressed and the Select List is open", () => {
+      CypressMountWithProviders(<PopoverContainerWithSelect />);
+      popoverSettingsIcon().click();
+      selectText().click();
+      selectListText("red").trigger("keydown", keyCode("downarrow"));
+      pressESCKey();
+      selectListText("red").should("not.be.visible");
+      popoverContainerContent().should("be.visible");
+    });
+
+    it("should close Popover Container when the escape key is pressed with focus on the Select component", () => {
+      CypressMountWithProviders(<PopoverContainerWithSelect />);
+      popoverSettingsIcon().click();
+      selectText().click();
+      pressESCKey();
+      pressESCKey();
+      popoverContainerContent().should("not.exist");
     });
   });
 
@@ -338,6 +367,18 @@ context("Test for Popover Container component", () => {
       }
     );
 
+    it("should call onClose callback when the escape is pressed", () => {
+      const callback: PopoverContainerProps["onClose"] = cy
+        .stub()
+        .as("onClose");
+      CypressMountWithProviders(
+        <PopoverContainerComponent onClose={callback} open />
+      );
+
+      pressESCKey();
+      cy.get("@onClose").should("have.been.calledOnce");
+    });
+
     it("should call onClose callback when a click event is triggered outside the container", () => {
       const callback: PopoverContainerProps["onClose"] = cy
         .stub()
@@ -364,63 +405,63 @@ context("Test for Popover Container component", () => {
   });
 
   describe("Accessibility tests for Popover Container component", () => {
-    it("should pass accessibilty tests for Popover Container Default story", () => {
+    it("should pass accessibility tests for Popover Container Default story", () => {
       CypressMountWithProviders(<stories.Default />);
 
       popoverSettingsIcon().click();
       cy.checkAccessibility();
     });
 
-    it("should pass accessibilty tests for Popover Container Title story", () => {
+    it("should pass accessibility tests for Popover Container Title story", () => {
       CypressMountWithProviders(<stories.Title />);
 
       popoverSettingsIcon().click();
       cy.checkAccessibility();
     });
 
-    it("should pass accessibilty tests for Popover Container Position story", () => {
+    it("should pass accessibility tests for Popover Container Position story", () => {
       CypressMountWithProviders(<stories.Position />);
 
       popoverSettingsIcon().click();
       cy.checkAccessibility();
     });
 
-    it("should pass accessibilty tests for Popover Container CoverButton story", () => {
+    it("should pass accessibility tests for Popover Container CoverButton story", () => {
       CypressMountWithProviders(<stories.CoverButton />);
 
       popoverSettingsIcon().click();
       cy.checkAccessibility();
     });
 
-    it("should pass accessibilty tests for Popover Container RenderProps story", () => {
+    it("should pass accessibility tests for Popover Container RenderProps story", () => {
       CypressMountWithProviders(<stories.RenderProps />);
 
       popoverSettingsIcon().click();
       cy.checkAccessibility();
     });
 
-    it("should pass accessibilty tests for Popover Container Controlled story", () => {
+    it("should pass accessibility tests for Popover Container Controlled story", () => {
       CypressMountWithProviders(<stories.Controlled />);
 
       popoverSettingsIcon().click();
       cy.checkAccessibility();
     });
 
-    it("should pass accessibilty tests for Popover Container Complex story", () => {
+    it("should pass accessibility tests for Popover Container Complex story", () => {
       CypressMountWithProviders(<stories.Complex />);
 
       popoverSettingsIcon().click();
       cy.checkAccessibility();
     });
 
-    it("should pass accessibilty tests for Popover Container Filter story", () => {
+    it("should pass accessibility tests for Popover Container Filter story", () => {
       CypressMountWithProviders(<stories.Filter />);
 
       popoverSettingsIcon().click();
       cy.checkAccessibility();
     });
 
-    it("should pass accessibilty tests for Popover Container Filter story with filter button clicked", () => {
+    it("should pass accessibility tests for Popover Container Filter story with filter button clicked", () => {
       CypressMountWithProviders(<stories.Filter />);
 
       popoverSettingsIcon().click();

--- a/src/components/popover-container/popover-container.stories.tsx
+++ b/src/components/popover-container/popover-container.stories.tsx
@@ -280,7 +280,7 @@ export const Filter: ComponentStory<typeof PopoverContainer> = () => {
     });
   };
   return (
-    <div style={{ height: 280 }}>
+    <Box margin={2} height="280px">
       <PopoverContainer
         title="How to create Filter component"
         open={open}
@@ -311,6 +311,6 @@ export const Filter: ComponentStory<typeof PopoverContainer> = () => {
         </Button>
       </PopoverContainer>
       {renderPills()}
-    </div>
+    </Box>
   );
 };

--- a/src/components/popover-container/popover-container.stories.tsx
+++ b/src/components/popover-container/popover-container.stories.tsx
@@ -9,6 +9,8 @@ import Link from "../link";
 import Pill from "../pill";
 import Badge from "../badge";
 import isChromatic from "../../../.storybook/isChromatic";
+import Box from "../box";
+import { Select, Option } from "../select";
 
 const defaultOpenState = isChromatic();
 
@@ -168,6 +170,21 @@ export const Complex: ComponentStory<typeof PopoverContainer> = () => {
           <Button>Small</Button>
           <Button ml={2}>Compact</Button>
         </div>
+        <Box mt="4px" mb="4px">
+          <Select name="simple" id="simple" label="color" labelInline>
+            <Option text="Amber" value="1" />
+            <Option text="Black" value="2" />
+            <Option text="Blue" value="3" />
+            <Option text="Brown" value="4" />
+            <Option text="Green" value="5" />
+            <Option text="Orange" value="6" />
+            <Option text="Pink" value="7" />
+            <Option text="Purple" value="8" />
+            <Option text="Red" value="9" />
+            <Option text="White" value="10" />
+            <Option text="Yellow" value="11" />
+          </Select>
+        </Box>
         <DraggableContainer>
           <DraggableItem key="1" id={1}>
             <Checkbox name="one" label="Draggable Label One" />


### PR DESCRIPTION
This fix ensures that the PopoverContainer component close when the escape key is pressed. The only exception to this is if Select is currently focused/open as we want Select to still function as it's default behaviour when escape key is pressed.

fixes #6195

### Proposed behaviour

- Component should be closed when Esc key is pressed.

### Current behaviour

- Component does not close when Esc key is pressed. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

If the `PopoverContainer` contains a `Select` component, then the popover should not close when `Select` is focused/ `SelectList` is open as we want to preserve the default functionality of `Select` in this particular case.

### Testing instructions

- Esc key closes the `PopoverContainer`. 
- In the `complex` example, then the correct behaviour is that the `PopoverContainer` should not close when `Select` is focused and the `SelectList` is open as we want to preserve the default functionality of `Select` in this particular case.
- No other functional or styling regressions have occurred to `PopoverContainer`.
