### PR TITLE
docs(dialog-full-screen): address invalid DOM nesting in stories - FE-5025

### DIFF
--- a/src/components/dialog-full-screen/components.test-pw.tsx
+++ b/src/components/dialog-full-screen/components.test-pw.tsx
@@ -11,6 +11,12 @@ import Toast from "../toast";
 import { Accordion } from "../accordion";
 import useMediaQuery from "../../hooks/useMediaQuery";
 import Typography from "../typography";
+import Drawer from "../drawer/drawer.component";
+import { Tabs, Tab } from "../tabs";
+import Link from "../link";
+import Icon from "../icon";
+import { ActionPopover, ActionPopoverItem } from "../action-popover";
+import { Dl, Dt, Dd } from "../definition-list";
 
 const mainDialogTitle = "Main Dialog";
 const nestedDialogTitle = "Nested Dialog";
@@ -502,5 +508,405 @@ export const DialogFullScreenWithTitleAsReactComponent = (
     >
       <Textbox label="textbox" />
     </DialogFullScreen>
+  );
+};
+
+export const WithComplexExample = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState("tab-1");
+  const padding40 = useMediaQuery("(min-width: 1260px)");
+  const padding32 = useMediaQuery("(min-width: 960px)");
+  const padding24 = useMediaQuery("(min-width: 600px)");
+  const setCorrectPadding = () => {
+    if (padding40) {
+      return 5;
+    }
+    if (padding32) {
+      return 4;
+    }
+    if (padding24) {
+      return 3;
+    }
+    return 2;
+  };
+  const aboveBreakpoint = useMediaQuery("(min-width: 411px)");
+  const verticalMargin = aboveBreakpoint ? "26px" : 0;
+  const HeaderChildren = (
+    <Box margin={`${verticalMargin} 0 26px`}>
+      <Box display="flex">
+        <Pill fill>A pill</Pill>
+        <Pill fill ml={2} mr={1}>
+          Another pill
+        </Pill>
+        <ActionPopover>
+          <ActionPopoverItem onClick={() => {}}>Example Item</ActionPopoverItem>
+        </ActionPopover>
+      </Box>
+    </Box>
+  );
+  const SidebarContent = (
+    <Box height="600px">
+      <Box pl={setCorrectPadding()}>
+        <Typography
+          display="block"
+          pt={5}
+          pb={1}
+          textTransform="uppercase"
+          variant="b"
+        >
+          Organisations
+        </Typography>
+      </Box>
+      <Tabs
+        onTabChange={(id) => setActiveTab(id)}
+        borders="no sides"
+        align="left"
+        selectedTabId={activeTab}
+        position="left"
+      >
+        <Tab
+          tabId="tab-1"
+          title="Tab 1"
+          key="tab-1"
+          customLayout={
+            <Box pl={setCorrectPadding()} pr={1} py={1}>
+              <Box display="flex">
+                <Box flexGrow={1}>
+                  <Typography variant="b">Example text</Typography>
+                  <Typography mb={0}>Example text without bold</Typography>
+                </Box>
+                <Icon mt={1} type="flag" />
+              </Box>
+            </Box>
+          }
+        >
+          Content for tab 1
+        </Tab>
+        <Tab
+          tabId="tab-2"
+          title="Tab 2"
+          key="tab-2"
+          customLayout={
+            <Box pl={setCorrectPadding()} pr={1} py={1}>
+              <Box display="flex">
+                <Box flexGrow={1}>
+                  <Typography variant="b">Example text</Typography>
+                  <Typography mb={0}>Example text without bold</Typography>
+                </Box>
+                <Icon mt={1} type="flag" />
+              </Box>
+            </Box>
+          }
+        >
+          Content for tab 2
+        </Tab>
+        <Tab
+          tabId="tab-3"
+          title="Tab 3"
+          key="tab-3"
+          customLayout={
+            <Box pl={setCorrectPadding()} pr={1} py={1}>
+              <Box display="flex">
+                <Box flexGrow={1}>
+                  <Typography variant="b">Example text</Typography>
+                  <Typography mb={0}>Example text without bold</Typography>
+                </Box>
+                <Icon mt={1} type="flag" />
+              </Box>
+            </Box>
+          }
+        >
+          Content for tab 3
+        </Tab>
+      </Tabs>
+      <Button
+        ml={setCorrectPadding()}
+        mt={1}
+        p={0}
+        buttonType="tertiary"
+        iconType="plus"
+        iconPosition="after"
+      >
+        Button Tertiary
+      </Button>
+      <Box pl={setCorrectPadding()}>
+        <Typography
+          display="block"
+          pt={5}
+          pb={1}
+          textTransform="uppercase"
+          variant="b"
+        >
+          Contacts
+        </Typography>
+      </Box>
+      <Tabs
+        onTabChange={(id) => setActiveTab(id)}
+        borders="no sides"
+        align="left"
+        position="left"
+        selectedTabId={activeTab}
+      >
+        <Tab
+          tabId="tab-contact-4"
+          title="Tab 4"
+          key="tab-4"
+          customLayout={
+            <Box pl={setCorrectPadding()} pr={1} py={2}>
+              <Box display="flex">
+                <Box flexGrow={1} display="flex">
+                  <Typography variant="b" pr={1}>
+                    Example text
+                  </Typography>
+                  <Pill pillRole="status" size="S">
+                    Primary
+                  </Pill>
+                </Box>
+                <Icon type="flag" />
+              </Box>
+            </Box>
+          }
+        >
+          Content for tab 1
+        </Tab>
+        <Tab
+          tabId="tab-contact-5"
+          title="Tab 5"
+          key="tab-5"
+          customLayout={
+            <Box pl={setCorrectPadding()} pr={1} py={2}>
+              <Box display="flex">
+                <Box flexGrow={1}>
+                  <Typography variant="b">Example text</Typography>
+                </Box>
+                <Icon type="flag" />
+              </Box>
+            </Box>
+          }
+        >
+          Content for tab 2
+        </Tab>
+        <Tab
+          tabId="tab-contact-6"
+          title="Tab 6"
+          key="tab-6"
+          customLayout={
+            <Box pl={setCorrectPadding()} pr={1} py={2}>
+              <Box display="flex" justifyContent="space-between">
+                <Box flexGrow={1}>
+                  <Typography variant="b">Example text</Typography>
+                </Box>
+              </Box>
+            </Box>
+          }
+        >
+          Content for tab 3
+        </Tab>
+      </Tabs>
+    </Box>
+  );
+  const ContentOne = (
+    <Box>
+      <Accordion
+        borders="none"
+        title={<Typography variant="h2">Example one details</Typography>}
+      >
+        <Dl dtTextAlign="right" ddTextAlign="left">
+          <Dt>Type</Dt>
+          <Dd>Example Type Text</Dd>
+          <Dt>Display name</Dt>
+          <Dd>Example Display Name</Dd>
+          <Dt>Registered name</Dt>
+          <Dd>Example Registered Name</Dd>
+          <Dt>Email</Dt>
+          <Dd>
+            <Link href="mailto:example@email.com">example@mail.com </Link>
+          </Dd>
+          <Dt>Phone</Dt>
+          <Dd>
+            <Link href="tel: 000 000 000">000 000 000</Link>
+          </Dd>
+          <Dt>Main and registered address</Dt>
+          <Dd>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box py={2}>
+              <Link
+                href="https://www.google.com/"
+                icon="link"
+                iconAlign="right"
+              >
+                View in Google Maps
+              </Link>
+            </Box>
+          </Dd>
+        </Dl>
+      </Accordion>
+      <Accordion
+        borders="none"
+        title={<Typography variant="h2">Example one products</Typography>}
+      >
+        <Box mt={2}>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+      </Accordion>
+    </Box>
+  );
+  const ContentTwo = (
+    <Box>
+      <Accordion
+        borders="none"
+        title={<Typography variant="h2">Example two details</Typography>}
+      >
+        <Dl dtTextAlign="right" ddTextAlign="left">
+          <Dt>Type</Dt>
+          <Dd>Example Type Text</Dd>
+          <Dt>Display name</Dt>
+          <Dd>Example Display Name</Dd>
+          <Dt>Registered name</Dt>
+          <Dd>Example Registered Name</Dd>
+          <Dt>Email</Dt>
+          <Dd>
+            <Link href="mailto:example@email.com">example@mail.com </Link>
+          </Dd>
+          <Dt>Phone</Dt>
+          <Dd>
+            <Link href="tel: 000 000 000">000 000 000</Link>
+          </Dd>
+          <Dt>Main and registered address</Dt>
+          <Dd>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box padding="16px 0">
+              <Link
+                href="https://www.google.com/"
+                icon="link"
+                iconAlign="right"
+              >
+                View in Google Maps
+              </Link>
+            </Box>
+          </Dd>
+        </Dl>
+      </Accordion>
+      <Accordion
+        borders="none"
+        title={<Typography variant="h2">Example two products</Typography>}
+      >
+        <Box mt={2}>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+      </Accordion>
+    </Box>
+  );
+  const ContentThree = (
+    <Box>
+      <Accordion
+        borders="none"
+        title={<Typography variant="h2">Example three details</Typography>}
+      >
+        <Dl dtTextAlign="right" ddTextAlign="left">
+          <Dt>Type</Dt>
+          <Dd>Example Type Text</Dd>
+          <Dt>Display name</Dt>
+          <Dd>Example Display Name</Dd>
+          <Dt>Registered name</Dt>
+          <Dd>Example Registered Name</Dd>
+          <Dt>Email</Dt>
+          <Dd>
+            <Link href="mailto:example@email.com">example@mail.com </Link>
+          </Dd>
+          <Dt>Phone</Dt>
+          <Dd>
+            <Link href="tel: 000 000 000">000 000 000</Link>
+          </Dd>
+          <Dt>Main and registered address</Dt>
+          <Dd>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box padding="16px 0">
+              <Link
+                href="https://www.google.com/"
+                icon="link"
+                iconAlign="right"
+              >
+                View in Google Maps
+              </Link>
+            </Box>
+          </Dd>
+        </Dl>
+      </Accordion>
+      <Accordion
+        borders="none"
+        title={<Typography variant="h2">Example three products</Typography>}
+      >
+        <Box mt={2}>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+      </Accordion>
+    </Box>
+  );
+  const showCorrectContent = () => {
+    switch (activeTab) {
+      case "tab-1":
+        return ContentOne;
+      case "tab-2":
+        return ContentTwo;
+      case "tab-3":
+        return ContentThree;
+      default:
+        return "no content provided";
+    }
+  };
+  const handleCancel = () => {
+    setIsOpen(false);
+  };
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+
+  return (
+    <Box>
+      <Button onClick={handleOpen}>Open DialogFullScreen</Button>
+      <DialogFullScreen
+        open={isOpen}
+        onCancel={handleCancel}
+        title="Dialog Title"
+        subtitle="Dialog subtitle"
+        headerChildren={HeaderChildren}
+        enableBackgroundUI={false}
+        disableEscKey={false}
+        showCloseIcon
+        disableContentPadding
+      >
+        <Drawer sidebar={SidebarContent}>
+          <Box p={5}>{showCorrectContent()}</Box>
+        </Drawer>
+      </DialogFullScreen>
+    </Box>
   );
 };

--- a/src/components/dialog-full-screen/dialog-full-screen.pw.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.pw.tsx
@@ -14,6 +14,7 @@ import {
   OtherFocusableContainers,
   FocusingADifferentFirstElement,
   DialogFullScreenWithTitleAsReactComponent,
+  WithComplexExample,
 } from "./components.test-pw";
 import {
   portal,
@@ -490,6 +491,22 @@ test.describe("Accessibility for DialogFullScreen", () => {
       .getByRole("button")
       .filter({ hasText: "Open DialogFullScreen" });
     await openButton.click();
+    await checkAccessibility(page);
+  });
+
+  test("should check accessibility with complex example", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<WithComplexExample />);
+
+    const openButton = page
+      .getByRole("button")
+      .filter({ hasText: "Open DialogFullScreen" });
+    await openButton.click();
+    await expect(getDataElementByValue(page, "title")).toHaveText(
+      "Dialog Title"
+    );
     await checkAccessibility(page);
   });
 });

--- a/src/components/dialog-full-screen/dialog-full-screen.stories.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.tsx
@@ -12,7 +12,6 @@ import Drawer from "../drawer/drawer.component";
 import { Tabs, Tab } from "../tabs";
 import useMediaQuery from "../../hooks/useMediaQuery";
 import Link from "../link";
-import IconButton from "../icon-button/icon-button.component";
 import Icon from "../icon";
 import { ActionPopover, ActionPopoverItem } from "../action-popover";
 import Typography from "../typography";
@@ -44,9 +43,9 @@ export const Default = () => {
             </Button>
           }
         >
-          <div>
+          <Box>
             This is an example of a full screen Dialog with a Form as content
-          </div>
+          </Box>
           <Textbox label="First Name" />
           <Textbox label="Middle Name" />
           <Textbox label="Surname" />
@@ -99,11 +98,7 @@ export const WithComplexExample = () => {
   const aboveBreakpoint = useMediaQuery("(min-width: 411px)");
   const verticalMargin = aboveBreakpoint ? "26px" : 0;
   const HeaderChildren = (
-    <div
-      style={{
-        margin: `${verticalMargin} 0 26px`,
-      }}
-    >
+    <Box margin={`${verticalMargin} 0 26px`}>
       <Box display="flex">
         <Pill fill>A pill</Pill>
         <Pill fill ml={2} mr={1}>
@@ -113,10 +108,10 @@ export const WithComplexExample = () => {
           <ActionPopoverItem onClick={() => {}}>Example Item</ActionPopoverItem>
         </ActionPopover>
       </Box>
-    </div>
+    </Box>
   );
   const SidebarContent = (
-    <div style={{ height: "600px" }}>
+    <Box height="600px">
       <Box pl={setCorrectPadding()}>
         <Typography
           display="block"
@@ -146,14 +141,7 @@ export const WithComplexExample = () => {
                   <Typography variant="b">Example text</Typography>
                   <Typography mb={0}>Example text without bold</Typography>
                 </Box>
-                <IconButton onClick={() => {}} aria-label="flag-button">
-                  <Icon type="flag" />
-                </IconButton>
-                <ActionPopover>
-                  <ActionPopoverItem onClick={() => {}}>
-                    Example Item
-                  </ActionPopoverItem>
-                </ActionPopover>
+                <Icon mt={1} type="flag" />
               </Box>
             </Box>
           }
@@ -171,14 +159,7 @@ export const WithComplexExample = () => {
                   <Typography variant="b">Example text</Typography>
                   <Typography mb={0}>Example text without bold</Typography>
                 </Box>
-                <IconButton onClick={() => {}} aria-label="flag-button">
-                  <Icon type="flag" />
-                </IconButton>
-                <ActionPopover>
-                  <ActionPopoverItem onClick={() => {}}>
-                    Example Item
-                  </ActionPopoverItem>
-                </ActionPopover>
+                <Icon mt={1} type="flag" />
               </Box>
             </Box>
           }
@@ -196,14 +177,7 @@ export const WithComplexExample = () => {
                   <Typography variant="b">Example text</Typography>
                   <Typography mb={0}>Example text without bold</Typography>
                 </Box>
-                <IconButton onClick={() => {}} aria-label="flag-button">
-                  <Icon type="flag" />
-                </IconButton>
-                <ActionPopover>
-                  <ActionPopoverItem onClick={() => {}}>
-                    Example Item
-                  </ActionPopoverItem>
-                </ActionPopover>
+                <Icon mt={1} type="flag" />
               </Box>
             </Box>
           }
@@ -213,6 +187,7 @@ export const WithComplexExample = () => {
       </Tabs>
       <Button
         ml={setCorrectPadding()}
+        mt={1}
         p={0}
         buttonType="tertiary"
         iconType="plus"
@@ -253,14 +228,7 @@ export const WithComplexExample = () => {
                     Primary
                   </Pill>
                 </Box>
-                <IconButton onClick={() => {}} aria-label="flag-button">
-                  <Icon type="flag" />
-                </IconButton>
-                <ActionPopover>
-                  <ActionPopoverItem onClick={() => {}}>
-                    Example Item
-                  </ActionPopoverItem>
-                </ActionPopover>
+                <Icon type="flag" />
               </Box>
             </Box>
           }
@@ -273,19 +241,12 @@ export const WithComplexExample = () => {
           key="tab-5"
           customLayout={
             <Box pl={setCorrectPadding()} pr={1} py={2}>
-              <div style={{ display: "flex" }}>
-                <div style={{ flexGrow: 1 }}>
+              <Box display="flex">
+                <Box flexGrow={1}>
                   <Typography variant="b">Example text</Typography>
-                </div>
-                <IconButton onClick={() => {}} aria-label="flag-button">
-                  <Icon type="flag" />
-                </IconButton>
-                <ActionPopover>
-                  <ActionPopoverItem onClick={() => {}}>
-                    Example Item
-                  </ActionPopoverItem>
-                </ActionPopover>
-              </div>
+                </Box>
+                <Icon type="flag" />
+              </Box>
             </Box>
           }
         >
@@ -297,26 +258,21 @@ export const WithComplexExample = () => {
           key="tab-6"
           customLayout={
             <Box pl={setCorrectPadding()} pr={1} py={2}>
-              <div style={{ display: "flex", justifyContent: "space-between" }}>
-                <div style={{ flexGrow: 1 }}>
+              <Box display="flex" justifyContent="space-between">
+                <Box flexGrow={1}>
                   <Typography variant="b">Example text</Typography>
-                </div>
-                <ActionPopover>
-                  <ActionPopoverItem onClick={() => {}}>
-                    Example Item
-                  </ActionPopoverItem>
-                </ActionPopover>
-              </div>
+                </Box>
+              </Box>
             </Box>
           }
         >
           Content for tab 3
         </Tab>
       </Tabs>
-    </div>
+    </Box>
   );
   const ContentOne = (
-    <div>
+    <Box>
       <Accordion
         borders="none"
         title={<Typography variant="h2">Example one details</Typography>}
@@ -338,10 +294,10 @@ export const WithComplexExample = () => {
           </Dd>
           <Dt>Main and registered address</Dt>
           <Dd>
-            <div>Example Text Address</div>
-            <div>Example Text Address</div>
-            <div>Example Text Address</div>
-            <div>Example Text Address</div>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
             <Box py={2}>
               <Link
                 href="https://www.google.com/"
@@ -358,20 +314,20 @@ export const WithComplexExample = () => {
         borders="none"
         title={<Typography variant="h2">Example one products</Typography>}
       >
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
+        <Box mt={2}>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
       </Accordion>
-    </div>
+    </Box>
   );
   const ContentTwo = (
-    <div>
+    <Box>
       <Accordion
         borders="none"
         title={<Typography variant="h2">Example two details</Typography>}
@@ -393,11 +349,11 @@ export const WithComplexExample = () => {
           </Dd>
           <Dt>Main and registered address</Dt>
           <Dd>
-            <div>Example Text Address</div>
-            <div>Example Text Address</div>
-            <div>Example Text Address</div>
-            <div>Example Text Address</div>
-            <div style={{ padding: "16px 0" }}>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box padding="16px 0">
               <Link
                 href="https://www.google.com/"
                 icon="link"
@@ -405,7 +361,7 @@ export const WithComplexExample = () => {
               >
                 View in Google Maps
               </Link>
-            </div>
+            </Box>
           </Dd>
         </Dl>
       </Accordion>
@@ -413,20 +369,20 @@ export const WithComplexExample = () => {
         borders="none"
         title={<Typography variant="h2">Example two products</Typography>}
       >
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
+        <Box mt={2}>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
       </Accordion>
-    </div>
+    </Box>
   );
   const ContentThree = (
-    <div>
+    <Box>
       <Accordion
         borders="none"
         title={<Typography variant="h2">Example three details</Typography>}
@@ -448,11 +404,11 @@ export const WithComplexExample = () => {
           </Dd>
           <Dt>Main and registered address</Dt>
           <Dd>
-            <div>Example Text Address</div>
-            <div>Example Text Address</div>
-            <div>Example Text Address</div>
-            <div>Example Text Address</div>
-            <div style={{ padding: "16px 0" }}>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box>Example Text Address</Box>
+            <Box padding="16px 0">
               <Link
                 href="https://www.google.com/"
                 icon="link"
@@ -460,7 +416,7 @@ export const WithComplexExample = () => {
               >
                 View in Google Maps
               </Link>
-            </div>
+            </Box>
           </Dd>
         </Dl>
       </Accordion>
@@ -468,17 +424,17 @@ export const WithComplexExample = () => {
         borders="none"
         title={<Typography variant="h2">Example three products</Typography>}
       >
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
-        <div>Example Product Content</div>
+        <Box mt={2}>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
+        <Box>Example Product Content</Box>
       </Accordion>
-    </div>
+    </Box>
   );
   const showCorrectContent = () => {
     switch (activeTab) {
@@ -502,7 +458,7 @@ export const WithComplexExample = () => {
   };
 
   return (
-    <div>
+    <Box>
       <Button onClick={handleOpen}>Open DialogFullScreen</Button>
       <DialogFullScreen
         open={isOpen}
@@ -519,7 +475,7 @@ export const WithComplexExample = () => {
           <Box p={5}>{showCorrectContent()}</Box>
         </Drawer>
       </DialogFullScreen>
-    </div>
+    </Box>
   );
 };
 
@@ -547,9 +503,9 @@ export const WithDisableContentPadding = () => {
             </Button>
           }
         >
-          <div>
+          <Box>
             This is an example of a full screen Dialog with a Form as content
-          </div>
+          </Box>
           <Textbox label="First Name" />
           <Textbox label="Middle Name" />
           <Textbox label="Surname" />
@@ -568,12 +524,12 @@ export const WithHeaderChildren = () => {
   const aboveBreakpoint = useMediaQuery("(min-width: 568px)");
   const verticalMargin = aboveBreakpoint ? "26px" : 0;
   const HeaderChildren = (
-    <div style={{ margin: `${verticalMargin} 0 26px` }}>
+    <Box margin={`${verticalMargin} 0 26px`}>
       <Pill fill>A pill</Pill>
       <Pill fill ml={2} mr={1}>
         Another pill
       </Pill>
-    </div>
+    </Box>
   );
   return (
     <>
@@ -596,9 +552,9 @@ export const WithHeaderChildren = () => {
             </Button>
           }
         >
-          <div>
+          <Box>
             This is an example of a full screen Dialog with a Form as content
-          </div>
+          </Box>
           <Textbox label="First Name" />
           <Textbox label="Middle Name" />
           <Textbox label="Surname" />
@@ -635,9 +591,9 @@ export const WithHelp = () => {
             </Button>
           }
         >
-          <div>
+          <Box>
             This is an example of a full screen Dialog with a Form as content
-          </div>
+          </Box>
           <Textbox label="First Name" />
           <Textbox label="Middle Name" />
           <Textbox label="Surname" />
@@ -655,12 +611,12 @@ export const WithHideableHeaderChildren = () => {
   const aboveBreakpoint = useMediaQuery("(min-width: 568px)");
   const verticalMargin = aboveBreakpoint ? "26px" : 0;
   const HeaderChildrenAboveBreakpoint = (
-    <div style={{ margin: `${verticalMargin} 0 26px` }}>
+    <Box margin={`${verticalMargin} 0 26px`}>
       <Pill fill>A pill</Pill>
       <Pill fill ml={2} mr={1}>
         Another pill
       </Pill>
-    </div>
+    </Box>
   );
   const HeaderChildrenBelowBreakpoint = (
     <Accordion
@@ -706,9 +662,9 @@ export const WithHideableHeaderChildren = () => {
             </Button>
           }
         >
-          <div>
+          <Box>
             This is an example of a full screen Dialog with a Form as content
-          </div>
+          </Box>
           <Textbox label="First Name" />
           <Textbox label="Middle Name" />
           <Textbox label="Surname" />
@@ -747,9 +703,9 @@ export const WithBox = () => {
               </Button>
             }
           >
-            <div>
+            <Box>
               This is an example of a full screen Dialog with a Form as content
-            </div>
+            </Box>
             <Textbox label="First Name" />
             <Textbox label="Middle Name" />
             <Textbox label="Surname" />
@@ -780,20 +736,18 @@ export const FocusingADifferentFirstElement = () => {
         title="Title"
         subtitle="Subtitle"
       >
-        <p>Focus an element that doesnt support autofocus</p>
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "space-around",
-            height: "150px",
-          }}
+        <p>Focus an element that doesn't support autofocus</p>
+        <Box
+          display="flex"
+          flexDirection="column"
+          justifyContent="space-around"
+          height="150px"
         >
           <Button onClick={() => setIsOpenOne(false)}>Not focused</Button>
           <Button forwardRef={ref} onClick={() => setIsOpenOne(false)}>
             This should be focused first now
           </Button>
-        </div>
+        </Box>
         <Textbox label="Not Focused" />
       </DialogFullScreen>
       <Button ml={2} onClick={() => setIsOpenTwo(true)}>
@@ -807,17 +761,15 @@ export const FocusingADifferentFirstElement = () => {
         subtitle="Subtitle"
       >
         <p>Focus an element that supports autoFocus</p>
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "space-around",
-            height: "150px",
-          }}
+        <Box
+          display="flex"
+          flexDirection="column"
+          justifyContent="space-around"
+          height="150px"
         >
           <Button onClick={() => setIsOpenTwo(false)}>Not focused</Button>
           <Button onClick={() => setIsOpenTwo(false)}>Not focused</Button>
-        </div>
+        </Box>
         <Textbox label="This should be focused first now" autoFocus />
       </DialogFullScreen>
     </>


### PR DESCRIPTION
fixes #4942

### Proposed behaviour

- Address invalid DOM nesting warning in the `with complex` example of `DialogFullScreen`
- Replace any `div` element with our `Box` component
- Address a few styling issues with the `Button Tertiary +` button and the text inside of `Example One Products`, `Example Two Products` and `Example Three Products`.

### Current behaviour

invalid DOM nesting warning in the `with complex` example of `DialogFullScreen`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- No visual or functional regressions in the `DialogFullScreen` Examples.
- No console errors regarding invalid DOM nesting.
