### PR TITLE
fix(filterable-select): ensure no runtime error is triggered when component has a single option - FE-6413

### DIFF
--- a/src/components/select/filterable-select/filterable-select-test.stories.tsx
+++ b/src/components/select/filterable-select/filterable-select-test.stories.tsx
@@ -610,3 +610,23 @@ export const OnChangeWithDeleteStory = () => {
     </>
   );
 };
+
+export const SingleOption = () => (
+  <FilterableSelect
+    name="simple"
+    id="simple"
+    label="color"
+    labelInline
+    onOpen={partialAction("onOpen")}
+    onChange={partialAction("onChange")}
+    onClick={partialAction("onClick")}
+    onFilterChange={partialAction("onFilterChange")}
+    onFocus={partialAction("onFocus")}
+    onBlur={partialAction("onBlur")}
+    onKeyDown={partialAction("onKeyDown")}
+  >
+    <Option text="Amber" value="1" />
+  </FilterableSelect>
+);
+
+SingleOption.storyName = "Single Option";

--- a/src/components/select/filterable-select/filterable-select.component.tsx
+++ b/src/components/select/filterable-select/filterable-select.component.tsx
@@ -202,8 +202,8 @@ export const FilterableSelect = React.forwardRef(
       textToMatch: string,
       list: React.ReactNode
     ) {
-      return (list as React.ReactElement[]).find((child) => {
-        const { text } = child.props;
+      return React.Children.toArray(list).find((child) => {
+        const { text } = (child as React.ReactElement).props;
 
         return text?.toLowerCase().indexOf(textToMatch?.toLowerCase()) !== -1;
       });
@@ -213,7 +213,10 @@ export const FilterableSelect = React.forwardRef(
       (newFilterText: string, isDeleteEvent: boolean) => {
         setSelectedValue((previousValue) => {
           const trimmed = newFilterText.trimStart();
-          const match = findElementWithMatchingText(trimmed, children);
+          const match = findElementWithMatchingText(
+            trimmed,
+            children
+          ) as React.ReactElement;
           const isFilterCleared = isDeleteEvent && !newFilterText.length;
 
           if (!match || isFilterCleared || match.props.disabled) {

--- a/src/components/select/filterable-select/filterable-select.spec.tsx
+++ b/src/components/select/filterable-select/filterable-select.spec.tsx
@@ -106,6 +106,21 @@ describe("FilterableSelect", () => {
 
   testStyledSystemMargin((props) => getSelect(props));
 
+  it("should not throw an error when component has only one value and a value is typed in the Select Textbox", () => {
+    const wrapper = mount(
+      <FilterableSelect name="testSelect" id="testSelect">
+        <Option value="opt1" text="red" />
+      </FilterableSelect>
+    );
+
+    expect(wrapper.find(Option).length).toBe(1);
+    expect(() => {
+      act(() => {
+        wrapper.find("input").simulate("change", { target: { value: "r" } });
+      });
+    }).not.toThrow();
+  });
+
   it('the Textbox should have type of "text"', () => {
     const wrapper = renderSelect();
 

--- a/src/components/select/multi-select/multi-select-test.stories.tsx
+++ b/src/components/select/multi-select/multi-select-test.stories.tsx
@@ -537,3 +537,31 @@ export const MultiSelectWithDisabledOption = () => {
     </MultiSelect>
   );
 };
+
+export const SingleOption = () => {
+  const [selectedPills, setSelectedPills] = useState([] as string[]);
+  const handleActivityChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedPills((event.target.value as unknown) as string[]);
+    partialAction("onChange")();
+  };
+  return (
+    <MultiSelect
+      name="testing"
+      value={selectedPills}
+      onChange={handleActivityChange}
+      onOpen={partialAction("onOpen")}
+      onClick={partialAction("onClick")}
+      onFilterChange={partialAction("onFilterChange")}
+      onFocus={partialAction("onFocus")}
+      onBlur={partialAction("onBlur")}
+      onKeyDown={partialAction("onKeyDown")}
+      openOnFocus
+      label="Test"
+      placeholder=" "
+    >
+      <Option value="1" text="One" />
+    </MultiSelect>
+  );
+};
+
+SingleOption.storyName = "Single Option";

--- a/src/components/select/multi-select/multi-select.component.tsx
+++ b/src/components/select/multi-select/multi-select.component.tsx
@@ -231,17 +231,20 @@ export const MultiSelect = React.forwardRef(
       textToMatch: string,
       list: React.ReactNode
     ) {
-      return (list as React.ReactElement[]).find((child) => {
-        const { text } = child.props;
+      return React.Children.toArray(list).find((child) => {
+        const { text } = (child as React.ReactElement).props;
 
-        return text?.toLowerCase().indexOf(textToMatch.toLowerCase()) !== -1;
+        return text?.toLowerCase().indexOf(textToMatch?.toLowerCase()) !== -1;
       });
     }
 
     const handleTextboxChange = useCallback(
       (event) => {
         const newValue = event.target.value;
-        const match = findElementWithMatchingText(newValue, children);
+        const match = findElementWithMatchingText(
+          newValue,
+          children
+        ) as React.ReactElement;
 
         if (match) {
           setHighlightedValue(match.props.value);

--- a/src/components/select/multi-select/multi-select.spec.tsx
+++ b/src/components/select/multi-select/multi-select.spec.tsx
@@ -79,6 +79,21 @@ describe("MultiSelect", () => {
     mockDOMRect(200, 200, "select-list-scrollable-container");
   });
 
+  it("should not throw an error when component has only one value and a value is typed in the Select Textbox", () => {
+    const wrapper = mount(
+      <MultiSelect name="testSelect" id="testSelect">
+        <Option value="opt1" text="red" />
+      </MultiSelect>
+    );
+
+    expect(wrapper.find(Option).length).toBe(1);
+    expect(() => {
+      act(() => {
+        wrapper.find("input").simulate("change", { target: { value: "v" } });
+      });
+    }).not.toThrow();
+  });
+
   describe("Deprecation warning for uncontrolled", () => {
     beforeEach(() => {
       loggerSpy = jest.spyOn(Logger, "deprecate");


### PR DESCRIPTION
### Proposed behaviour

Filterable-Select: No runtime error should be thrown when the component has just one option.

https://github.com/Sage/carbon/assets/56251247/a3b930d5-21ef-4252-921b-10f837f20273

Multi-Select: No console error should be thrown when the component has just one option.

https://github.com/Sage/carbon/assets/56251247/e9ffb572-c002-452e-a8bd-c89afa3769d0

### Current behaviour

Filterable-Select: If the component has a single option, a runtime error is thrown when the select textbox is typed in.

https://github.com/Sage/carbon/assets/56251247/c7ae402a-aa5a-4856-a67e-0eebcb406ea0


Multi-Select: If the component has a single option, a console error is thrown when the select textbox is typed in.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A 

### Testing instructions

Filterable-Select: 
- Visit new `Single Option` story in the `Test` folder for Filterable-Select. 
- Type in the Select Textbox. 
- The component should not throw a runtime error. 

Multi-Select: 
- Visit new `Single Option` story in the `Test` folder for Multi-Select. 
- Type in the Select Textbox. 
- The component should not throw a console error. 

It might also be worth doing a regression test on the other Filterable-Select and Multi-Select examples just as a sanity check. 