### PR TITLE
Fix animation issues pw

### DIFF
--- a/playwright/support/helper.ts
+++ b/playwright/support/helper.ts
@@ -350,3 +350,8 @@ export const continuePressingSHIFTTAB = async (page: Page, count: number) => {
 
   await Promise.all(promises);
 };
+
+export const waitForAnimationEnd = (locator: Locator) =>
+  locator.evaluate((element) =>
+    Promise.all(element.getAnimations().map((animation) => animation.finished))
+  );

--- a/src/components/dialog/dialog.pw.tsx
+++ b/src/components/dialog/dialog.pw.tsx
@@ -25,6 +25,7 @@ import toastComponent from "../../../playwright/components/toast";
 import {
   checkAccessibility,
   getStyle,
+  waitForAnimationEnd,
 } from "../../../playwright/support/helper";
 import { CHARACTERS, SIZE } from "../../../playwright/support/constants";
 
@@ -374,6 +375,7 @@ test.describe(
       await openToastButton.click();
 
       const toast = toastComponent(page);
+      await waitForAnimationEnd(toast);
       await expect(toast).toBeFocused();
     });
 

--- a/src/components/drawer/__snapshots__/drawer.spec.tsx.snap
+++ b/src/components/drawer/__snapshots__/drawer.spec.tsx.snap
@@ -55,6 +55,7 @@ exports[`Drawer uncontrolled matches snapshot 1`] = `
   <styled.div
     animationDuration="0.5s"
     className="open"
+    data-element="drawer-content"
     expandedWidth="20%"
   >
     <Styled(Box)

--- a/src/components/drawer/drawer.component.tsx
+++ b/src/components/drawer/drawer.component.tsx
@@ -213,6 +213,7 @@ export const Drawer = ({
         className={getClassNames()}
         ref={drawerSidebarContentRef}
         backgroundColor={backgroundColor}
+        data-element="drawer-content"
       >
         {stickyHeader && (
           <StyledSidebarHeader isExpanded={isExpanded}>

--- a/src/components/drawer/drawer.pw.tsx
+++ b/src/components/drawer/drawer.pw.tsx
@@ -17,6 +17,7 @@ import {
   checkAccessibility,
   assertCssValueIsApproximately,
   isInViewport,
+  waitForAnimationEnd,
 } from "../../../playwright/support/helper";
 
 test.describe(
@@ -359,6 +360,10 @@ test.describe("Accessibility tests for Drawer component", () => {
     }) => {
       await mount(
         <DrawerCustom showControls animationDuration={animationDuration} />
+      );
+
+      await waitForAnimationEnd(
+        page.locator('[data-element="drawer-content"]')
       );
 
       const drawerToggleButton = drawerToggle(page);


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Adds a util to ensure animations are complete before asserting the state of UI in playwright tests

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
We assert that there are no accessibility failures on Dialog and Drawer but we trigger actions as part of these tests and they run animations. This means that the tests are occasionally asserting whilst the animation is still running and failing incorrectly

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Playwright automation tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
