### PR TITLE
feat(preview): add rounded corners styling to component - FE-6056

### DIFF
--- a/src/components/preview/__internal__/preview-placeholder.style.ts
+++ b/src/components/preview/__internal__/preview-placeholder.style.ts
@@ -20,6 +20,7 @@ export const StyledPreviewPlaceholder = styled.span<StyledPreviewPlaceholderProp
   height: ${({ height }) => height || "15px"};
   opacity: 0.6;
   width: ${({ width }) => width || "100%"};
+  border-radius: var(--borderRadius050);
 
   & + & {
     margin-top: 3px;

--- a/src/components/preview/preview.pw.tsx
+++ b/src/components/preview/preview.pw.tsx
@@ -12,6 +12,7 @@ import {
   assertCssValueIsApproximately,
   checkAccessibility,
 } from "../../../playwright/support/helper";
+import { HooksConfig } from "../../../playwright";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const pixelsData = [256, 275, 300];
@@ -84,6 +85,28 @@ test.describe("check Preview component properties", () => {
       const elementsCount = await lineComponent(page).count();
       expect(elementsCount).toBe(line);
     });
+  });
+});
+
+test.describe("Border radius", () => {
+  test("should have the expected styling when roundedCornersOptOut is false", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<Preview />);
+
+    await expect(lineComponent(page)).toHaveCSS("border-radius", "4px");
+  });
+
+  test("should have the expected styling when roundedCornersOptOut is true", async ({
+    mount,
+    page,
+  }) => {
+    await mount<HooksConfig>(<Preview />, {
+      hooksConfig: { roundedCornersOptOut: true },
+    });
+
+    await expect(lineComponent(page)).toHaveCSS("border-radius", "0px");
   });
 });
 

--- a/src/components/preview/preview.spec.tsx
+++ b/src/components/preview/preview.spec.tsx
@@ -80,4 +80,17 @@ describe("Preview", () => {
     testStyledSystemMargin((props) => <Preview {...props} />);
     testStyledSystemMargin((props) => <Preview {...props} loading />);
   });
+
+  describe("Border radius", () => {
+    it("should have the expected styling", () => {
+      const wrapper = mount(<Preview />);
+
+      assertStyleMatch(
+        {
+          borderRadius: "var(--borderRadius050)",
+        },
+        wrapper.find(PreviewPlaceholder)
+      );
+    });
+  });
 });


### PR DESCRIPTION
Applies a border radius to the component to ensure it is updated to have rounded corners.

fixes #6174

### Proposed behaviour

![Screenshot 2024-01-23 at 14 54 20](https://github.com/Sage/carbon/assets/56251247/cb3391ad-b000-4af1-802c-26c7976be1fb)

### Current behaviour

![Screenshot 2024-01-23 at 14 54 31](https://github.com/Sage/carbon/assets/56251247/8c618c8f-df31-489e-962b-e37535287b50)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Component should have the expected border-radius values.
- Turning the `Rounded corners` flag to `off` in Storybook should display the component with squared corners.
- No other styling or functional regression to this component.