### PR TITLE
feat(filterable-select): add disableDefaultFiltering prop

### DIFF
--- a/src/components/select/filterable-select/filterable-select.component.tsx
+++ b/src/components/select/filterable-select/filterable-select.component.tsx
@@ -84,6 +84,9 @@ export interface FilterableSelectProps
    * Higher values make for smoother scrolling but may impact performance.
    * Only used if the `enableVirtualScroll` prop is set. */
   virtualScrollOverscan?: number;
+  /** Boolean to disable automatic filtering and highlighting of options.
+   * This allows custom filtering and option styling to be performed outside of the component when the filter text changes. */
+  disableDefaultFiltering?: boolean;
 }
 
 export const FilterableSelect = React.forwardRef(
@@ -125,6 +128,7 @@ export const FilterableSelect = React.forwardRef(
       inputRef,
       enableVirtualScroll,
       virtualScrollOverscan,
+      disableDefaultFiltering = false,
       ...textboxProps
     }: FilterableSelectProps,
     ref
@@ -626,33 +630,37 @@ export const FilterableSelect = React.forwardRef(
       };
     }
 
-    const selectList = (
-      <FilterableSelectList
-        ref={listboxRef}
-        id={selectListId.current}
-        labelId={labelId}
-        anchorElement={textboxRef?.parentElement || undefined}
-        onSelect={onSelectOption}
-        onSelectListClose={onSelectListClose}
-        onMouseDown={handleListMouseDown}
-        filterText={filterText}
-        highlightedValue={highlightedValue}
-        noResultsMessage={noResultsMessage}
-        disablePortal={disablePortal}
-        listActionButton={listActionButton}
-        listMaxHeight={listMaxHeight}
-        onListAction={handleOnListAction}
-        isLoading={isLoading}
-        onListScrollBottom={onListScrollBottom}
-        tableHeader={tableHeader}
-        multiColumn={multiColumn}
-        loaderDataRole="filterable-select-list-loader"
-        listPlacement={listPlacement}
-        flipEnabled={flipEnabled}
-        isOpen={isOpen}
-        enableVirtualScroll={enableVirtualScroll}
-        virtualScrollOverscan={virtualScrollOverscan}
-      >
+    const selectListProps = {
+      ref: listboxRef,
+      id: selectListId.current,
+      labelId,
+      anchorElement: textboxRef?.parentElement || undefined,
+      onSelect: onSelectOption,
+      onSelectListClose,
+      onMouseDown: handleListMouseDown,
+      filterText,
+      highlightedValue,
+      noResultsMessage,
+      disablePortal,
+      listActionButton,
+      listMaxHeight,
+      onListAction: handleOnListAction,
+      isLoading,
+      onListScrollBottom,
+      tableHeader,
+      multiColumn,
+      loaderDataRole: "filterable-select-list-loader",
+      listPlacement,
+      flipEnabled,
+      isOpen,
+      enableVirtualScroll,
+      virtualScrollOverscan,
+    };
+
+    const selectList = disableDefaultFiltering ? (
+      <SelectList {...selectListProps}>{children}</SelectList>
+    ) : (
+      <FilterableSelectList {...selectListProps} filterText={filterText}>
         {children}
       </FilterableSelectList>
     );

--- a/src/components/select/filterable-select/filterable-select.spec.tsx
+++ b/src/components/select/filterable-select/filterable-select.spec.tsx
@@ -1334,33 +1334,64 @@ describe("FilterableSelect", () => {
       wrapper.find(StyledSelectListContainer)
     );
   });
-});
 
-describe("coverage filler for else path", () => {
-  const wrapper = renderSelect();
-  simulateSelectTextboxEvent(wrapper, "blur");
-});
-
-describe("when maxWidth is passed", () => {
-  it("should be passed to InputPresentation", () => {
-    const wrapper = renderSelect({ maxWidth: "67%" });
-
-    assertStyleMatch(
-      {
-        maxWidth: "67%",
-      },
-      wrapper.find(InputPresentation)
-    );
+  describe("coverage filler for else path", () => {
+    const wrapper = renderSelect();
+    simulateSelectTextboxEvent(wrapper, "blur");
   });
 
-  it("renders with maxWidth as 100% when no maxWidth is specified", () => {
-    const wrapper = renderSelect({ maxWidth: "" });
+  describe("when maxWidth is passed", () => {
+    it("should be passed to InputPresentation", () => {
+      const wrapper = renderSelect({ maxWidth: "67%" });
 
-    assertStyleMatch(
-      {
-        maxWidth: "100%",
-      },
-      wrapper.find(InputPresentation)
-    );
+      assertStyleMatch(
+        {
+          maxWidth: "67%",
+        },
+        wrapper.find(InputPresentation)
+      );
+    });
+
+    it("renders with maxWidth as 100% when no maxWidth is specified", () => {
+      const wrapper = renderSelect({ maxWidth: "" });
+
+      assertStyleMatch(
+        {
+          maxWidth: "100%",
+        },
+        wrapper.find(InputPresentation)
+      );
+    });
+  });
+  describe("when the disableDefaultFiltering prop is set", () => {
+    it('shows all options when "disableDefaultFiltering" is true', () => {
+      const wrapper = renderSelect({ disableDefaultFiltering: true });
+
+      simulateSelectTextboxEvent(wrapper, "change", {
+        target: { value: "red" },
+      });
+
+      expect(wrapper.find(Option)).toHaveLength(4);
+    });
+
+    it('hides filtered options when "disableDefaultFiltering" is false', () => {
+      const wrapper = renderSelect({ disableDefaultFiltering: false });
+
+      simulateSelectTextboxEvent(wrapper, "change", {
+        target: { value: "red" },
+      });
+
+      expect(wrapper.find(Option)).toHaveLength(1);
+    });
+
+    it('hides filtered options when "disableDefaultFiltering" is unspecified', () => {
+      const wrapper = renderSelect();
+
+      simulateSelectTextboxEvent(wrapper, "change", {
+        target: { value: "red" },
+      });
+
+      expect(wrapper.find(Option)).toHaveLength(1);
+    });
   });
 });

--- a/src/components/select/filterable-select/filterable-select.stories.mdx
+++ b/src/components/select/filterable-select/filterable-select.stories.mdx
@@ -177,6 +177,17 @@ a `selectionConfirmed` property on the emitted event when the enter key is press
   <Story name="selection confirmed" story={stories.SelectionConfirmedStory} />
 </Canvas>
 
+### Custom filtering and option styles
+
+By default, filtering and highlighting of options is handled by the component itself.  In order to use custom filtering behaviour, or to use custom styling of option values, the
+default filtering can be disabled using the `disableDefaultFiltering` prop.  
+
+This allows use-cases like server-side filtering of options, or rich formatting of options.
+
+<Canvas>
+  <Story name="custom filtering and option styles" story={stories.CustomFilterAndOptionStyle} />
+</Canvas>
+
 ## Props
 
 ### Filterable Select

--- a/src/components/select/filterable-select/filterable-select.stories.tsx
+++ b/src/components/select/filterable-select/filterable-select.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useMemo, useCallback } from "react";
 import {
   CustomSelectChangeEvent,
   FilterableSelect,
@@ -753,3 +753,71 @@ export const SelectionConfirmedStory = () => {
 };
 
 SelectionConfirmedStory.parameters = { chromatic: { disableSnapshot: true } };
+
+export const CustomFilterAndOptionStyle = () => {
+  const [filterText, setFilterText] = useState("");
+  const [selectedColor, setSelectedColor] = useState<string | undefined>();
+
+  const data = useMemo(
+    () =>
+      [
+        { text: "Amber", color: "#FFBF00" },
+        { text: "Black", color: "#000000" },
+        { text: "Blue", color: "#0000FF" },
+        { text: "Brown", color: "#A52A2A" },
+        { text: "Green", color: "#008000" },
+        { text: "Orange", color: "#FFA500" },
+        { text: "Pink", color: "#FFC0CB" },
+        { text: "Purple", color: "#800080" },
+        { text: "Red", color: "#FF0000" },
+        { text: "White", color: "#FFFFFF" },
+        { text: "Yellow", color: "#FFFF00" },
+      ].filter(
+        ({ text }) =>
+          !filterText ||
+          (filterText.trim().length &&
+            text.toLowerCase().includes(filterText.trim().toLowerCase()))
+      ),
+    [filterText]
+  );
+
+  const handleChange = useCallback((e: CustomSelectChangeEvent) => {
+    if (e.selectionConfirmed && e.target?.value) {
+      setSelectedColor(e.target.value as string);
+    } else {
+      setSelectedColor(undefined);
+    }
+  }, []);
+
+  return (
+    <Box p={1}>
+      <Typography variant="strong" mb={2} display="block">
+        Selected Color:{" "}
+        {selectedColor ? (
+          <Icon type="favourite" color={selectedColor} />
+        ) : (
+          "[none]"
+        )}
+      </Typography>
+      <FilterableSelect
+        onChange={handleChange}
+        onFilterChange={setFilterText}
+        name="Custom filter and option styles"
+        id="custom-filter-and-option-styles"
+        label="Color"
+        disableDefaultFiltering
+      >
+        {data.map(({ text, color }) => (
+          <Option text={text} value={color} key={color}>
+            <Icon type="favourite" color={color} mr={1} />
+            {text}
+          </Option>
+        ))}
+      </FilterableSelect>
+    </Box>
+  );
+};
+
+CustomFilterAndOptionStyle.parameters = {
+  chromatic: { disableSnapshot: true },
+};


### PR DESCRIPTION
### Proposed behaviour

Adds a new boolean prop to the FilterableSelect component, `disableDefaultFiltering`.

- By default `disableDefaultFiltering` is `false`, and filtering and highlighting of options is handled by the component itself. 
 - If `disableDefaultFiltering` is set to `true`, the component does not automatically filter or highlight options as the user enters a text filter.

This allows use-cases like server-side filtering of options, or rich formatting of options.  Our use-case is an address search dropdown.

The new implementation uses a `FilterableSelectList` by default, and a `SelectList` if `disableDefaultFiltering` is `true`.  It is still appropriate to use a `FilterableSelect` in this case, because we still want access to the filter which is typed into the textbox.

Screenshot of the storybook demo:
<img width="1024" alt="custom-filterable-select" src="https://github.com/Sage/carbon/assets/12202813/6d22f851-7900-4a79-803a-f86f04a03634">

### Current behaviour

Custom filtering and styling is not possible, because the `FilterableSelectList` component manipulates the child `Option` components as the user enters a text filter.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the previous behaviour, where filtering breaks the option styling:
https://codesandbox.io/s/carbon-quickstart-j5pb2

You can see the new behaviour by looking at the version below:
https://codesandbox.io/p/sandbox/carbon-quickstart-typescript-forked-lr2pr9
