### PR TITLE
feat(sort): add sortIcon prop to ensure sorting icons are customizable 

### DIFF
--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, ArgsTable, Canvas, Story } from "@storybook/addon-docs";
-import { useEffect, useLayoutEffect, useState, useRef } from "react";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import {
   FlatTable,
@@ -13,19 +12,6 @@ import {
   Sort,
   FlatTableBodyDraggable,
 } from ".";
-import BatchSelection from "../batch-selection";
-import IconButton from "../icon-button";
-import Icon from "../icon";
-import Textbox from "../textbox";
-import Pager from "../pager";
-import {
-  ActionPopover,
-  ActionPopoverItem,
-  ActionPopoverMenu,
-} from "../action-popover";
-import { DrawerSidebarContext } from "../drawer";
-import Box from "../box";
-import Button from "../button";
 import * as stories from "./flat-table.stories";
 
 <Meta title="Flat Table" parameters={{ info: { disable: true } }} />

--- a/src/components/flat-table/flat-table.stories.mdx
+++ b/src/components/flat-table/flat-table.stories.mdx
@@ -219,6 +219,15 @@ By using the `hasMaxHeight` prop you can automatically apply a max-height of 100
   <Story name="with sorting headers" story={stories.WithSortingHeaders} />
 </Canvas>
 
+### With sorting headers and customizable icons
+
+Any valid node can be passed to the `Sort` component, via the `sortIcon`
+prop, which will override the default `sort_up` and `sort_down` icons.
+
+<Canvas>
+  <Story name="with sorting headers and customizable icons" story={stories.WithSortingHeadersAndCustomIcons} />
+</Canvas>
+
 ### With a cell spanning the whole row
 
 <Canvas>

--- a/src/components/flat-table/flat-table.stories.tsx
+++ b/src/components/flat-table/flat-table.stories.tsx
@@ -1370,6 +1370,141 @@ WithSortingHeaders.parameters = {
   },
 };
 
+export const WithSortingHeadersAndCustomIcons: ComponentStory<
+  typeof FlatTable
+> = (args) => {
+  const headDataItems: HeadDataItems = [
+    { name: "client", isActive: true },
+    { name: "total", isActive: false },
+  ];
+  const bodyDataItems: BodyDataItems = [
+    { client: "Jason Atkinson", total: 1349 },
+    { client: "Monty Parker", total: 849 },
+    { client: "Blake Sutton", total: 3840 },
+    { client: "Tyler Webb", total: 280 },
+  ];
+  const [headData, setHeadData] = useState(headDataItems);
+  const [sortType, setSortType] = useState<SortType>("ascending");
+  const [sortValue, setSortValue] = useState<SortValue>("client");
+
+  const sortByNumber = (
+    dataToSort: BodyDataItems,
+    sortByValue: SortValue,
+    type: SortType
+  ) => {
+    const sortedData = dataToSort.sort((a, b) => {
+      if (type === "ascending") {
+        return Number(a[sortByValue]) - Number(b[sortByValue]);
+      }
+      if (type === "descending") {
+        return Number(b[sortByValue]) - Number(a[sortByValue]);
+      }
+      return 0;
+    });
+    return sortedData;
+  };
+
+  const sortByString = (
+    dataToSort: BodyDataItems,
+    sortByValue: SortValue,
+    type: SortType
+  ) => {
+    const sortedData = dataToSort.sort((a, b) => {
+      const nameA = String(a[sortByValue]).toUpperCase();
+      const nameB = String(b[sortByValue]).toUpperCase();
+
+      if (type === "ascending") {
+        if (nameA < nameB) {
+          return -1;
+        }
+        if (nameA > nameB) {
+          return 1;
+        }
+      }
+      if (type === "descending") {
+        if (nameA > nameB) {
+          return -1;
+        }
+        if (nameA < nameB) {
+          return 1;
+        }
+      }
+      return 0;
+    });
+    return sortedData;
+  };
+
+  const handleClick = (value: SortValue) => {
+    const tempHeadData = headData;
+    tempHeadData.forEach((item) => {
+      item.isActive = false;
+      if (item.name === value) {
+        item.isActive = !item.isActive;
+      }
+    });
+    setSortValue(value);
+    setSortType(sortType === "ascending" ? "descending" : "ascending");
+    setHeadData([...tempHeadData]);
+  };
+
+  const renderSortedData = (sortByValue: SortValue) => {
+    let sortedData = bodyDataItems;
+    if (typeof bodyDataItems[0][sortByValue] === "string") {
+      sortedData = sortByString(sortedData, sortByValue, sortType);
+    }
+    if (typeof bodyDataItems[0][sortByValue] === "number") {
+      sortedData = sortByNumber(sortedData, sortByValue, sortType);
+    }
+
+    return sortedData.map(({ client, total }) => {
+      return (
+        <FlatTableRow key={client}>
+          <FlatTableCell>{client}</FlatTableCell>
+          <FlatTableCell>{total}</FlatTableCell>
+        </FlatTableRow>
+      );
+    });
+  };
+
+  return (
+    <FlatTable {...args}>
+      <FlatTableHead>
+        <FlatTableRow>
+          {headData.map(({ name, isActive }) => {
+            return (
+              <FlatTableHeader key={name}>
+                <Sort
+                  onClick={() => handleClick(name)}
+                  {...(isActive && { sortType })}
+                  sortIcon={
+                    <Icon
+                      type={sortType === "ascending" ? "like" : "like_no"}
+                      color="--colorsUtilityMajor200"
+                    />
+                  }
+                >
+                  {name}
+                </Sort>
+              </FlatTableHeader>
+            );
+          })}
+        </FlatTableRow>
+      </FlatTableHead>
+      <FlatTableBody>{renderSortedData(sortValue)}</FlatTableBody>
+    </FlatTable>
+  );
+};
+
+WithSortingHeadersAndCustomIcons.storyName =
+  "with sorting headers and customizable icons";
+WithSortingHeadersAndCustomIcons.parameters = {
+  docs: {
+    source: {
+      type: "code",
+    },
+  },
+};
+
 export const WithColspan: ComponentStory<typeof FlatTable> = () => {
   return (
     <FlatTable>

--- a/src/components/flat-table/sort/sort.component.tsx
+++ b/src/components/flat-table/sort/sort.component.tsx
@@ -5,15 +5,20 @@ import { StyledSort, StyledSpaceHolder } from "./sort.style";
 import guid from "../../../__internal__/utils/helpers/guid";
 
 export interface SortProps {
-  /** if `asc` it will show `sort_up` icon, if `desc` it will show `sort_down` */
+  /** if `ascending` the `sort_up` icon will be displayed by default, if `descending`
+   * `sort_down` will be displayed by default. However both icon types can be
+   * overridden with the `sortIcon` prop
+   */
   sortType?: "ascending" | "descending" | false;
+  /** Override the default sort Icon */
+  sortIcon?: React.ReactNode;
   /** Callback fired when the `FlatTableSortHeader` is clicked */
   onClick?: () => void;
   /** Sets the content of `FlatTableSortHeader` */
   children?: React.ReactNode;
 }
 
-const Sort = ({ children, onClick, sortType }: SortProps) => {
+const Sort = ({ children, onClick, sortType, sortIcon }: SortProps) => {
   const id = useRef(guid());
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (Event.isEnterOrSpaceKey(e)) {
@@ -23,6 +28,13 @@ const Sort = ({ children, onClick, sortType }: SortProps) => {
 
     return null;
   };
+
+  const renderedIcon = sortType ? (
+    <Icon
+      type={sortType === "ascending" ? "sort_up" : "sort_down"}
+      color="--colorsUtilityMajor200"
+    />
+  ) : null;
 
   return (
     <>
@@ -39,12 +51,7 @@ const Sort = ({ children, onClick, sortType }: SortProps) => {
         aria-labelledby={id.current}
       >
         {children}
-        {sortType && (
-          <Icon
-            type={sortType === "ascending" ? "sort_up" : "sort_down"}
-            color="--colorsUtilityMajor200"
-          />
-        )}
+        {sortIcon && sortType ? sortIcon : renderedIcon}
       </StyledSort>
       {!sortType && <StyledSpaceHolder />}
     </>

--- a/src/components/flat-table/sort/sort.component.tsx
+++ b/src/components/flat-table/sort/sort.component.tsx
@@ -38,6 +38,7 @@ const Sort = ({ children, onClick, sortType, sortIcon }: SortProps) => {
 
   return (
     <>
+      {/* FE-6358 has been raised for the below (html hidden attribute used + poor translation support) */}
       <span hidden id={id.current}>
         {children}
         {sortType ? `, sort type ${sortType}` : ", sortable"}
@@ -47,13 +48,12 @@ const Sort = ({ children, onClick, sortType, sortIcon }: SortProps) => {
         onKeyDown={onKeyDown}
         tabIndex={0}
         onClick={onClick}
-        sortType={sortType}
         aria-labelledby={id.current}
       >
         {children}
-        {sortIcon && sortType ? sortIcon : renderedIcon}
+        {sortIcon || renderedIcon}
       </StyledSort>
-      {!sortType && <StyledSpaceHolder />}
+      {!sortType && !sortIcon && <StyledSpaceHolder />}
     </>
   );
 };

--- a/src/components/flat-table/sort/sort.component.tsx
+++ b/src/components/flat-table/sort/sort.component.tsx
@@ -51,4 +51,6 @@ const Sort = ({ children, onClick, sortType }: SortProps) => {
   );
 };
 
+Sort.displayName = "Sort";
+
 export default Sort;

--- a/src/components/flat-table/sort/sort.spec.tsx
+++ b/src/components/flat-table/sort/sort.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { mount, ReactWrapper } from "enzyme";
 import Sort, { SortProps } from "./sort.component";
-import Icon from "../../icon";
+import Icon, { IconType } from "../../icon";
 import { StyledSort, StyledSpaceHolder } from "./sort.style";
 
 function renderSort(props: SortProps = {}) {
@@ -35,17 +35,37 @@ describe("Sort", () => {
     expect(wrapper.find(Icon).exists()).toBe(false);
   });
 
-  it('should render Icon `sort_up` if sortType="ascending"', () => {
+  it('should render default Icon `sort_up` if sortType="ascending"', () => {
     wrapper = renderSort({ sortType: "ascending" });
 
     expect(wrapper.find(Icon).props().type).toBe("sort_up");
   });
 
-  it('should render Icon `sort_down` if sortType="descending"', () => {
+  it('should render default Icon `sort_down` if sortType="descending"', () => {
     wrapper = renderSort({ sortType: "descending" });
 
     expect(wrapper.find(Icon).props().type).toBe("sort_down");
   });
+
+  it("should render the correct node when the Icon component is passed", () => {
+    const iconNode = <Icon type="sort_up" />;
+    wrapper = renderSort({ sortType: "ascending", sortIcon: iconNode });
+
+    expect(wrapper.find(Icon).length).toBe(1);
+  });
+
+  it.each(["filter", "play", "chevron_down", "dropdown"] as IconType[])(
+    'should render correct icon when the Icon component is passed as a node and the icon type value is "%s",',
+    (iconType) => {
+      const iconNode = <Icon type={iconType} />;
+      wrapper = renderSort({
+        sortType: "ascending",
+        sortIcon: iconNode,
+      });
+
+      expect(wrapper.find(Icon).props().type).toBe(iconType);
+    }
+  );
 
   it("should fire callback if clicked", () => {
     wrapper.find(StyledSort).props().onClick();

--- a/src/components/flat-table/sort/sort.spec.tsx
+++ b/src/components/flat-table/sort/sort.spec.tsx
@@ -16,6 +16,8 @@ describe("Sort", () => {
   const SPACE_KEY = { key: " " };
   const RANDOM_KEY = { key: "a" };
 
+  const renderedSortIcon = <Icon type="sort_up" />;
+
   beforeEach(() => {
     onClickFn = jest.fn();
     wrapper = renderSort({ onClick: onClickFn });
@@ -91,13 +93,23 @@ describe("Sort", () => {
     expect(onClickFn).not.toHaveBeenCalled();
   });
 
-  it("should render `<StyledSpaceHolder />` if `sortType` prop is not provided", () => {
+  it("should render `<StyledSpaceHolder />` if both `sortIcon` & `sortType` props are not provided", () => {
+    wrapper = renderSort();
     expect(wrapper.find(StyledSpaceHolder).exists()).toBe(true);
   });
 
-  it("should not render `StyledSpaceHolder` if `sortType` prop is provided", () => {
-    wrapper = renderSort({ sortType: "ascending" });
+  it("should not render `<StyledSpaceHolder />` if `sortIcon` prop is provided", () => {
+    wrapper = renderSort({ sortIcon: renderedSortIcon });
+    expect(wrapper.find(StyledSpaceHolder).exists()).toBe(false);
+  });
 
+  it("should not render `<StyledSpaceHolder />` if `sortType` prop is provided", () => {
+    wrapper = renderSort({ sortType: "ascending" });
+    expect(wrapper.find(StyledSpaceHolder).exists()).toBe(false);
+  });
+
+  it("should not render `<StyledSpaceHolder />` if both `sortIcon` & `sortType` props are provided", () => {
+    wrapper = renderSort({ sortType: "ascending", sortIcon: renderedSortIcon });
     expect(wrapper.find(StyledSpaceHolder).exists()).toBe(false);
   });
 });

--- a/src/components/flat-table/sort/sort.style.ts
+++ b/src/components/flat-table/sort/sort.style.ts
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import StyledIcon from "../../icon/icon.style";
-import { SortProps } from "./sort.component";
 import addFocusStyling from "../../../style/utils/add-focus-styling";
 import baseTheme from "../../../style/themes/base";
 
@@ -8,7 +7,7 @@ const oldFocusStyling = `
   outline: solid 1px var(--colorsSemanticFocus500);
 `;
 
-const StyledSort = styled.div<Pick<SortProps, "sortType">>`
+const StyledSort = styled.div`
   display: inline-flex;
   align-items: center;
   padding-left: 2px;


### PR DESCRIPTION
fix #6491

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

The `ascendingIconType` and `descendingIconType` props have been added to provide consumers with the ability to choose different icons for sorting up and down, both props will accept all valid icon types

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

The current icons are locked to sort_up and sort_down and cannot be changed or overriden

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!-- How can a reviewer test this PR? -->

The following CodeSandbox is an example of the broken behaviour.
You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.

<!-- Add CodeSandbox here -->
