### PR TITLE
docs(portal): add new documentation for component - FE-6322

### DIFF
--- a/src/components/portal/portal.stories.mdx
+++ b/src/components/portal/portal.stories.mdx
@@ -1,0 +1,64 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { ArgsTable } from "@storybook/components";
+
+<Meta title="Portal" parameters={{ info: { disable: true } }} />
+
+# Portal
+
+The Portal component allows you to render children into a different part of the DOM, whilst also allowing the use of styling using the Design System's `design-tokens` package.
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Usage](#usage)
+- [Props](#props)
+
+## Quick Start
+
+```javascript
+import Portal from "carbon-react/lib/components/portal";
+```
+
+## Usage
+
+This example demonstrates how to render a Portal with a Box component as a child that uses a design-token for the background color.
+```javascript
+import Portal from "carbon-react/lib/components/portal";
+import Box from "carbon-react/lib/components/box";
+
+/* ... */
+<Portal>
+  <Box bg="var(--colorsUtilityMajor010)">Portal content</Box>
+</Portal>
+```
+
+## Props
+
+<ArgsTable
+  rows={[
+    {
+      name: "children",
+      type: { summary: "ReactNode" },
+      description:
+        "The content of the portal.",
+    },
+    {
+      name: "className",
+      type: { summary: "string" },
+      description:
+        "Classname attached to portal container.",
+    },
+    {
+      name: "id",
+      type: { summary: "string" },
+      description:
+        "Id attribute attached to portal container.",
+    },
+    {
+      name: "onReposition",
+      type: { summary: "(() => void)" },
+      description:
+        "Callback function triggered when parent element is scrolled or window resized.",
+    },
+  ]}
+/>

--- a/src/components/portrait/portrait.stories.mdx
+++ b/src/components/portrait/portrait.stories.mdx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 

--- a/src/components/preview/preview.stories.mdx
+++ b/src/components/preview/preview.stories.mdx
@@ -1,11 +1,7 @@
-import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 import { ArgsTable } from "@storybook/components";
 
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
-
-import Preview from "./preview.component";
-import Button from "../button";
 
 import * as stories from "./preview.stories"
 

--- a/src/components/progress-tracker/progress-tracker.stories.mdx
+++ b/src/components/progress-tracker/progress-tracker.stories.mdx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
 
 import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";

--- a/src/components/search/search.stories.mdx
+++ b/src/components/search/search.stories.mdx
@@ -1,5 +1,4 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs";
-import { useState } from "react";
 
 import StyledSystemProps from "../../../.storybook/utils/styled-system-props";
 


### PR DESCRIPTION
### Proposed behaviour

Create new document that informs our consumers of Portal's existence 

### Current behaviour

No documentation for Portal.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Cypress automation tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Ensure document renders in Storybook correctly. 