### PR TITLE
feat(dialog): allow subtitle prop to accept a node

### DIFF
--- a/src/components/dialog-full-screen/dialog-full-screen-test.stories.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen-test.stories.tsx
@@ -1,13 +1,16 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
+import { StoryObj } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import DialogFullScreen, { DialogFullScreenProps } from ".";
 import Dialog from "../dialog";
 import Button from "../button";
 import Form from "../form";
+import Icon from "../icon";
+import Textbox from "../textbox";
 
 export default {
   title: "Dialog Full Screen/Test",
-  includeStories: ["DefaultStory"],
+  includeStories: ["DefaultStory", "WithTwoDifferentNodes"],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -128,3 +131,48 @@ export const Nested = () => {
 };
 
 Nested.storyName = "nested";
+
+type StoryType = StoryObj<typeof DialogFullScreen>;
+
+export const WithTwoDifferentNodes: StoryType = ({
+  ...props
+}: Partial<DialogFullScreenProps>) => {
+  const [isOpen, setIsOpen] = useState(true);
+  const ref = useRef<HTMLButtonElement | null>(null);
+  return (
+    <>
+      <DialogFullScreen
+        focusFirstElement={ref}
+        open={isOpen}
+        showCloseIcon
+        title="Example Dialog Full Screen"
+        subtitle={
+          <>
+            <Icon type="add" />
+            <br />
+            Subtitle line 2
+          </>
+        }
+        onCancel={() => setIsOpen(false)}
+        {...props}
+      >
+        <Textbox label="Textbox1" value="Textbox1" />
+        <Textbox label="Textbox2" value="Textbox2" />
+        <Textbox label="Textbox3" value="Textbox3" />
+      </DialogFullScreen>
+    </>
+  );
+};
+
+WithTwoDifferentNodes.storyName = "with two different nodes in subtitle";
+WithTwoDifferentNodes.decorators = [
+  (Story) => (
+    <div style={{ height: 900, width: "100%" }}>
+      <Story />
+    </div>
+  ),
+];
+WithTwoDifferentNodes.parameters = {
+  layout: "fullscreen",
+  chromatic: { disableSnapshot: false },
+};

--- a/src/components/dialog-full-screen/dialog-full-screen.component.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.component.tsx
@@ -58,8 +58,8 @@ export interface DialogFullScreenProps extends ModalProps {
   showCloseIcon?: boolean;
   /** Data tag prop bag for close Button */
   closeButtonDataProps?: Pick<TagProps, "data-role" | "data-element">;
-  /** Subtitle displayed at top of dialog */
-  subtitle?: string;
+  /** Subtitle displayed at top of dialog. Its consumers' responsibility to set a suitable accessible name/description for the Dialog if they pass a node to subtitle prop. */
+  subtitle?: React.ReactNode;
   /** Title displayed at top of dialog */
   title?: React.ReactNode;
   /** The ARIA role to be applied to the DialogFullscreen container */
@@ -149,7 +149,8 @@ export const DialogFullScreen = ({
   const ariaProps = {
     "aria-labelledby":
       title && typeof title === "string" ? titleId : ariaLabelledBy,
-    "aria-describedby": subtitle ? subtitleId : ariaDescribedBy,
+    "aria-describedby":
+      subtitle && typeof subtitle === "string" ? subtitleId : ariaDescribedBy,
     "aria-label": ariaLabel,
   };
 

--- a/src/components/dialog-full-screen/dialog-full-screen.spec.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.spec.tsx
@@ -639,6 +639,30 @@ describe("DialogFullScreen", () => {
       });
     });
 
+    describe("when the aria-describedby prop is specified", () => {
+      it("then the container should have the same aria-describedby attribute", () => {
+        const subtitleId = "foo";
+
+        wrapper = mount(
+          <DialogFullScreen
+            aria-describedby={subtitleId}
+            open
+            onCancel={() => {}}
+            data-role="baz"
+            data-element="bar"
+            subtitle={<div id={subtitleId}>Foo</div>}
+          />
+        );
+
+        expect(
+          wrapper
+            .find("[data-element='dialog-full-screen']")
+            .first()
+            .prop("aria-describedby")
+        ).toBe(subtitleId);
+      });
+    });
+
     describe("when the role prop is specified", () => {
       it("then the container should have the same role attribute", () => {
         const dialogRole = "foo";

--- a/src/components/dialog/dialog-test.stories.tsx
+++ b/src/components/dialog/dialog-test.stories.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { StoryObj } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import { EditorState } from "draft-js";
 
@@ -8,6 +9,7 @@ import { DIALOG_SIZES } from "./dialog.config";
 import Form from "../form";
 import Textbox from "../textbox";
 import Button from "../button";
+import Icon from "../icon";
 import DateInput, { DateChangeEvent } from "../date";
 import { Checkbox } from "../checkbox";
 import { Select, Option } from "../select";
@@ -175,3 +177,41 @@ Default.args = {
   disableEscKey: false,
   stickyFooter: false,
 };
+
+type StoryType = StoryObj<typeof Dialog>;
+
+export const WithTwoDifferentNodes: StoryType = (
+  props: Partial<DialogProps>
+) => {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <Dialog
+      open={isOpen}
+      title="Example Dialog"
+      subtitle={
+        <>
+          <Icon type="add" />
+          <br />
+          Subtitle line 2
+        </>
+      }
+      showCloseIcon
+      onCancel={() => setIsOpen(false)}
+      {...props}
+    >
+      <Textbox label="Textbox1" value="Textbox1" />
+      <Textbox label="Textbox2" value="Textbox2" />
+      <Textbox label="Textbox3" value="Textbox3" />
+    </Dialog>
+  );
+};
+
+WithTwoDifferentNodes.storyName = "with two different nodes in subtitle";
+WithTwoDifferentNodes.decorators = [
+  (Story) => (
+    <div style={{ height: 400, width: "100%" }}>
+      <Story />
+    </div>
+  ),
+];
+WithTwoDifferentNodes.parameters = { chromatic: { disableSnapshot: false } };

--- a/src/components/dialog/dialog.component.tsx
+++ b/src/components/dialog/dialog.component.tsx
@@ -85,9 +85,9 @@ export interface DialogProps extends ModalProps, TagProps {
   closeButtonDataProps?: Pick<TagProps, "data-role" | "data-element">;
   /** Size of dialog, default size is 750px */
   size?: DialogSizes;
-  /** Subtitle displayed at top of dialog */
-  subtitle?: string;
-  /** Title displayed at top of dialog */
+  /** Subtitle displayed at top of dialog. Its consumers' responsibility to set a suitable accessible name/description for the Dialog if they pass a node to subtitle prop. */
+  subtitle?: React.ReactNode;
+  /** Title displayed at top of dialog. Its consumers' responsibility to set a suitable accessible name/description for the Dialog if they pass a node to title prop. */
   title?: React.ReactNode;
   /** The ARIA role to be applied to the Dialog container */
   role?: string;
@@ -276,7 +276,10 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
       dialogHeight,
       "aria-labelledby":
         title && typeof title === "string" ? titleId : rest["aria-labelledby"],
-      "aria-describedby": subtitle ? subtitleId : rest["aria-describedby"],
+      "aria-describedby":
+        subtitle && typeof subtitle === "string"
+          ? subtitleId
+          : rest["aria-describedby"],
       "aria-label": rest["aria-label"],
     };
 

--- a/src/components/dialog/dialog.spec.tsx
+++ b/src/components/dialog/dialog.spec.tsx
@@ -621,7 +621,7 @@ describe("Dialog", () => {
       });
     });
 
-    describe("when a subtitle is specified", () => {
+    describe("when a subtitle is specified as a string", () => {
       it("then the container should have aria-describedby attribute set to it's subtitle id", () => {
         (guid as jest.MockedFunction<typeof guid>).mockImplementation(
           () => "baz"
@@ -656,6 +656,27 @@ describe("Dialog", () => {
             .first()
             .prop("aria-labelledby")
         ).toBe(titleId);
+      });
+    });
+
+    describe("when the aria-describedby prop is specified", () => {
+      it("then the container should have the same aria-describedby attribute", () => {
+        const subtitleId = "foo";
+
+        const wrapper = enzymeMount(
+          <Dialog
+            aria-describedby={subtitleId}
+            open
+            subtitle={<div id={subtitleId}>Foo</div>}
+          />
+        );
+
+        expect(
+          wrapper
+            .find("[data-element='dialog']")
+            .first()
+            .prop("aria-describedby")
+        ).toBe(subtitleId);
       });
     });
 


### PR DESCRIPTION
enable consumers to pass a node as the subtitle prop

fix #5844

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Allow the consumers to pass a node as the subtitle prop

### Current behaviour

Currently the type of the subtitle prop can only be  `string`

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in provided StackBlitz sandbox/Storybook
- [x] Add new Playwright test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
