### PR TITLE
fix(form): remove 4px margin bottom from Textarea FormField

### DIFF
--- a/src/components/form/form.spec.tsx
+++ b/src/components/form/form.spec.tsx
@@ -62,17 +62,23 @@ describe("Form", () => {
   });
 
   describe("when search used in Form component", () => {
-    it("should have no addition margin-bottom", () => {
-      wrapper = mount(<StyledForm fieldSpacing={0} />);
+    it.each([
+      ["Search", StyledSearch],
+      ["Textarea", StyledTextarea],
+    ])(
+      "should have no addition margin-bottom on form field when %s rendered",
+      (_, sc) => {
+        wrapper = mount(<StyledForm fieldSpacing={0} />);
 
-      assertStyleMatch(
-        {
-          marginBottom: "0px",
-        },
-        wrapper,
-        { modifier: `${StyledSearch} ${StyledFormField}` }
-      );
-    });
+        assertStyleMatch(
+          {
+            marginBottom: "var(--spacing000)",
+          },
+          wrapper,
+          { modifier: `${sc} ${StyledFormField}` }
+        );
+      }
+    );
   });
 
   describe("when height prop is set", () => {

--- a/src/components/form/form.style.ts
+++ b/src/components/form/form.style.ts
@@ -91,14 +91,10 @@ export const StyledForm = styled.form<StyledFormProps>`
     css`
       height: ${height};
     `}
-    
-    ${StyledTextarea}
-      ${StyledFormField} {
-    margin-bottom: 4px;
-  }
 
-  ${StyledSearch} ${StyledFormField} {
-    margin-bottom: 0px;
+  // field spacing is also applied to form field here so we need to override
+  ${StyledSearch} ${StyledFormField}, ${StyledTextarea} ${StyledFormField} {
+    margin-bottom: var(--spacing000);
   }
 
   ${({ stickyFooter, isInModal, isInSidebar }) =>


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Removes the 4px margin bottom from FormField rendered as part of Textarea when in Form
### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
--> 
There is 4px margin bottom added to FormField rendered as part of Textarea when in Form

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Unit tests added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
