### PR TITLE
chore(ci): prevent redundant runs of jest tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
     strategy:
       matrix:
         node: ["18.x", "20.x"]
-        shard: [1, 2, 3, 4]
 
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +30,4 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm ci
       - run: |
-          npm test -- --ci --maxWorkers=4 --shard=${{ matrix.shard }} --colors
-
-        env:
-          CONTAINER: ${{ matrix.shard }}
+          npm test -- --ci --maxWorkers=4 --colors


### PR DESCRIPTION
### Proposed behaviour

- Ensure our Jest test suite is only run once for each node version

### Current behaviour

- All Jest tests are running four times in CI for each node version

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

Our CI doesn't parallelise our Jest tests due to Carbon using Jest v27. [Parallelisation was added in v28](https://jestjs.io/blog/2022/04/25/jest-28#sharding-of-test-run).

### Testing instructions

Verify CI only runs Jest tests once for each node version
