### PR TITLE
chore: prevent duplication of @testing-library/dom package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "@storybook/react": "^7.6.4",
         "@storybook/react-webpack5": "^7.6.4",
         "@storybook/theming": "^7.6.4",
+        "@testing-library/dom": "^9.0.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.1.5",
         "@testing-library/react-hooks": "^8.0.1",
@@ -8940,7 +8941,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
       "integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -9036,25 +9036,6 @@
         "react-test-renderer": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
-      "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@testing-library/user-event": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@storybook/react": "^7.6.4",
     "@storybook/react-webpack5": "^7.6.4",
     "@storybook/theming": "^7.6.4",
+    "@testing-library/dom": "^9.0.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^8.0.1",
@@ -202,7 +203,8 @@
     "styled-system": "^5.1.5"
   },
   "overrides": {
-    "playwright-core": "$@playwright/experimental-ct-react17"
+    "playwright-core": "$@playwright/experimental-ct-react17",
+    "@testing-library/dom": "$@testing-library/dom"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
### Proposed behaviour

- Remove duplicates of `@testing-library/dom` package, to ensure `@testing-library/react` and `@testing-library/user-event` use the same copy. [Not doing so can lead to bugs](https://testing-library.com/docs/user-event/install).

```shell
$ npm ls @testing-library/dom

├── @testing-library/dom@9.3.4 overridden
├─┬ @testing-library/react@12.1.5
│ └── @testing-library/dom@9.3.4 deduped
├─┬ @testing-library/user-event@14.5.2
│ └── @testing-library/dom@9.3.4 deduped
└─┬ eslint-plugin-jest-dom@5.2.0
  └── @testing-library/dom@9.3.4 deduped
```

### Current behaviour

- Carbon's installed packages contain two copies of `@testing-library/dom`. This means `@testing-library/dom` is not resolved to the same installation, causing bugs such as excessive act warnings:
   - https://github.com/testing-library/react-testing-library/issues/1336#issuecomment-2178199922
   - https://github.com/testing-library/react-testing-library/issues/1051#issuecomment-1351896922

```shell
$ npm ls @testing-library/dom

├─┬ @testing-library/react@12.1.5
│ └── @testing-library/dom@8.20.1
├─┬ @testing-library/user-event@14.5.2
│ └── @testing-library/dom@9.3.4
└─┬ eslint-plugin-jest-dom@5.2.0
  └── @testing-library/dom@9.3.4 deduped
```

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

- The introduced override can be removed once `@testing-library/react` has been upgraded to version v16, [since `@testing-library/dom` was made a peer dependency of it](https://github.com/testing-library/react-testing-library/releases/tag/v16.0.0). 

### Testing instructions

Run `npm test -- /dialog.test.tsx` - check act warning [which is thrown for this test](https://github.com/Sage/carbon/blob/51851f1c91311a841f8f953c52451bd327f403c0/src/components/dialog/dialog.test.tsx#L162-L176) has been resolved