### PR TITLE
fix(popover): update portal landmark role to 'region'

### DIFF
--- a/src/__internal__/popover/popover.component.tsx
+++ b/src/__internal__/popover/popover.component.tsx
@@ -37,6 +37,8 @@ export interface PopoverProps {
   popoverStrategy?: "absolute" | "fixed";
   // Allows child ref to be set via a prop instead of dynamically finding it via children iteration
   childRefOverride?: MutableRefObject<HTMLDivElement | null>;
+  /** Prop to specify the aria-labelledby attribute of the input */
+  ariaLabelledBy?: string;
 }
 
 const defaultMiddleware = [
@@ -56,6 +58,7 @@ const Popover = ({
   animationFrame,
   popoverStrategy = "absolute",
   childRefOverride,
+  ariaLabelledBy,
 }: PopoverProps) => {
   const elementDOM = useRef<HTMLDivElement | null>(null);
   const { isInModal } = useContext<ModalContextProps>(ModalContext);
@@ -79,6 +82,10 @@ const Popover = ({
     content = children;
   } else {
     content = React.cloneElement(children, { ref: floatingReference });
+  }
+  if (elementDOM.current && !disablePortal && ariaLabelledBy) {
+    elementDOM.current.setAttribute("role", "region");
+    elementDOM.current.setAttribute("aria-labelledby", ariaLabelledBy);
   }
 
   useFloating({

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -279,7 +279,11 @@ export const ActionPopover = ({
         }}
       >
         {isOpen && (
-          <Popover placement={mappedPlacement} reference={buttonRef}>
+          <Popover
+            placement={mappedPlacement}
+            reference={buttonRef}
+            ariaLabelledBy={parentID}
+          >
             <ActionPopoverMenu
               data-component="action-popover"
               ref={menu}

--- a/src/components/action-popover/action-popover.stories.tsx
+++ b/src/components/action-popover/action-popover.stories.tsx
@@ -62,6 +62,7 @@ export const Default: Story = () => {
       </ActionPopoverItem>
     </ActionPopoverMenu>
   );
+
   return (
     <Box mt={40} height={275}>
       <ActionPopover onOpen={() => {}} onClose={() => {}}>

--- a/src/components/form/components.test-pw.tsx
+++ b/src/components/form/components.test-pw.tsx
@@ -637,9 +637,9 @@ export const WithLabelsInline = () => (
       labelWidth={30}
       labelId="inline-inputs"
     >
-      <Textbox aria-labelledby="inline-inputs" />
-      <Textbox aria-labelledby="inline-inputs" />
-      <Select aria-labelledby="inline-inputs">
+      <Textbox aria-label="inline input A" />
+      <Textbox aria-label="inline input B" />
+      <Select aria-label="inline select A">
         <Option value="1" text="option 1" key="1" />
         <Option value="2" text="option 2" key="1" />
         <Option value="3" text="option 3" key="1" />
@@ -651,9 +651,9 @@ export const WithLabelsInline = () => (
       labelWidth={30}
       labelId="inline-inputs-second"
     >
-      <Textbox aria-labelledby="inline-inputs-second" />
-      <Textbox aria-labelledby="inline-inputs-second" />
-      <Select aria-labelledby="inline-inputs-second">
+      <Textbox aria-label="inline input second A" />
+      <Textbox aria-label="inline input second B" />
+      <Select aria-label="inline select B">
         <Option value="1" text="option 1" key="1" />
         <Option value="2" text="option 2" key="1" />
         <Option value="3" text="option 3" key="1" />

--- a/src/components/form/form.stories.tsx
+++ b/src/components/form/form.stories.tsx
@@ -689,9 +689,9 @@ export const WithLabelsInline: Story = () => (
       labelWidth={30}
       labelId="inline-inputs"
     >
-      <Textbox aria-labelledby="inline-inputs" />
-      <Textbox aria-labelledby="inline-inputs" />
-      <Select aria-labelledby="inline-inputs">
+      <Textbox aria-label="inline input A" />
+      <Textbox aria-label="inline input B" />
+      <Select aria-label="inline select A">
         <Option value="1" text="option 1" key="1" />
         <Option value="2" text="option 2" key="1" />
         <Option value="3" text="option 3" key="1" />
@@ -703,9 +703,9 @@ export const WithLabelsInline: Story = () => (
       labelWidth={30}
       labelId="inline-inputs-second"
     >
-      <Textbox aria-labelledby="inline-inputs-second" />
-      <Textbox aria-labelledby="inline-inputs-second" />
-      <Select aria-labelledby="inline-inputs-second">
+      <Textbox aria-label="inline input second A" />
+      <Textbox aria-label="inline input second B" />
+      <Select aria-label="inline select B">
         <Option value="1" text="option 1" key="1" />
         <Option value="2" text="option 2" key="1" />
         <Option value="3" text="option 3" key="1" />

--- a/src/components/popover-container/popover-container.component.tsx
+++ b/src/components/popover-container/popover-container.component.tsx
@@ -340,6 +340,7 @@ export const PopoverContainer = ({
         {(state: TransitionStatus) =>
           isOpen && (
             <Popover
+              ariaLabelledBy={popoverContainerId}
               reference={popoverReference}
               placement={position === "right" ? "bottom-start" : "bottom-end"}
               popoverStrategy={

--- a/src/components/select/select-list/select-list.component.tsx
+++ b/src/components/select/select-list/select-list.component.tsx
@@ -98,6 +98,8 @@ export interface SelectListProps {
   virtualScrollOverscan?: number;
   /** @private @ignore A callback for when a mouseDown event occurs on the component */
   onMouseDown?: () => void;
+  /** Unique ID for the menu's parent */
+  parentID?: string;
 }
 
 const TABLE_HEADER_HEIGHT = 48;
@@ -128,6 +130,7 @@ const SelectList = React.forwardRef(
       multiselectValues,
       enableVirtualScroll,
       virtualScrollOverscan = 5,
+      parentID,
       ...listProps
     }: SelectListProps,
     listContainerRef: React.ForwardedRef<HTMLDivElement>
@@ -635,10 +638,9 @@ const SelectList = React.forwardRef(
             {tableHeader}
           </StyledSelectListTableHeader>
           <StyledSelectListTableBody
-            {...listBoxProps}
-            aria-labelledby={labelId}
             ref={tableRef}
             listHeight={listHeight - TABLE_HEADER_HEIGHT}
+            {...listBoxProps}
           >
             {renderedChildren}
           </StyledSelectListTableBody>
@@ -654,6 +656,7 @@ const SelectList = React.forwardRef(
         }}
       >
         <Popover
+          ariaLabelledBy={parentID}
           placement={listPlacement}
           disablePortal
           reference={anchorRef}

--- a/src/components/select/simple-select/simple-select.component.tsx
+++ b/src/components/select/simple-select/simple-select.component.tsx
@@ -512,6 +512,7 @@ export const SimpleSelect = React.forwardRef(
       <SelectList
         ref={listboxRef}
         id={selectListId.current}
+        parentID={inputId.current}
         labelId={labelId}
         anchorElement={textboxRef?.parentElement || undefined}
         onSelect={onSelectOption}


### PR DESCRIPTION
fix (#6403)

### Proposed behaviour
for Dashboard MFE, inside Tasks tab there is one ActionPopover implemented [here](https://github.com/Sage/sbc.common.project.ui/blob/master/src/tasks/Tile/taskTile.tsx)  for Actions button. This having the issue with "Portal" landmark, so one option to solve we can either use DisablePortal prop inside the carbon component https://github.com/Sage/carbon/blob/master/src/components/action-popover/action-popover.component.tsx#L279 or to change the landmark when it comes to a Portal.

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

Current Popover component as renders at top DOM level it asks for main Landmarks to wrap it and their content. 
Renders a simple div and it should use role="region", this also affects or add extra A11y rules as making these landmarks unique and by doing it you should describe them either by aria-label or aria-labelledby, this also affects some other E2E components that uses Popover somehow. 

This issue can be skipped by using disablePortal prop but lets say this developmnet will allow both situations to live together.


<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
