### PR TITLE
feat(search): search button is rendered at all times when `searchButton` prop is set FE-6078

### DIFF
--- a/src/components/card/card-footer/__snapshots__/card-footer.spec.tsx.snap
+++ b/src/components/card/card-footer/__snapshots__/card-footer.spec.tsx.snap
@@ -92,64 +92,64 @@ exports[`CardFooter matches expected styling when it contains non-interactive co
   display: block;
 }
 
-.c1 a,
-.c1 button {
-  font-size: 14px;
+.c1 > a,
+.c1 > button {
+  font-size: var(--fontSizes100);
   color: var(--colorsActionMajor500);
 }
 
-.c1 a .c2,
-.c1 button .c2 {
+.c1 > a .c2,
+.c1 > button .c2 {
   color: var(--colorsActionMajor500);
 }
 
-.c1 a:hover,
-.c1 button:hover {
+.c1 > a:hover,
+.c1 > button:hover {
   color: var(--colorsActionMajor600);
 }
 
-.c1 a:hover .c2,
-.c1 button:hover .c2 {
+.c1 > a:hover > .c2,
+.c1 > button:hover > .c2 {
   color: var(--colorsActionMajor600);
 }
 
-.c1 a:focus,
-.c1 button:focus {
+.c1 > a:focus,
+.c1 > button:focus {
   background-color: var(--colorsSemanticFocus250);
   border-radius: var(--borderRadius025);
 }
 
-.c1 a,
-.c1 button {
+.c1 > a,
+.c1 > button {
   -webkit-text-decoration: underline;
   text-decoration: underline;
 }
 
-.c1 a > .c2,
-.c1 button > .c2 {
+.c1 > a > .c2,
+.c1 > button > .c2 {
   display: inline-block;
   position: relative;
   vertical-align: middle;
   margin-right: var(--spacing050);
 }
 
-.c1 a:hover,
-.c1 button:hover {
+.c1 > a:hover,
+.c1 > button:hover {
   cursor: pointer;
 }
 
-.c1 a:focus,
-.c1 button:focus {
+.c1 > a:focus,
+.c1 > button:focus {
   color: var(--colorsActionMajorYin090);
   outline: none;
 }
 
-.c1 a:focus .c2,
-.c1 button:focus .c2 {
+.c1 > a:focus .c2,
+.c1 > button:focus .c2 {
   color: var(--colorsActionMajorYin090);
 }
 
-.c1 button {
+.c1 > button {
   background-color: transparent;
   border: none;
   padding: 0;

--- a/src/components/link/link.spec.tsx
+++ b/src/components/link/link.spec.tsx
@@ -42,15 +42,15 @@ describe("Link", () => {
       assertStyleMatch(
         {
           position: "absolute",
-          paddingLeft: "24px",
-          paddingRight: "24px",
+          paddingLeft: "var(--spacing300)",
+          paddingRight: "var(--spacing300)",
           lineHeight: "36px",
-          fontSize: "16px",
+          fontSize: "var(--fontSizes200)",
           left: "-999em",
           color: "var(--colorsUtilityYin090)",
           zIndex: `${baseTheme.zIndex.aboveAll}`,
-          boxShadow: `inset 0 0 0 2px var(--colorsActionMajor500)`,
-          border: `2px solid var(--colorsUtilityYang100)`,
+          boxShadow: `inset 0 0 0 var(--spacing025) var(--colorsActionMajor500)`,
+          border: `var(--spacing025) solid var(--colorsUtilityYang100)`,
         },
         skipLinkWrapper,
         { modifier: "a" }
@@ -58,9 +58,8 @@ describe("Link", () => {
 
       assertStyleMatch(
         {
-          top: "8px",
-          left: "8px",
-          color: "var(--colorsActionMajorYin090)",
+          top: "var(--spacing100)",
+          left: "var(--spacing100)",
         },
         skipLinkWrapper,
         { modifier: "a:focus" }
@@ -75,7 +74,7 @@ describe("Link", () => {
           cursor: "not-allowed",
         },
         renderLink({ disabled: true }),
-        { modifier: "a:hover" }
+        { modifier: "> a:hover" }
       );
     });
 
@@ -149,7 +148,7 @@ describe("Link", () => {
           position: "relative",
         },
         wrapper.find(StyledLink),
-        { modifier: `a > ${StyledIcon}` }
+        { modifier: `> a > ${StyledIcon}` }
       );
     });
 
@@ -162,7 +161,7 @@ describe("Link", () => {
           position: "relative",
         },
         wrapper.find(StyledLink),
-        { modifier: `a > ${StyledIcon}` }
+        { modifier: `> a > ${StyledIcon}` }
       );
     });
 
@@ -177,7 +176,7 @@ describe("Link", () => {
           position: "relative",
         },
         wrapper.find(StyledLink),
-        { modifier: `a > ${StyledIcon}` }
+        { modifier: `> a > ${StyledIcon}` }
       );
     });
 
@@ -190,7 +189,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajor600)",
         },
         wrapper.find(StyledLink),
-        { modifier: `a:hover ${StyledIcon}` }
+        { modifier: `> a:hover > ${StyledIcon}` }
       );
     });
 
@@ -219,7 +218,7 @@ describe("Link", () => {
           textDecoration: "none",
         },
         wrapper.find(StyledLink),
-        { modifier: "a" }
+        { modifier: "> a" }
       );
     });
 
@@ -229,7 +228,7 @@ describe("Link", () => {
           display: "inline",
         },
         wrapper.find(StyledLink),
-        { modifier: `a > ${StyledIcon}` }
+        { modifier: `> a > ${StyledIcon}` }
       );
     });
   });
@@ -337,7 +336,7 @@ describe("Link", () => {
           color: "var(--colorsSemanticNegative500)",
         },
         wrapper,
-        { modifier: "a" }
+        { modifier: "> a" }
       );
 
       assertStyleMatch(
@@ -345,7 +344,7 @@ describe("Link", () => {
           color: "var(--colorsSemanticNegative500)",
         },
         wrapper,
-        { modifier: `a ${StyledIcon}` }
+        { modifier: `> a ${StyledIcon}` }
       );
 
       assertStyleMatch(
@@ -353,7 +352,7 @@ describe("Link", () => {
           color: "var(--colorsSemanticNegative600)",
         },
         wrapper,
-        { modifier: "a:hover" }
+        { modifier: "> a:hover" }
       );
 
       assertStyleMatch(
@@ -361,7 +360,7 @@ describe("Link", () => {
           color: "var(--colorsSemanticNegative600)",
         },
         wrapper,
-        { modifier: `a:hover ${StyledIcon}` }
+        { modifier: `> a:hover > ${StyledIcon}` }
       );
 
       assertStyleMatch(
@@ -370,7 +369,7 @@ describe("Link", () => {
           backgroundColor: "var(--colorsSemanticFocus250)",
         },
         wrapper,
-        { modifier: "a:focus" }
+        { modifier: "> a:focus" }
       );
 
       assertStyleMatch(
@@ -378,7 +377,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajorYin090)",
         },
         wrapper,
-        { modifier: `a:focus ${StyledIcon}` }
+        { modifier: `> a:focus ${StyledIcon}` }
       );
     });
   });
@@ -397,7 +396,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajorYin090)",
         },
         wrapper,
-        { modifier: "a" }
+        { modifier: "> a" }
       );
 
       assertStyleMatch(
@@ -405,7 +404,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajorYin090)",
         },
         wrapper,
-        { modifier: `a ${StyledIcon}` }
+        { modifier: `> a ${StyledIcon}` }
       );
 
       assertStyleMatch(
@@ -413,7 +412,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajor600)",
         },
         wrapper,
-        { modifier: "a:hover" }
+        { modifier: "> a:hover" }
       );
 
       assertStyleMatch(
@@ -421,7 +420,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajor600)",
         },
         wrapper,
-        { modifier: `a:hover ${StyledIcon}` }
+        { modifier: `> a:hover > ${StyledIcon}` }
       );
 
       assertStyleMatch(
@@ -430,7 +429,7 @@ describe("Link", () => {
           backgroundColor: "var(--colorsSemanticFocus250)",
         },
         wrapper,
-        { modifier: "a:focus" }
+        { modifier: "> a:focus" }
       );
 
       assertStyleMatch(
@@ -438,7 +437,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajorYin090)",
         },
         wrapper,
-        { modifier: `a:focus ${StyledIcon}` }
+        { modifier: `> a:focus ${StyledIcon}` }
       );
     });
   });
@@ -456,7 +455,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajor350)",
         },
         wrapper,
-        { modifier: "a" }
+        { modifier: "> a" }
       );
 
       assertStyleMatch(
@@ -464,7 +463,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajor350)",
         },
         wrapper,
-        { modifier: `a ${StyledIcon}` }
+        { modifier: `> a ${StyledIcon}` }
       );
 
       assertStyleMatch(
@@ -472,7 +471,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajor450)",
         },
         wrapper,
-        { modifier: "a:hover" }
+        { modifier: "> a:hover" }
       );
 
       assertStyleMatch(
@@ -480,7 +479,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajor450)",
         },
         wrapper,
-        { modifier: `a:hover ${StyledIcon}` }
+        { modifier: `> a:hover > ${StyledIcon}` }
       );
 
       assertStyleMatch(
@@ -489,7 +488,7 @@ describe("Link", () => {
           backgroundColor: "var(--colorsSemanticFocus250)",
         },
         wrapper,
-        { modifier: "a:focus" }
+        { modifier: "> a:focus" }
       );
 
       assertStyleMatch(
@@ -497,7 +496,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajorYin090)",
         },
         wrapper,
-        { modifier: `a:focus ${StyledIcon}` }
+        { modifier: `> a:focus ${StyledIcon}` }
       );
     });
 
@@ -513,7 +512,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajorYang030)",
         },
         wrapper,
-        { modifier: "a" }
+        { modifier: "> a" }
       );
     });
 
@@ -530,7 +529,7 @@ describe("Link", () => {
           color: "var(--colorsSemanticNegative350)",
         },
         wrapper,
-        { modifier: "a" }
+        { modifier: "> a" }
       );
 
       assertStyleMatch(
@@ -538,7 +537,7 @@ describe("Link", () => {
           color: "var(--colorsSemanticNegative350)",
         },
         wrapper,
-        { modifier: `a ${StyledIcon}` }
+        { modifier: `> a ${StyledIcon}` }
       );
 
       assertStyleMatch(
@@ -546,7 +545,7 @@ describe("Link", () => {
           color: "var(--colorsSemanticNegative450)",
         },
         wrapper,
-        { modifier: "a:hover" }
+        { modifier: "> a:hover" }
       );
 
       assertStyleMatch(
@@ -554,7 +553,7 @@ describe("Link", () => {
           color: "var(--colorsSemanticNegative450)",
         },
         wrapper,
-        { modifier: `a:hover ${StyledIcon}` }
+        { modifier: `> a:hover > ${StyledIcon}` }
       );
 
       assertStyleMatch(
@@ -563,7 +562,7 @@ describe("Link", () => {
           backgroundColor: "var(--colorsSemanticFocus250)",
         },
         wrapper,
-        { modifier: "a:focus" }
+        { modifier: "> a:focus" }
       );
 
       assertStyleMatch(
@@ -571,7 +570,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajorYin090)",
         },
         wrapper,
-        { modifier: `a:focus ${StyledIcon}` }
+        { modifier: `> a:focus ${StyledIcon}` }
       );
     });
 
@@ -588,7 +587,7 @@ describe("Link", () => {
           color: "var(--colorsActionMinor100)",
         },
         wrapper,
-        { modifier: "a" }
+        { modifier: "> a" }
       );
 
       assertStyleMatch(
@@ -596,7 +595,7 @@ describe("Link", () => {
           color: "var(--colorsActionMinor100)",
         },
         wrapper,
-        { modifier: `a ${StyledIcon}` }
+        { modifier: `> a ${StyledIcon}` }
       );
 
       assertStyleMatch(
@@ -604,7 +603,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajor450)",
         },
         wrapper,
-        { modifier: "a:hover" }
+        { modifier: "> a:hover" }
       );
 
       assertStyleMatch(
@@ -612,7 +611,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajor450)",
         },
         wrapper,
-        { modifier: `a:hover ${StyledIcon}` }
+        { modifier: `> a:hover > ${StyledIcon}` }
       );
 
       assertStyleMatch(
@@ -621,7 +620,7 @@ describe("Link", () => {
           backgroundColor: "var(--colorsSemanticFocus250)",
         },
         wrapper,
-        { modifier: "a:focus" }
+        { modifier: "> a:focus" }
       );
 
       assertStyleMatch(
@@ -629,7 +628,7 @@ describe("Link", () => {
           color: "var(--colorsActionMajorYin090)",
         },
         wrapper,
-        { modifier: `a:focus ${StyledIcon}` }
+        { modifier: `> a:focus ${StyledIcon}` }
       );
     });
   });
@@ -649,7 +648,9 @@ describe("Link", () => {
         </MenuContext.Provider>
       );
 
-      assertStyleMatch({ display: "inline-block" }, wrapper, { modifier: "a" });
+      assertStyleMatch({ display: "inline-block" }, wrapper, {
+        modifier: "> a",
+      });
     });
 
     it("when not inside a menu, link element has default display", () => {
@@ -659,7 +660,7 @@ describe("Link", () => {
         icon: "home",
       });
 
-      assertStyleMatch({ display: undefined }, wrapper, { modifier: "a" });
+      assertStyleMatch({ display: undefined }, wrapper, { modifier: "> a" });
     });
   });
 });

--- a/src/components/link/link.style.ts
+++ b/src/components/link/link.style.ts
@@ -91,14 +91,14 @@ const StyledLink = styled.span<StyledLinkProps & PrivateStyledLinkProps>`
       css`
         a {
           position: absolute;
-          padding-left: 24px;
-          padding-right: 24px;
+          padding-left: var(--spacing300);
+          padding-right: var(--spacing300);
           line-height: 36px;
           left: -999em;
           z-index: ${theme.zIndex.aboveAll};
-          box-shadow: inset 0 0 0 2px var(--colorsActionMajor500);
-          border: 2px solid var(--colorsUtilityYang100);
-          font-size: 16px;
+          box-shadow: inset 0 0 0 var(--spacing025) var(--colorsActionMajor500);
+          border: var(--spacing025) solid var(--colorsUtilityYang100);
+          font-size: var(--fontSizes200);
           color: var(--colorsUtilityYin090);
 
           &:hover {
@@ -116,16 +116,16 @@ const StyledLink = styled.span<StyledLinkProps & PrivateStyledLinkProps>`
         }
 
         a:focus {
-          top: 8px;
-          left: 8px;
+          top: var(--spacing100);
+          left: var(--spacing100);
         }
       `}
 
       ${!isSkipLink &&
       css`
-        a,
-        button {
-          font-size: 14px;
+        > a,
+        > button {
+          font-size: var(--fontSizes100);
 
           ${!disabled &&
           css`
@@ -137,7 +137,7 @@ const StyledLink = styled.span<StyledLinkProps & PrivateStyledLinkProps>`
             &:hover {
               color: ${hoverColor};
 
-              ${StyledIcon} {
+              > ${StyledIcon} {
                 color: ${hoverColor};
               }
             }
@@ -159,8 +159,8 @@ const StyledLink = styled.span<StyledLinkProps & PrivateStyledLinkProps>`
         }
       `}
 
-      a,
-      button {
+      > a,
+      > button {
         text-decoration: ${hasContent ? "underline" : "none"};
         ${isMenuItem && "display: inline-block;"}
 
@@ -206,20 +206,20 @@ const StyledLink = styled.span<StyledLinkProps & PrivateStyledLinkProps>`
       !theme.focusRedesignOptOut &&
       hasFocus &&
       css`
-        a,
-        button {
+        > a,
+        > button {
           outline: none;
           text-decoration: none;
           border-bottom-left-radius: var(--borderRadius000);
           border-bottom-right-radius: var(--borderRadius000);
         }
         max-width: fit-content;
-        box-shadow: 0 4px 0 0 var(--colorsUtilityYin090);
+        box-shadow: 0 var(--spacing050) 0 0 var(--colorsUtilityYin090);
         border-bottom-left-radius: var(--borderRadius025);
         border-bottom-right-radius: var(--borderRadius025);
       `}
 
-      button {
+      > button {
         background-color: transparent;
         border: none;
         padding: 0;

--- a/src/components/menu/__internal__/submenu/submenu.spec.tsx
+++ b/src/components/menu/__internal__/submenu/submenu.spec.tsx
@@ -1292,7 +1292,7 @@ describe("Submenu component", () => {
             backgroundColor: menuConfigVariants[menuType].submenuItemBackground,
           },
           wrapper.find(StyledSubmenu),
-          { modifier: `${StyledMenuItemWrapper} ${el}:${pseudo}` }
+          { modifier: `${StyledMenuItemWrapper} > ${el}:${pseudo}` }
         );
       });
 
@@ -1308,7 +1308,7 @@ describe("Submenu component", () => {
               color: "var(--colorsComponentsMenuYang100)",
             },
             wrapper.find(StyledSubmenu),
-            { modifier: `${StyledMenuItemWrapper} ${el}:${pseudo}` }
+            { modifier: `${StyledMenuItemWrapper} > ${el}:${pseudo}` }
           );
         });
 
@@ -1320,7 +1320,7 @@ describe("Submenu component", () => {
             },
             wrapper.find(StyledSubmenu),
             {
-              modifier: `${StyledMenuItemWrapper} ${el}:${pseudo} [data-component="icon"]`,
+              modifier: `${StyledMenuItemWrapper} > ${el}:${pseudo} > [data-component="icon"]`,
             }
           );
         });
@@ -1492,48 +1492,6 @@ describe("Submenu component", () => {
 
       expect(searchInput).toBeFocused();
     });
-
-    it.each<MenuType>(["dark", "black", "light", "white"])(
-      "should render with correct styles for search icon for menuType=%s",
-      (menuType) => {
-        wrapper = renderWithSearch(menuType);
-        openSubmenu(wrapper);
-
-        assertStyleMatch(
-          {
-            borderBottomColor: "var(--colorsUtilityMajor150)",
-          },
-          wrapper.find(StyledSubmenu),
-          {
-            modifier: `
-              ${StyledMenuItemWrapper} ${StyledSearch}:hover
-            `,
-          }
-        );
-        assertStyleMatch(
-          {
-            color: "var(--colorsUtilityMajor200)",
-          },
-          wrapper.find(StyledSubmenu),
-          {
-            modifier: `
-              ${StyledMenuItemWrapper} ${StyledSearch} span > [data-component="icon"]
-            `,
-          }
-        );
-        assertStyleMatch(
-          {
-            color: "var(--colorsUtilityMajor150)",
-          },
-          wrapper.find(StyledSubmenu),
-          {
-            modifier: `
-              ${StyledMenuItemWrapper} ${StyledSearch} span > [data-component="icon"]:hover
-            `,
-          }
-        );
-      }
-    );
 
     it("should be focusable by using down arrow key", () => {
       wrapper = renderWithSearch("dark");

--- a/src/components/menu/__internal__/submenu/submenu.style.ts
+++ b/src/components/menu/__internal__/submenu/submenu.style.ts
@@ -3,7 +3,7 @@ import { baseTheme } from "../../../../style/themes";
 import { StyledLink } from "../../../link/link.style";
 import { StyledMenuItem } from "../../menu.style";
 import StyledMenuItemWrapper from "../../menu-item/menu-item.style";
-import StyledSearch from "../../../search/search.style";
+import StyledIcon from "../../../icon/icon.style";
 import menuConfigVariants from "../../menu.config";
 import { SubmenuProps } from "./submenu.component";
 import { MenuType } from "../../menu.context";
@@ -122,18 +122,18 @@ const StyledSubmenu = styled.ul<StyledSubmenuProps>`
       css`
         background-color: ${menuConfigVariants[menuType].submenuItemBackground};
 
-        a:focus,
-        button:focus {
+        > a:focus,
+        > button:focus {
           background-color: ${menuConfigVariants[menuType]
             .submenuItemBackground};
         }
 
-        a:hover,
-        button:hover {
+        > a:hover,
+        > button:hover {
           background-color: transparent;
           color: var(--colorsComponentsMenuYang100);
 
-          [data-component="icon"] {
+          > [data-component="icon"] {
             color: var(--colorsComponentsMenuYang100);
           }
         }
@@ -143,17 +143,26 @@ const StyledSubmenu = styled.ul<StyledSubmenuProps>`
         text-decoration: none;
       }
 
-      ${StyledSearch} span > [data-component="icon"] {
-        color: var(--colorsUtilityMajor200);
+      > ${StyledIcon} {
+        width: 16px;
+        height: 16px;
+        margin-right: 5px;
+      }
+    }
 
-        &:hover {
-          color: var(--colorsUtilityMajor150);
-        }
+    [data-component="icon"] {
+      line-height: 20px;
+
+      &:before {
+        line-height: unset;
       }
 
-      ${StyledSearch} {
-        :hover {
-          border-bottom-color: var(--colorsUtilityMajor150);
+      span {
+        vertical-align: middle;
+
+        svg {
+          height: 16px;
+          width: 16px;
         }
       }
     }

--- a/src/components/menu/component.test-pw.tsx
+++ b/src/components/menu/component.test-pw.tsx
@@ -355,7 +355,7 @@ export const MenuComponentScrollableParent = (
   const [itemSearch, setItemSearch] = React.useState(items);
   const [searchString, setSearchString] = React.useState("");
 
-  const handleTextChange = (e: { target: { value: any } }) => {
+  const handleTextChange = (e: { target: { value: string } }) => {
     const searchStr = e.target.value;
     setSearchString(searchStr);
     let found;

--- a/src/components/menu/menu-full-screen/menu-full-screen.component.tsx
+++ b/src/components/menu/menu-full-screen/menu-full-screen.component.tsx
@@ -59,33 +59,6 @@ export const MenuFullscreen = ({
   const transitionDuration = 200;
   const locale = useLocale();
 
-  // TODO: Remove this temporary event handler as part of FE-6078
-  const handleFocusedSearchButton = (ev: React.KeyboardEvent<HTMLElement>) => {
-    const search = modalRef.current?.querySelector('[data-component="search"]');
-    const searchInput = search?.querySelector("input");
-    const searchButton = search?.querySelector("button");
-
-    // if there is no value in the search input the button disappears when the input blurs
-    // this means we need to programmatically set focus to the next menu item
-    if (
-      searchButton &&
-      searchInput &&
-      !searchInput.value &&
-      searchInput === document.activeElement
-    ) {
-      ev.preventDefault();
-
-      const elements = Array.from(
-        modalRef.current?.querySelectorAll(
-          "a, input, button"
-        ) as NodeListOf<HTMLElement>
-      );
-
-      const index = elements.indexOf(searchInput);
-      elements[index + 2]?.focus();
-    }
-  };
-
   const flattenedChildren = React.Children.toArray(children);
   const childArray = React.Children.toArray(
     flattenedChildren.map((child, index) => {
@@ -141,11 +114,6 @@ export const MenuFullscreen = ({
                 data-element={dataElement}
                 data-role={dataRole}
                 menuType={menuType}
-                onKeyDown={(ev) =>
-                  Events.isTabKey(ev) &&
-                  !Events.isShiftKey(ev) &&
-                  handleFocusedSearchButton(ev)
-                }
                 ref={modalRef}
                 role="dialog"
                 tabIndex={-1}

--- a/src/components/menu/menu-full-screen/menu-full-screen.spec.tsx
+++ b/src/components/menu/menu-full-screen/menu-full-screen.spec.tsx
@@ -15,9 +15,6 @@ import {
   StyledMenuModal,
 } from "./menu-full-screen.style";
 import StyledIconButton from "../../icon-button/icon-button.style";
-import Search from "../../search";
-import StyledSearch from "../../search/search.style";
-import StyledSearchButton from "../../search/search-button.style";
 import {
   assertStyleMatch,
   testStyledSystemPadding,
@@ -27,6 +24,8 @@ import { baseTheme, sageTheme } from "../../../style/themes";
 import { StyledMenuItem } from "../menu.style";
 import menuConfigVariants from "../menu.config";
 import { StyledSubmenu } from "../__internal__/submenu/submenu.style";
+import StyledMenuItemWrapper from "../menu-item/menu-item.style";
+import { StyledLink } from "../../link/link.style";
 
 const AllTheProviders = ({
   children,
@@ -96,33 +95,6 @@ const TestMenu = ({ isOpen }: Pick<MenuFullscreenProps, "isOpen">) => (
     </MenuItem>
   </MenuFullscreen>
 );
-
-const MockMenuWithSearch = ({
-  isOpen,
-  focusInput,
-}: {
-  isOpen?: boolean;
-  focusInput?: boolean;
-}) => {
-  const ref = React.useRef(null);
-
-  React.useEffect(() => {
-    if (focusInput && ref.current) {
-      (ref.current as HTMLInputElement).focus();
-    }
-  }, [focusInput]);
-
-  return (
-    <MenuFullscreen isOpen={isOpen} onClose={() => {}}>
-      <MenuItem maxWidth="200px">
-        <Search value="" ref={ref} defaultValue="" searchButton />
-      </MenuItem>
-      <MenuItem maxWidth="200px" href="#">
-        Menu Item One
-      </MenuItem>
-    </MenuFullscreen>
-  );
-};
 
 const MockMenuWithFalsyValues = ({ isOpen }: { isOpen?: boolean }) => (
   <MenuFullscreen isOpen={isOpen} onClose={() => {}}>
@@ -238,17 +210,14 @@ describe("MenuFullscreen", () => {
           wrapper.find(StyledMenuFullscreen)
         );
 
-        assertStyleMatch(
-          {
-            backgroundColor: menuConfigVariants[menuType].background,
-          },
-          wrapper.find(StyledMenuModal)
-        );
-
-        ["a", "button", "div"].forEach((el) => {
+        [
+          `&& ${StyledLink} > a`,
+          `&& ${StyledLink} > button`,
+          "&& > div",
+        ].forEach((el) => {
           assertStyleMatch(
             {
-              fontSize: "16px",
+              fontSize: "var(--fontSizes200)",
             },
             wrapper.find(StyledMenuModal),
             { modifier: el }
@@ -325,7 +294,8 @@ describe("MenuFullscreen", () => {
           </MenuContext.Provider>
         ),
         { pt: "10px", pb: "10px" },
-        (component) => component.find(StyledMenuItem)
+        (component) => component.find(StyledMenuItem),
+        { modifier: `${StyledMenuItemWrapper}` }
       );
     });
 
@@ -349,7 +319,8 @@ describe("MenuFullscreen", () => {
           </MenuContext.Provider>
         ),
         undefined,
-        (component) => component.find(StyledSubmenu).find(StyledMenuItem)
+        (component) => component.find(StyledSubmenu).find(StyledMenuItem),
+        { modifier: `${StyledMenuItemWrapper}` }
       );
     });
   });
@@ -412,42 +383,6 @@ describe("MenuFullscreen", () => {
     it("focuses the root container, when menu is opened", () => {
       render(<TestMenu isOpen />);
       expect(screen.getByRole("dialog")).toBeFocused();
-    });
-
-    describe("when pressing tab key without shift", () => {
-      it("does not prevent the browser default behaviour when no Search input with searchButton and no value is rendered", () => {
-        const preventDefault = jest.fn();
-        const wrapper = mount(<TestMenu isOpen />);
-
-        wrapper.find(StyledMenuModal).prop("onKeyDown")({
-          key: "Tab",
-          preventDefault,
-        });
-        wrapper.find(StyledMenuModal).prop("onKeyDown")({
-          key: "Tab",
-          preventDefault,
-        });
-        expect(preventDefault).not.toHaveBeenCalled();
-        wrapper.find(StyledMenuModal).prop("onKeyDown")({
-          key: "Tab",
-          preventDefault,
-        });
-        expect(preventDefault).not.toHaveBeenCalled();
-      });
-
-      it("prevents the browser default behaviour when Search input with searchButton and no value rendered", () => {
-        const preventDefault = jest.fn();
-        const wrapper = mount(<MockMenuWithSearch isOpen focusInput />);
-
-        expect(wrapper.find(StyledSearch).find("input")).toBeFocused();
-        expect(wrapper.find(StyledSearchButton).exists()).toBe(true);
-        wrapper.find(StyledMenuModal).prop("onKeyDown")({
-          key: "Tab",
-          preventDefault,
-        });
-        expect(preventDefault).toHaveBeenCalled();
-        expect(wrapper.find(StyledMenuItem).last().find("a")).toBeFocused();
-      });
     });
   });
 

--- a/src/components/menu/menu-full-screen/menu-full-screen.style.ts
+++ b/src/components/menu/menu-full-screen/menu-full-screen.style.ts
@@ -8,6 +8,7 @@ import StyledButton from "../../button/button.style";
 import menuConfigVariants from "../menu.config";
 import { MenuType } from "../menu.context";
 import addFocusStyling from "../../../style/utils/add-focus-styling";
+import { StyledLink } from "../../link/link.style";
 
 const oldFocusStyling = `
 outline: solid 3px var(--colorsSemanticFocus500);
@@ -56,42 +57,25 @@ const StyledMenuModal = styled.div<{ menuType: MenuType }>`
   width: 100vw;
   outline: none;
 
-  a,
-  button,
-  div {
-    font-size: 16px;
+  && {
+    ${StyledLink} {
+      max-width: 100vw;
+    }
+
+    ${StyledLink} > a,
+    ${StyledLink} > button,
+    > div {
+      font-size: var(--fontSizes200);
+    }
   }
 
   ${({ menuType, theme }) => css`
     background-color: ${menuConfigVariants[menuType].background};
 
     && {
-      ${menuType === "dark" &&
-      css`
-        ${StyledSearch} span > [data-component="icon"] {
-          color: var(--colorsUtilityMajor200);
-
-          &:hover {
-            color: var(--colorsUtilityMajor150);
-          }
-        }
-      `}
-
-      ${menuType === "light" &&
-      css`
-        ${StyledSearch} span > [data-component="icon"] {
-          color: var(--colorsUtilityMajor200);
-
-          &:hover {
-            color: var(--colorsUtilityMajor400);
-          }
-        }
-      `}
-
-    ${StyledSearch} {
+      ${StyledSearch} {
         ${StyledIcon} {
           display: inline-flex;
-          margin-right: 0;
           bottom: auto;
         }
 

--- a/src/components/menu/menu-item/menu-item.component.tsx
+++ b/src/components/menu/menu-item/menu-item.component.tsx
@@ -151,10 +151,6 @@ export const MenuItem = ({
     ? submenuFocusId === menuItemId.current
     : undefined;
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const inputIcon = useRef<HTMLSpanElement | null>(null);
-  inputIcon.current = ref.current
-    ? ref.current.querySelector("[data-element='input-icon-toggle']")
-    : null;
   inputRef.current = ref.current
     ? ref.current.querySelector("[data-element='input']")
     : null;
@@ -174,6 +170,9 @@ export const MenuItem = ({
   }, [registerItem, unregisterItem]);
 
   useEffect(() => {
+    const inputIcon = ref.current?.querySelector(
+      "[data-element='input-icon-toggle']"
+    );
     if (!openSubmenuId && focusFromSubmenu === undefined && focusFromMenu) {
       /* istanbul ignore else */
       if (focusRef.current) {
@@ -181,7 +180,7 @@ export const MenuItem = ({
       }
     } else if (
       focusFromSubmenu &&
-      !(shiftTabPressed && inputIcon.current?.getAttribute("tabindex") === "0")
+      !(shiftTabPressed && inputIcon?.getAttribute("tabindex") === "0")
     ) {
       /* istanbul ignore else */
       if (focusRef.current) {
@@ -192,7 +191,6 @@ export const MenuItem = ({
     openSubmenuId,
     focusFromMenu,
     focusFromSubmenu,
-    inputIcon,
     shiftTabPressed,
     focusRef,
   ]);
@@ -213,8 +211,12 @@ export const MenuItem = ({
         (ref.current as HTMLElement)?.focus();
       }
 
+      const inputIcon = ref.current?.querySelector(
+        "[data-element='input-icon-toggle']"
+      );
+
       const shouldFocusIcon =
-        inputIcon.current?.getAttribute("tabindex") === "0" &&
+        inputIcon?.getAttribute("tabindex") === "0" &&
         document.activeElement === inputRef.current &&
         inputRef.current?.value;
 
@@ -222,8 +224,7 @@ export const MenuItem = ({
       if (
         Events.isTabKey(event) &&
         ((!Events.isShiftKey(event) && shouldFocusIcon) ||
-          (Events.isShiftKey(event) &&
-            document.activeElement === inputIcon.current))
+          (Events.isShiftKey(event) && document.activeElement === inputIcon))
       ) {
         return;
       }
@@ -232,7 +233,7 @@ export const MenuItem = ({
         handleSubmenuKeyDown(event);
       }
     },
-    [onKeyDown, handleSubmenuKeyDown, inputIcon]
+    [onKeyDown, handleSubmenuKeyDown]
   );
 
   const elementProps = {

--- a/src/components/menu/menu-item/menu-item.style.ts
+++ b/src/components/menu/menu-item/menu-item.style.ts
@@ -200,8 +200,13 @@ const StyledMenuItemWrapper = styled.a.attrs({
         ${!hasInput && `color: ${menuConfigVariants[menuType].color};`}
       }
 
-      ${StyledIcon} {
-        display: inline-block;
+      ${
+        !inFullscreenView &&
+        css`
+          a > ${StyledIcon}, button > ${StyledIcon} {
+            display: inline-block;
+          }
+        `
       }
     }
 
@@ -395,10 +400,10 @@ const StyledMenuItemWrapper = styled.a.attrs({
       }
 
       && {
-        a:focus,
-        a:hover,
-        button:focus,
-        button:hover {
+        > a:focus,
+        > a:hover,
+        > button:focus,
+        > button:hover {
           background-color: var(--colorsComponentsMenuAutumnStandard600);
           color: var(--colorsComponentsMenuYang100);
 

--- a/src/components/menu/menu.pw.tsx
+++ b/src/components/menu/menu.pw.tsx
@@ -1454,6 +1454,9 @@ test.describe("Prop tests for Menu Fullscreen component", () => {
     const searchInput = searchDefaultInput(page);
     await expect(searchInput).toBeFocused();
     await page.keyboard.press("Tab");
+    const button = searchButton(page);
+    await expect(button).toBeFocused();
+    await page.keyboard.press("Tab");
     const item2 = menuItem(page).last().locator("a");
     await expect(item2).toBeFocused();
   });
@@ -1511,6 +1514,18 @@ test.describe("Prop tests for Menu Fullscreen component", () => {
     await page.keyboard.press("Tab");
     const item2 = menuItem(page).last().locator("a");
     await expect(item2).toBeFocused();
+  });
+
+  test(`should apply the expected hover styling to the search button`, async ({
+    mount,
+    page,
+  }) => {
+    await mount(<MenuFullScreenWithSearchButton searchValue="foo" />);
+
+    const button = searchButton(page);
+    await button.hover();
+
+    await expect(button).toHaveCSS("background-color", "rgb(0, 103, 56)");
   });
 });
 

--- a/src/components/menu/menu.style.ts
+++ b/src/components/menu/menu.style.ts
@@ -16,6 +16,7 @@ import {
 import { StyledLink } from "../link/link.style";
 import { MenuProps } from "./menu.component";
 import { baseTheme } from "../../style/themes";
+import StyledMenuItemWrapper from "./menu-item/menu-item.style";
 
 interface StyledMenuProps
   extends Pick<MenuProps, "menuType">,
@@ -94,7 +95,9 @@ const StyledMenuItem = styled.li<StyledMenuItemProps>`
       }
     `}
 
-  ${padding}
+  ${StyledMenuItemWrapper} {
+    ${padding}
+  }
 `;
 
 StyledMenuItem.defaultProps = {

--- a/src/components/profile/profile.spec.tsx
+++ b/src/components/profile/profile.spec.tsx
@@ -319,7 +319,7 @@ describe("Profile", () => {
           color: "var(--colorsActionMajor500)",
         },
         wrapper.find(ProfileEmailStyle),
-        { modifier: "a" }
+        { modifier: "> a" }
       );
     });
 

--- a/src/components/search/index.ts
+++ b/src/components/search/index.ts
@@ -1,2 +1,6 @@
 export { default } from "./search.component";
-export type { SearchProps, SearchEvent } from "./search.component";
+export type {
+  SearchProps,
+  SearchEvent,
+  SearchHandle,
+} from "./search.component";

--- a/src/components/search/search-button.style.ts
+++ b/src/components/search/search-button.style.ts
@@ -16,7 +16,7 @@ const StyledSearchButton = styled.div`
   border-bottom: none;
 
   & ${StyledButton} {
-    background-color: var(--colorsActionMajor500);
+    color: var(--colorsActionMajorYang100);
     border-color: var(--colorsActionMajorTransparent);
     border-bottom-left-radius: var(--borderRadius000);
     border-top-left-radius: var(--borderRadius000);
@@ -24,13 +24,18 @@ const StyledSearchButton = styled.div`
     border-top-right-radius: var(--borderRadius050);
 
     :hover {
-      background: var(--colorsActionMajor600);
       border-color: var(--colorsActionMajorTransparent);
     }
 
-    width: 40px;
+    width: fit-content;
+
+    ${StyledIcon}${StyledIcon} {
+      color: var(--colorsActionMajorYang100);
+    }
+
     margin: 0px 0px;
     padding-bottom: 3px;
+
     :focus {
       z-index: ${({ theme }) => theme.zIndex.smallOverlay};
     }

--- a/src/components/search/search.component.tsx
+++ b/src/components/search/search.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useImperativeHandle } from "react";
 import invariant from "invariant";
 import { MarginProps } from "styled-system";
 import { filterStyledSystemMarginProps } from "../../style/utils";
@@ -70,9 +70,14 @@ export interface SearchProps extends ValidationProps, MarginProps {
   tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
+export type SearchHandle = {
+  /** Programmatically focus on root container of Dialog. */
+  focus: () => void;
+} | null;
+
 let deprecateUncontrolledWarnTriggered = false;
 
-export const Search = React.forwardRef(
+export const Search = React.forwardRef<SearchHandle, SearchProps>(
   (
     {
       defaultValue,
@@ -97,13 +102,24 @@ export const Search = React.forwardRef(
       info,
       tooltipPosition,
       ...rest
-    }: SearchProps,
-    ref: React.ForwardedRef<HTMLInputElement>
+    },
+    ref
   ) => {
     const isControlled = value !== undefined;
     const initialValue = isControlled ? value : defaultValue;
     const locale = useLocale();
     const searchRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useImperativeHandle<SearchHandle, SearchHandle>(
+      ref,
+      () => ({
+        focus() {
+          inputRef.current?.focus();
+        },
+      }),
+      []
+    );
 
     if (!deprecateUncontrolledWarnTriggered && !isControlled) {
       deprecateUncontrolledWarnTriggered = true;
@@ -170,8 +186,7 @@ export const Search = React.forwardRef(
         });
       }
 
-      const input = searchRef.current?.querySelector("input");
-      input?.focus();
+      inputRef.current?.focus();
     };
 
     const handleMouseDown = (event: React.MouseEvent<HTMLElement>) => {
@@ -233,7 +248,7 @@ export const Search = React.forwardRef(
           onBlur={handleBlur}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
-          ref={ref}
+          ref={inputRef}
           tabIndex={tabIndex}
           error={error}
           warning={warning}

--- a/src/components/search/search.component.tsx
+++ b/src/components/search/search.component.tsx
@@ -29,8 +29,6 @@ export interface SearchProps extends ValidationProps, MarginProps {
   defaultValue?: string;
   /** Prop for `id` */
   id?: string;
-  /** A callback to retrieve the input reference */
-  inputRef?: React.MutableRefObject<HTMLInputElement | null>;
   /** Prop for `name` */
   name?: string;
   /** Prop for `onBlur` events */
@@ -72,7 +70,6 @@ export interface SearchProps extends ValidationProps, MarginProps {
   tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
 
-let deprecateInputRefWarnTriggered = false;
 let deprecateUncontrolledWarnTriggered = false;
 
 export const Search = React.forwardRef(
@@ -94,7 +91,6 @@ export const Search = React.forwardRef(
       placeholder,
       variant = "default",
       "aria-label": ariaLabel = "search",
-      inputRef,
       tabIndex,
       error,
       warning,
@@ -108,13 +104,6 @@ export const Search = React.forwardRef(
     const initialValue = isControlled ? value : defaultValue;
     const locale = useLocale();
     const searchRef = useRef<HTMLDivElement>(null);
-
-    if (!deprecateInputRefWarnTriggered && inputRef) {
-      deprecateInputRefWarnTriggered = true;
-      Logger.deprecate(
-        "The `inputRef` prop in `Search` component is deprecated and will soon be removed. Please use `ref` instead."
-      );
-    }
 
     if (!deprecateUncontrolledWarnTriggered && !isControlled) {
       deprecateUncontrolledWarnTriggered = true;
@@ -244,7 +233,7 @@ export const Search = React.forwardRef(
           onBlur={handleBlur}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
-          ref={ref || inputRef}
+          ref={ref}
           tabIndex={tabIndex}
           error={error}
           warning={warning}

--- a/src/components/search/search.mdx
+++ b/src/components/search/search.mdx
@@ -1,6 +1,7 @@
 import { Meta, ArgTypes, Canvas } from "@storybook/blocks";
 
 import * as SearchStories from "./search.stories";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 
 <Meta title="Search" of={SearchStories} />
 
@@ -46,6 +47,16 @@ import Search from "carbon-react/lib/components/search";
 Please note, if you need to apply your own custom aria-label for the search button, this can be done by using the `searchButtonAriaLabel` prop. By default the aria-label is `search button`.
 
 <Canvas of={SearchStories.WithSearchButton} />
+
+You can also override the text of the search button by passing a string value to the `searchButton` prop.
+Please note that any string passed here will take precedence over the locale string value passed via the 
+`searchButtonText` translation key.
+
+<Canvas of={SearchStories.WithSearchButtonLocaleOverride} />
+
+You can also use the locale provider to override the button's text via the `searchButtonText` translation key.
+
+<Canvas of={SearchStories.WithSearchButtonLocaleOverride} />
 
 ### Search without Search Button, default width and colour background
 
@@ -126,3 +137,19 @@ It is possible to use the `tooltipPosition` to override the default placement of
 ### Search
 
 <ArgTypes of={SearchStories} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object
+to the [i18nProvider](../?path=/docs/documentation-i18n--docs).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "search.searchButtonText",
+      description: "The text for search button",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
+/>

--- a/src/components/search/search.pw.tsx
+++ b/src/components/search/search.pw.tsx
@@ -84,7 +84,7 @@ test.describe("When focused", () => {
 
     const searchDefaultInputElement = searchDefaultInput(page);
     await searchDefaultInputElement.clear();
-    await searchDefaultInputElement.type(testDataStandard);
+    await searchDefaultInputElement.fill(testDataStandard);
     const searchButtonElement = searchButton(page);
     await searchButtonElement.click({
       force: true,
@@ -108,7 +108,7 @@ test.describe("When focused", () => {
 
     const searchDefaultInputElement = searchDefaultInput(page);
     await searchDefaultInputElement.clear();
-    await searchDefaultInputElement.type(testDataStandard);
+    await searchDefaultInputElement.fill(testDataStandard);
     const searchButtonElement = searchButton(page);
     await searchButtonElement.click({
       force: true,
@@ -132,7 +132,7 @@ test.describe("When focused", () => {
 
     const searchDefaultInputElement = searchDefaultInput(page);
     await searchDefaultInputElement.clear();
-    await searchDefaultInputElement.type(testDataStandard);
+    await searchDefaultInputElement.fill(testDataStandard);
     await searchDefaultInputElement.press("Tab");
     const searchCrossIconElementParent = searchCrossIcon(page).locator("..");
 
@@ -154,7 +154,7 @@ test.describe("When focused", () => {
 
     const searchDefaultInputElement = searchDefaultInput(page);
     await searchDefaultInputElement.clear();
-    await searchDefaultInputElement.type(testDataStandard);
+    await searchDefaultInputElement.fill(testDataStandard);
     await searchDefaultInputElement.press("Tab");
     const searchCrossIconElementParent = searchCrossIcon(page).locator("..");
 
@@ -246,7 +246,7 @@ test.describe("Prop tests for Search component", () => {
     );
     const searchDefaultInputElement = searchDefaultInput(page);
     await searchDefaultInputElement.clear();
-    await searchDefaultInputElement.type(testDataStandard);
+    await searchDefaultInputElement.fill(testDataStandard);
     const searchButtonElement = searchButton(page);
 
     await expect(searchButtonElement).toHaveAttribute(
@@ -275,6 +275,15 @@ test.describe("Prop tests for Search component", () => {
         await expect(searchFindIconElement).not.toBeInViewport();
       }
     });
+  });
+
+  test("should render Search with button text overridden when searchButton is passed a string value", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<Search searchButton="foo" defaultValue={testDataStandard} />);
+
+    await expect(page.getByText("foo")).toBeVisible();
   });
 
   ([
@@ -346,7 +355,7 @@ test.describe("Prop tests for Search component", () => {
 
 ([
   ["default", "rgb(102, 132, 148)"],
-  ["dark", "rgb(153, 173, 183)"],
+  ["dark", "rgba(255, 255, 255, 0.8)"],
 ] as [SearchProps["variant"], string][]).forEach(
   ([variant, backgroundColor]) => {
     test(`should render Search with variant prop set to ${variant}`, async ({
@@ -378,7 +387,7 @@ test.describe("Prop tests for Search component", () => {
 
 ([
   ["default", "rgb(51, 91, 112)"],
-  ["dark", "rgb(204, 214, 219)"],
+  ["dark", "rgb(255, 255, 255)"],
 ] as [SearchProps["variant"], string][]).forEach(([variant, hoverColor]) => {
   test(`should render Search with variant prop set to ${variant} on hover`, async ({
     mount,
@@ -542,7 +551,7 @@ test.describe("Functionality tests for Search component", () => {
 
     const searchDefaultInputElement = searchDefaultInput(page);
     await searchDefaultInputElement.clear();
-    await searchDefaultInputElement.type(testDataStandard);
+    await searchDefaultInputElement.fill(testDataStandard);
     const searchButtonElement = searchButton(page);
     await searchButtonElement.click({
       force: true,
@@ -561,13 +570,31 @@ test.describe("Functionality tests for Search component", () => {
 
     const searchDefaultInputElement = searchDefaultInput(page);
     await searchDefaultInputElement.clear();
-    await searchDefaultInputElement.type(testDataStandard);
+    await searchDefaultInputElement.fill(testDataStandard);
     const searchCrossIconElement = searchCrossIcon(page);
     await searchCrossIconElement.click({
       force: true,
     });
 
     await expect(searchDefaultInputElement).toHaveValue("");
+    await expect(searchDefaultInputElement).toBeFocused();
+  });
+
+  test("should clear a Search input after enter key pressed and cross icon is focused", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<SearchComponent />);
+
+    const searchDefaultInputElement = searchDefaultInput(page);
+    await searchDefaultInputElement.clear();
+    await searchDefaultInputElement.fill(testDataStandard);
+    const searchCrossIconElementParent = searchCrossIcon(page).locator("..");
+    await searchCrossIconElementParent.focus();
+    await searchCrossIconElementParent.press("Enter");
+
+    await expect(searchDefaultInputElement).toHaveValue("");
+    await expect(searchDefaultInputElement).toBeFocused();
   });
 });
 
@@ -607,7 +634,7 @@ test.describe("Event tests for Search component", () => {
     );
 
     const searchDefaultInputElement = searchDefaultInput(page);
-    await searchDefaultInputElement.type("1");
+    await searchDefaultInputElement.fill("1");
 
     await expect(callbackCount).toEqual(1);
   });

--- a/src/components/search/search.spec.tsx
+++ b/src/components/search/search.spec.tsx
@@ -13,11 +13,12 @@ import StyledTextInput from "../../__internal__/input/input-presentation.style";
 import StyledInputIconToggle from "../../__internal__/input-icon-toggle/input-icon-toggle.style";
 import StyledIcon from "../icon/icon.style";
 import Icon from "../icon";
-import TextBox from "../textbox";
+import Textbox from "../textbox";
 import { rootTagTest } from "../../__internal__/utils/helpers/tags/tags-specs";
 import Logger from "../../__internal__/utils/logger";
 import StyledInput from "../../__internal__/input/input.style";
 import StyledButton from "../button/button.style";
+import I18nProvider from "../i18n-provider";
 
 jest.mock("../../__internal__/utils/logger");
 
@@ -67,9 +68,9 @@ describe("Search", () => {
     it("matches the expected styles", () => {
       assertStyleMatch(
         {
-          borderBottom: "2px solid var(--colorsUtilityMajor300)",
+          borderBottom: "var(--spacing025) solid var(--colorsUtilityMajor300)",
           display: "inline-flex",
-          fontSize: "14px",
+          fontSize: "var(--fontSize100)",
           fontWeight: "700",
         },
         renderSearch({ value: "" })
@@ -79,9 +80,9 @@ describe("Search", () => {
     it("applies the default width when the user does not specify a width", () => {
       assertStyleMatch(
         {
-          borderBottom: "2px solid var(--colorsUtilityMajor300)",
+          borderBottom: "var(--spacing025) solid var(--colorsUtilityMajor300)",
           display: "inline-flex",
-          fontSize: "14px",
+          fontSize: "var(--fontSize100)",
           fontWeight: "700",
           width: "100%",
         },
@@ -92,9 +93,9 @@ describe("Search", () => {
     it("applies the correct width specified by the user", () => {
       assertStyleMatch(
         {
-          borderBottom: "2px solid var(--colorsUtilityMajor300)",
+          borderBottom: "var(--spacing025) solid var(--colorsUtilityMajor300)",
           display: "inline-flex",
-          fontSize: "14px",
+          fontSize: "var(--fontSize100)",
           fontWeight: "700",
           width: "400px",
         },
@@ -109,59 +110,33 @@ describe("Search", () => {
 
       assertStyleMatch(
         {
-          borderBottom: "2px solid var(--colorsUtilityMajor300)",
+          borderBottom: "var(--spacing025) solid var(--colorsUtilityMajor300)",
         },
         wrapper
       );
     });
 
-    it("matches the expected styles when variant is dark, the input is not focused and has a value", () => {
+    it("should render the bottom border when variant is dark, the input is not focused and has a value", () => {
       wrapper = renderSearch({ value: "search", variant: "dark" });
 
       assertStyleMatch(
         {
-          borderBottom: "2px solid var(--colorsUtilityMajor200)",
+          borderBottom: "var(--spacing025) solid var(--colorsUtilityYang080)",
           backgroundColor: "transparent",
         },
         wrapper
       );
     });
 
-    it("matches the expected styles when the input is not focused, has a value and search has button", () => {
+    it("should not render the bottom border when the input is not focused, has a value and search has button", () => {
       wrapper = renderSearch({ value: "search", searchButton: true });
 
       assertStyleMatch(
         {
-          borderBottom: "2px solid var(--colorsUtilityMajor300)",
+          borderBottom: undefined,
           backgroundColor: "transparent",
         },
         wrapper
-      );
-    });
-
-    it("matches the expected styles for icon when variant is dark", () => {
-      wrapper = renderSearch({
-        value: "",
-        searchButton: true,
-        id: "Search",
-        name: "Search",
-        variant: "dark",
-      });
-      const icon = wrapper
-        .find(Icon)
-        .findWhere((n) => n.props().type === "search")
-        .hostNodes();
-      act(() => {
-        const input = wrapper.find(Input);
-        input.simulate("focus");
-      });
-      wrapper.update();
-
-      assertStyleMatch(
-        {
-          color: "var(--colorsYin090)",
-        },
-        icon
       );
     });
 
@@ -170,7 +145,7 @@ describe("Search", () => {
 
       assertStyleMatch(
         {
-          fontSize: "14px",
+          fontSize: "var(--fontSize100)",
           fontWeight: "700",
         },
         wrapper,
@@ -206,7 +181,7 @@ describe("Search", () => {
           color: "var(--colorsActionMinor500)",
         },
         wrapper,
-        { modifier: `${StyledIcon}` }
+        { modifier: `${StyledIcon}:not([data-element="search"])` }
       );
 
       assertStyleMatch(
@@ -214,7 +189,7 @@ describe("Search", () => {
           color: "var(--colorsActionMinor600)",
         },
         wrapper,
-        { modifier: `${StyledIcon}:hover` }
+        { modifier: `${StyledIcon}:not([data-element="search"]):hover` }
       );
     });
 
@@ -230,18 +205,18 @@ describe("Search", () => {
 
       assertStyleMatch(
         {
-          color: "var(--colorsUtilityMajor200)",
+          color: "var(--colorsUtilityYang080)",
         },
         wrapper,
-        { modifier: `${StyledIcon}` }
+        { modifier: `${StyledIcon}:not([data-element="search"])` }
       );
 
       assertStyleMatch(
         {
-          color: "var(--colorsUtilityMajor100)",
+          color: "var(--colorsUtilityYang100)",
         },
         wrapper,
-        { modifier: `${StyledIcon}:hover` }
+        { modifier: `${StyledIcon}:not([data-element="search"]):hover` }
       );
     });
 
@@ -263,18 +238,18 @@ describe("Search", () => {
 
       assertStyleMatch(
         {
-          color: "var(--colorsUtilityMajor400)",
+          color: "var(--colorsUtilityYang080)",
         },
         wrapper,
-        { modifier: `${StyledIcon}` }
+        { modifier: `${StyledIcon}:not([data-element="search"])` }
       );
 
       assertStyleMatch(
         {
-          color: "var(--colorsUtilityMajor500)",
+          color: "var(--colorsUtilityYang100)",
         },
         wrapper,
-        { modifier: `${StyledIcon}:hover` }
+        { modifier: `${StyledIcon}:not([data-element="search"]):hover` }
       );
     });
 
@@ -312,25 +287,82 @@ describe("Search", () => {
     });
   });
 
-  describe("When button is true and textbox is active", () => {
-    it("does not render an icon in textbox", () => {
-      wrapper = renderSearch({
-        value: "",
-        searchButton: true,
-        id: "Search",
-        name: "Search",
-      });
-      const icon = wrapper
-        .find(Icon)
-        .findWhere((n) => n.props().type === "search")
-        .hostNodes();
-      act(() => {
-        const input = wrapper.find(Input);
-        input.simulate("focus");
-      });
-      wrapper.update();
-      expect(icon.props().value).toEqual(undefined);
+  it("should not render an icon in textbox when searchButton is passed a truthy boolean value", () => {
+    wrapper = renderSearch({
+      value: "",
+      searchButton: true,
+      id: "Search",
+      name: "Search",
     });
+    const searchButton = wrapper.find(Button);
+    const icon = wrapper
+      .find(Textbox)
+      .find(Icon)
+      .findWhere((n) => n.props().type === "search")
+      .hostNodes();
+    act(() => {
+      const input = wrapper.find(Input);
+      input.simulate("focus");
+    });
+    wrapper.update();
+    expect(searchButton.text()).toBe("Search");
+    expect(icon.exists()).toBe(false);
+  });
+
+  it("should not render an icon in textbox when searchButton is passed a string value", () => {
+    wrapper = renderSearch({
+      value: "",
+      searchButton: "Foo",
+      id: "Search",
+      name: "Search",
+    });
+    const searchButton = wrapper.find(Button);
+    const icon = wrapper
+      .find(Textbox)
+      .find(Icon)
+      .findWhere((n) => n.props().type === "search")
+      .hostNodes();
+    act(() => {
+      const input = wrapper.find(Input);
+      input.simulate("focus");
+    });
+    wrapper.update();
+    expect(searchButton.text()).toBe("Foo");
+    expect(icon.exists()).toBe(false);
+  });
+
+  it("should render an icon in textbox when searchButton is passed a falsy value", () => {
+    wrapper = renderSearch({
+      value: "",
+      searchButton: false,
+      id: "Search",
+      name: "Search",
+    });
+    const searchButton = wrapper.find(Button);
+    const icon = wrapper
+      .find(Textbox)
+      .find(Icon)
+      .findWhere((n) => n.props().type === "search")
+      .hostNodes();
+    act(() => {
+      const input = wrapper.find(Input);
+      input.simulate("focus");
+    });
+    wrapper.update();
+    expect(searchButton.exists()).toBe(false);
+    expect(icon.exists()).toBe(true);
+  });
+
+  it("should allow the search Button text to be overridden via the locale context", () => {
+    wrapper = mount(
+      <I18nProvider
+        locale={{ search: { searchButtonText: () => "text override" } }}
+      >
+        <Search searchButton value="search" onChange={() => {}} />
+      </I18nProvider>
+    );
+    const searchButton = wrapper.find(Button);
+    expect(searchButton.text()).toBe("text override");
   });
 
   describe("supports being an uncontrolled component", () => {
@@ -561,23 +593,6 @@ describe("Search", () => {
     });
   });
 
-  describe("Prop Types", () => {
-    let consoleSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-      consoleSpy = jest
-        .spyOn(global.console, "error")
-        .mockImplementation(() => {});
-    });
-
-    it("validates children prop types", () => {
-      expect(() => mount(<Search value="Foo" threshold={-4} />)).toThrow(
-        "Threshold must be a positive number"
-      );
-      consoleSpy.mockRestore();
-    });
-  });
-
   describe("tags", () => {
     describe("on component", () => {
       const wrapperWithTags = shallow(<Search value="" />);
@@ -594,7 +609,7 @@ describe("Search", () => {
         id: "Search",
         name: "Search",
       });
-      const input = wrapper.find(TextBox);
+      const input = wrapper.find(Textbox);
       expect(input.prop("iconTabIndex")).toEqual(0);
     });
 
@@ -604,7 +619,7 @@ describe("Search", () => {
         id: "Search",
         name: "Search",
       });
-      const input = wrapper.find(TextBox);
+      const input = wrapper.find(Textbox);
       expect(input.prop("iconTabIndex")).toEqual(-1);
     });
   });
@@ -712,7 +727,7 @@ describe("Search", () => {
   describe("aria-label", () => {
     it("has a default aria-label passed to Search", () => {
       wrapper = renderSearch({ defaultValue: "foo" });
-      const search = wrapper.find(TextBox);
+      const search = wrapper.find(Textbox);
       expect(search.prop("aria-label")).toEqual("search");
     });
 

--- a/src/components/search/search.spec.tsx
+++ b/src/components/search/search.spec.tsx
@@ -1,9 +1,11 @@
-import React from "react";
+import React, { useRef } from "react";
 import { mount, ReactWrapper, shallow } from "enzyme";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { act } from "react-dom/test-utils";
 import { Input } from "../../__internal__/input";
 import Button from "../button";
-import Search, { SearchProps } from "./search.component";
+import Search, { SearchHandle, SearchProps } from "./search.component";
 import StyledSearchButton from "./search-button.style";
 import {
   assertStyleMatch,
@@ -685,28 +687,28 @@ describe("Search", () => {
     });
   });
 
-  describe("refs", () => {
-    it("accepts ref as a ref object", () => {
-      const ref = { current: null };
-      wrapper = renderSearch({ ref, value: "" });
+  describe("passing a ref", () => {
+    const MockComponent = () => {
+      const ref = useRef<SearchHandle>(null);
 
-      expect(ref.current).toBe(wrapper.find("input").getDOMNode());
-    });
+      return (
+        <div>
+          <button type="button" onClick={() => ref.current?.focus()}>
+            Focus input
+          </button>
+          <Search value="foo" onChange={() => {}} ref={ref} />
+        </div>
+      );
+    };
 
-    it("accepts ref as a ref callback", () => {
-      const ref = jest.fn();
-      wrapper = renderSearch({ ref, value: "" });
+    it("should allow input to be programmatically focused", async () => {
+      render(<MockComponent />);
+      const user = userEvent.setup();
+      const button = screen.getByText("Focus input");
 
-      expect(ref).toHaveBeenCalledWith(wrapper.find("input").getDOMNode());
-    });
+      await user.click(button);
 
-    it("sets ref to empty after unmount", () => {
-      const ref = { current: null };
-      wrapper = renderSearch({ ref, value: "" });
-
-      wrapper.unmount();
-
-      expect(ref.current).toBe(null);
+      expect(screen.getByDisplayValue("foo")).toHaveFocus();
     });
   });
 

--- a/src/components/search/search.spec.tsx
+++ b/src/components/search/search.spec.tsx
@@ -686,20 +686,6 @@ describe("Search", () => {
   });
 
   describe("refs", () => {
-    it("should display deprecation warning when the inputRef prop is used", () => {
-      const ref = { current: null };
-
-      wrapper = renderSearch({ inputRef: ref, value: "" });
-
-      expect(loggerSpy).toHaveBeenCalledWith(
-        "The `inputRef` prop in `Search` component is deprecated and will soon be removed. Please use `ref` instead."
-      );
-
-      wrapper.setProps({ prop1: true });
-      expect(loggerSpy).toHaveBeenCalledTimes(1);
-      loggerSpy.mockRestore();
-    });
-
     it("accepts ref as a ref object", () => {
       const ref = { current: null };
       wrapper = renderSearch({ ref, value: "" });

--- a/src/components/search/search.stories.tsx
+++ b/src/components/search/search.stories.tsx
@@ -6,6 +6,7 @@ import generateStyledSystemProps from "../../../.storybook/utils/styled-system-p
 import Box from "../box";
 import Button from "../button";
 import Search, { SearchEvent } from ".";
+import I18nProvider from "../i18n-provider/i18n-provider.component";
 
 const styledSystemProps = generateStyledSystemProps({
   margin: true,
@@ -52,14 +53,46 @@ Controlled.storyName = "Controlled";
 
 export const WithSearchButton: Story = () => {
   return (
-    <Search
-      defaultValue="Here is some text"
-      searchButton
-      searchButtonAriaLabel="search button aria label"
-    />
+    <Box m={1}>
+      <Search
+        defaultValue="Here is some text"
+        searchButton
+        searchButtonAriaLabel="search button aria label"
+      />
+    </Box>
   );
 };
 WithSearchButton.storyName = "With Search Button";
+
+export const WithSearchButtonPropTextOverride: Story = () => {
+  return (
+    <Box m={1}>
+      <Search
+        defaultValue="Here is some text"
+        searchButton="Find"
+        searchButtonAriaLabel="search button aria label"
+      />
+    </Box>
+  );
+};
+WithSearchButtonPropTextOverride.storyName =
+  "With Search Button text override via prop";
+
+export const WithSearchButtonLocaleOverride: Story = () => {
+  return (
+    <Box m={1}>
+      <I18nProvider locale={{ search: { searchButtonText: () => "Find" } }}>
+        <Search
+          defaultValue="Here is some text"
+          searchButton
+          searchButtonAriaLabel="search button aria label"
+        />
+      </I18nProvider>
+    </Box>
+  );
+};
+WithSearchButtonLocaleOverride.storyName =
+  "With Search Button text override via locale";
 
 export const DefaultWithColourBackground: Story = () => {
   return <Search placeholder="Search..." defaultValue="" />;
@@ -83,11 +116,13 @@ DefaultWithColourBackground.parameters = {
 
 export const WithSearchButtonAndColourBackground: Story = () => {
   return (
-    <Search
-      placeholder="Search..."
-      defaultValue="Here is some text"
-      searchButton
-    />
+    <Box m={1}>
+      <Search
+        placeholder="Search..."
+        defaultValue="Here is some text"
+        searchButton
+      />
+    </Box>
   );
 };
 WithSearchButtonAndColourBackground.storyName =
@@ -115,7 +150,13 @@ CustomWidthUsingPx.storyName = "Custom Width Using Px";
 
 export const WithSearchButtonAndCustomWidthUsingPx: Story = () => {
   return (
-    <Search defaultValue="Here is some text" searchButton searchWidth="375px" />
+    <Box m={1}>
+      <Search
+        defaultValue="Here is some text"
+        searchButton
+        searchWidth="375px"
+      />
+    </Box>
   );
 };
 WithSearchButtonAndCustomWidthUsingPx.storyName =
@@ -128,7 +169,9 @@ CustomWidthUsingPercentage.storyName = "Custom Width Using Percentage";
 
 export const WithSearchButtonAndCustomWidthUsingPercentage: Story = () => {
   return (
-    <Search defaultValue="Here is some text" searchButton searchWidth="70%" />
+    <Box m={1}>
+      <Search defaultValue="Here is some text" searchButton searchWidth="70%" />
+    </Box>
   );
 };
 WithSearchButtonAndCustomWidthUsingPercentage.storyName =
@@ -136,27 +179,22 @@ WithSearchButtonAndCustomWidthUsingPercentage.storyName =
 
 export const WithCustomMaxWidth: Story = () => {
   return (
-    <Search defaultValue="Here is some text" searchButton maxWidth="50%" />
+    <Box m={1}>
+      <Search defaultValue="Here is some text" searchButton maxWidth="50%" />
+    </Box>
   );
 };
 WithCustomMaxWidth.storyName = "With Custom Max Width";
 
 export const WithAltStyling: Story = () => {
   return (
-    <Box width="700px" height="108px">
-      <div
-        style={{
-          padding: "32px",
-          backgroundColor: "#003349",
-        }}
-      >
-        <Search
-          placeholder="Search..."
-          defaultValue="Here is some text"
-          searchButton
-          variant="dark"
-        />
-      </div>
+    <Box width="700px" height="108px" p={4} backgroundColor="#000000">
+      <Search
+        placeholder="Search..."
+        defaultValue="Here is some text"
+        searchButton
+        variant="dark"
+      />
     </Box>
   );
 };

--- a/src/components/search/search.style.ts
+++ b/src/components/search/search.style.ts
@@ -12,7 +12,6 @@ interface StyledSearchProps {
   name?: string;
   isFocused?: boolean;
   searchHasValue?: boolean;
-  searchIsActive?: boolean;
   searchWidth?: string;
   maxWidth?: string;
   showSearchButton?: boolean;
@@ -24,7 +23,6 @@ const StyledSearch = styled.div<StyledSearchProps>`
     isFocused,
     searchWidth,
     maxWidth,
-    searchIsActive,
     searchHasValue,
     showSearchButton,
     theme,
@@ -32,54 +30,40 @@ const StyledSearch = styled.div<StyledSearchProps>`
   }) => {
     const darkVariant = variant === "dark";
     const variantColor = darkVariant
-      ? "var(--colorsUtilityMajor200)"
+      ? "var(--colorsUtilityYang080)"
       : "var(--colorsUtilityMajor300)";
 
-    const iconColor =
-      darkVariant &&
-      ((searchHasValue && isFocused) ||
-        (!searchHasValue && isFocused) ||
-        (!isFocused && searchHasValue && showSearchButton));
     return css`
       ${margin}
       width: ${searchWidth ? `${searchWidth}` : "100%"};
       max-width: ${maxWidth ? `${maxWidth}` : "100%"};
-      padding-bottom: 2px;
+      padding-bottom: var(--spacing025);
       background-color: transparent;
-      border-bottom: 2px solid ${variantColor};
       display: inline-flex;
-      font-size: 14px;
+      font-size: var(--fontSize100);
       font-weight: 700;
-      :hover {
-        border-bottom-color: ${darkVariant
-          ? "var(--colorsUtilityMajor100)"
-          : "var(--colorsUtilityMajor400)"};
-        cursor: pointer;
-      }
-      ${(isFocused || searchHasValue) &&
+
+      ${!showSearchButton &&
       css`
-        border-color: transparent;
-        transition: background 0.2s ease;
+        border-bottom: var(--spacing025) solid ${variantColor};
+
         :hover {
-          border-color: transparent;
-        }
-      `}
-      ${isFocused &&
-      !searchIsActive &&
-      css`
-        border-color: transparent;
-      `}
-      ${!isFocused &&
-      searchHasValue &&
-      !showSearchButton &&
-      css`
-        border-bottom: 2px solid ${variantColor};
-        :hover {
-          border-bottom-color: var(--colorsUtilityMajor400);
+          border-bottom-color: ${darkVariant
+            ? "var(--colorsUtilityYang100)"
+            : "var(--colorsUtilityMajor400)"};
           cursor: pointer;
         }
-      `}
 
+        ${(searchHasValue || isFocused) &&
+        css`
+          border-bottom-color: transparent;
+
+          :hover {
+            border-bottom-color: transparent;
+            cursor: default;
+          }
+        `}
+      `}
 
       ${StyledInput} {
         ::-moz-placeholder {
@@ -91,19 +75,17 @@ const StyledSearch = styled.div<StyledSearchProps>`
         }
 
         ${darkVariant &&
-        !isFocused &&
         css`
           ::-moz-placeholder {
-            color: var(--colorsUtilityMajor200);
+            color: var(--colorsUtilityYang080);
             opacity: 1;
           }
           ::placeholder {
-            color: var(--colorsUtilityMajor200);
+            color: var(--colorsUtilityYang080);
           }
         `}
 
         ${darkVariant &&
-        !isFocused &&
         searchHasValue &&
         !showSearchButton &&
         css`
@@ -112,9 +94,41 @@ const StyledSearch = styled.div<StyledSearchProps>`
       }
 
       ${StyledInputPresentation} {
-        background-color: ${searchHasValue || isFocused
-          ? "var(--colorsUtilityYang100)"
-          : "transparent"};
+        [data-element="search"] {
+          height: auto;
+
+          ${!darkVariant &&
+          css`
+            color: var(--colorsUtilityYin065);
+
+            :hover {
+              color: var(--colorsUtilityYin100);
+            }
+          `}
+
+          ${darkVariant &&
+          css`
+            color: var(--colorsUtilityYang080);
+
+            :hover {
+              color: var(--colorsUtilityYang100);
+            }
+          `}
+        }
+
+        ${darkVariant &&
+        !showSearchButton &&
+        css`
+          background-color: transparent;
+          border-color: var(--colorsUtilityYang080);
+        `}
+
+        ${!darkVariant &&
+        css`
+          background-color: ${searchHasValue || isFocused || showSearchButton
+            ? "var(--colorsUtilityYang100)"
+            : "transparent"};
+        `}
 
         ${showSearchButton &&
         css`
@@ -123,21 +137,23 @@ const StyledSearch = styled.div<StyledSearchProps>`
         `}
 
         flex: 1;
-        font-size: 14px;
+        font-size: var(--fontSize100);
         font-weight: 700;
-        padding-bottom: 2px;
+        padding-bottom: var(--spacing025);
         padding-top: 1px;
         cursor: pointer;
+
         ${!isFocused &&
         !searchHasValue &&
+        !showSearchButton &&
         css`
           border: 1px solid transparent;
         `}
+
         ${!isFocused &&
         searchHasValue &&
         !showSearchButton &&
         css`
-          border: 1px solid transparent;
           background-color: ${darkVariant
             ? "transparent"
             : "var(--colorsUtilityYang100)"};
@@ -148,38 +164,28 @@ const StyledSearch = styled.div<StyledSearchProps>`
         flex: 1;
         z-index: ${theme.zIndex.smallOverlay};
       }
+
       ${StyledIcon} {
-        ${darkVariant &&
-        css`
-          ${iconColor &&
+        :not([data-element="search"]) {
+          ${darkVariant &&
+          !showSearchButton &&
           css`
-            color: var(--colorsUtilityMajor400);
+            color: var(--colorsUtilityYang080);
 
             :hover {
-              color: var(--colorsUtilityMajor500);
+              color: var(--colorsUtilityYang100);
             }
           `}
-          ${!iconColor &&
+
+          ${!darkVariant &&
           css`
-            color: var(--colorsUtilityMajor200);
+            color: var(--colorsActionMinor500);
 
             :hover {
-              color: var(--colorsUtilityMajor100);
+              color: var(--colorsActionMinor600);
             }
           `}
-        `}
-
-        ${!darkVariant &&
-        css`
-          color: var(--colorsActionMinor500);
-
-          :hover {
-            color: var(--colorsActionMinor600);
-          }
-        `}
-
-        width: 20px;
-        height: 20px;
+        }
         cursor: pointer;
       }
 

--- a/src/locales/__internal__/es-es.ts
+++ b/src/locales/__internal__/es-es.ts
@@ -153,6 +153,9 @@ const esES: Locale = {
   pod: {
     undo: () => "Deshacer",
   },
+  search: {
+    searchButtonText: () => "Buscar",
+  },
   select: {
     actionButtonText: () => "Añadir un nuevo elemento",
     placeholder: () => "Por favor seleccione...",

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -151,6 +151,9 @@ const enGB: Locale = {
   pod: {
     undo: () => "Undo",
   },
+  search: {
+    searchButtonText: () => "Search",
+  },
   select: {
     actionButtonText: () => "Add New Item",
     placeholder: () => "Please Select...",

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -119,6 +119,9 @@ interface Locale {
   pod: {
     undo: () => string;
   };
+  search: {
+    searchButtonText: () => string;
+  };
   select: {
     actionButtonText: () => string;
     placeholder: () => string;


### PR DESCRIPTION
fix #6581
fix #6597

BREAKING CHANGE: The `threshold` prop has been removed as it no longer does anything in the
redesigned component

BREAKING CHANGE: The `inputRef` is no more

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Implements new designs for `Search` component. The button is now rendered at all times when the
`searchButton` is set; expands the type of this prop to also accept string values which will support
more granular control over the text rendered in the button. Support for overriding the button text
via the locale provider has also been added. Updates have also been made to `Link` and `Menu` style
files to ensure the styling is correct when `Search` is rendered in a `Menu`. Styling targeting the
search input in menus has also been removed. These changes have also addressed the issue with
padding of `MenuItem` components that render `Search`.

Search redesign:
![image](https://github.com/Sage/carbon/assets/44157880/83d55811-29d6-4f20-89f3-4bc4368d29d4)
![image](https://github.com/Sage/carbon/assets/44157880/1e918d9c-5e4c-437b-b246-5053a054de61)
![image](https://github.com/Sage/carbon/assets/44157880/aa01113f-3df0-4177-9621-7685413473cd)
![image](https://github.com/Sage/carbon/assets/44157880/818f9de0-ccf7-4279-a461-6d86739e8890)
![image](https://github.com/Sage/carbon/assets/44157880/45d8677b-8ccf-4e86-8b83-87c8204ee483)

![image](https://github.com/Sage/carbon/assets/44157880/6836a2f6-2483-4c84-a978-723816398355)
![image](https://github.com/Sage/carbon/assets/44157880/298d2488-6f2d-4f16-983e-44892a5f7ad4)
![image](https://github.com/Sage/carbon/assets/44157880/c251cf0d-4b1d-498f-92bf-01d9b82d3ee7)
![image](https://github.com/Sage/carbon/assets/44157880/95e86e26-ea0a-4467-b71a-60dbc9a8ae45)

Fixes to menu:
![image](https://github.com/Sage/carbon/assets/44157880/092dacc5-9d63-445c-976e-cbb03bc99cbc)
![image](https://github.com/Sage/carbon/assets/44157880/6124316d-6d8f-4de9-8eb7-7e0ced8a2aca)
![image](https://github.com/Sage/carbon/assets/44157880/a6d2d1b4-20ec-46ea-8b60-8a2647cb4793)


Deprecated the `inputRef` prop, consumers should use `ref` in order to get a ref to the input
element.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Designs support search Button appearing on focus or when there is a value in the input but disappearing when the user blurs, this creates issues for users tabbing to navigate as the DOM tries to focus the button that is no longer there.

Style regression with Search in Menu
![image](https://github.com/Sage/carbon/assets/44157880/f1d3efe6-d10d-4b39-a308-b303a83c2380)

Style regression with menu items and Search in MenuFullscreen

![image](https://github.com/Sage/carbon/assets/44157880/1bf23642-1060-468d-a1c9-977091f300a7)
![image](https://github.com/Sage/carbon/assets/44157880/a71c682b-8254-4718-a69d-538be5e73095)


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
