### PR TITLE
fix(menu): ensure scrollbars meet colour contrast guidelines - FE-5290

### DIFF
--- a/src/components/menu/menu-full-screen/menu-full-screen.style.ts
+++ b/src/components/menu/menu-full-screen/menu-full-screen.style.ts
@@ -95,13 +95,21 @@ const StyledMenuModal = styled.div<{ menuType: MenuType }>`
         }
       }
     }
-  `}
 
-  ${StyledBox} {
-    &::-webkit-scrollbar {
-      width: 16px;
+    ${StyledBox} {
+      scrollbar-color: ${menuConfigVariants[menuType].scrollbarColor};
+
+      &::-webkit-scrollbar {
+        width: var(--sizing150);
+      }
+      &::-webkit-scrollbar-thumb {
+        background-color: ${menuConfigVariants[menuType].scrollbarThumb};
+      }
+      &::-webkit-scrollbar-track {
+        background-color: ${menuConfigVariants[menuType].scrollbarTrack};
+      }
     }
-  }
+  `}
 `;
 
 const StyledMenuFullscreenHeader = styled.div<{

--- a/src/components/menu/menu.config.ts
+++ b/src/components/menu/menu.config.ts
@@ -12,6 +12,9 @@ export default {
     alternate: "var(--colorsComponentsMenuSpringChildAlt500)",
     alternateHover: "var(--colorsComponentsMenuSpringChildAlt600)",
     divider: "var(--colorsComponentsMenuSpringChild400)",
+    scrollbarThumb: "#597a8b",
+    scrollbarTrack: "#f2f5f6",
+    scrollbarColor: "#597a8b #f2f5f6",
   },
   dark: {
     background: "var(--colorsComponentsMenuAutumnStandard500)",
@@ -26,6 +29,9 @@ export default {
     alternate: "var(--colorsComponentsMenuAutumnChildAlt500)",
     alternateHover: "var(--colorsComponentsMenuAutumnChildAlt600)",
     divider: "var(--colorsComponentsMenuAutumnChild400)",
+    scrollbarThumb: "#597a8b",
+    scrollbarTrack: "#f2f5f6",
+    scrollbarColor: "#597a8b #f2f5f6",
   },
   black: {
     background: "var(--colorsComponentsMenuWinterStandard500)",
@@ -40,6 +46,9 @@ export default {
     alternate: "var(--colorsComponentsMenuWinterChildAlt500)",
     alternateHover: "var(--colorsComponentsMenuWinterChildAlt600)",
     divider: "var(--colorsComponentsMenuWinterChild400)",
+    scrollbarThumb: "#CCCCCC",
+    scrollbarTrack: "#808080",
+    scrollbarColor: "#CCCCCC #808080",
   },
   white: {
     background: "var(--colorsComponentsMenuSummerStandard500)",
@@ -54,5 +63,8 @@ export default {
     alternate: "var(--colorsComponentsMenuSummerChildAlt500)",
     alternateHover: "var(--colorsComponentsMenuSummerChildAlt600)",
     divider: "var(--colorsComponentsMenuSummerChild400)",
+    scrollbarThumb: "#597a8b",
+    scrollbarTrack: "#f2f5f6",
+    scrollbarColor: "#597a8b #f2f5f6",
   },
 };

--- a/src/components/menu/menu.pw.tsx
+++ b/src/components/menu/menu.pw.tsx
@@ -2512,6 +2512,66 @@ test.describe(
       );
     });
 
+    test("should apply the expected styling to the scrollbar when menuType is white", async ({
+      mount,
+      page,
+    }) => {
+      await mount(<MenuComponentScrollable />);
+      const subMenu = submenu(page).first();
+      await subMenu.hover();
+      const scrollableBlock = scrollBlock(page).first();
+
+      await expect(scrollableBlock).toHaveCSS(
+        "scrollbar-color",
+        "rgb(89, 122, 139) rgb(242, 245, 246)"
+      );
+    });
+
+    test("should apply the expected styling to the scrollbar when menuType is light", async ({
+      mount,
+      page,
+    }) => {
+      await mount(<MenuComponentScrollable />);
+      const subMenu = submenu(page).nth(2);
+      await subMenu.hover();
+      const scrollableBlock = scrollBlock(page).first();
+
+      await expect(scrollableBlock).toHaveCSS(
+        "scrollbar-color",
+        "rgb(89, 122, 139) rgb(242, 245, 246)"
+      );
+    });
+
+    test("should apply the expected styling to the scrollbar when menuType is dark", async ({
+      mount,
+      page,
+    }) => {
+      await mount(<MenuComponentScrollable />);
+      const subMenu = submenu(page).nth(5);
+      await subMenu.hover();
+      const scrollableBlock = scrollBlock(page).first();
+
+      await expect(scrollableBlock).toHaveCSS(
+        "scrollbar-color",
+        "rgb(89, 122, 139) rgb(242, 245, 246)"
+      );
+    });
+
+    test("should apply the expected styling to the scrollbar when menuType is black", async ({
+      mount,
+      page,
+    }) => {
+      await mount(<MenuComponentScrollable />);
+      const subMenu = submenu(page).nth(6);
+      await subMenu.hover();
+      const scrollableBlock = scrollBlock(page).first();
+
+      await expect(scrollableBlock).toHaveCSS(
+        "scrollbar-color",
+        "rgb(204, 204, 204) rgb(128, 128, 128)"
+      );
+    });
+
     test(`should verify that tabbing forward through the menu and back to the start should not make the background scroll to the bottom`, async ({
       mount,
       page,

--- a/src/components/menu/scrollable-block/scrollable-block.style.ts
+++ b/src/components/menu/scrollable-block/scrollable-block.style.ts
@@ -18,6 +18,7 @@ const StyledScrollableBlock = styled.li<StyledScrollableBlockProps>`
       background-color: ${variant === "default"
         ? menuConfigVariants[menuType].submenuItemBackground
         : menuConfigVariants[menuType].alternate};
+      padding-right: var(--spacing150);
     }
 
     ${StyledBox} {
@@ -29,6 +30,18 @@ const StyledScrollableBlock = styled.li<StyledScrollableBlockProps>`
       ${StyledMenuItem}:last-child button {
         border-bottom-left-radius: var(--borderRadius100);
         border-bottom-right-radius: var(--borderRadius000);
+      }
+
+      scrollbar-color: ${menuConfigVariants[menuType].scrollbarColor};
+
+      &::-webkit-scrollbar {
+        width: var(--sizing150);
+      }
+      &::-webkit-scrollbar-thumb {
+        background-color: ${menuConfigVariants[menuType].scrollbarThumb};
+      }
+      &::-webkit-scrollbar-track {
+        background-color: ${menuConfigVariants[menuType].scrollbarTrack};
       }
     }
   `}


### PR DESCRIPTION
To ensure we pass accessibility on scrollbars, we must ensure they cover a 24px space, this implies width of scroll + gap to next interactive component. The black variant of the Menu component uses a Navy tint scrollbar customisation, which we would like to correct the colours of.

fixes FE-5290

### Proposed behaviour

- Update colours for scrollbars
- Apply padding between MenuItem and Scrollbar

Chrome: 

![Screenshot 2024-05-23 at 11 39 43](https://github.com/Sage/carbon/assets/56251247/456cd356-2af1-46f0-a706-9ef05c99a508)

![Screenshot 2024-05-23 at 13 29 51](https://github.com/Sage/carbon/assets/56251247/115e3a3f-d4aa-4725-ba2a-234fde55359f)

Safari: 
<img width="206" alt="Screenshot 2024-05-23 at 11 40 52" src="https://github.com/Sage/carbon/assets/56251247/df0b0bb9-f4b5-428d-b2d0-45f7ba3ca797">

<img width="213" alt="Screenshot 2024-05-23 at 13 30 39" src="https://github.com/Sage/carbon/assets/56251247/ee1919bd-fb75-46db-bca4-3cfd1f51b345">


### Current behaviour

- Colours currently don't meet accessibility guidelines
- No padding between MenuItem and Scrollbar

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

On Mac using Chrome, the scroll bar will have rounded corners. These don't exactly match the designs provided on the ticket but the colours should match.

### Testing instructions

- Ensure that the examples provided in the `scrollable-submenu` story have the expected styling applied to the scrollbar and the MenuItem's in the scrollable block have the correct gap. This will need to be tested on Windows and Mac.
- No other visual regressions have been caused by these changes. 