### PR TITLE
fix(link): ensure styling overrides apply to open button when popover-container renders in menu

### DIFF
--- a/src/components/button/button.component.tsx
+++ b/src/components/button/button.component.tsx
@@ -84,6 +84,12 @@ export interface ButtonProps extends SpaceProps, TagProps {
   target?: string;
   /** HTML rel attribute */
   rel?: string;
+  /**
+   * @private
+   * @internal
+   * Set a class name on the button element
+   */
+  className?: string;
 }
 
 interface RenderChildrenProps

--- a/src/components/card/card-footer/__snapshots__/card-footer.spec.tsx.snap
+++ b/src/components/card/card-footer/__snapshots__/card-footer.spec.tsx.snap
@@ -149,7 +149,8 @@ exports[`CardFooter matches expected styling when it contains non-interactive co
   color: var(--colorsActionMajorYin090);
 }
 
-.c1 > button {
+.c1 > button,
+.c1 .sc-fjdhpX:not(.search-button) {
   background-color: transparent;
   border: none;
   padding: 0;

--- a/src/components/link/link.style.ts
+++ b/src/components/link/link.style.ts
@@ -1,6 +1,7 @@
 import styled, { css } from "styled-components";
 import baseTheme from "../../style/themes/base";
 import StyledIcon from "../icon/icon.style";
+import StyledButton from "../button/button.style";
 
 type Variants = "default" | "negative" | "neutral";
 export interface StyledLinkProps {
@@ -219,7 +220,7 @@ const StyledLink = styled.span<StyledLinkProps & PrivateStyledLinkProps>`
         border-bottom-right-radius: var(--borderRadius025);
       `}
 
-      > button {
+      > button, ${StyledButton}:not(.search-button) {
         background-color: transparent;
         border: none;
         padding: 0;

--- a/src/components/popover-container/popover-container-test.stories.tsx
+++ b/src/components/popover-container/popover-container-test.stories.tsx
@@ -5,9 +5,10 @@ import PopoverContainer, {
   PopoverContainerProps,
 } from "./popover-container.component";
 import { Select, Option } from "../select";
-import { Menu, MenuItem } from "../menu";
+import { Menu, MenuItem, MenuSegmentTitle } from "../menu";
 import Heading from "../heading";
 import Typography from "../typography";
+import Search from "../search";
 import IconButton from "../icon-button";
 import Icon from "../icon";
 
@@ -17,7 +18,8 @@ export default {
     "Default",
     "WithSelect",
     "InAScrollableBlock",
-    "InSideMenu",
+    "InsideMenu",
+    "InsideMenuWithOpenButton",
     "WithFullWidthButton",
   ],
   parameters: {
@@ -103,7 +105,7 @@ export const InAScrollableBlock = () => {
   );
 };
 
-export const InSideMenu = () => {
+export const InsideMenu = () => {
   const [open, setOpen] = useState(false);
   return (
     <Menu menuType="black">
@@ -116,7 +118,7 @@ export const InSideMenu = () => {
           open={open}
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           renderOpenComponent={({ isOpen, ref, onClick }) => (
-            <IconButton aria-label="Notifications" ref={ref} onAction={onClick}>
+            <IconButton aria-label="Notifications" ref={ref} onClick={onClick}>
               <Icon type="alert" />
             </IconButton>
           )}
@@ -140,6 +142,58 @@ export const InSideMenu = () => {
           </Box>
         </PopoverContainer>
       </MenuItem>
+    </Menu>
+  );
+};
+
+export const InsideMenuWithOpenButton = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <Menu menuType="black">
+      <MenuItem href="#">Menu Item One</MenuItem>
+      <MenuItem onClick={() => {}} submenu="Menu Item Two">
+        <MenuItem href="#">Submenu Item One</MenuItem>
+        <MenuItem href="#">Submenu Item Two</MenuItem>
+      </MenuItem>
+      <MenuItem submenu="Search">
+        <MenuSegmentTitle text="My Title" variant="alternate">
+          <MenuItem>
+            <Search
+              key="business-search"
+              defaultValue=""
+              variant="dark"
+              placeholder="Search all businesses"
+              searchWidth="100%"
+            />
+          </MenuItem>
+          <MenuItem href="#">Submenu Item Two</MenuItem>
+        </MenuSegmentTitle>
+      </MenuItem>
+      <MenuItem>
+        <PopoverContainer
+          disableAnimation
+          containerAriaLabel="notifications"
+          closeButtonAriaLabel="closeContainerAriaLabel"
+          position="left"
+          shouldCoverButton
+          onOpen={() => setOpen(true)}
+          onClose={() => setOpen(false)}
+          open={open}
+          renderOpenComponent={({ ref, onClick }) => (
+            <Box data-role="gblnav-notificationui-bell">
+              <Button aria-label="Notifications" ref={ref} onClick={onClick}>
+                <Box alignItems="center" display="flex" px={2}>
+                  <Icon type="alert" />
+                  notifications
+                </Box>
+              </Button>
+            </Box>
+          )}
+        >
+          Content
+        </PopoverContainer>
+      </MenuItem>
+      <MenuItem href="#">Menu Item Six</MenuItem>
     </Menu>
   );
 };

--- a/src/components/search/search.component.tsx
+++ b/src/components/search/search.component.tsx
@@ -267,6 +267,7 @@ export const Search = React.forwardRef<SearchHandle, SearchProps>(
               buttonType="primary"
               iconPosition="before"
               iconType="search"
+              className="search-button"
               {...buttonProps}
             >
               {searchButtonText}


### PR DESCRIPTION
fix #6725

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Update `Link` (which are rendered as part of MenuItem) styling is  applied to any open button rendered when `PopoverContainer` is a child of a `MenuItem`

![image](https://github.com/Sage/carbon/assets/44157880/32612d11-a0cd-479b-9409-73a780abc62c)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
PopoverContainer open button has border added and rounded corners

![image](https://github.com/Sage/carbon/assets/44157880/506a399d-0b3c-4811-9a20-6cb91b2532be)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->
I've added a `popover-container-test--inside-menu-with-open-button` test story for chromatic to capture any regressions

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
