### PR TITLE
fix(link): focus underline fix

### DIFF
--- a/src/components/link/link.pw.tsx
+++ b/src/components/link/link.pw.tsx
@@ -272,6 +272,7 @@ test.describe("when focused", () => {
       "box-shadow",
       "rgba(0, 0, 0, 0.9) 0px 4px 0px 0px"
     );
+    await expect(linkWrapper).toHaveCSS("max-width", "fit-content");
   });
 });
 

--- a/src/components/link/link.style.ts
+++ b/src/components/link/link.style.ts
@@ -213,6 +213,7 @@ const StyledLink = styled.span<StyledLinkProps & PrivateStyledLinkProps>`
           border-bottom-left-radius: var(--borderRadius000);
           border-bottom-right-radius: var(--borderRadius000);
         }
+        max-width: fit-content;
         box-shadow: 0 4px 0 0 var(--colorsUtilityYin090);
         border-bottom-left-radius: var(--borderRadius025);
         border-bottom-right-radius: var(--borderRadius025);


### PR DESCRIPTION
fix #6434

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

`link` focus underline only wraps the component's children and is not affected by the width of the parent container. 

![image](https://github.com/Sage/carbon/assets/78361608/c937f3af-1871-45bf-86c9-ac72437a05fe)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

When `link` is focused the focus underline extends to the width of the parent container.

![image](https://github.com/Sage/carbon/assets/78361608/74f3a60c-06cc-44bb-9e81-c424d458a2b5)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
