### PR TITLE
feat(numeral-date): add date format and update to align with DS

### DIFF
--- a/cypress/components/numeral-date/numeral-date.cy.tsx
+++ b/cypress/components/numeral-date/numeral-date.cy.tsx
@@ -23,6 +23,7 @@ import {
 import {
   numeralDateComponent,
   numeralDateInputByPosition,
+  numeralDateLabelByPosition,
 } from "../../locators/numeralDate";
 
 import {
@@ -288,26 +289,27 @@ context("Tests for NumeralDate component", () => {
       CypressMountWithProviders(
         <NumeralDateComponent dateFormat={["dd", "mm", "yyyy"]} />
       );
-      numeralDateInputByPosition(0).should("have.attr", "placeholder", "dd");
-      numeralDateInputByPosition(1).should("have.attr", "placeholder", "mm");
-      numeralDateInputByPosition(2).should("have.attr", "placeholder", "yyyy");
+
+      numeralDateLabelByPosition(0).should("have.text", "Day");
+      numeralDateLabelByPosition(1).should("have.text", "Month");
+      numeralDateLabelByPosition(2).should("have.text", "Year");
     });
 
     it('should render NumeralDate with `["mm", "dd", "yyyy"]` dateFormat prop', () => {
       CypressMountWithProviders(
         <NumeralDateComponent dateFormat={["mm", "dd", "yyyy"]} />
       );
-      numeralDateInputByPosition(0).should("have.attr", "placeholder", "mm");
-      numeralDateInputByPosition(1).should("have.attr", "placeholder", "dd");
-      numeralDateInputByPosition(2).should("have.attr", "placeholder", "yyyy");
+      numeralDateLabelByPosition(0).should("have.text", "Month");
+      numeralDateLabelByPosition(1).should("have.text", "Day");
+      numeralDateLabelByPosition(2).should("have.text", "Year");
     });
 
     it('should render NumeralDate with `["dd", "mm"]` dateFormat prop', () => {
       CypressMountWithProviders(
         <NumeralDateComponent dateFormat={["dd", "mm"]} />
       );
-      numeralDateInputByPosition(0).should("have.attr", "placeholder", "dd");
-      numeralDateInputByPosition(1).should("have.attr", "placeholder", "mm");
+      numeralDateLabelByPosition(0).should("have.text", "Day");
+      numeralDateLabelByPosition(1).should("have.text", "Month");
       numeralDateInputByPosition(2).should("not.exist");
     });
 
@@ -315,8 +317,8 @@ context("Tests for NumeralDate component", () => {
       CypressMountWithProviders(
         <NumeralDateComponent dateFormat={["mm", "dd"]} />
       );
-      numeralDateInputByPosition(0).should("have.attr", "placeholder", "mm");
-      numeralDateInputByPosition(1).should("have.attr", "placeholder", "dd");
+      numeralDateLabelByPosition(0).should("have.text", "Month");
+      numeralDateLabelByPosition(1).should("have.text", "Day");
       numeralDateInputByPosition(2).should("not.exist");
     });
 
@@ -324,8 +326,8 @@ context("Tests for NumeralDate component", () => {
       CypressMountWithProviders(
         <NumeralDateComponent dateFormat={["mm", "yyyy"]} />
       );
-      numeralDateInputByPosition(0).should("have.attr", "placeholder", "mm");
-      numeralDateInputByPosition(1).should("have.attr", "placeholder", "yyyy");
+      numeralDateLabelByPosition(0).should("have.text", "Month");
+      numeralDateLabelByPosition(1).should("have.text", "Year");
       numeralDateInputByPosition(2).should("not.exist");
     });
 
@@ -439,16 +441,6 @@ context("Tests for NumeralDate component", () => {
         "aria-label",
         CHARACTERS.STANDARD
       );
-    });
-
-    it("should have the expected border radius styling when no search button enabled", () => {
-      CypressMountWithProviders(<NumeralDateComponent />);
-      numeralDateInputByPosition(0)
-        .parent()
-        .should("have.css", "border-radius", "4px 0px 0px 4px");
-      numeralDateInputByPosition(2)
-        .parent()
-        .should("have.css", "border-radius", "0px 4px 4px 0px");
     });
   });
 

--- a/cypress/locators/numeralDate/index.js
+++ b/cypress/locators/numeralDate/index.js
@@ -5,3 +5,5 @@ export const numeralDateComponent = () => cy.get(NUMERAL_DATE_COMPONENT);
 export const numeralDateInput = () => numeralDateComponent().find(DATE_INPUT);
 export const numeralDateInputByPosition = (index) =>
   numeralDateInput().eq(index);
+export const numeralDateLabelByPosition = (index) =>
+  numeralDateComponent().find("p").eq(index);

--- a/src/components/numeral-date/numeral-date.component.tsx
+++ b/src/components/numeral-date/numeral-date.component.tsx
@@ -7,7 +7,9 @@ import { filterStyledSystemMarginProps } from "../../style/utils";
 import Events from "../../__internal__/utils/helpers/events";
 import { StyledNumeralDate, StyledDateField } from "./numeral-date.style";
 import Textbox from "../textbox";
-import { StyledHintText } from "../textbox/textbox.style";
+import Box from "../box";
+import Typography from "../typography";
+import { ErrorBorder, StyledHintText } from "../textbox/textbox.style";
 import ValidationMessage from "../../__internal__/validation-message";
 import guid from "../../__internal__/utils/helpers/guid";
 import useLocale from "../../hooks/__internal__/useLocale";
@@ -18,12 +20,14 @@ import { NewValidationContext } from "../carbon-provider/carbon-provider.compone
 import NumeralDateContext from "./numeral-date-context";
 import FormSpacingProvider from "../../__internal__/form-spacing-provider";
 import Logger from "../../__internal__/utils/logger";
+import Locale from "../../locales/locale";
 
 let deprecateUncontrolledWarnTriggered = false;
 
 export const ALLOWED_DATE_FORMATS = [
   ["dd", "mm", "yyyy"],
   ["mm", "dd", "yyyy"],
+  ["yyyy", "mm", "dd"],
   ["dd", "mm"],
   ["mm", "dd"],
   ["mm", "yyyy"],
@@ -80,6 +84,7 @@ export interface NumeralDateProps<DateType extends NumeralDateObject = FullDate>
   Allowed formats:
   ['dd', 'mm', 'yyyy'],
   ['mm', 'dd', 'yyyy'],
+  ['yyyy', 'mm', 'dd'],
   ['dd', 'mm'],
   ['mm', 'dd'],
   ['mm', 'yyyy'] */
@@ -145,6 +150,7 @@ const incorrectDateFormatMessage =
   "Only one of these date formats is allowed: " +
   "['dd', 'mm', 'yyyy'], " +
   "['mm', 'dd', 'yyyy'], " +
+  "['yyyy', 'mm', 'dd'], " +
   "['dd', 'mm'], " +
   "['mm', 'dd'], " +
   "['mm', 'yyyy']";
@@ -161,6 +167,17 @@ const validations: ValidationsObject = {
   dd: isDayValid,
   mm: isMonthValid,
   yyyy: isYearValid,
+};
+
+const getDateLabel = (datePart: string, locale: Locale) => {
+  switch (datePart) {
+    case "mm":
+      return locale.numeralDate.labels.month();
+    case "yyyy":
+      return locale.numeralDate.labels.year();
+    default:
+      return locale.numeralDate.labels.day();
+  }
 };
 
 export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
@@ -199,7 +216,7 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
   yearRef,
   ...rest
 }: NumeralDateProps<DateType>) => {
-  const l = useLocale();
+  const locale = useLocale();
   const { validationRedesignOptIn } = useContext(NewValidationContext);
 
   const { current: uniqueId } = useRef(id || guid());
@@ -207,6 +224,8 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
   const initialValue = isControlled.current ? value : defaultValue;
 
   const refs = useRef<(HTMLInputElement | null)[]>(dateFormat.map(() => null));
+
+  const labelIds = useRef([guid(), guid(), guid()]);
 
   const [internalMessages, setInternalMessages] = useState<DateType>({
     ...((Object.fromEntries(
@@ -238,9 +257,9 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
   }, [value]);
 
   const validationMessages = {
-    dd: l.numeralDate.validation.day(),
-    mm: l.numeralDate.validation.month(),
-    yyyy: l.numeralDate.validation.year(),
+    dd: locale.numeralDate.validation.day(),
+    mm: locale.numeralDate.validation.month(),
+    yyyy: locale.numeralDate.validation.year(),
   };
 
   const [dateValue, setDateValue] = useState<DateType>({
@@ -260,7 +279,7 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
     },
   });
 
-  const onKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
+  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     const isValidKey =
       Events.isNumberKey(event) ||
       Events.isTabKey(event) ||
@@ -357,7 +376,7 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
           labelInline={labelInline}
           labelWidth={labelWidth}
           labelAlign={labelAlign}
-          labelHelp={labelHelp}
+          labelHelp={!validationRedesignOptIn && labelHelp}
           labelSpacing={labelSpacing}
           fieldHelp={fieldHelp}
           adaptiveLabelBreakpoint={adaptiveLabelBreakpoint}
@@ -368,101 +387,117 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
           {validationRedesignOptIn && labelHelp && (
             <StyledHintText>{labelHelp}</StyledHintText>
           )}
-          {validationRedesignOptIn && (
-            <ValidationMessage
-              error={internalError}
-              warning={internalWarning}
-            />
-          )}
-          <StyledNumeralDate
-            name={name}
-            onKeyPress={onKeyPress}
-            data-component="numeral-date"
-          >
-            {dateFormat.map((datePart, index) => {
-              const isStart = index === 0;
-              const isEnd = index === dateFormat.length - 1;
-              const isMiddle = index === 1;
 
-              const validation = error || warning || info;
-              const isStringValidation = typeof validation === "string";
-              const hasValidationIcon =
-                isStringValidation && !!validation.length;
+          <Box position="relative">
+            {validationRedesignOptIn && (
+              <>
+                <ValidationMessage
+                  error={internalError}
+                  warning={internalWarning}
+                />
 
-              let inputRef: React.ForwardedRef<HTMLInputElement> | undefined;
+                {(internalError || internalWarning) && (
+                  <ErrorBorder
+                    warning={!!(!internalError && internalWarning)}
+                  />
+                )}
+              </>
+            )}
 
-              switch (datePart.slice(0, 2)) {
-                case "dd":
-                  inputRef = dayRef;
-                  break;
-                case "mm":
-                  inputRef = monthRef;
-                  break;
-                case "yy":
-                  inputRef = yearRef;
-                  break;
-                /* istanbul ignore next */
-                default:
-                  break;
-              }
+            <StyledNumeralDate
+              name={name}
+              onKeyDown={onKeyDown}
+              data-component="numeral-date"
+            >
+              {dateFormat.map((datePart, index) => {
+                const isEnd = index === dateFormat.length - 1;
 
-              return (
-                <NumeralDateContext.Provider
-                  value={{ disableErrorBorder: index !== 0 }}
-                  key={datePart}
-                >
-                  <StyledDateField
+                const labelId = labelIds.current[index];
+                const validation = internalError || internalWarning || info;
+                const isStringValidation = typeof validation === "string";
+                const hasValidationIcon =
+                  isStringValidation && !!validation.length;
+
+                let inputRef: React.ForwardedRef<HTMLInputElement> | undefined;
+
+                switch (datePart.slice(0, 2)) {
+                  case "dd":
+                    inputRef = dayRef;
+                    break;
+                  case "mm":
+                    inputRef = monthRef;
+                    break;
+                  case "yy":
+                    inputRef = yearRef;
+                    break;
+                  /* istanbul ignore next */
+                  default:
+                    break;
+                }
+
+                return (
+                  <NumeralDateContext.Provider
+                    value={{ disableErrorBorder: true }}
                     key={datePart}
-                    isYearInput={datePart.length === 4}
-                    isStart={isStart}
-                    isMiddle={isMiddle}
-                    isEnd={isEnd}
-                    hasValidationIcon={hasValidationIcon}
                   >
-                    <FormSpacingProvider marginBottom={undefined}>
-                      <Textbox
-                        {...(index === 0 && { id: uniqueId })}
-                        disabled={disabled}
-                        readOnly={readOnly}
-                        placeholder={datePart}
-                        value={dateValue[datePart as keyof NumeralDateObject]}
-                        onChange={(e) =>
-                          handleChange(e, datePart as keyof NumeralDateObject)
-                        }
-                        ref={(element) => {
-                          refs.current[index] = element;
-                          if (!inputRef) {
-                            return;
+                    <StyledDateField
+                      key={datePart}
+                      isYearInput={datePart.length === 4}
+                      isEnd={isEnd}
+                      hasValidationIconInField={
+                        hasValidationIcon &&
+                        !validationOnLabel &&
+                        !validationRedesignOptIn
+                      }
+                    >
+                      <FormSpacingProvider marginBottom={undefined}>
+                        <Typography mb="4px" id={labelId}>
+                          {getDateLabel(datePart, locale)}
+                        </Typography>
+                        <Textbox
+                          {...(index === 0 && { id: uniqueId })}
+                          disabled={disabled}
+                          readOnly={readOnly}
+                          value={dateValue[datePart as keyof NumeralDateObject]}
+                          onChange={(e) =>
+                            handleChange(e, datePart as keyof NumeralDateObject)
                           }
-                          if (typeof inputRef === "function") {
-                            inputRef(element);
-                          } else {
-                            inputRef.current = element;
+                          ref={(element) => {
+                            refs.current[index] = element;
+                            if (!inputRef) {
+                              return;
+                            }
+                            if (typeof inputRef === "function") {
+                              inputRef(element);
+                            } else {
+                              inputRef.current = element;
+                            }
+                          }}
+                          onBlur={() =>
+                            handleBlur(datePart as keyof NumeralDateObject)
                           }
-                        }}
-                        onBlur={() =>
-                          handleBlur(datePart as keyof NumeralDateObject)
-                        }
-                        error={!!internalError}
-                        warning={!!internalWarning}
-                        info={!!info}
-                        {...(required && { required })}
-                        {...(isEnd &&
-                          !validationRedesignOptIn &&
-                          !validationOnLabel && {
-                            error: internalError,
-                            warning: internalWarning,
-                            info,
-                          })}
-                        size={size}
-                        tooltipPosition={tooltipPosition}
-                      />
-                    </FormSpacingProvider>
-                  </StyledDateField>
-                </NumeralDateContext.Provider>
-              );
-            })}
-          </StyledNumeralDate>
+                          error={!!internalError}
+                          warning={!!internalWarning}
+                          info={!!info}
+                          {...(required && { required })}
+                          {...(isEnd &&
+                            !validationRedesignOptIn &&
+                            !validationOnLabel && {
+                              error: internalError,
+                              warning: internalWarning,
+                              info,
+                            })}
+                          size={size}
+                          tooltipPosition={tooltipPosition}
+                          aria-labelledby={labelId}
+                        />
+                      </FormSpacingProvider>
+                    </StyledDateField>
+                  </NumeralDateContext.Provider>
+                );
+              })}
+            </StyledNumeralDate>
+          </Box>
         </FormField>
       </InputGroupBehaviour>
     </TooltipProvider>

--- a/src/components/numeral-date/numeral-date.spec.tsx
+++ b/src/components/numeral-date/numeral-date.spec.tsx
@@ -7,7 +7,8 @@ import NumeralDate, {
   ValidDateFormat,
 } from "./numeral-date.component";
 import Textbox from "../textbox";
-import { StyledDateField, StyledNumeralDate } from "./numeral-date.style";
+import Typography from "../typography";
+import { StyledNumeralDate } from "./numeral-date.style";
 import {
   assertStyleMatch,
   testStyledSystemMargin,
@@ -21,7 +22,6 @@ import CarbonProvider from "../carbon-provider/carbon-provider.component";
 import { ErrorBorder, StyledHintText } from "../textbox/textbox.style";
 import StyledValidationMessage from "../../__internal__/validation-message/validation-message.style";
 import Logger from "../../__internal__/utils/logger";
-import StyledInputPresentation from "../../__internal__/input/input-presentation.style";
 
 jest.mock("../../__internal__/utils/logger");
 
@@ -117,7 +117,7 @@ describe("NumeralDate", () => {
       const expected =
         "Forbidden prop dateFormat supplied to NumeralDate. " +
         "Only one of these date formats is allowed: " +
-        "['dd', 'mm', 'yyyy'], ['mm', 'dd', 'yyyy'], ['dd', 'mm'], ['mm', 'dd'], ['mm', 'yyyy']";
+        "['dd', 'mm', 'yyyy'], ['mm', 'dd', 'yyyy'], ['yyyy', 'mm', 'dd'], ['dd', 'mm'], ['mm', 'dd'], ['mm', 'yyyy']";
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore:next-line testing incorrect date format
@@ -196,7 +196,6 @@ describe("NumeralDate", () => {
       assertStyleMatch(
         {
           display: "inline-flex",
-          height: "40px",
           fontSize: "14px",
           fontWeight: "400",
         },
@@ -378,9 +377,10 @@ describe("NumeralDate", () => {
 
   it("has proper default dateFormat prop", () => {
     wrapper = renderWrapper({ dateFormat: undefined });
-    expect(wrapper.find(Textbox).at(0).props().placeholder).toEqual("dd");
-    expect(wrapper.find(Textbox).at(1).props().placeholder).toEqual("mm");
-    expect(wrapper.find(Textbox).at(2).props().placeholder).toEqual("yyyy");
+
+    expect(wrapper.find(Typography).at(0).text()).toBe("Day");
+    expect(wrapper.find(Typography).at(1).text()).toBe("Month");
+    expect(wrapper.find(Typography).at(2).text()).toBe("Year");
   });
 
   describe("Clicking off the component", () => {
@@ -462,7 +462,7 @@ describe("NumeralDate", () => {
       const input = wrapper.find("input").at(0);
       const event = { key: "1", preventDefault: preventDefaultMock };
       act(() => {
-        input.simulate("keypress", event);
+        input.simulate("keydown", event);
       });
       expect(preventDefaultMock).not.toHaveBeenCalled();
     });
@@ -471,7 +471,7 @@ describe("NumeralDate", () => {
       const input = wrapper.find("input").at(0);
       const event = { key: key[0], preventDefault: preventDefaultMock };
       act(() => {
-        input.simulate("keypress", event);
+        input.simulate("keydown", event);
       });
       expect(preventDefaultMock).toHaveBeenCalled();
     });
@@ -544,15 +544,12 @@ describe("NumeralDate", () => {
   });
 
   describe("new validation design", () => {
-    describe("hint text/labelHelp", () => {
-      it("is visible when the prop is passed", () => {
-        wrapper = renderNewValidationsWrapper({
-          labelHelp: "Example hint text",
-        });
-        expect(wrapper.find(StyledHintText).text()).toEqual(
-          "Example hint text"
-        );
+    it("hint text is visible and tooltip is not rendered when the labelHelp prop is passed", () => {
+      wrapper = renderNewValidationsWrapper({
+        labelHelp: "Example hint text",
       });
+      expect(wrapper.find(StyledHintText).text()).toEqual("Example hint text");
+      expect(wrapper.find(StyledHelp).exists()).toEqual(false);
     });
 
     describe("on error", () => {
@@ -690,26 +687,5 @@ describe("NumeralDate", () => {
         expect(ref.current).toBe(null);
       });
     });
-  });
-
-  it("renders with the expected border radius styling on first and last inputs", () => {
-    wrapper = renderWrapper({ value: { dd: "02", mm: "01", yyyy: "2020" } });
-    assertStyleMatch(
-      {
-        borderTopLeftRadius: "var(--borderRadius050)",
-        borderBottomLeftRadius: "var(--borderRadius050)",
-      },
-      wrapper.find(StyledDateField).first(),
-      { modifier: `${StyledInputPresentation}` }
-    );
-
-    assertStyleMatch(
-      {
-        borderTopRightRadius: "var(--borderRadius050)",
-        borderBottomRightRadius: "var(--borderRadius050)",
-      },
-      wrapper.find(StyledDateField).last(),
-      { modifier: `${StyledInputPresentation}` }
-    );
   });
 });

--- a/src/components/numeral-date/numeral-date.stories.mdx
+++ b/src/components/numeral-date/numeral-date.stories.mdx
@@ -49,6 +49,16 @@ import NumeralDate from "carbon-react/lib/components/numeral-date";
   <Story name="allowed date formats" story={stories.AllowedDateFormats} />
 </Canvas>
 
+### Validation
+
+<Canvas>
+  <Story name="validation" story={stories.Validation} />
+</Canvas>
+
+<Canvas>
+  <Story name="new validation" story={stories.NewValidation} />
+</Canvas>
+
 ### Internal validation
 
 `NumeralDate` has an optional internal validation mechanism implemented to check if the date partial values are correct.

--- a/src/components/numeral-date/numeral-date.stories.tsx
+++ b/src/components/numeral-date/numeral-date.stories.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from "react";
 import { ComponentStory } from "@storybook/react";
 import NumeralDate from ".";
+import Box from "../box";
+import CarbonProvider from "../carbon-provider";
 
 export const Default: ComponentStory<typeof NumeralDate> = () => (
   <NumeralDate
@@ -25,6 +27,7 @@ export const AllowedDateFormats: ComponentStory<typeof NumeralDate> = () => (
   <>
     <NumeralDate label="DD/MM/YYYY - default" />
     <NumeralDate label="MM/DD/YYYY" dateFormat={["mm", "dd", "yyyy"]} />
+    <NumeralDate label="YYYY/MM/DD" dateFormat={["yyyy", "mm", "dd"]} />
     <NumeralDate label="DD/MM" dateFormat={["dd", "mm"]} />
     <NumeralDate label="MM/DD" dateFormat={["mm", "dd"]} />
     <NumeralDate label="MM/YYYY" dateFormat={["mm", "yyyy"]} />
@@ -60,6 +63,98 @@ export const InternalValidationWarning: ComponentStory<
       onChange={(e) => setValue(e.target.value)}
       value={value}
     />
+  );
+};
+
+export const Validation: ComponentStory<typeof NumeralDate> = () => {
+  const [value, setValue] = useState({ dd: "", mm: "", yyyy: "" });
+  return (
+    <>
+      <NumeralDate
+        label="Validation as string"
+        error="Error Message (Fix is required)"
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+      />
+
+      <NumeralDate
+        label="Validation as string on label"
+        error="Error Message (Fix is required)"
+        validationOnLabel
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+      />
+
+      <NumeralDate
+        label="Validation as boolean"
+        error
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+      />
+
+      <NumeralDate
+        label="Validation as string"
+        warning="Warning Message (Fix is optional)"
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+      />
+
+      <NumeralDate
+        label="Validation as string on label"
+        warning="Warning Message (Fix is optional)"
+        validationOnLabel
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+      />
+
+      <NumeralDate
+        label="Validation as boolean"
+        warning
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+      />
+    </>
+  );
+};
+
+export const NewValidation: ComponentStory<typeof NumeralDate> = () => {
+  const [value, setValue] = useState({ dd: "", mm: "", yyyy: "" });
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      <Box m={2}>
+        <NumeralDate
+          label="Validation as string - Error"
+          labelHelp="Label help"
+          error="Error Message (Fix is required)"
+          onChange={(e) => setValue(e.target.value)}
+          value={value}
+        />
+
+        <NumeralDate
+          label="Validation as boolean - Error"
+          labelHelp="Label help"
+          error
+          onChange={(e) => setValue(e.target.value)}
+          value={value}
+        />
+
+        <NumeralDate
+          label="Validation as string - Warning"
+          labelHelp="Label help"
+          warning="Warning Message (Fix is optional)"
+          onChange={(e) => setValue(e.target.value)}
+          value={value}
+        />
+
+        <NumeralDate
+          label="Validation as boolean - Warning"
+          labelHelp="Label help"
+          warning
+          onChange={(e) => setValue(e.target.value)}
+          value={value}
+        />
+      </Box>
+    </CarbonProvider>
   );
 };
 

--- a/src/components/numeral-date/numeral-date.style.ts
+++ b/src/components/numeral-date/numeral-date.style.ts
@@ -1,60 +1,47 @@
 import styled, { css } from "styled-components";
 import StyledValidationIcon from "../../__internal__/validations/validation-icon.style";
 import StyledIconSpan from "../../__internal__/input-icon-toggle/input-icon-toggle.style";
-import StyledInputPresentantion from "../../__internal__/input/input-presentation.style";
+import StyledInputPresentation from "../../__internal__/input/input-presentation.style";
+import StyledInput from "../../__internal__/input/input.style";
 import StyledFormField from "../../__internal__/form-field/form-field.style";
+import StyledLabel from "../../__internal__/label/label.style";
+import { StyledHintText } from "../textbox/textbox.style";
 
 interface StyledDateFieldProps {
-  isStart?: boolean;
   isEnd?: boolean;
-  isMiddle?: boolean;
   isYearInput?: boolean;
-  hasValidationIcon?: boolean;
+  hasValidationIconInField?: boolean;
 }
 
 export const StyledNumeralDate = styled.div<{ name?: string }>`
   display: inline-flex;
-  height: 40px;
   font-size: 14px;
   font-weight: 400;
 
   ${StyledFormField} {
     margin-top: 0px;
   }
+  ${StyledLabel} {
+    font-weight: 400;
+  }
+
+  ${StyledHintText} {
+    color: var(--colorsUtilityYin090);
+  }
 `;
 
 export const StyledDateField = styled.div<StyledDateFieldProps>`
-  ${({ isStart, isYearInput, isEnd, hasValidationIcon, isMiddle }) => {
-    const yearInputOrError = isYearInput || (isEnd && hasValidationIcon);
-
+  ${({ isYearInput, isEnd, hasValidationIconInField }) => {
     return css`
-      ${StyledInputPresentantion} {
+      ${StyledInputPresentation} {
         position: relative;
-        width: ${yearInputOrError ? "78px;" : "58px;"};
-        text-align: center;
-        border-radius: var(--borderRadius000);
+        margin-right: ${isEnd ? "0" : "12px"};
+        min-width: ${isYearInput ? "80px" : "55px"};
 
-        ${
-          isStart &&
-          css`
-            border-top-left-radius: var(--borderRadius050);
-            border-bottom-left-radius: var(--borderRadius050);
-          `
-        }
-
-        ${
-          isEnd &&
-          css`
-            border-top-right-radius: var(--borderRadius050);
-            border-bottom-right-radius: var(--borderRadius050);
-          `
-        }
-
-        ${
-          (isMiddle || isEnd) &&
-          css`
-            margin-left: -1px;
-          `
+        ${StyledInput} {
+          text-align: center;
+          padding: 0 12px;
+          ${hasValidationIconInField && isEnd && "padding-right: 0"}
         }
 
         ${StyledIconSpan} {
@@ -65,6 +52,7 @@ export const StyledDateField = styled.div<StyledDateFieldProps>`
         ${StyledValidationIcon} {
           z-index: 9000;
         }
-      `;
+      }
+    `;
   }}
 `;

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -108,6 +108,11 @@ const enGB: Locale = {
       month: () => "Month should be a number within a 1-12 range.",
       year: () => "Year should be a number within a 1800-2200 range.",
     },
+    labels: {
+      day: () => "Day",
+      month: () => "Month",
+      year: () => "Year",
+    },
   },
   pager: {
     show: () => "Show",

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -83,6 +83,11 @@ interface Locale {
       month: () => string;
       year: () => string;
     };
+    labels: {
+      day: () => string;
+      month: () => string;
+      year: () => string;
+    };
   };
   pager: {
     show: () => string;

--- a/src/locales/pl-pl.ts
+++ b/src/locales/pl-pl.ts
@@ -167,6 +167,11 @@ const plPL: Locale = {
       month: () => "Miesiąć musi być liczbą w zakresie 1-12.",
       year: () => "Rok musi być liczbą w zakresie 1800-2200.",
     },
+    labels: {
+      day: () => "Dzień",
+      month: () => "Miesiąć",
+      year: () => "Rok",
+    },
   },
   pager: {
     show: () => "Pokaż",


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

- Component has 3 separate fields with distinct labels for 'Day', 'Month' and 'Year'. 
- Fields have a gap between them. 
- Supports YYYY/MM/DD date format. 
- New validation side border reaches the message. 
- `labelHelp` tooltip does not appear with new validation hint text. 

![Screenshot 2023-11-23 at 09 35 48](https://github.com/Sage/carbon/assets/78361608/6965b7af-5577-44e0-a4e2-4031a7750ed9)

![Screenshot 2023-11-23 at 09 36 13](https://github.com/Sage/carbon/assets/78361608/89f06a0b-c24c-4ddc-af24-d8e714a33270)

![Screenshot 2023-11-23 at 11 12 40](https://github.com/Sage/carbon/assets/78361608/35430d72-6e6b-4919-9e5c-5f9b43cb1f89)


### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

- Component does not support YYYY/MM/DD date format. 
- Fields do not have distinct labels.
- Fields don't have a gap between them. 
- New validation side border does not reach the message. 
- `labelHelp` tooltip still shows with new validation hint text. 

![Screenshot 2023-11-23 at 09 35 31](https://github.com/Sage/carbon/assets/78361608/fdae4e08-4fbe-4e3e-a532-a4e5a5246702)

![Screenshot 2023-11-23 at 09 36 02](https://github.com/Sage/carbon/assets/78361608/9613195f-8b35-40a8-8118-6a76af40152c)

![Screenshot 2023-11-23 at 11 08 26](https://github.com/Sage/carbon/assets/78361608/6ee9fdc0-1fe5-4850-b915-998aaf10c088)


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
