### PR TITLE
fix(button-toggle): ensure the first button toggle in a group is focusable via mouse click on Safari - FE-6389

### DIFF
--- a/src/components/button-toggle/__snapshots__/button-toggle.spec.tsx.snap
+++ b/src/components/button-toggle/__snapshots__/button-toggle.spec.tsx.snap
@@ -98,6 +98,7 @@ exports[`ButtonToggle General styling renders correctly when grouped 1`] = `
       onFocus={[Function]}
       onKeyDown={[Function]}
       size="medium"
+      tabIndex={0}
     >
       Text
     </button>
@@ -117,6 +118,7 @@ exports[`ButtonToggle General styling renders correctly when grouped 1`] = `
       onFocus={[Function]}
       onKeyDown={[Function]}
       size="medium"
+      tabIndex={0}
     >
       Text
     </button>

--- a/src/components/button-toggle/button-toggle-group/button-toggle-group-test.stories.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group-test.stories.tsx
@@ -29,7 +29,7 @@ export const DefaultStory = () => {
       label="Button Toggle Group test"
       labelHelp="help message"
       helpAriaLabel="Help"
-      fieldHelp="field help mesage"
+      fieldHelp="field help message"
       onChange={onChangeHandler}
       value={value}
     >

--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.spec.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.spec.tsx
@@ -426,7 +426,7 @@ describe("ButtonToggleGroup", () => {
           .at(0)
           .getDOMNode()
           .getAttribute("tabindex")
-      ).toBeNull();
+      ).toBe("0");
       expect(
         wrapper
           .find(StyledButtonToggle)
@@ -460,7 +460,7 @@ describe("ButtonToggleGroup", () => {
           .at(1)
           .getDOMNode()
           .getAttribute("tabindex")
-      ).toBeNull();
+      ).toBe("0");
       expect(
         wrapper
           .find(StyledButtonToggle)

--- a/src/components/button-toggle/button-toggle.component.tsx
+++ b/src/components/button-toggle/button-toggle.component.tsx
@@ -202,7 +202,9 @@ export const ButtonToggle = ({
         onBlur={handleBlur}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
-        {...(tabbable ? {} : { tabIndex: -1 })}
+        // In Safari non-text input elements do not gain focus on click. To get around this, we have to apply a tab-index of 0 here.
+        // This is to allow the ButtonToggle component to be focused when it is the first tabbable element.
+        {...(tabbable ? { tabIndex: 0 } : { tabIndex: -1 })}
         allowDeselect={allowDeselect}
         ref={callbackRef}
       >


### PR DESCRIPTION
### Proposed behaviour

First `ButtonToggle` component in a group is focusable via a mouse click when using Safari. 

### Current behaviour

First `ButtonToggle` component in a group is not focusable via a mouse click when using Safari. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

No Playwright test has been added to cover this bug because it is a Safari specific bug, so Playwright would not be able to catch this anyway.

### Testing instructions

- Open the example called  `Default` in `Button Toggle Group -> Test` using Safari. 
- Click the first `ButtonToggle` component. 
- `ButtonToggle` component should be focused.

Might be worth doing a regression check on other browsers too. Just to make sure this fix hasn't unearthed any demons in the other examples in the other browsers. 
