### PR TITLE
test(dialog, dialog-full-screen): add test for focusableSelectors - FE-5533

### DIFF
--- a/playwright/support/helper.ts
+++ b/playwright/support/helper.ts
@@ -380,3 +380,16 @@ export const checkElementBorderColours = async (
   await expect(element).toHaveCSS("border-right-color", color);
   await expect(element).toHaveCSS("border-top-color", color);
 };
+
+/* Util to ensure that a particular element is focused before proceeding.
+ * Useful for avoiding race conditions when the component code auto-focuses some element in an effect.
+ * @param page Returns the value of the `pageFunction` invocation. (see: https://playwright.dev/docs/api/class-page)
+ * @param locator The Playwright locator to evaluate (see: https://playwright.dev/docs/locators)
+ */
+export const waitForElementFocus = async (page: Page, locator: Locator) => {
+  const focusedElement = await locator.elementHandle();
+  await page.waitForFunction(
+    (element) => document.activeElement === element,
+    focusedElement
+  );
+};

--- a/src/components/dialog-full-screen/components.test-pw.tsx
+++ b/src/components/dialog-full-screen/components.test-pw.tsx
@@ -962,3 +962,49 @@ export const DialogFullScreenWithAutoFocusSelect = () => {
     </DialogFullScreen>
   );
 };
+
+export const DialogFSComponentFocusableSelectors = (
+  props: Partial<DialogFullScreenProps>
+) => {
+  const [setIsDialogOpen] = React.useState(false);
+  const [isToastOpen, setIsToastOpen] = React.useState(false);
+  const toastRef = React.useRef(null);
+  const CUSTOM_SELECTOR = "button, .focusable-container input";
+  return (
+    <>
+      <DialogFullScreen
+        open
+        onCancel={() => setIsDialogOpen}
+        title="Dialog Title"
+        focusableContainers={[toastRef]}
+        focusableSelectors={CUSTOM_SELECTOR}
+        {...props}
+      >
+        <Box className="focusable-container">
+          <Textbox label="First Name" />
+        </Box>
+        <Box>
+          <Textbox label="Surname" />
+        </Box>
+        <Box className="focusable-container">
+          <Button
+            buttonType="primary"
+            data-element="open-toast"
+            onClick={() => setIsToastOpen(true)}
+          >
+            Show toast
+          </Button>
+        </Box>
+      </DialogFullScreen>
+      <Toast
+        open={isToastOpen}
+        onDismiss={() => setIsToastOpen(false)}
+        ref={toastRef}
+        targetPortalId="stacked"
+        data-element="toast"
+      >
+        Toast Message
+      </Toast>
+    </>
+  );
+};

--- a/src/components/dialog-full-screen/dialog-full-screen.pw.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.pw.tsx
@@ -17,6 +17,7 @@ import {
   WithComplexExample,
   TopModalOverride,
   DialogFullScreenWithAutoFocusSelect,
+  DialogFSComponentFocusableSelectors,
 } from "./components.test-pw";
 import {
   portal,
@@ -29,6 +30,7 @@ import {
   continuePressingSHIFTTAB,
   checkAccessibility,
   waitForAnimationEnd,
+  waitForElementFocus,
 } from "../../../playwright/support/helper";
 import { CHARACTERS } from "../../../playwright/support/constants";
 
@@ -460,6 +462,30 @@ test.describe("render DialogFullScreen component and check properties", () => {
     await dialog.press("Shift+Tab");
     await dialog.press("Shift+Tab");
     await expect(select).toBeFocused();
+  });
+
+  test("should render component with first input and button as focusableSelectors", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<DialogFSComponentFocusableSelectors />);
+
+    const dialogElement = page.getByRole("dialog");
+    const focusedElement = page.locator("*:focus");
+    const firstInputElement = page.getByLabel("First name");
+    const secondInputElement = page.getByLabel("Surname");
+    const openToastElement = getDataElementByValue(page, "open-toast");
+
+    await waitForElementFocus(page, dialogElement);
+    await dialogElement.press("Tab");
+    await focusedElement.press("Tab");
+
+    await expect(firstInputElement).toBeFocused();
+
+    await focusedElement.press("Tab");
+
+    await expect(secondInputElement).not.toBeFocused();
+    await expect(openToastElement).toBeFocused();
   });
 });
 

--- a/src/components/dialog/components.test-pw.tsx
+++ b/src/components/dialog/components.test-pw.tsx
@@ -214,3 +214,49 @@ export const DialogWithStepSequence = (props: Partial<DialogProps>) => {
     </Dialog>
   );
 };
+
+export const DialogComponentFocusableSelectors = (
+  props: Partial<DialogProps>
+) => {
+  const [setIsDialogOpen] = React.useState(false);
+  const [isToastOpen, setIsToastOpen] = React.useState(false);
+  const toastRef = React.useRef(null);
+  const CUSTOM_SELECTOR = "button, .focusable-container input";
+  return (
+    <>
+      <Dialog
+        open
+        onCancel={() => setIsDialogOpen}
+        title="Dialog Title"
+        focusableContainers={[toastRef]}
+        focusableSelectors={CUSTOM_SELECTOR}
+        {...props}
+      >
+        <Box className="focusable-container">
+          <Textbox label="First Name" />
+        </Box>
+        <Box>
+          <Textbox label="Surname" />
+        </Box>
+        <Box className="focusable-container">
+          <Button
+            buttonType="primary"
+            data-element="open-toast"
+            onClick={() => setIsToastOpen(true)}
+          >
+            Show toast
+          </Button>
+        </Box>
+      </Dialog>
+      <Toast
+        open={isToastOpen}
+        onDismiss={() => setIsToastOpen(false)}
+        ref={toastRef}
+        targetPortalId="stacked"
+        data-element="toast"
+      >
+        Toast Message
+      </Toast>
+    </>
+  );
+};

--- a/src/components/dialog/dialog.pw.tsx
+++ b/src/components/dialog/dialog.pw.tsx
@@ -10,6 +10,7 @@ import {
   TopModalOverride,
   DialogWithAutoFocusSelect,
   DialogWithStepSequence,
+  DialogComponentFocusableSelectors,
 } from "./components.test-pw";
 
 import {
@@ -29,6 +30,7 @@ import {
   checkAccessibility,
   getStyle,
   waitForAnimationEnd,
+  waitForElementFocus,
 } from "../../../playwright/support/helper";
 import { CHARACTERS, SIZE } from "../../../playwright/support/constants";
 import { getDataElementByValue } from "../../../playwright/components";
@@ -381,6 +383,30 @@ test.describe("Testing Dialog component properties", () => {
     await dialog.press("Shift+Tab");
     await dialog.press("Shift+Tab");
     await expect(select).toBeFocused();
+  });
+
+  test("should render component with first input and button as focusableSelectors", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<DialogComponentFocusableSelectors />);
+
+    const dialogElement = page.getByRole("dialog");
+    const focusedElement = page.locator("*:focus");
+    const firstInputElement = page.getByLabel("First name");
+    const secondInputElement = page.getByLabel("Surname");
+    const openToastElement = getDataElementByValue(page, "open-toast");
+
+    await waitForElementFocus(page, dialogElement);
+    await dialogElement.press("Tab");
+    await focusedElement.press("Tab");
+
+    await expect(firstInputElement).toBeFocused();
+
+    await focusedElement.press("Tab");
+
+    await expect(secondInputElement).not.toBeFocused();
+    await expect(openToastElement).toBeFocused();
   });
 });
 


### PR DESCRIPTION
### Proposed behaviour

Add an automation test to cover `focusableSelectors` prop.

### Current behaviour

Currently no automation test for `focusableSelectors` prop.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

Test has had to be commented out for now as there is a known issue with Playwright and our Modal-based components testing internal focus behaviours. 

### Testing instructions

N/A