### PR TITLE
test(popover-container): pass disableAnimation prop to component and instead of styled-component - (FE-6336)

### DIFF
--- a/src/components/popover-container/popover-container.spec.tsx
+++ b/src/components/popover-container/popover-container.spec.tsx
@@ -739,13 +739,13 @@ describe("PopoverContainerContentStyle", () => {
     });
 
     it("if the disableAnimation prop is true", () => {
-      const wrapper = mount(<PopoverContainerContentStyle disableAnimation />);
+      const wrapper = mount(<PopoverContainer open disableAnimation />);
 
       assertStyleMatch(
         {
           opacity: "1",
         },
-        wrapper
+        wrapper.find(PopoverContainerContentStyle)
       );
     });
   });


### PR DESCRIPTION
### Proposed behaviour

Fixes issue in test whereby the `disableAnimation` prop is passed directly to the styled-component and not the component itself.

### Current behaviour

`disableAnimation` prop is passed directly to the styled-component 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

N/A