### PR TITLE
chore: exclude docs/ directory in TS build config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 ### [128.1.1](https://github.com/Sage/carbon/compare/v128.1.0...v128.1.1) (2024-04-02)
 
 
+### ⚠ NOTE
+
+**This version was not published. Please use version 128.1.2.**
+
 ### Bug Fixes
 
 * **pager:** use activation trigger for onkeydown and onclick ([664a43b](https://github.com/Sage/carbon/commit/664a43b4fb3675dcc8a999ef866192b916f0fcdd)), closes [#6289](https://github.com/Sage/carbon/issues/6289)
 
 ## [128.1.0](https://github.com/Sage/carbon/compare/v128.0.0...v128.1.0) (2024-04-02)
 
+
+### ⚠ NOTE
+
+**This version was not published. Please use version 128.1.2.**
 
 ### Features
 

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,7 +1,13 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./src/",
+    "rootDir": "./src/"
   },
-  "exclude": ["src/**/*.stories.*", "src/**/*.spec.*", "./src/**/*.pw.ts*", "./src/**/*.test-pw.ts*"]
+  "exclude": [
+    "docs/",
+    "src/**/*.stories.*",
+    "src/**/*.spec.*",
+    "./src/**/*.pw.ts*",
+    "./src/**/*.test-pw.ts*"
+  ]
 }


### PR DESCRIPTION
### Proposed behaviour

- Exclude any TypeScript files in `docs/` directory when building types for production code.
- Include notes in changelog about unpublished versions.

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- Manually trigger build process via `npm run precompile`
- Check if build artifacts are successfully generated with TypeScript declaration files
- Sanity check that fix will trigger a new patch version
