### PR TITLE
test: configure RTL *ByTestId queries to use data-role tags (FE-5549)

### DIFF
--- a/src/__internal__/focus-trap/focus-trap.spec.tsx
+++ b/src/__internal__/focus-trap/focus-trap.spec.tsx
@@ -19,7 +19,6 @@ interface MockComponentProps extends Omit<FocusTrapProps, "wrapperRef"> {
   tabIndex?: number;
   children: React.ReactNode;
   shouldFocusFirstElement?: boolean;
-  dataTestId?: string;
   onKeyDown?: (ev: React.KeyboardEvent) => void;
 }
 
@@ -57,7 +56,6 @@ const MockComponent = ({
   isAnimationComplete,
   tabIndex,
   shouldFocusFirstElement,
-  dataTestId = WRAPPER_ID,
   onKeyDown,
   ...rest
 }: MockComponentProps) => {
@@ -75,7 +73,7 @@ const MockComponent = ({
           isOpen
           focusFirstElement={shouldFocusFirstElement ? firstRef : undefined}
         >
-          <div ref={ref} data-testid={dataTestId} tabIndex={tabIndex}>
+          <div ref={ref} data-role={WRAPPER_ID} tabIndex={tabIndex}>
             {React.Children.map(children, (child) => {
               const focusableChild = child as React.ReactElement;
 
@@ -143,7 +141,7 @@ const WithAdditionalWrapperRefs = () => {
   ];
 
   return (
-    <div data-testid={WRAPPER_ID}>
+    <div data-role={WRAPPER_ID}>
       <button type="button" id="outside1">
         outside focus trap
       </button>
@@ -1063,7 +1061,7 @@ describe("FocusTrap", () => {
             additionalWrapperRefs={[additionalRef]}
             isOpen
           >
-            <div data-testid={WRAPPER_ID} ref={wrapperRef}>
+            <div data-role={WRAPPER_ID} ref={wrapperRef}>
               <button type="button" id="insidewrapper1">
                 {BUTTON_ONE}
               </button>

--- a/src/__internal__/sticky-footer/sticky-footer.spec.tsx
+++ b/src/__internal__/sticky-footer/sticky-footer.spec.tsx
@@ -6,7 +6,7 @@ const MockFooterContainer = (props: Partial<StickyFooterProps> = {}) => {
   const mockRef = useRef(null);
 
   return (
-    <div data-testid="container" ref={mockRef}>
+    <div data-role="container" ref={mockRef}>
       <StickyFooter containerRef={mockRef} {...props}>
         Some content
       </StickyFooter>

--- a/src/__spec_helper__/index.ts
+++ b/src/__spec_helper__/index.ts
@@ -1,3 +1,4 @@
+import { configure } from "@testing-library/react";
 import { enableFetchMocks } from "jest-fetch-mock";
 import { setupMatchMediaMock } from "./mock-match-media";
 import setupResizeObserverMock from "./mock-resize-observer";
@@ -7,3 +8,8 @@ enableFetchMocks();
 setupResizeObserverMock();
 setupMatchMediaMock();
 setupScrollToMock();
+
+configure({
+  testIdAttribute:
+    "data-role" /** Configure React Testing Library *ByTestId queries to use data-role tag */,
+});

--- a/src/components/flat-table/flat-table-body-draggable/flat-table-body-draggable.component.tsx
+++ b/src/components/flat-table/flat-table-body-draggable/flat-table-body-draggable.component.tsx
@@ -33,7 +33,7 @@ const DropTarget = ({
 
   return (
     <StyledFlatTableBodyDraggable
-      data-testid="flat-table-body-draggable"
+      data-role="flat-table-body-draggable"
       ref={drop}
       isDragging={isDragging}
       {...rest}

--- a/src/components/flat-table/flat-table-body-draggable/flat-table-body-draggable.spec.tsx
+++ b/src/components/flat-table/flat-table-body-draggable/flat-table-body-draggable.spec.tsx
@@ -26,7 +26,7 @@ describe("FlatTableBodyDraggable", () => {
     test("should be added to the FlatTableBody", () => {
       render(
         <FlatTable>
-          <FlatTableBodyDraggable data-testid="test">
+          <FlatTableBodyDraggable data-role="test">
             <FlatTableRow key={0} id={0}>
               <FlatTableCell>UK</FlatTableCell>
             </FlatTableRow>
@@ -317,20 +317,20 @@ describe("FlatTableBodyDraggable", () => {
     beforeEach(() => {
       render(
         <div>
-          <FlatTable data-testid="table-1">
+          <FlatTable data-role="table-1">
             <FlatTableBodyDraggable>
-              <FlatTableRow expandable key="0" id={0} data-testid="table-1-row">
+              <FlatTableRow expandable key="0" id={0} data-role="table-1-row">
                 <FlatTableCell>Row one</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow expandable key="1" id={1} data-testid="table-1-row">
+              <FlatTableRow expandable key="1" id={1} data-role="table-1-row">
                 <FlatTableCell>Row two</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow expandable key="2" id={2} data-testid="table-1-row">
+              <FlatTableRow expandable key="2" id={2} data-role="table-1-row">
                 <FlatTableCell>Row three</FlatTableCell>
               </FlatTableRow>
             </FlatTableBodyDraggable>
           </FlatTable>
-          <FlatTable data-testid="table-2">
+          <FlatTable data-role="table-2">
             <FlatTableBodyDraggable>
               <FlatTableRow expandable key="3" id={3}>
                 <FlatTableCell>Row four</FlatTableCell>

--- a/src/components/flat-table/flat-table.spec.tsx
+++ b/src/components/flat-table/flat-table.spec.tsx
@@ -585,9 +585,7 @@ describe("FlatTable", () => {
 
     it("when table's footer contains a Pager, override Pager's top border styling so it connects to the table", () => {
       rtlRender(
-        <FlatTable
-          footer={<Pager data-testid="pager" onPagination={() => {}} />}
-        >
+        <FlatTable footer={<Pager data-role="pager" onPagination={() => {}} />}>
           <FlatTableHead>
             <FlatTableRow>
               <td>heading one</td>
@@ -613,7 +611,7 @@ describe("FlatTable", () => {
       rtlRender(
         <FlatTable
           hasStickyFooter
-          footer={<Pager data-testid="pager" onPagination={() => {}} />}
+          footer={<Pager data-role="pager" onPagination={() => {}} />}
         >
           <FlatTableHead>
             <FlatTableRow>
@@ -773,11 +771,11 @@ describe("FlatTable", () => {
         rtlRender(
           <FlatTable>
             <FlatTableBody>
-              <FlatTableRow data-testid="one" onClick={() => {}}>
+              <FlatTableRow data-role="one" onClick={() => {}}>
                 <FlatTableCell>one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="two" onClick={() => {}}>
+              <FlatTableRow data-role="two" onClick={() => {}}>
                 <FlatTableCell>three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
@@ -842,19 +840,19 @@ describe("FlatTable", () => {
         rtlRender(
           <FlatTable>
             <FlatTableBody>
-              <FlatTableRow data-testid="one" onClick={() => {}}>
+              <FlatTableRow data-role="one" onClick={() => {}}>
                 <FlatTableCell>one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="two" onClick={() => {}}>
+              <FlatTableRow data-role="two" onClick={() => {}}>
                 <FlatTableCell>three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="three" onClick={() => {}}>
+              <FlatTableRow data-role="three" onClick={() => {}}>
                 <FlatTableCell>five</FlatTableCell>
                 <FlatTableCell>six</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="four" onClick={() => {}}>
+              <FlatTableRow data-role="four" onClick={() => {}}>
                 <FlatTableCell>seven</FlatTableCell>
                 <FlatTableCell>eight</FlatTableCell>
               </FlatTableRow>
@@ -883,19 +881,19 @@ describe("FlatTable", () => {
         rtlRender(
           <FlatTable>
             <FlatTableBody>
-              <FlatTableRow data-testid="one" onClick={() => {}}>
+              <FlatTableRow data-role="one" onClick={() => {}}>
                 <FlatTableCell>one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="two" onClick={() => {}}>
+              <FlatTableRow data-role="two" onClick={() => {}}>
                 <FlatTableCell>three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="three" onClick={() => {}}>
+              <FlatTableRow data-role="three" onClick={() => {}}>
                 <FlatTableCell>five</FlatTableCell>
                 <FlatTableCell>six</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="four" onClick={() => {}}>
+              <FlatTableRow data-role="four" onClick={() => {}}>
                 <FlatTableCell>seven</FlatTableCell>
                 <FlatTableCell>eight</FlatTableCell>
               </FlatTableRow>
@@ -924,19 +922,19 @@ describe("FlatTable", () => {
         rtlRender(
           <FlatTable>
             <FlatTableBody>
-              <FlatTableRow data-testid="one" onClick={() => {}}>
+              <FlatTableRow data-role="one" onClick={() => {}}>
                 <FlatTableCell>one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="two" onClick={() => {}}>
+              <FlatTableRow data-role="two" onClick={() => {}}>
                 <FlatTableCell>three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="three" onClick={() => {}}>
+              <FlatTableRow data-role="three" onClick={() => {}}>
                 <FlatTableCell>five</FlatTableCell>
                 <FlatTableCell>six</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="four" onClick={() => {}}>
+              <FlatTableRow data-role="four" onClick={() => {}}>
                 <FlatTableCell>seven</FlatTableCell>
                 <FlatTableCell>eight</FlatTableCell>
               </FlatTableRow>
@@ -956,19 +954,19 @@ describe("FlatTable", () => {
         rtlRender(
           <FlatTable>
             <FlatTableBody>
-              <FlatTableRow data-testid="one" expandable>
+              <FlatTableRow data-role="one" expandable>
                 <FlatTableCell>one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="two" expandable>
+              <FlatTableRow data-role="two" expandable>
                 <FlatTableCell>three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="three" expandable>
+              <FlatTableRow data-role="three" expandable>
                 <FlatTableCell>five</FlatTableCell>
                 <FlatTableCell>six</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="four" expandable>
+              <FlatTableRow data-role="four" expandable>
                 <FlatTableCell>seven</FlatTableCell>
                 <FlatTableCell>eight</FlatTableCell>
               </FlatTableRow>
@@ -997,19 +995,19 @@ describe("FlatTable", () => {
         rtlRender(
           <FlatTable>
             <FlatTableBody>
-              <FlatTableRow data-testid="one" expandable>
+              <FlatTableRow data-role="one" expandable>
                 <FlatTableCell>one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="two" expandable>
+              <FlatTableRow data-role="two" expandable>
                 <FlatTableCell>three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="three" expandable>
+              <FlatTableRow data-role="three" expandable>
                 <FlatTableCell>five</FlatTableCell>
                 <FlatTableCell>six</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="four" expandable>
+              <FlatTableRow data-role="four" expandable>
                 <FlatTableCell>seven</FlatTableCell>
                 <FlatTableCell>eight</FlatTableCell>
               </FlatTableRow>
@@ -1042,7 +1040,7 @@ describe("FlatTable", () => {
                 <FlatTableCheckbox />
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
-              <FlatTableRow data-testid="two" onClick={() => {}}>
+              <FlatTableRow data-role="two" onClick={() => {}}>
                 <FlatTableCell>three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
@@ -1063,7 +1061,7 @@ describe("FlatTable", () => {
         rtlRender(
           <FlatTable>
             <FlatTableBody>
-              <FlatTableRow data-testid="one" onClick={() => {}}>
+              <FlatTableRow data-role="one" onClick={() => {}}>
                 <FlatTableCell>one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
@@ -1091,11 +1089,11 @@ describe("FlatTable", () => {
           <FlatTable>
             <FlatTableBody>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell data-testid="one">one</FlatTableCell>
+                <FlatTableCell data-role="one">one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell data-testid="two">three</FlatTableCell>
+                <FlatTableCell data-role="two">three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
             </FlatTableBody>
@@ -1112,11 +1110,11 @@ describe("FlatTable", () => {
           <FlatTable>
             <FlatTableBody>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell data-testid="one">one</FlatTableCell>
+                <FlatTableCell data-role="one">one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow highlighted expandableArea="firstColumn" expandable>
-                <FlatTableCell data-testid="two">three</FlatTableCell>
+                <FlatTableCell data-role="two">three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
             </FlatTableBody>
@@ -1133,11 +1131,11 @@ describe("FlatTable", () => {
           <FlatTable>
             <FlatTableBody>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell data-testid="one">one</FlatTableCell>
+                <FlatTableCell data-role="one">one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow selected expandableArea="firstColumn" expandable>
-                <FlatTableCell data-testid="two">three</FlatTableCell>
+                <FlatTableCell data-role="two">three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
             </FlatTableBody>
@@ -1154,13 +1152,13 @@ describe("FlatTable", () => {
           <FlatTable>
             <FlatTableBody>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableRowHeader data-testid="one" id="one">
+                <FlatTableRowHeader data-role="one" id="one">
                   one
                 </FlatTableRowHeader>
                 <FlatTableCell id="two">two</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableRowHeader data-testid="two" id="three">
+                <FlatTableRowHeader data-role="two" id="three">
                   three
                 </FlatTableRowHeader>
                 <FlatTableCell id="four">four</FlatTableCell>
@@ -1179,13 +1177,13 @@ describe("FlatTable", () => {
           <FlatTable>
             <FlatTableBody>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableRowHeader data-testid="one" id="one">
+                <FlatTableRowHeader data-role="one" id="one">
                   one
                 </FlatTableRowHeader>
                 <FlatTableCell id="two">two</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow highlighted expandableArea="firstColumn" expandable>
-                <FlatTableRowHeader data-testid="two" id="three">
+                <FlatTableRowHeader data-role="two" id="three">
                   three
                 </FlatTableRowHeader>
                 <FlatTableCell id="four">four</FlatTableCell>
@@ -1204,13 +1202,13 @@ describe("FlatTable", () => {
           <FlatTable>
             <FlatTableBody>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableRowHeader data-testid="one" id="one">
+                <FlatTableRowHeader data-role="one" id="one">
                   one
                 </FlatTableRowHeader>
                 <FlatTableCell id="two">two</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow selected expandableArea="firstColumn" expandable>
-                <FlatTableRowHeader data-testid="two" id="three">
+                <FlatTableRowHeader data-role="two" id="three">
                   three
                 </FlatTableRowHeader>
                 <FlatTableCell id="four">four</FlatTableCell>
@@ -1229,19 +1227,19 @@ describe("FlatTable", () => {
           <FlatTable>
             <FlatTableBody>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell data-testid="one">one</FlatTableCell>
+                <FlatTableCell data-role="one">one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell data-testid="two">three</FlatTableCell>
+                <FlatTableCell data-role="two">three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell data-testid="three">five</FlatTableCell>
+                <FlatTableCell data-role="three">five</FlatTableCell>
                 <FlatTableCell>six</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell data-testid="four">seven</FlatTableCell>
+                <FlatTableCell data-role="four">seven</FlatTableCell>
                 <FlatTableCell>eight</FlatTableCell>
               </FlatTableRow>
             </FlatTableBody>
@@ -1270,19 +1268,19 @@ describe("FlatTable", () => {
           <FlatTable>
             <FlatTableBody>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell data-testid="one">one</FlatTableCell>
+                <FlatTableCell data-role="one">one</FlatTableCell>
                 <FlatTableCell>two</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell data-testid="two">three</FlatTableCell>
+                <FlatTableCell data-role="two">three</FlatTableCell>
                 <FlatTableCell>four</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell data-testid="three">five</FlatTableCell>
+                <FlatTableCell data-role="three">five</FlatTableCell>
                 <FlatTableCell>six</FlatTableCell>
               </FlatTableRow>
               <FlatTableRow expandableArea="firstColumn" expandable>
-                <FlatTableCell data-testid="four">seven</FlatTableCell>
+                <FlatTableCell data-role="four">seven</FlatTableCell>
                 <FlatTableCell>eight</FlatTableCell>
               </FlatTableRow>
             </FlatTableBody>

--- a/src/components/global-header/global-header.spec.tsx
+++ b/src/components/global-header/global-header.spec.tsx
@@ -36,7 +36,7 @@ describe("Global Header", () => {
     });
 
     it("and logo is a svg element, logo is visible with correct accessible name", () => {
-      const logo = <svg aria-label="Carbon logo" data-testid="carbon-logo" />;
+      const logo = <svg aria-label="Carbon logo" data-role="carbon-logo" />;
       renderer({ logo });
       expect(screen.getByTestId("carbon-logo")).toHaveAccessibleName(
         "Carbon logo"

--- a/src/components/navigation-bar/fixed-navigation-bar-context.spec.tsx
+++ b/src/components/navigation-bar/fixed-navigation-bar-context.spec.tsx
@@ -10,7 +10,7 @@ const useResizeObserverSpy = jest.spyOn(useResizeObserverModule, "default");
 
 const ConsumerComponent = () => {
   const { submenuMaxHeight } = useContext(FixedNavigationBarContext);
-  return <div data-testid="output">{submenuMaxHeight}</div>;
+  return <div data-role="output">{submenuMaxHeight}</div>;
 };
 
 const mockNavbarElement = { offsetHeight: 40 } as HTMLElement;

--- a/src/components/tile/flex-tile-cell/flex-tile-cell.spec.tsx
+++ b/src/components/tile/flex-tile-cell/flex-tile-cell.spec.tsx
@@ -17,7 +17,7 @@ describe("FlexTileCell", () => {
   ));
 
   it("does not render when falsy children are passed", () => {
-    render(<FlexTileCell data-testid="flex-tile-cell">{null}</FlexTileCell>);
+    render(<FlexTileCell data-role="flex-tile-cell">{null}</FlexTileCell>);
 
     expect(screen.queryByTestId("flex-tile-cell")).not.toBeInTheDocument();
   });
@@ -30,11 +30,7 @@ describe("FlexTileCell", () => {
 
   it("has proper data attributes applied", () => {
     render(
-      <FlexTileCell
-        data-testid="flex-tile-cell"
-        data-element="foo"
-        data-role="bar"
-      >
+      <FlexTileCell data-element="foo" data-role="bar">
         <FlexTileDivider />
         Cell Content
       </FlexTileCell>

--- a/src/components/tile/flex-tile-container/flex-tile-container.spec.tsx
+++ b/src/components/tile/flex-tile-container/flex-tile-container.spec.tsx
@@ -19,7 +19,7 @@ describe("FlexTileContainer", () => {
 
   it("does not render when falsy children are passed", () => {
     render(
-      <FlexTileContainer data-testid="flex-tile-container">
+      <FlexTileContainer data-role="flex-tile-container">
         {null}
       </FlexTileContainer>
     );

--- a/src/components/tile/tile-content/tile-content.spec.tsx
+++ b/src/components/tile/tile-content/tile-content.spec.tsx
@@ -18,13 +18,13 @@ describe("TileContent", () => {
   testStyledSystemHeight((props) => <TileContent {...props}>Test</TileContent>);
 
   it("does not render when no children are passed", () => {
-    render(<TileContent data-testid="tile-content" />);
+    render(<TileContent data-role="tile-content" />);
 
     expect(screen.queryByTestId("tile-content")).not.toBeInTheDocument();
   });
 
   it("does not render when falsy children are passed", () => {
-    render(<TileContent data-testid="tile-content">{null}</TileContent>);
+    render(<TileContent data-role="tile-content">{null}</TileContent>);
 
     expect(screen.queryByTestId("tile-content")).not.toBeInTheDocument();
   });
@@ -113,11 +113,7 @@ describe("TileContent", () => {
 
   it("has proper data attributes applied", () => {
     render(
-      <TileContent
-        data-testid="tile-content"
-        data-element="foo"
-        data-role="bar"
-      >
+      <TileContent data-element="foo" data-role="bar">
         Tile Content
       </TileContent>
     );

--- a/src/components/tooltip/__snapshots__/tooltip.spec.tsx.snap
+++ b/src/components/tooltip/__snapshots__/tooltip.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Tooltip controlled matches snapshot when isVisible is false 1`] = `
 <div>
   <div
-    data-testid="tooltip-target"
+    data-role="tooltip-target"
   >
     foo
   </div>
@@ -19,7 +19,7 @@ exports[`Tooltip controlled matches snapshot when isVisible is true 1`] = `
 
 <div>
   <div
-    data-testid="tooltip-target"
+    data-role="tooltip-target"
   >
     foo
   </div>

--- a/src/components/tooltip/tooltip.spec.tsx
+++ b/src/components/tooltip/tooltip.spec.tsx
@@ -20,7 +20,7 @@ const positions: TooltipPositions[] = ["top", "bottom", "left", "right"];
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function render(props: Partial<TooltipProps> = {}) {
-  const children = <div data-testid="tooltip-target">foo</div>;
+  const children = <div data-role="tooltip-target">foo</div>;
   const message = "foo";
 
   return renderRTL(

--- a/src/hooks/__internal__/useClickAwayListener/useClickAwayListener.spec.tsx
+++ b/src/hooks/__internal__/useClickAwayListener/useClickAwayListener.spec.tsx
@@ -20,7 +20,7 @@ const MockComponent = ({
   };
 
   return (
-    <div data-testid="target-element" {...onInsideClickProp}>
+    <div data-role="target-element" {...onInsideClickProp}>
       Child
     </div>
   );

--- a/src/hooks/__internal__/useFloating/useFloating.spec.tsx
+++ b/src/hooks/__internal__/useFloating/useFloating.spec.tsx
@@ -27,13 +27,13 @@ const MockComponent = ({
   return (
     <div
       ref={reference}
-      data-testid="reference-element"
+      data-role="reference-element"
       style={{ width: "100px", height: "20px" }}
     >
       <div
         style={{ top: "100px", left: "50px", position: "static" }}
         ref={floating}
-        data-testid="floating-element"
+        data-role="floating-element"
       >
         Child
       </div>

--- a/src/hooks/__internal__/useMenuKeyboardNavigation/useMenuKeyboardNavigation.spec.tsx
+++ b/src/hooks/__internal__/useMenuKeyboardNavigation/useMenuKeyboardNavigation.spec.tsx
@@ -31,9 +31,9 @@ const MockComponent = ({ hideCb }: MockComponentProps) => {
 
   const getButtonChildren = useCallback(
     () =>
-      document.querySelectorAll(
-        `[data-testid="${containerID}"] button`
-      ) as NodeListOf<HTMLButtonElement>,
+      document.querySelectorAll<HTMLButtonElement>(
+        `[data-role="${containerID}"] button`
+      ),
     []
   );
 
@@ -46,14 +46,14 @@ const MockComponent = ({ hideCb }: MockComponentProps) => {
 
   return (
     <>
-      <button type="button" ref={mainRef} data-testid={mainButtonID}>
+      <button type="button" ref={mainRef} data-role={mainButtonID}>
         Main Button
       </button>
-      <button type="button" data-testid={nextDOMElementID}>
+      <button type="button" data-role={nextDOMElementID}>
         Next Element in DOM
       </button>
       <div
-        data-testid={containerID}
+        data-role={containerID}
         role="presentation"
         onKeyDown={handleKeyDown}
       >

--- a/src/hooks/__internal__/useModalAria/useModalAria.spec.tsx
+++ b/src/hooks/__internal__/useModalAria/useModalAria.spec.tsx
@@ -282,13 +282,13 @@ describe("useModalAria", () => {
     beforeEach(() => {
       render(
         <CarbonProvider>
-          <div data-testid="old-aria-hidden" aria-hidden="false" />
+          <div data-role="old-aria-hidden" aria-hidden="false" />
           <ModalComponent openButtonText="open" closeButtonText="close" />
           {/* need to ts-ignore as inert is not recognised by React yet - see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/60822
           and https://github.com/facebook/react/pull/24730 */
           /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
           /* @ts-ignore:next-line */}
-          <div data-testid="old-inert" inert="foo" />
+          <div data-role="old-inert" inert="foo" />
         </CarbonProvider>
       );
     });


### PR DESCRIPTION
### Proposed behaviour

- Configure RTL to [override the attribute looked up by the *ByTestId queries](https://testing-library.com/docs/queries/bytestid#overriding-data-testid), given Carbon already uses `data-role` extensively as a test identifier.

### Current behaviour

- RTL's *ByTestId queries search for elements with a matching `data-testid` attribute.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
