### PR TITLE
refactor(action-popover-menu): reactor code to use findLastIndex now we no longer support Node 16 - FE-6248

### DIFF
--- a/src/components/action-popover/action-popover-menu/action-popover-menu.component.tsx
+++ b/src/components/action-popover/action-popover-menu/action-popover-menu.component.tsx
@@ -127,24 +127,18 @@ const ActionPopoverMenu = React.forwardRef<
     );
 
     const firstFocusableItem = items.findIndex(
-      (_, index) => !isItemDisabled(index)
+      (
+        _: React.ReactChild | React.ReactFragment | React.ReactPortal,
+        index: number
+      ) => !isItemDisabled(index)
     );
 
-    // FIX-ME: FE-6248
-    // Once we no longer support Node 16, this function can be removed and `findLastIndex()` can be used in it's place.
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex
-    function findLastFocusableItem() {
-      let lastFocusableItem = -1;
-      for (let i = items.length - 1; i >= 0; i--) {
-        if (!isItemDisabled(i)) {
-          lastFocusableItem = i;
-          break;
-        }
-      }
-      return lastFocusableItem;
-    }
-
-    const lastFocusableItem = findLastFocusableItem();
+    const lastFocusableItem = items.findLastIndex(
+      (
+        _: React.ReactChild | React.ReactFragment | React.ReactPortal,
+        index: number
+      ) => !isItemDisabled(index)
+    );
 
     useEffect(() => {
       if (isOpen && firstFocusableItem !== -1)


### PR DESCRIPTION
### Proposed behaviour

Refactor code to use `findLastIndex()`

### Current behaviour

Needlessly complicated function to find last index. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Ensure no functional regressions regarding keyboard navigation.  
