### PR TITLE
 feat(image): add position prop to component - FE-6226 

### DIFF
--- a/docs/extending-styles-using-styled-components.stories.mdx
+++ b/docs/extending-styles-using-styled-components.stories.mdx
@@ -1,0 +1,70 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
+import styled from "styled-components";
+import Box from "../src/components/box";
+
+<Meta title="Documentation/Extending Styles of Carbon Components" />
+
+# Extending Styles of Carbon Components
+
+There may be a rare use case where you need to extend the styles of a Carbon component. This can be done by creating a custom component using the `styled-components` library and extending the component you would like the additional styling applied to.
+
+**We would always recommend this as a last resort as Carbon should already cater to a lot of your use cases**.
+
+## Usage
+
+Here we are using the `Box` component and applying styles that are not available in the `Box` component.
+We would always recommend not using this method to manage z-indexes, as this can cause issues with the stacking order of components. 
+**This method is to be used as a last resort.**
+
+```jsx
+// import `styled` interface from the `styled-components` library.
+import styled from "styled-components";
+// import the component you would like to extend the styles of. In this case, we are using the `Box` component.
+import Box from "carbon-react/lib/components/box";
+
+// Creating the custom components for the additional styling to be applied to. 
+const CustomStyledBox = styled(Box)`
+  z-index: 2;
+  border: solid 2px red;
+`;
+
+const CustomStyledBoxBorders = styled(Box)`
+  border-right: dotted 2px red;
+  border-left: solid 3px red;
+  border-top: dashed 2px black;
+  border-bottom: solid 2px black;
+`;
+
+// Using the `CustomStyledBox` and `CustomStyledBoxBorders` alongside props that are currently available to the Box component.
+return (
+  <>
+    <CustomStyledBox m={2} bg="aqua" height="250px" width="250px" />
+    <CustomStyledBoxBorders m={2} bg="grey" height="250px" width="250px" />
+  </>
+);
+```
+
+Here is an example of the above code in action.
+
+<Canvas>
+  <Story name="CustomStyledBox example">
+    {() => {
+      const CustomStyledBox = styled(Box)`
+        z-index: 2;
+        border: solid 2px red;
+      `;
+      const CustomStyledBoxBorders = styled(Box)`
+        border-right: dotted 2px red;
+        border-left: solid 3px red;
+        border-top: dashed 2px black;
+        border-bottom: solid 2px black;
+      `;
+      return (
+        <>
+          <CustomStyledBox m={2} bg="aqua" height="250px" width="250px" />
+          <CustomStyledBoxBorders m={2} bg="#CCCCCC" height="250px" width="250px" />
+        </>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/docs/extending-styles-using-styled-system.stories.mdx
+++ b/docs/extending-styles-using-styled-system.stories.mdx
@@ -1,0 +1,70 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
+import styled from "styled-components";
+import Box from "../src/components/box";
+
+<Meta title="Documentation/Extending Styles of Carbon Components" />
+
+# Extending Styles of Carbon Components
+
+There may be a rare use case where you need to extend the styles of a Carbon component. This can be done by creating a custom component using the `styled-components` library and extending the component you would like the additional styling applied to.
+
+**We would always recommend this as a last resort as Carbon should already cater to a lot of your use cases**.
+
+## Useage
+
+Here we are using the `Box` component and applying styles that are not available in the `Box` component.
+We would always recommend not using this method to manage z-indexes, as this can cause issues with the stacking order of components. 
+**This method is to be used as a last resort.**
+
+```jsx
+// import `styled` interface from the `styled-components` library.
+import styled from "styled-components";
+// import the component you would like to extend the styles of. In this case, we are using the `Box` component.
+import Box from "carbon-react/lib/components/box";
+
+// Creating the custom components for the additional styling to be applied to. 
+const CustomStyledBox = styled(Box)`
+  z-index: 2;
+  border: solid 2px red;
+`;
+
+const CustomStyledBoxBorders = styled(Box)`
+  border-right: dotted 2px red;
+  border-left: solid 3px red;
+  border-top: dashed 2px black;
+  border-bottom: solid 2px black;
+`;
+
+// Using the `CustomStyledBox` and `CustomStyledBoxBorders` alongside props that are currently available to the Box component.
+return (
+  <>
+    <CustomStyledBox m={2} bg="aqua" height="250px" width="250px" />
+    <CustomStyledBoxBorders m={2} bg="grey" height="250px" width="250px" />
+  </>
+);
+```
+
+Here is an example of the above code in action.
+
+<Canvas>
+  <Story name="CustomStyledBox example">
+    {() => {
+      const CustomStyledBox = styled(Box)`
+        z-index: 2;
+        border: solid 2px red;
+      `;
+      const CustomStyledBoxBorders = styled(Box)`
+        border-right: dotted 2px red;
+        border-left: solid 3px red;
+        border-top: dashed 2px black;
+        border-bottom: solid 2px black;
+      `;
+      return (
+        <>
+          <CustomStyledBox m={2} bg="aqua" height="250px" width="250px" />
+          <CustomStyledBoxBorders m={2} bg="#CCCCCC" height="250px" width="250px" />
+        </>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/src/components/box/box.component.tsx
+++ b/src/components/box/box.component.tsx
@@ -27,12 +27,12 @@ type BoxShadowsType = Extract<DesignTokensType, `boxShadow${string}`>;
 type BorderRadiusType = Extract<DesignTokensType, `borderRadius${string}`>;
 
 export interface BoxProps
-  extends SpaceProps,
-    LayoutProps,
-    FlexboxProps,
+  extends FlexboxProps,
     Omit<GridProps, "gridGap" | "gridRowGap" | "gridColumnGap">,
-    TagProps,
-    Omit<PositionProps, "zIndex"> {
+    LayoutProps,
+    Omit<PositionProps, "zIndex">,
+    SpaceProps,
+    TagProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
   /** Set the ID attribute of the Box component */

--- a/src/components/image/image.component.tsx
+++ b/src/components/image/image.component.tsx
@@ -7,6 +7,11 @@ export const Image = ({
   decorative = false,
   src,
   children,
+  position,
+  top,
+  right,
+  bottom,
+  left,
   ...rest
 }: StyledImageProps) => {
   invariant(
@@ -20,7 +25,17 @@ export const Image = ({
   );
 
   return (
-    <StyledImage alt={alt} decorative={decorative} src={src} {...rest}>
+    <StyledImage
+      alt={alt}
+      decorative={decorative}
+      src={src}
+      position={position}
+      top={top}
+      right={right}
+      bottom={bottom}
+      left={left}
+      {...rest}
+    >
       {children}
     </StyledImage>
   );

--- a/src/components/image/image.pw.tsx
+++ b/src/components/image/image.pw.tsx
@@ -10,24 +10,88 @@ import {
   Default,
 } from "./components.test-pw";
 
-test("When hidden prop is false, component should be visible to sighted users", async ({
-  mount,
-  page,
-}) => {
-  await mount(<CarbonLogoImage />);
+test.describe("check props for Image component", () => {
+  test("When hidden prop is false, component should be visible to sighted users", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<CarbonLogoImage />);
 
-  const imageElement = page.locator("img");
-  await expect(imageElement).toBeInViewport();
-});
+    const imageElement = page.locator("img");
+    await expect(imageElement).toBeInViewport();
+  });
 
-test("When hidden prop is true, component should not be visible to sighted users", async ({
-  mount,
-  page,
-}) => {
-  await mount(<CarbonLogoImage hidden />);
+  test("When hidden prop is true, component should not be visible to sighted users", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<CarbonLogoImage hidden />);
 
-  const imageElement = page.locator("img");
-  await expect(imageElement).not.toBeInViewport();
+    const imageElement = page.locator("img");
+    await expect(imageElement).not.toBeInViewport();
+  });
+
+  (["absolute", "fixed", "relative", "static", "sticky"] as const).forEach(
+    (positionValue) => {
+      test(`When position prop is ${positionValue} it should apply the expected CSS`, async ({
+        mount,
+        page,
+      }) => {
+        await mount(<CarbonLogoImage position={positionValue} />);
+
+        const imageElement = page.locator("img");
+        await expect(imageElement).toHaveCSS("position", positionValue);
+      });
+    }
+  );
+
+  (["10px", "5%", "auto"] as const).forEach((topValue) => {
+    test(`When top prop is ${topValue} it should apply the expected CSS`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(<CarbonLogoImage top={topValue} />);
+
+      const imageElement = page.locator("img");
+      await expect(imageElement).toHaveCSS("top", topValue);
+    });
+  });
+
+  (["10px", "5%", "auto"] as const).forEach((rightValue) => {
+    test(`When right prop is ${rightValue} it should apply the expected CSS`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(<CarbonLogoImage right={rightValue} />);
+
+      const imageElement = page.locator("img");
+      await expect(imageElement).toHaveCSS("right", rightValue);
+    });
+  });
+
+  (["10px", "5%", "auto"] as const).forEach((bottomValue) => {
+    test(`When bottom prop is ${bottomValue} it should apply the expected CSS`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(<CarbonLogoImage bottom={bottomValue} />);
+
+      const imageElement = page.locator("img");
+      await expect(imageElement).toHaveCSS("bottom", bottomValue);
+    });
+  });
+
+  (["10px", "5%", "auto"] as const).forEach((leftValue) => {
+    test(`When left prop is ${leftValue} it should apply the expected CSS`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(<CarbonLogoImage left={leftValue} />);
+
+      const imageElement = page.locator("img");
+      await expect(imageElement).toHaveCSS("left", leftValue);
+    });
+  });
 });
 
 test.describe("Accessibility tests for Image component", () => {

--- a/src/components/image/image.spec.tsx
+++ b/src/components/image/image.spec.tsx
@@ -4,8 +4,10 @@ import {
   testStyledSystemMargin,
   testStyledSystemLayout,
   testStyledSystemBackground,
+  assertStyleMatch,
 } from "../../__spec_helper__/test-utils";
 import Image from "./image.component";
+import { StyledImage } from "./image.style";
 
 describe("Image", () => {
   testStyledSystemMargin((props) => <Image {...props} />);
@@ -79,5 +81,120 @@ describe("Image", () => {
         mount(<Image src="foo.jpg" alt="" />);
       }).toThrow(errorMessage);
     });
+  });
+
+  describe.each(["absolute", "fixed", "relative", "static", "sticky"] as const)(
+    "when position prop is passed",
+    (positionValue) => {
+      it(`should apply the correct styling for position of ${positionValue}`, () => {
+        const wrapper = mount(
+          <Image
+            src="foo.jpg"
+            alt="foo"
+            backgroundImage="url('foo.jpg')"
+            position={positionValue}
+          />
+        );
+
+        assertStyleMatch(
+          {
+            position: positionValue,
+          },
+          wrapper.find(StyledImage)
+        );
+      });
+    }
+  );
+
+  describe("when top prop is passed", () => {
+    it.each(["2px", "3em", "10%", "inherit"])(
+      "should apply the correct styling for position of %s",
+      (topValue) => {
+        const wrapper = mount(
+          <Image
+            src="foo.jpg"
+            alt="foo"
+            backgroundImage="url('foo.jpg')"
+            top={topValue}
+          />
+        );
+
+        assertStyleMatch(
+          {
+            top: topValue,
+          },
+          wrapper.find(StyledImage)
+        );
+      }
+    );
+  });
+
+  describe("when right prop is passed", () => {
+    it.each(["2px", "3em", "10%", "inherit"])(
+      "should apply the correct styling for position of %s",
+      (rightValue) => {
+        const wrapper = mount(
+          <Image
+            src="foo.jpg"
+            alt="foo"
+            backgroundImage="url('foo.jpg')"
+            right={rightValue}
+          />
+        );
+
+        assertStyleMatch(
+          {
+            right: rightValue,
+          },
+          wrapper.find(StyledImage)
+        );
+      }
+    );
+  });
+
+  describe("when bottom prop is passed", () => {
+    it.each(["2px", "3em", "10%", "inherit"])(
+      "should apply the correct styling for position of %s",
+      (bottomValue) => {
+        const wrapper = mount(
+          <Image
+            src="foo.jpg"
+            alt="foo"
+            backgroundImage="url('foo.jpg')"
+            bottom={bottomValue}
+          />
+        );
+
+        assertStyleMatch(
+          {
+            bottom: bottomValue,
+          },
+          wrapper.find(StyledImage)
+        );
+      }
+    );
+  });
+
+  describe("when left prop is passed", () => {
+    it.each(["2px", "3em", "10%", "inherit"])(
+      "should apply the correct styling for position of %s",
+      (leftValue) => {
+        const wrapper = mount(
+          <Image
+            src="foo.jpg"
+            alt="foo"
+            backgroundImage="url('foo.jpg')"
+            left={leftValue}
+          />
+        );
+
+        assertStyleMatch(
+          {
+            left: leftValue,
+          },
+          wrapper.find(StyledImage)
+        );
+      }
+    );
   });
 });

--- a/src/components/image/image.stories.mdx
+++ b/src/components/image/image.stories.mdx
@@ -41,6 +41,16 @@ css attribute.
   <Story name="default" story={stories.DefaultStory} />
 </Canvas>
 
+### With `position` Prop
+
+To apply a CSS position to the component, pass in a valid CSS string value to the `position` prop. 
+
+To effect the `top`, `right`, `bottom` and `left` position of the component, pass in a valid CSS string value to the `top`, `right`, `bottom` and `left` props. 
+
+<Canvas>
+  <Story name="with position" story={stories.ImageWithPosition} />
+</Canvas>
+
 ### As an img element
 
 If you want to render an `img` element pass in a value to the `src` prop. The component will not accept `children` when

--- a/src/components/image/image.stories.tsx
+++ b/src/components/image/image.stories.tsx
@@ -109,3 +109,24 @@ export const DecorativeStory: StoryFn = () => (
   <Image alt="" src={pointSvg} decorative />
 );
 DecorativeStory.parameters = { info: { disable: true } };
+
+export const ImageWithPosition: StoryFn = () => (
+  <Image
+    m={3}
+    height="700px"
+    backgroundImage={`url(${flexibleSvg})`}
+    position="static"
+  >
+    <Box
+      height="700px"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Typography variant="h4">
+        Here is an example of Image with position static
+      </Typography>
+    </Box>
+  </Image>
+);
+ImageWithPosition.parameters = { info: { disable: true } };

--- a/src/components/image/image.style.ts
+++ b/src/components/image/image.style.ts
@@ -9,10 +9,16 @@ import {
 } from "styled-system";
 import { baseTheme } from "../../style/themes";
 
+export type PositionProps =
+  | "absolute"
+  | "fixed"
+  | "relative"
+  | "static"
+  | "sticky";
 export interface StyledImageProps
-  extends MarginProps,
-    BackgroundProps,
-    LayoutProps {
+  extends BackgroundProps,
+    LayoutProps,
+    MarginProps {
   /** HTML alt property to display when an img fails to load */
   alt?: string;
   /** Prop to specify if the image is decorative  */
@@ -23,18 +29,50 @@ export interface StyledImageProps
   hidden?: boolean;
   /** Children elements, will only render if component is a div element */
   children?: React.ReactNode;
+  /** Any valid CSS string for position */
+  position?: PositionProps;
+  /** Any valid CSS string for top */
+  top?: string;
+  /** Any valid CSS string for right */
+  right?: string;
+  /** Any valid CSS string for bottom */
+  bottom?: string;
+  /** Any valid CSS string for left */
+  left?: string;
 }
 
 const StyledImage = styled.div.attrs(
-  ({ src, children, hidden = false }: StyledImageProps) => ({
+  ({
+    src,
+    children,
+    hidden = false,
+    position,
+    top,
+    right,
+    bottom,
+    left,
+  }: StyledImageProps) => ({
     ...(src && { as: "img" }),
     children: src ? undefined : children,
     src,
     hidden,
+    position,
+    top,
+    right,
+    bottom,
+    left,
   })
 )<StyledImageProps>`
   ${margin}
   ${layout}
+
+  ${({ position, top, right, bottom, left }) => css`
+    position: ${position};
+    top: ${top};
+    right: ${right};
+    bottom: ${bottom};
+    left: ${left};
+  `}
 
   ${({ as }) =>
     as !== "img" &&


### PR DESCRIPTION
### Proposed behaviour

- Add `position` prop to `Image` component.
- Add new document outlining how to extend the styling of Carbon's components. 

### Current behaviour

- No `position` prop on the `Image` component.
- No document outlining how to extend the styling of Carbon's components. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- There should be no regression with the `Image` component.
- Passing `position` prop to `Image` component should apply the correct position to CSS of component.
- New document should render in Storybook and explain how to correctly extend the styling.