### PR TITLE
fix(submenu): ensure that the last segment child has the correct styling - FE-6308

### DIFF
--- a/src/components/menu/__internal__/submenu/submenu.spec.tsx
+++ b/src/components/menu/__internal__/submenu/submenu.spec.tsx
@@ -20,6 +20,7 @@ import menuConfigVariants from "../../menu.config";
 import { VariantType } from "../../menu-item";
 import GlobalHeader from "../../../global-header";
 import Logger from "../../../../__internal__/utils/logger";
+import StyledScrollableBlock from "../../scrollable-block/scrollable-block.style";
 
 // mock Logger.deprecate so that Typography (used for the alert dialog's heading) doesn't trigger a warning while running the tests,
 // and nor does the uncontrolled Search which is needed for coverage
@@ -521,7 +522,7 @@ describe("Submenu component", () => {
       });
     });
 
-    it.each([`a`, `button`, `> span`, `> div`])(
+    it.each([`a`, `button`])(
       "should have the expected border-radius styling on the %s element of the last menu item",
       (modifier) => {
         assertStyleMatch(
@@ -530,10 +531,23 @@ describe("Submenu component", () => {
             borderBottomLeftRadius: "var(--borderRadius100)",
           },
           wrapper.find(StyledSubmenu),
-          { modifier: `${StyledMenuItem}:last-child ${modifier}` }
+          { modifier: `${StyledMenuItem}:last-of-type ${modifier}` }
         );
       }
     );
+
+    it("should have the expected border-radius styling on a menu item inside scrollable block when the item is not in a segment", () => {
+      assertStyleMatch(
+        {
+          borderBottomRightRadius: "var(--borderRadius000)",
+          borderBottomLeftRadius: "var(--borderRadius100)",
+        },
+        wrapper.find(StyledSubmenu),
+        {
+          modifier: `:has(> ${StyledScrollableBlock}):not(+ ${StyledMenuItem}):not(> ul)`,
+        }
+      );
+    });
   });
 
   describe("keyboard navigation", () => {

--- a/src/components/menu/__internal__/submenu/submenu.style.ts
+++ b/src/components/menu/__internal__/submenu/submenu.style.ts
@@ -1,4 +1,7 @@
 import styled, { css } from "styled-components";
+
+import { StyledSegmentChildren } from "../../../menu/menu-segment-title/menu-segment-title.style";
+import StyledScrollableBlock from "../../scrollable-block/scrollable-block.style";
 import { baseTheme } from "../../../../style/themes";
 import { StyledLink } from "../../../link/link.style";
 import { StyledMenuItem } from "../../menu.style";
@@ -91,12 +94,20 @@ const StyledSubmenu = styled.ul<StyledSubmenuProps>`
       overflow-y: auto;
       ${maxHeight && `max-height: ${maxHeight};`}
 
-      ${StyledMenuItem}:last-child a,
-      ${StyledMenuItem}:last-child button,
-      ${StyledMenuItem}:last-child > span,
-      ${StyledMenuItem}:last-child > div {
-        border-bottom-left-radius: var(--borderRadius100);
+      ${StyledMenuItem}:last-of-type a, ${StyledMenuItem}:last-of-type button {
         border-bottom-right-radius: var(--borderRadius100);
+        border-bottom-left-radius: var(--borderRadius100);
+      }
+
+      ${StyledSegmentChildren} > ${StyledMenuItem}:last-of-type a, 
+      ${StyledSegmentChildren} > ${StyledMenuItem}:last-of-type button {
+        border-bottom-right-radius: var(--borderRadius000);
+        border-bottom-left-radius: var(--borderRadius000);
+      }
+
+      :has(> ${StyledScrollableBlock}):not(+ ${StyledMenuItem}):not(> ul) {
+        border-bottom-right-radius: var(--borderRadius000);
+        border-bottom-left-radius: var(--borderRadius100);
       }
     `}
 

--- a/src/components/menu/menu-segment-title/menu-segment-title.component.tsx
+++ b/src/components/menu/menu-segment-title/menu-segment-title.component.tsx
@@ -37,7 +37,11 @@ const MenuSegmentTitle = React.forwardRef<HTMLDivElement, MenuTitleProps>(
         >
           {text}
         </StyledTitle>
-        {children && <StyledSegmentChildren>{children}</StyledSegmentChildren>}
+        {children && (
+          <StyledSegmentChildren data-element="segment-child">
+            {children}
+          </StyledSegmentChildren>
+        )}
       </StyledMenuItem>
     );
   }

--- a/src/components/menu/menu-test.stories.tsx
+++ b/src/components/menu/menu-test.stories.tsx
@@ -1,10 +1,17 @@
 import React, { useState, useEffect } from "react";
 import { action } from "@storybook/addon-actions";
-import { Menu, MenuItem, MenuFullscreen, MenuFullscreenProps } from ".";
+import {
+  Menu,
+  MenuItem,
+  MenuFullscreen,
+  MenuFullscreenProps,
+  MenuSegmentTitle,
+} from ".";
 import { MenuType } from "./menu.context";
 import Search from "../search";
 import NavigationBar, { NavigationBarProps } from "../navigation-bar";
 import GlobalHeader from "../global-header";
+import Box from "../box";
 
 export default {
   title: "Menu/Test",
@@ -14,6 +21,7 @@ export default {
     "InGlobalHeaderStory",
     "InNavigationBarStory",
     "MenuFullScreenKeysTest",
+    "MenuWithTwoSegments",
   ],
   parameters: {
     info: { disable: true },
@@ -256,5 +264,33 @@ export const MenuFullScreenKeysTest = () => {
       </MenuItem>
       <UpdatingSubmenu />
     </MenuFullscreen>
+  );
+};
+
+export const MenuWithTwoSegments = () => {
+  return (
+    <Box margin="0 25px">
+      <Menu menuType="black">
+        <MenuItem submenu="Menu Item">
+          <MenuItem href="#" minWidth="200px">
+            Submenu
+          </MenuItem>
+          <MenuSegmentTitle text="segment title 1" variant="alternate">
+            <MenuItem href="#" variant="alternate">
+              Menu Item 1
+            </MenuItem>
+          </MenuSegmentTitle>
+          <MenuSegmentTitle text="segment title 2" variant="alternate">
+            <MenuItem href="#" variant="alternate">
+              Menu Item 2
+            </MenuItem>
+            <MenuItem href="#" variant="alternate">
+              Menu Item 3
+            </MenuItem>
+          </MenuSegmentTitle>
+          <MenuItem href="#">Menu Item 4</MenuItem>
+        </MenuItem>
+      </Menu>
+    </Box>
   );
 };

--- a/src/components/menu/menu.pw.tsx
+++ b/src/components/menu/menu.pw.tsx
@@ -2358,7 +2358,7 @@ test.describe(
       const scrollableItem = scrollBlock(page).locator("a").last();
       await expect(scrollableItem).toHaveCSS(
         "border-radius",
-        "0px 0px 0px 8px"
+        "0px 0px 8px 8px"
       );
     });
 

--- a/src/components/menu/scrollable-block/scrollable-block.spec.tsx
+++ b/src/components/menu/scrollable-block/scrollable-block.spec.tsx
@@ -11,9 +11,6 @@ import MenuDivider from "../menu-divider/menu-divider.component";
 import Search from "../../search";
 import { assertStyleMatch } from "../../../__spec_helper__/test-utils";
 import StyledScrollableBlock from "./scrollable-block.style";
-import StyledBox from "../../box/box.style";
-import { StyledMenuItem } from "../menu.style";
-import { StyledLink } from "../../link/link.style";
 import Logger from "../../../__internal__/utils/logger";
 
 // mock Logger.deprecate so that Typography (used for the alert dialog's heading) doesn't trigger a warning while running the tests
@@ -111,36 +108,6 @@ describe("ScrollableBlock", () => {
           );
         });
       });
-
-      it("should apply the expected border-radius styling on the list container element", () => {
-        assertStyleMatch(
-          {
-            borderRadius: "var(--borderRadius000)",
-          },
-          render(menuType, { variant: "default" }),
-          { modifier: `${StyledBox}` }
-        );
-      });
-
-      it.each([
-        ["StyledLink", `${StyledLink}`],
-        ["a", "a"],
-        ["button", "button"],
-      ])(
-        "should apply the expected border-radius styling on the %s element of the last menu item",
-        (_, modifier) => {
-          assertStyleMatch(
-            {
-              borderBottomLeftRadius: "var(--borderRadius100)",
-              borderBottomRightRadius: "var(--borderRadius000)",
-            },
-            (wrapper = render(menuType, { variant: "default" })),
-            {
-              modifier: `${StyledBox} ${StyledMenuItem}:last-child ${modifier}`,
-            }
-          );
-        }
-      );
     }
   );
 

--- a/src/components/menu/scrollable-block/scrollable-block.style.ts
+++ b/src/components/menu/scrollable-block/scrollable-block.style.ts
@@ -4,8 +4,6 @@ import menuConfigVariants from "../menu.config";
 import { MenuType } from "../menu.context";
 import { VariantType } from "../menu-item";
 import StyledBox from "../../box/box.style";
-import { StyledMenuItem } from "../menu.style";
-import { StyledLink } from "../../link/link.style";
 
 interface StyledScrollableBlockProps {
   menuType: MenuType;
@@ -23,13 +21,6 @@ const StyledScrollableBlock = styled.li<StyledScrollableBlockProps>`
     ${StyledBox} {
       border-radius: var(--borderRadius000);
       border-bottom-left-radius: var(--borderRadius100);
-
-      ${StyledMenuItem}:last-child ${StyledLink},
-      ${StyledMenuItem}:last-child a,
-      ${StyledMenuItem}:last-child button {
-        border-bottom-left-radius: var(--borderRadius100);
-        border-bottom-right-radius: var(--borderRadius000);
-      }
     }
   `}
 `;


### PR DESCRIPTION
The last child of the segment children was having the corners rounded, when it should not have rounded corners.

fixes #6488

### Proposed behaviour

Ensure that the last child of a segment in a submenu does not have rounded corners.

https://github.com/Sage/carbon/assets/56251247/2cce2370-9175-46c8-85d1-e843e5fa6d03

### Current behaviour

Each last child of a segment in a submenu has rounded corners.

https://github.com/Sage/carbon/assets/56251247/ffabdb67-36a0-46e5-b570-d57fbeabaf8f

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Instructions to follow