### PR TITLE
chore: remove unnecessary act calls in RTL tests

### DIFF
--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.test.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.test.tsx
@@ -6,8 +6,6 @@ import CarbonProvider from "../../carbon-provider/carbon-provider.component";
 import { testStyledSystemMargin } from "../../../__spec_helper__/__internal__/test-utils";
 import FormFieldStyle from "../../../__internal__/form-field/form-field.style";
 
-// TODO FE-6647 - Investigate act() warning for userEvent tests
-
 test("should render with provided children", () => {
   render(
     <ButtonToggleGroup id="button-toggle-group-id" onChange={() => {}}>

--- a/src/components/date-range/date-range.test.tsx
+++ b/src/components/date-range/date-range.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, act, screen, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import DateRange, { DateRangeChangeEvent } from "./date-range.component";
@@ -409,12 +409,9 @@ test("should not call `onBlur` callback when focus moves from 'start' to 'end' i
       onBlur={onBlur}
     />
   );
-  await act(async () => {
-    await user.click(screen.getByRole("textbox", { name: "start" }));
-  });
-  await act(async () => {
-    await user.click(screen.getByRole("textbox", { name: "end" }));
-  });
+
+  await user.click(screen.getByRole("textbox", { name: "start" }));
+  await user.click(screen.getByRole("textbox", { name: "end" }));
 
   expect(onBlur).not.toHaveBeenCalled();
 });
@@ -432,12 +429,9 @@ test("should not call `onBlur` callback when focus moves from 'end' to 'start' i
       onBlur={onBlur}
     />
   );
-  await act(async () => {
-    await user.click(screen.getByRole("textbox", { name: "end" }));
-  });
-  await act(async () => {
-    await user.click(screen.getByRole("textbox", { name: "start" }));
-  });
+
+  await user.click(screen.getByRole("textbox", { name: "end" }));
+  await user.click(screen.getByRole("textbox", { name: "start" }));
 
   expect(onBlur).not.toHaveBeenCalled();
 });
@@ -666,16 +660,13 @@ test("should close the open 'start' picker when the user moves focus to the `end
   );
   const startDate = screen.getByTestId("start");
   const endDate = screen.getByTestId("end");
-  await act(async () => {
-    await user.click(screen.getByRole("textbox", { name: "start" }));
-  });
+
+  await user.click(screen.getByRole("textbox", { name: "start" }));
 
   expect(within(startDate).getByRole("grid")).toBeVisible();
   expect(within(endDate).queryByRole("grid")).not.toBeInTheDocument();
 
-  await act(async () => {
-    await user.click(screen.getByRole("textbox", { name: "end" }));
-  });
+  await user.click(screen.getByRole("textbox", { name: "end" }));
 
   expect(within(endDate).getByRole("grid")).toBeVisible();
   expect(within(startDate).queryByRole("grid")).not.toBeInTheDocument();
@@ -695,16 +686,13 @@ test("should close the open 'end' picker when the user moves focus to the `start
   );
   const startDate = screen.getByTestId("start");
   const endDate = screen.getByTestId("end");
-  await act(async () => {
-    await user.click(screen.getByRole("textbox", { name: "end" }));
-  });
+
+  await user.click(screen.getByRole("textbox", { name: "end" }));
 
   expect(within(endDate).getByRole("grid")).toBeVisible();
   expect(within(startDate).queryByRole("grid")).not.toBeInTheDocument();
 
-  await act(async () => {
-    await user.click(screen.getByRole("textbox", { name: "start" }));
-  });
+  await user.click(screen.getByRole("textbox", { name: "start" }));
 
   expect(within(startDate).getByRole("grid")).toBeVisible();
   expect(within(endDate).queryByRole("grid")).not.toBeInTheDocument();

--- a/src/components/date/date.test.tsx
+++ b/src/components/date/date.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { render, screen, act, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   enGB as enGBLocale,
@@ -268,9 +268,7 @@ test("should call `onBlur` and `onChange` callbacks when the user clicks away fr
   );
   const input = screen.getByRole("textbox");
   await user.click(input);
-  await act(async () => {
-    await user.click(document.body);
-  });
+  await user.click(document.body);
 
   expect(onBlur).toHaveBeenCalled();
   expect(onChange).toHaveBeenCalled();
@@ -285,9 +283,7 @@ test("should call `onBlur` but not `onChange` callbacks when the user clicks awa
   );
   const input = screen.getByRole("textbox");
   await user.click(input);
-  await act(async () => {
-    await user.click(document.body);
-  });
+  await user.click(document.body);
 
   expect(onBlur).toHaveBeenCalled();
   expect(onChange).not.toHaveBeenCalled();
@@ -307,9 +303,7 @@ test("should call `onBlur` but not `onChange` callbacks when the user clicks awa
   );
   const input = screen.getByRole("textbox");
   await user.click(input);
-  await act(async () => {
-    await user.click(document.body);
-  });
+  await user.click(document.body);
 
   expect(onBlur).toHaveBeenCalled();
   expect(onChange).not.toHaveBeenCalled();
@@ -330,9 +324,7 @@ test("should not call `onBlur` or `onChange` callbacks when user clicks away fro
   );
   const input = screen.getByRole("textbox");
   await user.click(input);
-  await act(async () => {
-    await user.click(document.body);
-  });
+  await user.click(document.body);
 
   expect(onBlur).not.toHaveBeenCalled();
   expect(onChange).not.toHaveBeenCalled();
@@ -347,9 +339,7 @@ test("should not call `onBlur` when the user clicks on the input and then the in
   const input = screen.getByRole("textbox");
   const icon = screen.getByTestId("input-icon-toggle");
   await user.click(input);
-  await act(async () => {
-    await user.click(icon);
-  });
+  await user.click(icon);
 
   expect(onBlur).not.toHaveBeenCalled();
 });
@@ -361,9 +351,7 @@ test("should call `onChange` callback with expected values when user clicks away
   const input = screen.getByRole("textbox");
   await user.click(input);
   await user.type(input, "12.12.69");
-  await act(async () => {
-    await user.click(document.body);
-  });
+  await user.click(document.body);
 
   expect(onChange).toHaveBeenCalledWith({
     formattedValue: "12/12/1969",
@@ -379,9 +367,7 @@ test("should call `onChange` callback with expected values when user clicks away
   const input = screen.getByRole("textbox");
   await user.click(input);
   await user.type(input, "12.12.20");
-  await act(async () => {
-    await user.click(document.body);
-  });
+  await user.click(document.body);
 
   expect(onChange).toHaveBeenCalledWith({
     formattedValue: "12/12/2020",
@@ -397,9 +383,7 @@ test("should call `onChange` callback with expected values when user clicks away
   const input = screen.getByRole("textbox");
   await user.click(input);
   await user.type(input, "12.12.00");
-  await act(async () => {
-    await user.click(document.body);
-  });
+  await user.click(document.body);
 
   expect(onChange).toHaveBeenCalledWith({
     formattedValue: "12/12/2000",
@@ -421,9 +405,7 @@ test("should call `onChange` callback when user clears the input and clicks away
   const input = screen.getByRole("textbox");
   await user.click(input);
   await user.clear(input);
-  await act(async () => {
-    await user.click(document.body);
-  });
+  await user.click(document.body);
 
   expect(onChange).toHaveBeenCalledWith({
     formattedValue: "",
@@ -473,9 +455,7 @@ test("should close the open picker when a user presses the 'Escape' key", async 
   render(<DateInput onChange={() => {}} value="" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
-  await act(async () => {
-    await user.keyboard("{Escape}");
-  });
+  await user.keyboard("{Escape}");
 
   expect(screen.queryByRole("grid")).not.toBeInTheDocument();
 });
@@ -486,9 +466,7 @@ test("should close the open picker when the user presses the 'Escape' key and fo
   const input = screen.getByRole("textbox");
   await user.click(input);
   await user.tab();
-  await act(async () => {
-    await user.keyboard("{Escape}");
-  });
+  await user.keyboard("{Escape}");
 
   expect(screen.queryByRole("grid")).not.toBeInTheDocument();
 });
@@ -533,9 +511,7 @@ test("should close the picker when the user presses shift + tab and the input is
   await user.click(input);
 
   expect(screen.getByRole("grid")).toBeVisible();
-  await act(async () => {
-    await user.tab({ shift: true });
-  });
+  await user.tab({ shift: true });
   expect(screen.queryByRole("grid")).not.toBeInTheDocument();
 });
 
@@ -547,9 +523,7 @@ test("should close the picker when the user presses shift + tab and the previous
   await user.tab();
 
   expect(screen.getByRole("button", { name: "Previous month" })).toHaveFocus();
-  await act(async () => {
-    await user.tab({ shift: true });
-  });
+  await user.tab({ shift: true });
   expect(screen.queryByRole("grid")).not.toBeInTheDocument();
 });
 
@@ -562,9 +536,7 @@ test("should not close the picker when the user presses shift + tab and neither 
   await user.tab();
 
   expect(screen.getByRole("button", { name: "Next month" })).toHaveFocus();
-  await act(async () => {
-    await user.tab({ shift: true });
-  });
+  await user.tab({ shift: true });
   expect(screen.getByRole("grid")).toBeVisible();
 });
 

--- a/src/components/dialog/dialog.test.tsx
+++ b/src/components/dialog/dialog.test.tsx
@@ -164,11 +164,6 @@ describe("closing behaviour", () => {
     const user = userEvent.setup();
     render(<MockApp onCancel={onCancel} />, { wrapper: AllTheProviders });
 
-    /**
-     * TODO: FE-6647 Pressing Escape triggers an effect that calls MockApp's setOpen, leading to an additional re-render that isn’t wrapped in act().
-     * To investigate if we could eliminate any effects causing unnecessary re-renders.
-     * See https://react.dev/learn/you-might-not-need-an-effect#updating-state-based-on-props-or-state
-     */
     await user.keyboard("{Escape}");
     await waitForElementToBeRemoved(() => screen.queryByRole("dialog"));
 

--- a/src/components/menu/menu-item/menu-item.test.tsx
+++ b/src/components/menu/menu-item/menu-item.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen, act, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { MenuItem } from "..";
@@ -664,9 +664,7 @@ describe("when MenuItem has a submenu", () => {
     );
     const submenuParentItem = screen.getByRole("link", { name: "Item One" });
     await user.click(submenuParentItem);
-    await act(async () => {
-      await user.unhover(submenuParentItem);
-    });
+    await user.unhover(submenuParentItem);
     await user.keyboard("{arrowdown}");
     await user.keyboard("{arrowdown}");
     const submenuItem = screen.getByRole("link", { name: "Submenu Item One" });
@@ -687,9 +685,7 @@ describe("when MenuItem has a submenu", () => {
     );
     const submenuParentItem = screen.getByRole("link", { name: "Item One" });
     await user.click(submenuParentItem);
-    await act(async () => {
-      await user.unhover(submenuParentItem);
-    });
+    await user.unhover(submenuParentItem);
     await user.keyboard("{arrowup}");
     await user.keyboard("{arrowup}");
     const submenuItem = screen.getByRole("link", { name: "Submenu Item One" });
@@ -710,9 +706,7 @@ describe("when MenuItem has a submenu", () => {
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
     await user.click(submenuParentItem);
-    await act(async () => {
-      await user.unhover(submenuParentItem);
-    });
+    await user.unhover(submenuParentItem);
     await user.keyboard("{arrowdown}");
     const submenuItem = screen.getByRole("link", { name: "Submenu Item One" });
 
@@ -732,9 +726,7 @@ describe("when MenuItem has a submenu", () => {
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
     await user.click(submenuParentItem);
-    await act(async () => {
-      await user.unhover(submenuParentItem);
-    });
+    await user.unhover(submenuParentItem);
     await user.keyboard("{arrowup}");
     const submenuItem = screen.getByRole("link", { name: "Submenu Item One" });
 
@@ -754,9 +746,7 @@ describe("when MenuItem has a submenu", () => {
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
     await user.click(submenuParentItem);
-    await act(async () => {
-      await user.unhover(submenuParentItem);
-    });
+    await user.unhover(submenuParentItem);
     await user.keyboard("{arrowdown}");
     const submenuItem = screen.getByRole("link", { name: "Submenu Item One" });
 
@@ -776,9 +766,7 @@ describe("when MenuItem has a submenu", () => {
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
     await user.click(submenuParentItem);
-    await act(async () => {
-      await user.unhover(submenuParentItem);
-    });
+    await user.unhover(submenuParentItem);
     await user.keyboard("{arrowleft}");
     const submenuItem = screen.queryByRole("link", {
       name: "Submenu Item One",
@@ -821,9 +809,7 @@ describe("when MenuItem has a submenu", () => {
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
     submenuParentItem.focus();
     await user.keyboard("{arrowdown}");
-    await act(async () => {
-      await user.keyboard("{Escape}");
-    });
+    await user.keyboard("{Escape}");
 
     expect(screen.queryByRole("list")).not.toBeInTheDocument();
     expect(submenuParentItem).toHaveFocus();
@@ -846,9 +832,7 @@ describe("when MenuItem has a submenu", () => {
     submenuParentItem.focus();
     await user.keyboard("{arrowdown}");
     await user.keyboard("{arrowdown}");
-    await act(async () => {
-      await user.keyboard("{Enter}");
-    });
+    await user.keyboard("{Enter}");
 
     expect(screen.getByRole("list")).toBeVisible();
   });
@@ -870,9 +854,7 @@ describe("when MenuItem has a submenu", () => {
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
     submenuParentItem.focus();
     await user.keyboard("{arrowdown}");
-    await act(async () => {
-      await user.keyboard("{Enter}");
-    });
+    await user.keyboard("{Enter}");
 
     expect(screen.queryByRole("list")).not.toBeInTheDocument();
     jest.useRealTimers();

--- a/src/components/menu/menu.test.tsx
+++ b/src/components/menu/menu.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen, render, act } from "@testing-library/react";
+import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { Menu, MenuItem } from ".";
@@ -163,18 +163,15 @@ test("should close any open submenus when a new submenu is opened", async () => 
   );
   const firstSubmenuItem = screen.getByRole("button", { name: "submenu 1" });
   const secondSubmenuItem = screen.getByRole("button", { name: "submenu 2" });
-  await act(async () => {
-    await user.click(firstSubmenuItem);
-  });
+
+  await user.click(firstSubmenuItem);
 
   expect(screen.getByRole("link", { name: "submenu 1 item 1" })).toBeVisible();
   expect(
     screen.queryByRole("link", { name: "submenu 2 item 2" })
   ).not.toBeInTheDocument();
 
-  await act(async () => {
-    await user.click(secondSubmenuItem);
-  });
+  await user.click(secondSubmenuItem);
 
   expect(
     screen.queryByRole("link", { name: "submenu 1 item 1" })
@@ -199,9 +196,9 @@ test("should support menu items unmounting", async () => {
   render(<MockMenu />);
 
   expect(screen.getAllByRole("button").length).toBe(2);
-  await act(async () => {
-    await user.click(screen.getByRole("button", { name: "test element 1" }));
-  });
+
+  await user.click(screen.getByRole("button", { name: "test element 1" }));
+
   expect(screen.getAllByRole("button").length).toBe(1);
 });
 

--- a/src/components/split-button/split-button.test.tsx
+++ b/src/components/split-button/split-button.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { act, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import SplitButton from "./split-button.component";
 import Button from "../button";
@@ -635,9 +635,7 @@ test("should hide the additional buttons when a click event detected outside the
   const childButton = screen.getByRole("button", { name: "Single Button" });
 
   expect(childButton).toBeVisible();
-  await act(async () => {
-    await user.click(document.body);
-  });
+  await user.click(document.body);
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
 });
 
@@ -658,9 +656,7 @@ test("should hide the additional buttons when a 'Escape' keydown event detected 
   });
 
   expect(button1).toBeVisible();
-  await act(async () => {
-    await user.keyboard("{Escape}");
-  });
+  await user.keyboard("{Escape}");
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
 });
 
@@ -679,9 +675,7 @@ test("should hide the additional buttons when a 'Escape' keydown event detected 
   });
 
   expect(button1).toBeVisible();
-  await act(async () => {
-    await user.keyboard("{Escape}");
-  });
+  await user.keyboard("{Escape}");
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
 });
 
@@ -742,9 +736,8 @@ test("should call the relevant 'onClick' callback and hide the additional button
   await user.click(toggle);
   const child = await screen.findByRole("button", { name: "Child Button" });
 
-  await act(async () => {
-    await user.click(child);
-  });
+  await user.click(child);
+
   expect(onClickOnChildMock).toHaveBeenCalled();
   expect(onClickMock).not.toHaveBeenCalled();
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
@@ -767,9 +760,8 @@ test("should hide the additional buttons when the main button is clicked", async
 
   expect(childButton).toBeVisible();
 
-  await act(async () => {
-    await user.click(main);
-  });
+  await user.click(main);
+
   expect(childButton).not.toBeInTheDocument();
 });
 
@@ -919,9 +911,7 @@ test("should support navigating the additional buttons via tab key and hide the 
   expect(button2).toHaveFocus();
   await user.tab();
   expect(button3).toHaveFocus();
-  await act(async () => {
-    await user.tab();
-  });
+  await user.tab();
 
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
 });
@@ -956,9 +946,8 @@ test("should support navigating the additional buttons via shift+tab key, hide t
   expect(button2).toHaveFocus();
   await user.tab({ shift: true });
   expect(button1).toHaveFocus();
-  await act(async () => {
-    await user.tab({ shift: true });
-  });
+  await user.tab({ shift: true });
+
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
   expect(toggle).toHaveFocus();
 });


### PR DESCRIPTION
### Proposed behaviour

In our RTL tests, remove unnecessary `act` calls previously needed before [this fix](https://github.com/Sage/carbon/pull/6814) was released. 

### Current behaviour


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
