### PR TITLE
docs(step-flow, textarea): ensure proper page structure when translation keys table is used

### DIFF
--- a/src/components/step-flow/step-flow.mdx
+++ b/src/components/step-flow/step-flow.mdx
@@ -132,6 +132,11 @@ as users who can see the component. Please see below how this has been achieved 
 
 <ArgTypes of={StepFlowStories} />
 
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](../?path=/docs/documentation-i18n--docs).
+
 <TranslationKeysTable
   translationData={[
     {

--- a/src/components/textarea/textarea.mdx
+++ b/src/components/textarea/textarea.mdx
@@ -170,6 +170,11 @@ It is possible to use the `tooltipPosition` to override the default placement of
 
 **Any other supplied props will be provided to the underlying HTML input element**
 
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](../?path=/docs/documentation-i18n--docs).
+
 <TranslationKeysTable
   translationData={[
     {


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Ensures proper page structure is used above the translation keys table to properly inform users about the keys, locales, `i18nProvider` etc.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, there is a lack of heading above the translation keys table on the storybok page for `StepFlow` and `Textarea`, meaning some consumers may struggle to locate the keys, or understand what they are for.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
