### PR TITLE
fix(textbox): ensure no action is triggered when disabled or readOnly input or input icon is clicked FE-6293

### DIFF
--- a/src/components/date/date.component.tsx
+++ b/src/components/date/date.component.tsx
@@ -328,10 +328,6 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
     const handleClick = (
       ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>
     ) => {
-      if (disabled || readOnly) {
-        return;
-      }
-
       if (onClick) {
         onClick(ev);
       }
@@ -339,10 +335,6 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
 
     const handleMouseDown = (ev: React.MouseEvent<HTMLElement>) => {
       handleClickInside();
-
-      if (disabled || readOnly) {
-        return;
-      }
 
       if (setInputRefMap) {
         isBlurBlocked.current = true;

--- a/src/components/select/select-textbox/select-textbox.component.tsx
+++ b/src/components/select/select-textbox/select-textbox.component.tsx
@@ -163,10 +163,6 @@ const SelectTextbox = React.forwardRef(
     function handleTextboxClick(
       event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>
     ) {
-      if (disabled || readOnly) {
-        return;
-      }
-
       onClick?.(event as React.MouseEvent<HTMLInputElement>);
     }
 
@@ -238,7 +234,7 @@ const SelectTextbox = React.forwardRef(
           <SelectText
             transparent={transparent}
             placeholder={placeholder || l.select.placeholder()}
-            onClick={handleTextboxClick}
+            onClick={disabled || readOnly ? undefined : handleTextboxClick}
             disabled={disabled}
             readOnly={readOnly}
             size={size}

--- a/src/components/textbox/textbox.component.tsx
+++ b/src/components/textbox/textbox.component.tsx
@@ -282,9 +282,9 @@ export const Textbox = React.forwardRef(
           onBlur={onBlur}
           onChange={onChange}
           onChangeDeferred={onChangeDeferred}
-          onClick={onClick}
+          onClick={disabled || readOnly ? undefined : onClick}
           onFocus={onFocus}
-          onMouseDown={onMouseDown}
+          onMouseDown={disabled || readOnly ? undefined : onMouseDown}
           placeholder={disabled || readOnly ? "" : placeholder}
           readOnly={readOnly}
           value={typeof formattedValue === "string" ? formattedValue : value}
@@ -299,8 +299,10 @@ export const Textbox = React.forwardRef(
           iconTabIndex={iconTabIndex}
           info={info}
           inputIcon={inputIcon}
-          onClick={iconOnClick || onClick}
-          onMouseDown={iconOnMouseDown || onMouseDown}
+          onClick={disabled || readOnly ? undefined : iconOnClick || onClick}
+          onMouseDown={
+            disabled || readOnly ? undefined : iconOnMouseDown || onMouseDown
+          }
           readOnly={readOnly}
           size={size}
           useValidationIcon={!(validationRedesignOptIn || validationOnLabel)}

--- a/src/components/textbox/textbox.pw.tsx
+++ b/src/components/textbox/textbox.pw.tsx
@@ -769,6 +769,90 @@ test.describe("Event checks", () => {
     expect(callbackCount).toBe(1);
   });
 
+  ["disabled", "readOnly"].forEach((propName) => {
+    test(`should not call onClick callback when a click event is triggered and input is ${propName}`, async ({
+      mount,
+      page,
+    }) => {
+      let callbackCount = 0;
+      await mount(
+        <TextboxComponent
+          onClick={() => {
+            callbackCount += 1;
+          }}
+          disabled={propName === "disabled"}
+          readOnly={propName === "readOnly"}
+        />
+      );
+
+      await textboxInput(page).dispatchEvent("click");
+
+      expect(callbackCount).toBe(0);
+    });
+
+    test(`should not call onMouseDown callback when a click event is triggered and input is ${propName}`, async ({
+      mount,
+      page,
+    }) => {
+      let callbackCount = 0;
+      await mount(
+        <TextboxComponent
+          onMouseDown={() => {
+            callbackCount += 1;
+          }}
+          disabled={propName === "disabled"}
+          readOnly={propName === "readOnly"}
+        />
+      );
+
+      await textboxInput(page).dispatchEvent("mousedown");
+
+      expect(callbackCount).toBe(0);
+    });
+
+    test(`should not call iconOnMouseDown callback when a click event is triggered and input is ${propName}`, async ({
+      mount,
+      page,
+    }) => {
+      let callbackCount = 0;
+      await mount(
+        <TextboxComponent
+          iconOnMouseDown={() => {
+            callbackCount += 1;
+          }}
+          inputIcon="add"
+          disabled={propName === "disabled"}
+          readOnly={propName === "readOnly"}
+        />
+      );
+
+      await getDataComponentByValue(page, "icon").click({ button: "left" });
+
+      expect(callbackCount).toBe(0);
+    });
+
+    test(`should not call iconOnClick callback when a click event is triggered and input is ${propName}`, async ({
+      mount,
+      page,
+    }) => {
+      let callbackCount = 0;
+      await mount(
+        <TextboxComponent
+          iconOnClick={() => {
+            callbackCount += 1;
+          }}
+          inputIcon="add"
+          disabled={propName === "disabled"}
+          readOnly={propName === "readOnly"}
+        />
+      );
+
+      await getDataComponentByValue(page, "icon").click();
+
+      expect(callbackCount).toBe(0);
+    });
+  });
+
   test("should call onClick callback when a click event is triggered", async ({
     mount,
     page,

--- a/src/components/textbox/textbox.spec.tsx
+++ b/src/components/textbox/textbox.spec.tsx
@@ -177,6 +177,7 @@ describe("Textbox", () => {
       expect(wrapper.find(InputPresentation).props().hasIcon).toBe(true);
     }
   );
+
   it("supports a separate onClick handler passing for the icon", () => {
     const onClick = jest.fn();
     const iconOnClick = jest.fn();
@@ -196,6 +197,100 @@ describe("Textbox", () => {
     expect(iconOnClick).toHaveBeenCalled();
     expect(onClick).not.toHaveBeenCalled();
   });
+
+  it.each(["disabled", "readOnly"])(
+    "does not call iconOnClick handler for the icon when input is %s",
+    (propName) => {
+      const onClick = jest.fn();
+      const iconOnClick = jest.fn();
+
+      const wrapper = mount(
+        <Textbox
+          value="foobar"
+          inputIcon="search"
+          onClick={onClick}
+          iconOnClick={iconOnClick}
+          disabled={propName === "disabled"}
+          readOnly={propName === "readOnly"}
+        >
+          normal children
+        </Textbox>
+      );
+      const icon = wrapper.find(InputIconToggle);
+      icon.simulate("click");
+      expect(iconOnClick).not.toHaveBeenCalled();
+      expect(onClick).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(["disabled", "readOnly"])(
+    "does not call iconOnMouseDown handler for the icon when input is %s",
+    (propName) => {
+      const onMouseDown = jest.fn();
+      const iconOnMouseDown = jest.fn();
+
+      const wrapper = mount(
+        <Textbox
+          value="foobar"
+          inputIcon="search"
+          onMouseDown={onMouseDown}
+          iconOnMouseDown={iconOnMouseDown}
+          disabled={propName === "disabled"}
+          readOnly={propName === "readOnly"}
+        >
+          normal children
+        </Textbox>
+      );
+      const icon = wrapper.find(InputIconToggle);
+      icon.simulate("click");
+      expect(iconOnMouseDown).not.toHaveBeenCalled();
+      expect(onMouseDown).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(["disabled", "readOnly"])(
+    "does not call onClick handler when input is %s and icon is clicked",
+    (propName) => {
+      const onClick = jest.fn();
+
+      const wrapper = mount(
+        <Textbox
+          value="foobar"
+          inputIcon="search"
+          onClick={onClick}
+          disabled={propName === "disabled"}
+          readOnly={propName === "readOnly"}
+        >
+          normal children
+        </Textbox>
+      );
+      const icon = wrapper.find(InputIconToggle);
+      icon.simulate("click");
+      expect(onClick).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(["disabled", "readOnly"])(
+    "does not call onMouseDown handler when input is %s and icon is clicked",
+    (propName) => {
+      const onMouseDown = jest.fn();
+
+      const wrapper = mount(
+        <Textbox
+          value="foobar"
+          inputIcon="search"
+          onMouseDown={onMouseDown}
+          disabled={propName === "disabled"}
+          readOnly={propName === "readOnly"}
+        >
+          normal children
+        </Textbox>
+      );
+      const icon = wrapper.find(InputIconToggle);
+      icon.simulate("click");
+      expect(onMouseDown).not.toHaveBeenCalled();
+    }
+  );
 
   describe("validation icon", () => {
     const validationTypes = ["error", "warning", "info"];


### PR DESCRIPTION
fix #6471

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

Ensures that `click` and `mousedown` event handlers are not triggered when `disabled` or `readOnly` `Textbox` based components or the input `Icon` is clicked.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Textbox based components set to readOnly or disabled can still trigger and action when clicked

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Playwright automation tests added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
