### PR TITLE
feat(loader): add gradient color to component

### DIFF
--- a/src/components/loader/loader-square.spec.tsx
+++ b/src/components/loader/loader-square.spec.tsx
@@ -5,6 +5,11 @@ import StyledLoaderSquare, {
 } from "./loader-square.style";
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
+import Loader from ".";
+
+jest.mock("../../hooks/useMediaQuery", () => {
+  return jest.fn(() => true);
+});
 
 function render(props: StyledLoaderSquareProps = {}) {
   return mount(<StyledLoaderSquare {...props} />);
@@ -12,18 +17,54 @@ function render(props: StyledLoaderSquareProps = {}) {
 
 describe("Loader square", () => {
   let wrapper;
-  it("renders as expected", () => {
-    wrapper = render();
+
+  it.each([0, 1, 2])("each loader square renders as expected", (index) => {
+    wrapper = mount(<Loader />);
     assertStyleMatch(
       {
         backgroundColor: "var(--colorsActionMajor500)",
-        height: "12px",
-        width: "12px",
-        marginRight: "6px",
+        height: "16px",
+        width: "16px",
+        marginRight: "8px",
         borderRadius: "var(--borderRadiusCircle)",
       },
-      wrapper
+      wrapper.find(StyledLoaderSquare).at(index)
     );
+  });
+
+  describe("when the variant prop is set to 'gradient'", () => {
+    it("first loader square has Salem (#13A038) background color", () => {
+      wrapper = mount(<Loader variant="gradient" />);
+
+      assertStyleMatch(
+        {
+          backgroundColor: "#13A038",
+        },
+        wrapper.find(StyledLoaderSquare).at(0)
+      );
+    });
+
+    it("second loader square has Cerulean (#0092DB) background color", () => {
+      wrapper = mount(<Loader variant="gradient" />);
+
+      assertStyleMatch(
+        {
+          backgroundColor: "#0092DB",
+        },
+        wrapper.find(StyledLoaderSquare).at(1)
+      );
+    });
+
+    it("third loader square has Electric Violet (#8F49FE) background color", () => {
+      wrapper = mount(<Loader variant="gradient" />);
+
+      assertStyleMatch(
+        {
+          backgroundColor: "#8F49FE",
+        },
+        wrapper.find(StyledLoaderSquare).at(2)
+      );
+    });
   });
 
   describe("when inside button", () => {

--- a/src/components/loader/loader-square.style.ts
+++ b/src/components/loader/loader-square.style.ts
@@ -8,6 +8,8 @@ export interface StyledLoaderSquareProps {
   isInsideButton?: boolean;
   /** Applies slate color. Available only when isInsideButton is true. */
   isActive?: boolean;
+  /** The background color of each loader square */
+  backgroundColor?: string;
 }
 
 const loaderAnimation = keyframes`
@@ -53,9 +55,9 @@ const getDimentions = (
 };
 
 const StyledLoaderSquare = styled.div<StyledLoaderSquareProps>`
-  ${({ size, isInsideButton, isActive, theme }) => css`
+  ${({ size, isInsideButton, isActive, theme, backgroundColor }) => css`
     animation: ${loaderAnimation} 1s infinite ease-in-out both;
-    background-color: var(--colorsActionMajor500);
+    background-color: ${backgroundColor};
     display: inline-block;
     ${getDimentions(size, theme.roundedCornersOptOut)}
 

--- a/src/components/loader/loader-test.stories.tsx
+++ b/src/components/loader/loader-test.stories.tsx
@@ -29,6 +29,12 @@ export default {
         type: "select",
       },
     },
+    variant: {
+      options: ["default", "colorful"],
+      control: {
+        type: "select",
+      },
+    },
   },
 };
 
@@ -36,6 +42,7 @@ export const Default = ({
   isInsideButton,
   size,
   isActive,
+  variant,
   ...args
 }: LoaderProps) => {
   if (isInsideButton) {
@@ -46,24 +53,17 @@ export const Default = ({
             isInsideButton,
             size,
             isActive,
+            variant,
             ...args,
           }}
         />
       </Button>
     );
   }
-  return <Loader size={size} />;
+  return <Loader size={size} variant={variant} />;
 };
 
 Default.storyName = "default";
 Default.args = {
   size: "medium",
-};
-
-export const LoaderInsideButtonTest = (props: LoaderProps) => {
-  return (
-    <Button buttonType="primary" aria-label="Loading">
-      <Loader isInsideButton {...props} />
-    </Button>
-  );
 };

--- a/src/components/loader/loader.component.tsx
+++ b/src/components/loader/loader.component.tsx
@@ -12,14 +12,17 @@ import StyledLoaderSquare, {
 } from "./loader-square.style";
 
 export interface LoaderProps
-  extends StyledLoaderSquareProps,
+  extends Omit<StyledLoaderSquareProps, "backgroundColor">,
     MarginProps,
     TagProps {
+  /** Toggle between the default variant and gradient variant */
+  variant?: string;
   /** Specify a custom accessible name for the Loader component */
   "aria-label"?: string;
 }
 
 export const Loader = ({
+  variant = "default",
   "aria-label": ariaLabel,
   size = "medium",
   isInsideButton,
@@ -32,6 +35,14 @@ export const Loader = ({
     "screen and (prefers-reduced-motion: no-preference)"
   );
 
+  const loaderSquareProps = {
+    isInsideButton,
+    isActive,
+    size,
+    variant,
+  };
+
+  // FE-6368 has been raised for the below, changed hex values for design tokens (when added)
   return (
     <StyledLoader
       aria-label={ariaLabel || l.loader.loading()}
@@ -43,21 +54,15 @@ export const Loader = ({
         l.loader.loading()
       ) : (
         <>
-          <StyledLoaderSquare
-            isInsideButton={isInsideButton}
-            isActive={isActive}
-            size={size}
-          />
-          <StyledLoaderSquare
-            isInsideButton={isInsideButton}
-            isActive={isActive}
-            size={size}
-          />
-          <StyledLoaderSquare
-            isInsideButton={isInsideButton}
-            isActive={isActive}
-            size={size}
-          />
+          {["#13A038", "#0092DB", "#8F49FE"].map((color) => (
+            <StyledLoaderSquare
+              key={color}
+              backgroundColor={
+                variant === "gradient" ? color : "var(--colorsActionMajor500)"
+              }
+              {...loaderSquareProps}
+            />
+          ))}
         </>
       )}
     </StyledLoader>

--- a/src/components/loader/loader.stories.mdx
+++ b/src/components/loader/loader.stories.mdx
@@ -47,9 +47,17 @@ import Loader from "carbon-react/lib/components/loader";
 ### Default
 
 This example of the Loader component demonstrates how it will appear as default.
-
+ 
 <Canvas>
   <Story name="default" story={stories.Default} />
+</Canvas>
+
+### with gradient variant
+
+This is an example of the Loader component with the `variant` prop set to `gradient`.
+
+<Canvas>
+  <Story name="with gradient variant" story={stories.Variant} />
 </Canvas>
 
 ### Small

--- a/src/components/loader/loader.stories.tsx
+++ b/src/components/loader/loader.stories.tsx
@@ -7,6 +7,10 @@ import Box from "../box";
 
 export const Default: ComponentStory<typeof Loader> = () => <Loader />;
 
+export const Variant: ComponentStory<typeof Loader> = () => (
+  <Loader variant="gradient" />
+);
+
 export const Small: ComponentStory<typeof Loader> = () => (
   <Loader size="small" />
 );


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

adds a `color` prop, with the option for a `gradient` type . This new variant will give each loader a different color (green, blue, purple) to achieve a gradient appearance.

![Screenshot 2024-02-09 at 14 50 37](https://github.com/Sage/carbon/assets/114918852/13d98ea1-a742-4634-bf34-27241640bf7c)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, there is no way to achieve a gradient appearance on the `Loader` component, as each loader has the same set colour.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
