### PR TITLE
chore(version picker): change order of addon registration and refactor version selector

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -5,6 +5,17 @@ import { ADDON_ID, TOOL_ID } from "./version-picker/constants";
 import { VersionPicker } from "./version-picker";
 import { API_PreparedIndexEntry, API_StatusObject } from "@storybook/types";
 
+if (process.env.NODE_ENV === "production") {
+  addons.register(ADDON_ID, () => {
+    addons.add(TOOL_ID, {
+      type: types.TOOL,
+      title: "Version picker",
+      match: ({ viewMode }) => !!(viewMode && viewMode.match(/^(story|docs)$/)),
+      render: VersionPicker,
+    });
+  });
+}
+
 addons.setConfig({
   theme: sageTheme,
   panelPosition: "bottom",
@@ -22,14 +33,3 @@ addons.setConfig({
     },
   },
 });
-
-if (process.env.NODE_ENV === "production") {
-  addons.register(ADDON_ID, () => {
-    addons.add(TOOL_ID, {
-      type: types.TOOL,
-      title: "Version picker",
-      match: ({ viewMode }) => !!(viewMode && viewMode.match(/^(story|docs)$/)),
-      render: VersionPicker,
-    });
-  });
-}

--- a/.storybook/version-picker/index.js
+++ b/.storybook/version-picker/index.js
@@ -36,13 +36,11 @@ export const VersionPicker = () => {
   const [currentVersion, setCurrentVersion] = useState("Latest");
 
   useEffect(() => {
-    const url = window.location.href;
-    if (url.includes("/v/")) {
-      const startIndex = url.indexOf("/v/");
-      const endIndex = url.indexOf("/", startIndex + 4);
+    const urlParams = new URLSearchParams(window.location.search);
+    const version = urlParams.get("v");
 
-      const urlVersion = url.substring(startIndex + 3, endIndex);
-      setCurrentVersion(`v${urlVersion}`);
+    if (version) {
+      setCurrentVersion(`v${version}`);
     }
 
     const getData = async () => {
@@ -58,7 +56,7 @@ export const VersionPicker = () => {
       <WithTooltip
         placement="top"
         trigger="click"
-        closeOnClick
+        closeOnOutsideClick
         tooltip={({ onHide }) => {
           return (
             <TooltipLinkList links={getDisplayedItems(versions, onHide)} />


### PR DESCRIPTION
### Proposed behaviour

- resolve issue with addon registration so that version selector shows
- refactor the version selector code to tidy it up a bit

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

- version selector is no longer showing

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
