### PR TITLE
chore(playwright): configure `getByTestId` locator to find `data-role` tags

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 __spec__.js
 __definition__.js
+*.md

--- a/.eslintrc
+++ b/.eslintrc
@@ -145,10 +145,7 @@
         ]
       },
       "plugins": ["@typescript-eslint"],
-      "extends": [
-        "plugin:@typescript-eslint/recommended",
-        "prettier"
-      ],
+      "extends": ["plugin:@typescript-eslint/recommended", "prettier"],
       "settings": {
         "mdx/code-blocks": true,
         "react": {
@@ -159,7 +156,7 @@
         "import/named": "off",
         "react/prefer-stateless-function": "off",
         "no-use-before-define": "off",
-        "@typescript-eslint/no-use-before-define": ["error"],
+        "@typescript-eslint/no-use-before-define": "error",
         "@typescript-eslint/no-empty-function": [
           "error",
           { "allow": ["arrowFunctions"] }

--- a/contributing/testing-guide.md
+++ b/contributing/testing-guide.md
@@ -2,32 +2,31 @@
 
 ## Contents
 
-- [Testing guide](#testing-guide)
-  - [Contents](#contents)
-  - [Introduction](#introduction)
-  - [Component testing](#component-testing)
-    - [Custom utilities](#custom-utilities)
-    - [Use of Snapshot tests](#use-of-snapshot-tests)
-    - [Continuous Integration (CI)](#continuous-integration-ci)
-  - [Functional Browser Testing](#functional-browser-testing)
-    - [Playwright File Structure](#playwright-file-structure)
-    - [Locators](#locators)
-  - [Visual Testing](#visual-testing)
-    - [Adding new visual tests](#adding-new-visual-tests)
+- [Component tests](#component-tests)
+  - [Enzyme utilities](#enzyme-utilities)
+  - [React Testing Library test ID tests](#react-testing-library-test-id-tests)
+  - [Use of Snapshot tests](#use-of-snapshot-tests)
+  - [Continuous Integration (CI)](#continuous-integration-ci)
+- [Browser-based component tests](#browser-based-component-tests)
+  - [Playwright File Structure](#playwright-file-structure)
+  - [Locators](#locators)
+- [Visual Testing](#visual-testing)
 
 ## Introduction
 
-This guide details Carbon's testing setup, common conventions and utilities available to you.
+This guide details Carbon's testing setup, common conventions, and utilities available to you.
 
-## Component testing
+## Component tests
 
-We use the [Jest](https://facebook.github.io/jest/) framework and [Enzyme](https://enzymejs.github.io/enzyme/) library for our component tests. Tests should describe the **behaviour of the components** rather than describe the implementation to keep the tests clean and reliable. All props, branches and paths and each of their conditions need to be tested to meet Carbon's 100% coverage policy.
+> **NOTE**: From March 2024, we're transitioning from Enzyme to [React Testing Library (RTL)](https://testing-library.com/docs/react-testing-library/intro/). Please use RTL where possible when testing new functionality.
 
-### Custom utilities
+We use the [Jest](https://jestjs.io/) framework and [Enzyme](https://enzymejs.github.io/enzyme/) library for our component tests. Tests should describe the **behaviour of the components** rather than describe the implementation to keep the tests clean and reliable. All props, branches, and paths and each of their conditions need to be tested to meet Carbon's 100% coverage policy.
 
-To help with common testing scenarios, we have a number of custom utilities available in `/src/__spec_helper__` that can be imported directly into your tests.
+### Enzyme utilities
 
-For example the `assertStyleMatch` method which asserts if all the expected CSS properties have been applied to a DOM element or React component:
+To help with common testing scenarios, we have several custom utilities available in `/src/__spec_helper__` that can be imported directly into your tests.
+
+For example, the `assertStyleMatch` method asserts if all the expected CSS properties have been applied to a DOM element or React component:
 
 ```tsx
 describe("FlatTableRow", () => {
@@ -45,32 +44,49 @@ describe("FlatTableRow", () => {
 });
 ```
 
+### React Testing Library test ID tests
+
+[RTL](https://testing-library.com/docs/react-testing-library/intro/) follows a user-centric testing approach. To encourage this the library provides query functions for locating DOM elements by user-facing attributes like text, ARIA roles, etc.
+
+If you need to use [RTL's `*ByTestId()` query functions](https://testing-library.com/docs/queries/bytestid), we have configured RTL to locate the `data-role` attribute:
+
+```tsx
+<span data-role="icon" data-element="pdf" />
+```
+
+```ts
+const icon = screen.getByTestId("icon");
+
+await expect(icon).toBeInTheDocument();
+await expect(icon).toHaveAttribute("data-element", "pdf");
+```
+
 ### Use of Snapshot tests
 
-Snapshots are left up to the developer to be used where there is value. If you do want to use them, ensure they are small, focused and effective.
+Snapshots are left up to the developer to be used where there is value. If you do want to use them, ensure they are small, focused, and effective.
 
 > Further information on snapshots can be found on [Jest's official docs](https://jestjs.io/docs/snapshot-testing).
 
 ### Continuous Integration (CI)
 
-GitHub Actions runs unit tests for a Pull Request on creation and every commit push. You can manually run these steps with:
+GitHub Actions runs component tests for a particular Pull Request when it is created and on every commit push. You can manually run these steps with:
 
 1. `npm format` - run prettier to format code under `/src`.
 2. `npm run lint` - run linter on code under `/src`.
 3. `npm run type-check` - run TypeScript compiler to check for type errors.
 4. `npm test` - runs unit tests.
 
-## Functional Browser Testing
+## Browser-based component tests
 
-We use the [Playwright](https://playwright.dev) framework to test component behaviour that requires a browser environment. Functionality which has already been tested via Jest tests does not need to be tested again using Playwright, unless it would be beneficial to test the behaviour in a manner similar to how a user would in a browser.
+We use [Playwright](https://playwright.dev) for conducting component tests that necessitate a real browser environment. This is particularly useful for certain scenarios, such as event handling, where it is beneficial to more accurately simulate and test user interactions.
 
-Further details on installing Playwright and our configuration for it can be found in our [Getting started with Playwright](../playwright/README.md) guide.
+Further details on installing Playwright and our configuration for it can be found in our [Getting Started with Playwright](../playwright/README.md) guide.
 
 ### Playwright File Structure
 
 All Playwright tests must go within `*.pw.tsx` for the relevant component.
 
-```
+```none
 .
 ├── src/
 │   ├── components/
@@ -102,25 +118,55 @@ import { test, expect } from "@playwright/experimental-ct-react17";
 import Button from "./button.component";
 import { buttonComponent } from "../../../playwright/component/button/index";
 
-  test.describe("Check props for Button component", async () => {
-    test("should render Button label when passed to the component", async ({ mount, page }) => {
-      
-      const label = "foobar";
-      
-      await mount(<Button>{label}</Button>);
+test.describe("Check props for Button component", async () => {
+  test("should render Button label when passed to the component", async ({
+    mount,
+    page,
+  }) => {
+    const label = "foobar";
 
-      await expect(buttonComponent(page)).toHaveText(label);
-    });
+    await mount(<Button>{label}</Button>);
+
+    await expect(buttonComponent(page)).toHaveText(label);
   });
+});
 ```
 
 Where `mount` renders the component in the real browser (`chromium`/`webkit`/`firefox`/`opera`) and `buttonComponent` is a _locator_ that returns the DOM element we want to test.
 
 ### Locators
 
-We write dedicated functions to access rendered DOM elements in order to make our tests easier to read. Locators for a component typically follow this structure:
+Playwright offers [built-in locators](https://playwright.dev/docs/locators) to find DOM elements within a rendered component. These locators focus on finding user-facing attributes like text and ARIA roles to encourage the creation of resilient tests.
 
-`index.ts`
+```tsx
+await page.getByLabel("User Name").fill("John");
+
+await page.getByRole("button", { name: "Sign in" }).click();
+
+await expect(page.getByText("Welcome, John!")).toBeVisible();
+```
+
+#### Test ID tests
+
+If you need to use [Playwright's `page.getByTestId()` locator](https://playwright.dev/docs/locators#locate-by-test-id), we have configured Playwright to locate the `data-role` attribute:
+
+```tsx
+<span data-role="icon" data-element="pdf" />
+```
+
+```ts
+const icon = page.getByTestId("icon");
+
+await expect(icon).toBeAttached();
+await expect(icon).toHaveAttribute("data-element", "pdf");
+```
+
+#### Custom locators
+
+We also have custom locators for many of our components. These locators typically follow a specific structure:
+
+`playwright/components/<component-name>/index.ts`
+
 ```ts
 /* in index.ts */
 import type { Page } from "@playwright/test";
@@ -128,16 +174,17 @@ import { BUTTON_DATA_COMPONENT, BUTTON_SUBTEXT } from "./locators";
 
 const buttonComponent = (page: Page) => {
   return page.locator(BUTTON_DATA_COMPONENT);
-}
+};
 
 const buttonSubtext = (page: Page) => {
   return page.locator(BUTTON_SUBTEXT);
-}
+};
 
 export { buttonComponent, buttonSubtext };
 ```
 
-`locators.ts`
+`playwright/components/<component-name>/locators.ts`
+
 ```ts
 /* locators.ts */
 // `data-component` prop is typically reserved for the root element of the component. Whereas `data-element` is for specific elements.
@@ -151,7 +198,7 @@ We use [Chromatic](https://www.chromatic.com/) for flagging any visual regressio
 
 ### Adding new visual tests
 
-Chromatic is set-up to check for regressions in all component stories. Typically components will have the following stories files:
+Chromatic is set up to check for visual regressions in all component stories. Typically, components will have the following story files:
 
 ```none
 .
@@ -161,4 +208,40 @@ Chromatic is set-up to check for regressions in all component stories. Typically
           └── [component-name]-test.stories.* (private stories)
 ```
 
-To introduce a new visual test, create a story in the relevant stories file that demonstrates the behaviour and it will automatically be detected by Chromatic.
+To introduce a new visual test, create a story in the relevant stories file that demonstrates the behaviour.
+
+Carbon automatically enables snapshots for all stories, though be wary that this can be overridden by story files. Make sure to check if snapshots have been disabled for a story file in its metadata-level parameters:
+
+```tsx
+// Button.stories.tsx
+import Button from "./button":
+import type { Meta } from "@storybook/react";
+
+const meta: Meta<typeof Button> = {
+  title: "Button",
+  component: ActionPopover,
+  // 👇 Disables snapshots for all stories in this file
+  parameters: { chromatic: { disableSnapshot: true } },
+};
+
+export default meta;
+```
+
+If required, you can explicitly enable snapshots for a story via its own parameters:
+
+```tsx
+// Button.stories.tsx
+import { Button } from "./Button";
+import type { StoryObj } from "@storybook/react";
+
+type Story = StoryObj<typeof Button>;
+
+export const OnDark: Story = {
+  // 👇 Story-level parameters
+  parameters: {
+    chromatic: {
+      disableSnapshot: false,
+    },
+  },
+};
+```

--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -52,7 +52,7 @@ export default defineConfig({
       name: "chromium",
       use: {
         ...devices["Desktop Chrome"],
-        testIdAttribute: "data-component",
+        testIdAttribute: "data-role",
         viewport: { width: 1366, height: 768 },
       },
     },

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -5,15 +5,20 @@
 - [Installation](#installation)
 - [Running Tests](#running-tests)
 - [Continuous Integration (CI)](#continuous-integration-ci)
-- [Debugging playwright](#debugging-playwright)
+- [Debugging Playwright](#debugging-playwright)
 
 ## Installation
 
-We are planning to use [Playwright](https://playwright.dev) testing framework for functional and regression testing. Playwright is already installed in the Carbon project. Clone and install the carbon repository to apply the installation:
+Ensure Carbon is first installed on your machine by doing the following:
 
-1. Clone the carbon repository `git clone git@github.com:Sage/carbon.git`.
+1. Clone the repository `git clone git@github.com:Sage/carbon.git`.
 2. Install with `npm install`.
-3. Also (for the first time) we would need to install browser using `npx playwright install`;
+
+When running Playwright tests for the first time, you will need to install the required browser binaries:
+
+```shell
+npx playwright install
+```
 
 ## Running Tests
 
@@ -22,8 +27,8 @@ To run the tests locally:
 1. Open a new terminal in the root path of the project.
 2. To run Playwright using the `playwright` runner, run `npm run test:ct:ui` and then select the required test file. Test results can be seen directly in the Playwright Test Runner UI.
 3. To run the suite of Playwright tests in CI mode, run `npm run test:ct`. Test results can be seen in the console run summary. Or could be shown in a separate report by running `npm run test:ct:report`.
-4. To run specific Playwright test at the command line run `npm run test:ct -- ./src/components/[component]/*.pw.tsx`. Test results can be seen in the console run summary.
-5. We have specified three browsers to run tests on. So to run Playwright tests in a specific browser run `npm run test:ct -- --project=chromium` or `npm run test:ct -- --project=firefox`. If you want to run Playwright tests on a specific browser using `UI` runner you need manually select which browser you want to use (or all available in `playwright-ct.config.ts`).
+4. To run specific Playwright tests at the command line run `npm run test:ct -- ./src/components/[component]/*.pw.tsx`. Test results can be seen in the console run summary.
+5. We have specified three browsers to run tests on. So to run Playwright tests in a specific browser run `npm run test:ct -- --project=chromium` or `npm run test:ct -- --project=firefox`. If you want to run Playwright tests on a specific browser using `UI` runner you need to manually select which browser you want to use (or all available in `playwright-ct.config.ts`).
 
 > If you use VSCode as your code editor, you can also run tests via the official [Playwright Test for VSCode](https://playwright.dev/docs/getting-started-vscode) extension.
 
@@ -33,7 +38,7 @@ Every commit/pull request in the repository initiates a Playwright test run usin
 
 The build result can be seen in GitHub in the pull request/branch and the detailed results can be seen in the GitHub Actions Artifacts.
 
-NOTE: If the tests failed for a reason such as if there is an issue with GitHub and we need to re-run the run exactly as it was, select `Cancel workflow` in the `Actions` tab and then select `Re-run jobs` -> `Re-run all jobs` from the `Checks` tab.
+NOTE: If the tests failed for a reason such as if there is an issue with GitHub, and we need to re-run the run exactly as it was, select `Cancel workflow` in the `Actions` tab and then select `Re-run jobs` -> `Re-run all jobs` from the `Checks` tab.
 
 ## Debugging Playwright
 

--- a/src/components/card/card-footer/__snapshots__/card-footer.spec.tsx.snap
+++ b/src/components/card/card-footer/__snapshots__/card-footer.spec.tsx.snap
@@ -175,6 +175,7 @@ exports[`CardFooter matches expected styling when it contains non-interactive co
         className="c2 c3"
         data-component="icon"
         data-element="link"
+        data-role="icon"
         fontSize="small"
         type="link"
       />

--- a/src/components/dialog-full-screen/components.test-pw.tsx
+++ b/src/components/dialog-full-screen/components.test-pw.tsx
@@ -180,7 +180,7 @@ export const DialogFullScreenBackgroundScrollTestComponent = () => {
     <DialogFullScreen open onCancel={() => {}}>
       <Textbox label="textbox" />
       <Box height="2000px" position="relative">
-        <Box height="100px" id="bottom-box" position="absolute" bottom="0px">
+        <Box height="100px" position="absolute" bottom="0px">
           I should not be scrolled into view
         </Box>
       </Box>
@@ -200,7 +200,7 @@ export const DialogFullScreenBackgroundScrollWithOtherFocusableContainers = () =
       >
         <Textbox label="textbox" />
         <Box height="2000px" position="relative">
-          <Box height="100px" id="bottom-box" position="absolute" bottom="0px">
+          <Box height="100px" position="absolute" bottom="0px">
             I should not be scrolled into view
           </Box>
         </Box>

--- a/src/components/dialog-full-screen/dialog-full-screen.pw.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.pw.tsx
@@ -626,7 +626,9 @@ test.describe("test background scroll when tabbing", () => {
 
     await continuePressingTAB(page, 3);
     await iconIsFocused(page, 0);
-    await expect(page.getByTestId("#bottom-box")).not.toBeInViewport();
+    await expect(
+      page.getByText("I should not be scrolled into view")
+    ).not.toBeInViewport();
   });
 
   test("tabbing backward through the dialog and back to the start should not make the background scroll to the bottom", async ({
@@ -638,7 +640,9 @@ test.describe("test background scroll when tabbing", () => {
     await page.waitForTimeout(500);
     await continuePressingSHIFTTAB(page, 2);
     await iconIsFocused(page, 0);
-    await expect(page.getByTestId("#bottom-box")).not.toBeInViewport();
+    await expect(
+      page.getByText("I should not be scrolled into view")
+    ).not.toBeInViewport();
   });
 
   test("tabbing forward through the dialog and other focusable containers back to the start should not make the background scroll to the bottom", async ({
@@ -654,7 +658,9 @@ test.describe("test background scroll when tabbing", () => {
     await toastIcon.focus();
     await continuePressingTAB(page, 5);
     await iconIsFocused(page, 0);
-    await expect(page.getByTestId("#bottom-box")).not.toBeInViewport();
+    await expect(
+      page.getByText("I should not be scrolled into view")
+    ).not.toBeInViewport();
   });
 
   test("tabbing backward through the dialog and other focusable containers back to the start should not make the background scroll to the bottom", async ({
@@ -668,6 +674,8 @@ test.describe("test background scroll when tabbing", () => {
     await page.waitForTimeout(500);
     await continuePressingSHIFTTAB(page, 8);
     await iconIsFocused(page, 0);
-    await expect(page.getByTestId("#bottom-box")).not.toBeInViewport();
+    await expect(
+      page.getByText("I should not be scrolled into view")
+    ).not.toBeInViewport();
   });
 });

--- a/src/components/file-input/file-input.pw.tsx
+++ b/src/components/file-input/file-input.pw.tsx
@@ -286,7 +286,10 @@ test.describe("with uploadStatus prop", () => {
           uploadStatus={{ ...statusProps, iconType: "pdf" }}
         />
       );
-      const icon = await page.getByTestId("icon");
+
+      const icon = page.getByTestId("icon");
+
+      await expect(icon).toBeAttached();
       await expect(icon).toHaveAttribute("data-element", "pdf");
     });
   });
@@ -297,7 +300,10 @@ test.describe("with uploadStatus prop", () => {
       page,
     }) => {
       await mount(<FileInputComponent uploadStatus={{ ...statusProps }} />);
-      const icon = await page.getByTestId("icon");
+
+      const icon = page.getByTestId("icon");
+
+      await expect(icon).toBeAttached();
       await expect(icon).toHaveAttribute("data-element", "file_generic");
     });
   });

--- a/src/components/icon/icon.component.tsx
+++ b/src/components/icon/icon.component.tsx
@@ -4,7 +4,7 @@ import invariant from "invariant";
 import Tooltip from "../tooltip";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { TooltipContext } from "../../__internal__/tooltip-provider";
-import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+import { TagProps } from "../../__internal__/utils/helpers/tags/tags";
 import StyledIcon, { StyledIconProps } from "./icon.style";
 import { ICON_TOOLTIP_POSITIONS } from "./icon-config";
 import { IconType } from "./icon-type";
@@ -19,7 +19,10 @@ export type LegacyIconTypes =
   | "success"
   | "messages";
 
-export interface IconProps extends Omit<StyledIconProps, "type">, MarginProps {
+export interface IconProps
+  extends Omit<StyledIconProps, "type">,
+    MarginProps,
+    Omit<TagProps, "data-component"> {
   /** Set whether icon should be recognised by assistive technologies */
   "aria-hidden"?: boolean;
   /** Aria label for accessibility purposes */
@@ -70,6 +73,8 @@ const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
       bgSize,
       className,
       color,
+      "data-element": dataElement,
+      "data-role": dataRole,
       disabled,
       focusable = true,
       fontSize = "small",
@@ -162,8 +167,9 @@ const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
       bgShape,
       className: className || undefined,
       color,
-      "data-element": iconType,
-      "data-role": "icon",
+      "data-component": "icon",
+      "data-element": dataElement ?? iconType,
+      "data-role": dataRole ?? "icon",
       disabled: disabledFromContext || disabled,
       fontSize,
       hasTooltip,
@@ -174,7 +180,6 @@ const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
       role,
       tabIndex: computedTabIndex,
       type: iconType,
-      ...tagComponent("icon", rest),
       ...filterStyledSystemMarginProps(rest),
     };
 

--- a/src/components/icon/icon.component.tsx
+++ b/src/components/icon/icon.component.tsx
@@ -163,6 +163,7 @@ const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
       className: className || undefined,
       color,
       "data-element": iconType,
+      "data-role": "icon",
       disabled: disabledFromContext || disabled,
       fontSize,
       hasTooltip,

--- a/src/components/menu/component.test-pw.tsx
+++ b/src/components/menu/component.test-pw.tsx
@@ -250,7 +250,7 @@ export const MenuComponentFullScreen = (
 export const MenuFullScreenBackgroundScrollTest = () => {
   return (
     <Box height="2000px" position="relative">
-      <Box height="100px" id="bottom-box" position="absolute" bottom="0px">
+      <Box height="100px" position="absolute" bottom="0px">
         I should not be scrolled into view
       </Box>
       <MenuFullscreen isOpen onClose={() => {}}>

--- a/src/components/menu/menu.pw.tsx
+++ b/src/components/menu/menu.pw.tsx
@@ -2356,9 +2356,14 @@ test.describe(
       await mount(<MenuFullScreenBackgroundScrollTest />);
 
       await continuePressingTAB(page, 4);
+
       const closeIcon = closeIconButton(page);
       await expect(closeIcon).toBeFocused();
-      await expect(page.getByTestId("#bottom-box")).not.toBeInViewport();
+
+      const offscreenText = page.getByText(
+        "I should not be scrolled into view"
+      );
+      await expect(offscreenText).not.toBeInViewport();
     });
 
     test(`should verify that tabbing backward through the menu and back to the start should not make the background scroll to the bottom`, async ({
@@ -2368,9 +2373,14 @@ test.describe(
       await mount(<MenuFullScreenBackgroundScrollTest />);
 
       await continuePressingSHIFTTAB(page, 3);
+
       const closeIcon = closeIconButton(page);
       await expect(closeIcon).toBeFocused();
-      await expect(page.getByTestId("#bottom-box")).not.toBeInViewport();
+
+      const offscreenText = page.getByText(
+        "I should not be scrolled into view"
+      );
+      await expect(offscreenText).not.toBeInViewport();
     });
 
     test(`should render with all the content of a long submenu accessible with the keyboard while remaining visible`, async ({

--- a/src/components/message/type-icon/__snapshots__/type-icon.spec.tsx.snap
+++ b/src/components/message/type-icon/__snapshots__/type-icon.spec.tsx.snap
@@ -65,6 +65,7 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
     className="c1"
     data-component="icon"
     data-element="error"
+    data-role="icon"
     fontSize="small"
     type="error"
   />
@@ -136,6 +137,7 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
     className="c1"
     data-component="icon"
     data-element="info"
+    data-role="icon"
     fontSize="small"
     type="info"
   />
@@ -207,6 +209,7 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
     className="c1"
     data-component="icon"
     data-element="info"
+    data-role="icon"
     fontSize="small"
     type="info"
   />
@@ -278,6 +281,7 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
     className="c1"
     data-component="icon"
     data-element="tick_circle"
+    data-role="icon"
     fontSize="small"
     type="tick_circle"
   />
@@ -349,6 +353,7 @@ exports[`TypeIcon when rendered with no additional props should match the snapsh
     className="c1"
     data-component="icon"
     data-element="warning"
+    data-role="icon"
     fontSize="small"
     type="warning"
   />
@@ -425,6 +430,7 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
     className="c1"
     data-component="icon"
     data-element="info"
+    data-role="icon"
     fontSize="small"
     type="info"
   />
@@ -501,6 +507,7 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
     className="c1"
     data-component="icon"
     data-element="error"
+    data-role="icon"
     fontSize="small"
     type="error"
   />
@@ -577,6 +584,7 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
     className="c1"
     data-component="icon"
     data-element="tick_circle"
+    data-role="icon"
     fontSize="small"
     type="tick_circle"
   />
@@ -653,6 +661,7 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
     className="c1"
     data-component="icon"
     data-element="warning"
+    data-role="icon"
     fontSize="small"
     type="warning"
   />
@@ -729,6 +738,7 @@ exports[`TypeIcon when transparent prop is set to true applies white background 
     className="c1"
     data-component="icon"
     data-element="info"
+    data-role="icon"
     fontSize="small"
     type="info"
   />

--- a/src/components/multi-action-button/__snapshots__/multi-action-button.spec.tsx.snap
+++ b/src/components/multi-action-button/__snapshots__/multi-action-button.spec.tsx.snap
@@ -401,6 +401,7 @@ exports[`MultiActionButton when rendered should match the snapshot 1`] = `
       color="--colorsActionMajor500"
       data-component="icon"
       data-element="dropdown"
+      data-role="icon"
       disabled={false}
       fontSize="small"
       type="dropdown"

--- a/src/components/portal/__snapshots__/portal.spec.tsx.snap
+++ b/src/components/portal/__snapshots__/portal.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`Portal mount a <p/> tag as child 1`] = `"<div class=\\"carbon-portal\\"
 
 exports[`Portal when id prop is given matches snapshot 1`] = `"<div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\" id=\\"abc\\"><div class=\\"sc-bdVaJa ibReFo\\"><span>a1</span></div><div class=\\"sc-bdVaJa ibReFo\\"><span>a2</span></div></div>"`;
 
-exports[`Portal when using default node then the portal will mount on body 1`] = `"<div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><div class=\\"sc-bdVaJa ibReFo\\"><span class=\\"sc-EHOje iDLBLV\\" data-element=\\"tick\\" data-role=\\"icon\\" font-size=\\"small\\" tabindex=\\"0\\" type=\\"tick\\" data-component=\\"icon\\"></span></div></div>"`;
+exports[`Portal when using default node then the portal will mount on body 1`] = `"<div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><div class=\\"sc-bdVaJa ibReFo\\"><span class=\\"sc-EHOje iDLBLV\\" data-component=\\"icon\\" data-element=\\"tick\\" data-role=\\"icon\\" font-size=\\"small\\" tabindex=\\"0\\" type=\\"tick\\"></span></div></div>"`;
 
 exports[`Portal when using default node to match snapshot 1`] = `
 <styled.span

--- a/src/components/portal/__snapshots__/portal.spec.tsx.snap
+++ b/src/components/portal/__snapshots__/portal.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`Portal mount a <p/> tag as child 1`] = `"<div class=\\"carbon-portal\\"
 
 exports[`Portal when id prop is given matches snapshot 1`] = `"<div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\" id=\\"abc\\"><div class=\\"sc-bdVaJa ibReFo\\"><span>a1</span></div><div class=\\"sc-bdVaJa ibReFo\\"><span>a2</span></div></div>"`;
 
-exports[`Portal when using default node then the portal will mount on body 1`] = `"<div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><div class=\\"sc-bdVaJa ibReFo\\"><span class=\\"sc-EHOje iDLBLV\\" data-element=\\"tick\\" font-size=\\"small\\" tabindex=\\"0\\" type=\\"tick\\" data-component=\\"icon\\"></span></div></div>"`;
+exports[`Portal when using default node then the portal will mount on body 1`] = `"<div class=\\"carbon-portal\\" data-portal-exit=\\"guid-12345\\"><div class=\\"sc-bdVaJa ibReFo\\"><span class=\\"sc-EHOje iDLBLV\\" data-element=\\"tick\\" data-role=\\"icon\\" font-size=\\"small\\" tabindex=\\"0\\" type=\\"tick\\" data-component=\\"icon\\"></span></div></div>"`;
 
 exports[`Portal when using default node to match snapshot 1`] = `
 <styled.span

--- a/src/components/select/list-action-button/__snapshots__/list-action-button.spec.tsx.snap
+++ b/src/components/select/list-action-button/__snapshots__/list-action-button.spec.tsx.snap
@@ -172,6 +172,7 @@ exports[`Option renders properly 1`] = `
       color="--colorsActionMajor500"
       data-component="icon"
       data-element="add"
+      data-role="icon"
       disabled={false}
       fontSize="small"
       type="add"

--- a/src/components/select/option-group-header/__snapshots__/option-group-header.spec.tsx.snap
+++ b/src/components/select/option-group-header/__snapshots__/option-group-header.spec.tsx.snap
@@ -126,6 +126,7 @@ exports[`OptionGroupHeader when icon prop is set then it should display the icon
     className="c1 c2"
     data-component="icon"
     data-element="individual"
+    data-role="icon"
     fontSize="small"
     type="individual"
   />

--- a/src/components/sidebar/components.test-pw.tsx
+++ b/src/components/sidebar/components.test-pw.tsx
@@ -185,7 +185,7 @@ export const SidebarComponentFocusable = (props: Partial<SidebarProps>) => {
         onDismiss={() => setIsToastOpen(false)}
         ref={toastRef}
         targetPortalId="stacked"
-        data-element="toast"
+        data-role="toast"
       >
         Toast Message
       </Toast>

--- a/src/components/sidebar/sidebar.pw.tsx
+++ b/src/components/sidebar/sidebar.pw.tsx
@@ -373,7 +373,8 @@ test.describe("Check background scroll when tabbing", () => {
     const closeIconButtonElement = closeIconButton(page);
 
     await expect(closeIconButtonElement).toBeFocused();
-    const boxElement = getDataElementByValue(page, "test-box");
+
+    const boxElement = page.getByText("I should not be scrolled into view");
     await expect(boxElement).not.toBeInViewport();
   });
 
@@ -388,7 +389,7 @@ test.describe("Check background scroll when tabbing", () => {
 
     await expect(closeIconButtonElement).toBeFocused();
 
-    const boxElement = getDataElementByValue(page, "test-box");
+    const boxElement = page.getByText("I should not be scrolled into view");
     await expect(boxElement).not.toBeInViewport();
   });
 
@@ -404,7 +405,7 @@ test.describe("Check background scroll when tabbing", () => {
 
     await expect(closeIconButtonElement).toBeFocused();
 
-    const boxElement = getDataElementByValue(page, "test-box");
+    const boxElement = page.getByText("I should not be scrolled into view");
     await expect(boxElement).not.toBeInViewport();
   });
 
@@ -419,7 +420,7 @@ test.describe("Check background scroll when tabbing", () => {
 
     await expect(closeIconButtonElement).toBeFocused();
 
-    const boxElement = getDataElementByValue(page, "test-box");
+    const boxElement = page.getByText("I should not be scrolled into view");
     await expect(boxElement).not.toBeInViewport();
   });
 });

--- a/src/components/vertical-menu/components.test-pw.tsx
+++ b/src/components/vertical-menu/components.test-pw.tsx
@@ -272,7 +272,7 @@ export const VerticalMenuFullScreenCustom = (
 export const VerticalMenuFullScreenBackgroundScrollTest = () => {
   return (
     <Box height="2000px" position="relative">
-      <Box height="100px" id="bottom-box" position="absolute" bottom="0px">
+      <Box height="100px" position="absolute" bottom="0px">
         I should not be scrolled into view
       </Box>
       <VerticalMenuFullScreen isOpen onClose={() => {}}>

--- a/src/components/vertical-menu/vertical-menu.pw.tsx
+++ b/src/components/vertical-menu/vertical-menu.pw.tsx
@@ -538,7 +538,11 @@ test.describe(
       await page.keyboard.press("Tab");
 
       await expect(closeIconButton(page)).toBeFocused();
-      await expect(page.getByTestId("#bottom-box")).not.toBeInViewport();
+
+      const offscreenText = page.getByText(
+        "I should not be scrolled into view"
+      );
+      await expect(offscreenText).not.toBeInViewport();
     });
 
     test(`tabbing backward through the menu and back to the start should not make the background scroll to the bottom`, async ({
@@ -552,7 +556,11 @@ test.describe(
       await page.keyboard.press("Shift+Tab");
 
       await expect(closeIconButton(page)).toBeFocused();
-      await expect(page.getByTestId("#bottom-box")).not.toBeInViewport();
+
+      const offscreenText = page.getByText(
+        "I should not be scrolled into view"
+      );
+      await expect(offscreenText).not.toBeInViewport();
     });
   }
 );


### PR DESCRIPTION
### Proposed behaviour

- Configure Playwright's `getByTestId` locator to find `data-role` tags, given Carbon uses data-role extensively as a test identifier and to match RTL.
- Update testing guide's sections on Playwright and Jest

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
