### PR TITLE
feat: accessibility improvements to ActionPopover, SplitButton and MultiActionButton

### DIFF
--- a/playwright/components/action-popover/index.ts
+++ b/playwright/components/action-popover/index.ts
@@ -20,7 +20,7 @@ export const actionPopoverInnerItem = (page: Page, index: number) =>
   page
     .locator(ACTION_POPOVER_DATA_COMPONENT)
     .first()
-    .locator("> div")
+    .locator("> li")
     .nth(index)
     .locator("button")
     .first();
@@ -29,7 +29,7 @@ export const actionPopoverSubmenu = (page: Page, index: number) =>
   page
     .locator(ACTION_POPOVER_SUBMENU)
     .nth(1)
-    .locator(`> div:nth-child(${index + 1})`)
+    .locator(`> li:nth-child(${index + 1})`)
     .locator("button");
 
 export const actionPopoverMenuItemIcon = (page: Page) =>

--- a/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
+++ b/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
@@ -18,7 +18,6 @@ import {
 import Events from "../../../__internal__/utils/helpers/events";
 import createGuid from "../../../__internal__/utils/helpers/guid";
 import ActionPopoverContext, { Alignment } from "../action-popover-context";
-import useLocale from "../../../hooks/__internal__/useLocale";
 
 import { IconType } from "../../icon";
 import ActionPopoverMenu, {
@@ -120,7 +119,6 @@ export const ActionPopoverItem = ({
   isASubmenu = false,
   ...rest
 }: ActionPopoverItemProps) => {
-  const l = useLocale();
   const context = useContext(ActionPopoverContext);
 
   invariant(
@@ -313,7 +311,6 @@ export const ActionPopoverItem = ({
       },
     }),
     "aria-haspopup": "true",
-    "aria-label": l.actionPopover.ariaLabel(),
     "aria-controls": `ActionPopoverMenu_${guid}`,
     "aria-expanded": isOpen,
   };

--- a/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
+++ b/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
@@ -147,7 +147,7 @@ export const ActionPopoverItem = ({
   const [isOpen, setOpen] = useState(false);
   const [focusIndex, setFocusIndex] = useState<number>(0);
 
-  const submenuRef = useRef<HTMLDivElement>(null);
+  const submenuRef = useRef<HTMLUListElement>(null);
   const ref = useRef<HTMLButtonElement>(null);
   const mouseEnterTimer = useRef<NodeJS.Timeout | null>(null);
   const mouseLeaveTimer = useRef<NodeJS.Timeout | null>(null);
@@ -318,9 +318,9 @@ export const ActionPopoverItem = ({
     "aria-expanded": isOpen,
   };
 
-  const wrapperDivProps = {
+  const wrapperProps = {
     ...(!disabled && {
-      onMouseEnter: (e: React.MouseEvent<HTMLDivElement>) => {
+      onMouseEnter: (e: React.MouseEvent<HTMLLIElement>) => {
         if (mouseEnterTimer.current) clearTimeout(mouseEnterTimer.current);
 
         setFocusIndex(-1);
@@ -329,7 +329,7 @@ export const ActionPopoverItem = ({
         }, INTERVAL);
         e.stopPropagation();
       },
-      onMouseLeave: (e: React.MouseEvent<HTMLDivElement>) => {
+      onMouseLeave: (e: React.MouseEvent<HTMLLIElement>) => {
         if (mouseLeaveTimer.current) clearTimeout(mouseLeaveTimer.current);
 
         mouseLeaveTimer.current = setTimeout(() => {
@@ -359,14 +359,13 @@ export const ActionPopoverItem = ({
   };
 
   return (
-    <StyledMenuItemWrapper {...(submenu && wrapperDivProps)}>
+    <StyledMenuItemWrapper {...(submenu && wrapperProps)}>
       <div onKeyDown={onKeyDown} role="presentation">
         <StyledMenuItem
           {...rest}
           ref={ref}
           onClick={onClick}
           type="button"
-          role="menuitem"
           tabIndex={0}
           isDisabled={disabled}
           horizontalAlignment={horizontalAlignment}

--- a/src/components/action-popover/action-popover-menu/action-popover-menu.component.tsx
+++ b/src/components/action-popover/action-popover-menu/action-popover-menu.component.tsx
@@ -51,10 +51,10 @@ export interface ActionPopoverMenuBaseProps {
 
 export interface ActionPopoverMenuProps
   extends ActionPopoverMenuBaseProps,
-    React.RefAttributes<HTMLDivElement> {}
+    React.RefAttributes<HTMLUListElement> {}
 
 const ActionPopoverMenu = React.forwardRef<
-  HTMLDivElement,
+  HTMLUListElement,
   ActionPopoverMenuBaseProps
 >(
   (
@@ -288,8 +288,8 @@ const ActionPopoverMenu = React.forwardRef<
         onKeyDown={onKeyDown}
         id={menuID}
         aria-labelledby={parentID}
-        role="menu"
         ref={ref}
+        role="list"
         {...rest}
       >
         {clonedChildren}

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -53,6 +53,8 @@ export interface ActionPopoverProps extends MarginProps {
   renderButton?: (buttonProps: RenderButtonProps) => React.ReactNode;
   /** Boolean to control whether menu should align to right */
   rightAlignMenu?: boolean;
+  /** Prop to specify an aria-label for the component */
+  "aria-label"?: string;
 }
 
 const onOpenDefault = () => {};
@@ -68,6 +70,7 @@ export const ActionPopover = ({
   placement = "bottom",
   horizontalAlignment = "left",
   submenuPosition = "left",
+  "aria-label": ariaLabel,
   ...rest
 }: ActionPopoverProps) => {
   const l = useLocale();
@@ -221,7 +224,7 @@ export const ActionPopover = ({
         "data-element": "action-popover-button",
         ariaAttributes: {
           "aria-haspopup": "true",
-          "aria-label": l.actionPopover.ariaLabel(),
+          "aria-label": ariaLabel || l.actionPopover.ariaLabel(),
           "aria-controls": menuID,
           "aria-expanded": `${isOpen}`,
         },
@@ -232,7 +235,7 @@ export const ActionPopover = ({
       <StyledButtonIcon
         role="button"
         aria-haspopup="true"
-        aria-label={l.actionPopover.ariaLabel()}
+        aria-label={ariaLabel || l.actionPopover.ariaLabel()}
         aria-controls={menuID}
         aria-expanded={isOpen}
         tabIndex={isOpen ? -1 : 0}

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -75,7 +75,7 @@ export const ActionPopover = ({
   const [focusIndex, setFocusIndex] = useState(0);
   const [guid] = useState(createGuid());
   const buttonRef = useRef<HTMLDivElement>(null);
-  const menu = useRef<HTMLDivElement>(null);
+  const menu = useRef<HTMLUListElement>(null);
 
   const itemCount = useMemo(() => {
     return React.Children.toArray(children).filter((child) => {
@@ -279,7 +279,6 @@ export const ActionPopover = ({
           <Popover placement={mappedPlacement} reference={buttonRef}>
             <ActionPopoverMenu
               data-component="action-popover"
-              role="menu"
               ref={menu}
               {...menuProps}
             >

--- a/src/components/action-popover/action-popover.pw.tsx
+++ b/src/components/action-popover/action-popover.pw.tsx
@@ -498,7 +498,7 @@ test.describe("check functionality for ActionPopover component", () => {
     await actionPopoverButton(page).click();
 
     // check download item has 'download' property
-    const downloadItem = page.getByRole("menuitem", { name: "Download" });
+    const downloadItem = page.getByRole("link", { name: "Download" });
     await expect(downloadItem).toHaveAttribute("download", "");
 
     // click download item and wait for download to start

--- a/src/components/action-popover/action-popover.pw.tsx
+++ b/src/components/action-popover/action-popover.pw.tsx
@@ -843,6 +843,14 @@ test.describe("check props for ActionPopover component", () => {
       await expect(itemChevron).toHaveAttribute("type", chevronType);
     });
   });
+
+  test("should render with aria-label prop", async ({ mount, page }) => {
+    await mount(<ActionPopoverWithProps aria-label="test-aria-label" />);
+    await expect(actionPopoverButton(page).nth(0)).toHaveAttribute(
+      "aria-label",
+      "test-aria-label"
+    );
+  });
 });
 
 test.describe("check events for ActionPopover component", () => {

--- a/src/components/action-popover/action-popover.spec.tsx
+++ b/src/components/action-popover/action-popover.spec.tsx
@@ -591,6 +591,12 @@ describe("ActionPopover", () => {
     expect(buttonIcon.prop("aria-label")).toBe("actions");
   });
 
+  it("uses the aria-label prop if provided", () => {
+    render({ "aria-label": "test aria label" });
+    const { buttonIcon } = getElements();
+    expect(buttonIcon.prop("aria-label")).toBe("test aria label");
+  });
+
   it("renders with the menu closed by default", () => {
     render();
     const { menu } = getElements();

--- a/src/components/action-popover/action-popover.spec.tsx
+++ b/src/components/action-popover/action-popover.spec.tsx
@@ -1363,9 +1363,6 @@ describe("ActionPopover", () => {
         expect(item.find("button").at(0).props()["aria-haspopup"]).toEqual(
           "true"
         );
-        expect(item.find("button").at(0).props()["aria-label"]).not.toEqual(
-          undefined
-        );
         expect(item.find("button").at(0).props()["aria-controls"]).not.toEqual(
           undefined
         );

--- a/src/components/action-popover/action-popover.style.ts
+++ b/src/components/action-popover/action-popover.style.ts
@@ -12,10 +12,11 @@ const oldFocusStyling = `
   outline: solid 3px var(--colorsSemanticFocus500);
 `;
 
-const Menu = styled.div`
+const Menu = styled.ul`
   ${({ isOpen }: { isOpen?: boolean }) =>
     isOpen ? "display: block;" : "visibility: hidden;"}
   margin: 0;
+  list-style: none;
   padding: var(--spacing100) 0;
   box-shadow: var(--boxShadow100);
   position: absolute;
@@ -215,11 +216,11 @@ StyledMenuItem.defaultProps = {
   theme: baseTheme,
 };
 
-const StyledMenuItemWrapper = styled.div`
+const StyledMenuItemWrapper = styled.li`
   position: relative;
 `;
 
-const MenuItemDivider = styled.div.attrs({
+const MenuItemDivider = styled.li.attrs({
   "data-element": "action-popover-divider",
 })`
   background-color: var(--colorsUtilityMajor050);

--- a/src/components/button/button.component.tsx
+++ b/src/components/button/button.component.tsx
@@ -311,7 +311,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         buttonType={buttonType}
         disabled={disabled}
         destructive={destructive}
-        role={inSplitButton ? "menuitem" : "button"}
         type={href ? undefined : "button"}
         iconType={iconType}
         size={size}

--- a/src/components/multi-action-button/__snapshots__/multi-action-button.spec.tsx.snap
+++ b/src/components/multi-action-button/__snapshots__/multi-action-button.spec.tsx.snap
@@ -384,7 +384,6 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
     onKeyDown={[Function]}
     onMouseEnter={[Function]}
     onTouchStart={[Function]}
-    role="button"
     size="medium"
     type="button"
   >

--- a/src/components/multi-action-button/multi-action-button.component.tsx
+++ b/src/components/multi-action-button/multi-action-button.component.tsx
@@ -79,13 +79,11 @@ export const MultiActionButton = ({
 
   const renderAdditionalButtons = () => (
     <Popover placement="bottom-end" reference={buttonNode}>
-      <StyledButtonChildrenContainer
-        {...wrapperProps}
-        aria-label={text}
-        align={align}
-      >
+      <StyledButtonChildrenContainer {...wrapperProps} align={align}>
         <SplitButtonContext.Provider value={contextValue}>
-          {children}
+          {React.Children.map(children, (child) => (
+            <li>{child}</li>
+          ))}
         </SplitButtonContext.Provider>
       </StyledButtonChildrenContainer>
     </Popover>

--- a/src/components/multi-action-button/multi-action-button.pw.tsx
+++ b/src/components/multi-action-button/multi-action-button.pw.tsx
@@ -97,10 +97,11 @@ test.describe("Prop tests", () => {
 
         const actionButton = getComponent(page, "multi-action-button");
         await actionButton.click();
-        await expect(page.getByRole("menuitem").first()).toHaveCSS(
-          "justify-content",
-          alignment as string
-        );
+        await expect(
+          getDataElementByValue(page, "additional-buttons")
+            .getByRole("button")
+            .first()
+        ).toHaveCSS("justify-content", alignment as string);
       });
     }
   );
@@ -117,7 +118,9 @@ test.describe("Prop tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButton = getComponent(page, "multi-action-button");
+    const actionButton = getComponent(page, "multi-action-button").locator(
+      "button"
+    );
     await actionButton.hover();
     const listButton1 = getDataElementByValue(page, "additional-buttons")
       .locator("span > span")
@@ -142,11 +145,10 @@ test.describe("Prop tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButtonComp = getComponent(page, "multi-action-button");
-    await actionButtonComp.hover();
     const actionButton = getComponent(page, "multi-action-button").locator(
       "button"
     );
+    await actionButton.hover();
     await expect(actionButton).toHaveCSS("background-color", "rgb(0, 77, 42)");
   });
 
@@ -161,7 +163,9 @@ test.describe("Prop tests", () => {
     );
 
     await accordionDefaultTitle(page).click();
-    const actionButton = getComponent(page, "multi-action-button");
+    const actionButton = getComponent(page, "multi-action-button").locator(
+      "button"
+    );
     await actionButton.hover();
     const listButton1 = getDataElementByValue(page, "additional-buttons")
       .locator("span > span")
@@ -186,11 +190,10 @@ test.describe("Prop tests", () => {
   }) => {
     await mount(<MultiActionButtonList width="70%" />);
 
-    const actionButtonComp = getComponent(page, "multi-action-button");
-    await actionButtonComp.hover();
     const actionButton = getComponent(page, "multi-action-button").locator(
       "button"
     );
+    await actionButton.hover();
     await expect(actionButton).toHaveCSS("justify-content", "space-between");
   });
 
@@ -200,11 +203,10 @@ test.describe("Prop tests", () => {
   }) => {
     await mount(<MultiActionButtonList width="70%" />);
 
-    const actionButtonComp = getComponent(page, "multi-action-button");
-    await actionButtonComp.hover();
     const actionButton = getComponent(page, "multi-action-button").locator(
       "button"
     );
+    await actionButton.hover();
     await assertCssValueIsApproximately(actionButton, "width", 956);
   });
 
@@ -239,7 +241,10 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    await getComponent(page, "multi-action-button").first().click();
+    await getComponent(page, "multi-action-button")
+      .first()
+      .locator("button")
+      .click();
     await expect(getDataElementByValue(page, "additional-buttons")).toHaveCount(
       1
     );
@@ -252,10 +257,16 @@ test.describe("Functional tests", () => {
     }) => {
       await mount(<MultiActionButtonList />);
 
-      const actionButton = getComponent(page, "multi-action-button");
+      const actionButton = getComponent(page, "multi-action-button").locator(
+        "button"
+      );
       await actionButton.focus();
       await page.keyboard.press(key);
-      await expect(getDataElementByValue(page, "menuitem").first()).toBeFocused;
+      await expect(
+        getDataElementByValue(page, "additional-buttons")
+          .getByRole("button")
+          .first()
+      ).toBeFocused();
     });
   });
 
@@ -265,8 +276,10 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionNestedInDialog />);
 
-    const actionButtonComp = getComponent(page, "multi-action-button");
-    await actionButtonComp.hover();
+    const actionButton = getComponent(page, "multi-action-button").locator(
+      "button"
+    );
+    await actionButton.hover();
     const listButton1 = getDataElementByValue(page, "additional-buttons")
       .locator("span > span")
       .nth(0);
@@ -285,9 +298,13 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButtonComp = getComponent(page, "multi-action-button").first();
-    await actionButtonComp.click();
-    const listButton1 = page.getByRole("menuitem").nth(0);
+    const actionButton = getComponent(page, "multi-action-button")
+      .first()
+      .locator("button");
+    await actionButton.click();
+    const listButton1 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(0);
     await continuePressingTAB(page, 2);
     await page.keyboard.press("ArrowUp");
     await expect(listButton1).toBeFocused();
@@ -303,10 +320,16 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButtonComp = getComponent(page, "multi-action-button").first();
-    await actionButtonComp.click();
-    const listButton1 = page.getByRole("menuitem").nth(0);
-    const listButton2 = page.getByRole("menuitem").nth(1);
+    const actionButton = getComponent(page, "multi-action-button")
+      .first()
+      .locator("button");
+    await actionButton.click();
+    const listButton1 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(0);
+    const listButton2 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(1);
     await continuePressingTAB(page, 2);
     await expect(listButton2).toBeFocused();
     await page.keyboard.press("Shift+Tab");
@@ -323,9 +346,13 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButtonComp = getComponent(page, "multi-action-button").first();
-    await actionButtonComp.click();
-    const listButton3 = page.getByRole("menuitem").nth(2);
+    const actionButton = getComponent(page, "multi-action-button")
+      .first()
+      .locator("button");
+    await actionButton.click();
+    const listButton3 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(2);
     await continuePressingTAB(page, 3);
     await expect(listButton3).toBeFocused();
     await page.keyboard.press("ArrowDown");
@@ -339,9 +366,15 @@ test.describe("Functional tests", () => {
     await mount(<MultiActionTwoButtons />);
 
     await page.keyboard.press("Tab");
-    const listButton1 = page.getByRole("menuitem").nth(0);
-    const listButton2 = page.getByRole("menuitem").nth(1);
-    const listButton3 = page.getByRole("menuitem").nth(2);
+    const listButton1 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(0);
+    const listButton2 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(1);
+    const listButton3 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(2);
     await page.keyboard.press("Space");
     await expect(listButton1).toBeFocused();
     await page.keyboard.press("Tab");
@@ -360,10 +393,16 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButtonComp = getComponent(page, "multi-action-button").first();
-    await actionButtonComp.click();
-    const listButton1 = page.getByRole("menuitem").nth(0);
-    const listButton3 = page.getByRole("menuitem").nth(2);
+    const actionButton = getComponent(page, "multi-action-button")
+      .first()
+      .locator("button");
+    await actionButton.click();
+    const listButton1 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(0);
+    const listButton3 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(2);
     await continuePressingTAB(page, 3);
     await expect(listButton3).toBeFocused();
     await page.keyboard.down("Meta");
@@ -378,10 +417,16 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButtonComp = getComponent(page, "multi-action-button").first();
-    await actionButtonComp.click();
-    const listButton1 = page.getByRole("menuitem").nth(0);
-    const listButton3 = page.getByRole("menuitem").nth(2);
+    const actionButton = getComponent(page, "multi-action-button")
+      .first()
+      .locator("button");
+    await actionButton.click();
+    const listButton1 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(0);
+    const listButton3 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(2);
     await continuePressingTAB(page, 3);
     await expect(listButton3).toBeFocused();
     await page.keyboard.down("Control");
@@ -396,10 +441,16 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButtonComp = getComponent(page, "multi-action-button").first();
-    await actionButtonComp.click();
-    const listButton1 = page.getByRole("menuitem").nth(0);
-    const listButton3 = page.getByRole("menuitem").nth(2);
+    const actionButton = getComponent(page, "multi-action-button")
+      .first()
+      .locator("button");
+    await actionButton.click();
+    const listButton1 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(0);
+    const listButton3 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(2);
     await continuePressingTAB(page, 3);
     await expect(listButton3).toBeFocused();
     await page.keyboard.press("Home");
@@ -412,10 +463,16 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButtonComp = getComponent(page, "multi-action-button").first();
-    await actionButtonComp.click();
-    const listButton1 = page.getByRole("menuitem").nth(0);
-    const listButton3 = page.getByRole("menuitem").nth(2);
+    const actionButton = getComponent(page, "multi-action-button")
+      .first()
+      .locator("button");
+    await actionButton.click();
+    const listButton1 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(0);
+    const listButton3 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(2);
     await page.keyboard.press("Tab");
     await expect(listButton1).toBeFocused();
     await page.keyboard.down("Meta");
@@ -430,10 +487,16 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButtonComp = getComponent(page, "multi-action-button").first();
-    await actionButtonComp.click();
-    const listButton1 = page.getByRole("menuitem").nth(0);
-    const listButton3 = page.getByRole("menuitem").nth(2);
+    const actionButton = getComponent(page, "multi-action-button")
+      .first()
+      .locator("button");
+    await actionButton.click();
+    const listButton1 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(0);
+    const listButton3 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(2);
     await page.keyboard.press("Tab");
     await expect(listButton1).toBeFocused();
     await page.keyboard.down("Control");
@@ -448,10 +511,16 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButtonComp = getComponent(page, "multi-action-button").first();
-    await actionButtonComp.click();
-    const listButton1 = page.getByRole("menuitem").nth(0);
-    const listButton3 = page.getByRole("menuitem").nth(2);
+    const actionButton = getComponent(page, "multi-action-button")
+      .first()
+      .locator("button");
+    await actionButton.click();
+    const listButton1 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(0);
+    const listButton3 = getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(2);
     await page.keyboard.press("Tab");
     await expect(listButton1).toBeFocused();
     await page.keyboard.press("End");
@@ -464,8 +533,10 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButtonComp = getComponent(page, "multi-action-button").first();
-    await actionButtonComp.click();
+    const actionButton = getComponent(page, "multi-action-button")
+      .first()
+      .locator("button");
+    await actionButton.click();
     await expect(getDataElementByValue(page, "additional-buttons")).toHaveCount(
       1
     );
@@ -481,11 +552,17 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    await getComponent(page, "multi-action-button").first().click();
+    await getComponent(page, "multi-action-button")
+      .first()
+      .locator("button")
+      .click();
     await expect(getDataElementByValue(page, "additional-buttons")).toHaveCount(
       1
     );
-    await page.getByRole("menuitem").nth(0).click();
+    await getDataElementByValue(page, "additional-buttons")
+      .getByRole("button")
+      .nth(0)
+      .click();
     await expect(getDataElementByValue(page, "additional-buttons")).toHaveCount(
       0
     );
@@ -501,12 +578,13 @@ test.describe(
     }) => {
       await mount(<WithWrapper />);
 
-      const actionButtonComp = getComponent(
-        page,
-        "multi-action-button"
-      ).first();
-      await actionButtonComp.click();
-      const listButton1 = page.getByRole("menuitem").nth(0);
+      const actionButton = getComponent(page, "multi-action-button")
+        .locator("button")
+        .first();
+      await actionButton.click();
+      const listButton1 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(0);
       await continuePressingTAB(page, 2);
       await page.keyboard.press("ArrowUp");
       await expect(listButton1).toBeFocused();
@@ -522,13 +600,16 @@ test.describe(
     }) => {
       await mount(<WithWrapper />);
 
-      const actionButtonComp = getComponent(
-        page,
-        "multi-action-button"
-      ).first();
-      await actionButtonComp.click();
-      const listButton1 = page.getByRole("menuitem").nth(0);
-      const listButton2 = page.getByRole("menuitem").nth(1);
+      const actionButton = getComponent(page, "multi-action-button")
+        .locator("button")
+        .first();
+      await actionButton.click();
+      const listButton1 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(0);
+      const listButton2 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(1);
       await continuePressingTAB(page, 2);
       await expect(listButton2).toBeFocused();
       await page.keyboard.press("Shift+Tab");
@@ -545,12 +626,13 @@ test.describe(
     }) => {
       await mount(<WithWrapper />);
 
-      const actionButtonComp = getComponent(
-        page,
-        "multi-action-button"
-      ).first();
-      await actionButtonComp.click();
-      const listButton3 = page.getByRole("menuitem").nth(2);
+      const actionButton = getComponent(page, "multi-action-button")
+        .locator("button")
+        .first();
+      await actionButton.click();
+      const listButton3 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(2);
       await continuePressingTAB(page, 3);
       await expect(listButton3).toBeFocused();
       await page.keyboard.press("ArrowDown");
@@ -564,9 +646,15 @@ test.describe(
       await mount(<WithWrapperTwoButtons />);
 
       await page.keyboard.press("Tab");
-      const listButton1 = page.getByRole("menuitem").nth(0);
-      const listButton2 = page.getByRole("menuitem").nth(1);
-      const listButton3 = page.getByRole("menuitem").nth(2);
+      const listButton1 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(0);
+      const listButton2 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(1);
+      const listButton3 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(2);
       await page.keyboard.press("Space");
       await expect(listButton1).toBeFocused();
       await page.keyboard.press("Tab");
@@ -585,13 +673,16 @@ test.describe(
     }) => {
       await mount(<WithWrapper />);
 
-      const actionButtonComp = getComponent(
-        page,
-        "multi-action-button"
-      ).first();
-      await actionButtonComp.click();
-      const listButton1 = page.getByRole("menuitem").nth(0);
-      const listButton3 = page.getByRole("menuitem").nth(2);
+      const actionButton = getComponent(page, "multi-action-button")
+        .locator("button")
+        .first();
+      await actionButton.click();
+      const listButton1 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(0);
+      const listButton3 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(2);
       await continuePressingTAB(page, 3);
       await expect(listButton3).toBeFocused();
       await page.keyboard.down("Meta");
@@ -606,13 +697,16 @@ test.describe(
     }) => {
       await mount(<WithWrapper />);
 
-      const actionButtonComp = getComponent(
-        page,
-        "multi-action-button"
-      ).first();
+      const actionButtonComp = getComponent(page, "multi-action-button")
+        .locator("button")
+        .first();
       await actionButtonComp.click();
-      const listButton1 = page.getByRole("menuitem").nth(0);
-      const listButton3 = page.getByRole("menuitem").nth(2);
+      const listButton1 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(0);
+      const listButton3 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(2);
       await continuePressingTAB(page, 3);
       await expect(listButton3).toBeFocused();
       await page.keyboard.down("Control");
@@ -627,13 +721,16 @@ test.describe(
     }) => {
       await mount(<WithWrapper />);
 
-      const actionButtonComp = getComponent(
-        page,
-        "multi-action-button"
-      ).first();
-      await actionButtonComp.click();
-      const listButton1 = page.getByRole("menuitem").nth(0);
-      const listButton3 = page.getByRole("menuitem").nth(2);
+      const actionButton = getComponent(page, "multi-action-button")
+        .locator("button")
+        .first();
+      await actionButton.click();
+      const listButton1 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(0);
+      const listButton3 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(2);
       await continuePressingTAB(page, 3);
       await expect(listButton3).toBeFocused();
       await page.keyboard.press("Home");
@@ -646,13 +743,16 @@ test.describe(
     }) => {
       await mount(<WithWrapper />);
 
-      const actionButtonComp = getComponent(
-        page,
-        "multi-action-button"
-      ).first();
-      await actionButtonComp.click();
-      const listButton1 = page.getByRole("menuitem").nth(0);
-      const listButton3 = page.getByRole("menuitem").nth(2);
+      const actionButton = getComponent(page, "multi-action-button")
+        .locator("button")
+        .first();
+      await actionButton.click();
+      const listButton1 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(0);
+      const listButton3 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(2);
       await page.keyboard.press("Tab");
       await expect(listButton1).toBeFocused();
       await page.keyboard.down("Meta");
@@ -667,13 +767,16 @@ test.describe(
     }) => {
       await mount(<WithWrapper />);
 
-      const actionButtonComp = getComponent(
-        page,
-        "multi-action-button"
-      ).first();
-      await actionButtonComp.click();
-      const listButton1 = page.getByRole("menuitem").nth(0);
-      const listButton3 = page.getByRole("menuitem").nth(2);
+      const actionButton = getComponent(page, "multi-action-button")
+        .locator("button")
+        .first();
+      await actionButton.click();
+      const listButton1 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(0);
+      const listButton3 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(2);
       await page.keyboard.press("Tab");
       await expect(listButton1).toBeFocused();
       await page.keyboard.down("Control");
@@ -688,13 +791,16 @@ test.describe(
     }) => {
       await mount(<WithWrapper />);
 
-      const actionButtonComp = getComponent(
-        page,
-        "multi-action-button"
-      ).first();
-      await actionButtonComp.click();
-      const listButton1 = page.getByRole("menuitem").nth(0);
-      const listButton3 = page.getByRole("menuitem").nth(2);
+      const actionButton = getComponent(page, "multi-action-button")
+        .locator("button")
+        .first();
+      await actionButton.click();
+      const listButton1 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(0);
+      const listButton3 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(2);
       await page.keyboard.press("Tab");
       await expect(listButton1).toBeFocused();
       await page.keyboard.press("End");
@@ -707,11 +813,10 @@ test.describe(
     }) => {
       await mount(<WithWrapper />);
 
-      const actionButtonComp = getComponent(
-        page,
-        "multi-action-button"
-      ).first();
-      await actionButtonComp.click();
+      const actionButton = getComponent(page, "multi-action-button")
+        .locator("button")
+        .first();
+      await actionButton.click();
       await expect(
         getDataElementByValue(page, "additional-buttons")
       ).toHaveCount(1);
@@ -727,11 +832,17 @@ test.describe(
     }) => {
       await mount(<WithWrapper />);
 
-      await getComponent(page, "multi-action-button").first().click();
+      await getComponent(page, "multi-action-button")
+        .locator("button")
+        .first()
+        .click();
       await expect(
         getDataElementByValue(page, "additional-buttons")
       ).toHaveCount(1);
-      await page.getByRole("menuitem").nth(0).click();
+      await getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(0)
+        .click();
       await expect(
         getDataElementByValue(page, "additional-buttons")
       ).toHaveCount(0);
@@ -840,7 +951,7 @@ test.describe("Accessibility tests", () => {
     await mount(<InOverflowHiddenContainer />);
 
     await getDataElementByValue(page, "accordion-title-container").click();
-    await getComponent(page, "multi-action-button").click();
+    await getComponent(page, "multi-action-button").locator("button").click();
     await checkAccessibility(page);
   });
 });
@@ -868,9 +979,15 @@ test.describe(
       await actionButton.hover();
       const listContainer = getDataElementByValue(page, "additional-buttons");
       await expect(listContainer).toHaveCSS("border-radius", "8px");
-      const listButton1 = page.getByRole("menuitem").nth(0);
-      const listButton2 = page.getByRole("menuitem").nth(1);
-      const listButton3 = page.getByRole("menuitem").nth(2);
+      const listButton1 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(0);
+      const listButton2 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(1);
+      const listButton3 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(2);
       await expect(listButton1).toHaveCSS("border-radius", "8px 8px 0px 0px");
       await expect(listButton2).toHaveCSS("border-radius", "0px");
       await expect(listButton3).toHaveCSS("border-radius", "0px 0px 8px 8px");
@@ -884,9 +1001,21 @@ test.describe(
 
       const actionButton = page.getByRole("button");
       await actionButton.hover();
-      const listButton1 = page.getByRole("menuitem").nth(0);
-      const listButton2 = page.getByRole("menuitem").nth(1);
-      const listButton3 = page.getByRole("menuitem").nth(2);
+      const listButton1 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("listitem")
+        .nth(0)
+        .locator("> *")
+        .first();
+      const listButton2 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("listitem")
+        .nth(1)
+        .locator("> *")
+        .first();
+      const listButton3 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("listitem")
+        .nth(2)
+        .locator("> *")
+        .first();
       await expect(listButton1).toHaveCSS("border-radius", "8px 8px 0px 0px");
       await expect(listButton2).toHaveCSS("border-radius", "0px");
       await expect(listButton3).toHaveCSS("border-radius", "0px 0px 8px 8px");
@@ -900,7 +1029,9 @@ test.describe(
 
       const actionButton = page.getByRole("button");
       await actionButton.hover();
-      const listButton1 = page.getByRole("menuitem").nth(0);
+      const listButton1 = getDataElementByValue(page, "additional-buttons")
+        .getByRole("button")
+        .nth(0);
       await expect(listButton1).toHaveCSS("border-radius", "8px");
     });
 

--- a/src/components/multi-action-button/multi-action-button.style.ts
+++ b/src/components/multi-action-button/multi-action-button.style.ts
@@ -80,7 +80,7 @@ type StyledButtonChildrenContainerProps = {
   minWidth: number;
 };
 
-const StyledButtonChildrenContainer = styled.div<StyledButtonChildrenContainerProps>`
+const StyledButtonChildrenContainer = styled.ul<StyledButtonChildrenContainerProps>`
   ${({ theme, align, minWidth }) => css`
     background-color: var(--colorsActionMajorYang100);
     min-width: ${minWidth}px;
@@ -88,6 +88,9 @@ const StyledButtonChildrenContainer = styled.div<StyledButtonChildrenContainerPr
     z-index: ${theme.zIndex.popover};
     box-shadow: var(--boxShadow100);
     border-radius: var(--borderRadius100);
+    list-style: none;
+    padding: 0;
+    margin: 0;
 
     ${borderRadiusStyling}
 

--- a/src/components/select/list-action-button/__snapshots__/list-action-button.spec.tsx.snap
+++ b/src/components/select/list-action-button/__snapshots__/list-action-button.spec.tsx.snap
@@ -155,7 +155,6 @@ exports[`Option renders properly 1`] = `
     disabled={false}
     draggable={false}
     onClick={[Function]}
-    role="button"
     size="medium"
     type="button"
   >

--- a/src/components/split-button/split-button-children.style.ts
+++ b/src/components/split-button/split-button-children.style.ts
@@ -4,22 +4,22 @@ import StyledButton from "../button/button.style";
 
 export const borderRadiusStyling = `
   > {
-    &:first-child:last-child {
+    &:first-child:last-child > * {
       border-radius: var(--borderRadius100);
     }
 
-    &:first-child:not(:last-child) {
+    &:first-child:not(:last-child) > * {
       border-top-left-radius: var(--borderRadius100);
       border-top-right-radius: var(--borderRadius100);
       border-bottom-right-radius: var(--borderRadius000);
       border-bottom-left-radius: var(--borderRadius000);
     }
 
-    &:not(:first-child):not(:last-child) {
+    &:not(:first-child):not(:last-child) > * {
       border-radius: var(--borderRadius000);
     }
 
-    &:last-child:not(:first-child) {
+    &:last-child:not(:first-child) > * {
       border-top-right-radius: var(--borderRadius000);
       border-top-left-radius: var(--borderRadius000);
       border-bottom-left-radius: var(--borderRadius100);
@@ -34,7 +34,7 @@ type StyledSplitButtonChildrenContainerProps = {
   minWidth: number;
 };
 
-const StyledSplitButtonChildrenContainer = styled.div<StyledSplitButtonChildrenContainerProps>`
+const StyledSplitButtonChildrenContainer = styled.ul<StyledSplitButtonChildrenContainerProps>`
   border-radius: var(--borderRadius100);
   ${({ theme, align, minWidth }) => css`
     background-color: var(--colorsActionMajorYang100);
@@ -42,6 +42,9 @@ const StyledSplitButtonChildrenContainer = styled.div<StyledSplitButtonChildrenC
     white-space: nowrap;
     z-index: ${theme.zIndex.popover};
     box-shadow: var(--boxShadow100);
+    list-style: none;
+    padding: 0;
+    margin: 0;
 
     ${borderRadiusStyling}
 

--- a/src/components/split-button/split-button.component.tsx
+++ b/src/components/split-button/split-button.component.tsx
@@ -160,13 +160,11 @@ export const SplitButton = ({
 
     return (
       <Popover placement="bottom-end" reference={buttonNode}>
-        <StyledSplitButtonChildrenContainer
-          {...wrapperProps}
-          aria-label={text}
-          align={align}
-        >
+        <StyledSplitButtonChildrenContainer {...wrapperProps} align={align}>
           <SplitButtonContext.Provider value={contextValue}>
-            {children}
+            {React.Children.map(children, (child) => (
+              <li>{child}</li>
+            ))}
           </SplitButtonContext.Provider>
         </StyledSplitButtonChildrenContainer>
       </Popover>

--- a/src/hooks/__internal__/useChildButtons/useChildButtons.tsx
+++ b/src/hooks/__internal__/useChildButtons/useChildButtons.tsx
@@ -10,7 +10,7 @@ const useChildButtons = (
   const [minWidth, setMinWidth] = useState(0);
 
   const buttonNode = useRef<HTMLDivElement>(null);
-  const childrenContainer = useRef<HTMLDivElement>(null);
+  const childrenContainer = useRef<HTMLUListElement>(null);
   const focusFirstChildButtonOnOpen = useRef(false);
 
   const hideButtons = useCallback(() => {
@@ -88,8 +88,8 @@ const useChildButtons = (
   }, [toggleButtonRef]);
 
   const wrapperProps = {
-    role: "menu",
     "data-element": "additional-buttons",
+    role: "list",
     onKeyDown: handleKeyDown,
     minWidth,
     ref: childrenContainer,


### PR DESCRIPTION
### Proposed behaviour

- ActionPopover, SplitButton and MultiActionButton should not use the `menu` and `menuitem` roles, but simply present buttons in a semantic HTML list
- the consumer should be able to override the `aria-label` attribute for the main button on ActionPopover should
- no `aria-label` should be placed on menu items that open a submenu, so that screenreaders read the text of the item rather than a vague word like "actions"

<!--
A clear and concise description of what changes this PR makes.

If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.

Please DO NOT share screenshots or the source code of your project.

You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2

If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
it with the new built version of carbon.
-->

### Current behaviour

<!--
A clear and concise description of the behaviour before this change.

If applicable, add screenshots. You can paste these directly into GitHub.
-->

- ActionPopover, SplitButton and MultiActionButton use ARIA menu roles, which are not semantically appropriate for a simple list of actions/buttons
- It is not possible to override the `aria-label` of "actions" on the main button for ActionPopover, which may lead to a poor experience for users (potentially many duplicate labels on a page, none of them meaningful for what the component is actually used for)
- There is the same `aria-label="actions"` on each menu item that opens a submenu, which causes screenreaders to announce the item as "actions" rather than the actual text that a sighted user can read

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Cypress automation tests added or updated if required
- [X] Playwright automation tests added or updated if required
- [X] Storybook added or updated if required
- [X] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [X] Typescript `d.ts` file added or updated if required
- [X] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

NOTE: marked as requiring UX QA, this is for an accessibility review rather than more general UX. (Nothing should have changed for users who don't use assistive technology.)
