### PR TITLE
fix(sort): add a prop and translation support to provide an accessible name

### DIFF
--- a/src/components/drawer/drawer.stories.tsx
+++ b/src/components/drawer/drawer.stories.tsx
@@ -888,7 +888,7 @@ export const SideViewNavigation: Story = () => {
   const [isExpanded, setIsExpanded] = useState(true);
   const [isFilterOpen, setFilterOpen] = useState(false);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [sortType, setSortType] = useState<"ascending" | "descending" | false>(
+  const [sortType, setSortType] = useState<"ascending" | "descending">(
     "descending"
   );
   const [pickedUpData, setPickedUpData] = useState<dataPropTypes>();

--- a/src/components/flat-table/components.test-pw.tsx
+++ b/src/components/flat-table/components.test-pw.tsx
@@ -1546,7 +1546,7 @@ export const FlatTableSortingComponent = (
                 <FlatTableHeader key={name}>
                   <Sort
                     onClick={() => handleClick(name)}
-                    sortType={isActive && sortType}
+                    sortType={isActive ? sortType : undefined}
                   >
                     {name}
                   </Sort>

--- a/src/components/flat-table/flat-table.mdx
+++ b/src/components/flat-table/flat-table.mdx
@@ -10,6 +10,7 @@ import * as FlatTableRowHeaderStories from "./flat-table-row-header/flat-table-r
 import * as FlatTableCheckboxStories from "./flat-table-checkbox/flat-table-checkbox.stories";
 import * as SortStories from "./sort/sort.stories";
 import * as FlatTableStories from "./flat-table.stories";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 
 <Meta title="Flat Table" of={FlatTableStories} />
 
@@ -287,3 +288,21 @@ The `FlatTableRow` relies on specific child composition to identify sticky colum
 ### FlatTableCheckbox
 
 <ArgTypes of={FlatTableCheckboxStories} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](../?path=/docs/documentation-i18n--docs).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "sort.accessibleName",
+      description: "The accessible name that is announced on interaction with the component."+
+      " It is recommended that the current sort type as well as the current content of the component"+
+      " are included in this string. Both can be accessed via the `sortContent` and `sortType` parameters.",
+      type: "func",
+      returnType: "string",
+    }
+  ]}
+/>

--- a/src/components/flat-table/flat-table.mdx
+++ b/src/components/flat-table/flat-table.mdx
@@ -178,6 +178,14 @@ By using the `hasMaxHeight` prop you can automatically apply a max-height of 100
 
 <Canvas of={FlatTableStories.WithSortingHeaders} />
 
+### With sorting headers and custom accessible name 
+
+A custom accessible name can be provided to the `<Sort>` component with the `accessibleName` prop. It is recommended 
+that text content of the `<Sort>` component as well as the current `sortType` are included
+in this accessible name.
+
+<Canvas of={FlatTableStories.WithSortingHeadersAndCustomAccessibleName} />
+
 ### With a cell spanning the whole row
 
 <Canvas of={FlatTableStories.WithColspan} />

--- a/src/components/flat-table/flat-table.stories.tsx
+++ b/src/components/flat-table/flat-table.stories.tsx
@@ -1390,6 +1390,136 @@ export const WithSortingHeaders: Story = {
   },
 };
 
+export const WithSortingHeadersAndCustomAccessibleName: Story = {
+  render: (args: FlatTableProps) => {
+    const headDataItems: HeadDataItems = [
+      { name: "client", isActive: true },
+      { name: "total", isActive: false },
+    ];
+    const bodyDataItems: BodyDataItems = [
+      { client: "Jason Atkinson", total: 1349 },
+      { client: "Monty Parker", total: 849 },
+      { client: "Blake Sutton", total: 3840 },
+      { client: "Tyler Webb", total: 280 },
+    ];
+    /* eslint-disable react-hooks/rules-of-hooks */
+    const [headData, setHeadData] = useState(headDataItems);
+    const [sortType, setSortType] = useState<SortType>("ascending");
+    const [sortValue, setSortValue] = useState<SortValue>("client");
+    /* eslint-enable react-hooks/rules-of-hooks */
+
+    const sortByNumber = (
+      dataToSort: BodyDataItems,
+      sortByValue: SortValue,
+      type: SortType
+    ) => {
+      const sortedData = dataToSort.sort((a, b) => {
+        if (type === "ascending") {
+          return Number(a[sortByValue]) - Number(b[sortByValue]);
+        }
+        if (type === "descending") {
+          return Number(b[sortByValue]) - Number(a[sortByValue]);
+        }
+        return 0;
+      });
+      return sortedData;
+    };
+
+    const sortByString = (
+      dataToSort: BodyDataItems,
+      sortByValue: SortValue,
+      type: SortType
+    ) => {
+      const sortedData = dataToSort.sort((a, b) => {
+        const nameA = String(a[sortByValue]).toUpperCase();
+        const nameB = String(b[sortByValue]).toUpperCase();
+
+        if (type === "ascending") {
+          if (nameA < nameB) {
+            return -1;
+          }
+          if (nameA > nameB) {
+            return 1;
+          }
+        }
+        if (type === "descending") {
+          if (nameA > nameB) {
+            return -1;
+          }
+          if (nameA < nameB) {
+            return 1;
+          }
+        }
+        return 0;
+      });
+      return sortedData;
+    };
+
+    const handleClick = (value: SortValue) => {
+      const tempHeadData = headData;
+      tempHeadData.forEach((item) => {
+        item.isActive = false;
+        if (item.name === value) {
+          item.isActive = !item.isActive;
+        }
+      });
+      setSortValue(value);
+      setSortType(sortType === "ascending" ? "descending" : "ascending");
+      setHeadData([...tempHeadData]);
+    };
+
+    const renderSortedData = (sortByValue: SortValue) => {
+      let sortedData = bodyDataItems;
+      if (typeof bodyDataItems[0][sortByValue] === "string") {
+        sortedData = sortByString(sortedData, sortByValue, sortType);
+      }
+      if (typeof bodyDataItems[0][sortByValue] === "number") {
+        sortedData = sortByNumber(sortedData, sortByValue, sortType);
+      }
+
+      return sortedData.map(({ client, total }) => {
+        return (
+          <FlatTableRow key={client}>
+            <FlatTableCell>{client}</FlatTableCell>
+            <FlatTableCell>{total}</FlatTableCell>
+          </FlatTableRow>
+        );
+      });
+    };
+
+    return (
+      <FlatTable {...args}>
+        <FlatTableHead>
+          <FlatTableRow>
+            {headData.map(({ name, isActive }) => {
+              return (
+                <FlatTableHeader key={name}>
+                  <Sort
+                    accessibleName={`Sort ${name}s in an ${sortType} order`}
+                    onClick={() => handleClick(name)}
+                    {...(isActive && { sortType })}
+                  >
+                    {name}
+                  </Sort>
+                </FlatTableHeader>
+              );
+            })}
+          </FlatTableRow>
+        </FlatTableHead>
+        <FlatTableBody>{renderSortedData(sortValue)}</FlatTableBody>
+      </FlatTable>
+    );
+  },
+  name: "With Sorting Headers and custom accessible name",
+  parameters: {
+    docs: {
+      source: {
+        type: "code",
+      },
+    },
+  },
+};
+
 export const WithColspan: Story = () => {
   return (
     <FlatTable>

--- a/src/components/flat-table/sort/sort.component.tsx
+++ b/src/components/flat-table/sort/sort.component.tsx
@@ -1,20 +1,24 @@
 import React, { useRef, useContext } from "react";
 import Event from "../../../__internal__/utils/helpers/events";
+import Typography from "../../typography";
 import { StyledSort, StyledSpaceHolder, StyledSortIcon } from "./sort.style";
 import guid from "../../../__internal__/utils/helpers/guid";
+import useLocale from "../../../hooks/__internal__/useLocale";
 import { FlatTableThemeContext } from "../flat-table.component";
 
 export interface SortProps {
   /** if `asc` it will show `sort_up` icon, if `desc` it will show `sort_down` */
-  sortType?: "ascending" | "descending" | false;
-  /** Callback fired when the `FlatTableSortHeader` is clicked */
+  sortType?: "ascending" | "descending";
+  /** Callback fired when the component is clicked */
   onClick?: () => void;
-  /** Sets the content of `FlatTableSortHeader` */
-  children?: React.ReactNode;
+  /** Sets the text content of the component */
+  children?: string;
 }
 
 export const Sort = ({ children, onClick, sortType }: SortProps) => {
   const id = useRef(guid());
+  const locale = useLocale();
+
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (Event.isEnterOrSpaceKey(e)) {
       e.preventDefault();
@@ -28,10 +32,9 @@ export const Sort = ({ children, onClick, sortType }: SortProps) => {
 
   return (
     <>
-      <span hidden id={id.current}>
-        {children}
-        {sortType ? `, sort type ${sortType}` : ", sortable"}
-      </span>
+      <Typography screenReaderOnly id={id.current}>
+        {locale.sort.accessibleName(children, sortType)}
+      </Typography>
       <StyledSort
         role="button"
         onKeyDown={onKeyDown}

--- a/src/components/flat-table/sort/sort.component.tsx
+++ b/src/components/flat-table/sort/sort.component.tsx
@@ -13,9 +13,16 @@ export interface SortProps {
   onClick?: () => void;
   /** Sets the text content of the component */
   children?: string;
+  /** Sets the accessible name of the component */
+  accessibleName?: string;
 }
 
-export const Sort = ({ children, onClick, sortType }: SortProps) => {
+export const Sort = ({
+  children,
+  onClick,
+  sortType,
+  accessibleName,
+}: SortProps) => {
   const id = useRef(guid());
   const locale = useLocale();
 
@@ -33,7 +40,7 @@ export const Sort = ({ children, onClick, sortType }: SortProps) => {
   return (
     <>
       <Typography screenReaderOnly id={id.current}>
-        {locale.sort.accessibleName(children, sortType)}
+        {accessibleName || locale.sort.accessibleName(children, sortType)}
       </Typography>
       <StyledSort
         role="button"

--- a/src/components/flat-table/sort/sort.spec.tsx
+++ b/src/components/flat-table/sort/sort.spec.tsx
@@ -4,6 +4,7 @@ import { assertStyleMatch } from "__spec_helper__/test-utils";
 import Sort, { SortProps } from "./sort.component";
 import Icon from "../../icon";
 import StyledIcon from "../../icon/icon.style";
+import Typography from "../../typography";
 import { StyledSort, StyledSpaceHolder } from "./sort.style";
 import { FlatTableThemeContext, FlatTableProps } from "../flat-table.component";
 
@@ -48,6 +49,39 @@ describe("Sort", () => {
     wrapper = renderSort({ sortType: "descending" });
 
     expect(wrapper.find(Icon).props().type).toBe("sort_down");
+  });
+
+  it("should render a default accessible name when a child and the `sortType` prop is passed", () => {
+    wrapper = mount(<Sort sortType="ascending">Accountants</Sort>);
+
+    expect(wrapper.find(Typography).text()).toBe(
+      "Sort all Accountants in an ascending order."
+    );
+  });
+
+  it("should render a default accessible name when just a child is passed", () => {
+    wrapper = mount(<Sort>Accountants</Sort>);
+
+    expect(wrapper.find(Typography).text()).toBe(
+      "Sort all Accountants in an ascending or descending order."
+    );
+  });
+
+  it("should render a default accessible name when just the `sortType` prop is passed", () => {
+    const sortType = "ascending";
+    wrapper = mount(<Sort sortType={sortType} />);
+
+    expect(wrapper.find(Typography).text()).toBe(
+      "Sort all contents in an ascending order."
+    );
+  });
+
+  it("should render a default accessible name when neither a child or the `sortType` prop is passed", () => {
+    wrapper = mount(<Sort />);
+
+    expect(wrapper.find(Typography).text()).toBe(
+      "Sort all contents in an ascending or descending order."
+    );
   });
 
   it("should fire callback if clicked", () => {

--- a/src/components/flat-table/sort/sort.spec.tsx
+++ b/src/components/flat-table/sort/sort.spec.tsx
@@ -51,6 +51,14 @@ describe("Sort", () => {
     expect(wrapper.find(Icon).props().type).toBe("sort_down");
   });
 
+  it("should render the correct accessible name when the `accessibleName` prop is passed", () => {
+    const sortType = "ascending";
+    const customAccessibleName = `Sort all accountants below in an ${sortType} order.`;
+    wrapper = renderSort({ accessibleName: customAccessibleName, sortType });
+
+    expect(wrapper.find(Typography).text()).toBe(customAccessibleName);
+  });
+
   it("should render a default accessible name when a child and the `sortType` prop is passed", () => {
     wrapper = mount(<Sort sortType="ascending">Accountants</Sort>);
 

--- a/src/components/flat-table/sort/sort.stories.tsx
+++ b/src/components/flat-table/sort/sort.stories.tsx
@@ -20,6 +20,6 @@ type Story = StoryObj<typeof Sort>;
 
 export const Default: Story = {
   args: {
-    children: [],
+    children: "",
   },
 };

--- a/src/locales/__internal__/es-es.ts
+++ b/src/locales/__internal__/es-es.ts
@@ -163,6 +163,16 @@ const esES: Locale = {
       close: () => "Cerrar",
     },
   },
+  sort: {
+    accessibleName: (sortContent, sortType) =>
+      `Ordenar todo ${sortContent || "contenido"}${
+        sortType
+          ? ` en orden ${
+              sortType === "ascending" ? "ascendente" : "descendente"
+            }.`
+          : " en orden ascendente o descendente."
+      }`,
+  },
   splitButton: {
     ariaLabel: () => "Mostrar más",
   },

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -161,6 +161,14 @@ const enGB: Locale = {
       close: () => "Close",
     },
   },
+  sort: {
+    accessibleName: (sortContent, sortType) =>
+      `Sort all ${sortContent || "contents"}${
+        sortType
+          ? ` in an ${sortType} order.`
+          : " in an ascending or descending order."
+      }`,
+  },
   splitButton: {
     ariaLabel: () => "Show more",
   },

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -129,12 +129,14 @@ interface Locale {
       close: () => string;
     };
   };
+  sort: {
+    accessibleName: (
+      sortContent?: string,
+      sortType?: "ascending" | "descending"
+    ) => string;
+  };
   splitButton: {
     ariaLabel: () => string;
-  };
-  switch: {
-    on: () => string;
-    off: () => string;
   };
   stepFlow: {
     stepLabel: (currentStep: number, totalSteps: number) => string;
@@ -145,6 +147,10 @@ interface Locale {
       category?: string
     ) => string;
     closeIconAriaLabel?: () => string;
+  };
+  switch: {
+    on: () => string;
+    off: () => string;
   };
   textEditor: {
     tooltipMessages: {


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

adds the `accessibleName` prop as well as translation support for a new visually hidden span which provides the component with an accessible name

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

The current accessible name uses string interpolation with the sort type and children props, which may result in English-only announcements for users of another language. The accessible name is also contained in a span with the `hidden` attribute applied to it, making it in theory inaccessible to screen readers

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
