### PR TITLE
fix: ensure any auto-focused element is focused first when a child of a focus trapped component

### DIFF
--- a/cypress/components/select/filterable-select/filterable-select.cy.tsx
+++ b/cypress/components/select/filterable-select/filterable-select.cy.tsx
@@ -1146,6 +1146,15 @@ context("Tests for FilterableSelect component", () => {
       selectList().should("not.be.visible");
       commonDataElementInputPreview().should("not.be.focused");
     });
+
+    it("should focus the Select and open the list when autoFocus and openOnFocus props set", () => {
+      CypressMountWithProviders(
+        <stories.FilterableSelectNestedInDialog autofocus openOnFocus />
+      );
+
+      commonDataElementInputPreview().should("be.focused");
+      selectList().should("be.visible");
+    });
   });
 
   describe("selection confirmed", () => {

--- a/cypress/components/select/multi-select/multi-select.cy.tsx
+++ b/cypress/components/select/multi-select/multi-select.cy.tsx
@@ -1015,6 +1015,15 @@ context("Tests for MultiSelect component", () => {
       commonDataElementInputPreview().should("not.be.focused");
     });
 
+    it("should focus the select input and open the list when autoFocus and openOnFocus props set", () => {
+      CypressMountWithProviders(
+        <stories.MultiSelectNestedInDialog autofocus openOnFocus />
+      );
+
+      commonDataElementInputPreview().should("be.focused");
+      selectList().should("be.visible");
+    });
+
     it("should contain custom option id option1", () => {
       CypressMountWithProviders(<stories.MultiSelectComponent />);
 

--- a/cypress/components/select/simple-select/simple-select.cy.tsx
+++ b/cypress/components/select/simple-select/simple-select.cy.tsx
@@ -989,6 +989,15 @@ context("Tests for SimpleSelect component", () => {
       commonDataElementInputPreview().should("not.be.focused");
     });
 
+    it("should focus the select input and open the list when autoFocus and openOnFocus props set", () => {
+      CypressMountWithProviders(
+        <stories.SimpleSelectNestedInDialog autofocus openOnFocus />
+      );
+
+      commonDataElementInputPreview().should("be.focused");
+      selectList().should("be.visible");
+    });
+
     it("should be able to focus the last item in the select list when the select list has an OptionGroupHeader ", () => {
       CypressMountWithProviders(<stories.SelectWithOptionGroupHeader />);
 

--- a/src/__internal__/checkable-input/hidden-checkable-input.component.tsx
+++ b/src/__internal__/checkable-input/hidden-checkable-input.component.tsx
@@ -119,6 +119,7 @@ const HiddenCheckableInput = React.forwardRef(
         aria-describedby={combinedDescription}
         aria-labelledby={ariaLabelledBy}
         autoFocus={autoFocus}
+        data-has-autofocus={autoFocus ? true : undefined}
         aria-checked={checked}
         checked={checked}
         name={name}

--- a/src/__internal__/focus-trap/focus-trap-utils.ts
+++ b/src/__internal__/focus-trap/focus-trap-utils.ts
@@ -131,7 +131,8 @@ const onTabGuardFocus = (
   const isTop = position === "top";
   const currentIndex = trapWrappers.indexOf(guardWrapperRef);
   let index = currentIndex;
-  let nextWrapper, allFocusableElementsInNextWrapper: NodeList | undefined;
+  let nextWrapper;
+  let allFocusableElementsInNextWrapper: Element[] | undefined;
 
   do {
     index += isTop ? -1 : 1;
@@ -142,9 +143,11 @@ const onTabGuardFocus = (
       index -= trapWrappers.length;
     }
     nextWrapper = trapWrappers[index];
-    allFocusableElementsInNextWrapper = nextWrapper?.current?.querySelectorAll(
-      focusableSelectors || defaultFocusableSelectors
-    );
+    allFocusableElementsInNextWrapper = Array.from(
+      nextWrapper?.current?.querySelectorAll(
+        focusableSelectors || defaultFocusableSelectors
+      ) || /* istanbul ignore next */ []
+    ).filter((el) => Number((el as HTMLElement).tabIndex) !== -1);
   } while (
     index !== currentIndex &&
     !allFocusableElementsInNextWrapper?.length

--- a/src/__internal__/focus-trap/focus-trap.component.tsx
+++ b/src/__internal__/focus-trap/focus-trap.component.tsx
@@ -142,22 +142,6 @@ const FocusTrap = ({
 
   const prevShouldSetFocus = usePrevious(shouldSetFocus);
 
-  useEffect(() => {
-    if (shouldSetFocus && !prevShouldSetFocus) {
-      const candidateFirstElement =
-        focusFirstElement && "current" in focusFirstElement
-          ? focusFirstElement.current
-          : focusFirstElement;
-      const elementToFocus =
-        (candidateFirstElement as HTMLElement | null | undefined) ||
-        wrapperRef.current;
-      // istanbul ignore else
-      if (elementToFocus) {
-        setElementFocus(elementToFocus);
-      }
-    }
-  }, [shouldSetFocus, prevShouldSetFocus, focusFirstElement, wrapperRef]);
-
   const getFocusableElements = useCallback(
     (selector: string) => {
       const elements: Element[] = [];
@@ -175,6 +159,32 @@ const FocusTrap = ({
     },
     [trapWrappers]
   );
+
+  useEffect(() => {
+    if (shouldSetFocus && !prevShouldSetFocus) {
+      const candidateFirstElement =
+        focusFirstElement && "current" in focusFirstElement
+          ? focusFirstElement.current
+          : focusFirstElement;
+      const autoFocusedElement = getFocusableElements(
+        defaultFocusableSelectors
+      ).find((el) => el.getAttribute("data-has-autofocus") === "true");
+      const elementToFocus =
+        (candidateFirstElement as HTMLElement) ||
+        autoFocusedElement ||
+        wrapperRef.current;
+      // istanbul ignore else
+      if (elementToFocus) {
+        setElementFocus(elementToFocus);
+      }
+    }
+  }, [
+    shouldSetFocus,
+    prevShouldSetFocus,
+    getFocusableElements,
+    focusFirstElement,
+    wrapperRef,
+  ]);
 
   useEffect(() => {
     const trapFn = (ev: KeyboardEvent) => {

--- a/src/__internal__/focus-trap/focus-trap.spec.tsx
+++ b/src/__internal__/focus-trap/focus-trap.spec.tsx
@@ -8,6 +8,8 @@ import FocusTrap, { FocusTrapProps } from "./focus-trap.component";
 import { RadioButton, RadioButtonGroup } from "../../components/radio-button";
 import { ModalContext } from "../../components/modal/modal.component";
 import TopModalContext from "../../components/carbon-provider/top-modal-context";
+import { Option, Select } from "../../components/select";
+import { Checkbox } from "../../components/checkbox";
 
 jest.useFakeTimers();
 
@@ -1365,5 +1367,50 @@ describe("FocusTrap", () => {
       await tabPress();
       expect(screen.getByText(BUTTON_SIX)).toHaveFocus();
     });
+  });
+
+  it("should focus the first input that has the `autoFocus` prop set on it", () => {
+    render(
+      <MockComponent>
+        <Select value="" onChange={() => {}} autoFocus label="Autofocus me">
+          <Option value="1" text="one" />
+        </Select>
+        <Checkbox label="Do not autofocus me" autoFocus />
+      </MockComponent>
+    );
+
+    expect(screen.getByRole("combobox")).toHaveFocus();
+  });
+
+  it("should loop to the last element when there is elements with tabIndex of -1 (SelectList) and shift + tab pressed", async () => {
+    render(
+      <MockComponent>
+        <Select value="" onChange={() => {}} autoFocus label="Autofocus me">
+          <Option value="1" text="one" />
+        </Select>
+        <Checkbox label="Do not autofocus me" autoFocus />
+      </MockComponent>
+    );
+
+    expect(screen.getByRole("combobox")).toHaveFocus();
+    await shiftTabPress();
+    await shiftTabPress();
+    expect(screen.getByRole("combobox")).toHaveFocus();
+  });
+
+  it("should set focus on the `focusFirstElement` when it and an input with `autoFocus` are detected", () => {
+    render(
+      mockComponentToRender({
+        children: (
+          <Select value="" onChange={() => {}} autoFocus label="Autofocus me">
+            <Option value="1" text="one" />
+          </Select>
+        ),
+        shouldFocusFirstElement: true,
+      })
+    );
+
+    expect(screen.getByText(FIRST_ELEMENT)).toHaveFocus();
+    expect(screen.getByRole("combobox")).not.toHaveFocus();
   });
 });

--- a/src/__internal__/input/input.component.tsx
+++ b/src/__internal__/input/input.component.tsx
@@ -219,6 +219,7 @@ const Input = React.forwardRef<
     return (
       <StyledInput
         {...rest}
+        data-has-autofocus={autoFocus ? true : undefined}
         aria-describedby={combinedDescription}
         aria-labelledby={ariaLabelledBy}
         align={align}

--- a/src/components/dialog-full-screen/components.test-pw.tsx
+++ b/src/components/dialog-full-screen/components.test-pw.tsx
@@ -18,6 +18,7 @@ import Icon from "../icon";
 import { ActionPopover, ActionPopoverItem } from "../action-popover";
 import { Dl, Dt, Dd } from "../definition-list";
 import Sidebar from "../sidebar";
+import { Select, Option } from "../select";
 
 const mainDialogTitle = "Main Dialog";
 const nestedDialogTitle = "Nested Dialog";
@@ -948,5 +949,16 @@ export const TopModalOverride = () => {
         <Textbox label="Sidebar textbox" />
       </Sidebar>
     </>
+  );
+};
+
+export const DialogFullScreenWithAutoFocusSelect = () => {
+  return (
+    <DialogFullScreen open title="My dialog" onCancel={() => {}}>
+      <Select autoFocus label="select">
+        <Option value="1" text="one" />
+      </Select>
+      <Textbox label="textbox" />
+    </DialogFullScreen>
   );
 };

--- a/src/components/dialog-full-screen/dialog-full-screen.pw.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.pw.tsx
@@ -16,6 +16,7 @@ import {
   DialogFullScreenWithTitleAsReactComponent,
   WithComplexExample,
   TopModalOverride,
+  DialogFullScreenWithAutoFocusSelect,
 } from "./components.test-pw";
 import {
   portal,
@@ -442,6 +443,22 @@ test.describe("render DialogFullScreen component and check properties", () => {
     await expect(dialogTextbox).toBeFocused();
     await dialogTextbox.press("Tab");
     await expect(dialogClose).toBeFocused();
+  });
+
+  test("should loop focus when a Select component is passed as children and the user presses shift + tab", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<DialogFullScreenWithAutoFocusSelect />);
+
+    const dialog = page.getByRole("dialog");
+    const select = dialog.getByRole("combobox");
+
+    await expect(select).toBeFocused();
+    await dialog.press("Shift+Tab");
+    await dialog.press("Shift+Tab");
+    await dialog.press("Shift+Tab");
+    await expect(select).toBeFocused();
   });
 });
 

--- a/src/components/dialog/components.test-pw.tsx
+++ b/src/components/dialog/components.test-pw.tsx
@@ -9,6 +9,7 @@ import Toast from "../toast";
 import Box from "../box";
 import DialogFullScreen from "../dialog-full-screen";
 import Sidebar from "../sidebar";
+import { Select, Option } from "../select";
 
 export const DialogComponent = (props: Partial<DialogProps>) => {
   const [isOpen, setIsOpen] = useState(true);
@@ -138,5 +139,16 @@ export const TopModalOverride = () => {
         <Textbox label="Sidebar textbox" />
       </Sidebar>
     </>
+  );
+};
+
+export const DialogWithAutoFocusSelect = () => {
+  return (
+    <Dialog open title="My dialog" onCancel={() => {}}>
+      <Select autoFocus label="select">
+        <Option value="1" text="one" />
+      </Select>
+      <Textbox label="textbox" />
+    </Dialog>
   );
 };

--- a/src/components/dialog/dialog.pw.tsx
+++ b/src/components/dialog/dialog.pw.tsx
@@ -8,6 +8,7 @@ import {
   DialogBackgroundScrollTest,
   DialogWithOpenToastsBackgroundScrollTest,
   TopModalOverride,
+  DialogWithAutoFocusSelect,
 } from "./components.test-pw";
 
 import {
@@ -358,6 +359,22 @@ test.describe("Testing Dialog component properties", () => {
     await expect(
       page.getByText("I should not be scrolled into view")
     ).not.toBeInViewport();
+  });
+
+  test("should loop focus when a Select component is passed as children and the user presses shift + tab", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<DialogWithAutoFocusSelect />);
+
+    const dialog = page.getByRole("dialog");
+    const select = dialog.getByRole("combobox");
+
+    await expect(select).toBeFocused();
+    await dialog.press("Shift+Tab");
+    await dialog.press("Shift+Tab");
+    await dialog.press("Shift+Tab");
+    await expect(select).toBeFocused();
   });
 });
 

--- a/src/components/select/filterable-select/filterable-select-test.stories.tsx
+++ b/src/components/select/filterable-select/filterable-select-test.stories.tsx
@@ -634,11 +634,19 @@ export const FilterableSelectWithManyOptionsAndVirtualScrolling = () => (
   </FilterableSelect>
 );
 
-export const FilterableSelectNestedInDialog = () => {
+export const FilterableSelectNestedInDialog = ({
+  openOnFocus = false,
+  autofocus = false,
+}) => {
   const [isOpen, setIsOpen] = useState(true);
   return (
     <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
-      <FilterableSelect name="testSelect" id="testSelect">
+      <FilterableSelect
+        openOnFocus={openOnFocus}
+        autoFocus={autofocus}
+        name="testSelect"
+        id="testSelect"
+      >
         <Option value="opt1" text="red" />
         <Option value="opt2" text="green" />
         <Option value="opt3" text="blue" />

--- a/src/components/select/filterable-select/filterable-select.spec.tsx
+++ b/src/components/select/filterable-select/filterable-select.spec.tsx
@@ -20,7 +20,7 @@ import StyledInput from "../../../__internal__/input/input.style";
 
 const mockedGuid = "mocked-guid";
 jest.mock("../../../__internal__/utils/logger");
-
+jest.useFakeTimers();
 jest.mock("../../../__internal__/utils/helpers/guid");
 
 (guid as jest.MockedFunction<typeof guid>).mockReturnValue(mockedGuid);
@@ -1100,7 +1100,10 @@ describe("FilterableSelect", () => {
       it("the SelectList should be rendered", () => {
         const wrapper = renderSelect({ openOnFocus: true });
 
-        wrapper.find("input").simulate("focus");
+        act(() => {
+          wrapper.find("input").simulate("focus");
+          jest.runOnlyPendingTimers();
+        });
         wrapper
           .find(Option)
           .forEach((option) => expect(option.getDOMNode()).toBeVisible());
@@ -1131,7 +1134,10 @@ describe("FilterableSelect", () => {
             openOnFocus: true,
           });
 
-          wrapper.find("input").simulate("focus");
+          act(() => {
+            wrapper.find("input").simulate("focus");
+            jest.runOnlyPendingTimers();
+          });
           expect(onFocusFn).toHaveBeenCalled();
         });
       });
@@ -1148,7 +1154,10 @@ describe("FilterableSelect", () => {
         });
 
         it("then that prop should have been called", () => {
-          wrapper.find("input").simulate("focus");
+          act(() => {
+            wrapper.find("input").simulate("focus");
+            jest.runOnlyPendingTimers();
+          });
           expect(onOpenFn).toHaveBeenCalled();
         });
 
@@ -1180,7 +1189,10 @@ describe("FilterableSelect", () => {
 
           wrapper = mount(<Component />);
           expect(wrapper.find("#call-counter").text()).toBe("0");
-          wrapper.find("input").simulate("focus");
+          act(() => {
+            wrapper.find("input").simulate("focus");
+            jest.runOnlyPendingTimers();
+          });
           expect(wrapper.find("#call-counter").text()).toBe("1");
           wrapper.setProps({});
           expect(wrapper.find("#call-counter").text()).toBe("1");
@@ -1188,7 +1200,10 @@ describe("FilterableSelect", () => {
 
         describe("and with the SelectList already open", () => {
           it("then that prop should not be called", () => {
-            wrapper.find("input").simulate("focus");
+            act(() => {
+              wrapper.find("input").simulate("focus");
+              jest.runOnlyPendingTimers();
+            });
             onOpenFn.mockReset();
             wrapper
               .find(Option)
@@ -1201,7 +1216,10 @@ describe("FilterableSelect", () => {
         describe("and the focus triggered by mouseDown on the input", () => {
           it("then that prop should have been called", () => {
             wrapper.find("input").simulate("mousedown");
-            wrapper.find("input").simulate("focus");
+            act(() => {
+              wrapper.find("input").simulate("focus");
+              jest.runOnlyPendingTimers();
+            });
             expect(onOpenFn).toHaveBeenCalled();
           });
         });

--- a/src/components/select/multi-select/multi-select-test.stories.tsx
+++ b/src/components/select/multi-select/multi-select-test.stories.tsx
@@ -536,11 +536,19 @@ export const MultiSelectWithManyOptionsAndVirtualScrolling = () => (
   </MultiSelect>
 );
 
-export const MultiSelectNestedInDialog = () => {
+export const MultiSelectNestedInDialog = ({
+  openOnFocus = false,
+  autofocus = false,
+}) => {
   const [isOpen, setIsOpen] = useState(true);
   return (
     <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
-      <MultiSelect name="testSelect" id="testSelect">
+      <MultiSelect
+        openOnFocus={openOnFocus}
+        autoFocus={autofocus}
+        name="testSelect"
+        id="testSelect"
+      >
         <Option value="opt1" text="red" />
         <Option value="opt2" text="green" />
         <Option value="opt3" text="blue" />

--- a/src/components/select/multi-select/multi-select.spec.tsx
+++ b/src/components/select/multi-select/multi-select.spec.tsx
@@ -21,7 +21,7 @@ import StyledInput from "../../../__internal__/input/input.style";
 
 const mockedGuid = "mocked-guid";
 jest.mock("../../../__internal__/utils/helpers/guid");
-
+jest.useFakeTimers();
 (guid as jest.MockedFunction<typeof guid>).mockReturnValue(mockedGuid);
 
 function getSelect(props: Partial<MultiSelectProps> = {}) {
@@ -104,7 +104,10 @@ describe("MultiSelect", () => {
 
     describe("and that element is part of the Select", () => {
       it("then the SelectList should be open", () => {
-        wrapper.find("input").simulate("focus");
+        act(() => {
+          wrapper.find("input").simulate("focus");
+          jest.runOnlyPendingTimers();
+        });
         wrapper
           .find(Option)
           .forEach((option) => expect(option.getDOMNode()).toBeVisible());
@@ -122,7 +125,10 @@ describe("MultiSelect", () => {
 
     describe("and that element is not part of the Select", () => {
       it("then the SelectList should be closed", () => {
-        wrapper.find("input").simulate("focus");
+        act(() => {
+          wrapper.find("input").simulate("focus");
+          jest.runOnlyPendingTimers();
+        });
         wrapper
           .find(Option)
           .forEach((option) => expect(option.getDOMNode()).toBeVisible());
@@ -648,7 +654,10 @@ describe("MultiSelect", () => {
       it("the SelectList should be rendered", () => {
         const wrapper = renderSelect({ openOnFocus: true });
 
-        wrapper.find("input").simulate("focus");
+        act(() => {
+          wrapper.find("input").simulate("focus");
+          jest.runOnlyPendingTimers();
+        });
         wrapper
           .find(Option)
           .forEach((option) => expect(option.getDOMNode()).toBeVisible());
@@ -679,7 +688,10 @@ describe("MultiSelect", () => {
             openOnFocus: true,
           });
 
-          wrapper.find("input").simulate("focus");
+          act(() => {
+            wrapper.find("input").simulate("focus");
+            jest.runOnlyPendingTimers();
+          });
           expect(onFocusFn).toHaveBeenCalled();
         });
       });
@@ -694,13 +706,19 @@ describe("MultiSelect", () => {
         });
 
         it("then that prop should have been called", () => {
-          wrapper.find("input").simulate("focus");
+          act(() => {
+            wrapper.find("input").simulate("focus");
+            jest.runOnlyPendingTimers();
+          });
           expect(onOpenFn).toHaveBeenCalled();
         });
 
         describe("and with the SelectList already open", () => {
           it("then that prop should not be called", () => {
-            wrapper.find("input").simulate("focus");
+            act(() => {
+              wrapper.find("input").simulate("focus");
+              jest.runOnlyPendingTimers();
+            });
             onOpenFn.mockReset();
             wrapper
               .find(Option)
@@ -713,7 +731,10 @@ describe("MultiSelect", () => {
         describe("and the focus triggered by mouseDown on the input", () => {
           it("then that prop should have been called", () => {
             wrapper.find("input").simulate("mouseDown");
-            wrapper.find("input").simulate("focus");
+            act(() => {
+              wrapper.find("input").simulate("focus");
+              jest.runOnlyPendingTimers();
+            });
             expect(onOpenFn).toHaveBeenCalled();
           });
         });
@@ -731,7 +752,10 @@ describe("MultiSelect", () => {
             .find('[type="dropdown"]')
             .first()
             .simulate("mouseDown");
-          wrapper.find("input").simulate("focus");
+          act(() => {
+            wrapper.find("input").simulate("focus");
+            jest.runOnlyPendingTimers();
+          });
           expect(onOpenFn).toHaveBeenCalled();
         });
       });
@@ -788,7 +812,10 @@ describe("MultiSelect", () => {
     it("the SelectList should not be closed", () => {
       const wrapper = renderSelect({ openOnFocus: true });
 
-      wrapper.find("input").simulate("focus");
+      act(() => {
+        wrapper.find("input").simulate("focus");
+        jest.runOnlyPendingTimers();
+      });
       wrapper
         .find(Option)
         .forEach((option) => expect(option.getDOMNode()).toBeVisible());
@@ -864,7 +891,10 @@ describe("MultiSelect", () => {
     it("then the SelectList should not be closed", () => {
       const wrapper = renderSelect({ openOnFocus: true });
 
-      wrapper.find("input").simulate("focus");
+      act(() => {
+        wrapper.find("input").simulate("focus");
+        jest.runOnlyPendingTimers();
+      });
       act(() => {
         wrapper.find(Option).first().simulate("click");
       });
@@ -962,7 +992,10 @@ describe("MultiSelect", () => {
     it("the SelectList should be closed", () => {
       const wrapper = renderSelect({ openOnFocus: true });
 
-      wrapper.find("input").simulate("focus");
+      act(() => {
+        wrapper.find("input").simulate("focus");
+        jest.runOnlyPendingTimers();
+      });
       wrapper
         .find(Option)
         .forEach((option) => expect(option.getDOMNode()).toBeVisible());

--- a/src/components/select/simple-select/simple-select-test.stories.tsx
+++ b/src/components/select/simple-select/simple-select-test.stories.tsx
@@ -658,11 +658,19 @@ export const SimpleSelectWithManyOptionsAndVirtualScrolling = () => (
   </SimpleSelect>
 );
 
-export const SimpleSelectNestedInDialog = () => {
+export const SimpleSelectNestedInDialog = ({
+  openOnFocus = false,
+  autofocus = false,
+}) => {
   const [isOpen, setIsOpen] = useState(true);
   return (
     <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
-      <SimpleSelect name="testSelect" id="testSelect">
+      <SimpleSelect
+        openOnFocus={openOnFocus}
+        autoFocus={autofocus}
+        name="testSelect"
+        id="testSelect"
+      >
         <Option value="opt1" text="red" />
         <Option value="opt2" text="green" />
         <Option value="opt3" text="blue" />

--- a/src/components/select/simple-select/simple-select.component.tsx
+++ b/src/components/select/simple-select/simple-select.component.tsx
@@ -154,6 +154,7 @@ export const SimpleSelect = React.forwardRef(
       id: inputId.current,
       label,
     });
+    const focusTimer = useRef<null | ReturnType<typeof setTimeout>>(null);
 
     if (!deprecateInputRefWarnTriggered && inputRef) {
       deprecateInputRefWarnTriggered = true;
@@ -404,16 +405,24 @@ export const SimpleSelect = React.forwardRef(
       }
 
       if (openOnFocus) {
-        setOpenState((isAlreadyOpen) => {
-          if (isAlreadyOpen) {
+        if (focusTimer.current) {
+          clearTimeout(focusTimer.current);
+        }
+
+        // we need to use a timeout here as there is a race condition when rendered in a modal
+        // whereby the select list isn't visible when the select is auto focused straight away
+        focusTimer.current = setTimeout(() => {
+          setOpenState((isAlreadyOpen) => {
+            if (isAlreadyOpen) {
+              return true;
+            }
+
+            if (onOpen) {
+              onOpen();
+            }
+
             return true;
-          }
-
-          if (onOpen) {
-            onOpen();
-          }
-
-          return true;
+          });
         });
       }
     }

--- a/src/components/select/simple-select/simple-select.spec.tsx
+++ b/src/components/select/simple-select/simple-select.spec.tsx
@@ -21,7 +21,7 @@ import SelectTextbox from "../select-textbox";
 
 const mockedGuid = "mocked-guid";
 jest.mock("../../../__internal__/utils/helpers/guid");
-
+jest.useFakeTimers();
 (guid as jest.MockedFunction<typeof guid>).mockReturnValue(mockedGuid);
 
 function getSelect(props: Partial<SimpleSelectProps> = {}) {
@@ -45,7 +45,10 @@ function simulateSelectTextboxEvent(
 ) {
   const selectText = container.find('input[type="text"]').first();
 
-  selectText.simulate(eventType);
+  act(() => {
+    selectText.simulate(eventType);
+    if (eventType === "focus") jest.runOnlyPendingTimers();
+  });
 }
 
 function simulateKeyDown(
@@ -678,14 +681,13 @@ describe("SimpleSelect", () => {
 
     describe("and another keys are typed with a long break before the last change", () => {
       it("then the first option with text starting the last typed character should be selected", () => {
-        jest.useFakeTimers();
         const wrapper = renderSelect();
 
         act(() => {
           simulateSelectTextboxEvent(wrapper, "focus");
           simulateKeyDown(wrapper, "b");
           simulateKeyDown(wrapper, "l");
-          jest.runAllTimers();
+          jest.runOnlyPendingTimers();
           simulateKeyDown(wrapper, "g");
         });
 


### PR DESCRIPTION
fix #6384

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Ensures that when a Carbon input has the `autoFocus` prop set on it and rendered as a child of a focus trapped parent (`Dialog`, `DialogFullScreen`, `Sidebar`, `Confirm` and so on) is focused first when rendered. Also ensures that any elements with tabIndex of -1 are ignored by the tab guards, rendered as part of the FocusTrap, when selecting which element to focus next.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Children with `autoFocus` are not focused when a focus trapped parent is rendered
Elements with tabIndex -1 are not ignored by the tab guards in the FocusTrap

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
https://codesandbox.io/s/charming-water-jvt46y?file=/src/App.js