### PR TITLE
fix(fieldset): invalid fieldset HTML fix

### DIFF
--- a/playwright/components/tileSelect/index.ts
+++ b/playwright/components/tileSelect/index.ts
@@ -1,7 +1,7 @@
 import type { Page } from "@playwright/test";
 import {
   TILE_SELECT_DATA_COMPONENT,
-  TILE_SELECT_LEGEND_STYLE,
+  TILE_SELECT_GROUP_DESCRIPTION,
 } from "./locators";
 
 export const tileSelectDataComponent = (page: Page) => {
@@ -23,6 +23,6 @@ export const subtitleElement = (page: Page) =>
 export const descElement = (page: Page) =>
   tileSelectChildren(page).locator("p");
 
-export const legendStyleComponent = (page: Page) => {
-  return page.locator(TILE_SELECT_LEGEND_STYLE).nth(0);
+export const tileGroupDescription = (page: Page) => {
+  return page.locator(TILE_SELECT_GROUP_DESCRIPTION);
 };

--- a/playwright/components/tileSelect/locators.ts
+++ b/playwright/components/tileSelect/locators.ts
@@ -1,4 +1,5 @@
 // component preview locators
 export const TILE_SELECT_DATA_COMPONENT = '[data-component="tile-select"]';
 
-export const TILE_SELECT_LEGEND_STYLE = '[data-component="fieldset-style"]';
+export const TILE_SELECT_GROUP_DESCRIPTION =
+  '[data-element="tile-select-group-description"]';

--- a/src/components/fieldset/__snapshots__/fieldset.spec.tsx.snap
+++ b/src/components/fieldset/__snapshots__/fieldset.spec.tsx.snap
@@ -12,16 +12,11 @@ exports[`Fieldset renders correctly 1`] = `
     data-component="fieldset"
     theme="[ theme object ]"
   >
-    <styled.div
-      data-component="fieldset-style"
-      inline={false}
-    >
-      <FormSpacingProvider>
-        <Textbox
-          onChange={[Function]}
-        />
-      </FormSpacingProvider>
-    </styled.div>
+    <FormSpacingProvider>
+      <Textbox
+        onChange={[Function]}
+      />
+    </FormSpacingProvider>
   </styled.fieldset>
 </ContextProvider>
 `;

--- a/src/components/fieldset/fieldset.component.tsx
+++ b/src/components/fieldset/fieldset.component.tsx
@@ -2,21 +2,15 @@ import React, { useState, useEffect } from "react";
 import { MarginProps } from "styled-system";
 
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
-import {
-  FieldsetStyle,
-  LegendContainerStyle,
-  FieldsetContentStyle,
-} from "./fieldset.style";
+import { FieldsetStyle, StyledLegend } from "./fieldset.style";
 import { NewValidationContext } from "../carbon-provider/carbon-provider.component";
 import FormSpacingProvider from "../../__internal__/form-spacing-provider";
 import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
 
 export interface FieldsetProps extends MarginProps {
-  /** When true, legend is placed in line with the children */
-  inline?: boolean;
   /** Child elements */
   children?: React.ReactNode;
-  /** The text for the fieldsets legend element. */
+  /** The text for the fieldset's legend element. */
   legend?: string;
   /** Flag to configure fields as mandatory. */
   required?: boolean;
@@ -26,28 +20,12 @@ export interface FieldsetProps extends MarginProps {
 
 export const Fieldset = ({
   children,
-  inline = false,
   legend,
   required,
   isOptional,
   ...rest
 }: FieldsetProps) => {
   const [ref, setRef] = useState<HTMLFieldSetElement | null>(null);
-  const getLegend = () => {
-    if (!legend) return null;
-
-    return (
-      <LegendContainerStyle
-        isRequired={required}
-        isOptional={isOptional}
-        inline={inline}
-        data-component="legend-style"
-      >
-        <legend data-element="legend">{legend}</legend>
-      </LegendContainerStyle>
-    );
-  };
-
   const marginProps = useFormSpacing(rest);
 
   useEffect(() => {
@@ -68,12 +46,18 @@ export const Fieldset = ({
         {...rest}
         {...marginProps}
       >
-        <FieldsetContentStyle data-component="fieldset-style" inline={inline}>
-          {getLegend()}
-          <FormSpacingProvider marginBottom={undefined}>
-            {children}
-          </FormSpacingProvider>
-        </FieldsetContentStyle>
+        {legend && (
+          <StyledLegend
+            data-element="legend"
+            isRequired={required}
+            isOptional={isOptional}
+          >
+            {legend}
+          </StyledLegend>
+        )}
+        <FormSpacingProvider marginBottom={undefined}>
+          {children}
+        </FormSpacingProvider>
       </FieldsetStyle>
     </NewValidationContext.Provider>
   );

--- a/src/components/fieldset/fieldset.pw.tsx
+++ b/src/components/fieldset/fieldset.pw.tsx
@@ -5,13 +5,9 @@ import Form, { FormProps } from "../form";
 import FieldsetComponent from "./components.test-pw";
 import Textbox from "../textbox";
 import { getDataElementByValue } from "../../../playwright/components/index";
-import {
-  assertCssValueIsApproximately,
-  checkAccessibility,
-} from "../../../playwright/support/helper";
+import { checkAccessibility } from "../../../playwright/support/helper";
 import { VALIDATION, CHARACTERS } from "../../../playwright/support/constants";
 import { ICON } from "../../../playwright/components/locators";
-import { FieldsetProps } from "./fieldset.component";
 
 const specialCharacters = [
   CHARACTERS.STANDARD,
@@ -31,28 +27,8 @@ test.describe("should render Fieldset component", () => {
   test(`should verify preview is not displayed`, async ({ mount, page }) => {
     await mount(<FieldsetComponent legend="" />);
 
-    await expect(getDataElementByValue(page, "legend")).toHaveCount(0);
+    await expect(getDataElementByValue(page, "legend")).not.toBeVisible();
   });
-
-  ([
-    ["inline", true, 33, 37, 73],
-    ["as a column", false, 16, 70, 930],
-  ] as [string, FieldsetProps["inline"], number, number, number][]).forEach(
-    ([state, bool, labelHeight, labelWidth, inputWidth]) => {
-      test(`should verify component is displayed ${state} if inline prop is ${bool}`, async ({
-        mount,
-        page,
-      }) => {
-        await mount(<FieldsetComponent inline={bool} />);
-
-        const label = getDataElementByValue(page, "label").nth(0);
-        await assertCssValueIsApproximately(label, "height", labelHeight);
-        await assertCssValueIsApproximately(label, "width", labelWidth);
-        const input = getDataElementByValue(page, "input").nth(0);
-        await assertCssValueIsApproximately(input, "width", inputWidth);
-      });
-    }
-  );
 
   ["error", "warning", "info"].forEach((type) => {
     test(`should verify ${type} validation icon is displayed on input`, async ({
@@ -173,20 +149,6 @@ test.describe("Accessibility tests for Fieldset component", () => {
       page,
     }) => {
       await mount(<FieldsetComponent legend={chars} />);
-
-      await checkAccessibility(page);
-    });
-  });
-
-  ([
-    ["inline", true],
-    ["as a column", false],
-  ] as [string, FieldsetProps["inline"]][]).forEach(([state, bool]) => {
-    test(`should pass accessibility tests when displayed ${state}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<FieldsetComponent inline={bool} />);
 
       await checkAccessibility(page);
     });

--- a/src/components/fieldset/fieldset.spec.tsx
+++ b/src/components/fieldset/fieldset.spec.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { shallow, mount } from "enzyme";
 import Fieldset, { FieldsetProps } from "./fieldset.component";
 import Textbox from "../textbox";
-import { LegendContainerStyle, FieldsetContentStyle } from "./fieldset.style";
+import { StyledLegend } from "./fieldset.style";
 import {
   assertStyleMatch,
   testStyledSystemMargin,
@@ -63,21 +63,11 @@ describe("Fieldset", () => {
   describe("Fieldset Legend", () => {
     it("is rendered if supplied", () => {
       const wrapper = render({ legend: "Legend" });
-      expect(wrapper.find(LegendContainerStyle).exists()).toEqual(true);
+      expect(wrapper.find(StyledLegend).exists()).toEqual(true);
     });
 
     it("is not rendered if omitted", () => {
-      expect(basicWrapper.find(LegendContainerStyle).exists()).toEqual(false);
-    });
-
-    it("applies the correct inline styles", () => {
-      assertStyleMatch(
-        {
-          marginRight: "32px",
-          height: "34px !important",
-        },
-        mount(<LegendContainerStyle inline />)
-      );
+      expect(basicWrapper.find(StyledLegend).exists()).toEqual(false);
     });
   });
 
@@ -89,8 +79,8 @@ describe("Fieldset", () => {
         fontWeight: "var(--fontWeights700)",
         marginLeft: "var(--spacing100)",
       },
-      mount(<LegendContainerStyle isRequired />),
-      { modifier: "legend::after" }
+      mount(<StyledLegend isRequired />),
+      { modifier: "::after" }
     );
   });
 
@@ -131,32 +121,8 @@ describe("Fieldset", () => {
       {
         content: '"(optional)"',
       },
-      mount(<LegendContainerStyle isOptional />),
-      { modifier: "legend::after" }
+      mount(<StyledLegend isOptional />),
+      { modifier: "::after" }
     );
-  });
-
-  describe("Fieldset FieldsetContentStyle", () => {
-    it("is rendered if supplied", () => {
-      const wrapper = render({ inline: true });
-      expect(wrapper.find(FieldsetContentStyle).get(0).props.inline).toEqual(
-        true
-      );
-    });
-
-    it("is not rendered if omitted", () => {
-      expect(
-        basicWrapper.find(FieldsetContentStyle).get(0).props.inline
-      ).toEqual(false);
-    });
-
-    it("applies the correct inline styles", () => {
-      assertStyleMatch(
-        {
-          display: "flex",
-        },
-        mount(<FieldsetContentStyle inline />)
-      );
-    });
   });
 });

--- a/src/components/fieldset/fieldset.style.ts
+++ b/src/components/fieldset/fieldset.style.ts
@@ -2,14 +2,10 @@ import styled, { css } from "styled-components";
 import { margin } from "styled-system";
 
 import FormFieldStyle from "../../__internal__/form-field/form-field.style";
-import ValidationIconStyle from "../../__internal__/validations/validation-icon.style";
-import StyledIcon from "../icon/icon.style";
 import baseTheme from "../../style/themes/base";
 import CheckboxStyle from "../checkbox/checkbox.style";
 
 export interface StyledFieldsetProps {
-  /** When true, legend is placed in line with the children */
-  inline?: boolean;
   /** Flag to configure fields as mandatory. */
   isRequired?: boolean;
   /** Flag to configure fields as optional. */
@@ -37,58 +33,41 @@ FieldsetStyle.defaultProps = {
   theme: baseTheme,
 };
 
-const LegendContainerStyle = styled.div<StyledFieldsetProps>`
-  ${({ inline }) =>
-    inline &&
-    `
-  margin-right: 32px;
-  height: 34px !important;
-  `}
+const StyledLegend = styled.legend<StyledFieldsetProps>`
   display: flex;
   align-items: center;
   margin-bottom: 32px;
+  font-size: 20px;
+  font-weight: var(--fontWeights700);
+  color: var(--colorsUtilityYin090);
+  line-height: 24px;
+  margin-right: 4px;
 
-  legend {
-    font-size: 20px;
-    font-weight: var(--fontWeights700);
-    color: var(--colorsUtilityYin090);
-    line-height: 24px;
-    margin-right: 4px;
+  ${({ isRequired }) =>
+    isRequired &&
+    css`
+      ::after {
+        content: "*";
+        line-height: 24px;
+        color: var(--colorsSemanticNegative500);
+        font-weight: var(--fontWeights700);
+        margin-left: var(--spacing100);
+        position: relative;
+        top: 1px;
+        left: -4px;
+      }
+    `}
 
-    ${({ isRequired }) =>
-      isRequired &&
-      css`
-        ::after {
-          content: "*";
-          line-height: 24px;
-          color: var(--colorsSemanticNegative500);
-          font-weight: var(--fontWeights700);
-          margin-left: var(--spacing100);
-          position: relative;
-          top: 1px;
-          left: -4px;
-        }
-      `}
-
-    ${({ isOptional }) =>
-      isOptional &&
-      css`
-        ::after {
-          content: "(optional)";
-          color: var(--colorsUtilityYin055);
-          font-weight: var(--fontWeights400);
-          margin-left: var(--spacing050);
-        }
-      `}
-  }
-
-  ${ValidationIconStyle} ${StyledIcon}:focus {
-    outline: 2px solid #ffb500;
-  }
+  ${({ isOptional }) =>
+    isOptional &&
+    css`
+      ::after {
+        content: "(optional)";
+        color: var(--colorsUtilityYin055);
+        font-weight: var(--fontWeights400);
+        margin-left: var(--spacing050);
+      }
+    `}
 `;
 
-const FieldsetContentStyle = styled.div<StyledFieldsetProps>`
-  ${({ inline }) => inline && "display: flex;"}
-`;
-
-export { FieldsetStyle, LegendContainerStyle, FieldsetContentStyle };
+export { FieldsetStyle, StyledLegend };

--- a/src/components/tile-select/tile-select-group/tile-select-group.component.tsx
+++ b/src/components/tile-select/tile-select-group/tile-select-group.component.tsx
@@ -75,12 +75,12 @@ export const TileSelectGroup = ({
       multiSelect={multiSelect}
       {...filterStyledSystemMarginProps(rest)}
     >
-      {description ? (
+      {description && (
         <StyledGroupDescription data-element="tile-select-group-description">
           {description}
         </StyledGroupDescription>
-      ) : null}
-      <div>{tiles}</div>
+      )}
+      {tiles}
     </StyledTileSelectFieldset>
   );
 };

--- a/src/components/tile-select/tile-select.component.tsx
+++ b/src/components/tile-select/tile-select.component.tsx
@@ -211,7 +211,7 @@ const TileSelect = React.forwardRef<HTMLInputElement, TileSelectProps>(
                     <StyledAdornment
                       hasAdditionalInformation={!!additionalInformation}
                     >
-                      {titleAdornment}
+                      {titleAdornment && <div>{titleAdornment}</div>}
                     </StyledAdornment>
                   )}
                 </StyledTitleContainer>

--- a/src/components/tile-select/tile-select.pw.tsx
+++ b/src/components/tile-select/tile-select.pw.tsx
@@ -32,7 +32,7 @@ import {
   subtitleElement,
   descElement,
   inputElement,
-  legendStyleComponent,
+  tileGroupDescription,
 } from "../../../playwright/components/tileSelect";
 import { CHARACTERS } from "../../../playwright/support/constants";
 
@@ -391,7 +391,7 @@ test.describe("check props for TileSelectGroup component", () => {
     }) => {
       await mount(<TileSelectGroupComponent description={description} />);
 
-      await expect(legendStyleComponent(page)).toBeVisible();
+      await expect(tileGroupDescription(page)).toHaveText(description);
     });
   });
 

--- a/src/components/tile-select/tile-select.style.ts
+++ b/src/components/tile-select/tile-select.style.ts
@@ -2,7 +2,7 @@ import styled, { css } from "styled-components";
 import { margin } from "styled-system";
 import Fieldset from "../fieldset";
 import { Input } from "../../__internal__/input";
-import { LegendContainerStyle } from "../fieldset/fieldset.style";
+import { StyledLegend } from "../fieldset/fieldset.style";
 import StyledIcon from "../icon/icon.style";
 import { baseTheme } from "../../style/themes";
 import addFocusStyling from "../../style/utils/add-focus-styling";
@@ -190,13 +190,11 @@ const StyledTileSelectFieldset = styled(Fieldset)<{
 }>`
   ${margin}
 
-  ${LegendContainerStyle} {
+  ${StyledLegend} {
     margin-bottom: 16px;
-    legend {
-      font-size: 16px;
-      line-height: 16px;
-      margin-left: -2px;
-    }
+    font-size: 16px;
+    line-height: 16px;
+    margin-left: -2px;
   }
   ${({ multiSelect }) =>
     multiSelect &&


### PR DESCRIPTION
BREAKING CHANGE: The `inline` prop has been removed from the `Fieldset` component.

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- Legend element is no longer nested in two div containers and is now a direct child of the fieldset element.
- `inline` prop has been removed. 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- Legend element in the `Fieldset` component is nested in two divs, which is invalid HTML. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
