### PR TITLE
feat(textarea): add new borderRadius prop - FE-6363

### DIFF
--- a/src/__internal__/input/__snapshots__/input-presentation.spec.tsx.snap
+++ b/src/__internal__/input/__snapshots__/input-presentation.spec.tsx.snap
@@ -20,7 +20,6 @@ exports[`InputPresentation renders presentational div and context provider for i
   align-items: stretch;
   background: var(--colorsUtilityYang100);
   border: 1px solid var(--colorsUtilityMajor300);
-  border-radius: var(--borderRadius050);
   box-sizing: border-box;
   cursor: text;
   display: -webkit-box;
@@ -32,6 +31,7 @@ exports[`InputPresentation renders presentational div and context provider for i
   flex-wrap: wrap;
   width: 100%;
   margin: 0;
+  border-radius: var(--borderRadius050);
   min-height: var(--sizing500);
 }
 

--- a/src/__internal__/input/__snapshots__/input.spec.tsx.snap
+++ b/src/__internal__/input/__snapshots__/input.spec.tsx.snap
@@ -4,7 +4,6 @@ exports[`Input renders with an input 1`] = `
 .c0 {
   background: transparent;
   border: none;
-  border-radius: var(--borderRadius050);
   color: var(--colorsUtilityYin090);
   -webkit-box-flex: 1;
   -webkit-flex-grow: 1;
@@ -15,6 +14,7 @@ exports[`Input renders with an input 1`] = `
   padding: 0;
   margin: 0;
   width: 30px;
+  border-radius: var(--borderRadius050);
 }
 
 .c0:-webkit-autofill {

--- a/src/__internal__/input/input-presentation.component.tsx
+++ b/src/__internal__/input/input-presentation.component.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+import { BorderRadiusType } from "../../components/box/box.component";
 import InputPresentationStyle, {
   StyledInputPresentationContainer,
 } from "./input-presentation.style";
@@ -29,6 +30,8 @@ export interface CommonInputPresentationProps extends ValidationProps {
   size?: Sizes;
   /** If true, the component has an icon rendered inside */
   hasIcon?: boolean;
+  /** Specify a custom border radius. Any valid border-radius design token, or an array of border-radius design tokens. */
+  borderRadius?: BorderRadiusType | BorderRadiusType[];
 }
 
 export interface InputPresentationProps extends CommonInputPresentationProps {
@@ -37,19 +40,20 @@ export interface InputPresentationProps extends CommonInputPresentationProps {
 }
 
 const InputPresentation = ({
+  align,
+  borderRadius = "borderRadius050",
   children,
-  positionedChildren,
-  prefix,
+  disabled,
+  error,
+  hasIcon,
+  info,
   inputWidth,
   maxWidth,
-  align,
-  disabled,
+  positionedChildren,
+  prefix,
   readOnly,
   size = "medium",
-  error,
   warning,
-  info,
-  hasIcon,
 }: InputPresentationProps): JSX.Element => {
   const { hasFocus, onMouseDown, onMouseEnter, onMouseLeave } = useContext(
     InputContext
@@ -93,6 +97,7 @@ const InputPresentation = ({
         info={info}
         validationRedesignOptIn={validationRedesignOptIn}
         hasIcon={hasIcon}
+        borderRadius={borderRadius}
       >
         {children}
       </InputPresentationStyle>

--- a/src/__internal__/input/input-presentation.style.ts
+++ b/src/__internal__/input/input-presentation.style.ts
@@ -69,19 +69,29 @@ const InputPresentationStyle = styled.div<
       | "warning"
       | "info"
       | "hasIcon"
+      | "borderRadius"
     > &
     Pick<CarbonProviderProps, "validationRedesignOptIn">
 >`
   align-items: stretch;
   background: var(--colorsUtilityYang100);
   border: 1px solid var(--colorsUtilityMajor300);
-  border-radius: var(--borderRadius050);
   box-sizing: border-box;
   cursor: text;
   display: flex;
   flex-wrap: wrap;
   width: 100%;
   margin: 0;
+
+  ${({ borderRadius }) => {
+    if (Array.isArray(borderRadius)) {
+      return `border-radius: ${borderRadius
+        .map((value) => `var(--${value})`)
+        .join(" ")};`;
+    }
+    return `border-radius: var(--${borderRadius});`;
+  }}
+
   ${({ size, hasIcon, align }) =>
     size &&
     css`

--- a/src/__internal__/input/input.component.tsx
+++ b/src/__internal__/input/input.component.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useContext, useRef, useCallback } from "react";
 import StyledInput from "./input.style";
 import { InputContext, InputGroupContext } from "../input-behaviour";
+import { BorderRadiusType } from "../../components/box/box.component";
 
 export interface CommonInputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> {
@@ -16,6 +17,8 @@ export interface CommonInputProps
   disabled?: boolean;
   /** HTML id attribute of the input */
   id?: string;
+  /** Specify a custom border radius for the input. Any valid border-radius design token, or an array of border-radius design tokens. */
+  inputBorderRadius?: BorderRadiusType | BorderRadiusType[];
   /** A callback to retrieve the input reference */
   inputRef?: (
     input: React.RefObject<HTMLInputElement | HTMLTextAreaElement>
@@ -101,6 +104,7 @@ const Input = React.forwardRef<
       id,
       name,
       validationIconId,
+      inputBorderRadius = "borderRadius050",
       ...rest
     }: InputProps,
     ref
@@ -235,6 +239,7 @@ const Input = React.forwardRef<
         onBlur={handleBlur}
         onClick={handleClick}
         onChange={handleChange}
+        inputBorderRadius={inputBorderRadius}
       />
     );
   }

--- a/src/__internal__/input/input.style.ts
+++ b/src/__internal__/input/input.style.ts
@@ -2,11 +2,13 @@ import styled, { css } from "styled-components";
 import { CommonInputProps } from "./input.component";
 
 const StyledInput = styled.input<
-  Pick<CommonInputProps, "align" | "disabled" | "readOnly">
+  Pick<
+    CommonInputProps,
+    "align" | "disabled" | "readOnly" | "inputBorderRadius"
+  >
 >`
   background: transparent;
   border: none;
-  border-radius: var(--borderRadius050);
   color: var(--colorsUtilityYin090);
   flex-grow: 1;
   font-size: var(--fontSizes100);
@@ -19,6 +21,15 @@ const StyledInput = styled.input<
     background-clip: text;
     -webkit-background-clip: text;
   }
+
+  ${({ inputBorderRadius }) => {
+    if (Array.isArray(inputBorderRadius)) {
+      return `border-radius: ${inputBorderRadius
+        .map((value) => `var(--${value})`)
+        .join(" ")};`;
+    }
+    return `border-radius: var(--${inputBorderRadius});`;
+  }}
 
   ${({ align }) =>
     align &&

--- a/src/components/box/box.component.tsx
+++ b/src/components/box/box.component.tsx
@@ -24,7 +24,10 @@ export type BoxSizing = "content-box" | "border-box";
 
 type DesignTokensType = keyof typeof DesignTokens;
 type BoxShadowsType = Extract<DesignTokensType, `boxShadow${string}`>;
-type BorderRadiusType = Extract<DesignTokensType, `borderRadius${string}`>;
+export type BorderRadiusType = Extract<
+  DesignTokensType,
+  `borderRadius${string}`
+>;
 
 export interface BoxProps
   extends FlexboxProps,

--- a/src/components/textarea/textarea-test.stories.tsx
+++ b/src/components/textarea/textarea-test.stories.tsx
@@ -92,6 +92,22 @@ export default {
         type: "text",
       },
     },
+    borderRadius: {
+      options: [
+        "",
+        "borderRadius000",
+        "borderRadius010",
+        "borderRadius025",
+        "borderRadius050",
+        "borderRadius100",
+        "borderRadius200",
+        "borderRadius400",
+        "borderRadiusCircle",
+      ],
+      control: {
+        type: "select",
+      },
+    },
   },
   args: {
     expandable: false,
@@ -111,6 +127,7 @@ export default {
     labelAlign: undefined,
     adaptiveLabelBreakpoint: undefined,
     required: false,
+    borderRadius: "borderRadius050",
   },
 };
 

--- a/src/components/textarea/textarea.component.tsx
+++ b/src/components/textarea/textarea.component.tsx
@@ -20,6 +20,7 @@ import ValidationMessage from "../../__internal__/validation-message";
 import Box from "../box";
 import Logger from "../../__internal__/utils/logger";
 import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
+import { BorderRadiusType } from "../box/box.component";
 
 export interface TextareaProps
   extends ValidationProps,
@@ -117,10 +118,13 @@ export interface TextareaProps
   Pass string to display icon, tooltip and orange border
   Pass true boolean to only display orange border */
   warning?: boolean | string;
+  /** Specify a custom border radius for the component. Any valid border-radius design token, or an array of border-radius design tokens. */
+  borderRadius?: BorderRadiusType | BorderRadiusType[];
 }
 
 let deprecateInputRefWarnTriggered = false;
 let deprecateUncontrolledWarnTriggered = false;
+let warnBorderRadiusArrayTooLarge = false;
 
 export const Textarea = React.forwardRef(
   (
@@ -162,6 +166,7 @@ export const Textarea = React.forwardRef(
       "data-role": dataRole,
       helpAriaLabel,
       inputRef,
+      borderRadius,
       ...rest
     }: TextareaProps,
     ref: React.ForwardedRef<HTMLTextAreaElement>
@@ -203,6 +208,18 @@ export const Textarea = React.forwardRef(
       Logger.deprecate(
         "Uncontrolled behaviour in `Textarea` is deprecated and support will soon be removed. Please make sure all your inputs are controlled."
       );
+    }
+
+    if (
+      Array.isArray(borderRadius) &&
+      borderRadius.length > 4 &&
+      !warnBorderRadiusArrayTooLarge
+    ) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "The `borderRadius` prop in `Textarea` component only supports up to 4 values."
+      );
+      warnBorderRadiusArrayTooLarge = true;
     }
 
     const minHeight = useRef(MIN_HEIGHT);
@@ -309,6 +326,7 @@ export const Textarea = React.forwardRef(
         error={error}
         warning={warning}
         info={info}
+        borderRadius={borderRadius}
       >
         <Input
           aria-invalid={!!error}
@@ -328,6 +346,7 @@ export const Textarea = React.forwardRef(
           as="textarea"
           inputRef={inputRef}
           validationIconId={validationRedesignOptIn ? undefined : validationId}
+          inputBorderRadius={borderRadius}
           {...rest}
         />
         {children}

--- a/src/components/textarea/textarea.pw.tsx
+++ b/src/components/textarea/textarea.pw.tsx
@@ -1013,7 +1013,7 @@ test.describe("Accessibility tests for Textarea component", () => {
   });
 });
 
-test("should have the expected border radius styling", async ({
+test("should have the expected default border radius styling", async ({
   mount,
   page,
 }) => {
@@ -1022,6 +1022,30 @@ test("should have the expected border radius styling", async ({
   const inputElementParent = getElement(page, "input").locator("..");
 
   await expect(inputElementParent).toHaveCSS("border-radius", "4px");
+});
+
+test("should have the expected custom border radius styling", async ({
+  mount,
+  page,
+}) => {
+  await mount(<TextareaComponent borderRadius="borderRadius400" />);
+
+  const inputElementParent = getElement(page, "input").locator("..");
+
+  await expect(inputElementParent).toHaveCSS("border-radius", "32px");
+});
+
+test("should have the expected custom border radius styling when an array is passed", async ({
+  mount,
+  page,
+}) => {
+  await mount(
+    <TextareaComponent borderRadius={["borderRadius400", "borderRadius010"]} />
+  );
+
+  const inputElementParent = getElement(page, "input").locator("..");
+
+  await expect(inputElementParent).toHaveCSS("border-radius", "32px 1px");
 });
 
 test("should not change the scroll position of a scrollable container when typing", async ({

--- a/src/components/textarea/textarea.spec.tsx
+++ b/src/components/textarea/textarea.spec.tsx
@@ -711,12 +711,65 @@ describe("componentWillUnmount", () => {
     });
   });
 
-  it("renders with the expected border radius styling", () => {
+  it("renders with the expected default border radius styling", () => {
     assertStyleMatch(
       {
         borderRadius: "var(--borderRadius050)",
       },
       mount(<Textarea />).find(StyledInputPresentation)
     );
+  });
+
+  it("renders with the expected custom border radius styling", () => {
+    assertStyleMatch(
+      {
+        borderRadius: "var(--borderRadius200)",
+      },
+      mount(<Textarea borderRadius="borderRadius200" />).find(
+        StyledInputPresentation
+      )
+    );
+  });
+
+  it("renders with the expected custom border radius styling as an array", () => {
+    assertStyleMatch(
+      {
+        borderRadius:
+          "var(--borderRadius050) var(--borderRadius100) var(--borderRadius200) var(--borderRadius400)",
+      },
+      mount(
+        <Textarea
+          borderRadius={[
+            "borderRadius050",
+            "borderRadius100",
+            "borderRadius200",
+            "borderRadius400",
+          ]}
+        />
+      ).find(StyledInputPresentation)
+    );
+  });
+
+  it("fires a console warning if more than four values are passed", () => {
+    const consoleSpy = jest.spyOn(console, "warn");
+    consoleSpy.mockImplementation(() => {});
+
+    mount(
+      <Textarea
+        borderRadius={[
+          "borderRadius050",
+          "borderRadius100",
+          "borderRadius200",
+          "borderRadius400",
+          "borderRadius050",
+        ]}
+      />
+    );
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "The `borderRadius` prop in `Textarea` component only supports up to 4 values."
+    );
+
+    consoleSpy.mockRestore();
   });
 });

--- a/src/components/textarea/textarea.stories.mdx
+++ b/src/components/textarea/textarea.stories.mdx
@@ -157,6 +157,15 @@ You can use the `required` prop to indicate if the field is mandatory.
   <Story name="required" story={stories.RequiredStory} />
 </Canvas>
 
+#### Customer Border Radius
+
+The `borderRadius` prop accepts either a single design token, or an array of them, that will be applied as the CSS `border-radius` property.
+See [MDN docs](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius) for examples of how this works with multiple values.
+
+<Canvas>
+  <Story name="with borderRadius" story={stories.BorderRadiusStory}/>
+</Canvas>
+
 ### Validations
 
 Validation status can be set by passing `error`, `warning` or `info` prop to the component

--- a/src/components/textarea/textarea.stories.tsx
+++ b/src/components/textarea/textarea.stories.tsx
@@ -269,3 +269,61 @@ export const ValidationBooleanStory: ComponentStory<typeof Textarea> = () => {
     </>
   );
 };
+
+export const BorderRadiusStory: ComponentStory<typeof Textarea> = () => {
+  const [stateOne, setStateOne] = useState("");
+  const [stateTwo, setStateTwo] = useState("");
+  const [stateThree, setStateThree] = useState("");
+  const [stateFour, setStateFour] = useState("");
+  const setValueOne = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setStateOne(target.value);
+  };
+  const setValueTwo = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setStateTwo(target.value);
+  };
+  const setValueThree = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setStateThree(target.value);
+  };
+  const setValueFour = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setStateFour(target.value);
+  };
+  return (
+    <>
+      <Textarea
+        label="Textarea with borderRadius100"
+        value={stateOne}
+        onChange={setValueOne}
+        borderRadius="borderRadius100"
+      />
+
+      <Textarea
+        mt={4}
+        label="Textarea with an array of two values"
+        value={stateTwo}
+        onChange={setValueTwo}
+        borderRadius={["borderRadius400", "borderRadius025"]}
+      />
+
+      <Textarea
+        mt={4}
+        label="Textarea with an array of three values"
+        value={stateThree}
+        onChange={setValueThree}
+        borderRadius={["borderRadius400", "borderRadius025", "borderRadius100"]}
+      />
+
+      <Textarea
+        mt={4}
+        label="Textarea with an array of four values"
+        value={stateFour}
+        onChange={setValueFour}
+        borderRadius={[
+          "borderRadius400",
+          "borderRadius025",
+          "borderRadius100",
+          "borderRadius400",
+        ]}
+      />
+    </>
+  );
+};


### PR DESCRIPTION
### Proposed behaviour

Allow a custom border radius to be specified on Textarea component

![Screenshot 2024-02-12 at 15 49 37](https://github.com/Sage/carbon/assets/56251247/17d9e22c-f21e-41d8-a82b-59695de2e884)

### Current behaviour

No option to apply a custom border radius to Textarea component

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A
### Testing instructions

- New story has been created called `with borderRadius`. This story should render has expected.
- `Controls` for `borderRadius` have been added to the `test` example of Textarea.
- There should be no visual regressions with Textarea. 