### PR TITLE
feat(option, option-row): add disabled prop

### DIFF
--- a/src/components/select/filterable-select/components.test-pw.tsx
+++ b/src/components/select/filterable-select/components.test-pw.tsx
@@ -628,3 +628,38 @@ export const SelectionConfirmed = () => {
     </>
   );
 };
+
+export const FilterableSelectWithDisabledOption = () => {
+  const [value, setValue] = useState("");
+  const [confirmedSelection, setConfirmedSelection] = useState("");
+
+  const handleChange = (event: CustomSelectChangeEvent) => {
+    setValue(event.target.value);
+    if (event.selectionConfirmed) {
+      setConfirmedSelection(event.target.value);
+    }
+  };
+  return (
+    <>
+      <FilterableSelect
+        name="testing"
+        value={value}
+        onChange={handleChange}
+        openOnFocus
+        label="Test"
+        placeholder=" "
+      >
+        <Option value="1" text="One" />
+        <Option value="2" text="Two" disabled />
+        <Option value="3" text="Three" />
+        <Option value="4" text="Four" />
+      </FilterableSelect>
+
+      {confirmedSelection ? (
+        <span data-element={`confirmed-selection-${confirmedSelection}`}>
+          {confirmedSelection}
+        </span>
+      ) : null}
+    </>
+  );
+};

--- a/src/components/select/filterable-select/filterable-select-test.stories.tsx
+++ b/src/components/select/filterable-select/filterable-select-test.stories.tsx
@@ -650,3 +650,27 @@ export const FilterableSelectNestedInDialog = ({
     </Dialog>
   );
 };
+
+export const FilterableSelectWithDisabledOption = () => {
+  const [value, setValue] = useState("");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  return (
+    <FilterableSelect
+      name="testing"
+      value={value}
+      onChange={onChangeHandler}
+      openOnFocus
+      label="Test"
+      placeholder=" "
+    >
+      <Option value="1" text="One" />
+      <Option value="2" text="Two" disabled />
+      <Option value="3" text="Three" />
+      <Option value="4" text="Four" />
+    </FilterableSelect>
+  );
+};

--- a/src/components/select/filterable-select/filterable-select.component.tsx
+++ b/src/components/select/filterable-select/filterable-select.component.tsx
@@ -214,7 +214,7 @@ export const FilterableSelect = React.forwardRef(
           const match = findElementWithMatchingText(newFilterText, children);
           const isFilterCleared = isDeleteEvent && newFilterText === "";
 
-          if (!match || isFilterCleared) {
+          if (!match || isFilterCleared || match.props.disabled) {
             setTextValue(newFilterText);
             triggerChange("", false);
 

--- a/src/components/select/filterable-select/filterable-select.pw.tsx
+++ b/src/components/select/filterable-select/filterable-select.pw.tsx
@@ -15,6 +15,7 @@ import {
   FilterableSelectWithManyOptionsAndVirtualScrolling,
   FilterableSelectNestedInDialog,
   SelectionConfirmed,
+  FilterableSelectWithDisabledOption,
 } from "../../../../src/components/select/filterable-select/components.test-pw";
 import {
   commonDataElementInputPreview,
@@ -1613,6 +1614,26 @@ test("should not throw when filter text does not match option text", async ({
   await commonDataElementInputPreview(page).type("abc");
   await selectInput(page).press("Enter");
   await expect(getDataElementByValue(page, "input")).toHaveValue("");
+});
+
+test("should not select a disabled option when a filter is typed", async ({
+  mount,
+  page,
+}) => {
+  await mount(<FilterableSelectWithDisabledOption />);
+
+  await dropdownButton(page).click();
+  const inputElement = selectInput(page);
+  await inputElement.type("t");
+  await inputElement.press("Enter");
+  await expect(
+    page.locator('[data-element="confirmed-selection-2"]')
+  ).not.toBeVisible();
+  await inputElement.press("ArrowDown");
+  await inputElement.press("Enter");
+  await expect(
+    page.locator('[data-element="confirmed-selection-3"]')
+  ).toBeVisible();
 });
 
 // see https://github.com/Sage/carbon/issues/6399

--- a/src/components/select/multi-select/components.test-pw.tsx
+++ b/src/components/select/multi-select/components.test-pw.tsx
@@ -573,3 +573,38 @@ export const SelectionConfirmed = () => {
     </>
   );
 };
+
+export const MultiSelectWithDisabledOption = () => {
+  const [value, setValue] = useState<string[]>([]);
+  const [confirmedSelections, setConfirmedSelections] = useState<string[]>([]);
+
+  const handleChange = (event: CustomSelectChangeEvent) => {
+    setValue((event.target.value as unknown) as string[]);
+    if (event.selectionConfirmed) {
+      setConfirmedSelections((event.target.value as unknown) as string[]);
+    }
+  };
+  return (
+    <>
+      <MultiSelect
+        name="testing"
+        value={value}
+        onChange={handleChange}
+        openOnFocus
+        label="Test"
+        placeholder=" "
+      >
+        <Option value="1" text="One" />
+        <Option value="2" text="Two" disabled />
+        <Option value="3" text="Three" />
+        <Option value="4" text="Four" />
+      </MultiSelect>
+
+      <div data-element="confirmed-selections">
+        {confirmedSelections.map((cs) => (
+          <span data-element={`confirmed-selection-${cs}`}>{cs}</span>
+        ))}
+      </div>
+    </>
+  );
+};

--- a/src/components/select/multi-select/multi-select-test.stories.tsx
+++ b/src/components/select/multi-select/multi-select-test.stories.tsx
@@ -598,3 +598,27 @@ export const MultiSelectErrorOnChangeNewValidation = () => {
     </CarbonProvider>
   );
 };
+
+export const MultiSelectWithDisabledOption = () => {
+  const [value, setValue] = useState<string[]>([]);
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue((event.target.value as unknown) as string[]);
+  }
+
+  return (
+    <MultiSelect
+      name="testing"
+      value={value}
+      onChange={onChangeHandler}
+      openOnFocus
+      label="Test"
+      placeholder=" "
+    >
+      <Option value="1" text="One" />
+      <Option value="2" text="Two" disabled />
+      <Option value="3" text="Three" />
+      <Option value="4" text="Four" />
+    </MultiSelect>
+  );
+};

--- a/src/components/select/multi-select/multi-select.pw.tsx
+++ b/src/components/select/multi-select/multi-select.pw.tsx
@@ -16,6 +16,7 @@ import {
   MultiSelectNestedInDialog,
   MultiSelectErrorOnChangeNewValidation,
   SelectionConfirmed,
+  MultiSelectWithDisabledOption,
 } from "../../../../src/components/select/multi-select/components.test-pw";
 import {
   commonDataElementInputPreview,
@@ -1549,6 +1550,29 @@ test("should not add an empty Pill when filter text does not match option text",
   await commonDataElementInputPreview(page).type("abc");
   await selectInput(page).press("Enter");
   await expect(pillElement).not.toBeVisible();
+});
+
+test("should not select a disabled option when a filter is typed", async ({
+  mount,
+  page,
+}) => {
+  await mount(<MultiSelectWithDisabledOption />);
+
+  await dropdownButton(page).click();
+  const inputElement = selectInput(page);
+  await inputElement.type("t");
+  await inputElement.press("Enter");
+  await expect(
+    page.locator('[data-element="confirmed-selection-2"]')
+  ).not.toBeVisible();
+  await inputElement.press("ArrowDown");
+  await inputElement.press("Enter");
+  await expect(
+    page.locator('[data-element="confirmed-selection-3"]')
+  ).toBeVisible();
+
+  const pillElement = multiSelectPill(page);
+  await expect(pillElement).toHaveCount(1);
 });
 
 // see https://github.com/Sage/carbon/issues/6399

--- a/src/components/select/option-row/option-row.component.tsx
+++ b/src/components/select/option-row/option-row.component.tsx
@@ -16,6 +16,8 @@ export interface OptionRowProps extends TagProps {
    * Will use a randomly generated GUID if none is provided.
    */
   id?: string;
+  /** If true, the component will be disabled */
+  disabled?: boolean;
   /**
    * @private
    * @ignore
@@ -48,6 +50,7 @@ const OptionRow = React.forwardRef(
       id,
       text,
       children,
+      disabled,
       onSelect,
       value,
       index,
@@ -58,6 +61,9 @@ const OptionRow = React.forwardRef(
     ref: React.ForwardedRef<HTMLTableRowElement>
   ) => {
     const handleClick = () => {
+      if (disabled) {
+        return;
+      }
       onSelect?.({ id, text, value });
     };
     const selectListContext = useContext(SelectListContext);
@@ -72,7 +78,9 @@ const OptionRow = React.forwardRef(
         id={id}
         ref={ref}
         aria-selected={isSelected}
+        aria-disabled={disabled}
         data-component="option-row"
+        isDisabled={disabled}
         onClick={handleClick}
         isHighlighted={selectListContext.currentOptionsListIndex === index}
         role="option"

--- a/src/components/select/option-row/option-row.spec.tsx
+++ b/src/components/select/option-row/option-row.spec.tsx
@@ -43,6 +43,43 @@ describe("OptionRow", () => {
     });
   });
 
+  describe("when disabled prop is set", () => {
+    it("should have expected style", () => {
+      const props = { value: "1", text: "foo", disabled: true };
+      expect(renderOptionRow(props, mount)).toHaveStyleRule(
+        "color",
+        "var(--colorsUtilityYin030)"
+      );
+      expect(renderOptionRow(props, mount)).toHaveStyleRule(
+        "cursor",
+        "not-allowed"
+      );
+    });
+
+    it("aria-disabled should be set to true", () => {
+      const props = { value: "1", text: "foo", disabled: true };
+      const wrapper = renderOptionRow(props, mount);
+      expect(
+        wrapper.find(OptionRow).getDOMNode().getAttribute("aria-disabled")
+      ).toBe("true");
+    });
+
+    it("onSelect should not be called when the element is clicked", () => {
+      const onSelect = jest.fn();
+      const props = {
+        id: "1",
+        value: "1",
+        text: "foo",
+        onSelect,
+        disabled: true,
+      };
+      const wrapper = renderOptionRow(props, mount);
+      wrapper.find(OptionRow).simulate("click");
+
+      expect(onSelect).not.toBeCalled();
+    });
+  });
+
   describe("when the multiselectValues list contains the element value", () => {
     it("then the aria-selected attribute should be set to true", () => {
       const wrapper = mount(

--- a/src/components/select/option-row/option-row.style.ts
+++ b/src/components/select/option-row/option-row.style.ts
@@ -3,6 +3,7 @@ import { OptionRowProps } from ".";
 
 interface StyledOptionRowProps extends Pick<OptionRowProps, "hidden"> {
   isHighlighted?: boolean;
+  isDisabled?: boolean;
 }
 
 const StyledOptionRow = styled.tr<StyledOptionRowProps>`
@@ -32,6 +33,16 @@ const StyledOptionRow = styled.tr<StyledOptionRowProps>`
       font-weight: 700;
     }
   }
+
+  ${({ isDisabled }) =>
+    isDisabled &&
+    css`
+      color: var(--colorsUtilityYin030);
+      cursor: not-allowed;
+      :hover {
+        background-color: var(--colorsUtilityYang100);
+      }
+    `}
 `;
 
 export default StyledOptionRow;

--- a/src/components/select/option/option.component.tsx
+++ b/src/components/select/option/option.component.tsx
@@ -24,6 +24,8 @@ export interface OptionProps
   borderColor?: string;
   /** MultiSelect only - fill Pill background with color */
   fill?: boolean;
+  /** If true, the component will be disabled */
+  disabled?: boolean;
   /**
    * @private
    * @ignore
@@ -50,6 +52,7 @@ const Option = React.forwardRef(
     {
       text,
       children,
+      disabled,
       onSelect,
       value,
       id,
@@ -69,6 +72,9 @@ const Option = React.forwardRef(
     }
 
     function handleClick() {
+      if (disabled) {
+        return;
+      }
       if (!onClick) {
         onSelect?.({ text, value, id });
       } else {
@@ -82,7 +88,9 @@ const Option = React.forwardRef(
         id={id}
         ref={ref}
         aria-selected={isSelected}
+        aria-disabled={disabled}
         data-component="option"
+        isDisabled={disabled}
         onClick={handleClick}
         isHighlighted={selectListContext.currentOptionsListIndex === index}
         role="option"

--- a/src/components/select/option/option.spec.tsx
+++ b/src/components/select/option/option.spec.tsx
@@ -39,6 +39,35 @@ describe("Option", () => {
     });
   });
 
+  describe("when disabled prop is set", () => {
+    it("should have expected style", () => {
+      const props = { value: "1", text: "foo", disabled: true };
+      expect(renderOption(props, mount)).toHaveStyleRule(
+        "color",
+        "var(--colorsUtilityYin030)"
+      );
+      expect(renderOption(props, mount)).toHaveStyleRule(
+        "cursor",
+        "not-allowed"
+      );
+    });
+
+    it("aria-disabled should be set to true", () => {
+      const props = { value: "1", text: "foo", disabled: true };
+      const wrapper = renderOption(props, mount);
+      expect(wrapper.getDOMNode().getAttribute("aria-disabled")).toBe("true");
+    });
+
+    it("onSelect should not be called when the element is clicked", () => {
+      const onSelect = jest.fn();
+      const props = { value: "1", text: "foo", onSelect, disabled: true };
+      const wrapper = renderOption(props, mount);
+      wrapper.simulate("click");
+
+      expect(onSelect).not.toBeCalled();
+    });
+  });
+
   describe("when the element is inside the multiselect", () => {
     it("then it should have expected background", () => {
       const props = { value: "1", text: "foo" };

--- a/src/components/select/option/option.style.ts
+++ b/src/components/select/option/option.style.ts
@@ -3,6 +3,7 @@ import { OptionProps } from ".";
 
 interface StyledOptionProps extends Pick<OptionProps, "id"> {
   isHighlighted?: boolean;
+  isDisabled?: boolean;
 }
 
 const StyledOption = styled.li<StyledOptionProps>`
@@ -28,6 +29,16 @@ const StyledOption = styled.li<StyledOptionProps>`
   :hover {
     background-color: var(--colorsUtilityMajor100);
   }
+
+  ${({ isDisabled }) =>
+    isDisabled &&
+    css`
+      color: var(--colorsUtilityYin030);
+      cursor: not-allowed;
+      :hover {
+        background-color: var(--colorsUtilityYang100);
+      }
+    `}
 `;
 
 export default StyledOption;

--- a/src/components/select/select-list/select-list.component.tsx
+++ b/src/components/select/select-list/select-list.component.tsx
@@ -335,9 +335,10 @@ const SelectList = React.forwardRef(
         const nextElement = childrenList[nextIndex];
 
         if (
-          React.isValidElement(nextElement) &&
-          nextElement.type !== Option &&
-          nextElement.type !== OptionRow
+          (React.isValidElement(nextElement) &&
+            nextElement.type !== Option &&
+            nextElement.type !== OptionRow) ||
+          nextElement.props.disabled
         ) {
           nextIndex = getNextHighlightableItemIndex(key, nextIndex);
         }
@@ -437,6 +438,10 @@ const SelectList = React.forwardRef(
           if (!React.isValidElement(currentOption)) {
             onSelectListClose();
 
+            return;
+          }
+
+          if (currentOption.props.disabled) {
             return;
           }
 

--- a/src/components/select/simple-select/simple-select-test.stories.tsx
+++ b/src/components/select/simple-select/simple-select-test.stories.tsx
@@ -711,3 +711,27 @@ SelectWithOptionGroupHeader.args = {
   listPlacement: undefined,
   flipEnabled: true,
 };
+
+export const SimpleSelectWithDisabledOption = () => {
+  const [value, setValue] = useState("");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  return (
+    <Select
+      name="testing"
+      value={value}
+      onChange={onChangeHandler}
+      openOnFocus
+      label="Test"
+      placeholder=" "
+    >
+      <Option value="1" text="One" />
+      <Option value="2" text="Two" disabled />
+      <Option value="3" text="Three" />
+      <Option value="4" text="Four" />
+    </Select>
+  );
+};


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

Add `disabled` prop to `Option` and `OptionRow` in `Select` component. A disabled option will:
- Have disabled styles
- Have an `aria-disabled` attribute
- The user cannot click or keyboard navigate to this option
- The option will still appear in a filtered select but cannot be selected

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

`Option` and `OptionRow` in `Select` component do not have the option to be disabled. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
