### PR TITLE
feat(step-flow): add new component

### DIFF
--- a/playwright/components/step-flow/index.ts
+++ b/playwright/components/step-flow/index.ts
@@ -1,0 +1,35 @@
+import { Page } from "playwright-core";
+import {
+  STEP_FLOW_PROGRESS_INDICATOR,
+  STEP_FLOW_CATEGORY_TEXT,
+  STEP_FLOW_TITLE_TEXT_WRAPPER,
+  STEP_FLOW_TITLE_TEXT,
+  STEP_FLOW_VISUALLY_HIDDEN_TITLE_TEXT,
+  STEP_FLOW_PROGRESS_INDICATOR_BAR,
+  STEP_FLOW_LABEL,
+  STEP_FLOW_DISMISS_ICON,
+} from "./locators";
+
+// component preview locators
+export const stepFlowProgressIndicator = (page: Page) =>
+  page.locator(STEP_FLOW_PROGRESS_INDICATOR);
+
+export const stepFlowCategoryText = (page: Page) =>
+  page.locator(STEP_FLOW_CATEGORY_TEXT);
+
+export const stepFlowTitleText = (page: Page) =>
+  page.locator(STEP_FLOW_TITLE_TEXT);
+
+export const stepFlowTitleTextWrapper = (page: Page) =>
+  page.locator(STEP_FLOW_TITLE_TEXT_WRAPPER);
+
+export const stepFlowVisuallyHiddenTitleText = (page: Page) =>
+  page.locator(STEP_FLOW_VISUALLY_HIDDEN_TITLE_TEXT);
+
+export const stepFlowProgressIndicatorBar = (page: Page) =>
+  page.locator(STEP_FLOW_PROGRESS_INDICATOR_BAR);
+
+export const stepFlowLabel = (page: Page) => page.locator(STEP_FLOW_LABEL);
+
+export const stepFlowDismissIcon = (page: Page) =>
+  page.locator(STEP_FLOW_DISMISS_ICON);

--- a/playwright/components/step-flow/locators.ts
+++ b/playwright/components/step-flow/locators.ts
@@ -1,0 +1,12 @@
+export const STEP_FLOW_PROGRESS_INDICATOR =
+  '[data-element="progress-indicator"]';
+export const STEP_FLOW_CATEGORY_TEXT = '[data-element="category-text"]';
+export const STEP_FLOW_TITLE_TEXT_WRAPPER =
+  '[data-element="title-text-wrapper"]';
+export const STEP_FLOW_TITLE_TEXT = '[data-element="visible-title-text"]';
+export const STEP_FLOW_VISUALLY_HIDDEN_TITLE_TEXT =
+  '[data-element="visually-hidden-title-text"]';
+export const STEP_FLOW_PROGRESS_INDICATOR_BAR =
+  '[data-element="progress-indicator-bar"]';
+export const STEP_FLOW_LABEL = '[data-element="step-label"]';
+export const STEP_FLOW_DISMISS_ICON = 'span[data-element="close"]';

--- a/src/components/step-flow/components.test-pw.tsx
+++ b/src/components/step-flow/components.test-pw.tsx
@@ -1,0 +1,37 @@
+import React, { useRef } from "react";
+import Button from "../button";
+import Box from "../box";
+import { StepFlow, StepFlowProps } from ".";
+import { StepFlowHandle } from "./step-flow.component";
+
+export const StepFlowComponent = (props: Partial<StepFlowProps>) => (
+  <StepFlow title="foo" currentStep={1} totalSteps={8} {...props} />
+);
+
+export const StepFlowComponentWithRefAndButtons = (
+  props: Partial<StepFlowProps>
+) => {
+  const stepFlowHandle = useRef<StepFlowHandle>(null);
+
+  const focusOnTitle = () => {
+    stepFlowHandle.current?.focus();
+  };
+
+  return (
+    <Box>
+      <StepFlow
+        title="foo"
+        currentStep={1}
+        totalSteps={8}
+        ref={stepFlowHandle}
+        {...props}
+      />
+      <Button buttonType="tertiary" onClick={() => focusOnTitle()} mr={2}>
+        Back
+      </Button>
+      <Button buttonType="primary" onClick={() => focusOnTitle()}>
+        Continue
+      </Button>
+    </Box>
+  );
+};

--- a/src/components/step-flow/index.ts
+++ b/src/components/step-flow/index.ts
@@ -1,0 +1,2 @@
+export { default as StepFlow } from "./step-flow.component";
+export type { StepFlowProps } from "./step-flow.component";

--- a/src/components/step-flow/step-flow-test.stories.tsx
+++ b/src/components/step-flow/step-flow-test.stories.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { StepFlow, StepFlowProps } from ".";
+
+export default {
+  title: "Step Flow/Test",
+  includeStories: ["Default"],
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disableSnapshot: true,
+    },
+  },
+  argTypes: {
+    category: {
+      control: {
+        type: "text",
+      },
+    },
+    title: {
+      control: {
+        type: "text",
+      },
+    },
+    totalSteps: {
+      control: {
+        min: 1,
+        max: 8,
+        step: 1,
+        type: "range",
+      },
+    },
+    currentStep: {
+      control: {
+        min: 1,
+        max: 8,
+        step: 1,
+        type: "range",
+      },
+    },
+    showProgressIndicator: {
+      control: {
+        type: "boolean",
+      },
+    },
+    showCloseIcon: {
+      control: {
+        type: "boolean",
+      },
+    },
+  },
+};
+
+export const Default = (props: Partial<StepFlowProps>) => (
+  <StepFlow title="default" currentStep={1} totalSteps={8} {...props} />
+);
+
+Default.storyName = "default";

--- a/src/components/step-flow/step-flow.component.tsx
+++ b/src/components/step-flow/step-flow.component.tsx
@@ -1,0 +1,230 @@
+import React, { useImperativeHandle, useRef, forwardRef } from "react";
+import { MarginProps } from "styled-system";
+import Icon from "../icon";
+import IconButton from "../icon-button";
+import {
+  StyledStepFlow,
+  StyledStepContent,
+  StyledStepContentText,
+  StyledStepLabelAndProgress,
+  StyledProgressIndicatorBar,
+  StyledProgressIndicator,
+  StyledTitleFocusWrapper,
+} from "./step-flow.style";
+import tagComponent, {
+  TagProps,
+} from "../../__internal__/utils/helpers/tags/tags";
+import Typography from "../typography";
+import useLocale from "../../hooks/__internal__/useLocale";
+
+export type Steps = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+export interface StepFlowProps extends MarginProps, TagProps {
+  /** A category for the user journey.  */
+  category?: string;
+  /** The title of the current step.  */
+  title: string;
+  /** Set the variant of the internal 'Typography' component which contains the title.
+   * However, despite the chosen variant the styling will always be overridden.
+   */
+  titleVariant?: "h1" | "h2";
+  /** The total steps in the user journey.  */
+  totalSteps: Steps;
+  /**
+   * The current step of the user journey. If the set `currentStep` is higher than
+   * `totalSteps`the value of `currentStep` will be that of `totalSteps` instead.
+   */
+  currentStep: Steps;
+  /** Determines if the progress indicator is shown. */
+  showProgressIndicator?: boolean;
+  /** Determines if the close icon button is shown */
+  showCloseIcon?: boolean;
+  /** function runs when user click dismiss button */
+  onDismiss?: (
+    e:
+      | React.KeyboardEvent<HTMLButtonElement>
+      | React.MouseEvent<HTMLButtonElement>
+  ) => void;
+}
+
+export type StepFlowHandle = {
+  /** Programmatically focus on root container of Dialog. */
+  focus: () => void;
+} | null;
+
+export const StepFlow = forwardRef<StepFlowHandle, StepFlowProps>(
+  (
+    {
+      category,
+      title,
+      titleVariant,
+      totalSteps,
+      currentStep,
+      showProgressIndicator = false,
+      showCloseIcon = false,
+      onDismiss,
+      ...rest
+    },
+    ref
+  ) => {
+    const totalStepsArray = Array.from(
+      { length: totalSteps },
+      (_, index) => index + 1
+    );
+
+    const validatedCurrentStep =
+      currentStep > totalSteps ? totalSteps : currentStep;
+
+    let currentStepWarnTriggered = false;
+    let noRefWarnTriggered = false;
+
+    /* eslint-disable no-console */
+    if (!currentStepWarnTriggered && currentStep > totalSteps) {
+      currentStepWarnTriggered = true;
+      console.warn(
+        "[WARNING] The `currentStep` prop should not be higher than the `totalSteps`prop in `StepFlow`." +
+          " Please ensure `currentStep`s value does not exceed that of `totalSteps`, in the meantime" +
+          " we have set `currentStep` value to that of `totalSteps`, and all indicators have been marked as completed."
+      );
+    }
+    if (!noRefWarnTriggered && !ref) {
+      noRefWarnTriggered = true;
+      console.warn(
+        "[WARNING] A `ref` should be provided to ensure focus is programmatically focused back to a title div," +
+          " this ensures screen reader users are informed regarding any changes and can navigate back down the page."
+      );
+    }
+
+    const progressIndicators = totalStepsArray.map((step) => {
+      const generateDataState = () => {
+        if (step === validatedCurrentStep) {
+          return "in-progress";
+        }
+        if (step < validatedCurrentStep) {
+          return "is-completed";
+        }
+        return "not-completed";
+      };
+
+      return (
+        <StyledProgressIndicator
+          key={step}
+          aria-hidden="true"
+          data-element="progress-indicator"
+          isCompleted={step < validatedCurrentStep}
+          isInProgress={step === validatedCurrentStep}
+          data-state={generateDataState()}
+        >
+          &nbsp;
+        </StyledProgressIndicator>
+      );
+    });
+
+    const locale = useLocale();
+
+    const closeIcon = (
+      <IconButton
+        data-element="close"
+        aria-label={locale.stepFlow.closeIconAriaLabel?.()}
+        onClick={onDismiss}
+      >
+        <Icon type="close" />
+      </IconButton>
+    );
+
+    const titleRef = useRef<HTMLDivElement>(null);
+
+    useImperativeHandle<StepFlowHandle, StepFlowHandle>(
+      ref,
+      () => ({
+        focus() {
+          titleRef.current?.focus();
+        },
+      }),
+      []
+    );
+
+    const stepFlowTitle = (
+      <StyledTitleFocusWrapper
+        data-element="title-text-wrapper"
+        tabIndex={-1}
+        ref={titleRef}
+      >
+        <Typography variant={titleVariant || "h1"} data-element="title-text">
+          <Typography
+            fontWeight="900"
+            fontSize="var(--fontSizes600)"
+            lineHeight="var(--sizing375)"
+            variant="span"
+            aria-hidden="true"
+            data-element="visible-title-text"
+          >
+            {title}
+          </Typography>
+          <Typography
+            variant="span"
+            data-element="visually-hidden-title-text"
+            screenReaderOnly
+          >
+            {locale.stepFlow.screenReaderOnlyTitle(
+              title,
+              validatedCurrentStep,
+              totalSteps,
+              category
+            )}
+          </Typography>
+        </Typography>
+      </StyledTitleFocusWrapper>
+    );
+
+    const stepFlowLabel = (
+      <Typography
+        variant="span"
+        fontWeight="400"
+        fontSize="var(--fontSizes200)"
+        lineHeight="var(--sizing300)"
+        data-element="step-label"
+        aria-hidden="true"
+      >
+        {locale.stepFlow.stepLabel(validatedCurrentStep, totalSteps)}
+      </Typography>
+    );
+
+    return (
+      <StyledStepFlow {...rest} {...tagComponent("step-flow", rest)}>
+        <StyledStepContent>
+          {category ? (
+            <StyledStepContentText>
+              <Typography
+                fontWeight="500"
+                fontSize="var(--fontSizes100)"
+                lineHeight="var(--sizing250)"
+                variant="span"
+                data-element="category-text"
+                aria-hidden="true"
+              >
+                {category}
+              </Typography>
+              {stepFlowTitle}
+            </StyledStepContentText>
+          ) : (
+            stepFlowTitle
+          )}
+          {showCloseIcon ? closeIcon : null}
+        </StyledStepContent>
+        {showProgressIndicator ? (
+          <StyledStepLabelAndProgress>
+            {stepFlowLabel}
+            <StyledProgressIndicatorBar data-element="progress-indicator-bar">
+              {progressIndicators}
+            </StyledProgressIndicatorBar>
+          </StyledStepLabelAndProgress>
+        ) : (
+          stepFlowLabel
+        )}
+      </StyledStepFlow>
+    );
+  }
+);
+
+export default StepFlow;

--- a/src/components/step-flow/step-flow.pw.tsx
+++ b/src/components/step-flow/step-flow.pw.tsx
@@ -1,0 +1,290 @@
+import React from "react";
+import { test, expect } from "@playwright/experimental-ct-react17";
+import {
+  checkAccessibility,
+  getDesignTokensByCssProperty,
+} from "../../../playwright/support/helper";
+import {
+  StepFlowComponent,
+  StepFlowComponentWithRefAndButtons,
+} from "./components.test-pw";
+
+import { Steps } from "./step-flow.component";
+
+import {
+  stepFlowProgressIndicator,
+  stepFlowCategoryText,
+  stepFlowTitleTextWrapper,
+  stepFlowTitleText,
+  stepFlowVisuallyHiddenTitleText,
+  stepFlowProgressIndicatorBar,
+  stepFlowLabel,
+  stepFlowDismissIcon,
+} from "../../../playwright/components/step-flow";
+
+import { button } from "../../../playwright/components";
+
+import { CHARACTERS } from "../../../playwright/support/constants";
+
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+
+test.describe("Prop checks for StepFlow component", () => {
+  testData.forEach((stringVals) => {
+    test(`should render with the category prop, when the prop's value is ${stringVals}`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(<StepFlowComponent category={stringVals} />);
+
+      await expect(stepFlowCategoryText(page)).toHaveText(stringVals);
+    });
+  });
+
+  testData.forEach((stringVals) => {
+    test(`should render with the title prop, when the prop's value is ${stringVals}`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(<StepFlowComponent title={stringVals} />);
+
+      await expect(stepFlowTitleText(page)).toHaveText(stringVals);
+    });
+  });
+
+  (["h1", "h2"] as const).forEach((titleVariants) => {
+    test(`should render with the titleVariant prop, when the prop's value is ${titleVariants}`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <StepFlowComponent title="foo" titleVariant={titleVariants} />
+      );
+
+      await expect(page.locator(titleVariants)).toContainText("foo");
+    });
+  });
+
+  test("should render the correct element when 'showProgressIndicator' is true", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<StepFlowComponent showProgressIndicator />);
+
+    await expect(stepFlowProgressIndicatorBar(page)).toBeVisible();
+  });
+
+  ([
+    [1, 1],
+    [2, 1],
+    [2, 3],
+  ] as [Steps, Steps][]).forEach(([totalSteps, currentStep]) => {
+    test(`should render the correct label when the 'totalSteps' prop is passed as ${totalSteps} and 'currentStep' is ${currentStep}`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <StepFlowComponent totalSteps={totalSteps} currentStep={currentStep} />
+      );
+
+      if (totalSteps >= currentStep) {
+        await expect(stepFlowLabel(page)).toHaveText(
+          `Step ${currentStep} of ${totalSteps}`
+        );
+      } else {
+        await expect(stepFlowLabel(page)).toHaveText(
+          `Step ${totalSteps} of ${totalSteps}`
+        );
+      }
+    });
+  });
+
+  ([
+    [1, 1],
+    [2, 1],
+    [2, 3],
+  ] as [Steps, Steps][]).forEach(([totalSteps, currentStep]) => {
+    test(`should render the correct visually hidden title when the 'totalSteps' prop is passed as ${totalSteps} and 'currentStep' is ${currentStep}, and the category and title props are also passed`, async ({
+      mount,
+      page,
+    }) => {
+      const category = "foo";
+      const title = "bar";
+
+      await mount(
+        <StepFlowComponent
+          totalSteps={totalSteps}
+          currentStep={currentStep}
+          category={category}
+          title={title}
+        />
+      );
+
+      if (totalSteps >= currentStep) {
+        await expect(stepFlowVisuallyHiddenTitleText(page)).toHaveText(
+          `${category}. ${title}. Step ${currentStep} of ${totalSteps}.`
+        );
+      } else {
+        await expect(stepFlowVisuallyHiddenTitleText(page)).toHaveText(
+          `${category}. ${title}. Step ${totalSteps} of ${totalSteps}.`
+        );
+      }
+    });
+  });
+
+  ([1, 2, 3, 4, 5, 6, 7, 8] as Steps[]).forEach((totalSteps) => {
+    test(`should render the correct amount of progress indicators when the 'totalSteps' prop is passed as ${totalSteps}`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <StepFlowComponent totalSteps={totalSteps} showProgressIndicator />
+      );
+
+      expect(await stepFlowProgressIndicator(page).count()).toEqual(totalSteps);
+    });
+  });
+
+  test("should render the correct element when 'showCloseIcon' is true", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<StepFlowComponent showCloseIcon />);
+
+    await expect(stepFlowDismissIcon(page)).toBeVisible();
+  });
+
+  test("background colour token should be correct when 'showCloseIcon' is true and the indicator is in progress", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <StepFlowComponent currentStep={1} totalSteps={1} showProgressIndicator />
+    );
+
+    const backgroundColorToken = await getDesignTokensByCssProperty(
+      page,
+      stepFlowProgressIndicator(page),
+      "background-color"
+    );
+
+    expect(backgroundColorToken[0]).toBe("--colorsUtilityYin090");
+  });
+
+  test("background colour token should be correct when 'showCloseIcon' is true and the indicator is completed", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <StepFlowComponent currentStep={2} totalSteps={3} showProgressIndicator />
+    );
+
+    const backgroundColorToken = await getDesignTokensByCssProperty(
+      page,
+      stepFlowProgressIndicator(page).nth(0),
+      "background-color"
+    );
+
+    expect(backgroundColorToken[0]).toBe("--colorsSemanticPositive500");
+  });
+
+  test("background colour should be correct when 'showCloseIcon' is true and the indicator is not completed", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <StepFlowComponent currentStep={2} totalSteps={3} showProgressIndicator />
+    );
+
+    const backgroundColorToken = await getDesignTokensByCssProperty(
+      page,
+      stepFlowProgressIndicator(page).nth(2),
+      "background-color"
+    );
+
+    expect(backgroundColorToken[0]).toBe("--colorsActionDisabled600");
+  });
+});
+
+test.describe("Event checks for StepFlow component", () => {
+  test("should call onDismiss callback when a click event is triggered", async ({
+    mount,
+    page,
+  }) => {
+    let callbackCount = 0;
+    await mount(
+      <StepFlowComponent
+        showCloseIcon
+        onDismiss={() => {
+          callbackCount += 1;
+        }}
+      />
+    );
+    await stepFlowDismissIcon(page).click();
+
+    expect(callbackCount).toBe(1);
+  });
+});
+
+test.describe("Ref checks for StepFlow component", () => {
+  test("should focus on title DOM element when a focus ref is passed", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<StepFlowComponentWithRefAndButtons />);
+
+    await expect(stepFlowTitleTextWrapper(page)).not.toBeFocused();
+    await button(page).nth(1).click();
+
+    await expect(stepFlowTitleTextWrapper(page)).toBeFocused();
+  });
+});
+
+test.describe("Accessibility tests for StepFlow component", () => {
+  test("should pass accessibility checks when component is rendered with required props", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<StepFlowComponent />);
+
+    await checkAccessibility(page);
+  });
+
+  test("should pass accessibility checks when component is rendered with a ref and buttons", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<StepFlowComponentWithRefAndButtons />);
+
+    await checkAccessibility(page);
+  });
+
+  test("should pass accessibility checks when 'showProgressIndicator' is true", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<StepFlowComponent showProgressIndicator />);
+
+    await checkAccessibility(page);
+  });
+
+  test("should pass accessibility checks when 'showProgressIndicator' is true and there are completed, not completed and in-progress indicator steps", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <StepFlowComponent showProgressIndicator currentStep={2} totalSteps={3} />
+    );
+
+    await checkAccessibility(page);
+  });
+
+  test("should pass accessibility checks when 'showCloseIcon' is true", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<StepFlowComponent showCloseIcon />);
+
+    await stepFlowDismissIcon(page).focus();
+    await checkAccessibility(page);
+  });
+});

--- a/src/components/step-flow/step-flow.spec.tsx
+++ b/src/components/step-flow/step-flow.spec.tsx
@@ -1,0 +1,424 @@
+import React from "react";
+import { render, RenderResult, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { StepFlow } from "./index";
+import { StepFlowHandle, Steps } from "./step-flow.component";
+import Button from "../button";
+
+describe("Step Flow component", () => {
+  function generateLimitedVariations(): [Steps, Steps][] {
+    const variations: [Steps, Steps][] = [];
+
+    for (let totalSteps = 1; totalSteps <= 8; totalSteps++) {
+      for (let currentStep = 1; currentStep <= totalSteps; currentStep++) {
+        variations.push([totalSteps as Steps, currentStep as Steps]);
+      }
+    }
+
+    return variations;
+  }
+
+  function generateCurrentStepOverTotalStepsVariations(): [Steps, Steps][] {
+    const variations: [Steps, Steps][] = [];
+
+    for (let totalSteps = 1; totalSteps <= 8; totalSteps++) {
+      for (let currentStep = totalSteps + 1; currentStep <= 8; currentStep++) {
+        variations.push([totalSteps as Steps, currentStep as Steps]);
+      }
+    }
+
+    return variations;
+  }
+
+  function calculateStepStateIndexes(
+    totalSteps: number,
+    currentStepParam: number
+  ) {
+    let currentStep = currentStepParam;
+
+    if (currentStep > totalSteps) {
+      currentStep = totalSteps;
+    }
+
+    const stepsBefore = currentStep - 1;
+    const stepsAfter = totalSteps - currentStep;
+
+    return [stepsBefore, stepsAfter];
+  }
+
+  describe("prop checks", () => {
+    it("when the 'category' prop is passed, the correct element and text renders", () => {
+      render(
+        <StepFlow title="foo" currentStep={5} totalSteps={6} category="bar" />
+      );
+
+      expect(screen.getByText("bar")).toBeInTheDocument();
+    });
+
+    it("when the 'title' prop is passed, the correct element and text renders", () => {
+      render(
+        <StepFlow title="baz" currentStep={5} totalSteps={6} category="bar" />
+      );
+
+      expect(screen.getByText("baz")).toBeInTheDocument();
+    });
+
+    it("when the 'titleVariant' prop is not passed, the variant is h1 by default", () => {
+      const { container } = render(
+        <StepFlow title="this title is a h1" currentStep={5} totalSteps={6} />
+      );
+
+      expect(container.querySelector("h1")).toHaveTextContent(
+        "this title is a h1"
+      );
+    });
+
+    it.each(["h1", "h2"] as const)(
+      "when the 'titleVariant' prop is passed as %s, the correct element renders",
+      (headingLevel) => {
+        const { container } = render(
+          <StepFlow
+            title="foo"
+            category="bar"
+            currentStep={5}
+            totalSteps={6}
+            titleVariant={headingLevel}
+          />
+        );
+
+        expect(container.querySelector(headingLevel)).toBeInTheDocument();
+      }
+    );
+
+    it("when the 'showProgressIndicator' prop is true, the correct element renders", () => {
+      const { container } = render(
+        <StepFlow
+          title="baz"
+          currentStep={5}
+          totalSteps={6}
+          showProgressIndicator
+        />
+      );
+      expect(
+        container.querySelector('[data-element="progress-indicator"]')
+      ).toBeInTheDocument();
+    });
+
+    it.each(generateLimitedVariations())(
+      "when 'totalSteps' is passed as %s and 'currentStep' prop is %s, the step label contains the correct text",
+      (totalSteps, currentStep) => {
+        const { container } = render(
+          <StepFlow
+            {...{
+              title: "baz",
+              totalSteps,
+              currentStep,
+              titleTabIndex: 0,
+            }}
+          />
+        );
+
+        expect(
+          container.querySelector('[data-element="step-label"]')
+        ).toHaveTextContent(`${currentStep} of ${totalSteps}`);
+      }
+    );
+
+    it.each(generateCurrentStepOverTotalStepsVariations())(
+      "when 'totalSteps' is passed as %s and is lower than the 'currentStep' prop of %s, the step label contains the correct text",
+      (totalSteps, currentStep) => {
+        const { container } = render(
+          <StepFlow
+            {...{
+              title: "baz",
+              totalSteps,
+              currentStep,
+              titleTabIndex: 0,
+            }}
+          />
+        );
+
+        expect(
+          container.querySelector('[data-element="step-label"]')
+        ).toHaveTextContent(`${totalSteps} of ${totalSteps}`);
+      }
+    );
+
+    it.each(generateLimitedVariations())(
+      "when 'totalSteps' is passed as %s and 'currentStep' prop is %s, the visually hidden title text contains the correct text",
+      (totalSteps, currentStep) => {
+        const category = "foo";
+        const title = "bar";
+
+        const { container } = render(
+          <StepFlow
+            {...{
+              category,
+              title,
+              totalSteps,
+              currentStep,
+              titleTabIndex: 0,
+            }}
+          />
+        );
+
+        expect(
+          container.querySelector('[data-element="visually-hidden-title-text"]')
+        ).toHaveTextContent(
+          `${category}. ${title}. Step ${currentStep} of ${totalSteps}.`
+        );
+      }
+    );
+
+    it.each(generateCurrentStepOverTotalStepsVariations())(
+      "when 'totalSteps' is passed as %s and is lower than the 'currentStep' prop of %s, the visually hidden title text contains the correct text",
+      (totalSteps, currentStep) => {
+        const category = "foo";
+        const title = "bar";
+
+        const { container } = render(
+          <StepFlow
+            {...{
+              category,
+              title,
+              totalSteps,
+              currentStep,
+              titleTabIndex: 0,
+            }}
+          />
+        );
+
+        expect(
+          container.querySelector('[data-element="visually-hidden-title-text"]')
+        ).toHaveTextContent(
+          `${category}. ${title}. Step ${totalSteps} of ${totalSteps}.`
+        );
+      }
+    );
+
+    it("when the 'showCloseIcon' prop is true, the correct element renders", () => {
+      render(
+        <StepFlow
+          {...{
+            title: "baz",
+            totalSteps: 6,
+            currentStep: 1,
+            showCloseIcon: true,
+          }}
+        />
+      );
+
+      expect(screen.getByLabelText("Close")).toBeInTheDocument();
+    });
+  });
+
+  describe.each(generateLimitedVariations())(
+    "indicator state checks - component used as intended (currentStep is always lower than totalSteps) - totalSteps is %s, currentStep is %s",
+    (totalSteps, currentStep) => {
+      it("only one in progress indicators are rendered", () => {
+        const { container } = render(
+          <StepFlow
+            {...{
+              title: "baz",
+              totalSteps,
+              currentStep,
+              showProgressIndicator: true,
+            }}
+          />
+        );
+
+        const count = container.querySelectorAll('[data-state="in-progress"]')
+          .length;
+        expect(count).toBe(1);
+      });
+
+      it("correct number of completed indicators are rendered", () => {
+        const { container } = render(
+          <StepFlow
+            {...{
+              title: "baz",
+              totalSteps,
+              currentStep,
+              showProgressIndicator: true,
+            }}
+          />
+        );
+
+        const count = container.querySelectorAll('[data-state="is-completed"]')
+          .length;
+        const currentCount = calculateStepStateIndexes(
+          totalSteps,
+          currentStep
+        )[0];
+
+        expect(count).toBe(currentCount);
+      });
+
+      it("correct number of not completed progress indicators are rendered", () => {
+        const { container } = render(
+          <StepFlow
+            {...{
+              title: "baz",
+              totalSteps,
+              currentStep,
+              showProgressIndicator: true,
+            }}
+          />
+        );
+
+        const count = container.querySelectorAll('[data-state="not-completed"]')
+          .length;
+        const currentCount = calculateStepStateIndexes(
+          totalSteps,
+          currentStep
+        )[1];
+
+        expect(count).toBe(currentCount);
+      });
+    }
+  );
+
+  describe.each(generateCurrentStepOverTotalStepsVariations())(
+    "indicator state checks - component not used as intended (currentStep is higher than totalSteps)- totalSteps is %s, currentStep is %s",
+    (totalSteps, currentStep) => {
+      it("only one in progress indicator is rendered", () => {
+        const { container } = render(
+          <StepFlow
+            {...{
+              title: "baz",
+              totalSteps,
+              currentStep,
+              showProgressIndicator: true,
+            }}
+          />
+        );
+
+        const count = container.querySelectorAll('[data-state="in-progress"]')
+          .length;
+        expect(count).toBe(1);
+      });
+
+      it("correct number of completed indicators are rendered", () => {
+        const { container } = render(
+          <StepFlow
+            {...{
+              title: "baz",
+              totalSteps,
+              currentStep,
+              showProgressIndicator: true,
+            }}
+          />
+        );
+
+        const count = container.querySelectorAll('[data-state="is-completed"]')
+          .length;
+        const currentCount = calculateStepStateIndexes(
+          totalSteps,
+          currentStep
+        )[0];
+
+        expect(count).toBe(currentCount);
+      });
+
+      it("no not completed indicators are rendered", () => {
+        const { container } = render(
+          <StepFlow
+            {...{
+              title: "baz",
+              totalSteps,
+              currentStep,
+              showProgressIndicator: true,
+            }}
+          />
+        );
+
+        const count = container.querySelectorAll('[data-state="not-completed"]')
+          .length;
+
+        expect(count).toBe(0);
+      });
+    }
+  );
+
+  describe("when ref handle is passed to StepFlow", () => {
+    it("calling exposed focus method refocuses on StepFlow's root container", async () => {
+      const MockComponent = () => {
+        const stepFlowHandle = React.useRef<StepFlowHandle>(null);
+
+        return (
+          <div>
+            <StepFlow
+              totalSteps={5}
+              currentStep={1}
+              ref={stepFlowHandle}
+              title="foo"
+            />
+            <Button onClick={() => stepFlowHandle.current?.focus()}>
+              Press me to refocus on Dialog
+            </Button>
+          </div>
+        );
+      };
+
+      const user = userEvent.setup();
+      const { container } = render(<MockComponent />);
+      const button = screen.getByRole("button");
+
+      await user.click(button);
+
+      expect(
+        container.querySelector('[data-element="title-text-wrapper"]')
+      ).toHaveFocus();
+    });
+  });
+
+  describe("console warning checks", () => {
+    let instance: RenderResult;
+    let loggerSpy: jest.SpyInstance | jest.Mock;
+
+    const currentStepWarnMessage =
+      "[WARNING] The `currentStep` prop should not be higher than the `totalSteps`prop in `StepFlow`." +
+      " Please ensure `currentStep`s value does not exceed that of `totalSteps`, in the meantime" +
+      " we have set `currentStep` value to that of `totalSteps`, and all indicators have been marked as completed.";
+
+    const noRefWarnMessage =
+      "[WARNING] A `ref` should be provided to ensure focus is programmatically focused back to a title div," +
+      " this ensures screen reader users are informed regarding any changes and can navigate back down the page.";
+    const mockRef = { current: null };
+
+    beforeEach(() => {
+      loggerSpy = jest.spyOn(console, "warn");
+      instance = render(
+        <StepFlow currentStep={4} totalSteps={1} title="foo" ref={mockRef} />
+      );
+    });
+
+    afterEach(() => {
+      loggerSpy.mockRestore();
+      instance.unmount();
+    });
+
+    afterAll(() => {
+      loggerSpy.mockClear();
+      jest.clearAllMocks();
+    });
+
+    it("validates a warning is logged in the console once when currentStep is higher than totalSteps", () => {
+      render(
+        <StepFlow currentStep={4} totalSteps={1} title="foo" ref={mockRef} />
+      );
+
+      expect(loggerSpy).toHaveBeenCalledWith(currentStepWarnMessage);
+
+      loggerSpy.mockRestore();
+    });
+
+    it("validates a warning is logged in the console once when a ref is not passed", () => {
+      render(<StepFlow currentStep={4} totalSteps={1} title="foo" />);
+
+      expect(loggerSpy).toHaveBeenCalledWith(noRefWarnMessage);
+
+      loggerSpy.mockRestore();
+    });
+  });
+});

--- a/src/components/step-flow/step-flow.stories.mdx
+++ b/src/components/step-flow/step-flow.stories.mdx
@@ -1,0 +1,170 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
+import { StepFlow } from "."
+import { StepFlowHandle } from "./step-flow.component"
+import * as stories from "./step-flow.stories.tsx";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
+
+<Meta
+  title="Step Flow"
+  parameters={{ info: { disable: true }, controls: { disabled: true } }}
+/>
+
+# Step Flow
+
+<a
+  target="_blank"
+  href="https://zeroheight.com/2ccf2b601/p/734c86-step-flow/b/83830f"
+  style={{ color: '#007E45', fontWeight: 'bold', textDecoration: 'underline' }}
+>
+  Product Design System component
+</a>
+
+Provide a way to represent an end-to-end journey that a user can complete in one go.
+
+This component has a specific start and end point, as well as showing the current step in the journey.
+
+Use a step flow to help a user complete tasks in a specific order, based on their needs.
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```js
+import StepFlow from "carbon-react/lib/components/step-flow";
+```
+
+## Examples
+
+To ensure focus is programmatically moved to the `title` of a given `StepFlow` when a user advances through each step,  
+passing a `ref` is  **strongly** recommended. This ensures screen reader users are made aware of all information throughout the user journey
+An example of how this can be achieved is provided in the **Example implementation** story.
+
+### Default
+
+<Canvas>
+  <Story name="default" story={stories.DefaultStory}/>
+</Canvas>
+
+### with category
+
+<Canvas>
+  <Story name="category" story={stories.CategoryStory}/>
+</Canvas>
+
+### with showProgressIndicator
+
+You can set the `showProgressIndicator` prop to `true` to render the progress indicator within the component.
+
+<Canvas>
+  <Story name="showProgressIndicator" story={stories.ShowProgressIndicatorStory}/>
+</Canvas>
+
+### with currentStep
+
+The `currentStep` prop can be used to set the current step, this will update the step label and update the progress indicator. Your
+current step can be between `1` and `8`.
+
+<Canvas>
+  <Story name="currentStep" story={stories.CurrentStepStory}/>
+</Canvas>
+
+### with totalSteps
+
+The `totalSteps` prop can be used to change the amount of steps, this will update the step label and determine the amount of step indicators rendered. 
+You can have between `1` and `8` total steps.
+
+<Canvas>
+  <Story name="totalSteps" story={stories.TotalStepsStory}/>
+</Canvas>
+
+
+### with showCloseIcon
+
+You can set the `showCloseIcon` prop to `true` to render a close icon within the component. You can also use the `onDismiss` prop to pass in a function
+which is called when a user clicks on the close icon.
+
+<Canvas>
+  <Story name="showCloseIcon" story={stories.ShowCloseIconStory}/>
+</Canvas>
+
+### Example implementation
+
+Please see below an example implementation of how the component can be used within the `Dialog` component, with the use of `Button`'s to advance through the user
+journey. Within the `Dialog` component, the `title` prop accepts a node, so the component can be passed, acting as the `Dialog`'s title. Also `showCloseIcon` can
+also be passed to render the close icon, and its `onDismiss` function can be used to close the modal instead of passing `onCancel` to `Dialog`.
+
+Also, the example below fully details the use of a ref to programmatically move focus to a title div which contains all of the necessary information for screen reader users
+(`title`, `currentStep`, `totalSteps` and `category` if added), in the form of a properly formatted, visually hidden string.
+
+Please see below an example of what this look like in the DOM.
+
+```jsx
+<span data-element="visually-hidden-title-text">Add client. Transaction Type. Step 1 of 3.</span>
+```
+
+<Canvas>
+  <Story name="Example implementation" story={stories.ExampleImplementation}/>
+</Canvas>
+
+To achieve this, a custom ref handle can be forwarded to the `StepFlow` component:
+
+```tsx
+const stepFlowHandle = useRef<StepFlowHandle>(null);
+return (
+  <StepFlow title="Refund details" totalSteps={3} currentStep={1} ref={stepFlowHandle}/>
+);
+```
+
+which exposes the `focus()` method of `StepFlow`'s root DOM node:
+
+```ts
+stepFlowHandle.current?.focus();
+```
+
+This will ensure that screen reader users are not only made aware of any changes to information, but can then also navigate down the page from the `StepFlow` component as they see fit.
+
+### Example implementation with translations
+
+Various translations can be applied to both the step label, screen reader only title and close icon aria-label.
+
+When providing the screen reader only title the `title`, `category` (if provided), `currentStep` and `totalSteps`, have all been passed to ensure screen reader users have all of the same information
+as users who can see the component. Please see below how this has been achieved with a French translation.
+
+<Canvas>
+  <Story name="Example implementation with translations" story={stories.ExampleImplementationWithTranslations}/>
+</Canvas>
+
+
+## Props
+
+### Content
+
+<StyledSystemProps of={StepFlow} margin noHeader />
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "stepFlow.stepLabel",
+      description: "The step label which shows the current step and the amount of total steps.",
+      type: "func",
+      returnType: "string",
+    },
+        {
+      name: "stepFlow.screenReaderOnlyTitle",
+      description: "The full visually hidden sentence which will be announced to users detailing their category, title, current steps and total steps.",
+      type: "func",
+      returnType: "string",
+    },
+        {
+      name: "stepFlow.closeIconAriaLabel",
+      description: "The aria label of the close icon which is rendered when 'showCloseIcon' is true.",
+      type: "func",
+      returnType: "string",
+    }
+  ]}
+/>

--- a/src/components/step-flow/step-flow.stories.tsx
+++ b/src/components/step-flow/step-flow.stories.tsx
@@ -1,0 +1,220 @@
+import React, { useState, useRef } from "react";
+import { ComponentStory } from "@storybook/react";
+import { StepFlow } from ".";
+import Button from "../button";
+import Form from "../form";
+import Dialog from "../dialog";
+import Typography from "../typography";
+import Textarea from "../textarea";
+import I18nProvider from "../i18n-provider/i18n-provider.component";
+import { Steps, StepFlowHandle } from "./step-flow.component";
+
+export const DefaultStory: ComponentStory<typeof StepFlow> = () => (
+  <StepFlow title="Step title" currentStep={1} totalSteps={6} />
+);
+
+export const CategoryStory: ComponentStory<typeof StepFlow> = () => (
+  <StepFlow
+    category="Main goal"
+    title="Step title"
+    currentStep={1}
+    totalSteps={6}
+  />
+);
+
+export const ShowProgressIndicatorStory: ComponentStory<
+  typeof StepFlow
+> = () => (
+  <StepFlow
+    category="Main goal"
+    title="Step title"
+    currentStep={1}
+    totalSteps={6}
+    showProgressIndicator
+  />
+);
+
+export const CurrentStepStory: ComponentStory<typeof StepFlow> = () => (
+  <StepFlow
+    category="Main goal"
+    title="Step title"
+    currentStep={5}
+    totalSteps={6}
+    showProgressIndicator
+  />
+);
+
+export const TotalStepsStory: ComponentStory<typeof StepFlow> = () => (
+  <StepFlow
+    category="Main goal"
+    title="Step title"
+    currentStep={5}
+    totalSteps={8}
+    showProgressIndicator
+  />
+);
+
+export const ShowCloseIconStory: ComponentStory<typeof StepFlow> = () => (
+  <StepFlow
+    category="Main goal"
+    title="Step title"
+    currentStep={1}
+    totalSteps={6}
+    showCloseIcon
+    onDismiss={() => ""}
+  />
+);
+
+export const ExampleImplementation: ComponentStory<typeof StepFlow> = () => {
+  const lowestStep = 1;
+  const highestStep = 3;
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [step, setStep] = useState(lowestStep);
+  const stepFlowHandle = useRef<StepFlowHandle>(null);
+
+  const stepTitles = ["Transaction Type", "Add refund", "Refund details"];
+
+  function handleClick(clickType: string) {
+    stepFlowHandle.current?.focus();
+
+    if (clickType === "Back") {
+      setStep(step > lowestStep ? step - 1 : step);
+    } else {
+      setStep(step < highestStep ? step + 1 : step);
+    }
+  }
+
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
+      <Dialog
+        open={isOpen}
+        showCloseIcon={false}
+        title={
+          <StepFlow
+            category="Add client"
+            title={stepTitles[step - 1]}
+            currentStep={step as Steps}
+            totalSteps={highestStep}
+            ref={stepFlowHandle}
+            showProgressIndicator
+            showCloseIcon
+            onDismiss={() => setIsOpen(false)}
+            mb="20px"
+          />
+        }
+      >
+        <Form
+          stickyFooter
+          leftSideButtons={
+            <Button buttonType="tertiary" onClick={() => handleClick("Back")}>
+              Back
+            </Button>
+          }
+          rightSideButtons={
+            <Button
+              buttonType="primary"
+              onClick={() => handleClick("Continue")}
+            >
+              Continue
+            </Button>
+          }
+        >
+          <Typography>
+            This is an example of a Dialog with a Form as content, with a Step
+            Flow to help users complete tasks in a specific order.
+          </Typography>
+          <Textarea label="Reason For Refund" />
+        </Form>
+      </Dialog>
+    </>
+  );
+};
+
+export const ExampleImplementationWithTranslations: ComponentStory<
+  typeof StepFlow
+> = () => {
+  const lowestStep = 1;
+  const highestStep = 3;
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [step, setStep] = useState(lowestStep);
+  const stepFlowHandle = useRef<StepFlowHandle>(null);
+
+  const stepTitles = [
+    "Type de transaction",
+    "Ajouter un remboursement",
+    "Détails du remboursement",
+  ];
+
+  function handleClick(clickType: string) {
+    stepFlowHandle.current?.focus();
+
+    if (clickType === "Back") {
+      setStep(step > lowestStep ? step - 1 : step);
+    } else {
+      setStep(step < highestStep ? step + 1 : step);
+    }
+  }
+
+  return (
+    <I18nProvider
+      locale={{
+        locale: () => "fr-FR",
+        stepFlow: {
+          stepLabel: (currentStep, totalSteps) =>
+            `Étape ${currentStep} de ${totalSteps}`,
+          screenReaderOnlyTitle: (title, currentStep, totalSteps, category) =>
+            `${category}. ${title}. Étape ${currentStep} de ${totalSteps}.`,
+          closeIconAriaLabel: () => "Fermer",
+        },
+      }}
+    >
+      <>
+        <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
+        <Dialog
+          open={isOpen}
+          showCloseIcon={false}
+          title={
+            <StepFlow
+              category="Ajouter un client"
+              title={stepTitles[step - 1]}
+              currentStep={step as Steps}
+              totalSteps={highestStep}
+              ref={stepFlowHandle}
+              showProgressIndicator
+              showCloseIcon
+              onDismiss={() => setIsOpen(false)}
+              mb="20px"
+            />
+          }
+        >
+          <Form
+            stickyFooter
+            leftSideButtons={
+              <Button buttonType="tertiary" onClick={() => handleClick("Back")}>
+                Retour
+              </Button>
+            }
+            rightSideButtons={
+              <Button
+                buttonType="primary"
+                onClick={() => handleClick("Continue")}
+              >
+                Continuer
+              </Button>
+            }
+          >
+            <Typography>
+              Il s'agit d'un exemple de boîte de dialogue avec un formulaire
+              comme contenu, avec un flux d'étapes pour aider les utilisateurs à
+              effectuer des tâches dans un ordre spécifique.
+            </Typography>
+            <Textarea label="Motif du remboursement" />
+          </Form>
+        </Dialog>
+      </>
+    </I18nProvider>
+  );
+};

--- a/src/components/step-flow/step-flow.style.ts
+++ b/src/components/step-flow/step-flow.style.ts
@@ -1,0 +1,64 @@
+import styled from "styled-components";
+import { margin } from "styled-system";
+
+const StyledStepFlow = styled.div`
+  ${margin}
+`;
+
+const StyledStepContent = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: var(--sizing200);
+`;
+
+const StyledStepContentText = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledTitleFocusWrapper = styled.div``;
+
+const StyledStepLabelAndProgress = styled.div`
+  margin-top: var(--sizing125);
+`;
+
+const StyledProgressIndicatorBar = styled.div`
+  display: flex;
+  margin-top: var(--sizing100);
+`;
+
+interface StyledProgressIndicatorProps {
+  isCompleted: boolean;
+  isInProgress: boolean;
+}
+
+function calculateProgressIndicatorColor({
+  isCompleted,
+  isInProgress,
+}: StyledProgressIndicatorProps) {
+  if (isInProgress) {
+    return "var(--colorsUtilityYin090)";
+  }
+  if (isCompleted) {
+    return "var(--colorsSemanticPositive500)";
+  }
+  return "var(--colorsActionDisabled600)";
+}
+
+const StyledProgressIndicator = styled.span<StyledProgressIndicatorProps>`
+  background-color: ${calculateProgressIndicatorColor};
+  width: 100%;
+  height: 8px;
+  border-radius: 8px;
+  margin-right: 12px;
+`;
+
+export {
+  StyledStepFlow,
+  StyledStepContent,
+  StyledStepContentText,
+  StyledTitleFocusWrapper,
+  StyledStepLabelAndProgress,
+  StyledProgressIndicatorBar,
+  StyledProgressIndicator,
+};

--- a/src/components/typography/index.ts
+++ b/src/components/typography/index.ts
@@ -1,4 +1,4 @@
 export { default } from "./typography.component";
 export { List, ListItem } from "./list.component";
-export type { TypographyProps } from "./typography.component";
+export type { TypographyProps, VariantTypes } from "./typography.component";
 export type { ListProps, ListItemProps } from "./list.component";

--- a/src/components/typography/typography.component.tsx
+++ b/src/components/typography/typography.component.tsx
@@ -83,6 +83,8 @@ export interface TypographyProps extends SpaceProps, TagProps {
    * Override the default color of the rendered element to match disabled styling
    * */
   isDisabled?: boolean;
+  /** @private @ignore Set whether the component should be recognised by assistive technologies */
+  "aria-hidden"?: "true" | "false";
 }
 
 export const Typography = ({
@@ -110,6 +112,7 @@ export const Typography = ({
   className,
   screenReaderOnly,
   isDisabled,
+  "aria-hidden": ariaHidden,
   ...rest
 }: TypographyProps) => {
   return (
@@ -136,6 +139,7 @@ export const Typography = ({
       className={className}
       screenReaderOnly={screenReaderOnly}
       isDisabled={isDisabled}
+      aria-hidden={ariaHidden}
       {...tagComponent(dataComponent, rest)}
       {...filterStyledSystemMarginProps(rest)}
       {...filterStyledSystemPaddingProps(rest)}

--- a/src/locales/__internal__/pl-pl.ts
+++ b/src/locales/__internal__/pl-pl.ts
@@ -215,6 +215,15 @@ const plPL: Locale = {
   splitButton: {
     ariaLabel: () => "Pokaż więcej",
   },
+  stepFlow: {
+    stepLabel: (currentStep, totalSteps) =>
+      `Krok ${currentStep} z ${totalSteps}`,
+    screenReaderOnlyTitle: (title, currentStep, totalSteps, category) =>
+      `${
+        category ? `${category}.` : ""
+      }. ${title}. Krok ${currentStep} of ${totalSteps}.`,
+    closeIconAriaLabel: () => "Zamknij",
+  },
   switch: {
     on: () => "WŁ",
     off: () => "WYŁ",

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -156,6 +156,15 @@ const enGB: Locale = {
   splitButton: {
     ariaLabel: () => "Show more",
   },
+  stepFlow: {
+    stepLabel: (currentStep, totalSteps) =>
+      `Step ${currentStep} of ${totalSteps}`,
+    screenReaderOnlyTitle: (title, currentStep, totalSteps, category) =>
+      `${
+        category ? `${category}.` : ""
+      } ${title}. Step ${currentStep} of ${totalSteps}.`,
+    closeIconAriaLabel: () => "Close",
+  },
   switch: {
     on: () => "ON",
     off: () => "OFF",

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -126,6 +126,16 @@ interface Locale {
     on: () => string;
     off: () => string;
   };
+  stepFlow: {
+    stepLabel: (currentStep: number, totalSteps: number) => string;
+    screenReaderOnlyTitle: (
+      title: string,
+      currentStep: number,
+      totalSteps: number,
+      category?: string
+    ) => string;
+    closeIconAriaLabel?: () => string;
+  };
   textEditor: {
     tooltipMessages: {
       bold: () => string;


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

![Screenshot 2023-12-08 at 16 27 29](https://github.com/Sage/carbon/assets/114918852/6dbcd90d-4604-48cb-93e9-5c2340cdde57)

This PR will add the `StepFlow` component which aims to help users advance through a user journey, and keep track of their progress. This is done initially with a very simple default configuration, with just the current title, current step and the total steps in the journey. This can also be contextualised further with an optional `category` prop.

![Screenshot 2023-12-08 at 16 27 40](https://github.com/Sage/carbon/assets/114918852/856a4235-9a42-4cde-8e2d-5523c3fe7836)

![Screenshot 2023-12-08 at 16 33 37](https://github.com/Sage/carbon/assets/114918852/42cd264d-7647-4281-b8a2-cde592684748)

However, a progress indicator can also be rendered via the `showProgressIndicator` prop, providing an added decorative indicator of progress, with indicators holding three individual states: completed, in progress, not completed ; each with their own background colours.

A close icon can also be rendered, with its own `onDismiss` prop, allowing consumers to pass functions to be called onClick such as closing a modal.

![Screenshot 2023-12-08 at 16 27 47](https://github.com/Sage/carbon/assets/114918852/85771b91-e034-4b5f-8ffa-be93e30a5cdf)

The component is also flexible, allowing for multiple steps to be set with the `currentStep` and `totalSteps` props, both can be between 1-8. Also `currentStep` can never exceed the value of `totalSteps`. When these are changed, the label underneath the title will change, as well as the indicator bar (if rendered).


 The component also has built-in accessibility considerations with a focus ref being provided which provides consumers with the ability to pull focus to a visually hidden  DOM element containing a formatted string with all of the relevant titles, category, step progress contained within.

 This ensures screen reader users are given all the relevant information through semantic HTML on first navigation, and then when they progress through the journey, using buttons, for example focus is then pulled to the DOM element shown above. This will announce all of the relevant text content and then allow them to navigate down the page through all the relevant content below.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

Currently there is no accessible component which provides means to track and display a step journey or sequence.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
