### PR TITLE
fix(text-editor): content overflows in small viewports

### DIFF
--- a/src/components/text-editor/text-editor-test.stories.tsx
+++ b/src/components/text-editor/text-editor-test.stories.tsx
@@ -57,7 +57,7 @@ export default {
 export const Default = ({ onChange, ...props }: Partial<TextEditorProps>) => {
   const [value, setValue] = useState(EditorState.createEmpty());
   return (
-    <div style={{ padding: "4px" }}>
+    <Box p={1}>
       <TextEditor
         onChange={(newValue) => {
           if (onChange) {
@@ -69,7 +69,7 @@ export const Default = ({ onChange, ...props }: Partial<TextEditorProps>) => {
         labelText="Text Editor Label"
         {...props}
       />
-    </div>
+    </Box>
   );
 };
 

--- a/src/components/text-editor/text-editor.spec.tsx
+++ b/src/components/text-editor/text-editor.spec.tsx
@@ -163,7 +163,6 @@ describe("TextEditor", () => {
         {
           minHeight: "inherit",
           height: "100%",
-          minWidth: "290px",
           margin: "4px",
         },
         wrapper.find(StyledEditorContainer),
@@ -174,7 +173,6 @@ describe("TextEditor", () => {
         {
           minHeight: "inherit",
           height: "100%",
-          minWidth: "290px",
           padding: "14px 8px",
         },
         wrapper.find(StyledEditorContainer),

--- a/src/components/text-editor/text-editor.style.ts
+++ b/src/components/text-editor/text-editor.style.ts
@@ -29,7 +29,6 @@ const StyledEditorContainer = styled.div<{
     div.DraftEditor-root {
       min-height: inherit;
       height: 100%;
-      min-width: 290px;
       margin: 4px;
     }
 
@@ -37,7 +36,6 @@ const StyledEditorContainer = styled.div<{
     div.public-DraftEditor-content {
       min-height: inherit;
       height: 100%;
-      min-width: 290px;
       background-color: var(--colorsUtilityYang100);
       line-height: ${lineHeight}px;
 


### PR DESCRIPTION
fix #6707

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Text container maintains the same width as the component and does not overflow. 
![Screenshot 2024-05-23 at 13 43 02](https://github.com/Sage/carbon/assets/78361608/80077e16-76e1-4c83-b777-dbd4c921e297)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Text container overflows outside of the component in small viewports. 
![Screenshot 2024-05-23 at 13 42 14](https://github.com/Sage/carbon/assets/78361608/d20f0be1-a535-425f-a4ed-f962d600870b)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
