### PR TITLE
docs: replace codesandbox references with stackblitz

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,4 +1,4 @@
-name: Bug Report
+name: 🐞 Bug Report
 description: Something isn't working as expected?
 labels:
   - Bug
@@ -8,71 +8,73 @@ body:
     attributes:
       value: |
         ### ⚠️ This bug report is public
-        Please create a reproducible example using one of our Codesandbox templates, using [Typescript](https://codesandbox.io/p/sandbox/carbon-quickstart-typescript-6sjfuz) or [Javascript](https://codesandbox.io/p/sandbox/carbon-quickstart-j5pb2)
-        Please do not include any confidential or commercially sensitive information.
 
+        **Please do not include any confidential or commercially sensitive information.**
         ---
   - type: textarea
-    id: current-behaviour
+    id: description
     attributes:
-      label: Current behaviour
+      label: Description
       description: |
-        Please give a clear and concise description of the current behaviour.
-        If applicable, add screenshots or screen recording of your CodeSandbox to help explain the problem. You can paste these directly into GitHub.
-    validations:
-      required: true
-  - type: textarea
-    id: expected-behaviour
-    attributes:
-      label: Expected behaviour
-      description: |
-        Please give a clear and concise description of the expected behaviour.
+        A clear and concise description of the bug. If applicable, add screenshots or screen recordings to help explain the problem.
+
+        If you intend to submit a PR for this, tell us in the description. Thanks!
+      placeholder: I am doing... What I expect is... What actually happens is...
     validations:
       required: true
   - type: input
     id: url
     attributes:
-      label: CodeSandbox or Storybook URL
+      label: Reproduction
       description: >-
-        Please fork one of our templates ([Typescript](https://codesandbox.io/p/sandbox/carbon-quickstart-typescript-6sjfuz) or [Javascript](https://codesandbox.io/s/carbon-quickstart-j5pb2)), and ensure you save your changes.
-        Alternatively, if your issue relates to [Storybook](https://carbon.sage.com) please link to the story.
-      placeholder: https://codesandbox.io/s/carbon-quickstart-j5pb2
+        Please provide a link via [our Stackblitz template](https://stackblitz.com/fork/github/Parsium/carbon-starter) that can reproduce the problem you encountered. Alternatively, if your issue relates to our [Storybook](https://carbon.sage.com) docs, please link to the story.
+      placeholder: Reproduction URL
     validations:
       required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce
+      description: |
+        Please describe any steps that need to be performed first to reproduce the bug. E.g. any user interactions like clicking, focusing, etc. or any build scripts that need to run.
+      placeholder: Click "Open dialog" button to open dialog, then click save button.
+    validation:
+      required: false
   - type: input
     id: jira-id
     attributes:
-      label: JIRA Ticket (Sage Only)
+      label: JIRA ticket numbers (Sage only)
       description: >-
-        Please include any related JIRA ticket numbers. If we accept this report, we'll create another JIRA ticket and add a `relates to` link to your tickets.
-        Do not include any URL's.
+        Any related JIRA ticket numbers. If we accept this report, we'll create another JIRA ticket and link it to your tickets.
+        **Please do not include any URLs.**
       placeholder: FE-123, SBS-456
   - type: textarea
     id: suggested-solution
     attributes:
-      label: Suggested Solution
+      label: Suggested solution
     validations:
       required: false
   - type: input
     id: carbon-version
     attributes:
-      label: Carbon Version
-      description: What version of carbon are you using?
-      placeholder: 77.13.2
+      label: Carbon version
+      description: Which version of Carbon are you using?
+      placeholder: 125.1.1
     validations:
       required: true
   - type: input
     id: design-tokens-version
     attributes:
-      label: Design Tokens Version
-      description: What version of [@sage/design-tokens](https://github.com/Sage/design-tokens) are you using? Only applicable if using Carbon v106.0.0 or above.
-      placeholder: 2.21.0
+      label: Design tokens version
+      description: Which version of [@sage/design-tokens](https://github.com/Sage/design-tokens) are you using? Only applicable if using Carbon v106.0.0 or above.
+      placeholder: 4.29.0
     validations:
       required: false
   - type: dropdown
     id: browsers
     attributes:
-      label: What browsers are you seeing the problem on?
+      label: Relevant browsers
+      description: Which browser(s) are you seeing the problem on?
       multiple: true
       options:
         - Firefox
@@ -85,7 +87,8 @@ body:
   - type: dropdown
     id: os
     attributes:
-      label: What Operating System are you seeing the problem on?
+      label: Relevant OSs
+      description: Which Operating System(s) are you seeing the problem on?
       multiple: true
       options:
         - MacOS
@@ -99,7 +102,8 @@ body:
   - type: textarea
     id: additional-info
     attributes:
-      label: Anything else we should know?
+      label: Additional context
+      description: Anything else we should know?
     validations:
       required: false
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,4 @@
-name: Feature Request
+name: 🏗️ New feature request
 description: Is there something that we should implement? Let us know!
 labels:
   - Enhancement
@@ -8,48 +8,48 @@ body:
     attributes:
       value: |
         ### ⚠️ This feature request is public
-        Please do not include any confidential or commercially sensitive information.
 
+        **Please do not include any confidential or commercially sensitive information.**
         ---
   - type: textarea
-    id: desired-behaviour
+    id: description
     attributes:
-      label: Desired behaviour
+      label: Description
       description: |
-        Please give a clear and concise description of the desired behaviour.
-        If applicable, add screenshots or screen recording of a CodeSandbox to help explain the request. You can paste these directly into GitHub.
-        We provide Codesandbox templates with Carbon and dependencies pre-loaded, using either [Typescript](https://codesandbox.io/p/sandbox/carbon-quickstart-typescript-6sjfuz) or [Javascript](https://codesandbox.io/p/sandbox/carbon-quickstart-j5pb2).
-    validations:
-      required: true
-  - type: textarea
-    id: current-behaviour
-    attributes:
-      label: Current behaviour
-      description: |
-        Please give a clear and concise description of the current behaviour.
+        A clear and concise description of the new feature. Please make the reason and use cases as detailed as possible. If applicable, add screenshots or screen recordings to help explain the request.
+
+        If you intend to submit a PR for this issue, tell us in description. Thanks!
+      placeholder: As a developer using Carbon, I want to [goal] so that [benefit].
     validations:
       required: true
   - type: textarea
     id: suggested-solution
     attributes:
-      label: Suggested Solution
+      label: Suggested solution
     validations:
-      required: false
+      required: true
   - type: input
     id: url
     attributes:
-      label: CodeSandbox or Storybook URL
+      label: Demo URL
       description: >-
-        Please fork one of our templates ([Typescript](https://codesandbox.io/p/sandbox/carbon-quickstart-typescript-6sjfuz) or [Javascript](https://codesandbox.io/s/carbon-quickstart-j5pb2)), and ensure you save your changes.
-        Alternatively, if your issue relates to [Storybook](https://carbon.sage.com) please link to the story.
-      placeholder: https://codesandbox.io/s/carbon-quickstart-j5pb2
+        If possible, please provide a link via [our Stackblitz template](https://stackblitz.com/fork/github/Parsium/carbon-starter) that can demonstrate the feature you are requesting.
+      placeholder: Reproduction URL
     validations:
       required: false
   - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: |
+        A clear and concise description of any alternative solutions or features you've tried or considered.
+    validations:
+      required: false
+ - type: textarea
     id: additional-info
     attributes:
-      label: Anything else we should know?
-      placeholder: Please describe any alternatives you've considered
+      label: Additional context
+      description: Anything else we should know?
     validations:
       required: false
   - type: checkboxes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,13 @@
 ### Proposed behaviour
 
 <!--
-A clear and concise description of what changes this PR makes.
-
-If applicable, add screenshots of a codesandbox to help explain your request. You can paste these directly into GitHub.
-
-Please DO NOT share screenshots or the source code of your project.
-
-You can create a codesandbox to show the behaviour before/after this pull request by forking this template https://codesandbox.io/s/carbon-quickstart-j5pb2
-
-If you include a CodeSandbox link, the bot will fork it with the new built version of carbon.
-If you have a commit that includes fixes #XXXX and issue #XXXX has a CodeSandbox link in the body, the bot will fork
-it with the new built version of carbon.
+A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
 -->
 
 ### Current behaviour
 
 <!--
-A clear and concise description of the behaviour before this change.
-
-If applicable, add screenshots. You can paste these directly into GitHub.
+A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
 -->
 
 ### Checklist
@@ -39,7 +27,7 @@ If applicable, add screenshots. You can paste these directly into GitHub.
 
 #### QA
 
-- [ ] Tested in CodeSandbox/storybook
+- [ ] Tested in provided StackBlitz sandbox/Storybook
 - [ ] Add new Playwright test coverage if required
 - [ ] Carbon implementation matches Design System/designs
 - [ ] UI Tests GitHub check reviewed if required
@@ -50,9 +38,9 @@ If applicable, add screenshots. You can paste these directly into GitHub.
 
 ### Testing instructions
 
-<!-- How can a reviewer test this PR? -->
+<!--
+How can a reviewer test this PR?
 
-The following CodeSandbox is an example of the broken behaviour.
-You can see the new behaviour by looking at the version in the comment by `codesandbox[bot]`.
-
-<!-- Add CodeSandbox here -->
+If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
+<https://stackblitz.com/fork/github/Parsium/carbon-starter>
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,9 @@ We use [GitHub Issues](https://github.com/Sage/carbon/issues) to keep track of i
 
 ### Reporting an issue
 
-Please provide as much as possible to help us replicate and understand the problem. The best way to do this is to provide a simplified example using Codesandbox. We have two templates available using [JavaScript](https://codesandbox.io/s/carbon-quickstart-j5pb2) and [TypeScript](https://codesandbox.io/s/carbon-quickstart-typescript-6sjfuz) to help you do this.
+Please provide as much as possible to help us replicate and understand the problem. The best way to do this is to provide a sandbox that reproduces the issue. We have a starter template to help you do this:
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/Parsium/carbon-starter)
 
 ### Proposing a large change
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Carbon [![npm](https://img.shields.io/npm/v/carbon-react.svg)](https://www.npmjs.com/package/carbon-react) [![Cypress](https://github.com/Sage/carbon/actions/workflows/cypress.yml/badge.svg)](https://github.com/Sage/carbon/actions/workflows/cypress.yml) [![Playwright](https://github.com/Sage/carbon/actions/workflows/playwright.yml/badge.svg)](https://github.com/Sage/carbon/actions/workflows/playwright.yml)
 
-Carbon is a [React](https://facebook.github.io/react/) component library developed by Sage.
+Carbon is a [React](https://react.dev/) component library developed by Sage.
 
 ## Getting started
 
@@ -8,7 +8,7 @@ Our [getting started guide](https://carbon.sage.com/?path=/story/getting-started
 
 ## Examples
 
-See the [storybook](https://carbon.sage.com/) for live examples.
+See our [docs](https://carbon.sage.com/) for live examples.
 
 ## Browser Support
 

--- a/docs/installation.stories.mdx
+++ b/docs/installation.stories.mdx
@@ -1,16 +1,25 @@
-import LinkTo from "@storybook/addon-links/react";
-
 <Meta title="Getting Started/Installation" />
 
 # Installation
 
 ## Contents
 
-- [Main installation](#main-installation)
-- [Peer dependencies](#peer-dependencies)
-- [Fonts and icons](#fonts-and-icons)
+- [Try Carbon](#try-carbon)
+- [Starting a new Carbon project](#starting-a-new-carbon-project)
+  - [Peer dependencies](#peer-dependencies)
+  - [Fonts and icons](#fonts-and-icons)
 
-## Main installation
+## Try Carbon
+
+You don't need to install anything to experiment with Carbon. Try playing with this live sandbox:
+
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/Parsium/carbon-starter)
+
+Or try Carbon locally on your computer, by [downloading or git cloning this GitHub template](https://github.com/Parsium/carbon-starter).
+
+> NOTE: You need to install **Node.js** and **npm** for local development.
+
+## Starting a new Carbon project
 
 Carbon is available as an [npm package](https://www.npmjs.com/package/carbon-react). To install it into your project run the following command:
 
@@ -18,9 +27,9 @@ Carbon is available as an [npm package](https://www.npmjs.com/package/carbon-rea
 npm install carbon-react
 ```
 
-## Peer dependencies
+### Peer dependencies
 
-You will need to install the following dependencies in your project, these are peer-dependencies of Carbon and are required.
+You will need to install the following dependencies in your project, as they are required for Carbon to work:
 
 ```shell
 npm install @sage/design-tokens@^4.0 react@^17.0 react-dom@^17.0 styled-components@^4.4.1
@@ -32,26 +41,32 @@ Carbon uses [draft-js](https://draftjs.org/) for the `TextEditor` or `Note` comp
 npm install draft-js
 ```
 
-## Fonts and icons
+### Fonts and icons
 
-Carbon requires the `Sage UI` and `CarbonIcons` fonts to display correctly. The CSS font face definitions are included in Carbon and can be imported directly in either your entry-point CSS:
+Carbon uses **Sage UI** font by default, or a fallback Sans-Serif font if it cannot find it. **Carbon does not come with Sage UI built in**, so make sure you have `@sage/design-tokens` installed as it provides the font assets:
+
+```shell
+npm install @sage/design-tokens@^4.0
+```
+
+For icons, Carbon comes with its own icon font out of the box, **CarbonIcons**, which is utilised by many Carbon components.
+
+To load both Sage UI and CarbonIcons into your project, add the following import to your entry-point CSS:
 
 ```css
 /* Import Sage UI and CarbonIcons fonts */
 @import "~carbon-react/lib/style/fonts.css";
 ```
 
-or your entry-point JavaScript:
+or this import to your entry-point JavaScript:
 
 ```js
 // Import Sage UI and CarbonIcons fonts
 import "carbon-react/lib/style/fonts.css";
 ```
 
-### Assets
+#### Self-storing font assets
 
-The font and icon assets themselves will **not** be automatically handled by Carbon, so you will be required to load these into your application yourself through your build system.
-
-Your build system must support CSS and file loading for this to work, e.g. `webpack` with `css-loader` and `file-loader`. This is pre-configured if you are using `create-react-app`, but it is possible to use other bundling solutions such as [Vite](https://vitejs.dev/) or [Parcel](https://parceljs.org/) if you wish.
-
-Note the `Sage UI` font assets themselves are provided by the [@sage/design-tokens](https://www.npmjs.com/package/@sage/design-tokens) library. If this has not been installed in your project beforehand, text will be rendered in the browser's default sans-serif font.
+If you intend to store the static Sage UI and CarbonIcons font assets directly in your own project, be aware **you will required to load these directly into your project yourself via your web bundler or build system**. Many popular web bundlers should have advice on how to achieve this:
+- [Webpack](https://webpack.js.org/guides/asset-modules/)
+- [Vite](https://vitejs.dev/guide/features.html#static-assets)

--- a/docs/usage.stories.mdx
+++ b/docs/usage.stories.mdx
@@ -1,20 +1,18 @@
-import LinkTo from "@storybook/addon-links/react";
-
 <Meta title="Getting Started/Usage" />
 
 # Usage
 
 ## Contents
 
-- [Quickstart](#quickstart)
+- [Quick start](#quick-start)
 - [Globals](#globals)
   - [Global styles](#global-styles)
   - [Theming](#theming)
   - [Localisation](#localisation)
 
-## Quickstart
+## Quick start
 
-A basic project `index.js` file would resemble this example:
+A basic project `index.(jsx|tsx)` file would resemble this example:
 
 ```jsx
 import React from "react";
@@ -37,10 +35,9 @@ const App = (props) => {
 ReactDOM.render(<App />, document.getElementById("app"));
 ```
 
-This can also be found in our Codesandbox templates:
+You can also find this in this live sandbox:
 
-- [JavaScript quickstart](https://codesandbox.io/s/carbon-quickstart-j5pb2).
-- [TypeScript quickstart](https://codesandbox.io/s/carbon-quickstart-typescript-6sjfuz)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/fork/github/Parsium/carbon-starter)
 
 ## Globals
 
@@ -67,7 +64,7 @@ Carbon supports two theming systems - the latest which uses Design Tokens in for
 
 The themes available in Carbon include:
 
-- **sage** - the latest theme which uses Design Tokens in form of CSS custom properties. _Note this theme requires installation of `@sage/design-tokens` library, otherwise styles fallback to the old mint theme for compatability._
+- **sage** - the latest theme which uses Design Tokens in form of CSS custom properties. _Note this theme requires installation of `@sage/design-tokens` library, otherwise styles fallback to the old mint theme for compatibility._
 - **mint**, **aegean** and **none** - legacy themes that use old theme properties consumed by [ThemeProvider from the styled-components library](https://styled-components.com/docs/advanced#theming).
 
 To supply the theme styles to your components, you can pass them via the <a href="../?path=/docs/carbon-provider--sage-theme" target="_self">Carbon Provider</a>.


### PR DESCRIPTION
### Proposed behaviour

- Replace all references to Codesandbox with link to [stackblitz starter template](https://stackblitz.com/fork/github/Parsium/carbon-starter)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Cypress automation tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in CodeSandbox/storybook
- [ ] Add new Cypress test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

- The Formik demo has not been updated yet as part of this PR: <http://localhost:9001/?path=/docs/documentation-validations--string-validation#formik-overview>
- Currently the code for the starter template used by Stackblitz is hosted externally: [Link to external repo](https://github.com/Parsium/carbon-starter). This ideally should be included in the Carbon repo in the future (see FE-6361).

### Testing instructions

- Check the edited files for any grammatical errors