### PR TITLE
fix(tabs): remove negative margin to resolve scrollbar appearing

### DIFF
--- a/src/components/tabs/__internal__/tabs-header/tabs-header.spec.tsx
+++ b/src/components/tabs/__internal__/tabs-header/tabs-header.spec.tsx
@@ -32,7 +32,6 @@ describe("TabsHeader", () => {
         display: "flex",
         cursor: "default",
         listStyle: "none",
-        margin: "-3px",
         padding: "3px",
       },
       renderStyles()
@@ -127,12 +126,6 @@ describe("TabsHeader", () => {
 
   describe("custom target styling", () => {
     const wrapper = render({ isInSidebar: true, position: "left" }, mount);
-    assertStyleMatch(
-      {
-        margin: "-3px",
-      },
-      wrapper.find(StyledTabsHeaderList)
-    );
     assertStyleMatch(
       {
         minWidth: "100%",

--- a/src/components/tabs/__internal__/tabs-header/tabs-header.style.ts
+++ b/src/components/tabs/__internal__/tabs-header/tabs-header.style.ts
@@ -67,7 +67,6 @@ const StyledTabsHeaderList = styled.div<StyledTabsHeaderListProps>`
     `}
   cursor: default;
   list-style: none;
-  margin: -${outlineWidth};
   padding: ${outlineWidth};
   overflow-x: auto;
   position: relative;


### PR DESCRIPTION
### Proposed behaviour

Remove negative margin to resolve issue where horizontal is appearing unnecessarily

fix #6511

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

A horizontal scrollbar appears unnecessarily on the Tabs component

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required

#### QA

- [x] Tested in provided StackBlitz sandbox/Storybook
- [x] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

https://stackblitz.com/edit/horizontal-scrollbar-appears-tabs?file=src%2FApp.tsx

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
