### PR TITLE
fix(select): maintain option ids according to key when children count changes

### DIFF
--- a/src/components/select/option-group-header/__snapshots__/option-group-header.spec.tsx.snap
+++ b/src/components/select/option-group-header/__snapshots__/option-group-header.spec.tsx.snap
@@ -39,6 +39,7 @@ exports[`OptionGroupHeader renders properly 1`] = `
 
 <div
   className="c0"
+  id="guid-12345"
 >
   <h4>
     Heading
@@ -119,6 +120,7 @@ exports[`OptionGroupHeader when icon prop is set then it should display the icon
 
 <div
   className="c0"
+  id="guid-12345"
 >
   <span
     className="c1 c2"

--- a/src/components/select/option-group-header/option-group-header.component.tsx
+++ b/src/components/select/option-group-header/option-group-header.component.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useRef } from "react";
 import { CSSProperties } from "styled-components";
 import { TagProps } from "__internal__/utils/helpers/tags";
+import guid from "../../../__internal__/utils/helpers/guid";
 import StyledOptionGroupHeader from "./option-group-header.style";
 import Icon, { IconProps } from "../../icon";
 
@@ -23,11 +24,18 @@ export interface OptionGroupHeaderProps extends TagProps {
 
 const OptionGroupHeader = React.forwardRef(
   (
-    { label, icon, style, ...rest }: OptionGroupHeaderProps,
+    { label, icon, style, id, ...rest }: OptionGroupHeaderProps,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
+    const internalIdRef = useRef(id || guid());
+
     return (
-      <StyledOptionGroupHeader style={style} {...rest} ref={ref}>
+      <StyledOptionGroupHeader
+        style={style}
+        id={internalIdRef.current}
+        {...rest}
+        ref={ref}
+      >
         {icon && <Icon type={icon} />}
         <h4>{label}</h4>
       </StyledOptionGroupHeader>

--- a/src/components/select/option-group-header/option-group-header.spec.tsx
+++ b/src/components/select/option-group-header/option-group-header.spec.tsx
@@ -2,6 +2,12 @@ import React from "react";
 import TestRenderer from "react-test-renderer";
 import { shallow, mount } from "enzyme";
 import OptionGroupHeader, { OptionGroupHeaderProps } from ".";
+import guid from "../../../__internal__/utils/helpers/guid";
+
+const mockedGuid = "guid-12345";
+jest.mock("../../../__internal__/utils/helpers/guid");
+
+(guid as jest.MockedFunction<typeof guid>).mockImplementation(() => mockedGuid);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function renderOption(props: OptionGroupHeaderProps, renderer: any = shallow) {

--- a/src/components/select/option-row/option-row.component.tsx
+++ b/src/components/select/option-row/option-row.component.tsx
@@ -1,6 +1,7 @@
-import React, { useContext } from "react";
+import React, { useContext, useRef } from "react";
 import { CSSProperties } from "styled-components";
 import { TagProps } from "__internal__/utils/helpers/tags";
+import guid from "../../../__internal__/utils/helpers/guid";
 import StyledOptionRow from "./option-row.style";
 import SelectListContext from "../__internal__/select-list-context";
 
@@ -60,12 +61,16 @@ const OptionRow = React.forwardRef(
     }: OptionRowProps,
     ref: React.ForwardedRef<HTMLTableRowElement>
   ) => {
+    const internalIdRef = useRef(id || guid());
+
     const handleClick = () => {
       if (disabled) {
         return;
       }
-      onSelect?.({ id, text, value });
+
+      onSelect?.({ text, value, id: internalIdRef.current });
     };
+
     const selectListContext = useContext(SelectListContext);
     let isSelected = selectListContext.currentOptionsListIndex === index;
 
@@ -75,7 +80,7 @@ const OptionRow = React.forwardRef(
 
     return (
       <StyledOptionRow
-        id={id}
+        id={internalIdRef.current}
         ref={ref}
         aria-selected={isSelected}
         aria-disabled={disabled}

--- a/src/components/select/option/__snapshots__/option.spec.tsx.snap
+++ b/src/components/select/option/__snapshots__/option.spec.tsx.snap
@@ -26,6 +26,7 @@ exports[`Option renders properly 1`] = `
   aria-selected={true}
   className="c0"
   data-component="option"
+  id="guid-12345"
   onClick={[Function]}
   role="option"
 >
@@ -59,6 +60,7 @@ exports[`Option when no children are provided renders with the text prop as chil
   aria-selected={true}
   className="c0"
   data-component="option"
+  id="guid-12345"
   onClick={[Function]}
   role="option"
 >

--- a/src/components/select/option/option.component.tsx
+++ b/src/components/select/option/option.component.tsx
@@ -1,5 +1,6 @@
-import React, { useContext } from "react";
-import { TagProps } from "__internal__/utils/helpers/tags";
+import React, { useContext, useRef } from "react";
+import guid from "../../../__internal__/utils/helpers/guid";
+import { TagProps } from "../../../__internal__/utils/helpers/tags";
 import StyledOption from "./option.style";
 import SelectListContext from "../__internal__/select-list-context";
 
@@ -66,6 +67,7 @@ const Option = React.forwardRef(
   ) => {
     const selectListContext = useContext(SelectListContext);
     let isSelected = selectListContext.currentOptionsListIndex === index;
+    const internalIdRef = useRef(id || guid());
 
     if (selectListContext.multiselectValues) {
       isSelected = selectListContext.multiselectValues.includes(value);
@@ -76,7 +78,7 @@ const Option = React.forwardRef(
         return;
       }
       if (!onClick) {
-        onSelect?.({ text, value, id });
+        onSelect?.({ text, value, id: internalIdRef.current });
       } else {
         onSelect?.();
         onClick(value);
@@ -85,7 +87,7 @@ const Option = React.forwardRef(
 
     return (
       <StyledOption
-        id={id}
+        id={internalIdRef.current}
         ref={ref}
         aria-selected={isSelected}
         aria-disabled={disabled}

--- a/src/components/select/option/option.spec.tsx
+++ b/src/components/select/option/option.spec.tsx
@@ -3,6 +3,12 @@ import TestRenderer from "react-test-renderer";
 import { shallow, mount } from "enzyme";
 import Option, { OptionProps } from ".";
 import SelectListContext from "../__internal__/select-list-context";
+import guid from "../../../__internal__/utils/helpers/guid";
+
+const mockedGuid = "guid-12345";
+jest.mock("../../../__internal__/utils/helpers/guid");
+
+(guid as jest.MockedFunction<typeof guid>).mockImplementation(() => mockedGuid);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function renderOption(props: OptionProps, renderer: any = shallow) {
@@ -111,6 +117,7 @@ describe("Option", () => {
       expect(onSelect).toHaveBeenCalledWith({
         text: props.text,
         value: props.value,
+        id: mockedGuid,
       });
     });
   });

--- a/src/components/select/select-list/select-list.component.tsx
+++ b/src/components/select/select-list/select-list.component.tsx
@@ -35,7 +35,6 @@ import ListActionButton from "../list-action-button";
 import StyledSelectListContainer from "./select-list-container.style";
 import Loader from "../../loader";
 import Option, { OptionProps } from "../option";
-import guid from "../../../__internal__/utils/helpers/guid";
 import SelectListContext from "../__internal__/select-list-context";
 
 export interface SelectListProps {
@@ -186,13 +185,32 @@ const SelectList = React.forwardRef(
 
     const items = virtualizer.getVirtualItems();
 
+    const childrenList = useMemo(() => React.Children.toArray(children), [
+      children,
+    ]) as React.ReactElement<OptionProps>[];
+
+    const getIndexOfMatch = useCallback(
+      (valueToMatch) => {
+        return childrenList.findIndex(
+          (child) =>
+            React.isValidElement(child) && child.props.value === valueToMatch
+        );
+      },
+      [childrenList]
+    );
+
     // getVirtualItems returns an empty array of items if the select list is currently closed - which is correct visually but
     // we need to ensure that any currently-selected option is still in the DOM to avoid any accessibility issues.
     // The isOpen prop will ensure that no options are visible regardless of what is in the items array.
-    if (items.length === 0 && currentOptionsListIndex !== -1) {
-      // only index property is required with the item not visible so the following type assertion, even though incorrect,
-      // should be OK
-      items.push({ index: currentOptionsListIndex } as VirtualItem);
+    if (items.length === 0) {
+      const currentIndex = highlightedValue
+        ? getIndexOfMatch(highlightedValue)
+        : currentOptionsListIndex;
+      if (currentIndex > -1) {
+        // only index property is required with the item not visible so the following type assertion, even though incorrect,
+        // should be OK
+        items.push({ index: currentIndex } as VirtualItem);
+      }
     }
 
     const listHeight = virtualizer.getTotalSize();
@@ -237,27 +255,9 @@ const SelectList = React.forwardRef(
       [onSelect]
     );
 
-    const childIdsRef: React.MutableRefObject<string[] | null> = useRef(null);
-
-    // childIds should be stable except when children are added or removed - can't use useMemo
-    // as that isn't absolutely guaranteed to never rerun when dependencies haven't changed.
-    const setChildIds = () => {
-      childIdsRef.current =
-        React.Children.map(
-          children,
-          (child) => (React.isValidElement(child) && child?.props.id) || guid()
-        ) || /* istanbul ignore next */ null;
-    };
-
-    if (childIdsRef.current?.length !== React.Children.count(children)) {
-      setChildIds();
-    }
-
-    const childIds = childIdsRef.current;
-
-    const childrenList = useMemo(() => React.Children.toArray(children), [
-      children,
-    ]) as React.ReactElement<OptionProps>[];
+    const childElementRefs = useRef<HTMLElement[]>(
+      Array.from({ length: React.Children.count(children) })
+    );
 
     const optionChildrenList = useMemo(
       () =>
@@ -294,7 +294,6 @@ const SelectList = React.forwardRef(
 
         const newProps = {
           index,
-          id: childIds ? childIds[index] : /* istanbul ignore next */ undefined,
           onSelect: handleSelect,
           hidden: isLoading && childrenList.length === 1,
           // these need to be inline styles rather than implemented in styled-components to avoid it generating thousands of classes
@@ -303,8 +302,12 @@ const SelectList = React.forwardRef(
           },
           "aria-setsize": isOption ? optionChildrenList.length : undefined,
           "aria-posinset": isOption ? optionChildIndex + 1 : undefined,
-          // needed to dynamically compute the size
-          ref: measureCallback,
+          ref: (optionElement: HTMLElement) => {
+            // needed to dynamically compute the size
+            measureCallback(optionElement);
+            // add the DOM element to the array of refs
+            childElementRefs.current[index] = optionElement;
+          },
           "data-index": index,
         };
 
@@ -348,16 +351,6 @@ const SelectList = React.forwardRef(
       [childrenList, lastOptionIndex, isLoading]
     );
 
-    const getIndexOfMatch = useCallback(
-      (valueToMatch) => {
-        return childrenList.findIndex(
-          (child) =>
-            React.isValidElement(child) && child.props.value === valueToMatch
-        );
-      },
-      [childrenList]
-    );
-
     const highlightNextItem = useCallback(
       (key) => {
         let currentIndex = currentOptionsListIndex;
@@ -382,9 +375,7 @@ const SelectList = React.forwardRef(
           text,
           value,
           selectionType: "navigationKey",
-          id: childIds
-            ? childIds[nextIndex]
-            : /* istanbul ignore next */ undefined,
+          id: childElementRefs.current[nextIndex]?.id,
           selectionConfirmed: false,
         });
       },
@@ -395,7 +386,6 @@ const SelectList = React.forwardRef(
         getNextHighlightableItemIndex,
         highlightedValue,
         onSelect,
-        childIds,
       ]
     );
 
@@ -448,9 +438,7 @@ const SelectList = React.forwardRef(
           const { text, value } = currentOption.props;
 
           onSelect({
-            id: childIds
-              ? childIds[currentOptionsListIndex]
-              : /* istanbul ignore next */ undefined,
+            id: childElementRefs.current[currentOptionsListIndex]?.id,
             text,
             value,
             selectionType: "enterKey",
@@ -471,7 +459,6 @@ const SelectList = React.forwardRef(
         highlightNextItem,
         focusOnAnchor,
         isOpen,
-        childIds,
       ]
     );
 

--- a/src/components/select/simple-select/components.test-pw.tsx
+++ b/src/components/select/simple-select/components.test-pw.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import Typography from "../../../components/typography";
 import Content from "../../../components/content";
 import {
@@ -576,5 +576,33 @@ export const SelectionConfirmed = () => {
         </span>
       ) : null}
     </>
+  );
+};
+
+const options = ["A", "B", "C"];
+const allOptions = ["All"];
+
+export const SelectWithDynamicallyAddedOption = () => {
+  const [optionsList, setOptionsList] = useState(options);
+  const [currentOption, setCurrentOption] = useState<string | null>(null);
+  useEffect(() => {
+    if (currentOption) {
+      setOptionsList([...allOptions, ...options]);
+    }
+  }, [currentOption]);
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCurrentOption(e.target.value);
+  };
+  return (
+    <Select
+      label="Choose your option"
+      data-role="selector"
+      onChange={handleChange}
+      value={currentOption || ""}
+    >
+      {optionsList.map((opt) => (
+        <Option data-role={`option-${opt}`} text={opt} value={opt} key={opt} />
+      ))}
+    </Select>
   );
 };

--- a/src/components/select/simple-select/simple-select.pw.tsx
+++ b/src/components/select/simple-select/simple-select.pw.tsx
@@ -15,6 +15,7 @@ import {
   SimpleSelectNestedInDialog,
   SelectWithOptionGroupHeader,
   SelectionConfirmed,
+  SelectWithDynamicallyAddedOption,
 } from "./components.test-pw";
 import {
   commonDataElementInputPreview,
@@ -1782,6 +1783,30 @@ test.describe("Accessibility tests for SimpleSelect component", () => {
     await mount(<SimpleSelectNestedInDialog />);
 
     await selectText(page).click();
+    await checkAccessibility(page, undefined, "scrollable-region-focusable");
+  });
+
+  test("should pass accessibility tests after selecting an option that dynamically adds a new option to the start of the list", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<SelectWithDynamicallyAddedOption />);
+
+    await selectText(page).click();
+    await selectOptionByText(page, "A").click();
+    await checkAccessibility(page, undefined, "scrollable-region-focusable");
+  });
+
+  test("should pass accessibility tests in dynamically-changing example when a different option is selected", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<SelectWithDynamicallyAddedOption />);
+
+    await selectText(page).click();
+    await selectOptionByText(page, "A").click();
+    await selectText(page).click();
+    await selectOptionByText(page, "B").click();
     await checkAccessibility(page, undefined, "scrollable-region-focusable");
   });
 });

--- a/src/components/select/simple-select/simple-select.stories.mdx
+++ b/src/components/select/simple-select/simple-select.stories.mdx
@@ -202,6 +202,30 @@ a `selectionConfirmed` property on the emitted event when the enter key is press
   <Story name="selection confirmed" story={stories.SelectionConfirmedStory} />
 </Canvas>
 
+### Dynamically adding options, and the importance of the `key` property
+
+You must take care if you want to dynamically add `Option` children to the select, particularly if you are adding them to the start
+of the list. The component uses the
+[aria-activedescendant attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendant)
+to expose the currently-selected option to assistive technologies such as screenreaders, and this ties in to the HTML `id` of the
+option. Each option gets a randomly-generated guid as its id (if one is not explicitly provided as a prop), but to ensure that each
+option keeps its id in its dynamically-changing context, a hint needs to be provided to React to keep the option's identity the same,
+and not rerender it with a new guid.
+
+This can be done by providing an appropriate [key](https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key) to
+each item in the list which unique identifies it, as in the example below which simply uses the option text. This is our recommendation
+for most circumstances.
+
+An alternative solution that works is to provide an explicit `id` prop for each option.
+
+If you do not either provide explicit ids or set keys appropriately, the `aria-activedescendant` property will get out of sync with
+the selected option, generating errors with automated accessibility-testing tools, and more importantly, making the component unusable
+for users who rely on assistive technology.
+
+<Canvas>
+  <Story name="dynamically adding options" story={stories.SelectWithDynamicallyAddedOption} />
+</Canvas>
+
 
 ## Props
 

--- a/src/components/select/simple-select/simple-select.stories.tsx
+++ b/src/components/select/simple-select/simple-select.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import {
   Select,
   Option,
@@ -742,3 +742,31 @@ export const SelectionConfirmedStory = () => {
 };
 
 SelectionConfirmedStory.parameters = { chromatic: { disableSnapshot: true } };
+
+const options = ["A", "B", "C"];
+const allOptions = ["All"];
+
+export const SelectWithDynamicallyAddedOption = () => {
+  const [optionsList, setOptionsList] = useState(options);
+  const [currentOption, setCurrentOption] = useState<string | null>(null);
+  useEffect(() => {
+    if (currentOption) {
+      setOptionsList([...allOptions, ...options]);
+    }
+  }, [currentOption]);
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCurrentOption(e.target.value);
+  };
+  return (
+    <Select
+      label="Choose your option"
+      data-role="selector"
+      onChange={handleChange}
+      value={currentOption || ""}
+    >
+      {optionsList.map((opt) => (
+        <Option data-role={`option-${opt}`} text={opt} value={opt} key={opt} />
+      ))}
+    </Select>
+  );
+};


### PR DESCRIPTION
Currently Select assigns a random guid as ID to each of its option children if no ids are provided explicitly, and regenerates this list of ids whenever the number of children changes. This results in unexpected behaviour when a new option is dynamically added to the start of the list on selection, as then the ids are regenerated and a critical axe error results from the aria-activedescendant property no longer referencing a valid child ID. To fix this, guids are now generated in Option itself (rather than SelectList as before) when the prop is not provided, and it is up to consumer to set keys on the list of option children to ensure individual child components maintain their identity correctly across renders even as children are added or removed.

fix #6378

### Proposed behaviour

Option ids, even when generated as random guids by the component internals, should remain stable when the Option component itself rerenders.

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

All Option guids are regenerated whenever one or more new options are added or removed.

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Cypress automation tests added or updated if required
- [X] Playwright automation tests added or updated if required
- [X] Storybook added or updated if required
- [X] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required
- [X] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

See codesandbox linked to in the original issue. Since the Option list there sets the `key` property correctly, it should work as intended in the branch of this PR.

Perform regression testing across all Select variants and all scenarios to ensure nothing has been broken accidentally. (Although unit and Playwright tests hopefully ensure that.)

<!-- Add CodeSandbox here -->
