### PR TITLE
fix(flat-table): ensure that focus size is correctly applied in Safari - FE-6315

### DIFF
--- a/src/components/flat-table/flat-table-row/flat-table-row.component.tsx
+++ b/src/components/flat-table/flat-table-row/flat-table-row.component.tsx
@@ -293,6 +293,7 @@ export const FlatTableRow = React.forwardRef<
         id={internalId.current}
         data-selected={selected && expandableArea === "wholeRow"}
         data-highlighted={highlighted && expandableArea === "wholeRow"}
+        rowHeight={rowRef?.current?.offsetHeight}
         {...interactiveRowProps}
         {...rest}
       >

--- a/src/components/flat-table/flat-table-row/flat-table-row.spec.tsx
+++ b/src/components/flat-table/flat-table-row/flat-table-row.spec.tsx
@@ -17,6 +17,8 @@ import FlatTableRowHeader from "../flat-table-row-header/flat-table-row-header.c
 import FlatTableHeader from "../flat-table-header/flat-table-header.component";
 import { FlatTableBodyDraggable } from "..";
 import { FlatTableThemeContext } from "../flat-table.component";
+import Box from "../../box";
+import * as browserTypeCheck from "../../../__internal__/utils/helpers/browser-type-check";
 
 const events = {
   enter: {
@@ -1373,6 +1375,51 @@ describe("FlatTableRow", () => {
           {
             modifier: `${StyledFlatTableCheckbox} + ${StyledFlatTableCell} > div`,
           }
+        );
+      });
+    });
+
+    describe("when a table row has content with custom height in Safari", () => {
+      let isSafariSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        isSafariSpy = jest.spyOn(browserTypeCheck, "isSafari");
+      });
+
+      beforeEach(() => {
+        // Mock the offsetHeight of the table row
+        Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+          configurable: true,
+          value: 200,
+        });
+      });
+
+      it("applies the correct height for focus styling", () => {
+        isSafariSpy.mockReturnValue(true);
+
+        const wrapper = mount(
+          <table>
+            <thead>
+              <FlatTableRow onClick={() => {}}>
+                <FlatTableCell>
+                  <Box height="200px">
+                    <Box>Option 2</Box>
+                  </Box>
+                </FlatTableCell>
+              </FlatTableRow>
+            </thead>
+          </table>
+        );
+
+        const row = wrapper.find(StyledFlatTableRow);
+        row.simulate("focus");
+
+        assertStyleMatch(
+          {
+            height: "200px",
+          },
+          row,
+          { modifier: `:focus:after` }
         );
       });
     });

--- a/src/components/flat-table/flat-table-row/flat-table-row.style.ts
+++ b/src/components/flat-table/flat-table-row/flat-table-row.style.ts
@@ -11,7 +11,6 @@ import { FlatTableProps } from "..";
 import { FlatTableRowProps } from "./flat-table-row.component";
 import addFocusStyling from "../../../style/utils/add-focus-styling";
 import { isSafari } from "../../../__internal__/utils/helpers/browser-type-check";
-import cellSizes from "../cell-sizes.style";
 
 const horizontalBorderSizes = {
   medium: "2px",
@@ -112,13 +111,6 @@ const verticalBorderColor = (colorTheme: FlatTableProps["colorTheme"]) => {
   }
 };
 
-const getFocusHeight = (size: StyledFlatTableRowProps["size"]) => {
-  if (!size) return "40px";
-  const { height } = cellSizes[size];
-
-  return height;
-};
-
 interface StyledFlatTableRowProps
   extends Pick<
     FlatTableRowProps,
@@ -144,6 +136,7 @@ interface StyledFlatTableRowProps
   isSubRow?: boolean;
   isFirstSubRow?: boolean;
   stickyOffset?: number;
+  rowHeight?: number;
 }
 
 const StyledFlatTableRow = styled.tr<StyledFlatTableRowProps>`
@@ -170,6 +163,7 @@ const StyledFlatTableRow = styled.tr<StyledFlatTableRowProps>`
     theme,
     isDragging,
     draggable,
+    rowHeight,
   }) => {
     const backgroundColor = bgColor ? toColor(theme, bgColor) : undefined;
     const customBorderColor = horizontalBorderColor
@@ -293,6 +287,7 @@ const StyledFlatTableRow = styled.tr<StyledFlatTableRowProps>`
               top: 0px;
             }
           }
+
           /* Styling for safari. Position relative does not work on tr elements on Safari  */
           ${isSafari(navigator) &&
           css`
@@ -312,10 +307,10 @@ const StyledFlatTableRow = styled.tr<StyledFlatTableRowProps>`
             css`
               position: -webkit-sticky;
               :after {
-                content: none;
                 border: none;
                 content: "";
-                height: ${getFocusHeight(size)} ${newFocusStyling};
+                height: ${rowHeight}px;
+                ${newFocusStyling}
               }
             `}
           `}

--- a/src/components/flat-table/flat-table-test.stories.tsx
+++ b/src/components/flat-table/flat-table-test.stories.tsx
@@ -90,6 +90,7 @@ export default {
     "ExpandableWithLink",
     "SortableStory",
     "SubRowsAsAComponentStory",
+    "FlatTableSizeFocus",
   ],
   parameters: {
     info: { disable: true },
@@ -3563,5 +3564,40 @@ export const HighlightedRowWithLoadingState = (
         <FlatTableBody>{update ? rows : loading}</FlatTableBody>
       </FlatTable>
     </div>
+  );
+};
+
+export const FlatTableSizeFocus = () => {
+  return (
+    <Box p={1}>
+      <FlatTable>
+        <FlatTableBody>
+          <FlatTableRow onClick={() => {}}>
+            <FlatTableCell>
+              <Box>
+                <Box py="3">Option 1</Box>
+              </Box>
+            </FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow onClick={() => {}}>
+            <FlatTableCell>
+              <Box my="3">
+                <Box>Option 2</Box>
+              </Box>
+            </FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow onClick={() => {}}>
+            <FlatTableCell>
+              <Box my={3}>
+                <Box height="69px">Option 3</Box>
+              </Box>
+            </FlatTableCell>
+          </FlatTableRow>
+          <FlatTableRow onClick={() => {}}>
+            <FlatTableCell>Option 4</FlatTableCell>
+          </FlatTableRow>
+        </FlatTableBody>
+      </FlatTable>
+    </Box>
   );
 };


### PR DESCRIPTION
This fix uses the offset height of the flat-table-row element to correctly apply the correct height when the row is focused. This is fix is only for the newer focus styling and the old style will continue to work as it did previously.

fixes #6496

### Proposed behaviour

https://github.com/Sage/carbon/assets/56251247/8140b568-257d-4301-83d7-3d4eff7cc86e

### Current behaviour

https://github.com/Sage/carbon/assets/56251247/7a0e677e-b6ac-4f99-8ba2-943ba308528a

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

This piece of work is purely to address the static styling of Flat Table Row in Safari. A further piece of work to address any dynamic styles will be addressed in FE-6334.

### Testing instructions

- Navigate to the new `Flat Table Size Focus` test story in Safari and ensure that the focus border is the correct size for the new focus styling. 
- There should be no other functional or styling regressions with regards to focus behaviour in any browser with this component. 