### PR TITLE
feat(text-editor): make container of toolbarElements a flex container for responsiveness (FE-6337 and FE-6340)

### DIFF
--- a/cypress/components/text-editor/text-editor.cy.tsx
+++ b/cypress/components/text-editor/text-editor.cy.tsx
@@ -65,7 +65,7 @@ context("Test for TextEditor component", () => {
         textEditorToolbar(buttonType).should(
           "have.css",
           "background-color",
-          "rgb(204, 214, 219)"
+          "rgb(0, 50, 76)"
         );
       }
     );
@@ -107,7 +107,7 @@ context("Test for TextEditor component", () => {
         textEditorToolbar(buttonType).should(
           "have.css",
           "background-color",
-          "rgb(204, 214, 219)"
+          "rgb(0, 50, 76)"
         );
       }
     );
@@ -163,7 +163,7 @@ context("Test for TextEditor component", () => {
         textEditorToolbar(buttonType).should(
           "have.css",
           "background-color",
-          "rgb(204, 214, 219)"
+          "rgb(0, 50, 76)"
         );
       }
     );
@@ -185,7 +185,7 @@ context("Test for TextEditor component", () => {
         textEditorToolbar(buttonType).should(
           "have.css",
           "background-color",
-          "rgb(204, 214, 219)"
+          "rgb(0, 50, 76)"
         );
       }
     );
@@ -278,17 +278,17 @@ context("Test for TextEditor component", () => {
 
       it("render with the expected border radius on the toolbar buttons", () => {
         CypressMountWithProviders(<TextEditorCustom />);
-        textEditorToolbar("bold").should("have.css", "border-radius", "4px");
-        textEditorToolbar("italic").should("have.css", "border-radius", "4px");
+        textEditorToolbar("bold").should("have.css", "border-radius", "8px");
+        textEditorToolbar("italic").should("have.css", "border-radius", "8px");
         textEditorToolbar("bullet-list").should(
           "have.css",
           "border-radius",
-          "4px"
+          "8px"
         );
         textEditorToolbar("number-list").should(
           "have.css",
           "border-radius",
-          "4px"
+          "8px"
         );
       });
     });
@@ -320,17 +320,17 @@ context("Test for TextEditor component", () => {
     describe("rounded corners", () => {
       it("should render with the expected border radius on the toolbar buttons", () => {
         CypressMountWithProviders(<TextEditorCustom />);
-        textEditorToolbar("bold").should("have.css", "border-radius", "4px");
-        textEditorToolbar("italic").should("have.css", "border-radius", "4px");
+        textEditorToolbar("bold").should("have.css", "border-radius", "8px");
+        textEditorToolbar("italic").should("have.css", "border-radius", "8px");
         textEditorToolbar("bullet-list").should(
           "have.css",
           "border-radius",
-          "4px"
+          "8px"
         );
         textEditorToolbar("number-list").should(
           "have.css",
           "border-radius",
-          "4px"
+          "8px"
         );
       });
     });

--- a/src/components/portal/__snapshots__/portal.spec.tsx.snap
+++ b/src/components/portal/__snapshots__/portal.spec.tsx.snap
@@ -4,10 +4,10 @@ exports[`Portal mount a <p/> tag as child 1`] = `"<div class=\\"carbon-portal\\"
 
 exports[`Portal when id prop is given matches snapshot 1`] = `"<div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\" id=\\"abc\\"><div class=\\"sc-bdVaJa ibReFo\\"><span>a1</span></div><div class=\\"sc-bdVaJa ibReFo\\"><span>a2</span></div></div>"`;
 
-exports[`Portal when using default node then the portal will mount on body 1`] = `"<div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><div class=\\"sc-bdVaJa ibReFo\\"><span class=\\"sc-bxivhb fYoASh\\" data-element=\\"tick\\" font-size=\\"small\\" tabindex=\\"0\\" type=\\"tick\\" data-component=\\"icon\\"></span></div></div>"`;
+exports[`Portal when using default node then the portal will mount on body 1`] = `"<div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><div class=\\"sc-bdVaJa ibReFo\\"><span class=\\"sc-ifAKCX lltdZt\\" data-element=\\"tick\\" font-size=\\"small\\" tabindex=\\"0\\" type=\\"tick\\" data-component=\\"icon\\"></span></div></div>"`;
 
 exports[`Portal when using default node to match snapshot 1`] = `
-<span
+<styled.span
   data-portal-entrance="guid-12345"
 >
   <Portal
@@ -627,5 +627,5 @@ exports[`Portal when using default node to match snapshot 1`] = `
       />
     </styled.div>
   </Portal>
-</span>
+</styled.span>
 `;

--- a/src/components/portal/portal.style.ts
+++ b/src/components/portal/portal.style.ts
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+const StyledPortalEntrance = styled.span`
+  display: none;
+  height: 0;
+  width: 0;
+`;
+
+export default StyledPortalEntrance;

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom";
 
 import guid from "../../__internal__/utils/helpers/guid";
 import CarbonScopedTokensProvider from "../../style/design-tokens/carbon-scoped-tokens-provider/carbon-scoped-tokens-provider.component";
+import StyledPortalEntrance from "./portal.style";
 
 interface PortalContextProps {
   renderInRoot?: boolean;
@@ -91,12 +92,12 @@ const Portal = ({ children, className, id, onReposition }: PortalProps) => {
   };
 
   return (
-    <span data-portal-entrance={uniqueId}>
+    <StyledPortalEntrance data-portal-entrance={uniqueId}>
       {ReactDOM.createPortal(
         <CarbonScopedTokensProvider>{children}</CarbonScopedTokensProvider>,
         getPortalContainer()
       )}
-    </span>
+    </StyledPortalEntrance>
   );
 };
 

--- a/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.spec.tsx
+++ b/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.spec.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { mount } from "enzyme";
 import { assertStyleMatch } from "../../../../../__spec_helper__/test-utils";
 import ToolbarButton from "./toolbar-button.component";
-import StyledIcon from "../../../../icon/icon.style";
 
 const onKeyDown = jest.fn();
 const onMouseDown = jest.fn();
@@ -31,13 +30,14 @@ describe("ToolbarButton", () => {
 
       assertStyleMatch(
         {
+          display: "inline-flex",
+          justifyContent: "center",
+          alignItems: "center",
+          padding: "6px",
           backgroundColor: "inherit",
           border: "none",
+          borderRadius: "var(--borderRadius100)",
           cursor: "pointer",
-          width: "32px",
-          fontSize: "14px",
-          height: "32px",
-          borderRadius: "var(--borderRadius050)",
         },
         wrapper
       );
@@ -49,20 +49,12 @@ describe("ToolbarButton", () => {
         wrapper,
         { modifier: ":hover" }
       );
-
-      assertStyleMatch(
-        {
-          width: "auto",
-        },
-        wrapper,
-        { modifier: `${StyledIcon}` }
-      );
     });
 
     it("matches the expected `background-color` when `activated` prop is truthy", () => {
       assertStyleMatch(
         {
-          backgroundColor: "var(--colorsActionMinor200)",
+          backgroundColor: "var(--colorsActionMinor600)",
         },
         render({ activated: true })
       );

--- a/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.style.ts
+++ b/src/components/text-editor/__internal__/toolbar/toolbar-button/toolbar-button.style.ts
@@ -1,28 +1,25 @@
 import styled, { css } from "styled-components";
-import StyledIcon from "../../../../icon/icon.style";
 import { baseTheme } from "../../../../../style/themes";
 import addFocusStyling from "../../../../../style/utils/add-focus-styling";
 
 const StyledToolbarButton = styled.button.attrs({ type: "button" })<{
   isActive?: boolean;
 }>`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 6px;
   background-color: inherit;
-  border-radius: var(--borderRadius050);
+  border-radius: var(--borderRadius100);
   border: none;
   cursor: pointer;
-  width: 32px;
-  font-size: 14px;
-  height: 32px;
-
-  ${StyledIcon} {
-    width: auto;
-  }
 
   ${({ isActive, theme }) => css`
     :focus,
     :active {
       z-index: 1;
       position: relative;
+
       ${theme.focusRedesignOptOut &&
       /* istanbul ignore next */
       css`
@@ -34,17 +31,15 @@ const StyledToolbarButton = styled.button.attrs({ type: "button" })<{
       css`
         ${addFocusStyling()}
       `}
-      border-radius: var(--borderRadius050);
     }
 
     :hover {
-      background-color: var(--colorsActionMinor200);
-      border-radius: var(--borderRadius050);
+      background-color: ${!isActive && "var(--colorsActionMinor200)"};
     }
 
     ${isActive &&
     css`
-      background-color: var(--colorsActionMinor200);
+      background-color: var(--colorsActionMinor600);
     `}
   `}
 `;

--- a/src/components/text-editor/__internal__/toolbar/toolbar.component.tsx
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.component.tsx
@@ -9,14 +9,8 @@ import Events from "../../../../__internal__/utils/helpers/events";
 import Icon from "../../../icon";
 import Tooltip from "../../../tooltip";
 import useLocale from "../../../../hooks/__internal__/useLocale";
-import {
-  BOLD,
-  ITALIC,
-  UNORDERED_LIST,
-  ORDERED_LIST,
-  InlineStyleType,
-  BlockType,
-} from "../../types";
+import { BOLD, ITALIC, UNORDERED_LIST, ORDERED_LIST } from "../../types";
+import type { InlineStyleType, BlockType } from "../../types";
 
 export interface ToolbarProps {
   /** Used to override the active status of the inline controls */
@@ -164,7 +158,14 @@ const Toolbar = ({
             onFocus={() => setActiveTooltip("Bold")}
             onBlur={() => setActiveTooltip("")}
           >
-            <Icon type="bold" />
+            <Icon
+              color={
+                activeControls[BOLD]
+                  ? "var(--colorsActionMinorYang100)"
+                  : undefined
+              }
+              type="bold"
+            />
           </ToolbarButton>
         </Tooltip>
         <Tooltip
@@ -184,7 +185,14 @@ const Toolbar = ({
             onFocus={() => setActiveTooltip("Italic")}
             onBlur={() => setActiveTooltip("")}
           >
-            <Icon type="italic" />
+            <Icon
+              color={
+                activeControls[ITALIC]
+                  ? "var(--colorsActionMinorYang100)"
+                  : undefined
+              }
+              type="italic"
+            />
           </ToolbarButton>
         </Tooltip>
         <Tooltip
@@ -204,7 +212,14 @@ const Toolbar = ({
             onFocus={() => setActiveTooltip("Bulleted List")}
             onBlur={() => setActiveTooltip("")}
           >
-            <Icon type="bullet_list_dotted" />
+            <Icon
+              color={
+                activeControls[UNORDERED_LIST]
+                  ? "var(--colorsActionMinorYang100)"
+                  : undefined
+              }
+              type="bullet_list_dotted"
+            />
           </ToolbarButton>
         </Tooltip>
         <Tooltip
@@ -224,7 +239,14 @@ const Toolbar = ({
             onFocus={() => setActiveTooltip("Numbered List")}
             onBlur={() => setActiveTooltip("")}
           >
-            <Icon type="bullet_list_numbers" />
+            <Icon
+              color={
+                activeControls[ORDERED_LIST]
+                  ? "var(--colorsActionMinorYang100)"
+                  : undefined
+              }
+              type="bullet_list_numbers"
+            />
           </ToolbarButton>
         </Tooltip>
       </StyledEditorStyleControls>

--- a/src/components/text-editor/__internal__/toolbar/toolbar.spec.tsx
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.spec.tsx
@@ -11,7 +11,6 @@ import {
   StyledEditorStyleControls,
   StyledEditorActionControls,
 } from "./toolbar.style";
-import StyledButton from "../../../button/button.style";
 import Button from "../../../button/button.component";
 import StyledToolbarButton from "./toolbar-button/toolbar-button.style";
 import ToolbarButton from "./toolbar-button/toolbar-button.component";
@@ -51,18 +50,18 @@ describe("Toolbar", () => {
     it("matches the expected for the main container", () => {
       assertStyleMatch(
         {
-          padding: "8px",
-          display: "flex",
-          justifyContent: "flex-start",
-          background: "white",
-          flexWrap: "wrap",
-          fontSize: "14px",
+          display: "inline-flex",
+          justifyContent: "space-between",
+          flexFlow: "row wrap",
+          gap: "8px",
+          padding: "12px",
           userSelect: "none",
-          order: "2",
           border: "none",
-          backgroundColor: "var(--colorsUtilityMajor025)",
           borderTop: "1px solid var(--colorsUtilityMajor200)",
-          minWidth: "290px",
+          backgroundColor: "var(--colorsUtilityMajor025)",
+          height: "fit-content",
+          width: "100%",
+          boxSizing: "border-box",
         },
         render()
       );
@@ -84,25 +83,15 @@ describe("Toolbar", () => {
     it("matches the expected for the action controls container", () => {
       assertStyleMatch(
         {
-          display: "inline-block",
-          textAlign: "right",
-          width: "50%",
-          minWidth: "60px",
+          flexGrow: "1",
+          display: "inline-flex",
+          justifyContent: "flex-end",
+          flexWrap: "wrap",
+          gap: "var(--spacing200)",
         },
         render({ toolbarElements: <Button>foo</Button> }).find(
           StyledEditorActionControls
         )
-      );
-
-      assertStyleMatch(
-        {
-          width: "62px",
-          minHeight: "33px",
-        },
-        render({ toolbarElements: <Button>foo</Button> }).find(
-          StyledEditorActionControls
-        ),
-        { modifier: `${StyledButton}` }
       );
     });
   });

--- a/src/components/text-editor/__internal__/toolbar/toolbar.spec.tsx
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.spec.tsx
@@ -70,11 +70,8 @@ describe("Toolbar", () => {
     it("matches the expected for the format styles controls container", () => {
       assertStyleMatch(
         {
-          display: "inline-block",
-          textAlign: "left",
-          width: "50%",
-          minWidth: "60px",
-          marginLeft: "-2px",
+          display: "inline-flex",
+          gap: "8px",
         },
         render().find(StyledEditorStyleControls)
       );
@@ -167,15 +164,6 @@ describe("Toolbar", () => {
     afterEach(() => {
       setInlineStyle.mockClear();
       setBlockStyle.mockClear();
-    });
-
-    it(`sets expected background-color when '${id.toLowerCase()}' is active`, () => {
-      assertStyleMatch(
-        {
-          backgroundColor: "var(--colorsActionMinor200)",
-        },
-        wrapper.find(ToolbarButton).at(index)
-      );
     });
 
     it(`calls expected callback when the '${id.toLowerCase()}' button is clicked`, () => {

--- a/src/components/text-editor/__internal__/toolbar/toolbar.style.ts
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.style.ts
@@ -17,11 +17,8 @@ const StyledToolbar = styled.div`
 `;
 
 const StyledEditorStyleControls = styled.div`
-  display: inline-block;
-  text-align: left;
-  width: 50%;
-  min-width: 60px;
-  margin-left: -2px;
+  display: inline-flex;
+  gap: 8px;
 `;
 
 const StyledEditorActionControls = styled.div`

--- a/src/components/text-editor/__internal__/toolbar/toolbar.style.ts
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.style.ts
@@ -1,19 +1,18 @@
 import styled from "styled-components";
-import StyledButton from "../../../button/button.style";
 
 const StyledToolbar = styled.div`
-  padding: 8px;
-  display: flex;
-  justify-content: flex-start;
-  background: white;
-  flex-wrap: wrap;
-  font-size: 14px;
-  user-select: none;
-  order: 2;
+  display: inline-flex;
+  justify-content: space-between;
+  flex-flow: row wrap;
+  gap: 8px;
+  padding: 12px;
+  height: fit-content;
+  width: 100%;
+  box-sizing: border-box;
   border: none;
   border-top: 1px solid var(--colorsUtilityMajor200);
   background-color: var(--colorsUtilityMajor025);
-  min-width: 290px;
+  user-select: none;
   z-index: 10;
 `;
 
@@ -26,15 +25,11 @@ const StyledEditorStyleControls = styled.div`
 `;
 
 const StyledEditorActionControls = styled.div`
-  display: inline-block;
-  text-align: right;
-  width: 50%;
-  min-width: 60px;
-
-  ${StyledButton} {
-    width: 62px;
-    min-height: 33px;
-  }
+  flex-grow: 1;
+  display: inline-flex;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: var(--spacing200);
 `;
 
 export { StyledToolbar, StyledEditorActionControls, StyledEditorStyleControls };

--- a/src/components/text-editor/text-editor-test.stories.tsx
+++ b/src/components/text-editor/text-editor-test.stories.tsx
@@ -4,10 +4,12 @@ import TextEditor, {
   TextEditorContentState as ContentState,
   TextEditorProps,
 } from "./text-editor.component";
+import Button from "../button";
+import Box from "../box";
 
 export default {
   title: "Text Editor/Test",
-  includeStories: ["Default"],
+  excludeStories: ["TextEditorCustom", "TextEditorCustomValidation"],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -73,6 +75,32 @@ export const Default = ({ onChange, ...props }: Partial<TextEditorProps>) => {
 };
 
 Default.storyName = "default";
+
+export const WithCustomToolbarContent = () => {
+  const [value, setValue] = useState(EditorState.createEmpty());
+  return (
+    <Box padding={1}>
+      <TextEditor
+        onChange={(newValue) => {
+          setValue(newValue);
+        }}
+        value={value}
+        toolbarElements={[
+          <Button aria-label="drucken" iconType="print" />,
+          <Button buttonType="secondary" destructive onClick={() => {}}>
+            Kündigen
+          </Button>,
+          <Button buttonType="primary" type="button" onClick={() => {}}>
+            Speichern und beenden
+          </Button>,
+        ]}
+        labelText="Text Editor Label"
+      />
+    </Box>
+  );
+};
+
+WithCustomToolbarContent.storyName = "with custom toolbar content";
 
 const createContent = (text?: string) => {
   if (text) {

--- a/src/components/text-editor/text-editor.spec.tsx
+++ b/src/components/text-editor/text-editor.spec.tsx
@@ -152,7 +152,6 @@ describe("TextEditor", () => {
       assertStyleMatch(
         {
           minHeight: "220px",
-          minWidth: "320px",
           backgroundColor: "var(--colorsUtilityYang100)",
           outline: "1px solid var(--colorsUtilityMajor200)",
           borderRadius: "var(--borderRadius050)",
@@ -785,7 +784,6 @@ describe("TextEditor", () => {
       it.each([["unordered-list-item"], ["ordered-list-item"]] as const)(
         "adds styling to %s control when currentBlock has a a given type",
         (style) => {
-          const index = style === "unordered-list-item" ? 2 : 3;
           act(() => {
             getEditorParent()
               .props()
@@ -797,12 +795,6 @@ describe("TextEditor", () => {
             wrapper.update();
           });
           expect(hasBlockStyle(style)).toBeTruthy();
-          assertStyleMatch(
-            {
-              backgroundColor: "var(--colorsActionMinor200)",
-            },
-            wrapper.find(ToolbarButton).at(index)
-          );
         }
       );
     });

--- a/src/components/text-editor/text-editor.stories.mdx
+++ b/src/components/text-editor/text-editor.stories.mdx
@@ -87,6 +87,16 @@ will prevent any input that would cause the content length to exceed it.
   />
 </Canvas>
 
+### Character counter with translations
+
+Various translation keys are available to assist with translating the character counter below the editor into different languages. These keys allow you to amend the messages shown when the counter exceeds or is below the set character limit.
+
+For screen reader users, the designated `characterCount.visuallyHiddenHint` key can be used to override the message that is announced when the user stops typing.
+
+<Canvas>
+  <Story name="character counter with translations" story={stories.CharacterCounterTranslations} />
+</Canvas>
+
 ### With validation
 
 It is possible apply validation to the `TextEditor` component by passing the desired string message to one of the `error`,
@@ -197,6 +207,32 @@ The following keys are available to override the translations for this component
       type: "func",
       description:
         "visible when the user hovers over the number list toolbar button",
+      returnType: "string",
+    },
+    {
+      name: "characterCount.tooManyCharacters",
+      description:
+        "The message displayed below the input which will inform"
+        +" users if they have exceeded the set `characterLimit` and how much by." 
+        +" This will also be announced to screen readers.",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "characterCount.charactersLeft",
+      description:
+        "The message displayed below the input which will inform"
+        +" users how many characters they have before they reach  or exceed the"
+        +" set `characterLimit`. This will also be announced to screen readers.",      
+        type: "func",
+      returnType: "string",
+    },
+    {
+      name: "characterCount.visuallyHiddenHint",
+      description:
+        "The message which will be read out to screen reader users, informing them"
+        +" of the set `characterLimit`.",
+      type: "func",
       returnType: "string",
     },
   ]}

--- a/src/components/text-editor/text-editor.stories.tsx
+++ b/src/components/text-editor/text-editor.stories.tsx
@@ -8,6 +8,7 @@ import Button from "../button";
 import EditorLinkPreview from "../link-preview";
 import Box from "../box";
 import CarbonProvider from "../carbon-provider";
+import I18nProvider from "../i18n-provider";
 
 export const Default = () => {
   const [value, setValue] = useState(EditorState.createEmpty());
@@ -96,6 +97,41 @@ export const WithOptionalCharacterLimit = () => {
 };
 
 WithOptionalCharacterLimit.storyName = "with optional character limit";
+
+export const CharacterCounterTranslations = () => {
+  const [value, setValue] = useState(EditorState.createEmpty());
+  const limit = 100;
+  return (
+    <I18nProvider
+      locale={{
+        locale: () => "fr-FR",
+        characterCount: {
+          tooManyCharacters: (count, formattedCount) =>
+            count === 1
+              ? `${formattedCount} caractère restant`
+              : `${formattedCount} caractères restants`,
+          charactersLeft: (count, formattedCount) =>
+            count === 1
+              ? `${formattedCount} caractère de trop`
+              : `${formattedCount} personnages de trop`,
+          visuallyHiddenHint: (formattedCount) =>
+            `Vous pouvez saisir jusqu'à ${formattedCount} caractères`,
+        },
+      }}
+    >
+      <Box padding={1}>
+        <TextEditor
+          onChange={(newValue) => {
+            setValue(newValue);
+          }}
+          value={value}
+          labelText="Text Editor Label"
+          characterLimit={limit}
+        />
+      </Box>
+    </I18nProvider>
+  );
+};
 
 export const WithValidation = () => {
   const [value, setValue] = useState(

--- a/src/components/text-editor/text-editor.stories.tsx
+++ b/src/components/text-editor/text-editor.stories.tsx
@@ -66,7 +66,6 @@ export const WithOptionalButtons = () => {
             buttonType="primary"
             type="button"
             onClick={() => {}}
-            ml={2}
           >
             Save
           </Button>,

--- a/src/components/text-editor/text-editor.style.ts
+++ b/src/components/text-editor/text-editor.style.ts
@@ -24,7 +24,6 @@ const StyledEditorContainer = styled.div<{
     min-height: ${rows
       ? `${rows * lineHeight}`
       : `${hasPreview ? 125 : 220}`}px;
-    min-width: 320px;
     position: relative;
 
     div.DraftEditor-root {
@@ -74,7 +73,6 @@ const StyledEditorOutline = styled.div<{
   ${({ isFocused, hasError, theme }) => css`
     border-radius: var(--borderRadius050);
     outline: none;
-    min-width: 320px;
 
     ${isFocused &&
     css`

--- a/src/components/tooltip/__snapshots__/tooltip.spec.tsx.snap
+++ b/src/components/tooltip/__snapshots__/tooltip.spec.tsx.snap
@@ -11,6 +11,12 @@ exports[`Tooltip controlled matches snapshot when isVisible is false 1`] = `
 `;
 
 exports[`Tooltip controlled matches snapshot when isVisible is true 1`] = `
+.c0 {
+  display: none;
+  height: 0;
+  width: 0;
+}
+
 <div>
   <div
     data-testid="tooltip-target"
@@ -18,6 +24,7 @@ exports[`Tooltip controlled matches snapshot when isVisible is true 1`] = `
     foo
   </div>
   <span
+    class="c0"
     data-portal-entrance="guid-12345"
   />
 </div>


### PR DESCRIPTION
addresses #6530 
addresses #6529

### Proposed behaviour

For `TextEditor`:

- Remove styling that fixes dimensions of custom toolbar elements added via `toolbarElements` prop:

![Screenshot 2024-01-31 at 09 46 13](https://github.com/Sage/carbon/assets/18368713/4983fad6-7d7e-4408-a727-58e011810236)


- Make toolbar of `TextEditor` a flex container and remove fixed dimensions on it - so content reflows when there isn't enough space:

https://github.com/Sage/carbon/assets/18368713/c9efa8cd-ad6f-4357-853a-07581db8e47f

- Amend styling of toolbar buttons - notably the background colour when active and gap between them:

![New dimensions of toolbar button](https://github.com/Sage/carbon/assets/18368713/30148baf-4f1b-49d3-9189-505e60e4aec1)

![Toolbar button when hovered](https://github.com/Sage/carbon/assets/18368713/1ae13d8d-d2bf-4593-9ce0-6d5eaf5843be)

![New background colour when button is active](https://github.com/Sage/carbon/assets/18368713/9f5b6612-b021-4b11-9352-4bf998189b40)

- Update documentation to include missing `characterCount` translation keys.


### Current behaviour

For `TextEditor`:

- Custom toolbar elements added via `toolbarElements` prop have their height and width fixed:
![Screenshot 2024-01-30 at 16 36 07](https://github.com/Sage/carbon/assets/18368713/4293f81b-55e0-4a99-9078-9ba6c2a9dc96)
- Missing documentation on supported `characterCount` translation keys.
- Styling of toolbar buttons doesn't match the Design System - particularly the active background colour and gaps between the buttons:

![Screenshot 2024-01-30 at 17 10 47](https://github.com/Sage/carbon/assets/18368713/1c3f8bc3-1082-4d16-8e37-f1ce9c669522)
![Screenshot 2024-01-30 at 17 10 43](https://github.com/Sage/carbon/assets/18368713/4090bcd2-ceee-48b9-988e-d6262775bbc3)


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [x] Tested in CodeSandbox/storybook
- [x] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

The following CodeSandbox is an example of the broken behaviour:
[Demo of visual bug](https://codesandbox.io/p/sandbox/bitter-dawn-9wws7l?file=%2Fsrc%2FApp.js%3A18%2C11-19%2C59)

The fixed behaviour can be observed with the newly-added story `Test/with custom toolbar content`
