### PR TITLE
fix(progress-tracker): apply box sizing of border box to the inner styled bar - FE-6672

### DIFF
--- a/src/components/progress-tracker/progress-tracker-test.stories.tsx
+++ b/src/components/progress-tracker/progress-tracker-test.stories.tsx
@@ -1,11 +1,17 @@
 import React from "react";
 import ProgressTracker, { ProgressTrackerProps } from ".";
 import { PROGRESS_TRACKER_SIZES } from "./progress-tracker.config";
+import {
+  FlexTileCell,
+  FlexTileContainer,
+  FlexTileDivider,
+  Tile,
+} from "../tile";
 
 export default {
   component: ProgressTracker,
   title: "Progress Tracker/Test",
-  includeStories: ["Default", "LeftLabelWithLabelWidth"],
+  includeStories: ["Default", "LeftLabelWithLabelWidth", "InsideFlexTile"],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -90,4 +96,27 @@ LeftLabelWithLabelWidth.parameters = {
 
 export const ProgressTrackerComponent = (props: ProgressTrackerProps) => {
   return <ProgressTracker progress={50} showDefaultLabels {...props} />;
+};
+
+export const InsideFlexTile = () => {
+  return (
+    <Tile m={0} py={0}>
+      <FlexTileContainer>
+        <FlexTileCell py={2}>
+          <FlexTileDivider />
+          <ProgressTracker
+            length="100%"
+            progress={50}
+            currentProgressLabel="Step 3"
+            maxProgressLabel="5"
+          />
+        </FlexTileCell>
+      </FlexTileContainer>
+    </Tile>
+  );
+};
+
+InsideFlexTile.storyName = "inside flex tile";
+InsideFlexTile.parameters = {
+  themeProvider: { chromatic: { disableSnapshot: false } },
 };

--- a/src/components/progress-tracker/progress-tracker.spec.tsx
+++ b/src/components/progress-tracker/progress-tracker.spec.tsx
@@ -207,11 +207,11 @@ describe("ProgressTracker", () => {
       );
     });
 
-    it("applies proper width and height to outer bar", () => {
+    it("applies proper width and min-height to outer bar", () => {
       assertStyleMatch(
         {
           width: "100%",
-          height: "var(--sizing200)",
+          minHeight: "fit-content",
         },
         wrapper.find(StyledProgressBar)
       );

--- a/src/components/progress-tracker/progress-tracker.style.ts
+++ b/src/components/progress-tracker/progress-tracker.style.ts
@@ -59,12 +59,13 @@ const StyledProgressBar = styled.span<
     position: relative;
     background-color: var(--colorsSemanticNeutral200);
     border: 1px solid ${getBorderColour({ progress, error })};
-    border-radius: ${theme.roundedCornersOptOut
-      ? "25px"
-      : "var(--borderRadius400)"};
+    border-radius: ${
+      theme.roundedCornersOptOut ? "25px" : "var(--borderRadius400)"
+    };
     overflow-x: hidden;
-    height: ${getHeight(size)};
-    width: 100%;
+    width: 100%
+    min-height: fit-content;
+    box-sizing: border-box;
   `}
 `;
 


### PR DESCRIPTION
Currently the progress tracker's border is being cut off when contained inside a FlexTile component. This applies a `box-sizing` of `border-box` to the inner styled bar. The height has also had to be re-calculated due to a 2px reduction in height because of the `box-sizing` styling. To solve this we have used a `min-height` of `fit-content`

fixes #6779

### Proposed behaviour

![Screenshot 2024-06-26 at 15 32 36](https://github.com/Sage/carbon/assets/56251247/496e6b41-7669-4339-a204-38b336b55852)

### Current behaviour

![Screenshot 2024-06-26 at 15 33 08](https://github.com/Sage/carbon/assets/56251247/9a08b96f-d42b-4166-b3b8-480b31f910bb)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Check for any regressions on `Progress Tracker`
- Added a new story in the test folder called `inside flex tile` which demonstrates this fixed inside of a flex tile. 
