### PR TITLE
fix(checkbox): fix reduced spacing between label and large checkbox

### DIFF
--- a/src/components/checkbox/checkbox-test.stories.tsx
+++ b/src/components/checkbox/checkbox-test.stories.tsx
@@ -2,10 +2,11 @@ import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
 
 import { Checkbox, CheckboxProps } from ".";
+import Box from "../box";
 
 export default {
   title: "Checkbox/Test",
-  includeStories: ["Default"],
+  includeStories: ["Default", "WithLongLabel"],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -94,4 +95,19 @@ Default.args = {
   ml: "0",
   adaptiveSpacingBreakpoint: undefined,
   required: false,
+};
+
+export const WithLongLabel = ({ label, size, ...args }: CheckboxProps) => {
+  return (
+    <Box padding="25px" width="250px">
+      <Checkbox size={size || "large"} label={label} mb={2} {...args} />
+      <Checkbox label={label} size={size} {...args} />
+    </Box>
+  );
+};
+
+WithLongLabel.storyName = "With long label";
+WithLongLabel.args = {
+  label: "A really long description that will wrap onto the next line.",
+  size: "",
 };

--- a/src/components/checkbox/checkbox.style.ts
+++ b/src/components/checkbox/checkbox.style.ts
@@ -132,6 +132,7 @@ const StyledCheckbox = styled.div<StyledCheckboxProps>`
       svg {
         height: 24px;
         width: 24px;
+        min-width: 24px;
       }
 
       ${StyledFieldHelp} {

--- a/src/components/checkbox/validations.stories.tsx
+++ b/src/components/checkbox/validations.stories.tsx
@@ -168,6 +168,7 @@ export const NewBooleanValidation: Story = () => {
         key="checkbox-one-error-boolean"
         label="Example checkbox one - Error"
         name="checkbox-one-error-boolean"
+        mb={1}
       />
       <Checkbox
         warning


### PR DESCRIPTION
fix #6683 

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Set the `min-width` of the input parent container to 24px for large checkboxes, which prevents the text and checkbox focus border from overlapping. 

![image](https://github.com/Sage/carbon/assets/78361608/b017b8aa-7e30-4f4c-9664-dabc556c5a0d)

![image](https://github.com/Sage/carbon/assets/78361608/ef0b16ec-245b-4076-b583-c95413ba30db)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

The `min-width` of the input parent container is still set to 16px for large checkboxes. This causes the space between longer descriptions and the checkbox to be reduced and the focus border to partially cover the text. 

![image](https://github.com/Sage/carbon/assets/78361608/f54e9f6e-ed38-46f3-8420-ef2468704ec2)

![image](https://github.com/Sage/carbon/assets/78361608/fcbbb5b6-c2f9-42f7-894e-a7a351e129b4)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
