### PR TITLE
fix(numeral-date): ensure internal validation uses given month and year values where possible

### DIFF
--- a/playwright/index.tsx
+++ b/playwright/index.tsx
@@ -17,6 +17,7 @@ import * as dateLocales from "../src/locales/date-fns-locales";
 export type HooksConfig = {
   roundedCornersOptOut?: boolean;
   focusRedesignOptOut?: boolean;
+  validationRedesignOptIn?: boolean;
   theme?: string;
   localeName?: keyof typeof dateLocales;
 };
@@ -56,12 +57,14 @@ beforeMount<HooksConfig>(async ({ App, hooksConfig }) => {
     focusRedesignOptOut,
     theme = "sage",
     localeName,
+    validationRedesignOptIn,
   } = hooksConfig || {};
   return (
     <CarbonProvider
       theme={mountedTheme(theme)}
       roundedCornersOptOut={roundedCornersOptOut}
       focusRedesignOptOut={focusRedesignOptOut}
+      validationRedesignOptIn={validationRedesignOptIn}
     >
       <GlobalStyle />
       <I18nProvider locale={localeName ? computedLocale(localeName) : enGB}>

--- a/src/components/numeral-date/numeral-date.spec.tsx
+++ b/src/components/numeral-date/numeral-date.spec.tsx
@@ -36,6 +36,21 @@ const ddmmyyyyMessage =
 
 type ValidationType = "error" | "warning" | "info";
 
+const months = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
 describe("NumeralDate", () => {
   let wrapper: ReactWrapper;
   const onBlur = jest.fn();
@@ -274,6 +289,30 @@ describe("NumeralDate", () => {
         }
       );
 
+      it.each(["13", "14", "15"])(
+        "renders internal validation when day field has 31, month is blurred and has incorrect value (%s)",
+        (value) => {
+          wrapper = renderWrapper({
+            defaultValue: { dd: "31", mm: value, yyyy: "" },
+            [internalValidationProp]: true,
+          });
+
+          const monthInput = wrapper.find("input").at(1);
+
+          monthInput.simulate("change", { target: { value } });
+          wrapper.update();
+          monthInput.simulate("blur");
+          jest.runAllTimers();
+          wrapper.update();
+
+          const dateTextboxes = wrapper.find(Textbox);
+
+          expect(
+            dateTextboxes.at(dateTextboxes.length - 1).props()[validationType]
+          ).toBe("Month should be a number within a 1-12 range.\n");
+        }
+      );
+
       it.each([
         ["", true],
         ["0", false],
@@ -370,6 +409,116 @@ describe("NumeralDate", () => {
               dateTextboxes.at(dateTextboxes.length - 1).props()[validationType]
             ).toBe(expectedMessage);
           });
+        }
+      );
+
+      it.each([
+        ["31", "January"],
+        ["28", "February"],
+        ["31", "March"],
+        ["30", "April"],
+        ["31", "May"],
+        ["30", "June"],
+        ["31", "July"],
+        ["31", "August"],
+        ["30", "September"],
+        ["31", "October"],
+        ["30", "November"],
+        ["31", "December"],
+      ])(
+        "should not display the internal validation when %s entered in day input and month is %s",
+        (dayValue, monthName) => {
+          const monthValue = months.indexOf(monthName);
+          wrapper = renderWrapper({
+            value: { dd: "", mm: String(monthValue + 1), yyyy: "2001" },
+            [internalValidationProp]: true,
+          });
+
+          const firstInput = wrapper.find("input").at(0);
+
+          firstInput.simulate("change", { target: { value: dayValue } });
+          wrapper.update();
+          firstInput.simulate("blur");
+          jest.runAllTimers();
+          wrapper.update();
+
+          const dateTextboxes = wrapper.find(Textbox);
+
+          expect(
+            dateTextboxes.at(dateTextboxes.length - 1).props()[validationType]
+          ).toBe("");
+        }
+      );
+
+      it.each([
+        ["32", "January", "31"],
+        ["29", "February", "28"],
+        ["32", "March", "31"],
+        ["31", "April", "30"],
+        ["32", "May", "31"],
+        ["31", "June", "30"],
+        ["32", "July", "31"],
+        ["32", "August", "31"],
+        ["31", "September", "30"],
+        ["32", "October", "31"],
+        ["31", "November", "30"],
+        ["32", "December", "31"],
+      ])(
+        "should display the internal validation when %s entered in day input and month is %s",
+        (dayValue, monthName, daysInMonth) => {
+          const monthValue = months.indexOf(monthName);
+          wrapper = renderWrapper({
+            value: { dd: "", mm: String(monthValue + 1), yyyy: "2001" },
+            [internalValidationProp]: true,
+          });
+
+          const firstInput = wrapper.find("input").at(0);
+
+          firstInput.simulate("change", { target: { value: dayValue } });
+          wrapper.update();
+          firstInput.simulate("blur");
+          jest.runAllTimers();
+          wrapper.update();
+
+          const dateTextboxes = wrapper.find(Textbox);
+
+          expect(
+            dateTextboxes.at(dateTextboxes.length - 1).props()[validationType]
+          ).toBe(
+            `Day in ${monthName} should be a number within 1-${daysInMonth}.\n`
+          );
+        }
+      );
+
+      it.each([
+        ["29", "2000"],
+        ["29", "2004"],
+        ["29", "2008"],
+        ["29", "2012"],
+        ["29", "2016"],
+        ["29", "2020"],
+        ["29", "2024"],
+      ])(
+        "should not display the internal validation when 29 entered in day input, month is February and year is %s",
+        (dayValue, yearValue) => {
+          wrapper = renderWrapper({
+            value: { dd: "", mm: "02", yyyy: yearValue },
+            [internalValidationProp]: true,
+          });
+
+          const firstInput = wrapper.find("input").at(0);
+
+          firstInput.simulate("change", { target: { value: dayValue } });
+          wrapper.update();
+          firstInput.simulate("blur");
+          jest.runAllTimers();
+          wrapper.update();
+
+          const dateTextboxes = wrapper.find(Textbox);
+
+          expect(
+            dateTextboxes.at(dateTextboxes.length - 1).props()[validationType]
+          ).toBe("");
         }
       );
     });

--- a/src/components/numeral-date/numeral-date.stories.tsx
+++ b/src/components/numeral-date/numeral-date.stories.tsx
@@ -37,32 +37,60 @@ export const AllowedDateFormats: ComponentStory<typeof NumeralDate> = () => (
 export const InternalValidationError: ComponentStory<
   typeof NumeralDate
 > = () => {
-  const [value, setValue] = useState({
+  const [valueOld, setValueOld] = useState({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
+  const [valueNew, setValueNew] = useState({
     dd: "",
     mm: "",
     yyyy: "",
   });
   return (
-    <NumeralDate
-      enableInternalError
-      onChange={(e) => setValue(e.target.value)}
-      label="Default"
-      value={value}
-    />
+    <>
+      <NumeralDate
+        enableInternalError
+        onChange={(e) => setValueOld(e.target.value)}
+        label="Default - legacy validation"
+        value={valueOld}
+      />
+      <br />
+      <CarbonProvider validationRedesignOptIn>
+        <NumeralDate
+          enableInternalError
+          label="Default - new validation"
+          onChange={(e) => setValueNew(e.target.value)}
+          value={valueNew}
+        />
+      </CarbonProvider>
+    </>
   );
 };
 
 export const InternalValidationWarning: ComponentStory<
   typeof NumeralDate
 > = () => {
-  const [value, setValue] = useState({ dd: "", mm: "", yyyy: "" });
+  const [valueOld, setValueOld] = useState({ dd: "", mm: "", yyyy: "" });
+  const [valueNew, setValueNew] = useState({ dd: "", mm: "", yyyy: "" });
   return (
-    <NumeralDate
-      enableInternalWarning
-      label="Default"
-      onChange={(e) => setValue(e.target.value)}
-      value={value}
-    />
+    <>
+      <NumeralDate
+        enableInternalWarning
+        label="Default - legacy validation"
+        onChange={(e) => setValueOld(e.target.value)}
+        value={valueOld}
+      />
+      <br />
+      <CarbonProvider validationRedesignOptIn>
+        <NumeralDate
+          enableInternalWarning
+          label="Default - new validation"
+          onChange={(e) => setValueNew(e.target.value)}
+          value={valueNew}
+        />
+      </CarbonProvider>
+    </>
   );
 };
 

--- a/src/locales/__internal__/pl-pl.ts
+++ b/src/locales/__internal__/pl-pl.ts
@@ -163,7 +163,12 @@ const plPL: Locale = {
   },
   numeralDate: {
     validation: {
-      day: () => "Dzień musi być liczbą w zakresie 1-31.",
+      day: (month, daysInMonth) => {
+        if (month && daysInMonth) {
+          return `Dzień W ${month} musi być liczbą zakresie 1-${daysInMonth}.`;
+        }
+        return "Dzień musi być liczbą w zakresie 1-31.";
+      },
       month: () => "Miesiąć musi być liczbą w zakresie 1-12.",
       year: () => "Rok musi być liczbą w zakresie 1800-2200.",
     },

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -104,7 +104,12 @@ const enGB: Locale = {
   },
   numeralDate: {
     validation: {
-      day: () => "Day should be a number within a 1-31 range.",
+      day: (month, daysInMonth) => {
+        if (month && daysInMonth) {
+          return `Day in ${month} should be a number within 1-${daysInMonth}.`;
+        }
+        return "Day should be a number within a 1-31 range.";
+      },
       month: () => "Month should be a number within a 1-12 range.",
       year: () => "Year should be a number within a 1800-2200 range.",
     },

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -79,7 +79,7 @@ interface Locale {
   };
   numeralDate: {
     validation: {
-      day: () => string;
+      day: (month?: string, daysInMonth?: string) => string;
       month: () => string;
       year: () => string;
     };


### PR DESCRIPTION
fix #6438

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
Built in internal validations will now use `month` and `year` values if provided to validate if `day` input value is within valid range. Adds optional dynamic message that includes the month and days in it when a value is invalid.

![image](https://github.com/Sage/carbon/assets/44157880/e93cd346-5451-4b8c-a534-8fa963051a36)
![image](https://github.com/Sage/carbon/assets/44157880/fb6e51f0-31f2-456d-bde0-696b874836a2)

![image](https://github.com/Sage/carbon/assets/44157880/c8e2d659-f8f4-40bd-8571-a58c5a050554)
![image](https://github.com/Sage/carbon/assets/44157880/eaf894aa-23b7-4711-a1df-7a966f6bf419)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
Built-in validations do not dynamically account for month or year values
 
### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
See internal validation stories for `NumeralDate`

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
