### PR TITLE
docs(loader): add new accessible example in button - FE-5224

### DIFF
--- a/src/components/loader/loader.stories.mdx
+++ b/src/components/loader/loader.stories.mdx
@@ -85,6 +85,12 @@ please remember to pass the `isInsideButton` prop to the `Loader` component.
   <Story name="inside Buttons" story={stories.InsideButtons} />
 </Canvas>
 
+This example demonstrates how to use the `Loader` component nested inside of a `Button` in an accessibile way.
+
+<Canvas>
+  <Story name="inside buttons - accessibile example" story={stories.AccessibleExample}/>
+</Canvas>
+
 ## Props
 
 ### Loader

--- a/src/components/loader/loader.stories.tsx
+++ b/src/components/loader/loader.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { ComponentStory } from "@storybook/react";
 
 import Loader from ".";
@@ -19,30 +19,66 @@ export const Large: ComponentStory<typeof Loader> = () => (
   <Loader size="large" />
 );
 
-export const InsideButtons: ComponentStory<typeof Loader> = () => (
-  <>
-    <Button buttonType="primary" aria-label="Loading">
-      <Loader isInsideButton />
-    </Button>
-    <Button ml={2} buttonType="primary" destructive aria-label="Loading">
-      <Loader isInsideButton />
-    </Button>
-    <Button ml={2} destructive aria-label="Loading">
-      <Loader isInsideButton />
-    </Button>
-    <Button ml={2} buttonType="tertiary" aria-label="Loading">
-      <Loader isInsideButton />
-    </Button>
-    <Button ml={2} buttonType="secondary" aria-label="Loading">
-      <Loader isInsideButton />
-    </Button>
-    <Button ml={2} buttonType="dashed" aria-label="Loading">
-      <Loader isInsideButton />
-    </Button>
-    <Box id="dark-background" mt={2} p={2} width="fit-content" bg="#000000">
-      <Button m={2} buttonType="darkBackground" aria-label="Loading">
+export const InsideButtons: ComponentStory<typeof Loader> = () => {
+  return (
+    <>
+      <Button buttonType="primary" aria-label="Loading">
         <Loader isInsideButton />
       </Button>
-    </Box>
-  </>
-);
+      <Button ml={2} buttonType="primary" destructive aria-label="Loading">
+        <Loader isInsideButton />
+      </Button>
+      <Button ml={2} destructive aria-label="Loading">
+        <Loader isInsideButton />
+      </Button>
+      <Button ml={2} buttonType="tertiary" aria-label="Loading">
+        <Loader isInsideButton />
+      </Button>
+      <Button ml={2} buttonType="secondary" aria-label="Loading">
+        <Loader isInsideButton />
+      </Button>
+      <Button ml={2} buttonType="dashed" aria-label="Loading">
+        <Loader isInsideButton />
+      </Button>
+      <Box id="dark-background" mt={2} p={2} width="fit-content" bg="#000000">
+        <Button m={2} buttonType="darkBackground" aria-label="Loading">
+          <Loader isInsideButton />
+        </Button>
+      </Box>
+    </>
+  );
+};
+
+export const AccessibleExample: ComponentStory<typeof Loader> = () => {
+  const [isLoading, setIsLoading] = useState(true);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const mimicLoading = () => {
+    setIsLoading(true);
+    buttonRef.current?.focus();
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 5000);
+  };
+  useEffect(() => {
+    mimicLoading();
+  }, []);
+  const handleButtonClick = () => {
+    mimicLoading();
+  };
+  const buttonContent = isLoading ? <Loader isInsideButton /> : "Click me";
+  const ariaProps = {
+    "aria-label": "Loading",
+  };
+  return (
+    <>
+      <Button
+        buttonType="primary"
+        {...(isLoading ? ariaProps : {})}
+        onClick={handleButtonClick}
+        ref={buttonRef}
+      >
+        {buttonContent}
+      </Button>
+    </>
+  );
+};


### PR DESCRIPTION
### Proposed behaviour

Create an accessible implementation docs example for Loader nested inside a Button. 

### Current behaviour

Currently no documentation on how this should be implemented in an accessible way.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Test that the new accessible example reads out correctly when used with a screenreader.