### PR TITLE
chore: configure linter to report unused disable directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "jest --config=./jest.config.json",
     "test-update": "jest --config=./jest.config.json --updateSnapshot",
     "format": "prettier --write './{src,playwright}/**/*.{js,jsx,ts,tsx}'",
-    "lint": "eslint ./src ./playwright",
+    "lint": "eslint ./src ./playwright --report-unused-disable-directives",
     "build": "node ./scripts/build.js",
     "copy-files": "node ./scripts/copy-files.js",
     "precompile": "npm run type-check && npm run clean-lib && npm run build && npm run build:types && npm run copy-files",

--- a/src/__spec_helper__/expect.ts
+++ b/src/__spec_helper__/expect.ts
@@ -29,7 +29,6 @@ expect.extend({
       });
 
       return `${hint}\n\n${
-        // eslint-disable-next-line multiline-ternary
         diffString && diffString.includes("- Expect")
           ? `Difference:\n\n${diffString}`
           : `Expected: ${this.utils.printExpected(

--- a/src/__spec_helper__/test-utils.ts
+++ b/src/__spec_helper__/test-utils.ts
@@ -1,6 +1,3 @@
-/* eslint-disable jest/no-conditional-expect */
-/* eslint-disable jest/no-identical-title */
-/* eslint-disable jest/no-export */
 import { mount, ReactWrapper, ShallowWrapper } from "enzyme";
 import { sprintf } from "sprintf-js";
 import {

--- a/src/components/action-popover/action-popover-test.stories.tsx
+++ b/src/components/action-popover/action-popover-test.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from "react";
 import { action } from "@storybook/addon-actions";
 

--- a/src/components/action-popover/components.test-pw.tsx
+++ b/src/components/action-popover/components.test-pw.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { useState } from "react";
 import Box from "../box";
 import Link from "../link";

--- a/src/components/advanced-color-picker/advanced-color-picker.spec.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.spec.tsx
@@ -328,7 +328,6 @@ describe("AdvancedColorPicker", () => {
   });
 
   describe("when the component value is controlled, and a color is selected", () => {
-    // eslint-disable-next-line react/prop-types
     let wrapper: ReactWrapper;
 
     beforeEach(() => {

--- a/src/components/alert/alert-test.stories.tsx
+++ b/src/components/alert/alert-test.stories.tsx
@@ -86,7 +86,6 @@ DefaultStory.story = {
 };
 
 export const AlertComponentTest = ({
-  // eslint-disable-next-line react/prop-types
   children = "This is an example of an alert",
   ...props
 }) => {

--- a/src/components/button-toggle/button-toggle-test.stories.tsx
+++ b/src/components/button-toggle/button-toggle-test.stories.tsx
@@ -139,7 +139,6 @@ export const ButtonToggleGroupComponent = ({ ...props }) => {
 };
 
 export const ButtonToggleComponent = ({
-  // eslint-disable-next-line react/prop-types
   children = "This is an example of an alert",
   ...props
 }: ButtonToggleProps) => {

--- a/src/components/button/button.component.tsx
+++ b/src/components/button/button.component.tsx
@@ -110,7 +110,6 @@ interface RenderChildrenProps
 }
 
 function renderChildren({
-  /* eslint-disable react/prop-types */
   iconType,
   iconPosition,
   size,
@@ -121,8 +120,7 @@ function renderChildren({
   iconTooltipMessage,
   iconTooltipPosition,
   tooltipTarget,
-}: /* eslint-enable */
-RenderChildrenProps) {
+}: RenderChildrenProps) {
   const iconColor = () => {
     if (buttonType === "primary") {
       return "--colorsActionMajorYang100";

--- a/src/components/card/components.test-pw.tsx
+++ b/src/components/card/components.test-pw.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unstable-nested-components */
 import React, { useState } from "react";
 import { DndProvider, useDrag, useDrop } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";

--- a/src/components/content/components.test-pw.tsx
+++ b/src/components/content/components.test-pw.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import Content from ".";
 
 const ContentComponentTest = ({
-  // eslint-disable-next-line react/prop-types
   children = "This is an example of some content",
   ...props
 }) => {

--- a/src/components/detail/detail.pw.tsx
+++ b/src/components/detail/detail.pw.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unescaped-entities */
 import React from "react";
 import { test, expect } from "@playwright/experimental-ct-react17";
 import Detail from "./detail.component";

--- a/src/components/drawer/drawer.spec.tsx
+++ b/src/components/drawer/drawer.spec.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 import React from "react";
 import { act } from "react-dom/test-utils";
 import { mount, ReactWrapper, shallow } from "enzyme";
@@ -615,7 +613,6 @@ describe("Drawer", () => {
     });
 
     describe("by an external control", () => {
-      // eslint-disable-next-line react/prop-types
       const MockComponent = ({ expanded = false }) => {
         const [isExpanded, setIsExpanded] = React.useState(expanded);
         return (

--- a/src/components/duelling-picklist/duelling-picklist.spec.tsx
+++ b/src/components/duelling-picklist/duelling-picklist.spec.tsx
@@ -188,7 +188,6 @@ describe("DuellingPicklist", () => {
     );
   };
 
-  // eslint-disable-next-line react/prop-types
   const MockComponent = ({ grouped }: { grouped?: boolean }) => {
     const [notSelectedListItems, setNotSelectedItems] = useState([0, 1, 2]);
     const [selectedListItems, setSelectedItems] = useState([3, 4, 5]);

--- a/src/components/flat-table/flat-table.pw.tsx
+++ b/src/components/flat-table/flat-table.pw.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-disabled-tests */
 import React from "react";
 import { test, expect } from "@playwright/experimental-ct-react17";
 import type { Locator } from "@playwright/test";

--- a/src/components/grid/grid-test.stories.tsx
+++ b/src/components/grid/grid-test.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from "react";
 
 import Pod from "../pod";

--- a/src/components/multi-action-button/multi-action-button.spec.tsx
+++ b/src/components/multi-action-button/multi-action-button.spec.tsx
@@ -217,7 +217,6 @@ describe("MultiActionButton", () => {
       ["End", "End", ""],
       ["Ctrl + ArrowDown", "ArrowDown", "ctrlKey"],
       ["Meta + ArrowDown", "ArrowDown", "metaKey"],
-      // eslint-disable-next-line
     ])("when %s key is pressed", (_, key, modifier) => {
       it("focuses the last button", () => {
         const additionalButtons = wrapper

--- a/src/components/pages/pages.spec.tsx
+++ b/src/components/pages/pages.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { useState } from "react";
 import { shallow, mount, ReactWrapper, ShallowWrapper } from "enzyme";
 import { act } from "react-dom/test-utils";

--- a/src/components/popover-container/popover-container.spec.tsx
+++ b/src/components/popover-container/popover-container.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { forwardRef } from "react";
 import { mount, ReactWrapper } from "enzyme";
 import { act } from "react-dom/test-utils";
@@ -420,7 +419,7 @@ describe("PopoverContainer", () => {
         document.body.appendChild(container);
         wrapper = renderAttached({
           title: "render props",
-          // eslint-disable-next-line react/display-name
+
           renderOpenComponent: ({
             tabIndex,
             "data-element": dataElement,
@@ -493,7 +492,7 @@ describe("PopoverContainer", () => {
       it("should not be focused if `ref` is not provided", () => {
         wrapper = render({
           title: "render props",
-          // eslint-disable-next-line react/display-name
+
           renderOpenComponent: ({
             tabIndex,
             "data-element": dataElement,

--- a/src/components/portrait/portrait.style.tsx
+++ b/src/components/portrait/portrait.style.tsx
@@ -39,7 +39,7 @@ export const StyledCustomImg = styled.img`
 `;
 
 // && is used here to increase the specificity
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+
 export const StyledIcon = styled(Icon)<Pick<StyledPortraitProps, "size">>`
   && {
     color: inherit;

--- a/src/components/select/multi-select/multi-select.component.tsx
+++ b/src/components/select/multi-select/multi-select.component.tsx
@@ -295,7 +295,6 @@ export const MultiSelect = React.forwardRef(
         if (isDeleteKey && (filterText === "" || textValue === "")) {
           removeSelectedValue(-1);
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
       },
       [onKeyDown, readOnly, filterText, textValue, setOpen, removeSelectedValue]
     );

--- a/src/components/tabs/tabs.spec.tsx
+++ b/src/components/tabs/tabs.spec.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { useEffect, useContext } from "react";
 import { mount, shallow, MountRendererProps, ReactWrapper } from "enzyme";
 import { act } from "react-dom/test-utils";

--- a/src/components/textarea/textarea-test.stories.tsx
+++ b/src/components/textarea/textarea-test.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { useState } from "react";
 import Textarea, { TextareaProps } from ".";
 import Dialog from "../dialog";

--- a/src/components/tooltip/tooltip-test.stories.tsx
+++ b/src/components/tooltip/tooltip-test.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { forwardRef, useState } from "react";
 import Tooltip from ".";
 import { TOOLTIP_POSITIONS, TooltipPositions } from "./tooltip.config";

--- a/src/components/tooltip/tooltip.config.ts
+++ b/src/components/tooltip/tooltip.config.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export const TOOLTIP_POSITIONS = ["bottom", "left", "right", "top"];
 
 export type TooltipPositions = "top" | "bottom" | "left" | "right";

--- a/src/components/vertical-menu/vertical-menu-test.stories.tsx
+++ b/src/components/vertical-menu/vertical-menu-test.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from "react";
 import { VerticalMenu, VerticalMenuItem, VerticalMenuProps } from ".";
 import Box from "../box";

--- a/src/style/utils/color.ts
+++ b/src/style/utils/color.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
 import { color as styledColor } from "styled-system";
 import tokens from "@sage/design-tokens/js/base/common";
 import { ThemeObject } from "../themes/base";


### PR DESCRIPTION
### Proposed behaviour

- Linter reports an error for any unused disable directives
- Remove unused disable directives

### Current behaviour

- Codebase contains many linter disable directives that are unused

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
