### PR TITLE
chore(playwright): create CI workflow for running specific tests multiple times

### DIFF
--- a/.github/workflows/playwright-audit.yml
+++ b/.github/workflows/playwright-audit.yml
@@ -1,0 +1,42 @@
+name: Audit a Playwright test
+run-name: ${{ github.actor }} is running tests that match ${{ inputs.test-filter }} ${{ inputs.repeat-each }} times
+
+on:
+  workflow_dispatch:
+    inputs:
+      repeat-each:
+        default: 5
+        type: number
+        description: The number of times to repeat the test
+      test-filter:
+        required: true
+        type: string
+        description: "Filter string used to match specific tests or test files to run with the `npm run test:ct` command. (Examples: 'src/components/alert/alert.pw.tsx', 'src/components/alert/alert.pw.tsx src/components/accordion/accordion.pw.tsx'). Can also specify tests on a line number with a colon ('src/components/alert/alert.pw.tsx:10')."
+
+jobs:
+  test:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.36.2-jammy
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          node-version: 20
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Run Playwright tests
+        run: npm run test:ct -- "${{ inputs.test-filter }}" --workers=1 --repeat-each=${{ inputs.repeat-each }}
+        env:
+          HOME: /root
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/

--- a/.github/workflows/playwright-audit.yml
+++ b/.github/workflows/playwright-audit.yml
@@ -1,5 +1,5 @@
 name: Audit a Playwright test
-run-name: ${{ github.actor }} is running tests that match ${{ inputs.test-filter }} ${{ inputs.repeat-each }} times
+run-name: ${{ github.actor }} is running ${{ inputs.component }} test${{ inputs.line-number && format(' on line {0}', inputs.line-number) || 's' }} ${{ inputs.repeat-each }} times
 
 on:
   workflow_dispatch:
@@ -8,10 +8,13 @@ on:
         default: 5
         type: number
         description: The number of times to repeat the test
-      test-filter:
+      component:
         required: true
         type: string
-        description: "Filter string used to match specific tests or test files to run with the `npm run test:ct` command. (Examples: 'src/components/alert/alert.pw.tsx', 'src/components/alert/alert.pw.tsx src/components/accordion/accordion.pw.tsx'). Can also specify tests on a line number with a colon ('src/components/alert/alert.pw.tsx:10')."
+        description: "Name of the component to test. (Examples: `button`, `anchor-navigation`, etc.)"
+      line-number:
+        type: number
+        description: "Optional file line number of a specific test to run. (Example: `10`)"
 
 jobs:
   test:
@@ -31,7 +34,7 @@ jobs:
         run: npm ci
 
       - name: Run Playwright tests
-        run: npm run test:ct -- "${{ inputs.test-filter }}" --workers=1 --repeat-each=${{ inputs.repeat-each }}
+        run: npm run test:ct -- "/${{ inputs.component }}.pw.tsx${{ inputs.line-number && format(':{0}', inputs.line-number) || '' }}" --workers=1 --repeat-each=${{ inputs.repeat-each }}
         env:
           HOME: /root
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.34.0-jammy
+      image: mcr.microsoft.com/playwright:v1.36.2-jammy
     strategy:
       fail-fast: false
       matrix:

--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -7,6 +7,8 @@ const playwrightDir = resolve(__dirname, "./playwright");
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
+  /** Directory with the test files. */
+  testDir: resolve(__dirname, "./src/components"),
   /* The base directory, relative to the config file, for snapshot files created with toMatchSnapshot and toHaveScreenshot. */
   snapshotDir: resolve(playwrightDir, "./__snapshots__"),
   /* The output directory for files created during test execution */


### PR DESCRIPTION
### Proposed behaviour

- Add new `playwright-audit.yml` workflow - allowing contributors with write permissions to run specific test(s) N times in a CI environment.
- Update Playwright container image in `playwright.yml` to match Playwright version in package lock file.

### Current behaviour

- Unable to run specific Playwright tests in CI, which would be useful when auditing tests for flakiness, particularly since test results can vary depending on the runtime environment.   

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

To experiment with the workflow, please contact me externally to access a privately-owned test repo.