### PR TITLE
docs(checkbox): add missing import for checkbox group

### DIFF
--- a/src/components/checkbox/checkbox.stories.mdx
+++ b/src/components/checkbox/checkbox.stories.mdx
@@ -30,7 +30,7 @@ import { Checkbox, CheckboxGroup } from ".";
 ## Quick Start
 
 ```javascript
-import { Checkbox } from "carbon-react/lib/components/checkbox";
+import { Checkbox, CheckboxGroup } from "carbon-react/lib/components/checkbox";
 ```
 
 ## Designer Notes


### PR DESCRIPTION
### Proposed behaviour

- Add `CheckboxGroup` import to `Checkbox`'s quick start section

### Current behaviour

- `CheckboxGroup` import in `Checkbox`'s quick start section is missing

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->