### PR TITLE
feat(button-minor): add forward ref to component

### DIFF
--- a/src/components/button-minor/button-minor.component.tsx
+++ b/src/components/button-minor/button-minor.component.tsx
@@ -8,40 +8,49 @@ export interface ButtonMinorProps extends ButtonProps {
   isInPassword?: boolean;
 }
 
-export const ButtonMinor = ({
-  buttonType: buttonTypeProp = "secondary",
-  disabled = false,
-  destructive = false,
-  size: sizeProp = "medium",
-  iconPosition: iconPositionProp = "before",
-  fullWidth: fullWidthProp = false,
-  ...rest
-}: ButtonMinorProps) => {
-  const {
-    buttonType: buttonTypeContext,
-    size: sizeContext,
-    iconPosition: iconPositionContext,
-    fullWidth: fullWidthContext,
-  } = useContext(ButtonBarContext);
+export const ButtonMinor = React.forwardRef<
+  HTMLButtonElement,
+  ButtonMinorProps
+>(
+  (
+    {
+      buttonType: buttonTypeProp = "secondary",
+      disabled = false,
+      destructive = false,
+      size: sizeProp = "medium",
+      iconPosition: iconPositionProp = "before",
+      fullWidth: fullWidthProp = false,
+      ...rest
+    }: ButtonMinorProps,
+    ref
+  ) => {
+    const {
+      buttonType: buttonTypeContext,
+      size: sizeContext,
+      iconPosition: iconPositionContext,
+      fullWidth: fullWidthContext,
+    } = useContext(ButtonBarContext);
 
-  const buttonType = buttonTypeContext || buttonTypeProp;
-  const size = sizeContext || sizeProp;
-  const iconPosition = iconPositionContext || iconPositionProp;
-  const fullWidth = fullWidthContext || fullWidthProp;
+    const buttonType = buttonTypeContext || buttonTypeProp;
+    const size = sizeContext || sizeProp;
+    const iconPosition = iconPositionContext || iconPositionProp;
+    const fullWidth = fullWidthContext || fullWidthProp;
 
-  return (
-    <StyledButtonMinor
-      data-component="button-minor"
-      size={size}
-      fullWidth={fullWidth}
-      iconPosition={iconPosition}
-      buttonType={buttonType}
-      disabled={disabled}
-      destructive={destructive}
-      {...rest}
-    />
-  );
-};
+    return (
+      <StyledButtonMinor
+        ref={ref}
+        data-component="button-minor"
+        size={size}
+        fullWidth={fullWidth}
+        iconPosition={iconPosition}
+        buttonType={buttonType}
+        disabled={disabled}
+        destructive={destructive}
+        {...rest}
+      />
+    );
+  }
+);
 
 ButtonMinor.displayName = "ButtonMinor";
 

--- a/src/components/button-minor/button-minor.spec.tsx
+++ b/src/components/button-minor/button-minor.spec.tsx
@@ -9,6 +9,7 @@ import {
 import StyledIcon from "../icon/icon.style";
 import ButtonMinor from "./button-minor.component";
 import { assertStyleMatch } from "../../__spec_helper__/test-utils";
+import StyledButtonMinor from "./button-minor.style";
 
 const render = (props: ButtonProps, renderer: typeof shallow = shallow) => {
   return renderer(<ButtonMinor {...props} />);
@@ -196,4 +197,34 @@ describe("when the iconPosition prop and iconType are being passed to Button Min
       );
     }
   );
+
+  it("accepts ref as a ref object", () => {
+    const ref = { current: null };
+    const wrapper = mount(<ButtonMinor ref={ref}>ButtonMinor</ButtonMinor>);
+
+    wrapper.update();
+
+    expect(ref.current).toBe(wrapper.find(StyledButtonMinor).getDOMNode());
+  });
+
+  it("accepts ref as a ref callback", () => {
+    const ref = jest.fn();
+    const wrapper = mount(<ButtonMinor ref={ref}>ButtonMinor</ButtonMinor>);
+
+    wrapper.update();
+
+    expect(ref).toHaveBeenCalledWith(
+      wrapper.find(StyledButtonMinor).getDOMNode()
+    );
+  });
+
+  it("sets ref to empty after unmount", () => {
+    const ref = { current: null };
+    const wrapper = mount(<ButtonMinor ref={ref}>ButtonMinor</ButtonMinor>);
+
+    wrapper.update();
+
+    wrapper.unmount();
+    expect(ref.current).toBe(null);
+  });
 });


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Add forward ref to MinorButton
### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
No support for ref on MinorButton
### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
