### PR TITLE
docs(loader): document accessible example when used inside of button - FE-5224

### DIFF
--- a/src/components/loader/loader-test.stories.tsx
+++ b/src/components/loader/loader-test.stories.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import Loader, { LoaderProps } from ".";
 import Button from "../button";
 import { LOADER_SIZES } from "./loader.config";
+import Box from "../box";
 
 export default {
   title: "Loader/Test",
-  includeStories: ["Default"],
+  includeStories: ["Default", "InsideButtons"],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -66,4 +67,36 @@ export const Default = ({
 Default.storyName = "default";
 Default.args = {
   size: "medium",
+};
+
+export const InsideButtons = () => {
+  return (
+    <>
+      <Button buttonType="primary" aria-label="Loading">
+        <Loader isInsideButton />
+      </Button>
+      <Button ml={2} buttonType="primary" destructive aria-label="Loading">
+        <Loader isInsideButton />
+      </Button>
+      <Button ml={2} destructive aria-label="Loading">
+        <Loader isInsideButton />
+      </Button>
+      <Button ml={2} buttonType="tertiary" aria-label="Loading">
+        <Loader isInsideButton />
+      </Button>
+      <Button ml={2} buttonType="secondary" aria-label="Loading">
+        <Loader isInsideButton />
+      </Button>
+      <Box id="dark-background" mt={2} p={2} width="fit-content" bg="#000000">
+        <Button m={2} buttonType="darkBackground" aria-label="Loading">
+          <Loader isInsideButton />
+        </Button>
+      </Box>
+    </>
+  );
+};
+InsideButtons.storyName = "Inside Buttons";
+InsideButtons.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
 };

--- a/src/components/loader/loader.mdx
+++ b/src/components/loader/loader.mdx
@@ -63,10 +63,16 @@ This is an example of the large Loader component. The larger size is only used w
 
 ### Inside Buttons
 
-These examples show a `Loader` nested inside of a `Button` component. To ensure that the correct styling is applied to the `Loader` component when it is nested inside of the `Button` component,
+This example shows a `Loader` nested inside of a `Button` component. To ensure that the correct styling is applied to the `Loader` component when it is nested inside of the `Button` component,
 please remember to pass the `isInsideButton` prop to the `Loader` component.
 
-<Canvas of={LoaderStories.InsideButtons} />
+This example also demonstrates how to ensure that the `Loader` component is accessible when used inside of the `Button` component. 
+It is important to wrap the `Button` component in a `span` (use when elements are inline) or `div` (use when elements are in a block) tag and pass the `aria-live` attribute with the value of `polite`. This will ensure that the screen reader will reliabily announce the updates of the button to the user.
+
+Please note that ARIA live regions provide a means for conveying dynamic updates to users who rely on assistive technologies like screen readers. 
+These updates in this case include changes to the button's content. By incorporating live regions permanently into the DOM, we can ensure that users are consistently informed of relevant changes as they occur.
+
+<Canvas of={LoaderStories.InsideButton} />
 
 ## Props
 

--- a/src/components/loader/loader.stories.tsx
+++ b/src/components/loader/loader.stories.tsx
@@ -1,11 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import generateStyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 import Loader from ".";
 import Button from "../button/button.component";
-import Box from "../box";
 
 const styledSystemProps = generateStyledSystemProps({
   margin: true,
@@ -41,30 +40,30 @@ export const Large: Story = () => {
 };
 Large.storyName = "Large";
 
-export const InsideButtons: Story = () => {
+export const InsideButton: Story = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const mimicLoading = () => {
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 5000);
+  };
+  const handleButtonClick = () => {
+    mimicLoading();
+  };
+  const buttonContent = isLoading ? <Loader isInsideButton /> : "Click me";
+  const ariaContent = isLoading ? "Loading" : "Click me";
   return (
-    <>
-      <Button buttonType="primary" aria-label="Loading">
-        <Loader isInsideButton />
+    <span aria-live="polite">
+      <Button
+        m={2}
+        buttonType="primary"
+        aria-label={ariaContent}
+        onClick={handleButtonClick}
+      >
+        {buttonContent}
       </Button>
-      <Button ml={2} buttonType="primary" destructive aria-label="Loading">
-        <Loader isInsideButton />
-      </Button>
-      <Button ml={2} destructive aria-label="Loading">
-        <Loader isInsideButton />
-      </Button>
-      <Button ml={2} buttonType="tertiary" aria-label="Loading">
-        <Loader isInsideButton />
-      </Button>
-      <Button ml={2} buttonType="secondary" aria-label="Loading">
-        <Loader isInsideButton />
-      </Button>
-      <Box id="dark-background" mt={2} p={2} width="fit-content" bg="#000000">
-        <Button m={2} buttonType="darkBackground" aria-label="Loading">
-          <Loader isInsideButton />
-        </Button>
-      </Box>
-    </>
+    </span>
   );
 };
-InsideButtons.storyName = "Inside Buttons";
+InsideButton.storyName = "Inside Button";


### PR DESCRIPTION
### Proposed behaviour

Document an accessible example of how to use `Loader` inside of `Button`. 

### Current behaviour

Currently no accessible example documentation demonstrating how to correctly use `Loader` inside of `Button`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Test updated `Inside Button` story using:
- VoiceOver with Safari (MacOS)
- NVDA with Chrome (Windows)