### PR TITLE
feat(dismissible-box): allows a custom data role to close button and translations to aria label - FE-6309

### DIFF
--- a/src/components/dismissible-box/dismissible-box-test.stories.tsx
+++ b/src/components/dismissible-box/dismissible-box-test.stories.tsx
@@ -27,6 +27,11 @@ export default {
         type: "select",
       },
     },
+    closeButtonDataProps: {
+      control: {
+        type: "object",
+      },
+    },
   },
 };
 

--- a/src/components/dismissible-box/dismissible-box.component.tsx
+++ b/src/components/dismissible-box/dismissible-box.component.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { SpaceProps } from "styled-system";
 
+import useLocale from "../../hooks/__internal__/useLocale";
 import {
   StyledDismissibleBox,
   StyledDismissibleBoxProps,
@@ -8,13 +9,17 @@ import {
 import IconButton from "../icon-button";
 import Icon from "../icon";
 import { BoxProps } from "../box";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 export interface DismissibleBoxProps
   extends SpaceProps,
     StyledDismissibleBoxProps,
-    Omit<BoxProps, "display" | "justifyContent"> {
+    Omit<BoxProps, "display" | "justifyContent">,
+    Omit<TagProps, "data-component"> {
   /** The content to render in the component */
   children?: React.ReactNode;
+  /** Data tag prop bag for close Button */
+  closeButtonDataProps?: TagProps;
   /** Callback to be called when the close icon button is clicked */
   onClose: (
     e:
@@ -30,23 +35,36 @@ export interface DismissibleBoxProps
 
 export const DismissibleBox = ({
   children,
+  closeButtonDataProps,
   onClose,
   borderRadius = "borderRadius100",
   ...rest
-}: DismissibleBoxProps) => (
-  <StyledDismissibleBox
-    p="20px 24px 20px 20px"
-    data-component="dismissible-box"
-    borderRadius={borderRadius}
-    {...rest}
-  >
-    {children}
-    <span data-element="close-button-wrapper">
-      <IconButton onClick={onClose} aria-label="close-button" ml={3}>
-        <Icon type="close" color="--colorsActionMinor500" />
-      </IconButton>
-    </span>
-  </StyledDismissibleBox>
-);
+}: DismissibleBoxProps) => {
+  const locale = useLocale();
+
+  return (
+    <StyledDismissibleBox
+      p="20px 24px 20px 20px"
+      data-component="dismissible-box"
+      borderRadius={borderRadius}
+      {...rest}
+    >
+      {children}
+      <span data-element="close-button-wrapper">
+        <IconButton
+          onClick={onClose}
+          aria-label={locale.dismissibleBox.ariaLabels.close()}
+          ml={3}
+          {...tagComponent("close-button", {
+            "data-element": "close-button",
+            ...closeButtonDataProps,
+          })}
+        >
+          <Icon type="close" color="--colorsActionMinor500" />
+        </IconButton>
+      </span>
+    </StyledDismissibleBox>
+  );
+};
 
 export default DismissibleBox;

--- a/src/components/dismissible-box/dismissible-box.pw.tsx
+++ b/src/components/dismissible-box/dismissible-box.pw.tsx
@@ -10,7 +10,10 @@ import {
   WithNoLeftBorderHighlight,
 } from "../../../src/components/dismissible-box/components.test-pw";
 import dismissibleBoxDataComponent from "../../../playwright/components/dismissible-box/index";
-import { icon } from "../../../playwright/components/index";
+import {
+  icon,
+  getDataElementByValue,
+} from "../../../playwright/components/index";
 import {
   assertCssValueIsApproximately,
   checkAccessibility,
@@ -98,6 +101,38 @@ test.describe("DismissibleBox component", () => {
       });
     }
   );
+
+  test("should have the expected data-role attribute on the IconButton, when a custom data-role is provided", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <DefaultDismissibleBox closeButtonDataProps={{ "data-role": "Foo" }} />
+    );
+
+    const closeButton = getDataElementByValue(
+      page,
+      "close-button-wrapper"
+    ).locator("button");
+
+    await expect(closeButton).toHaveAttribute("data-role", "Foo");
+  });
+
+  test("should have the expected data-element attribute on the IconButton, when a custom data-element is provided", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <DefaultDismissibleBox closeButtonDataProps={{ "data-element": "Bar" }} />
+    );
+
+    const closeButton = getDataElementByValue(
+      page,
+      "close-button-wrapper"
+    ).locator("button");
+
+    await expect(closeButton).toHaveAttribute("data-element", "Bar");
+  });
 });
 
 test.describe("Check events", () => {

--- a/src/components/dismissible-box/dismissible-box.spec.tsx
+++ b/src/components/dismissible-box/dismissible-box.spec.tsx
@@ -7,6 +7,7 @@ import { assertStyleMatch } from "../../__spec_helper__/test-utils";
 import StyledIcon from "../icon/icon.style";
 import IconButton from "../icon-button";
 import Logger from "../../__internal__/utils/logger";
+import { rootTagTest } from "../../__internal__/utils/helpers/tags/tags-specs";
 
 // mock Logger.deprecate so that no console warnings occur while running the tests
 const loggerSpy = jest.spyOn(Logger, "deprecate");
@@ -107,6 +108,22 @@ describe("DismissibleBox", () => {
       expect(onCloseMock).toHaveBeenCalledWith(
         expect.objectContaining({ type: "click" })
       );
+    });
+
+    it("allows custom data props to be assigned", () => {
+      const wrapper = mount(
+        <DismissibleBox
+          onClose={() => {}}
+          closeButtonDataProps={{
+            "data-element": "bang",
+            "data-role": "wallop",
+          }}
+        />
+      );
+
+      const closeButton = wrapper.find('[data-component="close-button"]').at(0);
+
+      rootTagTest(closeButton, "close-button", "bang", "wallop");
     });
   });
 });

--- a/src/locales/__internal__/pl-pl.ts
+++ b/src/locales/__internal__/pl-pl.ts
@@ -116,6 +116,11 @@ const plPL: Locale = {
       close: () => "Zamknij",
     },
   },
+  dismissibleBox: {
+    ariaLabels: {
+      close: () => "Zamknij",
+    },
+  },
   errors: {
     messages: {
       formSummary:

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -57,6 +57,11 @@ const enGB: Locale = {
       close: () => "Close",
     },
   },
+  dismissibleBox: {
+    ariaLabels: {
+      close: () => "Close",
+    },
+  },
   errors: {
     messages: {
       formSummary:

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -46,6 +46,11 @@ interface Locale {
       close: () => string;
     };
   };
+  dismissibleBox: {
+    ariaLabels: {
+      close: () => string;
+    };
+  };
   errors: {
     messages: {
       formSummary: (


### PR DESCRIPTION
This change allows a custom data-role to be applied to the close icon button and ensures that the aria-label can be translated via locales.

fixes #6487

### Proposed behaviour

- Allow a custom `data-role` to be specified as part of the new `closeButtonDataProps` prop bag. 
- Adds translation support to `aria-label`

### Current behaviour

-  No `data-role` is specified
- No translation support for `aria-label`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Check that `data-role` and `data-element` props can be passed to component using the test story. I have added `closeButtonDataProps` to the controls and they take an object. 