### PR TITLE
fix(popover-container): allow fullWidth button to be rendered as renderOpenComponent

### DIFF
--- a/src/components/popover-container/popover-container-test.stories.tsx
+++ b/src/components/popover-container/popover-container-test.stories.tsx
@@ -13,7 +13,13 @@ import Icon from "../icon";
 
 export default {
   title: "Popover Container/Test",
-  includeStories: ["Default", "WithSelect", "InAScrollableBlock", "InSideMenu"],
+  includeStories: [
+    "Default",
+    "WithSelect",
+    "InAScrollableBlock",
+    "InSideMenu",
+    "WithFullWidthButton",
+  ],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -25,6 +31,15 @@ export default {
 export const Default = ({ ...args }: PopoverContainerProps) => (
   <PopoverContainer {...args} />
 );
+
+Default.story = {
+  name: "default",
+  args: {
+    title: "Title",
+    open: true,
+    closeButtonDataProps: {},
+  },
+};
 
 export const WithSelect = () => {
   return (
@@ -46,15 +61,6 @@ export const WithSelect = () => {
 
 WithSelect.story = {
   name: "with select",
-};
-
-Default.story = {
-  name: "default",
-  args: {
-    title: "Title",
-    open: true,
-    closeButtonDataProps: {},
-  },
 };
 
 export const InAScrollableBlock = () => {
@@ -135,5 +141,26 @@ export const InSideMenu = () => {
         </PopoverContainer>
       </MenuItem>
     </Menu>
+  );
+};
+
+export const WithFullWidthButton = () => {
+  return (
+    <PopoverContainer
+      title="This is the title"
+      renderOpenComponent={({ ref, ...rest }) => (
+        <Button
+          iconPosition="after"
+          iconType="filter_new"
+          fullWidth
+          ref={ref}
+          {...rest}
+        >
+          Filter
+        </Button>
+      )}
+    >
+      Content
+    </PopoverContainer>
   );
 };

--- a/src/components/popover-container/popover-container.style.ts
+++ b/src/components/popover-container/popover-container.style.ts
@@ -41,6 +41,7 @@ function animationToRender({
 const PopoverContainerWrapperStyle = styled.div`
   position: relative;
   display: inline-block;
+  width: 100%;
 `;
 
 const PopoverContainerHeaderStyle = styled.div`


### PR DESCRIPTION
fix #5784

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

The `fullWidth` prop how has effect when used in a `Button` rendered as `renderOpenComponent`

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Component does not respect `fullWidth` prop in a `Button` set to `renderOpenComponent`. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

[Sandbox of original bug](https://stackblitz.com/edit/parsium-carbon-starter-mhynbq?file=src%2FApp.tsx)
See "WithFullWidthButton" test story for fix. 
