### PR TITLE
fix: component MenuFullScreen and MenuItem not truncating topic

### DIFF
--- a/src/components/menu/__internal__/submenu/submenu.style.ts
+++ b/src/components/menu/__internal__/submenu/submenu.style.ts
@@ -158,6 +158,12 @@ const StyledSubmenu = styled.ul<StyledSubmenuProps>`
       white-space: nowrap;
       cursor: pointer;
 
+      ${inFullscreenView &&
+      css`
+        white-space: normal;
+        height: auto;
+      `}
+
       ${!inFullscreenView &&
       menuType &&
       css`

--- a/src/components/menu/component.test-pw.tsx
+++ b/src/components/menu/component.test-pw.tsx
@@ -301,6 +301,104 @@ export const MenuComponentFullScreen = (
   );
 };
 
+export const MenuComponentFullScreenWithLongSubmenuText = (
+  props: Partial<MenuFullscreenProps>
+) => {
+  const [menuOpen, setMenuOpen] = useState({
+    light: false,
+    dark: false,
+    white: false,
+    black: false,
+  });
+  const fullscreenViewBreakPoint = useMediaQuery("(max-width: 1200px)");
+  const responsiveMenuItems = (
+    startPosition: "left" | "right",
+    menu: MenuType
+  ) => {
+    if (fullscreenViewBreakPoint) {
+      return [
+        <MenuItem
+          key="fullscreen-menu-item-1"
+          onClick={() => setMenuOpen((state) => ({ ...state, [menu]: true }))}
+        >
+          Menu
+        </MenuItem>,
+        <MenuFullscreen
+          key="fullscreen-menu-1"
+          startPosition={startPosition}
+          isOpen={menuOpen[menu]}
+          onClose={() => setMenuOpen((state) => ({ ...state, [menu]: false }))}
+          {...props}
+        >
+          <MenuItem href="#">Menu Item One</MenuItem>
+          <MenuItem
+            onClick={() => {}}
+            submenu="Menu item with a really long topic where the text should not be truncated but instead it should be wrapped"
+          >
+            <MenuItem href="#">
+              Submenu item with a really long topic where the text should not be
+              truncated but instead it should be wrapped
+            </MenuItem>
+            <MenuItem href="#">Submenu Item Two</MenuItem>
+          </MenuItem>
+          <MenuItem href="#">Menu Item Three</MenuItem>
+          <MenuItem href="#">Menu Item Four</MenuItem>
+          <MenuItem submenu="Menu Item Five">
+            <MenuItem href="#">Submenu Item One</MenuItem>
+            <MenuItem href="#">Submenu Item Two</MenuItem>
+          </MenuItem>
+          <MenuItem href="#">Menu Item Six</MenuItem>
+        </MenuFullscreen>,
+      ];
+    }
+    return [
+      <MenuItem key="default-menu-item-1" href="#">
+        Menu Item One
+      </MenuItem>,
+      <MenuItem
+        key="default-menu-item-2"
+        submenu="Menu item with a really long topic where the text should not be truncated but instead it should be wrapped"
+      >
+        <MenuItem href="#">
+          Submenu item with a really long topic where the text should not be
+          truncated but instead it should be wrapped
+        </MenuItem>
+        <MenuItem href="#">Submenu Item Two</MenuItem>
+      </MenuItem>,
+      <MenuItem key="default-menu-item-3" href="#">
+        Menu Item Three
+      </MenuItem>,
+      <MenuItem key="default-menu-item-4" href="#">
+        Menu Item Four
+      </MenuItem>,
+      <MenuItem key="default-menu-item-5" submenu="Menu Item Five">
+        <MenuItem href="#">Submenu Item One</MenuItem>
+        <MenuItem href="#">Submenu Item Two</MenuItem>
+      </MenuItem>,
+      <MenuItem key="default-menu-item-6" href="#">
+        Menu Item Six
+      </MenuItem>,
+    ];
+  };
+  return (
+    <Box>
+      {menuTypes.map((menuType) => (
+        <div key={menuType}>
+          <Typography variant="h4" textTransform="capitalize" my={2}>
+            {menuType}
+          </Typography>
+          <Menu menuType={menuType}>
+            {React.Children.map(
+              responsiveMenuItems("left", menuType),
+              (items) => items
+            )}
+          </Menu>
+        </div>
+      ))}
+    </Box>
+  );
+};
+
 export const MenuFullScreenBackgroundScrollTest = () => {
   return (
     <Box height="2000px" position="relative">

--- a/src/components/menu/menu-item/menu-item.style.ts
+++ b/src/components/menu/menu-item/menu-item.style.ts
@@ -186,6 +186,14 @@ const StyledMenuItemWrapper = styled.a.attrs({
       height: 40px;
       margin: 0px;
       text-align: left;
+
+      ${
+        inFullscreenView &&
+        css`
+          height: auto;
+          white-space: normal;
+        `
+      }
     }
 
     &&& {

--- a/src/components/menu/menu-test.stories.tsx
+++ b/src/components/menu/menu-test.stories.tsx
@@ -28,6 +28,8 @@ const meta: Meta<typeof Menu> = {
     "InNavigationBarStory",
     "MenuFullScreenKeysTest",
     "MenuWithTwoSegments",
+    "MenuFullScreenWithLargeMenuItems",
+    "MenuComponentFullScreenWithLongSubmenuText",
   ],
   parameters: {
     info: { disable: true },
@@ -115,6 +117,24 @@ export const MenuFullScreenStory = ({
           <MenuItem href="#">Submenu Item Two</MenuItem>
         </MenuItem>
         <MenuItem href="#">Menu Item Six</MenuItem>
+        <MenuItem onClick={() => {}}>
+          Menu item as button with a really long topic where the text should not
+          be truncated but instead it should be wrapped
+        </MenuItem>
+        <MenuItem href="#">
+          Menu item as link with a really long topic where the text should not
+          be truncated but instead it should be wrapped
+        </MenuItem>
+        <MenuItem submenu="Menu item with submenu and with a really long topic where the text should not be truncated but instead it should be wrapped">
+          <MenuItem href="#">
+            Submenu item as link with a really long topic where the text should
+            not be truncated but instead it should be wrapped
+          </MenuItem>
+          <MenuItem onClick={() => {}}>
+            Submenu item as button with a really long topic where the text
+            should not be truncated but instead it should be wrapped
+          </MenuItem>
+        </MenuItem>
       </MenuFullscreen>
     </Menu>
   );

--- a/src/components/menu/menu.pw.tsx
+++ b/src/components/menu/menu.pw.tsx
@@ -66,6 +66,7 @@ import {
   SubMenuWithVeryLongLabel,
   MenuComponentScrollableWithSearch,
   MenuSegmentTitleComponentWithAdditionalMenuItem,
+  MenuComponentFullScreenWithLongSubmenuText,
 } from "./component.test-pw";
 import { NavigationBarWithSubmenuAndChangingHeight } from "../navigation-bar/navigation-bar-test.stories";
 import { HooksConfig } from "../../../playwright";
@@ -1397,6 +1398,76 @@ test.describe("Prop tests for Menu Fullscreen component", () => {
     expect(fullMenuItemColor).toContain("rgb(255, 255, 255)");
 
     await expect(fullMenuItem).toBeFocused();
+  });
+
+  test(`when the menu item contains a very long text, the text is wrapped`, async ({
+    mount,
+    page,
+  }) => {
+    await page.setViewportSize({ width: 300, height: 800 });
+    await mount(<MenuComponentFullScreenWithLongSubmenuText />);
+
+    const item = menuItem(page).first();
+    await item.click();
+    const fullscreen = getComponent(page, "menu-fullscreen").first();
+    await waitForAnimationEnd(fullscreen);
+
+    const fullSubmenuItem = fullscreenMenu(page, 3)
+      .locator("li")
+      .locator("a")
+      .first();
+
+    const fullSubmenuItemTextWrap = await fullSubmenuItem.evaluate(
+      (element) => {
+        const style = window.getComputedStyle(element);
+        return style.getPropertyValue("text-wrap");
+      }
+    );
+
+    const fullSubmenuItemHeight = await fullSubmenuItem.evaluate((element) => {
+      const style = window.getComputedStyle(element);
+      return style.getPropertyValue("height");
+    });
+
+    expect(fullSubmenuItemTextWrap).toEqual("wrap");
+    expect(fullSubmenuItemHeight).not.toEqual("40px");
+
+    const fullMenuItemWrapper = fullscreenMenu(page, 3).first();
+
+    const fullMenuItemWrapperTextWrap = await fullMenuItemWrapper.evaluate(
+      (element) => {
+        const style = window.getComputedStyle(element);
+        return style.getPropertyValue("text-wrap");
+      }
+    );
+
+    const fullMenuItemWrapperHeight = await fullMenuItemWrapper.evaluate(
+      (element) => {
+        const style = window.getComputedStyle(element);
+        return style.getPropertyValue("height");
+      }
+    );
+
+    expect(fullMenuItemWrapperTextWrap).toEqual("wrap");
+    expect(fullMenuItemWrapperHeight).not.toEqual("40px");
+
+    const fullMenuItem = fullscreenMenu(page, 3)
+      .locator("span")
+      .locator("button")
+      .first();
+
+    const fullMenuItemTextWrap = await fullMenuItem.evaluate((element) => {
+      const style = window.getComputedStyle(element);
+      return style.getPropertyValue("text-wrap");
+    });
+
+    const fullMenuItemHeight = await fullMenuItem.evaluate((element) => {
+      const style = window.getComputedStyle(element);
+      return style.getPropertyValue("height");
+    });
+
+    expect(fullMenuItemTextWrap).toEqual("wrap");
+    expect(fullMenuItemHeight).not.toEqual("40px");
   });
 
   // TODO: Skipped due to flaky focus behaviour. To review in FE-6428

--- a/src/components/menu/menu.style.ts
+++ b/src/components/menu/menu.style.ts
@@ -92,6 +92,8 @@ const StyledMenuItem = styled.li<StyledMenuItemProps>`
       [data-component="submenu-wrapper"] > ${StyledLink} {
         width: 100%;
         box-sizing: border-box;
+        height: auto;
+        white-space: normal;
       }
     `}
 


### PR DESCRIPTION
### Proposed behaviour

The behaviour has been observed in the following scenarios, as it can be seen in the attached screenshot:
1. when the `MenuItem` renders as a button
2. when the `MenuItem` renders inside the `Submenu` as a button
3. when the `MenuItem` renders inside the `Submenu` as a link

For the first scenario changes have been applied to the `StyledMenuItem` and `StyledMenuItemWrapper` components. For the second and third scenarios the `StyledSubmenuWrapper` has been updated to ensure `StyledMenuItemWrapper` wraps the text and has flexible height, when we are in full screen view.

![after_1](https://github.com/Sage/carbon/assets/101639841/a5c3cff9-18c6-4937-ba5b-f183ddfee19d)

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

The `MenuItem` does not wrap the text when it renders as a button or inside of a `Submenu` when it renders as a link or a button.

![before_1](https://github.com/Sage/carbon/assets/101639841/d37aa516-28f0-4108-b7df-07fb937eb578)

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [X] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
