### PR TITLE
feat(time): add new component

### DIFF
--- a/playwright/support/helper.ts
+++ b/playwright/support/helper.ts
@@ -276,8 +276,15 @@ const verifyRequiredAsterisk = async (locator: Locator) => {
   await expect(contentValue).toBe('"*"');
 };
 
-export const verifyRequiredAsteriskForLabel = (page: Page) =>
-  verifyRequiredAsterisk(label(page));
+export const verifyRequiredAsteriskForLabel = (
+  page: Page,
+  locator?: Locator
+) => {
+  if (locator) {
+    return verifyRequiredAsterisk(locator);
+  }
+  return verifyRequiredAsterisk(label(page));
+};
 
 export const verifyRequiredAsteriskForLegend = (page: Page) =>
   verifyRequiredAsterisk(legendSpan(page));

--- a/src/__internal__/fieldset/fieldset.component.tsx
+++ b/src/__internal__/fieldset/fieldset.component.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { MarginProps } from "styled-system";
 
 import {
@@ -42,6 +42,18 @@ export interface FieldsetProps extends MarginProps {
   isRequired?: boolean;
   /** Controls whether group behaviour should be enabled */
   blockGroupBehaviour?: boolean;
+  /** Margin props for the legend element */
+  legendMargin?: Pick<MarginProps, "mb">;
+  /** Any valid CSS string to set the component's width */
+  width?: string;
+  /** Flag to configure component as optional in Form */
+  isOptional?: boolean;
+  /** Apply disabled styling to the legend content */
+  isDisabled?: boolean;
+  /** Set a name value on the component */
+  name?: string;
+  /** Set an id value on the component */
+  id?: string;
 }
 
 const Fieldset = ({
@@ -56,14 +68,33 @@ const Fieldset = ({
   info,
   isRequired,
   blockGroupBehaviour,
+  legendMargin = {},
+  isDisabled,
+  isOptional,
   ...rest
 }: FieldsetProps) => {
   const { validationRedesignOptIn } = useContext(NewValidationContext);
   const marginProps = useFormSpacing(rest);
+  const [ref, setRef] = useState<HTMLFieldSetElement | null>(null);
+
+  useEffect(() => {
+    if (ref && isRequired) {
+      Array.from(
+        ref.querySelectorAll("input") || /* istanbul ignore next */ []
+      ).forEach((el) => {
+        el.setAttribute("required", "");
+      });
+    }
+  }, [ref, isRequired]);
 
   return (
     <InputGroupBehaviour blockGroupBehaviour={blockGroupBehaviour}>
-      <StyledFieldset data-component="fieldset" {...rest} {...marginProps}>
+      <StyledFieldset
+        ref={setRef}
+        data-component="fieldset"
+        {...rest}
+        {...marginProps}
+      >
         {legend && (
           <InputGroupContext.Consumer>
             {({ onMouseEnter, onMouseLeave }) => (
@@ -74,8 +105,14 @@ const Fieldset = ({
                 width={legendWidth}
                 align={legendAlign}
                 rightPadding={legendSpacing}
+                {...legendMargin}
+                data-element="legend"
               >
-                <StyledLegendContent isRequired={isRequired}>
+                <StyledLegendContent
+                  isRequired={isRequired}
+                  isOptional={isOptional}
+                  isDisabled={isDisabled}
+                >
                   {legend}
                   {!validationRedesignOptIn && (
                     <ValidationIcon

--- a/src/__internal__/fieldset/fieldset.spec.tsx
+++ b/src/__internal__/fieldset/fieldset.spec.tsx
@@ -177,6 +177,7 @@ describe("Fieldset", () => {
       });
     }
   );
+
   it("add an asterisk after the text when the field is mandatory", () => {
     assertStyleMatch(
       {
@@ -187,6 +188,38 @@ describe("Fieldset", () => {
       },
       mount(<StyledLegendContent isRequired />),
       { modifier: "::after" }
+    );
+  });
+
+  it("adds the required attribute to any child inputs when isRequired is true", () => {
+    wrapper = mount(
+      <Fieldset isRequired>
+        <input />
+        <input />
+      </Fieldset>
+    );
+
+    expect(wrapper.find("input").first().getDOMNode()).toHaveAttribute(
+      "required"
+    );
+    expect(wrapper.find("input").last().getDOMNode()).toHaveAttribute(
+      "required"
+    );
+  });
+
+  it("does not add the required attribute to any child inputs when isRequired is falsy", () => {
+    wrapper = mount(
+      <Fieldset>
+        <input />
+        <input />
+      </Fieldset>
+    );
+
+    expect(wrapper.find("input").first().getDOMNode()).not.toHaveAttribute(
+      "required"
+    );
+    expect(wrapper.find("input").last().getDOMNode()).not.toHaveAttribute(
+      "required"
     );
   });
 });

--- a/src/__internal__/fieldset/fieldset.style.ts
+++ b/src/__internal__/fieldset/fieldset.style.ts
@@ -2,13 +2,18 @@ import styled, { css } from "styled-components";
 import { margin } from "styled-system";
 import BaseTheme from "../../style/themes/base";
 
-const StyledFieldset = styled.fieldset`
+type StyledFieldsetProps = {
+  width?: string;
+};
+
+const StyledFieldset = styled.fieldset<StyledFieldsetProps>`
   margin: 0;
   ${margin}
   border: none;
   padding: 0;
   min-width: 0;
   min-inline-size: 0;
+  ${({ width }) => width && `width: ${width};`}
 `;
 
 StyledFieldset.defaultProps = {
@@ -17,6 +22,8 @@ StyledFieldset.defaultProps = {
 
 type StyledLegendContentProps = {
   isRequired?: boolean;
+  isOptional?: boolean;
+  isDisabled?: boolean;
 };
 const StyledLegendContent = styled.span<StyledLegendContentProps>`
   display: flex;
@@ -31,6 +38,28 @@ const StyledLegendContent = styled.span<StyledLegendContentProps>`
         color: var(--colorsSemanticNegative500);
         font-weight: 700;
         margin-left: var(--spacing100);
+        position: relative;
+        top: 1px;
+        left: -4px;
+      }
+    `}
+
+  ${({ isOptional }) =>
+    isOptional &&
+    css`
+      ::after {
+        content: "(optional)";
+        font-weight: 350; //TODO: (tokens) use token var(--fontWeights400) - FE-6022
+        margin-left: 4px;
+      }
+    `}
+
+  ${({ isDisabled }) =>
+    isDisabled &&
+    css`
+      color: var(--colorsUtilityYin030);
+      ::after {
+        color: var(--colorsUtilityYin030);
       }
     `}
 `;
@@ -41,10 +70,11 @@ type StyledLegendProps = {
   align?: "left" | "right";
   rightPadding?: 1 | 2;
 };
+
 const StyledLegend = styled.legend<StyledLegendProps>`
   display: flex;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing100);
   padding: 0;
   font-weight: 600;
   ${({ inline, width, align, rightPadding }) =>
@@ -59,6 +89,7 @@ const StyledLegend = styled.legend<StyledLegendProps>`
         ? "var(--spacing100)"
         : "var(--spacing200)"};
     `}
+  ${margin}
 `;
 
 export { StyledFieldset, StyledLegend, StyledLegendContent };

--- a/src/__internal__/label/label.component.tsx
+++ b/src/__internal__/label/label.component.tsx
@@ -34,6 +34,10 @@ export interface LabelProps
   useValidationIcon?: boolean;
   /** Id of the validation icon */
   validationIconId?: string;
+  /** Sets className for component */
+  className?: string;
+  /** Sets aria-label for label element */
+  "aria-label"?: string;
 }
 
 const shouldDisplayValidationIcon = ({
@@ -76,6 +80,8 @@ export const Label = ({
   validationIconId,
   warning,
   width = 30,
+  className,
+  "aria-label": ariaLabel,
 }: LabelProps) => {
   const [isFocused, setFocus] = useState(false);
   const { onMouseEnter, onMouseLeave } = useContext(InputContext);
@@ -148,6 +154,7 @@ export const Label = ({
       optional={optional}
       pr={pr}
       pl={pl}
+      className={className}
     >
       <StyledLabel
         data-element="label"
@@ -158,6 +165,7 @@ export const Label = ({
         onMouseLeave={handleMouseLeave}
         isRequired={isRequired}
         as={as}
+        aria-label={ariaLabel}
       >
         {children}
       </StyledLabel>

--- a/src/components/box/box.component.tsx
+++ b/src/components/box/box.component.tsx
@@ -69,6 +69,8 @@ export interface BoxProps
   backgroundColor?: string;
   /** Set the opacity attribute of the Box component */
   opacity?: string | number;
+  /** Set the container to be hidden from screen readers */
+  "aria-hidden"?: "true" | "false";
 }
 
 export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
@@ -93,6 +95,7 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
       borderRadius,
       color,
       opacity,
+      "aria-hidden": ariaHidden,
       ...rest
     }: BoxProps,
     ref
@@ -117,6 +120,7 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
         borderRadius={borderRadius}
         color={color}
         opacity={opacity}
+        aria-hidden={ariaHidden}
         {...tagComponent(dataComponent, rest)}
         {...filterStyledSystemMarginProps(rest)}
         {...filterStyledSystemPaddingProps(rest)}

--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.component.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.component.tsx
@@ -63,6 +63,11 @@ export interface ButtonToggleGroupProps extends MarginProps, TagProps {
   helpAriaLabel?: string;
   /** set this to true to allow the buttons within the group to be deselected when already selected, leaving no selected button */
   allowDeselect?: boolean;
+  /**
+   * @private @ignore
+   * Set a class on the component
+   */
+  className?: string;
 }
 
 type ButtonToggleGroupContextType = {
@@ -117,6 +122,7 @@ const ButtonToggleGroup = ({
   helpAriaLabel,
   id,
   allowDeselect,
+  className,
   ...props
 }: ButtonToggleGroupProps) => {
   const hasCorrectItemStructure = useMemo(() => {
@@ -257,6 +263,7 @@ const ButtonToggleGroup = ({
                 data-element={dataElement}
                 id={id}
                 {...filterStyledSystemMarginProps(props)}
+                className={className}
               >
                 {children}
               </StyledButtonToggleGroup>

--- a/src/components/button-toggle/button-toggle.style.ts
+++ b/src/components/button-toggle/button-toggle.style.ts
@@ -6,19 +6,19 @@ import baseTheme from "../../style/themes/base";
 
 export type ButtonToggleIconSizes = "small" | "large";
 
-const heightConfig = {
+export const heightConfig = {
   small: 32,
   medium: 40,
   large: 48,
 };
 
-const fontSizeConfig = {
+export const fontSizeConfig = {
   small: 14,
   medium: 14,
   large: 16,
 };
 
-const paddingConfig = {
+export const paddingConfig = {
   small: 16,
   medium: 24,
   large: 32,

--- a/src/components/time/__internal__/time-toggle/index.ts
+++ b/src/components/time/__internal__/time-toggle/index.ts
@@ -1,0 +1,2 @@
+export { default as TimeToggle } from "./time-toggle.component";
+export type { ToggleProps, ToggleDataProps } from "./time-toggle.component";

--- a/src/components/time/__internal__/time-toggle/time-toggle.component.tsx
+++ b/src/components/time/__internal__/time-toggle/time-toggle.component.tsx
@@ -1,0 +1,85 @@
+import React, { useRef, useCallback } from "react";
+import guid from "../../../../__internal__/utils/helpers/guid";
+import { TagProps } from "../../../../__internal__/utils/helpers/tags";
+import { ToggleValue } from "../../time.component";
+import useLocale from "../../../../hooks/__internal__/useLocale";
+
+import ButtonToggleGroup from "./time-toggle.style";
+import { ButtonToggle } from "../../../button-toggle";
+
+export interface ToggleDataProps {
+  wrapperProps?: Omit<TagProps, "data-component">;
+  amToggleProps?: Omit<TagProps, "data-component">;
+  pmToggleProps?: Omit<TagProps, "data-component">;
+}
+
+export interface ToggleProps extends Omit<TagProps, "data-component"> {
+  size?: "small" | "medium" | "large";
+  onChange: (pressedValue: ToggleValue) => void;
+  toggleValue: ToggleValue;
+  disabled?: boolean;
+  toggleProps?: ToggleDataProps;
+}
+
+const Toggle = ({
+  size,
+  onChange,
+  toggleValue,
+  disabled,
+  toggleProps,
+}: ToggleProps) => {
+  const locale = useLocale();
+  const amText = locale.time.amText();
+  const pmText = locale.time.pmText();
+  const internalId = useRef(guid());
+  const { wrapperProps, amToggleProps, pmToggleProps } =
+    toggleProps || /* istanbul ignore next */ {};
+
+  const handleChange = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      const selectedButtonValue = (event.target as HTMLButtonElement).value;
+
+      if (selectedButtonValue !== toggleValue) {
+        onChange(selectedButtonValue as ToggleValue);
+      }
+    },
+    [toggleValue, onChange]
+  );
+
+  return (
+    <ButtonToggleGroup
+      {...wrapperProps}
+      data-component="time-button-toggle-group"
+      m="0px 0px 0px 8px"
+      id={internalId.current}
+      onChange={handleChange}
+      value={toggleValue}
+      disabled={disabled}
+    >
+      <ButtonToggle
+        {...amToggleProps}
+        data-component="am-button-toggle"
+        grouped
+        value="AM"
+        size={size}
+        disabled={disabled}
+      >
+        {amText}
+      </ButtonToggle>
+      <ButtonToggle
+        {...pmToggleProps}
+        data-component="pm-button-toggle"
+        grouped
+        value="PM"
+        size={size}
+        disabled={disabled}
+      >
+        {pmText}
+      </ButtonToggle>
+    </ButtonToggleGroup>
+  );
+};
+
+Toggle.displayName = "Toggle";
+
+export default Toggle;

--- a/src/components/time/__internal__/time-toggle/time-toggle.style.ts
+++ b/src/components/time/__internal__/time-toggle/time-toggle.style.ts
@@ -1,0 +1,19 @@
+import styled, { css } from "styled-components";
+import { ButtonToggleGroup } from "../../../button-toggle";
+
+// TODO this can be removed as part of FE-6335
+export default styled(ButtonToggleGroup)<{ disabled?: boolean }>`
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      opacity: 0.3;
+
+      [aria-pressed="true"] {
+        cursor: not-allowed;
+        :hover {
+          background-color: transparent;
+          box-shadow: inset 0px 0px 0px 3px var(--colorsActionMinor500);
+        }
+      }
+    `}
+`;

--- a/src/components/time/components.test-pw.tsx
+++ b/src/components/time/components.test-pw.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+import { Time, ToggleValue } from ".";
+import Box from "../box";
+import { TimeInputEvent, TimeProps, TimeValue } from "./time.component";
+
+interface AdditionalProps {
+  onChangeCb?: () => void;
+  onBlurCb?: () => void;
+  toggleValue?: ToggleValue;
+}
+
+const TimeComponent = ({
+  onChangeCb,
+  onBlurCb,
+  toggleValue,
+  ...rest
+}: Partial<TimeProps> & AdditionalProps) => {
+  const [value, setValue] = useState<TimeValue>({
+    hours: "",
+    minutes: "",
+    period: toggleValue,
+  });
+
+  const handleChange = (ev: TimeInputEvent) => {
+    setValue(ev.target.value);
+    onChangeCb?.();
+  };
+
+  return (
+    <Box p={2}>
+      <Time value={value} onChange={handleChange} onBlur={onBlurCb} {...rest} />
+    </Box>
+  );
+};
+
+export default TimeComponent;

--- a/src/components/time/index.ts
+++ b/src/components/time/index.ts
@@ -1,0 +1,7 @@
+export { default as Time } from "./time.component";
+export type {
+  TimeValue,
+  TimeProps,
+  TimeHandle,
+  ToggleValue,
+} from "./time.component";

--- a/src/components/time/time.component.tsx
+++ b/src/components/time/time.component.tsx
@@ -1,0 +1,363 @@
+import React, {
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
+import { MarginProps } from "styled-system";
+import { ValidationProps } from "../../__internal__/validations";
+import { TagProps } from "../../__internal__/utils/helpers/tags";
+import { Sizes } from "../../__internal__/input/input-presentation.component";
+import guid from "../../__internal__/utils/helpers/guid";
+import useLocale from "../../hooks/__internal__/useLocale";
+import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+import useInputAccessibility from "../../hooks/__internal__/useInputAccessibility";
+
+import Fieldset from "../../__internal__/fieldset";
+import Box from "../box";
+import { ErrorBorder } from "../textbox/textbox.style";
+import ValidationMessage from "../../__internal__/validation-message";
+import Number from "../number";
+import Typography from "../typography";
+import { StyledLabel as Label, StyledHintText as Hint } from "./time.style";
+import { TimeToggle, ToggleDataProps } from "./__internal__/time-toggle";
+
+export type ToggleValue = "AM" | "PM";
+
+export type TimeValue = {
+  hours: string;
+  minutes: string;
+  period?: ToggleValue;
+};
+
+export interface TimeInputEvent {
+  target: {
+    name?: string;
+    id: string;
+    value: TimeValue;
+  };
+}
+
+interface TimeInputProps
+  extends Omit<TagProps, "data-component">,
+    Omit<ValidationProps, "info"> {
+  /** Set an id value on the input */
+  id?: string;
+  /** Override the default label text */
+  label?: string;
+  /** Override the default aria-label text */
+  "aria-label"?: string;
+}
+
+export interface TimeProps
+  extends Omit<TagProps, "data-component">,
+    MarginProps {
+  /** Label text for the component */
+  label?: string;
+  /** Sets the size of the inputs */
+  size?: Sizes;
+  /** Additional hint text rendered above the input elements */
+  inputHint?: string;
+  /**
+   * Set custom `data-` and `id` attributes on the input element.
+   * Set the `label` and `aria-label` values for the associated Label element.
+   * Set the `error` and `warning` states for the input
+   *  */
+  hoursInputProps?: TimeInputProps;
+  /**
+   * Set custom `data-` and `id` attributes on the input element.
+   * Set the `label` and `aria-label` values for the associated Label element.
+   * Set the `error` and `warning` states for the input
+   *  */
+  minutesInputProps?: TimeInputProps;
+  /** The value of the input elements */
+  value: TimeValue;
+  /** Callback to handle change events in input elements */
+  onChange: (ev: TimeInputEvent) => void;
+  /** Set a name value on the component */
+  name?: string;
+  /** Callback called when focus is lost on input elements */
+  onBlur?: (ev?: React.FocusEvent<HTMLInputElement>) => void;
+  /** Flag to configure component as mandatory */
+  required?: boolean;
+  /** Flag to configure component as optional */
+  isOptional?: boolean;
+  /** If true, the component will be disabled */
+  disabled?: boolean;
+  /** If true, the component will be read-only */
+  readOnly?: boolean;
+  /** Set custom data- attributes on the toggle elements */
+  toggleProps?: ToggleDataProps;
+}
+
+export type TimeHandle = {
+  /** Programmatically focus the hours input. */
+  focusHoursInput: () => void;
+  /** Programmatically focus the minutes input. */
+  focusMinutesInput: () => void;
+} | null;
+
+const Time = React.forwardRef<TimeHandle, TimeProps>(
+  (
+    {
+      label,
+      size = "medium",
+      inputHint,
+      hoursInputProps = {},
+      minutesInputProps = {},
+      value,
+      name,
+      onChange,
+      onBlur,
+      required,
+      isOptional,
+      disabled,
+      readOnly,
+      toggleProps = {},
+      ...rest
+    },
+    ref
+  ) => {
+    const {
+      id: hoursInputId,
+      label: hoursLabel,
+      "aria-label": hoursAriaLabel,
+      error: hoursError,
+      warning: hoursWarning,
+    } = hoursInputProps;
+    const {
+      id: minutesInputId,
+      label: minutesLabel,
+      "aria-label": minutesAriaLabel,
+      error: minutesError,
+      warning: minutesWarning,
+    } = minutesInputProps;
+    const internalHrsId = useRef(hoursInputId || guid());
+    const internalMinsId = useRef(minutesInputId || guid());
+    const inputHintId = useRef(guid());
+    const internalId = useRef(
+      `${internalHrsId.current} ${internalMinsId.current}`
+    );
+    const {
+      hours: hourValue,
+      minutes: minuteValue,
+      period: toggleValue,
+    } = value;
+    const [inputValues, setInputValues] = useState([hourValue, minuteValue]);
+    const locale = useLocale();
+    const showToggle = toggleValue !== undefined;
+    const [period, setPeriod] = useState(toggleValue);
+    const hrsLabel = hoursLabel || locale.time.hoursLabelText();
+    const minsLabel = minutesLabel || locale.time.minutesLabelText();
+    const hrsAriaLabel = hoursAriaLabel || locale.time.hoursAriaLabelText();
+    const minsAriaLabel =
+      minutesAriaLabel || locale.time.minutesAriaLabelText();
+    const hoursRef = useRef<HTMLInputElement>(null);
+    const minsRef = useRef<HTMLInputElement>(null);
+
+    const computedValidations = (
+      hrs?: string | boolean,
+      mins?: string | boolean
+    ) => {
+      const hoursIsString = typeof hrs === "string";
+      const minutesIsString = typeof mins === "string";
+      if (!hoursIsString && !minutesIsString) {
+        return hrs || mins;
+      }
+
+      if (hoursIsString && !minutesIsString) {
+        return hrs;
+      }
+
+      if (minutesIsString && !hoursIsString) {
+        return mins;
+      }
+
+      return `${hrs} ${mins}`;
+    };
+
+    const error = computedValidations(hoursError, minutesError);
+    const warning = computedValidations(hoursWarning, minutesWarning);
+    const hasValidationFailure = !!(error || warning);
+
+    const { validationId, ariaDescribedBy } = useInputAccessibility({
+      id: internalId.current,
+      validationRedesignOptIn: true,
+      error,
+      warning,
+    });
+
+    const combinedAriaDescribedBy = [ariaDescribedBy, inputHintId.current]
+      .filter(Boolean)
+      .join(" ");
+
+    useImperativeHandle<TimeHandle, TimeHandle>(
+      ref,
+      () => ({
+        focusHoursInput() {
+          hoursRef.current?.focus();
+        },
+        focusMinutesInput() {
+          minsRef.current?.focus();
+        },
+      }),
+      []
+    );
+
+    const handleChange = (
+      ev: React.ChangeEvent<HTMLInputElement>,
+      inputName: "hrs" | "mins"
+    ) => {
+      const hours = inputName === "hrs" ? ev.target.value : inputValues[0];
+      const minutes = inputName === "mins" ? ev.target.value : inputValues[1];
+
+      setInputValues([hours, minutes]);
+      onChange({
+        target: {
+          name,
+          id: internalId.current,
+          value: { hours, minutes, period },
+        },
+      });
+    };
+
+    const handlePeriodChange = (periodName: ToggleValue) => {
+      const [hours, minutes] = inputValues;
+      setPeriod(periodName);
+      onChange({
+        target: {
+          name,
+          id: internalId.current,
+          value: { hours, minutes, period: periodName },
+        },
+      });
+    };
+
+    const handleBlur = useCallback(
+      (ev: React.FocusEvent<HTMLInputElement>) => {
+        setTimeout(() => {
+          if (
+            hoursRef.current !== document.activeElement &&
+            minsRef.current !== document.activeElement
+          ) {
+            onBlur?.(ev);
+          }
+        });
+      },
+      [onBlur]
+    );
+
+    return (
+      <Fieldset
+        legend={label}
+        legendMargin={{ mb: 0 }}
+        width="min-content"
+        isRequired={required}
+        isOptional={isOptional}
+        isDisabled={disabled}
+        name={name}
+        id={internalId.current}
+        {...rest}
+        {...tagComponent("time", rest)}
+        aria-describedby={combinedAriaDescribedBy}
+      >
+        {inputHint && (
+          <Hint id={inputHintId.current} isDisabled={disabled}>
+            {inputHint}
+          </Hint>
+        )}
+        <Box position="relative">
+          <ValidationMessage
+            validationId={validationId}
+            error={error}
+            warning={warning}
+          />
+          {hasValidationFailure && (
+            <ErrorBorder warning={!!(!error && warning)} />
+          )}
+          <Box display="flex">
+            <div>
+              <Label
+                aria-label={hrsAriaLabel}
+                htmlFor={internalHrsId.current}
+                disabled={disabled}
+              >
+                {hrsLabel}
+              </Label>
+              <Number
+                {...hoursInputProps}
+                label={undefined}
+                data-component="hours"
+                ref={hoursRef}
+                value={hourValue}
+                onChange={(ev) => handleChange(ev, "hrs")}
+                onBlur={handleBlur}
+                id={internalHrsId.current}
+                size={size}
+                error={!!hoursError}
+                warning={!!hoursWarning}
+                disabled={disabled}
+                readOnly={readOnly}
+              />
+            </div>
+            <Box
+              display="flex"
+              flexDirection="column"
+              justifyContent="center"
+              mx={1}
+              aria-hidden="true"
+            >
+              <span>&nbsp;</span>
+              <Typography isDisabled={disabled} variant="span" mb="-4px">
+                :
+              </Typography>
+            </Box>
+            <div>
+              <Label
+                aria-label={minsAriaLabel}
+                htmlFor={internalMinsId.current}
+                disabled={disabled}
+              >
+                {minsLabel}
+              </Label>
+              <Number
+                {...minutesInputProps}
+                label={undefined}
+                data-component="minutes"
+                ref={minsRef}
+                value={minuteValue}
+                onChange={(ev) => handleChange(ev, "mins")}
+                onBlur={handleBlur}
+                id={internalMinsId.current}
+                size={size}
+                error={!!minutesError}
+                warning={!!minutesWarning}
+                disabled={disabled}
+                readOnly={readOnly}
+              />
+            </div>
+            {showToggle && (
+              <Box
+                display="flex"
+                flexDirection="column"
+                justifyContent="flex-end"
+              >
+                <TimeToggle
+                  toggleProps={toggleProps}
+                  size={size}
+                  onChange={handlePeriodChange}
+                  toggleValue={toggleValue}
+                  disabled={disabled || readOnly}
+                />
+              </Box>
+            )}
+          </Box>
+        </Box>
+      </Fieldset>
+    );
+  }
+);
+
+Time.displayName = "Time";
+
+export default Time;

--- a/src/components/time/time.pw.tsx
+++ b/src/components/time/time.pw.tsx
@@ -1,0 +1,638 @@
+import { expect, test } from "@playwright/experimental-ct-react17";
+import React from "react";
+import { TimeProps } from ".";
+import {
+  getDataComponentByValue,
+  getDataElementByValue,
+  getDataRoleByValue,
+} from "../../../playwright/components";
+import {
+  assertCssValueIsApproximately,
+  checkAccessibility,
+  verifyRequiredAsteriskForLabel,
+} from "../../../playwright/support/helper";
+import TimeComponent from "./components.test-pw";
+import {
+  CHARACTERS,
+  SIZE,
+  VALIDATION,
+} from "../../../playwright/support/constants";
+
+const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
+
+test.describe("Time component", () => {
+  test("should render with data-element attribute set", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TimeComponent data-element={CHARACTERS.STANDARD} />);
+
+    await expect(
+      getDataElementByValue(page, CHARACTERS.STANDARD)
+    ).toBeVisible();
+  });
+
+  test("should render with data-role attribute set", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TimeComponent data-role={CHARACTERS.STANDARD} />);
+
+    await expect(getDataRoleByValue(page, CHARACTERS.STANDARD)).toBeVisible();
+  });
+
+  testData.forEach((text) => {
+    test(`should render with ${text} as a legend`, async ({ mount, page }) => {
+      await mount(<TimeComponent label={text} />);
+
+      const legend = getDataElementByValue(page, "legend");
+
+      await expect(legend).toHaveText(text);
+    });
+  });
+
+  testData.forEach((text) => {
+    test(`should render with ${text} as a hours input label`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(<TimeComponent hoursInputProps={{ label: text }} />);
+
+      const label = getDataElementByValue(page, "label").first();
+
+      await expect(label).toHaveText(text);
+    });
+  });
+
+  testData.forEach((text) => {
+    test(`should render with ${text} as a minutes input label`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(<TimeComponent minutesInputProps={{ label: text }} />);
+
+      const label = getDataElementByValue(page, "label").last();
+
+      await expect(label).toHaveText(text);
+    });
+  });
+
+  testData.forEach((inputHint) => {
+    test(`should render inputHint with ${inputHint} as text`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(<TimeComponent inputHint={inputHint} />);
+
+      const hint = page.getByText(inputHint);
+
+      await expect(hint).toBeVisible();
+    });
+  });
+
+  test("should render with required attribute set on inputs and `*` after legened element", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TimeComponent label="label" required />);
+
+    await verifyRequiredAsteriskForLabel(
+      page,
+      getDataElementByValue(page, "legend").locator("span")
+    );
+    await expect(
+      getDataComponentByValue(page, "hours").locator("input")
+    ).toHaveAttribute("required", "");
+    await expect(
+      getDataComponentByValue(page, "minutes").locator("input")
+    ).toHaveAttribute("required", "");
+  });
+
+  test("should render with name attribute on the root", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TimeComponent name={CHARACTERS.STANDARD} />);
+
+    await expect(getDataComponentByValue(page, "time")).toHaveAttribute(
+      "name",
+      CHARACTERS.STANDARD
+    );
+  });
+
+  test("should render with inputs and toggles disabled when prop set", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TimeComponent disabled toggleValue="AM" />);
+
+    const hoursInput = getDataComponentByValue(page, "hours").locator("input");
+    const minutesInput = getDataComponentByValue(page, "minutes").locator(
+      "input"
+    );
+    const amToggleButton = getDataComponentByValue(
+      page,
+      "am-button-toggle"
+    ).locator("button");
+    const pmToggleButton = getDataComponentByValue(
+      page,
+      "pm-button-toggle"
+    ).locator("button");
+
+    await expect(hoursInput).toBeDisabled();
+    await expect(minutesInput).toBeDisabled();
+    await expect(amToggleButton).toBeDisabled();
+    await expect(pmToggleButton).toBeDisabled();
+  });
+
+  test("should render with inputs as non-editable and toggles disabled when readOnly prop set", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TimeComponent readOnly toggleValue="AM" />);
+
+    const hoursInput = getDataComponentByValue(page, "hours").locator("input");
+    const minutesInput = getDataComponentByValue(page, "minutes").locator(
+      "input"
+    );
+    const amToggleButton = getDataComponentByValue(
+      page,
+      "am-button-toggle"
+    ).locator("button");
+    const pmToggleButton = getDataComponentByValue(
+      page,
+      "pm-button-toggle"
+    ).locator("button");
+
+    await expect(hoursInput).not.toBeEditable();
+    await expect(minutesInput).not.toBeEditable();
+    await expect(amToggleButton).toBeDisabled();
+    await expect(pmToggleButton).toBeDisabled();
+  });
+
+  test("should allow typing in inputs, verify the value and onChange was called correct number of times", async ({
+    mount,
+    page,
+  }) => {
+    let count = 0;
+    const onChangeCb = () => {
+      count += 1;
+    };
+    await mount(<TimeComponent onChangeCb={onChangeCb} />);
+
+    const inputValue = "1";
+    const hoursInput = getDataComponentByValue(page, "hours").locator("input");
+    const minutesInput = getDataComponentByValue(page, "minutes").locator(
+      "input"
+    );
+
+    await hoursInput.fill(inputValue);
+    await expect(hoursInput).toHaveValue(inputValue);
+    expect(count).toBe(1);
+    await minutesInput.fill(inputValue);
+    expect(count).toBe(2);
+    await expect(minutesInput).toHaveValue(inputValue);
+  });
+
+  test("should only call onBlur when the user navigates via tabbing and neither input is focused", async ({
+    mount,
+    page,
+  }) => {
+    let count = 0;
+    const onBlurCb = () => {
+      count += 1;
+    };
+    await mount(<TimeComponent onBlurCb={onBlurCb} />);
+
+    const hoursInput = getDataComponentByValue(page, "hours").locator("input");
+    const minutesInput = getDataComponentByValue(page, "minutes").locator(
+      "input"
+    );
+
+    await hoursInput.focus();
+    await page.keyboard.press("Tab");
+    await expect(minutesInput).toBeFocused();
+    expect(count).toBe(0);
+    await page.keyboard.press("Tab");
+    await expect(minutesInput).not.toBeFocused();
+    expect(count).toBe(1);
+  });
+
+  test("should only call onBlur when the user navigates via shift tabbing and neither input is focused", async ({
+    mount,
+    page,
+  }) => {
+    let count = 0;
+    const onBlurCb = () => {
+      count += 1;
+    };
+    await mount(<TimeComponent onBlurCb={onBlurCb} />);
+
+    const hoursInput = getDataComponentByValue(page, "hours").locator("input");
+    const minutesInput = getDataComponentByValue(page, "minutes").locator(
+      "input"
+    );
+
+    await minutesInput.focus();
+    await page.keyboard.press("Shift+Tab");
+    await expect(hoursInput).toBeFocused();
+    expect(count).toBe(0);
+    await page.keyboard.press("Shift+Tab");
+    await expect(hoursInput).not.toBeFocused();
+    expect(count).toBe(1);
+  });
+
+  ([
+    [VALIDATION.ERROR, "error", true],
+    [VALIDATION.WARNING, "warning", true],
+    ["rgb(102, 132, 148)", "error", false],
+    ["rgb(102, 132, 148)", "warning", false],
+  ] as [string, string, boolean][]).forEach(([borderColor, type, bool]) => {
+    test(`should render hours input with ${borderColor} border when ${type} is ${bool}`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <TimeComponent
+          label="label"
+          value={{ hours: "", minutes: "" }}
+          onChange={() => {}}
+          {...{ hoursInputProps: { [type]: bool } }}
+        />
+      );
+
+      const hoursInputPresentation = page
+        .locator("input")
+        .first()
+        .locator("..");
+
+      await expect(hoursInputPresentation).toHaveCSS(
+        "border-top-color",
+        borderColor
+      );
+      await expect(hoursInputPresentation).toHaveCSS(
+        "border-bottom-color",
+        borderColor
+      );
+      await expect(hoursInputPresentation).toHaveCSS(
+        "border-left-color",
+        borderColor
+      );
+      await expect(hoursInputPresentation).toHaveCSS(
+        "border-right-color",
+        borderColor
+      );
+    });
+  });
+
+  ([
+    [VALIDATION.ERROR, "error", true],
+    [VALIDATION.WARNING, "warning", true],
+    ["rgb(102, 132, 148)", "error", false],
+    ["rgb(102, 132, 148)", "warning", false],
+  ] as [string, string, boolean][]).forEach(([borderColor, type, bool]) => {
+    test(`should render minutes input with ${borderColor} border when ${type} is ${bool}`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <TimeComponent
+          label="label"
+          value={{ hours: "", minutes: "" }}
+          onChange={() => {}}
+          {...{ minutesInputProps: { [type]: bool } }}
+        />
+      );
+
+      const minutesInputPresentation = page
+        .locator("input")
+        .last()
+        .locator("..");
+
+      await expect(minutesInputPresentation).toHaveCSS(
+        "border-top-color",
+        borderColor
+      );
+      await expect(minutesInputPresentation).toHaveCSS(
+        "border-bottom-color",
+        borderColor
+      );
+      await expect(minutesInputPresentation).toHaveCSS(
+        "border-left-color",
+        borderColor
+      );
+      await expect(minutesInputPresentation).toHaveCSS(
+        "border-right-color",
+        borderColor
+      );
+    });
+  });
+
+  ([
+    [VALIDATION.ERROR, "error", true],
+    [VALIDATION.WARNING, "warning", true],
+    ["rgb(102, 132, 148)", "error", false],
+    ["rgb(102, 132, 148)", "warning", false],
+  ] as [string, string, boolean][]).forEach(([borderColor, type, bool]) => {
+    test(`should render both inputs with ${borderColor} border when ${type} is ${bool}`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <TimeComponent
+          label="label"
+          value={{ hours: "", minutes: "" }}
+          onChange={() => {}}
+          {...(type === "error" && {
+            hoursInputProps: { error: bool },
+            minutesInputProps: { error: bool },
+          })}
+          {...(type === "warning" && {
+            hoursInputProps: { warning: bool },
+            minutesInputProps: { warning: bool },
+          })}
+        />
+      );
+
+      const hoursInputPresentation = page
+        .locator("input")
+        .first()
+        .locator("..");
+      const minutesInputPresentation = page
+        .locator("input")
+        .last()
+        .locator("..");
+
+      await expect(hoursInputPresentation).toHaveCSS(
+        "border-top-color",
+        borderColor
+      );
+      await expect(hoursInputPresentation).toHaveCSS(
+        "border-bottom-color",
+        borderColor
+      );
+      await expect(hoursInputPresentation).toHaveCSS(
+        "border-left-color",
+        borderColor
+      );
+      await expect(hoursInputPresentation).toHaveCSS(
+        "border-right-color",
+        borderColor
+      );
+      await expect(minutesInputPresentation).toHaveCSS(
+        "border-top-color",
+        borderColor
+      );
+      await expect(minutesInputPresentation).toHaveCSS(
+        "border-bottom-color",
+        borderColor
+      );
+      await expect(minutesInputPresentation).toHaveCSS(
+        "border-left-color",
+        borderColor
+      );
+      await expect(minutesInputPresentation).toHaveCSS(
+        "border-right-color",
+        borderColor
+      );
+    });
+  });
+
+  ([
+    [SIZE.SMALL, 30],
+    [SIZE.MEDIUM, 38],
+    [SIZE.LARGE, 46],
+  ] as [TimeProps["size"], number][]).forEach(([size, height]) => {
+    test(`should render the inputs and toggles with height of ${height}px when size is ${size}`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <TimeComponent
+          label="label"
+          value={{ hours: "", minutes: "", period: "AM" }}
+          onChange={() => {}}
+          size={size}
+        />
+      );
+
+      const hoursInput = page.locator("input").first();
+      const minutesInput = page.locator("input").last();
+      const amToggleButton = getDataComponentByValue(
+        page,
+        "am-button-toggle"
+      ).locator("button");
+      const pmToggleButton = getDataComponentByValue(
+        page,
+        "pm-button-toggle"
+      ).locator("button");
+
+      await assertCssValueIsApproximately(hoursInput, "height", height);
+      await assertCssValueIsApproximately(minutesInput, "height", height);
+      await assertCssValueIsApproximately(amToggleButton, "height", height);
+      await assertCssValueIsApproximately(pmToggleButton, "height", height);
+    });
+  });
+
+  test.describe("Accessibility tests ", () => {
+    test("should pass for default implementation", async ({ mount, page }) => {
+      await mount(
+        <TimeComponent
+          label="label"
+          value={{ hours: "12", minutes: "30" }}
+          onChange={() => {}}
+        />
+      );
+
+      await checkAccessibility(page);
+    });
+
+    test("should pass when required prop set", async ({ mount, page }) => {
+      await mount(
+        <TimeComponent
+          required
+          label="label"
+          value={{ hours: "12", minutes: "30" }}
+          onChange={() => {}}
+        />
+      );
+
+      await checkAccessibility(page);
+    });
+
+    test("should pass when isOptional prop set", async ({ mount, page }) => {
+      await mount(
+        <TimeComponent
+          isOptional
+          label="label"
+          value={{ hours: "12", minutes: "30" }}
+          onChange={() => {}}
+        />
+      );
+
+      await checkAccessibility(page);
+    });
+
+    test("should pass when input hint text is rendered", async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <TimeComponent
+          label="label"
+          inputHint="input hint"
+          value={{ hours: "12", minutes: "30" }}
+          onChange={() => {}}
+        />
+      );
+
+      await checkAccessibility(page);
+    });
+
+    test("should pass when both inputs have an error", async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <TimeComponent
+          label="label"
+          hoursInputProps={{ error: "error" }}
+          minutesInputProps={{ error: "error" }}
+          value={{ hours: "12", minutes: "30" }}
+          onChange={() => {}}
+        />
+      );
+
+      await checkAccessibility(page);
+    });
+
+    test("should pass when both inputs have a warning", async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <TimeComponent
+          label="label"
+          hoursInputProps={{ warning: "warning" }}
+          minutesInputProps={{ warning: "warning" }}
+          value={{ hours: "12", minutes: "30" }}
+          onChange={() => {}}
+        />
+      );
+
+      await checkAccessibility(page);
+    });
+
+    test("should pass when the hours input has an error", async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <TimeComponent
+          label="label"
+          hoursInputProps={{ error: "error" }}
+          value={{ hours: "12", minutes: "30" }}
+          onChange={() => {}}
+        />
+      );
+
+      await checkAccessibility(page);
+    });
+
+    test("should pass when the minutes input has an error", async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <TimeComponent
+          label="label"
+          minutesInputProps={{ error: "error" }}
+          value={{ hours: "12", minutes: "30" }}
+          onChange={() => {}}
+        />
+      );
+
+      await checkAccessibility(page);
+    });
+
+    test("should pass when the hours input has a warning", async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <TimeComponent
+          label="label"
+          hoursInputProps={{ warning: "warning" }}
+          value={{ hours: "12", minutes: "30" }}
+          onChange={() => {}}
+        />
+      );
+
+      await checkAccessibility(page);
+    });
+
+    test("should pass when the minutes input has a warning", async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <TimeComponent
+          label="label"
+          minutesInputProps={{ warning: "warning" }}
+          value={{ hours: "12", minutes: "30" }}
+          onChange={() => {}}
+        />
+      );
+
+      await checkAccessibility(page);
+    });
+
+    test("should pass when toggle control rendered", async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <TimeComponent
+          label="label"
+          value={{ hours: "12", minutes: "30", period: "AM" }}
+          onChange={() => {}}
+        />
+      );
+
+      await checkAccessibility(page);
+    });
+
+    // disabled styling for label, input hint etc fail colour contrast
+    test("should pass when toggle control rendered and disabled prop set", async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <TimeComponent
+          disabled
+          label="label"
+          value={{ hours: "12", minutes: "30", period: "AM" }}
+          onChange={() => {}}
+        />
+      );
+
+      await checkAccessibility(page, undefined, "color-contrast");
+    });
+
+    test("should pass when toggle control rendered and readOnly prop set", async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <TimeComponent
+          readOnly
+          label="label"
+          value={{ hours: "12", minutes: "30", period: "AM" }}
+          onChange={() => {}}
+        />
+      );
+
+      await checkAccessibility(page);
+    });
+  });
+});

--- a/src/components/time/time.spec.tsx
+++ b/src/components/time/time.spec.tsx
@@ -1,0 +1,1006 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Time, TimeHandle } from ".";
+import { testStyledSystemMargin } from "../../__spec_helper__/test-utils";
+import inputSizes from "../../__internal__/input/input-sizes.style";
+import {
+  heightConfig,
+  paddingConfig,
+  fontSizeConfig,
+} from "../button-toggle/button-toggle.style";
+import I18nProvider from "../i18n-provider";
+import { rootTagTestRtl } from "../../__internal__/utils/helpers/tags/tags-specs";
+
+const localeMock = {
+  time: {
+    amText: () => "foo-toggle",
+    pmText: () => "bar-toggle",
+    hoursLabelText: () => "foo-label",
+    minutesLabelText: () => "bar-label",
+    hoursAriaLabelText: () => "foo-aria-label",
+    minutesAriaLabelText: () => "bar-aria-label",
+  },
+};
+
+const MockComponent = ({
+  focusTarget,
+}: {
+  focusTarget: "hours" | "minutes";
+}) => {
+  const timeHandle = React.useRef<TimeHandle>(null);
+
+  const handleClick = () => {
+    if (focusTarget === "hours") {
+      timeHandle.current?.focusHoursInput();
+    } else {
+      timeHandle.current?.focusMinutesInput();
+    }
+  };
+
+  return (
+    <>
+      <button type="button" onClick={handleClick}>
+        Focus input
+      </button>
+      <Time
+        ref={timeHandle}
+        onChange={() => {}}
+        value={{ hours: "12", minutes: "30" }}
+      />
+    </>
+  );
+};
+
+describe("Time component", () => {
+  testStyledSystemMargin((props) => (
+    <Time value={{ hours: "", minutes: "" }} onChange={() => {}} {...props} />
+  ));
+
+  it("should not display the AM/PM toggle by default", () => {
+    render(<Time value={{ hours: "", minutes: "" }} onChange={() => {}} />);
+
+    expect(screen.queryByText("AM")).not.toBeInTheDocument();
+    expect(screen.queryByText("PM")).not.toBeInTheDocument();
+  });
+
+  it("should display the AM/PM toggle and highlight the first button when toggleValue prop is `AM`", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "", period: "AM" }}
+        onChange={() => {}}
+      />
+    );
+
+    const amToggle = screen.queryByText("AM");
+    const pmToggle = screen.queryByText("PM");
+
+    expect(amToggle).toBeInTheDocument();
+    expect(amToggle).toHaveAttribute("aria-pressed", "true");
+    expect(pmToggle).toBeInTheDocument();
+    expect(pmToggle).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("should display the AM/PM toggle and highlight the second button when toggleValue prop is `PM`", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "", period: "PM" }}
+        onChange={() => {}}
+      />
+    );
+
+    const amToggle = screen.queryByText("AM");
+    const pmToggle = screen.queryByText("PM");
+
+    expect(amToggle).toBeInTheDocument();
+    expect(amToggle).toHaveAttribute("aria-pressed", "false");
+    expect(pmToggle).toBeInTheDocument();
+    expect(pmToggle).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("should render the input hint text when prop is set", () => {
+    render(
+      <Time
+        value={{ hours: "12", minutes: "30" }}
+        onChange={() => {}}
+        inputHint="hint text"
+      />
+    );
+
+    expect(screen.queryByText("hint text")).toBeInTheDocument();
+  });
+
+  it("should focus the relevant input when the associated label is clicked", async () => {
+    render(<Time value={{ hours: "12", minutes: "30" }} onChange={() => {}} />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText("Hrs."));
+
+    expect(screen.getByDisplayValue("12")).toBeFocused();
+
+    await user.click(screen.getByText("Mins."));
+
+    expect(screen.getByDisplayValue("30")).toBeFocused();
+  });
+
+  it("should focus each input in the expected order when user is tabbing", async () => {
+    render(
+      <Time
+        value={{ hours: "12", minutes: "30", period: "AM" }}
+        onChange={() => {}}
+      />
+    );
+
+    const user = userEvent.setup();
+    await act(async () => {
+      await user.tab();
+    });
+
+    expect(screen.getByDisplayValue("12")).toBeFocused();
+
+    await act(async () => {
+      await user.tab();
+    });
+
+    expect(screen.getByDisplayValue("30")).toBeFocused();
+
+    await act(async () => {
+      await user.tab();
+    });
+
+    expect(screen.queryByText("AM")).toBeFocused();
+  });
+
+  it("should focus each input in the expected order when user is shift tabbing", async () => {
+    render(
+      <Time
+        value={{ hours: "12", minutes: "30", period: "AM" }}
+        onChange={() => {}}
+      />
+    );
+
+    const user = userEvent.setup();
+    const hrsInput = screen.getByDisplayValue("12");
+    const minsInput = screen.getByDisplayValue("30");
+    const amToggle = screen.queryByText("AM");
+
+    act(() => {
+      amToggle?.focus();
+    });
+
+    expect(amToggle).toHaveFocus();
+
+    await act(async () => {
+      await user.tab({ shift: true });
+    });
+
+    expect(minsInput).toBeFocused();
+
+    await act(async () => {
+      await user.tab({ shift: true });
+    });
+
+    expect(hrsInput).toBeFocused();
+  });
+
+  it("should render a legend with any passed label text", () => {
+    render(
+      <Time
+        value={{ hours: "12", minutes: "30" }}
+        onChange={() => {}}
+        label="Time"
+      />
+    );
+
+    const legend = screen.queryByText("Time");
+
+    expect(legend).toBeInTheDocument();
+    expect(legend?.parentElement?.tagName).toBe("LEGEND");
+  });
+
+  it("should apply the `medium` `size` styling to inputs and toggles by default", () => {
+    render(
+      <Time
+        value={{ hours: "12", minutes: "30", period: "AM" }}
+        onChange={() => {}}
+      />
+    );
+
+    const [hrsInputPresentation, minsInputPresentation] = screen.getAllByRole(
+      "presentation"
+    );
+    const { height, horizontalPadding } = inputSizes.medium;
+    const amToggle = screen.queryByText("AM");
+    const pmToggle = screen.queryByText("PM");
+
+    expect(hrsInputPresentation).toHaveStyle({
+      "min-height": height,
+      padding: horizontalPadding,
+    });
+    expect(minsInputPresentation).toHaveStyle({
+      "min-height": height,
+      padding: horizontalPadding,
+    });
+    expect(amToggle).toHaveStyle({
+      height: `${heightConfig.medium}px`,
+      padding: `0 ${paddingConfig.medium}px`,
+      "font-size": `${fontSizeConfig.medium}px`,
+    });
+    expect(pmToggle).toHaveStyle({
+      height: `${heightConfig.medium}px`,
+      padding: `0 ${paddingConfig.medium}px`,
+      "font-size": `${fontSizeConfig.medium}px`,
+    });
+  });
+
+  it.each(["small", "medium", "large"] as const)(
+    "should apply the expected styling to the inputs and toggle when size is %s",
+    (size) => {
+      render(
+        <Time
+          value={{ hours: "12", minutes: "30", period: "AM" }}
+          onChange={() => {}}
+          size={size}
+        />
+      );
+
+      const [hrsInputPresentation, minsInputPresentation] = screen.getAllByRole(
+        "presentation"
+      );
+      const { height, horizontalPadding } = inputSizes[size];
+      const amToggle = screen.queryByText("AM");
+      const pmToggle = screen.queryByText("PM");
+
+      expect(hrsInputPresentation).toHaveStyle({
+        "min-height": height,
+        padding: horizontalPadding,
+      });
+      expect(minsInputPresentation).toHaveStyle({
+        "min-height": height,
+        padding: horizontalPadding,
+      });
+      expect(amToggle).toHaveStyle({
+        height: `${heightConfig[size]}px`,
+        padding: `0 ${paddingConfig[size]}px`,
+        "font-size": `${fontSizeConfig[size]}px`,
+      });
+      expect(pmToggle).toHaveStyle({
+        height: `${heightConfig[size]}px`,
+        padding: `0 ${paddingConfig[size]}px`,
+        "font-size": `${fontSizeConfig[size]}px`,
+      });
+    }
+  );
+
+  it("should apply the custom id on the hours input when `hoursInputProps` has an `id` set", () => {
+    const { container } = render(
+      <Time
+        value={{ hours: "12", minutes: "30" }}
+        onChange={() => {}}
+        hoursInputProps={{ id: "foo" }}
+      />
+    );
+
+    expect(container.querySelector("[id='foo']")).toBeInTheDocument();
+  });
+
+  it("should apply the custom id on the minutes input when `minutesInputProps` has an `id` set", () => {
+    const { container } = render(
+      <Time
+        value={{ hours: "12", minutes: "30" }}
+        onChange={() => {}}
+        minutesInputProps={{ id: "foo" }}
+      />
+    );
+
+    expect(container.querySelector("[id='foo']")).toBeInTheDocument();
+  });
+
+  it("should call onChange when a user types in the hours input and toggle is rendered", async () => {
+    const onChangeMock = jest.fn();
+    render(
+      <Time
+        value={{ hours: "", minutes: "", period: "AM" }}
+        onChange={onChangeMock}
+        hoursInputProps={{ id: "foo" }}
+        minutesInputProps={{ id: "bar" }}
+      />
+    );
+
+    const user = userEvent.setup();
+
+    await act(async () => {
+      await user.tab();
+      await user.keyboard(`{1}`);
+    });
+
+    expect(onChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: {
+          name: undefined,
+          id: "foo bar",
+          value: { hours: "1", minutes: "", period: "AM" },
+        },
+      })
+    );
+  });
+
+  it("should call onChange when a user types in the hours input and toggle is not rendered", async () => {
+    const onChangeMock = jest.fn();
+    render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={onChangeMock}
+        hoursInputProps={{ id: "foo" }}
+        minutesInputProps={{ id: "bar" }}
+      />
+    );
+
+    const user = userEvent.setup();
+    await user.tab();
+    await user.keyboard(`{1}`);
+
+    expect(onChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: {
+          name: undefined,
+          id: "foo bar",
+          value: { hours: "1", minutes: "" },
+        },
+      })
+    );
+  });
+
+  it("should call onChange when a user types in the minutes input and toggle is rendered", async () => {
+    const onChangeMock = jest.fn();
+    render(
+      <Time
+        value={{ hours: "", minutes: "", period: "AM" }}
+        onChange={onChangeMock}
+        hoursInputProps={{ id: "foo" }}
+        minutesInputProps={{ id: "bar" }}
+      />
+    );
+
+    const user = userEvent.setup();
+
+    await act(async () => {
+      await user.tab();
+      await user.tab();
+      await user.keyboard(`{1}`);
+    });
+
+    expect(onChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: {
+          name: undefined,
+          id: "foo bar",
+          value: { hours: "", minutes: "1", period: "AM" },
+        },
+      })
+    );
+  });
+
+  it("should call onChange when a user types in the minutes input and toggle is not rendered", async () => {
+    const onChangeMock = jest.fn();
+    render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={onChangeMock}
+        hoursInputProps={{ id: "foo" }}
+        minutesInputProps={{ id: "bar" }}
+      />
+    );
+
+    const user = userEvent.setup();
+    await user.tab();
+    await user.tab();
+    await user.keyboard(`{1}`);
+
+    expect(onChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: {
+          name: undefined,
+          id: "foo bar",
+          value: { hours: "", minutes: "1" },
+        },
+      })
+    );
+  });
+
+  it("should call onChange when a user clicks the toggle that is not currently selected", async () => {
+    const onChangeMock = jest.fn();
+    render(
+      <Time
+        value={{ hours: "", minutes: "", period: "AM" }}
+        onChange={onChangeMock}
+        hoursInputProps={{ id: "foo" }}
+        minutesInputProps={{ id: "bar" }}
+      />
+    );
+
+    const pmToggle = await screen.findByText("PM");
+
+    await act(async () => {
+      await userEvent.click(pmToggle);
+    });
+
+    expect(onChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target: {
+          name: undefined,
+          id: "foo bar",
+          value: { hours: "", minutes: "", period: "PM" },
+        },
+      })
+    );
+  });
+
+  it("should not call onChange when a user clicks the toggle that is currently selected", async () => {
+    const onChangeMock = jest.fn();
+    render(
+      <Time
+        value={{ hours: "", minutes: "", period: "AM" }}
+        onChange={onChangeMock}
+        hoursInputProps={{ id: "foo" }}
+        minutesInputProps={{ id: "bar" }}
+      />
+    );
+
+    const amToggle = await screen.findByText("AM");
+
+    await act(async () => {
+      await userEvent.click(amToggle);
+    });
+
+    expect(onChangeMock).not.toHaveBeenCalled();
+  });
+
+  it("should call onBlur when the hours input is focused and the user presses shift + tab", async () => {
+    const onBlurMock = jest.fn();
+    render(
+      <Time
+        value={{ hours: "12", minutes: "" }}
+        onChange={() => {}}
+        onBlur={onBlurMock}
+      />
+    );
+
+    const user = userEvent.setup();
+
+    screen.getByDisplayValue("12").focus();
+    await user.tab({ shift: true });
+
+    expect(onBlurMock).toHaveBeenCalled();
+  });
+
+  it("should not call onBlur when the hours input is focused and the user presses tab", async () => {
+    const onBlurMock = jest.fn();
+    render(
+      <Time
+        value={{ hours: "12", minutes: "" }}
+        onChange={() => {}}
+        onBlur={onBlurMock}
+      />
+    );
+
+    const user = userEvent.setup();
+
+    screen.getByDisplayValue("12").focus();
+    await user.tab();
+
+    expect(onBlurMock).not.toHaveBeenCalled();
+  });
+
+  it("should call onBlur when the minutes input is focused and the user presses tab", async () => {
+    const onBlurMock = jest.fn();
+    render(
+      <Time
+        value={{ hours: "", minutes: "12" }}
+        onChange={() => {}}
+        onBlur={onBlurMock}
+      />
+    );
+
+    const user = userEvent.setup();
+
+    screen.getByDisplayValue("12").focus();
+    await user.tab();
+
+    expect(onBlurMock).toHaveBeenCalled();
+  });
+
+  it("should not call onBlur when the minutes input is focused and the user presses shift + tab", async () => {
+    const onBlurMock = jest.fn();
+    render(
+      <Time
+        value={{ hours: "", minutes: "12" }}
+        onChange={() => {}}
+        onBlur={onBlurMock}
+      />
+    );
+
+    const user = userEvent.setup();
+
+    screen.getByDisplayValue("12").focus();
+    await user.tab({ shift: true });
+
+    expect(onBlurMock).not.toHaveBeenCalled();
+  });
+
+  it("should render the validation message text when the hours input has an error passed a string value", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={() => {}}
+        hoursInputProps={{ error: "There is an error" }}
+      />
+    );
+
+    expect(screen.getByText("There is an error")).toBeInTheDocument();
+  });
+
+  it("should render the validation message text when the minutes input has an error passed a string value", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={() => {}}
+        minutesInputProps={{ error: "There is an error" }}
+      />
+    );
+
+    expect(screen.getByText("There is an error")).toBeInTheDocument();
+  });
+
+  it("should render the validation message text when both the hours and minutes inputs have errors passed as string values", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={() => {}}
+        hoursInputProps={{ error: "There is an error in hours input." }}
+        minutesInputProps={{ error: "There is an error in minutes input." }}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        "There is an error in hours input. There is an error in minutes input."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("should render the expected input styling when the hours input has an error passed as a truthy boolean value", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={() => {}}
+        hoursInputProps={{ error: true }}
+      />
+    );
+
+    const [hrsInputPresentation, minsInputPresentation] = screen.getAllByRole(
+      "presentation"
+    );
+
+    expect(hrsInputPresentation).toHaveStyle({
+      "box-shadow":
+        "inset 1px 1px 0 var(--colorsSemanticNegative500),inset -1px -1px 0 var(--colorsSemanticNegative500)",
+    });
+    expect(minsInputPresentation).not.toHaveStyle({
+      "box-shadow":
+        "inset 1px 1px 0 var(--colorsSemanticNegative500),inset -1px -1px 0 var(--colorsSemanticNegative500)",
+    });
+  });
+
+  it("should render the expected input styling when the minutes input has an error passed as a truthy boolean value", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={() => {}}
+        minutesInputProps={{ error: true }}
+      />
+    );
+
+    const [hrsInputPresentation, minsInputPresentation] = screen.getAllByRole(
+      "presentation"
+    );
+
+    expect(hrsInputPresentation).not.toHaveStyle({
+      "box-shadow":
+        "inset 1px 1px 0 var(--colorsSemanticNegative500),inset -1px -1px 0 var(--colorsSemanticNegative500)",
+    });
+    expect(minsInputPresentation).toHaveStyle({
+      "box-shadow":
+        "inset 1px 1px 0 var(--colorsSemanticNegative500),inset -1px -1px 0 var(--colorsSemanticNegative500)",
+    });
+  });
+
+  it("should render the expected input styling when both the hours and minutes inputs have errors passed as truthy boolean values", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={() => {}}
+        hoursInputProps={{ error: true }}
+        minutesInputProps={{ error: true }}
+      />
+    );
+
+    const [hrsInputPresentation, minsInputPresentation] = screen.getAllByRole(
+      "presentation"
+    );
+
+    expect(hrsInputPresentation).toHaveStyle({
+      "box-shadow":
+        "inset 1px 1px 0 var(--colorsSemanticNegative500),inset -1px -1px 0 var(--colorsSemanticNegative500)",
+    });
+    expect(minsInputPresentation).toHaveStyle({
+      "box-shadow":
+        "inset 1px 1px 0 var(--colorsSemanticNegative500),inset -1px -1px 0 var(--colorsSemanticNegative500)",
+    });
+  });
+
+  it("should render the validation message text when the hours input has a warning passed as a string value", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={() => {}}
+        hoursInputProps={{ warning: "There is an warning" }}
+      />
+    );
+
+    expect(screen.getByText("There is an warning")).toBeInTheDocument();
+  });
+
+  it("should render the validation message text when the minutes input has a warning passed as a string value", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={() => {}}
+        minutesInputProps={{ warning: "There is an warning" }}
+      />
+    );
+
+    expect(screen.getByText("There is an warning")).toBeInTheDocument();
+  });
+
+  it("should render the validation message text when both the hours and minutes inputs have warnings passed as string values", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={() => {}}
+        hoursInputProps={{ warning: "There is an warning in hours input." }}
+        minutesInputProps={{ warning: "There is an warning in minutes input." }}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        "There is an warning in hours input. There is an warning in minutes input."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("should render the expected input styling when the hours input has a warning passed as a truthy boolean value", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={() => {}}
+        hoursInputProps={{ warning: true }}
+      />
+    );
+
+    const [hrsInputPresentation, minsInputPresentation] = screen.getAllByRole(
+      "presentation"
+    );
+
+    expect(hrsInputPresentation).toHaveStyle({
+      "border-color": "var(--colorsSemanticCaution500) !important",
+    });
+    expect(minsInputPresentation).toHaveStyle({
+      border: "1px solid var(--colorsUtilityMajor300)",
+    });
+  });
+
+  it("should render the expected input styling when the minutes inout has a warning passed as a truthy boolean value", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={() => {}}
+        minutesInputProps={{ warning: true }}
+      />
+    );
+
+    const [hrsInputPresentation, minsInputPresentation] = screen.getAllByRole(
+      "presentation"
+    );
+
+    expect(hrsInputPresentation).toHaveStyle({
+      border: "1px solid var(--colorsUtilityMajor300)",
+    });
+    expect(minsInputPresentation).toHaveStyle({
+      "border-color": "var(--colorsSemanticCaution500) !important",
+    });
+  });
+
+  it("should render the expected input styling when the hours and minutes inputs have warnings passed as truthy boolean values", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={() => {}}
+        hoursInputProps={{ warning: true }}
+        minutesInputProps={{ warning: true }}
+      />
+    );
+
+    const [hrsInputPresentation, minsInputPresentation] = screen.getAllByRole(
+      "presentation"
+    );
+
+    expect(hrsInputPresentation).toHaveStyle({
+      "border-color": "var(--colorsSemanticCaution500) !important",
+    });
+    expect(minsInputPresentation).toHaveStyle({
+      "border-color": "var(--colorsSemanticCaution500) !important",
+    });
+  });
+
+  it("should set the required attribute on the inputs when the prop is set", () => {
+    render(
+      <Time
+        value={{ hours: "12", minutes: "30" }}
+        onChange={() => {}}
+        required
+        label="Label"
+      />
+    );
+
+    expect(screen.getByDisplayValue("12")).toHaveAttribute("required");
+    expect(screen.getByDisplayValue("30")).toHaveAttribute("required");
+  });
+
+  it("should append the optional text on the label when isOptional prop is set", () => {
+    render(
+      <Time
+        value={{ hours: "12", minutes: "30" }}
+        onChange={() => {}}
+        isOptional
+        label="Label"
+      />
+    );
+
+    expect(screen.queryByText("Label")).toHaveStyleRule(
+      "content",
+      '"(optional)"',
+      { modifier: "::after" }
+    );
+  });
+
+  it("should render with the default translations if no overrides are provided", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "", period: "AM" }}
+        onChange={() => {}}
+        label="Label"
+      />
+    );
+
+    expect(screen.queryByText("Hrs.")).toBeInTheDocument();
+    expect(screen.queryByText("Mins.")).toBeInTheDocument();
+    expect(screen.queryByText("AM")).toBeInTheDocument();
+    expect(screen.queryByText("PM")).toBeInTheDocument();
+  });
+
+  it("should render with the overridden translations if provided", () => {
+    render(
+      <I18nProvider locale={localeMock}>
+        <Time
+          value={{ hours: "", minutes: "", period: "AM" }}
+          onChange={() => {}}
+          label="Label"
+        />
+      </I18nProvider>
+    );
+
+    expect(screen.queryByText("foo-label")).toBeInTheDocument();
+    expect(screen.queryByText("bar-label")).toBeInTheDocument();
+    expect(screen.queryByText("foo-toggle")).toBeInTheDocument();
+    expect(screen.queryByText("bar-toggle")).toBeInTheDocument();
+    expect(screen.queryByLabelText("foo-aria-label")).toBeInTheDocument();
+    expect(screen.queryByLabelText("bar-aria-label")).toBeInTheDocument();
+  });
+
+  it("should render the labels for the hours and minutes inputs if provided instead of the translations", () => {
+    render(
+      <I18nProvider locale={localeMock}>
+        <Time
+          hoursInputProps={{ label: "hours prop string" }}
+          minutesInputProps={{ label: "minutes prop string" }}
+          value={{ hours: "", minutes: "" }}
+          onChange={() => {}}
+          label="Label"
+        />
+      </I18nProvider>
+    );
+
+    expect(screen.queryByText("hours prop string")).toBeInTheDocument();
+    expect(screen.queryByText("minutes prop string")).toBeInTheDocument();
+  });
+
+  it("should call the exposed `focusHoursInput` and focus the hours input", async () => {
+    render(<MockComponent focusTarget="hours" />);
+
+    const user = userEvent.setup();
+    const button = screen.getByText("Focus input");
+
+    await user.click(button);
+
+    expect(screen.getByDisplayValue("12")).toHaveFocus();
+  });
+
+  it("calling the exposed `focusMinutesInput` and focus the minutes input", async () => {
+    render(<MockComponent focusTarget="minutes" />);
+
+    const user = userEvent.setup();
+    const button = screen.getByText("Focus input");
+
+    await user.click(button);
+
+    expect(screen.getByDisplayValue("30")).toHaveFocus();
+  });
+
+  it.each(["disabled", "readOnly"])(
+    "should not call onChange when `%s` prop is set and toggle is clicked",
+    async (prop) => {
+      const onChangeMock = jest.fn();
+      render(
+        <Time
+          value={{ hours: "", minutes: "", period: "AM" }}
+          onChange={onChangeMock}
+          {...{ [prop]: true }}
+        />
+      );
+
+      const pmToggle = await screen.findByText("PM");
+
+      await act(async () => {
+        await userEvent.click(pmToggle);
+      });
+
+      expect(onChangeMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("should apply the expected styling when disabled prop is set", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "", period: "AM" }}
+        onChange={() => {}}
+        label="label"
+        inputHint="hint"
+        disabled
+      />
+    );
+
+    const mainLabel = screen.getByText("label");
+    const hintText = screen.getByText("hint");
+    const hrsLabel = screen.getByText("Hrs.");
+    const minsLabel = screen.getByText("Mins.");
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_, toggle] = screen.getAllByRole("group");
+
+    expect(mainLabel).toHaveStyle({
+      color: "var(--colorsUtilityYin030)",
+    });
+    expect(hintText).toHaveStyle({
+      color: "var(--colorsUtilityYin030)",
+    });
+    expect(hrsLabel).toHaveStyle({
+      color: "var(--colorsUtilityYin030)",
+    });
+    expect(minsLabel).toHaveStyle({
+      color: "var(--colorsUtilityYin030)",
+    });
+    expect(toggle).toHaveStyle({
+      opacity: "0.3",
+    });
+  });
+
+  it("should apply the expected styling when readOnly prop is set", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "", period: "AM" }}
+        onChange={() => {}}
+        label="label"
+        inputHint="hint"
+        readOnly
+      />
+    );
+
+    const hintText = screen.queryByText("hint");
+    const hrsLabel = screen.queryByText("Hrs.");
+    const minsLabel = screen.queryByText("Mins.");
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_, toggle] = screen.getAllByRole("group");
+
+    expect(hintText).toHaveStyle({
+      color: "var(--colorsUtilityYin055)",
+    });
+    expect(hrsLabel).toHaveStyle({
+      color: "var(--colorsUtilityYin055)",
+    });
+    expect(minsLabel).toHaveStyle({
+      color: "var(--colorsUtilityYin055)",
+    });
+    expect(toggle).toHaveStyle({
+      opacity: "0.3",
+    });
+  });
+
+  it("should have the expected `data-` attributes set on the root element", () => {
+    render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={() => {}}
+        label="label"
+        data-element="foo"
+        data-role="bar"
+      />
+    );
+
+    rootTagTestRtl(screen.getByRole("group"), "time", "foo", "bar");
+  });
+
+  it("should apply the custom `data-` attributes on the inputs when they are passed via `hoursInputProps` and `minutesInputProps`", () => {
+    const { container } = render(
+      <Time
+        value={{ hours: "", minutes: "" }}
+        onChange={() => {}}
+        hoursInputProps={{ "data-element": "foo", "data-role": "bar" }}
+        minutesInputProps={{ "data-element": "foo", "data-role": "bar" }}
+      />
+    );
+
+    const hours = container.querySelector(
+      '[data-component="hours"]'
+    ) as HTMLElement;
+    const minutes = container.querySelector(
+      '[data-component="minutes"]'
+    ) as HTMLElement;
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    rootTagTestRtl(hours!, "hours", "foo", "bar");
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    rootTagTestRtl(minutes!, "minutes", "foo", "bar");
+  });
+
+  it("should apply the custom `data-` attributes on the toggle component elements when they are passed via `toggleProps`", () => {
+    const { container } = render(
+      <Time
+        value={{ hours: "", minutes: "", period: "AM" }}
+        onChange={() => {}}
+        toggleProps={{
+          wrapperProps: { "data-element": "foo", "data-role": "bar" },
+          amToggleProps: { "data-element": "foo", "data-role": "bar" },
+          pmToggleProps: { "data-element": "foo", "data-role": "bar" },
+        }}
+      />
+    );
+
+    const toggleGroup = container.querySelector(
+      '[data-component="time-button-toggle-group"]'
+    ) as HTMLElement;
+    const amToggle = container.querySelector(
+      '[data-component="am-button-toggle"]'
+    ) as HTMLElement;
+    const pmToggle = container.querySelector(
+      '[data-component="pm-button-toggle"]'
+    ) as HTMLElement;
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    rootTagTestRtl(toggleGroup!, "time-button-toggle-group", "foo", "bar");
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    rootTagTestRtl(amToggle!, "am-button-toggle", "foo", "bar");
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    rootTagTestRtl(pmToggle!, "pm-button-toggle", "foo", "bar");
+  });
+});

--- a/src/components/time/time.stories.mdx
+++ b/src/components/time/time.stories.mdx
@@ -1,0 +1,163 @@
+import { Meta, Story, Canvas } from "@storybook/addon-docs";
+import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
+
+import {Time} from ".";
+
+import * as stories from "./time.stories";
+
+<Meta
+  title="Time"
+  parameters={{
+    info: { disable: true },
+  }}
+/>
+
+# Time
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
+import {Time} from "carbon-react/lib/components/time";
+```
+
+## Examples
+
+### Default
+
+The component needs to be controlled via `value` and `onChange` props. The `value` prop accepts an object 
+with `hours` and `minutes` properties that correspond to the relevant input.
+
+<Canvas>
+  <Story name="default" story={stories.Default} />
+</Canvas>
+
+### AM/PM toggle
+
+In order to render the AM/PM toggle controls you should set the `period` property in the `value` object.
+
+<Canvas>
+  <Story name="am/pm toggle" story={stories.AmPmToggle} />
+</Canvas>
+
+### Input hint
+
+Passing a string to the `inputHint` prop will render some additional hint text above the inputs.
+
+<Canvas>
+  <Story name="input hint" story={stories.InputHint} />
+</Canvas>
+
+### Required
+
+<Canvas>
+  <Story name="required" story={stories.Required} />
+</Canvas>
+
+### Is optional
+
+<Canvas>
+  <Story name="is optional" story={stories.IsOptional} />
+</Canvas>
+
+### Disabled
+
+<Canvas>
+  <Story name="disabled" story={stories.Disabled} />
+</Canvas>
+
+### Read only
+
+<Canvas>
+  <Story name="read only" story={stories.ReadOnly} />
+</Canvas>
+
+### Sizes
+
+<Canvas>
+  <Story name="sizes" story={stories.Sizes} />
+</Canvas>
+
+### Validation
+
+It is possible to set the validation states on either both or individual inputs by using the `error` 
+and `warning` props passed via the `hoursInputProps` and `minutesInputProps` respectively.
+
+<Canvas>
+  <Story name="validation" story={stories.Validation} />
+</Canvas>
+
+### Focusing the inputs programmatically
+
+The component exposes `focusHoursInput` and `focusMinutesInput` functions that support programmatically 
+focusing the hours and minutes inputs which can be called by passing a `ref` to the component.
+
+<Canvas>
+  <Story name="focusing inputs programmatically" story={stories.FocusingInputs} />
+</Canvas>
+
+### Locale override
+
+It is possible to override the translations applied to this component, see the [table below](#translation-keys) 
+for the available keys. It is also possible to have more granular control of the label overrides via the 
+`label` and `aria-label` props passed via the `hoursInputProps` and `minutesInputProps` respectively.
+
+<Canvas>
+  <Story name="locale override" story={stories.LocaleOverride} />
+</Canvas>
+
+## Props
+
+<StyledSystemProps of={Time} margin noHeader />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object
+to the [i18nProvider](https://carbon.sage.com/?path=/story/documentation-i18n--page).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "time.amText",
+      description: "The text for AM button toggle",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "time.pmText",
+      description: "The text for the PM button toggle",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "time.hoursLabelText",
+      description: "The text for the hours input label",
+      type: "func",
+      returnType: "string",
+    },
+     {
+      name: "time.minutesLabelText",
+      description: "The text for the minutes input label",
+      type: "func",
+      returnType: "string",
+    },
+     {
+      name: "time.hoursAriaLabelText",
+      description: "The text for the aria-label of the hours input label",
+      type: "func",
+      returnType: "string",
+    },
+     {
+      name: "time.minutesAriaLabelText",
+      description: "The text for the aria-label of the minutes input label",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
+/>

--- a/src/components/time/time.stories.tsx
+++ b/src/components/time/time.stories.tsx
@@ -1,0 +1,396 @@
+import React, { useState, useRef } from "react";
+import { ComponentStory } from "@storybook/react";
+
+import { Time } from ".";
+import Box from "../box";
+import { TimeHandle, TimeInputEvent, TimeValue } from "./time.component";
+import Button from "../button";
+import I18nProvider from "../i18n-provider";
+
+export const Default: ComponentStory<typeof Time> = () => {
+  const [value, setValue] = useState<TimeValue>({
+    hours: "",
+    minutes: "",
+  });
+
+  const handleChange = (ev: TimeInputEvent) => {
+    setValue(ev.target.value);
+  };
+
+  return (
+    <Box p={2}>
+      <Time value={value} onChange={handleChange} label="Time" />
+    </Box>
+  );
+};
+
+Default.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const AmPmToggle: ComponentStory<typeof Time> = () => {
+  const [value, setValue] = useState<TimeValue>({
+    hours: "",
+    minutes: "",
+    period: "AM",
+  });
+
+  const handleChange = (ev: TimeInputEvent) => {
+    setValue(ev.target.value);
+  };
+
+  return (
+    <Box p={2}>
+      <Time value={value} onChange={handleChange} label="Time" />
+    </Box>
+  );
+};
+
+AmPmToggle.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const InputHint: ComponentStory<typeof Time> = () => {
+  const [value, setValue] = useState<TimeValue>({
+    hours: "",
+    minutes: "",
+  });
+
+  const handleChange = (ev: TimeInputEvent) => {
+    setValue(ev.target.value);
+  };
+
+  return (
+    <Box p={2}>
+      <Time
+        value={value}
+        onChange={handleChange}
+        label="Time"
+        inputHint="Hint text"
+      />
+    </Box>
+  );
+};
+
+InputHint.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const Required: ComponentStory<typeof Time> = () => {
+  const [value, setValue] = useState<TimeValue>({
+    hours: "",
+    minutes: "",
+  });
+
+  const handleChange = (ev: TimeInputEvent) => {
+    setValue(ev.target.value);
+  };
+
+  return (
+    <Box p={2}>
+      <Time required value={value} onChange={handleChange} label="Time" />
+    </Box>
+  );
+};
+
+Required.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const IsOptional: ComponentStory<typeof Time> = () => {
+  const [value, setValue] = useState<TimeValue>({
+    hours: "",
+    minutes: "",
+  });
+
+  const handleChange = (ev: TimeInputEvent) => {
+    setValue(ev.target.value);
+  };
+
+  return (
+    <Box p={2}>
+      <Time isOptional value={value} onChange={handleChange} label="Time" />
+    </Box>
+  );
+};
+
+IsOptional.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const Disabled: ComponentStory<typeof Time> = () => {
+  const [value, setValue] = useState<TimeValue>({
+    hours: "",
+    minutes: "",
+    period: "AM",
+  });
+
+  const handleChange = (ev: TimeInputEvent) => {
+    setValue(ev.target.value);
+  };
+
+  return (
+    <Box p={2}>
+      <Time
+        value={value}
+        onChange={handleChange}
+        label="Time"
+        inputHint="Hint text"
+        disabled
+      />
+    </Box>
+  );
+};
+
+Disabled.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const ReadOnly: ComponentStory<typeof Time> = () => {
+  const [value, setValue] = useState<TimeValue>({
+    hours: "",
+    minutes: "",
+    period: "AM",
+  });
+
+  const handleChange = (ev: TimeInputEvent) => {
+    setValue(ev.target.value);
+  };
+
+  return (
+    <Box p={2}>
+      <Time
+        value={value}
+        onChange={handleChange}
+        label="Time"
+        inputHint="Hint text"
+        readOnly
+      />
+    </Box>
+  );
+};
+
+ReadOnly.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const Sizes: ComponentStory<typeof Time> = () => {
+  const [value, setValue] = useState<{
+    small: TimeValue;
+    medium: TimeValue;
+    large: TimeValue;
+  }>({
+    small: {
+      hours: "",
+      minutes: "",
+      period: "AM",
+    },
+    medium: {
+      hours: "",
+      minutes: "",
+      period: "AM",
+    },
+    large: {
+      hours: "",
+      minutes: "",
+      period: "AM",
+    },
+  });
+
+  const handleChange = (
+    ev: TimeInputEvent,
+    size: "small" | "medium" | "large"
+  ) => {
+    setValue((p) => ({
+      ...p,
+      [size]: ev.target.value,
+    }));
+  };
+
+  return (
+    <Box p={2}>
+      <Time
+        size="small"
+        value={value.small}
+        onChange={(ev) => handleChange(ev, "small")}
+        label="Time - small"
+        inputHint="Hint text"
+        mb={1}
+      />
+      <Time
+        size="medium"
+        value={value.medium}
+        onChange={(ev) => handleChange(ev, "medium")}
+        label="Time - medium"
+        inputHint="Hint text"
+        mb={1}
+      />
+      <Time
+        size="large"
+        value={value.large}
+        onChange={(ev) => handleChange(ev, "large")}
+        label="Time - large"
+        inputHint="Hint text"
+        mb={1}
+      />
+    </Box>
+  );
+};
+
+Sizes.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const Validation: ComponentStory<typeof Time> = () => {
+  const valueInvalidHours: TimeValue = {
+    hours: "13",
+    minutes: "30",
+    period: "AM",
+  };
+  const valueInvalidMinutes: TimeValue = {
+    hours: "12",
+    minutes: "61",
+    period: "AM",
+  };
+  const valueInvalidBoth: TimeValue = {
+    hours: "13",
+    minutes: "61",
+    period: "AM",
+  };
+
+  return (
+    <Box p={2}>
+      <Time
+        value={valueInvalidHours}
+        onChange={() => {}}
+        label="Time - with error on hours"
+        hoursInputProps={{ error: "Hours value must be in AM/PM format." }}
+        mb={1}
+      />
+      <Time
+        value={valueInvalidMinutes}
+        onChange={() => {}}
+        label="Time - with error on minutes"
+        minutesInputProps={{ error: "Minutes value must be in  AM/PM format." }}
+        mb={1}
+      />
+      <Time
+        value={valueInvalidBoth}
+        onChange={() => {}}
+        label="Time - with error on both"
+        hoursInputProps={{ error: "Hours value must be in AM/PM format." }}
+        minutesInputProps={{ error: "Minutes value must be in  AM/PM format." }}
+        mb={2}
+      />
+      <Time
+        value={valueInvalidHours}
+        onChange={() => {}}
+        label="Time - with warning on hours"
+        hoursInputProps={{ warning: "Hours value must be in AM/PM format." }}
+        mb={1}
+      />
+      <Time
+        value={valueInvalidMinutes}
+        onChange={() => {}}
+        label="Time - with warning on minutes"
+        minutesInputProps={{
+          warning: "Minutes value must be in  AM/PM format.",
+        }}
+        mb={1}
+      />
+      <Time
+        value={valueInvalidBoth}
+        onChange={() => {}}
+        label="Time - with warning on both"
+        hoursInputProps={{ warning: "Hours value must be in AM/PM format." }}
+        minutesInputProps={{
+          warning: "Minutes value must be in  AM/PM format.",
+        }}
+      />
+    </Box>
+  );
+};
+
+Validation.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const FocusingInputs: ComponentStory<typeof Time> = () => {
+  const [value, setValue] = useState<TimeValue>({
+    hours: "",
+    minutes: "",
+  });
+
+  const ref = useRef<TimeHandle>(null);
+
+  const handleChange = (ev: TimeInputEvent) => {
+    setValue(ev.target.value);
+  };
+
+  return (
+    <Box p={2}>
+      <Button mr={1} onClick={() => ref.current?.focusHoursInput()}>
+        Focus hours input
+      </Button>
+      <Button onClick={() => ref.current?.focusMinutesInput()}>
+        Focus minutes input
+      </Button>
+      <Time
+        ref={ref}
+        value={value}
+        onChange={handleChange}
+        label="Time"
+        inputHint="Hint text"
+      />
+    </Box>
+  );
+};
+
+Default.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
+export const LocaleOverride: ComponentStory<typeof Time> = () => {
+  const [value, setValue] = useState<TimeValue>({
+    hours: "",
+    minutes: "",
+    period: "AM",
+  });
+
+  const handleChange = (ev: TimeInputEvent) => {
+    setValue(ev.target.value);
+  };
+
+  return (
+    <Box p={2}>
+      <I18nProvider
+        locale={{
+          time: {
+            amText: () => "A",
+            pmText: () => "P",
+            hoursLabelText: () => "Hours",
+            minutesLabelText: () => "Minutes",
+            hoursAriaLabelText: () => "Hours input",
+            minutesAriaLabelText: () => "Minutes input",
+          },
+        }}
+      >
+        <Time value={value} onChange={handleChange} label="Time" />
+      </I18nProvider>
+    </Box>
+  );
+};
+
+LocaleOverride.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};

--- a/src/components/time/time.style.ts
+++ b/src/components/time/time.style.ts
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+import Label from "../../__internal__/label";
+
+export const StyledLabel = styled(Label)`
+  label {
+    font-weight: var(--fontWeights500);
+  }
+`;
+
+export const StyledHintText = styled.div<{
+  isDisabled?: boolean;
+  hasError?: boolean;
+}>`
+  ::after {
+    content: " ";
+  }
+
+  margin-top: 0px;
+  margin-bottom: var(--spacing150);
+  color: ${({ isDisabled }) =>
+    isDisabled ? "var(--colorsUtilityYin030)" : "var(--colorsUtilityYin055)"};
+  font-size: 14px;
+`;

--- a/src/components/typography/typography.component.tsx
+++ b/src/components/typography/typography.component.tsx
@@ -77,6 +77,12 @@ export interface TypographyProps extends SpaceProps, TagProps {
   /** Set whether it will be visually hidden
    * NOTE: This is for screen readers only and will make a lot of the other props redundant */
   screenReaderOnly?: boolean;
+  /**
+   * @private
+   * @ignore
+   * Override the default color of the rendered element to match disabled styling
+   * */
+  isDisabled?: boolean;
 }
 
 export const Typography = ({
@@ -103,6 +109,7 @@ export const Typography = ({
   children,
   className,
   screenReaderOnly,
+  isDisabled,
   ...rest
 }: TypographyProps) => {
   return (
@@ -128,6 +135,7 @@ export const Typography = ({
       opacity={opacity}
       className={className}
       screenReaderOnly={screenReaderOnly}
+      isDisabled={isDisabled}
       {...tagComponent(dataComponent, rest)}
       {...filterStyledSystemMarginProps(rest)}
       {...filterStyledSystemPaddingProps(rest)}

--- a/src/components/typography/typography.style.ts
+++ b/src/components/typography/typography.style.ts
@@ -192,6 +192,11 @@ const StyledTypography = styled.span.attrs(
   ${space}
     ${({ color, bg, backgroundColor, ...rest }) =>
     styledColor({ color, bg, backgroundColor, ...rest })}
+  ${({ isDisabled }) =>
+    isDisabled &&
+    css`
+      color: var(--colorsUtilityYin030);
+    `}
 `;
 
 StyledTypography.defaultProps = {

--- a/src/locales/__internal__/pl-pl.ts
+++ b/src/locales/__internal__/pl-pl.ts
@@ -236,6 +236,14 @@ const plPL: Locale = {
   tileSelect: {
     deselect: () => "Odznacz",
   },
+  time: {
+    amText: () => "AM",
+    pmText: () => "PM",
+    hoursLabelText: () => "Hrs.",
+    minutesLabelText: () => "Min.",
+    hoursAriaLabelText: () => "Godziny",
+    minutesAriaLabelText: () => "Minuty",
+  },
   toast: {
     ariaLabels: {
       close: () => "Zamknij",

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -177,6 +177,14 @@ const enGB: Locale = {
   tileSelect: {
     deselect: () => "Deselect",
   },
+  time: {
+    amText: () => "AM",
+    pmText: () => "PM",
+    hoursLabelText: () => "Hrs.",
+    minutesLabelText: () => "Mins.",
+    hoursAriaLabelText: () => "Hours",
+    minutesAriaLabelText: () => "Minutes",
+  },
   toast: {
     ariaLabels: {
       close: () => "Close",

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -143,6 +143,14 @@ interface Locale {
   tileSelect: {
     deselect: () => string;
   };
+  time: {
+    amText: () => string;
+    pmText: () => string;
+    hoursLabelText: () => string;
+    minutesLabelText: () => string;
+    hoursAriaLabelText: () => string;
+    minutesAriaLabelText: () => string;
+  };
   toast: {
     ariaLabels: {
       close: () => string;


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->
 - Adds new `Time` component.
 - Updates `Label` (internal) to accept `className` and `aria-label` props.
 - Adds (private)`className` prop to `ButtonToggleGroup`. Temporarily extends it so disabled styling can be applied via opacity, ticket raised to address bug in actual component.
 - Adds `legendMargin`, `width`, `isOptional`, `isDisabled`, `name` and `id` props to `Fieldset` (internal).
 
 Default:
![image](https://github.com/Sage/carbon/assets/44157880/9a871e71-15f2-4764-a78b-9791a09acc04)

With toggle:
![image](https://github.com/Sage/carbon/assets/44157880/6b2417d6-8c09-4692-9de5-6e231c3c1d2b)

With hint text:
![image](https://github.com/Sage/carbon/assets/44157880/909caaa3-0d66-469c-92d9-9ccb4ad4e9df)

![image](https://github.com/Sage/carbon/assets/44157880/7ba5d18f-83ac-4199-844e-668bc035d253)

![image](https://github.com/Sage/carbon/assets/44157880/9764ffa0-d138-4a76-9ff4-93906e20a6af)

Validation:
![image](https://github.com/Sage/carbon/assets/44157880/6dec5ff1-1b51-4f88-9018-d22174260a24)

 
### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->
- No `Time` component exists
- Fieldset does not support required/ optional/ disabled styling or application of `width`/ `name`/ `id`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->
Stories added for new component

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
