### PR TITLE
fix(date): prevent dialog from closing if esc is pressed and date picker is open

### DIFF
--- a/src/components/date/__internal__/date-picker/date-picker.component.tsx
+++ b/src/components/date/__internal__/date-picker/date-picker.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import DayPicker, {
   DayPickerProps,
   DayModifiers,
@@ -159,12 +159,20 @@ export const DatePicker = ({
     }
   };
 
-  const handleOnKeyDown = (ev: React.KeyboardEvent<HTMLDivElement>) => {
-    if (Events.isEscKey(ev)) {
-      inputElement.current?.querySelector("input")?.focus();
-      setOpen(false);
-    }
+  const handleKeyUp = useCallback(
+    (ev) => {
+      /* istanbul ignore else */
+      if (open && Events.isEscKey(ev)) {
+        inputElement.current?.querySelector("input")?.focus();
+        setOpen(false);
+        ev.stopPropagation();
+      }
+    },
+    [inputElement, open, setOpen]
+  );
 
+  const handleOnKeyDown = (ev: React.KeyboardEvent<HTMLDivElement>) => {
+    /* istanbul ignore else */
     if (
       ref.current?.querySelector(".DayPicker-NavBar button") ===
         document.activeElement &&
@@ -233,6 +241,7 @@ export const DatePicker = ({
       <StyledDayPicker
         ref={ref}
         onMouseDown={pickerMouseDown}
+        onKeyUp={handleKeyUp}
         onKeyDown={handleOnKeyDown}
       >
         <div

--- a/src/components/date/components.test-pw.tsx
+++ b/src/components/date/components.test-pw.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import DateInput, { DateChangeEvent, DateInputProps } from "./date.component";
 import { CommonTextboxArgs } from "../textbox/textbox-test.stories";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
+import Dialog from "../dialog";
 
 export const DateInputCustom = ({
   onChange,
@@ -149,5 +150,44 @@ export const DateWithLocales = ({
       <div data-testid="raw-value">{rawValue}</div>
       <div data-testid="formatted-value">{formattedValue}</div>
     </>
+  );
+};
+
+export const DateInputInsideDialog = ({
+  onChange,
+  onBlur,
+  value,
+  ...props
+}: Partial<CommonTextboxArgs> & Partial<DateInputProps>) => {
+  const [isOpen, setIsOpen] = useState(true);
+  const [state, setState] = React.useState(
+    value?.length !== undefined ? value : "01/05/2022"
+  );
+
+  const handleOnChange = (ev: DateChangeEvent) => {
+    if (onChange) {
+      onChange(ev);
+    }
+
+    setState(ev.target.value.formattedValue);
+  };
+
+  const handleOnBlur = (ev: DateChangeEvent) => {
+    if (onBlur) {
+      onBlur(ev);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
+      <DateInput
+        label="Date"
+        name="date-input"
+        value={state}
+        onChange={handleOnChange}
+        onBlur={handleOnBlur}
+        {...props}
+      />
+    </Dialog>
   );
 };

--- a/src/components/date/date.component.tsx
+++ b/src/components/date/date.component.tsx
@@ -303,13 +303,20 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       }
     };
 
+    const handleKeyUp = useCallback(
+      (ev) => {
+        /* istanbul ignore else */
+        if (open && Events.isEscKey(ev)) {
+          setOpen(false);
+          ev.stopPropagation();
+        }
+      },
+      [open]
+    );
+
     const handleKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {
       if (onKeyDown) {
         onKeyDown(ev);
-      }
-
-      if (Events.isEscKey(ev)) {
-        setOpen(false);
       }
 
       if (open && Events.isTabKey(ev)) {
@@ -464,6 +471,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
           onChange={handleChange}
           onClick={handleClick}
           onFocus={handleFocus}
+          onKeyUp={handleKeyUp}
           onKeyDown={handleKeyDown}
           iconOnClick={handleClick}
           onMouseDown={handleMouseDown}

--- a/src/components/date/date.pw.tsx
+++ b/src/components/date/date.pw.tsx
@@ -7,6 +7,7 @@ import {
   DateInputValidationNewDesign,
   DateInputWithButton,
   DateWithLocales,
+  DateInputInsideDialog,
 } from "./components.test-pw";
 import { DateInputProps } from ".";
 import { getDataElementByValue } from "../../../playwright/components";
@@ -27,6 +28,7 @@ import {
   dayPickerHeading,
 } from "../../../playwright/components/date-input/index";
 import { HooksConfig } from "../../../playwright";
+import { alertDialogPreview } from "../../../playwright/components/dialog";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const DAY_PICKER_PREFIX = "DayPicker-Day--";
@@ -898,6 +900,29 @@ test.describe("Functionality tests", () => {
       "outline",
       "rgba(0, 0, 0, 0) solid 3px"
     );
+  });
+});
+
+test.describe("When nested inside of a Dialog component", () => {
+  test("should not close the Dialog when Datepicker is closed by pressing an escape key", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<DateInputInsideDialog />);
+
+    await page.focus("body");
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    const wrapper = dayPickerWrapper(page);
+    const dialogElement = alertDialogPreview(page);
+    await expect(wrapper).toHaveCount(1);
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Escape");
+    await expect(wrapper).toHaveCount(0);
+    await expect(getDataElementByValue(page, "input")).toBeFocused();
+    await expect(dialogElement).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(dialogElement).not.toBeVisible();
   });
 });
 

--- a/src/components/date/date.spec.tsx
+++ b/src/components/date/date.spec.tsx
@@ -156,6 +156,19 @@ function simulateMouseDownOnPicker(wrapper: ReactWrapper) {
   });
 }
 
+function simulateOnKeyUp(
+  wrapper: ReactWrapper,
+  key: string,
+  shiftKey?: boolean
+) {
+  const keyUpParams = { key, shiftKey };
+  const input = wrapper.find("input");
+
+  act(() => {
+    input.simulate("keyUp", keyUpParams);
+  });
+}
+
 function simulateOnKeyDown(
   wrapper: ReactWrapper,
   key: string,
@@ -509,6 +522,21 @@ describe("Date", () => {
     });
   });
 
+  describe('when the "keyUp" event is triggered on the input', () => {
+    beforeEach(() => {
+      wrapper = render();
+      simulateFocusOnInput(wrapper);
+    });
+
+    it('the "DatePicker" should close when the "Escape" key is pressed', () => {
+      expect(wrapper.update().find(DayPicker).exists()).toBe(true);
+      act(() => {
+        simulateOnKeyUp(wrapper, "Escape");
+      });
+      expect(wrapper.update().find(DayPicker).exists()).toBe(false);
+    });
+  });
+
   describe('when the "keyDown" event is triggered on the input', () => {
     beforeEach(() => {
       wrapper = render();
@@ -541,14 +569,6 @@ describe("Date", () => {
       expect(wrapper.find(StyledButton).first()).toBeFocused();
     });
 
-    it('the "DatePicker" should close when the "Escape" key is pressed', () => {
-      expect(wrapper.update().find(DayPicker).exists()).toBe(true);
-      act(() => {
-        simulateOnKeyDown(wrapper, "Escape");
-      });
-      expect(wrapper.update().find(DayPicker).exists()).toBe(false);
-    });
-
     it('the "DatePicker" should close when the "Shift" and "Tab" keys are pressed', () => {
       expect(wrapper.update().find(DayPicker).exists()).toBe(true);
       act(() => {
@@ -564,7 +584,7 @@ describe("Date", () => {
     });
   });
 
-  describe('when the "keyDown" event is triggered on the picker', () => {
+  describe('when the "keyUp" event is triggered on the picker', () => {
     beforeEach(() => {
       wrapper = render();
       simulateFocusOnInput(wrapper);
@@ -575,9 +595,16 @@ describe("Date", () => {
       simulateOnKeyDown(wrapper, "Tab");
       expect(wrapper.find(StyledButton).first()).toBeFocused();
       act(() => {
-        wrapper.find(StyledDayPicker).simulate("keydown", { key: "Escape" });
+        wrapper.find(StyledDayPicker).simulate("keyup", { key: "Escape" });
       });
       expect(wrapper.update().find(DayPicker).exists()).toBe(false);
+    });
+  });
+
+  describe('when the "keyDown" event is triggered on the picker', () => {
+    beforeEach(() => {
+      wrapper = render();
+      simulateFocusOnInput(wrapper);
     });
 
     it('should close the picker when "Shift" + "Tab" keys are pressed and focus is on previous month button', () => {


### PR DESCRIPTION
### Proposed behaviour

When datepicker is open the `esc` key should only close the datepicker and not the dialog, when it's contained in a dialog

fix #6505

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

Currently there's a bug that when `esc` is pressed it is closing the dialog as well as the datepicker

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

https://codesandbox.io/p/sandbox/esc-closes-dialog-when-datepicker-open-st56mm