### PR TITLE
feat(inline-inputs): add labelAlign prop

### DIFF
--- a/src/components/inline-inputs/inline-inputs.component.tsx
+++ b/src/components/inline-inputs/inline-inputs.component.tsx
@@ -35,6 +35,8 @@ export interface InlineInputsProps
   htmlFor?: string;
   /** Defines the label text for the heading. */
   label?: string;
+  /** Inline label alignment */
+  labelAlign?: "left" | "right";
   /**
    * Custom label id, could be used in combination with aria-labelledby prop of each input,
    * to make them accesible for screen readers.
@@ -57,6 +59,7 @@ const columnWrapper = (children: React.ReactNode, gutter: GutterOptions) => {
 const InlineInputs = ({
   adaptiveLabelBreakpoint,
   label,
+  labelAlign,
   labelId,
   htmlFor,
   children = null,
@@ -79,6 +82,7 @@ const InlineInputs = ({
 
     return (
       <Label
+        align={labelAlign}
         labelId={labelId}
         inline={inlineLabel}
         htmlFor={htmlFor}

--- a/src/components/inline-inputs/inline-inputs.pw.tsx
+++ b/src/components/inline-inputs/inline-inputs.pw.tsx
@@ -128,6 +128,27 @@ test.describe("InlineInputs", () => {
       await expect(inlineLabel(page)).toHaveAttribute("for", htmlFor);
     });
   });
+
+  ([
+    ["left", "flex-start"],
+    ["right", "flex-end"],
+  ] as [InlineInputsProps["labelAlign"], string][]).forEach(
+    ([labelAlign, cssValue]) => {
+      test(`should render with labelAlign prop set to ${labelAlign}`, async ({
+        mount,
+        page,
+      }) => {
+        await mount(
+          <InlineInputComponent labelAlign={labelAlign} labelWidth={30} />
+        );
+
+        await expect(inlinelabelWidth(page)).toHaveCSS(
+          "justify-content",
+          cssValue
+        );
+      });
+    }
+  );
 });
 
 test.describe("Accessibility tests for InlineInputs component", () => {

--- a/src/components/inline-inputs/inline-inputs.spec.tsx
+++ b/src/components/inline-inputs/inline-inputs.spec.tsx
@@ -203,6 +203,21 @@ describe("Inline Inputs", () => {
     });
   });
 
+  describe("when providing the labelAlign prop", () => {
+    beforeEach(() => {
+      wrapper = render({ label: "foo", labelAlign: "left", labelWidth: 30 });
+    });
+
+    it("sets the inline label to the provided alignemnt", () => {
+      assertStyleMatch(
+        {
+          justifyContent: "flex-start",
+        },
+        wrapper.find(Label)
+      );
+    });
+  });
+
   describe("when the inputWidth prop is not passed in", () => {
     beforeEach(() => {
       wrapper = render({});

--- a/src/components/inline-inputs/inline-inputs.stories.mdx
+++ b/src/components/inline-inputs/inline-inputs.stories.mdx
@@ -41,10 +41,7 @@ import InlineInputs from "carbon-react/lib/components/inline-inputs";
 ### Default
 
 <Canvas>
-  <Story
-    name="default"
-    story={stories.Default}
-  />
+  <Story name="default" story={stories.Default} />
 </Canvas>
 
 ## with adaptiveLabelBreakpoint
@@ -60,6 +57,12 @@ import InlineInputs from "carbon-react/lib/components/inline-inputs";
 
 <Canvas>
   <Story name="required" story={stories.Required} />
+</Canvas>
+
+## labelAlign
+
+<Canvas>
+  <Story name="labelAlign" story={stories.LabelAlign} />
 </Canvas>
 
 ## Props

--- a/src/components/inline-inputs/inline-inputs.stories.tsx
+++ b/src/components/inline-inputs/inline-inputs.stories.tsx
@@ -93,3 +93,21 @@ export const Required: ComponentStory<typeof InlineInputs> = () => {
   );
 };
 Required.parameters = { controls: { disable: true } };
+
+export const LabelAlign: ComponentStory<typeof InlineInputs> = () => {
+  return (
+    <Box>
+      {(["right", "left"] as const).map((alignment) => (
+        <InlineInputs
+          label="My Inline Inputs"
+          labelAlign={alignment}
+          labelId="inline-inputs-align"
+          labelWidth={30}
+        >
+          <Textbox aria-labelledby="inline-inputs-align" />
+          <Textbox aria-labelledby="inline-inputs-align" />
+        </InlineInputs>
+      ))}
+    </Box>
+  );
+};


### PR DESCRIPTION
### Proposed behaviour

Add a labelAlign prop that will take "left" or "right" params. 
Should replicate the behaviour of the inline label labelAlign for the Textarea component.

fix #6498

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

No such prop exists.

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required
