### PR TITLE
feat(accordion): add subtle variant and update default styles

### DIFF
--- a/src/components/accordion/accordion-test.stories.tsx
+++ b/src/components/accordion/accordion-test.stories.tsx
@@ -25,7 +25,7 @@ export default {
       },
     },
     iconType: {
-      options: ["chevron_down", "dropdown"],
+      options: ["chevron_down", "chevron_down_thick", "dropdown"],
       control: {
         type: "select",
       },
@@ -48,6 +48,12 @@ export default {
         type: "select",
       },
     },
+    variant: {
+      options: ["standard", "subtle"],
+      control: {
+        type: "select",
+      },
+    },
   },
 };
 
@@ -55,7 +61,6 @@ export const Default = ({ ...args }) => (
   <Accordion
     onChange={action("expansionToggled")}
     {...{
-      iconAlign: "right",
       customPadding: 0,
       title: "Title",
       subTitle: "Sub Title",
@@ -71,19 +76,31 @@ export const Default = ({ ...args }) => (
 
 Default.storyName = "default";
 
-export const Grouped = () => (
+export const Grouped = ({ ...args }) => (
   <AccordionGroup>
-    <Accordion title="First Accordion" onChange={action("expansionToggled")}>
+    <Accordion
+      title="First Accordion"
+      onChange={action("expansionToggled")}
+      {...args}
+    >
       <Box p={2}>
         <Textbox label="Textbox in an Accordion" />
       </Box>
     </Accordion>
-    <Accordion title="Second Accordion" onChange={action("expansionToggled")}>
+    <Accordion
+      title="Second Accordion"
+      onChange={action("expansionToggled")}
+      {...args}
+    >
       <Box p={2}>
         <Textbox label="Textbox in an Accordion" />
       </Box>
     </Accordion>
-    <Accordion title="Third Accordion" onChange={action("expansionToggled")}>
+    <Accordion
+      title="Third Accordion"
+      onChange={action("expansionToggled")}
+      {...args}
+    >
       <Box p={2}>
         <Box mt={2}>Content</Box>
         <Box>Content</Box>

--- a/src/components/accordion/accordion.pw.tsx
+++ b/src/components/accordion/accordion.pw.tsx
@@ -121,34 +121,37 @@ test.describe("should render Accordion component", () => {
     await expect(accordionContent(page)).toBeVisible();
   });
 
-  (["chevron_down", "dropdown"] as const).forEach((iconType) => {
-    test(`should set iconType to ${iconType} when Accordion row is closed`, async ({
-      page,
-      mount,
-    }) => {
-      await mount(<AccordionComponent iconType={iconType} />);
+  (["chevron_down", "dropdown", "chevron_down_thick"] as const).forEach(
+    (iconType) => {
+      test(`should set iconType to ${iconType} and transform when Accordion row is closed`, async ({
+        page,
+        mount,
+      }) => {
+        await mount(<AccordionComponent iconType={iconType} />);
 
-      await expect(accordionIcon(page)).toHaveAttribute("type", iconType);
-      await expect(accordionIcon(page)).toBeVisible();
-      const transformValue = await getStyle(accordionIcon(page), "transform");
-      await expect(getRotationAngle(transformValue)).toBe(90);
-    });
-  });
+        await expect(accordionIcon(page)).toHaveAttribute("type", iconType);
+        await expect(accordionIcon(page)).toBeVisible();
+        const transformValue = await getStyle(accordionIcon(page), "transform");
+        expect(getRotationAngle(transformValue)).toBe(0);
+      });
+    }
+  );
 
-  (["chevron_down", "dropdown"] as const).forEach((iconType) => {
-    test(`should set iconType to ${iconType} when Accordion row is open`, async ({
-      page,
-      mount,
-    }) => {
-      await mount(<AccordionComponent iconType={iconType} />);
+  (["chevron_down", "dropdown", "chevron_down_thick"] as const).forEach(
+    (iconType) => {
+      test(`should set iconType to ${iconType} and transform when Accordion row is open`, async ({
+        page,
+        mount,
+      }) => {
+        await mount(<AccordionComponent iconType={iconType} expanded />);
 
-      await accordionTitleContainer(page).click();
-
-      await expect(accordionIcon(page)).toHaveAttribute("type", iconType);
-      await expect(accordionIcon(page)).toBeVisible();
-      await expect(accordionIcon(page)).toHaveCSS("transform", "none");
-    });
-  });
+        await expect(accordionIcon(page)).toHaveAttribute("type", iconType);
+        await expect(accordionIcon(page)).toBeVisible();
+        const transformValue = await getStyle(accordionIcon(page), "transform");
+        expect(getRotationAngle(transformValue)).toBe(180);
+      });
+    }
+  );
 
   (["left", "right"] as const).forEach((iconAlign) => {
     test(`should set Accordion iconAlign to ${iconAlign}`, async ({
@@ -427,6 +430,18 @@ test.describe("should render Accordion component", () => {
     await accordionIcon(page).nth(0).click();
 
     await expect(accordionTitleContainer(page)).toContainText("Open");
+  });
+
+  test("should verify accordion subtitle does not render when variant is subtle", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <AccordionComponent title="subtle" variant="subtle" subTitle="subtitle" />
+    );
+
+    await expect(accordionTitleContainer(page)).toContainText("subtle");
+    await expect(accordionTitleContainer(page)).not.toContainText("subtitle");
   });
 });
 
@@ -730,6 +745,15 @@ test.describe("Accessibility tests for Accordion", () => {
     page,
   }) => {
     await mount(<AccordionWithDefinitionList />);
+
+    await checkAccessibility(page);
+  });
+
+  test("should pass accessibility tests for Accordion when variant is subtle", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<AccordionDefault variant="subtle" />);
 
     await checkAccessibility(page);
   });

--- a/src/components/accordion/accordion.stories.mdx
+++ b/src/components/accordion/accordion.stories.mdx
@@ -20,6 +20,7 @@ import {
   WithValidationIcon,
   WithDefinitionList,
   WithDynamicContent,
+  AccordionSubtle,
 } from "./accordion.stories.tsx";
 
 <Meta title="Accordion" parameters={{ info: { disable: true } }} />
@@ -115,7 +116,7 @@ Transparent scheme has transparent background.
 
 ### Small
 
-Small version has a smaller heading and less padding.
+Small version has a smaller heading, less padding and a smaller icon.
 
 <Canvas>
   <Story 
@@ -202,21 +203,6 @@ The box component can be used inside the accordion with different paddings
   />
 </Canvas>
 
-### Opening button
-
-Setting the `buttonHeading` prop will override the default styling for the `Accordion` control to look like Carbon's tertiary
-`Button`. It is also possible to use the `buttonWidth` prop to set the width of the control and the `headerSpacing` prop
-can be used to override the spacing styles.
-
-This is not currently designed to be used within a form using validation.
-
-<Canvas>
-  <Story
-    name="opening button"
-    story={OpeningButton}
-  />
-</Canvas>
-
 ### Grouped
 
 To group accordions import `AccordionGroup`. Accordions borders collapse when positioned next to each other making it easy to group them.
@@ -263,6 +249,17 @@ Accordion with a definiton list
     parameters={{ chromatic: { disableSnapshot: true } }}
     story={WithDefinitionList}
   />
+</Canvas>
+
+### Subtle Variant
+
+Setting the `variant` prop to `subtle` will override the default styling of an Accordion. 
+`subTitle` will not be rendered and the `scheme` prop will have no effect when used in combination with this variant. 
+
+This is not currently designed to be used within a form using validation.
+
+<Canvas>
+  <Story name="subtle variant" story={AccordionSubtle} />
 </Canvas>
 
 ## Props

--- a/src/components/accordion/accordion.stories.tsx
+++ b/src/components/accordion/accordion.stories.tsx
@@ -277,70 +277,6 @@ export const WithBoxComponentAndDifferentPaddings: ComponentStory<
   );
 };
 
-export const OpeningButton: ComponentStory<typeof Accordion> = () => {
-  return (
-    <Box m="8px">
-      <Accordion
-        title="More info"
-        openTitle="Less info"
-        scheme="transparent"
-        borders="none"
-        iconAlign="left"
-        buttonHeading
-        buttonWidth="200px"
-        error="hello"
-      >
-        <Box mt={2}>Content</Box>
-        <Box>Content</Box>
-        <Box>Content</Box>
-      </Accordion>
-      <br />
-      <Accordion
-        title="More info"
-        openTitle="Less info"
-        scheme="transparent"
-        borders="none"
-        iconAlign="right"
-        buttonHeading
-        buttonWidth="200px"
-      >
-        <Box mt={2}>Content</Box>
-        <Box>Content</Box>
-        <Box>Content</Box>
-      </Accordion>
-      <br />
-      <Accordion
-        scheme="transparent"
-        borders="none"
-        title="More info"
-        openTitle="Less info"
-        buttonHeading
-        headerSpacing={{ px: 0 }}
-        buttonWidth="96px"
-      >
-        <Box mt={2}>Content</Box>
-        <Box>Content</Box>
-        <Box>Content</Box>
-      </Accordion>
-      <br />
-      <Accordion
-        scheme="transparent"
-        borders="none"
-        title="More info"
-        openTitle="Less info"
-        iconAlign="left"
-        buttonHeading
-        buttonWidth="120px"
-        headerSpacing={{ px: 1 }}
-      >
-        <Box mt={2}>Content</Box>
-        <Box>Content</Box>
-        <Box>Content</Box>
-      </Accordion>
-    </Box>
-  );
-};
-
 export const Grouped: ComponentStory<typeof Accordion> = () => {
   return (
     <AccordionGroup>
@@ -577,6 +513,16 @@ export const WithDefinitionList: ComponentStory<typeof Accordion> = () => {
           </Button>
         </Dd>
       </Dl>
+    </Accordion>
+  );
+};
+
+export const AccordionSubtle: ComponentStory<typeof Accordion> = () => {
+  return (
+    <Accordion title="Heading" variant="subtle">
+      <Box>Content</Box>
+      <Box>Content</Box>
+      <Box>Content</Box>
     </Accordion>
   );
 };

--- a/src/components/accordion/accordion.style.ts
+++ b/src/components/accordion/accordion.style.ts
@@ -11,28 +11,30 @@ const StyledAccordionGroup = styled.div`
 `;
 
 export interface StyledAccordionContainerProps {
-  /** Toggles left and right borders */
+  /** Toggles left and right borders, set to none when variant is subtle */
   borders?: "default" | "full" | "none";
-  /** Renders the accordion heading in the style of a tertiary button */
+  /** (Deprecated) Renders the accordion heading in the style of a tertiary button */
   buttonHeading?: boolean;
-  /** Sets background as white or transparent */
+  /** (Deprecated) Sets background as white or transparent, set to transparent when variant is subtle */
   scheme?: "white" | "transparent";
   /** Sets accordion width */
   width?: string;
+  /** Sets accordion variant */
+  variant?: "standard" | "subtle";
 }
 
 const StyledAccordionContainer = styled.div<StyledAccordionContainerProps>`
   ${space}
   display: flex;
-  align-items: ${({ buttonHeading }) =>
-    buttonHeading ? "flex-start" : "stretch"};
+  align-items: ${({ buttonHeading, variant }) =>
+    buttonHeading || variant === "subtle" ? "flex-start" : "stretch"};
   justify-content: center;
   flex-direction: column;
   box-sizing: border-box;
   width: ${({ width }) => width || "100%"};
   color: var(--colorsUtilityYin090);
-  background-color: ${({ scheme }) =>
-    scheme === "white"
+  background-color: ${({ scheme, variant }) =>
+    scheme === "white" && variant !== "subtle"
       ? "var(--colorsUtilityYang100)"
       : "var(--colorsUtilityMajorTransparent)"};
   border: 1px solid var(--colorsUtilityMajor100);
@@ -48,20 +50,28 @@ const StyledAccordionContainer = styled.div<StyledAccordionContainerProps>`
       border: none;
     `}
 
-  & + & {
-    margin-top: -1px;
-    border-top: 1px solid var(--colorsUtilityMajor100);
-    border-bottom: 1px solid var(--colorsUtilityMajor100);
-  }
+  ${({ variant }) =>
+    variant !== "subtle" &&
+    css`
+      & + & {
+        margin-top: -1px;
+        border-top: 1px solid var(--colorsUtilityMajor100);
+        border-bottom: 1px solid var(--colorsUtilityMajor100);
+      }
+    `}
 `;
 
 interface StyledAccordionTitleProps {
   size?: "large" | "small";
+  variant?: "standard" | "subtle";
 }
 
 const StyledAccordionTitle = styled.h3<StyledAccordionTitleProps>`
-  font-size: ${({ size }) => (size === "small" ? "14" : "20")}px;
-  font-weight: ${({ size }) => (size === "small" ? 700 : 900)};
+  font-size: ${({ size, variant }) =>
+    size === "small" || variant === "subtle"
+      ? "var(--fontSizes200)"
+      : "var(--fontSizes400)"};
+  font-weight: 700;
   line-height: 1;
   user-select: none;
   margin: 0;
@@ -78,16 +88,19 @@ interface StyledAccordionIconProps {
 
 const StyledAccordionIcon = styled(Icon)<StyledAccordionIconProps>`
   transition: transform 0.3s;
+  transform: rotate(0deg);
   margin-right: ${({ iconAlign }) =>
     iconAlign === "left" ? "var(--spacing200)" : "var(--spacing000)"};
+
   ${({ isExpanded, iconAlign }) => {
     return (
-      !isExpanded &&
+      isExpanded &&
       (iconAlign === "right"
-        ? "transform: rotate(90deg)"
-        : "transform: rotate(-90deg)")
+        ? "transform: rotate(180deg)"
+        : "transform: rotate(-180deg)")
     );
   }};
+
   color: var(--colorsActionMinor500);
 `;
 
@@ -129,6 +142,8 @@ interface StyledAccordionTitleContainerProps {
   hasButtonProps?: boolean;
   iconAlign?: "left" | "right";
   size?: "large" | "small";
+  isExpanded?: boolean;
+  variant?: "standard" | "subtle";
 }
 
 const oldFocusStyling = `
@@ -143,6 +158,8 @@ const StyledAccordionTitleContainer = styled.div<StyledAccordionTitleContainerPr
     size,
     hasButtonProps,
     theme,
+    isExpanded,
+    variant,
   }) => css`
     padding: ${size === "small" ? "var(--spacing200)" : "var(--spacing300)"};
     ${space}
@@ -165,7 +182,27 @@ const StyledAccordionTitleContainer = styled.div<StyledAccordionTitleContainerPr
         : /* istanbul ignore next */ oldFocusStyling}
     }
 
+    ${variant === "subtle" &&
+    css`
+      color: var(--colorsActionMajor500);
+      padding: var(--spacing025);
+      margin-bottom: ${isExpanded && "var(--spacing200)"};
+
+      ${StyledAccordionIcon} {
+        color: var(--colorsActionMajor500);
+        ${iconAlign === "left" && "margin-right: var(--spacing050)"};
+      }
+
+      :hover {
+        color: var(--colorsActionMajor600);
+        ${StyledAccordionIcon} {
+          color: var(--colorsActionMajor600);
+        }
+      }
+    `}
+
     ${!buttonHeading &&
+    variant !== "subtle" &&
     css`
       &:hover {
         background-color: var(--colorsUtilityMajor050);
@@ -240,17 +277,26 @@ const StyledAccordionContentContainer = styled.div<StyledAccordionContentContain
 
 export interface StyledAccordionContentProps {
   disableContentPadding?: boolean;
+  variant?: "standard" | "subtle";
 }
 
 const StyledAccordionContent = styled.div<StyledAccordionContentProps>`
   padding: var(--spacing300);
-  padding-top: 0;
+  padding-top: var(--spacing100);
   overflow: hidden;
 
   ${({ disableContentPadding }) =>
     disableContentPadding &&
     css`
       padding: 0;
+    `}
+
+  ${({ variant }) =>
+    variant === "subtle" &&
+    css`
+      margin-left: var(--spacing150);
+      padding: var(--spacing100) var(--spacing200) var(--spacing300);
+      border-left: 2px solid var(--colorsUtilityMajor100);
     `}
 `;
 


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

- Introduced `variant` prop with "standard" and "subtle" options, default accordion is now standard variant. 
- "chevron_down_thick" added to `iconType` options.
- Update standard accordion styles to align with DS. 
- `scheme` and `buttonHeading` have been deprecated. 

Subtle variant:
- `iconAlign` is set to "left" by default
- `iconType` is set to "chevron_down_thick" by default
- `borders` is set to "none"
- `subTitle` will not be rendered
- Does not support validation

![Screenshot 2024-01-05 at 16 49 28](https://github.com/Sage/carbon/assets/78361608/0aae7207-af9b-4dd2-8144-30e61523c888)

![Screenshot 2024-01-05 at 16 35 56](https://github.com/Sage/carbon/assets/78361608/e354e9db-53e0-4617-b938-274db43ecfbb)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

- Accordion component does not have "subtle" variant. 
- Default styles do not align with DS. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
