### PR TITLE
fix(action-popover): right arrow in menu item with submenu not aligned with text in safari

### DIFF
--- a/src/components/action-popover/action-popover.stories.tsx
+++ b/src/components/action-popover/action-popover.stories.tsx
@@ -657,7 +657,6 @@ InFlatTable.storyName = "In Flat Table";
 
 export const OpeningAModal: Story = () => {
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
   return (
     <>
       <Box>
@@ -670,8 +669,7 @@ export const OpeningAModal: Story = () => {
         >
           <ActionPopoverItem
             onClick={() => {
-              setIsOpen(!isOpen);
-              setIsConfirmOpen(isConfirmOpen);
+              setIsConfirmOpen(!isConfirmOpen);
             }}
           >
             Open Confirm Dialog

--- a/src/components/action-popover/action-popover.style.ts
+++ b/src/components/action-popover/action-popover.style.ts
@@ -4,7 +4,6 @@ import { margin } from "styled-system";
 import Icon from "../icon";
 import StyledIcon from "../icon/icon.style";
 import StyledButton from "../button/button.style";
-import { isSafari } from "../../__internal__/utils/helpers/browser-type-check";
 import addFocusStyling from "../../style/utils/add-focus-styling";
 import baseTheme from "../../style/themes/base";
 
@@ -305,10 +304,6 @@ const SubMenuItemIcon = styled(ButtonIcon)`
     ${type === "chevron_right_thick" &&
     css`
       right: -5px;
-      ${isSafari(navigator) &&
-      css`
-        top: var(--sizing100);
-      `}
     `}
   `}
 `;


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- Right arrow in `ActionPopoverItem` with submenu is aligned with text in safari. 
<img width="304" alt="Screenshot 2024-06-17 at 15 19 23" src="https://github.com/Sage/carbon/assets/78361608/fd2f0beb-cfcb-4fa9-940b-9eafa426bf09">

- Confirm dialog does opens when "Open Confirm Dialog' menu item is clicked in "Opening a Modal" story. 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- Right arrow in `ActionPopoverItem` with submenu not aligned with text in safari. 
<img width="304" alt="Screenshot 2024-06-17 at 15 18 47" src="https://github.com/Sage/carbon/assets/78361608/692826c6-181f-447a-9db6-3c525672ffa0">

- Confirm dialog does not open when "Open Confirm Dialog' menu item is clicked in "Opening a Modal" story. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

- See "Sub Menu Positioned Right" story in Safari.
- See "Opening a Modal" story.
