### PR TITLE
Add translation keys to missing stories

### DIFF
--- a/src/components/advanced-color-picker/advanced-color-picker.mdx
+++ b/src/components/advanced-color-picker/advanced-color-picker.mdx
@@ -14,6 +14,7 @@ Selects a single colour from a defined set.
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/breadcrumbs/breadcrumbs.mdx
+++ b/src/components/breadcrumbs/breadcrumbs.mdx
@@ -24,6 +24,7 @@ Breadcrumbs are a secondary navigation aid that helps users easily understand th
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/confirm/confirm.mdx
+++ b/src/components/confirm/confirm.mdx
@@ -16,6 +16,7 @@ Confirms or cancels an action.
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/confirm/confirm.mdx
+++ b/src/components/confirm/confirm.mdx
@@ -1,5 +1,7 @@
 import { Meta, ArgTypes, Canvas } from "@storybook/blocks";
 
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
+
 import * as ConfirmStories from "./confirm.stories";
 
 <Meta title="Confirm" of={ConfirmStories} />
@@ -83,3 +85,28 @@ Allows to set variant which is supported in `<Button />` and it will be applied 
 ### Confirm
 
 <ArgTypes of={ConfirmStories} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](../?path=/docs/documentation-i18n--docs).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "confirm.no",
+      description:
+        `The text which appears within the "cancel" button.`,
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "confirm.yes",
+      description:
+        `The text which appears within the "confirm" button.`,
+      type: "func",
+      returnType: "string",
+    }
+  ]}
+/>
+

--- a/src/components/decimal/decimal.mdx
+++ b/src/components/decimal/decimal.mdx
@@ -14,6 +14,7 @@ Captures a number with a decimal point, or a currency value.
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/dialog-full-screen/dialog-full-screen.mdx
+++ b/src/components/dialog-full-screen/dialog-full-screen.mdx
@@ -15,6 +15,7 @@ A full-width and full-height dialog overlaid on top of any page.
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/dialog/dialog.mdx
+++ b/src/components/dialog/dialog.mdx
@@ -24,6 +24,7 @@ A dialog box overlaid on top of any page.
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/dismissible-box/dismissible-box.mdx
+++ b/src/components/dismissible-box/dismissible-box.mdx
@@ -16,6 +16,7 @@ and ‘help’ information.
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/dismissible-box/dismissible-box.mdx
+++ b/src/components/dismissible-box/dismissible-box.mdx
@@ -1,5 +1,7 @@
 import { Meta, ArgTypes, Canvas } from "@storybook/blocks";
 
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
+
 import * as DismissibleBoxStories from "./dismissible-box.stories";
 
 <Meta title="Dismissible Box" of={DismissibleBoxStories} />
@@ -49,3 +51,20 @@ It is also possible to override the `width` of the component: by default it will
 ### DismissibleBox
 
 <ArgTypes of={DismissibleBoxStories} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](../?path=/docs/documentation-i18n--docs).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "dismissibleBox.ariaLabels.close",
+      description:
+        "The text for close button's aria-label attribute.",
+      type: "func",
+      returnType: "string",
+    }
+  ]}
+/>

--- a/src/components/file-input/file-input.mdx
+++ b/src/components/file-input/file-input.mdx
@@ -24,6 +24,7 @@ Allows a single file to be uploaded.
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/flat-table/flat-table.mdx
+++ b/src/components/flat-table/flat-table.mdx
@@ -32,6 +32,7 @@ Logically structure content in a grid for the user to enter, view, or work with.
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/heading/heading.mdx
+++ b/src/components/heading/heading.mdx
@@ -19,6 +19,7 @@ Webaim have a good online Contrast Checker.
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/heading/heading.mdx
+++ b/src/components/heading/heading.mdx
@@ -1,5 +1,7 @@
 import { Meta, ArgTypes, Canvas } from "@storybook/blocks";
 
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
+
 import * as HeadingStories from "./heading.stories";
 
 <Meta title="Heading" of={HeadingStories} />
@@ -95,3 +97,21 @@ In this example, the Heading component has the Tile component and the Definition
 ### Heading
 
 <ArgTypes of={HeadingStories} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](../?path=/docs/documentation-i18n--docs).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "heading.backLinkAriaLabel",
+      description:
+        "The text for the back link's aria-label attribute.",
+      type: "func",
+      returnType: "string",
+    }
+  ]}
+/>
+

--- a/src/components/link/link.mdx
+++ b/src/components/link/link.mdx
@@ -23,6 +23,7 @@ Navigates the user to another location.
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/loader-bar/loader-bar.mdx
+++ b/src/components/loader-bar/loader-bar.mdx
@@ -25,6 +25,7 @@ In general, place a LoaderBar in the centre and middle of the page or container 
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/loader-spinner/loader-spinner.mdx
+++ b/src/components/loader-spinner/loader-spinner.mdx
@@ -26,6 +26,7 @@ Can be used to demonstrate a known or unknown wait time.
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/loader/loader.mdx
+++ b/src/components/loader/loader.mdx
@@ -26,6 +26,7 @@ Like many Design System elements, Loaders are made of square elements. They usua
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/menu/menu.mdx
+++ b/src/components/menu/menu.mdx
@@ -28,6 +28,7 @@ Provides navigation for an app, which can be used via mouse or keyboard.
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/numeral-date/numeral-date.mdx
+++ b/src/components/numeral-date/numeral-date.mdx
@@ -129,5 +129,26 @@ The following keys are available to override the translations for this component
       type: "func",
       returnType: "string",
     },
+        {
+      name: "numeralDate.labels.day",
+      description:
+        "The text displayed within the day label",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "numeralDate.labels.month",
+      description:
+        "The text displayed within the month label",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "numeralDate.labels.year",
+      description:
+        "The text displayed within the year label",
+      type: "func",
+      returnType: "string",
+    },
   ]}
 />

--- a/src/components/password/password.mdx
+++ b/src/components/password/password.mdx
@@ -23,6 +23,7 @@ Provide a way for the user to securely enter a password.
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/pod/pod.mdx
+++ b/src/components/pod/pod.mdx
@@ -15,6 +15,7 @@ Presents content grouped visually together. This can be text, or other component
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/progress-tracker/progress-tracker.mdx
+++ b/src/components/progress-tracker/progress-tracker.mdx
@@ -26,6 +26,7 @@ In general, place a `ProgressTracker` in the centre and middle of the page or co
 - [Examples](#examples)
 - [Accessibility](#accessibility)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/search/search.mdx
+++ b/src/components/search/search.mdx
@@ -23,6 +23,7 @@ This search component should be used if you require the user to conduct a search
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/sidebar/sidebar.mdx
+++ b/src/components/sidebar/sidebar.mdx
@@ -22,6 +22,7 @@ import * as SidebarStories from "./sidebar.stories.tsx";
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/split-button/split-button.mdx
+++ b/src/components/split-button/split-button.mdx
@@ -1,5 +1,7 @@
 import { Meta, ArgTypes, Canvas } from "@storybook/blocks";
 
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
+
 import * as ButtonStories from "../button/button.stories";
 import * as SplitButtonStories from "./split-button.stories";
 
@@ -96,5 +98,22 @@ Subtext only works when `size` is `large`
     "pb",
     "pl",
     "pr",
+  ]}
+/>
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](../?path=/docs/documentation-i18n--docs).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "splitButton.ariaLabel",
+      description:
+        "The text for the toggle button's aria-label attribute.",
+      type: "func",
+      returnType: "string",
+    }
   ]}
 />

--- a/src/components/split-button/split-button.mdx
+++ b/src/components/split-button/split-button.mdx
@@ -24,6 +24,7 @@ import * as SplitButtonStories from "./split-button.stories";
 - [Related Components](#related-components)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/step-flow/step-flow.mdx
+++ b/src/components/step-flow/step-flow.mdx
@@ -28,6 +28,7 @@ Use a step flow to help a user complete tasks in a specific order, based on thei
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/textarea/textarea.mdx
+++ b/src/components/textarea/textarea.mdx
@@ -25,6 +25,7 @@ import * as TextareaStories from "./textarea.stories";
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/textbox/textbox.mdx
+++ b/src/components/textbox/textbox.mdx
@@ -23,6 +23,7 @@ Captures a single line of text.
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/time/time.mdx
+++ b/src/components/time/time.mdx
@@ -13,6 +13,7 @@ import * as TimeStories from "./time.stories";
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/toast/toast.mdx
+++ b/src/components/toast/toast.mdx
@@ -32,6 +32,7 @@ Various types are available:
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 

--- a/src/components/vertical-menu/vertical-menu.mdx
+++ b/src/components/vertical-menu/vertical-menu.mdx
@@ -17,6 +17,7 @@ Provides a vertical navigation for an app, which can be used via mouse or keyboa
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Adds missing translation keys table/translation keys to `Confirm`, `dismissibleBox`, `Heading`, `numeralDate`, `splitButton`

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, not all translations are listed in their respective components' docs.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
