### PR TITLE
fix(select): input element extends outside textbox in smaller screens

### DIFF
--- a/playwright/components/flat-table/index.ts
+++ b/playwright/components/flat-table/index.ts
@@ -10,6 +10,7 @@ import {
   FLAT_TABLE_PAGE_SELECT_NEXT,
   FLAT_TABLE_PAGE_SELECT_PREVIOUS,
   FLAT_TABLE_CURRENT_PAGE,
+  PAGE_SELECT,
   PAGE_SELECT_INPUT,
   FLAT_TABLE_WRAPPER,
   FLAT_TABLE_PAGER,
@@ -60,6 +61,7 @@ export const flatTablePageSizeSelect = (page: Page) =>
   page.locator(FLAT_TABLE_PAGE_SIZE_SELECT);
 export const flatTablePageSelectListPosition = (page: Page) =>
   page.locator(FLAT_TABLE_PAGE_SELECT_LIST);
+export const pageSelectElement = (page: Page) => page.locator(PAGE_SELECT);
 export const pageSelectInput = (page: Page) => page.locator(PAGE_SELECT_INPUT);
 export const flatTablePager = (page: Page) => page.locator(FLAT_TABLE_PAGER);
 export const flatTablePageSelectNext = (page: Page) =>

--- a/playwright/components/flat-table/locators.ts
+++ b/playwright/components/flat-table/locators.ts
@@ -12,7 +12,7 @@ export const FLAT_TABLE_SUBROW = '[data-element="flat-table-sub-row"]';
 export const FLAT_TABLE_PAGE_SIZE_SELECT = '[data-element="dropdown"]';
 export const FLAT_TABLE_PAGE_SELECT_LIST =
   '[data-element="select-list-wrapper"]';
-export const PAGE_SELECT = "input";
+export const PAGE_SELECT = '[data-component="simple-select"]';
 export const PAGE_SELECT_INPUT = '[data-element="select-input"] input';
 export const FLAT_TABLE_PAGER = '[data-component="pager"]';
 export const FLAT_TABLE_PAGE_SELECT_NEXT = '[data-element="pager-link-next"]';

--- a/src/components/flat-table/flat-table.pw.tsx
+++ b/src/components/flat-table/flat-table.pw.tsx
@@ -70,6 +70,7 @@ import {
   flatTablePager,
   flatTablePageSizeSelect,
   flatTablePageSelectListPosition,
+  pageSelectElement,
   pageSelectInput,
   flatTablePageSelectNext,
   flatTablePageSelectPrevious,
@@ -2703,7 +2704,7 @@ test.describe("Prop tests", () => {
       const tableBodyRows = flatTableBodyRows(page);
       await expect(tableBodyRows).toHaveCount(5);
       await expect(flatTableBodyRows(page).first()).toBeInViewport();
-      await pageSelectInput(page).click();
+      await pageSelectElement(page).click();
       await flatTablePageSelectListPosition(page)
         .locator("li")
         .nth(option)

--- a/src/components/pager/pager.pw.tsx
+++ b/src/components/pager/pager.pw.tsx
@@ -529,6 +529,36 @@ test.describe("Functional tests", () => {
       await expect(currentPageSection(page).first()).toBeInViewport();
     });
   });
+
+  [1001, 901, 701, 601, 450].forEach((viewportWidth) => {
+    test(`should be able to access the firstArrow button with showPageSizeSelection in focus with ${viewportWidth}px width`, async ({
+      mount,
+      page,
+    }) => {
+      await page.setViewportSize({
+        width: Number(viewportWidth),
+        height: 768,
+      });
+
+      await mount(<PagerComponent showPageSizeSelection />);
+
+      const currentPage = currentPageWrapper(page)
+        .locator("div")
+        .nth(0)
+        .locator("div")
+        .nth(0)
+        .locator("div")
+        .nth(0)
+        .locator("input");
+
+      await expect(currentPage).toHaveAttribute("value", "1");
+      await nextArrow(page).click();
+      await expect(currentPage).toHaveAttribute("value", "2");
+      await pageSelect(page).focus();
+      await firstArrow(page).click();
+      await expect(currentPage).toHaveAttribute("value", "1");
+    });
+  });
 });
 
 test.describe("Events test", () => {
@@ -547,7 +577,7 @@ test.describe("Events test", () => {
       />
     );
 
-    await pageSelect(page).click();
+    await pageSelectElement(page).click();
     const listWrapper = selectListWrapper(page)
       .locator("li")
       .filter({ hasText: "25" });

--- a/src/components/select/select.style.ts
+++ b/src/components/select/select.style.ts
@@ -78,8 +78,9 @@ const StyledSelect = styled.div<StyledSelectProps>`
     css`
       ${StyledInput} {
         position: absolute;
-        width: auto;
+        width: inherit;
         opacity: 0;
+        padding: 0;
       }
     `}
   `}


### PR DESCRIPTION
fix #6490

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

The input element no longer extends outside of the `Select` component and inherits the width of the parent container. 
The input element in the dropdown in `Pager` no longer blocks the "First" link. 

![Screenshot 2024-04-16 at 11 33 35](https://github.com/Sage/carbon/assets/78361608/950f3925-ca87-4dfe-88ba-ae5396165734)

![Screenshot 2024-04-16 at 11 20 22](https://github.com/Sage/carbon/assets/78361608/45fdd5d7-f047-4cb7-8570-18cb76bab79a)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

The input element within the select textbox extends outside the textbox width in smaller screens. This causes the input element in the dropdown in `Pager` to block the "First" link and open the dropdown instead of following the link. 

![Screenshot 2024-04-16 at 11 32 20](https://github.com/Sage/carbon/assets/78361608/dc30ae6d-cc8b-41c8-96f7-92575fe4c7e7)

![Screenshot 2024-04-16 at 11 14 39](https://github.com/Sage/carbon/assets/78361608/189b6fbb-2b1e-4545-a4f9-127fa0088ccd)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
