### PR TITLE
fix: remove unused labelAlign prop from checkable input

### DIFF
--- a/cypress/components/button-toggle/button-toggle.cy.tsx
+++ b/cypress/components/button-toggle/button-toggle.cy.tsx
@@ -498,26 +498,6 @@ context("Testing Button-Toggle-Group component", () => {
       }
     );
 
-    it.each([
-      ["left", "flex-start"],
-      ["right", "flex-end"],
-    ])(
-      "should render Button-Toggle-Group with label inline and %s aligned",
-      (alignment, justifyContent) => {
-        CypressMountWithProviders(
-          <stories.ButtonToggleGroupComponent
-            labelInline
-            labelAlign={alignment}
-          />
-        );
-
-        buttonToggleGroup()
-          .parent()
-          .prev()
-          .should("have.css", "justify-content", justifyContent);
-      }
-    );
-
     it("should render Button-Toggle-Group with second button toggle pressed", () => {
       CypressMountWithProviders(<stories.DefaultStory />);
 

--- a/src/__internal__/checkable-input/checkable-input.component.tsx
+++ b/src/__internal__/checkable-input/checkable-input.component.tsx
@@ -58,8 +58,6 @@ export interface CheckableInputProps extends CommonCheckableInputProps {
   type: string;
   /** Value passed to the input */
   value?: string;
-  /** Text alignment of the label */
-  labelAlign?: "left" | "right";
   /** When true label is inline */
   labelInline?: boolean;
 }
@@ -82,7 +80,6 @@ const CheckableInput = React.forwardRef(
       value,
       inputWidth,
       label,
-      labelAlign,
       labelHelp,
       labelInline = true,
       labelSpacing = 1,
@@ -127,7 +124,6 @@ const CheckableInput = React.forwardRef(
       id,
       info,
       label,
-      labelAlign,
       labelHelp,
       labelHelpIcon: "info" as const,
       labelId,

--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.component.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.component.tsx
@@ -49,8 +49,6 @@ export interface ButtonToggleGroupProps extends MarginProps, TagProps {
   labelWidth?: number;
   /** If true all ButtonToggle children will flex to the full width of the ButtonToggleGroup parent */
   fullWidth?: boolean;
-  /** The alignment for the text in the label. */
-  labelAlign?: "left" | "right";
   /** Callback triggered by pressing one of the child buttons. Use with controlled components to set the value prop to the value argument */
   onChange?: (
     ev: React.MouseEvent<HTMLButtonElement>,
@@ -112,7 +110,6 @@ const ButtonToggleGroup = ({
   fullWidth,
   labelInline,
   labelWidth,
-  labelAlign,
   name,
   onChange,
   value,
@@ -225,7 +222,6 @@ const ButtonToggleGroup = ({
           fieldHelpInline={fieldHelpInline}
           labelInline={labelInline}
           labelWidth={labelWidth}
-          labelAlign={labelAlign}
           labelId={labelId.current}
           data-component={dataComponent}
           data-role={dataRole}

--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.spec.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.spec.tsx
@@ -245,7 +245,6 @@ describe("ButtonToggleGroup", () => {
       ["labelHelp", "help", "label help"],
       ["labelInline", "inline", true],
       ["labelWidth", "width", 30],
-      ["labelAlign", "align", "right"],
     ])("when the %s prop is passed", (propName, passedPropName, propValue) => {
       it("then it should be passed to the Label component", () => {
         const wrapper = render({

--- a/src/components/checkbox/checkbox.component.tsx
+++ b/src/components/checkbox/checkbox.component.tsx
@@ -26,8 +26,6 @@ export interface CheckboxProps extends CommonCheckableInputProps, MarginProps {
   "data-role"?: string;
   /** Aria label for rendered help component */
   helpAriaLabel?: string;
-  /** Text alignment of the label */
-  labelAlign?: "left" | "right";
   /** When true label is inline */
   labelInline?: boolean;
   /** Accepts a callback function which is triggered on click event */

--- a/src/components/checkbox/checkbox.stories.tsx
+++ b/src/components/checkbox/checkbox.stories.tsx
@@ -69,9 +69,8 @@ export const WithLabelHelp: ComponentStory<typeof Checkbox> = () => (
 
 export const WithCustomLabelWidth: ComponentStory<typeof Checkbox> = () => (
   <Checkbox
-    label="With custom labelWidth and label aligned to right"
+    label="With custom labelWidth"
     labelWidth={100}
-    labelAlign="right"
     name="checkbox-custom-label"
   />
 );

--- a/src/components/fieldset/components.test-pw.tsx
+++ b/src/components/fieldset/components.test-pw.tsx
@@ -26,13 +26,7 @@ const FieldsetComponent = (props: FieldsetProps) => {
           labelAlign="right"
           labelWidth={30}
         />
-        <Checkbox
-          label="Checkbox"
-          labelAlign="right"
-          labelWidth={30}
-          labelSpacing={2}
-          reverse
-        />
+        <Checkbox label="Checkbox" labelWidth={30} labelSpacing={2} reverse />
         <Textbox label="City" labelInline labelAlign="right" labelWidth={30} />
         <Textbox
           label="Country"

--- a/src/components/fieldset/fieldset.stories.tsx
+++ b/src/components/fieldset/fieldset.stories.tsx
@@ -17,13 +17,7 @@ export const Default: ComponentStory<typeof Fieldset> = () => (
     />
     <Textbox label="Last Name" labelInline labelAlign="right" labelWidth={30} />
     <Textbox label="Address" labelInline labelAlign="right" labelWidth={30} />
-    <Checkbox
-      label="Checkbox"
-      labelAlign="right"
-      labelWidth={30}
-      labelSpacing={2}
-      reverse
-    />
+    <Checkbox label="Checkbox" labelWidth={30} labelSpacing={2} reverse />
     <Textbox label="City" labelInline labelAlign="right" labelWidth={30} />
     <Textbox label="Country" labelInline labelAlign="right" labelWidth={30} />
     <Textbox label="Telephone" labelInline labelAlign="right" labelWidth={30} />

--- a/src/components/form/form-test.stories.tsx
+++ b/src/components/form/form-test.stories.tsx
@@ -81,7 +81,6 @@ export const FormAlignmentCustomMarginsTextInputs = () => {
         />
         <Checkbox
           label="Checkbox in Fieldset"
-          labelAlign="right"
           labelWidth={30}
           labelSpacing={2}
           reverse

--- a/src/components/radio-button/radio-button.component.tsx
+++ b/src/components/radio-button/radio-button.component.tsx
@@ -24,8 +24,6 @@ export interface RadioButtonProps
   "data-element"?: string;
   /** Identifier used for testing purposes, applied to the root element of the component. */
   "data-role"?: string;
-  /** Text alignment of the label */
-  labelAlign?: "left" | "right";
   /** Accepts a callback function which is triggered on click event */
   onClick?: (ev: React.MouseEvent<HTMLInputElement>) => void;
   /** the value of the Radio Button, passed on form submit */
@@ -56,7 +54,6 @@ export const RadioButton = React.forwardRef<
       inputWidth,
       label,
       labelHelp,
-      labelAlign,
       labelSpacing = 1,
       labelWidth,
       name,
@@ -128,7 +125,6 @@ export const RadioButton = React.forwardRef<
       onChange: handleChange,
       onBlur,
       onFocus,
-      labelAlign,
       labelInline: true,
       labelWidth,
       label,

--- a/src/components/switch/switch-test.stories.tsx
+++ b/src/components/switch/switch-test.stories.tsx
@@ -29,12 +29,6 @@ export default {
         step: 1,
       },
     },
-    labelAlign: {
-      options: ["left", "right"],
-      control: {
-        type: "select",
-      },
-    },
     labelSpacing: {
       options: [1, 2],
       control: {
@@ -90,7 +84,6 @@ Default.args = {
   loading: false,
   inputWidth: 0,
   labelWidth: 0,
-  labelAlign: "left",
   labelSpacing: 1,
   reverse: true,
   value: "test-value",
@@ -134,7 +127,6 @@ NewDefault.args = {
   loading: false,
   inputWidth: 0,
   labelWidth: 0,
-  labelAlign: "left",
   labelSpacing: 1,
   reverse: true,
   value: "test-value",

--- a/src/components/switch/switch.component.tsx
+++ b/src/components/switch/switch.component.tsx
@@ -26,8 +26,6 @@ export interface SwitchProps extends CommonCheckableInputProps, MarginProps {
   adaptiveLabelBreakpoint?: number;
   /** Set the default value of the Switch if component is meant to be used as uncontrolled */
   defaultChecked?: boolean;
-  /** Text alignment of the label */
-  labelAlign?: "left" | "right";
   /** When true label is inline */
   labelInline?: boolean;
   /** Triggers loading animation */

--- a/src/components/switch/switch.pw.tsx
+++ b/src/components/switch/switch.pw.tsx
@@ -305,16 +305,6 @@ test.describe("Prop tests for Switch component", () => {
     }
   );
 
-  // skipped because of https://jira.sage.com/browse/FE-5530
-  test.skip("should render with labelAlign set to right", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SwitchComponent labelAlign="right" />);
-
-    await expect(switchLabel(page)).toHaveCSS("align-items", "right");
-  });
-
   test("should render with labelHelp", async ({ mount, page }) => {
     await mount(
       <SwitchComponent label="Label For Switch" labelHelp="Label Help" />
@@ -823,15 +813,6 @@ test.describe("Accessibility tests", () => {
 
       await checkAccessibility(page);
     });
-  });
-
-  test("check accessibility with labelAlign to right", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SwitchComponent labelAlign="right" />);
-
-    await checkAccessibility(page);
   });
 
   test("check accessibility with labelHelp", async ({ mount, page }) => {


### PR DESCRIPTION
BREAKING CHANGE: The `labelAlign` prop has been removed from `Checkbox`, `RadioButton` and `Switch`

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

Remove `labelAlign` prop from checkable input components: `Checkbox`, `RadioButton` and `Switch`.  

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

The `labelAlign` has no effect on checkable inputs: `Checkbox`, `RadioButton` and `Switch`. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
