### PR TITLE
fix(icon): bgSize and fontSize bug fix

### DIFF
--- a/src/components/button-toggle/__snapshots__/button-toggle.spec.tsx.snap
+++ b/src/components/button-toggle/__snapshots__/button-toggle.spec.tsx.snap
@@ -44,6 +44,8 @@ exports[`ButtonToggle General styling renders correctly when grouped 1`] = `
 }
 
 .c2 .c4 {
+  width: 16px;
+  height: 16px;
   color: var(--colorsActionMinor500);
 }
 

--- a/src/components/button-toggle/button-toggle-icon.component.tsx
+++ b/src/components/button-toggle/button-toggle-icon.component.tsx
@@ -30,7 +30,6 @@ const ButtonToggleIcon = ({
       aria-hidden
       type={buttonIcon}
       fontSize={buttonIconSize}
-      bgSize="extra-small"
       disabled={disabled}
     />
   </StyledButtonToggleIcon>

--- a/src/components/button-toggle/button-toggle.style.ts
+++ b/src/components/button-toggle/button-toggle.style.ts
@@ -105,6 +105,8 @@ const StyledButtonToggle = styled.button<StyledButtonToggleProps>`
   }
 
   ${StyledIcon} {
+    width: 16px;
+    height: 16px;
     color: var(--colorsActionMinor500);
   }
 
@@ -184,6 +186,7 @@ const StyledButtonToggleIcon = styled.div<StyledButtonToggleIconProps>`
     css`
       margin-right: 0;
       ${StyledIcon} {
+        margin-left: 0;
         margin-right: 0;
         margin-bottom: 8px;
         height: ${`${iconFontSizes.largeIcon}px`};

--- a/src/components/button/__snapshots__/button.spec.tsx.snap
+++ b/src/components/button/__snapshots__/button.spec.tsx.snap
@@ -18,8 +18,8 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  height: 16px;
-  width: 16px;
+  height: 24px;
+  width: 24px;
 }
 
 .c3::before {
@@ -2572,8 +2572,8 @@ exports[`Button when only the "iconPosition" and "iconType" props are passed int
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  height: 16px;
-  width: 16px;
+  height: 24px;
+  width: 24px;
 }
 
 .c2::before {

--- a/src/components/button/button.component.tsx
+++ b/src/components/button/button.component.tsx
@@ -134,13 +134,12 @@ RenderChildrenProps) {
 
   const iconProps: Pick<
     IconProps,
-    "aria-hidden" | "disabled" | "color" | "bg" | "bgSize"
+    "aria-hidden" | "disabled" | "color" | "bg"
   > = {
     "aria-hidden": true,
     disabled,
     color: iconColor(),
     bg: "transparent",
-    bgSize: "extra-small",
   };
 
   const isValidChildren = children !== undefined && children !== false;

--- a/src/components/card/card-footer/__snapshots__/card-footer.spec.tsx.snap
+++ b/src/components/card/card-footer/__snapshots__/card-footer.spec.tsx.snap
@@ -75,8 +75,8 @@ exports[`CardFooter matches expected styling when it contains non-interactive co
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  height: 16px;
-  width: 16px;
+  height: 24px;
+  width: 24px;
 }
 
 .c3::before {
@@ -130,7 +130,7 @@ exports[`CardFooter matches expected styling when it contains non-interactive co
   display: inline-block;
   position: relative;
   vertical-align: middle;
-  margin-right: var(--spacing100);
+  margin-right: var(--spacing050);
 }
 
 .c1 a:hover,

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.component.tsx
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.component.tsx
@@ -90,7 +90,7 @@ export const FlatTableCell = ({
         expandable={expandable}
       >
         {expandable && isFirstCell && (
-          <Icon type="chevron_down_thick" bgSize="extra-small" mr="8px" />
+          <Icon type="chevron_down_thick" mr="8px" />
         )}
         {children}
       </StyledCellContent>

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.style.ts
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.style.ts
@@ -3,6 +3,7 @@ import { PaddingProps, padding } from "styled-system";
 import { FlatTableCellProps } from "./flat-table-cell.component";
 import baseTheme from "../../../style/themes/base";
 import { toColor } from "../../../style/utils/color";
+import StyledIcon from "../../icon/icon.style";
 
 const verticalBorderSizes = {
   small: "1px",
@@ -117,6 +118,11 @@ const StyledCellContent = styled.div<{ expandable?: boolean }>`
       display: flex;
       align-items: center;
       line-height: 1em;
+
+      ${StyledIcon} {
+        width: 16px;
+        height: 16px;
+      }
     `}
 `;
 

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.tsx
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.tsx
@@ -117,7 +117,7 @@ export const FlatTableRowHeader = ({
         expandable={expandable}
       >
         {expandable && isFirstCell && (
-          <Icon type="chevron_down_thick" bgSize="extra-small" mr="8px" />
+          <Icon type="chevron_down_thick" mr="8px" />
         )}
         {children}
       </StyledFlatTableRowHeaderContent>

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.ts
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.ts
@@ -4,6 +4,7 @@ import { padding } from "styled-system";
 import baseTheme from "../../../style/themes/base";
 import { toColor } from "../../../style/utils/color";
 import { FlatTableRowHeaderProps } from "./flat-table-row-header.component";
+import StyledIcon from "../../icon/icon.style";
 
 const verticalBorderSizes = {
   small: "1px",
@@ -115,6 +116,11 @@ const StyledFlatTableRowHeaderContent = styled.div<{ expandable?: boolean }>`
       display: flex;
       align-items: center;
       line-height: 1em;
+
+      ${StyledIcon} {
+        width: 16px;
+        height: 16px;
+      }
     `}
 `;
 

--- a/src/components/icon/icon-test.stories.tsx
+++ b/src/components/icon/icon-test.stories.tsx
@@ -60,6 +60,11 @@ export default {
         type: "select",
       },
     },
+    bg: {
+      control: {
+        type: "text",
+      },
+    },
   },
 };
 
@@ -112,6 +117,7 @@ export const All = () => (
               fontSize={fontSize}
               bgShape={bgShape}
               bgSize={bgSize}
+              bg="#00b000"
             />
           ));
         });

--- a/src/components/icon/icon.component.tsx
+++ b/src/components/icon/icon.component.tsx
@@ -10,6 +10,7 @@ import { ICON_TOOLTIP_POSITIONS } from "./icon-config";
 import { IconType } from "./icon-type";
 import { TooltipPositions } from "../tooltip/tooltip.config";
 import { TabTitleContext } from "../tabs/__internal__/tab-title";
+import Logger from "../../__internal__/utils/logger";
 
 export type LegacyIconTypes =
   | "help"
@@ -57,6 +58,8 @@ export interface IconProps extends Omit<StyledIconProps, "type">, MarginProps {
   tabIndex?: number;
 }
 
+let deprecatedExtraSmallBgSizeTriggered = false;
+
 const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
   (
     {
@@ -64,7 +67,7 @@ const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
       ariaLabel,
       bg,
       bgShape,
-      bgSize = "small",
+      bgSize,
       className,
       color,
       disabled,
@@ -92,6 +95,13 @@ const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
       tooltipFlipOverrides.every((override) =>
         ICON_TOOLTIP_POSITIONS.includes(override)
       );
+
+    if (!deprecatedExtraSmallBgSizeTriggered && bgSize === "extra-small") {
+      deprecatedExtraSmallBgSizeTriggered = true;
+      Logger.deprecate(
+        "The `extra-small` variant of the `bgSize` prop for `Icon` component has been deprecated and will soon be removed."
+      );
+    }
 
     if (tooltipFlipOverrides) {
       invariant(
@@ -148,7 +158,7 @@ const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
       "aria-hidden": ariaHidden,
       "aria-label": ariaLabel,
       bg,
-      bgSize,
+      bgSize: bgSize || fontSize,
       bgShape,
       className: className || undefined,
       color,

--- a/src/components/icon/icon.pw.tsx
+++ b/src/components/icon/icon.pw.tsx
@@ -227,7 +227,6 @@ test.describe("should check Icon component properties", () => {
   });
 
   ([
-    [SIZE.EXTRASMALL, 16],
     [SIZE.SMALL, 24],
     [SIZE.MEDIUM, 32],
     [SIZE.LARGE, 40],
@@ -488,13 +487,7 @@ test.describe("should check accessibility for Icon component", () => {
     }
   );
 
-  [
-    SIZE.EXTRASMALL,
-    SIZE.SMALL,
-    SIZE.MEDIUM,
-    SIZE.LARGE,
-    SIZE.EXTRALARGE,
-  ].forEach((size) => {
+  [SIZE.SMALL, SIZE.MEDIUM, SIZE.LARGE, SIZE.EXTRALARGE].forEach((size) => {
     test(`should pass accessibility tests when bgSize is set as ${size}`, async ({
       mount,
       page,

--- a/src/components/icon/icon.spec.tsx
+++ b/src/components/icon/icon.spec.tsx
@@ -25,6 +25,7 @@ import getColorValue from "../../style/utils/get-color-value";
 import { IconType } from "./icon-type";
 import { TooltipPositions } from "../tooltip/tooltip.config";
 import { TabTitleContext } from "../tabs/__internal__/tab-title/tab-title.component";
+import Logger from "../../__internal__/utils/logger";
 
 interface MismatchedPairs {
   prop: LegacyIconTypes;
@@ -60,6 +61,34 @@ describe("Icon component", () => {
     { prop: "success", rendersAs: "tick" },
     { prop: "messages", rendersAs: "message" },
   ];
+
+  describe("console warnings", () => {
+    it("should display 'extra-small' deprecation warning once", () => {
+      const loggerSpy = jest.spyOn(Logger, "deprecate");
+
+      mount(<Icon type="home" bgSize="extra-small" />);
+
+      expect(loggerSpy).toHaveBeenCalledWith(
+        "The `extra-small` variant of the `bgSize` prop for `Icon` component has been deprecated and will soon be removed."
+      );
+      expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+      loggerSpy.mockRestore();
+    });
+
+    it("should display larger bgSize warning once", () => {
+      const consoleSpy = jest.spyOn(console, "warn");
+
+      mount(<Icon type="home" bgSize="small" fontSize="medium" />);
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '[WARNING - Icon] The "small" `bgSize` is smaller than "medium" `fontSize`, the `bgSize` has been auto adjusted to a larger size.'
+      );
+      expect(consoleSpy).toHaveBeenCalledTimes(1);
+
+      consoleSpy.mockRestore();
+    });
+  });
 
   describe.each(mismatchedPairs)(
     "mismatched pairs of props and icons retrieved",
@@ -355,6 +384,30 @@ describe("Icon component", () => {
           {
             width: iconConfig.backgroundSize[size],
             height: iconConfig.backgroundSize[size],
+          },
+          wrapper.toJSON()
+        );
+      });
+    });
+
+    describe("with fontSize", () => {
+      it("adjusts background size to match font size when icon is larger", () => {
+        const wrapper = renderStyles({ bgSize: "small", fontSize: "large" });
+        assertStyleMatch(
+          {
+            width: iconConfig.backgroundSize.large,
+            height: iconConfig.backgroundSize.large,
+          },
+          wrapper.toJSON()
+        );
+      });
+
+      it("maintains background size value when icon is smaller", () => {
+        const wrapper = renderStyles({ bgSize: "large", fontSize: "medium" });
+        assertStyleMatch(
+          {
+            width: iconConfig.backgroundSize.large,
+            height: iconConfig.backgroundSize.large,
           },
           wrapper.toJSON()
         );

--- a/src/components/icon/icon.stories.mdx
+++ b/src/components/icon/icon.stories.mdx
@@ -77,6 +77,14 @@ such as `tooltipPosition`, `tooltipVisible` , `tooltipBgColor`, `tooltipFontColo
   <Story name="various bgSizes" story={stories.VariousBgSizes} />
 </Canvas>
 
+### bgSize and fontSize
+
+If using the `bgSize` prop in combination with `fontSize`, the `fontSize` prop value will take precedence and the background size may be adjusted to accommodate a larger icon. 
+
+<Canvas>
+  <Story name="bgSize and fontSize" story={stories.BgSizesAndFontSizes} />
+</Canvas>
+
 ### Custom colors
 
 It's possible to change the color of the Icon by using the `color` prop or background color by `bg` prop.

--- a/src/components/icon/icon.stories.tsx
+++ b/src/components/icon/icon.stories.tsx
@@ -87,6 +87,32 @@ export const VariousBgSizes: ComponentStory<typeof Icon> = () => {
   );
 };
 
+export const BgSizesAndFontSizes: ComponentStory<typeof Icon> = () => {
+  return (
+    <>
+      {(["small", "medium", "large", "extra-large"] as const).map(
+        (fontSize) => {
+          return ([
+            "small",
+            "medium",
+            "large",
+            "extra-large",
+          ] as const).map((bgSize) => (
+            <Icon
+              type="add"
+              bg="#00b000"
+              fontSize={fontSize}
+              bgSize={bgSize}
+              mr={1}
+              key={`${fontSize}_${bgSize}`}
+            />
+          ));
+        }
+      )}
+    </>
+  );
+};
+
 export const CustomColors: ComponentStory<typeof Icon> = () => (
   <>
     <Box mb={1}>

--- a/src/components/icon/icon.style.ts
+++ b/src/components/icon/icon.style.ts
@@ -58,8 +58,27 @@ export interface StyledIconInternalProps {
 }
 
 function adjustIconBgSize(fontSize?: FontSize, bgSize?: BgSize) {
-  if (fontSize && fontSize !== "small") {
-    return iconConfig.backgroundSize[fontSize];
+  const sizeValues: Record<BgSize | FontSize, number> = {
+    "extra-small": 1,
+    small: 2,
+    medium: 3,
+    large: 4,
+    "extra-large": 5,
+  };
+
+  if (fontSize && bgSize) {
+    const fontSizeValue = sizeValues[fontSize];
+    const bgSizeValue = sizeValues[bgSize];
+
+    if (bgSizeValue < fontSizeValue) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[WARNING - Icon] The "${bgSize}" \`bgSize\` is smaller than "${fontSize}" \`fontSize\`, the \`bgSize\` has been auto adjusted to a larger size.`
+      );
+      return iconConfig.backgroundSize[fontSize];
+    }
+
+    return iconConfig.backgroundSize[bgSize];
   }
 
   return bgSize ? iconConfig.backgroundSize[bgSize] : undefined;
@@ -84,6 +103,8 @@ const StyledIcon = styled.span<StyledIconProps & StyledIconInternalProps>`
     let finalHoverColor;
     let bgColor;
     let bgHoverColor;
+
+    const adjustedBgSize = adjustIconBgSize(fontSize, bgSize);
 
     try {
       if (disabled) {
@@ -118,8 +139,8 @@ const StyledIcon = styled.span<StyledIconProps & StyledIconInternalProps>`
       align-items: center;
       display: inline-flex;
       justify-content: center;
-      height: ${adjustIconBgSize(fontSize, bgSize)};
-      width: ${adjustIconBgSize(fontSize, bgSize)};
+      height: ${adjustedBgSize};
+      width: ${adjustedBgSize};
       ${bgShape ? `border-radius: ${iconConfig.backgroundShape[bgShape]}` : ""};
 
       ${isInteractive &&

--- a/src/components/link/link.component.tsx
+++ b/src/components/link/link.component.tsx
@@ -111,7 +111,6 @@ export const Link = React.forwardRef<
       return hasProperAlignment ? (
         <Icon
           type={icon}
-          bgSize="extra-small"
           disabled={disabled}
           ariaLabel={removeAriaLabelOnIcon ? undefined : ariaLabel}
           tooltipMessage={tooltipMessage}

--- a/src/components/link/link.spec.tsx
+++ b/src/components/link/link.spec.tsx
@@ -145,7 +145,7 @@ describe("Link", () => {
     it("should render an `Icon` on the left side of the component by default", () => {
       assertStyleMatch(
         {
-          marginRight: "var(--spacing100)",
+          marginRight: "var(--spacing050)",
           position: "relative",
         },
         wrapper.find(StyledLink),

--- a/src/components/link/link.style.ts
+++ b/src/components/link/link.style.ts
@@ -170,7 +170,7 @@ const StyledLink = styled.span<StyledLinkProps & PrivateStyledLinkProps>`
           vertical-align: middle;
           ${iconAlign === "left" &&
           css`
-            margin-right: ${hasContent ? "var(--spacing100)" : 0};
+            margin-right: ${hasContent ? "var(--spacing050)" : 0};
           `}
           ${iconAlign === "right" &&
           css`

--- a/src/components/menu/__internal__/submenu/submenu.style.ts
+++ b/src/components/menu/__internal__/submenu/submenu.style.ts
@@ -3,7 +3,6 @@ import { baseTheme } from "../../../../style/themes";
 import { StyledLink } from "../../../link/link.style";
 import { StyledMenuItem } from "../../menu.style";
 import StyledMenuItemWrapper from "../../menu-item/menu-item.style";
-import StyledIcon from "../../../icon/icon.style";
 import StyledSearch from "../../../search/search.style";
 import menuConfigVariants from "../../menu.config";
 import { SubmenuProps } from "./submenu.component";
@@ -144,12 +143,6 @@ const StyledSubmenu = styled.ul<StyledSubmenuProps>`
         text-decoration: none;
       }
 
-      > ${StyledIcon} {
-        width: 16px;
-        height: 16px;
-        margin-right: 5px;
-      }
-
       ${StyledSearch} span > [data-component="icon"] {
         color: var(--colorsUtilityMajor200);
 
@@ -161,24 +154,6 @@ const StyledSubmenu = styled.ul<StyledSubmenuProps>`
       ${StyledSearch} {
         :hover {
           border-bottom-color: var(--colorsUtilityMajor150);
-        }
-      }
-    }
-
-    [data-component="icon"] {
-      line-height: 16px;
-      top: -1px;
-
-      &:before {
-        line-height: unset;
-      }
-
-      span {
-        vertical-align: middle;
-
-        svg {
-          height: 16px;
-          width: 16px;
         }
       }
     }

--- a/src/components/menu/menu-item/menu-item.style.ts
+++ b/src/components/menu/menu-item/menu-item.style.ts
@@ -201,7 +201,6 @@ const StyledMenuItemWrapper = styled.a.attrs({
       }
 
       ${StyledIcon} {
-        bottom: 3px;
         display: inline-block;
       }
     }

--- a/src/components/multi-action-button/__snapshots__/multi-action-button.spec.tsx.snap
+++ b/src/components/multi-action-button/__snapshots__/multi-action-button.spec.tsx.snap
@@ -18,8 +18,8 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  height: 16px;
-  width: 16px;
+  height: 24px;
+  width: 24px;
 }
 
 .c5::before {

--- a/src/components/select/list-action-button/__snapshots__/list-action-button.spec.tsx.snap
+++ b/src/components/select/list-action-button/__snapshots__/list-action-button.spec.tsx.snap
@@ -18,8 +18,8 @@ exports[`Option renders properly 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  height: 16px;
-  width: 16px;
+  height: 24px;
+  width: 24px;
 }
 
 .c5::before {

--- a/src/components/split-button/split-button.component.tsx
+++ b/src/components/split-button/split-button.component.tsx
@@ -147,7 +147,6 @@ export const SplitButton = ({
       >
         <Icon
           type="dropdown"
-          bgSize="extra-small"
           color={getIconColor()}
           bg="transparent"
           disabled={disabled}

--- a/src/components/split-button/split-button.spec.tsx
+++ b/src/components/split-button/split-button.spec.tsx
@@ -169,7 +169,6 @@ describe("SplitButton", () => {
             type="dropdown"
             color="#008200"
             disabled={false}
-            bgSize="extra-small"
             bg="transparent"
           />
         )


### PR DESCRIPTION
fix #5812
fix #6353 

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

- If the `bgSize` value is smaller than the `fontSize` value, the background size will be adjusted to be equal to the icon size. Otherwise, the `fontSize` value has no effect on the background size. 
- "extra-small" option for `bgSize` prop has been deprecated, components internally using this size have been updated. 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

When using `bgSize` and `fontSize` props together on an `Icon`, if `fontSize` is not small its value will always override the `bgSize` value.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
