### PR TITLE
feat(link): update styling of skip link variant - FE-6719

### DIFF
--- a/src/components/link/link.pw.tsx
+++ b/src/components/link/link.pw.tsx
@@ -191,11 +191,15 @@ test.describe("check props for Link component", () => {
     await expect(skipLinkElement).toBeVisible();
     await expect(skipLinkElement).toHaveCSS(
       "background-color",
-      "rgb(255, 255, 255)"
+      "rgb(255, 188, 25)"
     );
-    await expect(skipLinkElement).toHaveCSS("font-size", "16px");
+    await expect(skipLinkElement).toHaveCSS("font-size", "14px");
     await expect(skipLinkElement).toHaveCSS("padding-left", "24px");
     await expect(skipLinkElement).toHaveCSS("padding-right", "24px");
+    await expect(skipLinkElement).toHaveCSS(
+      "box-shadow",
+      "rgba(0, 20, 30, 0.1) 0px 10px 30px 0px, rgba(0, 20, 30, 0.1) 0px 30px 60px 0px"
+    );
   });
 
   test("should apply correct focus styling to skip link", async ({
@@ -208,7 +212,13 @@ test.describe("check props for Link component", () => {
     const skipLinkElement = skipLink(page);
     await expect(skipLinkElement).toBeVisible();
     await expect(skipLinkElement).toHaveCSS("top", "8px");
-    await expect(skipLinkElement).toHaveCSS("left", "8px");
+    await expect(skipLinkElement).toHaveCSS("left", "0px");
+    await expect(skipLinkElement).toHaveCSS(
+      "text-decoration",
+      "underline 4px solid rgb(0, 0, 0)"
+    );
+    await expect(skipLinkElement).toHaveCSS("text-decoration-thickness", "4px");
+    await expect(skipLinkElement).toHaveCSS("text-underline-offset", "3px");
   });
 
   ([

--- a/src/components/link/link.style.ts
+++ b/src/components/link/link.style.ts
@@ -94,12 +94,14 @@ const StyledLink = styled.span<StyledLinkProps & PrivateStyledLinkProps>`
           position: absolute;
           padding-left: var(--spacing300);
           padding-right: var(--spacing300);
-          line-height: 36px;
+          line-height: var(--sizing600);
           left: -999em;
           z-index: ${theme.zIndex.aboveAll};
-          box-shadow: inset 0 0 0 var(--spacing025) var(--colorsActionMajor500);
-          border: var(--spacing025) solid var(--colorsUtilityYang100);
-          font-size: var(--fontSizes200);
+          border: 3px solid var(--colorsUtilityYin100);
+          box-shadow: var(--boxShadow300);
+          border-radius: var(--spacing000) var(--spacing100) var(--spacing100)
+            var(--spacing000);
+          font-size: var(--fontSizes100);
           color: var(--colorsUtilityYin090);
 
           &:hover {
@@ -112,13 +114,20 @@ const StyledLink = styled.span<StyledLinkProps & PrivateStyledLinkProps>`
           }
 
           &:focus {
-            background-color: var(--colorsUtilityYang100);
+            background-color: var(--colorsSemanticFocus500);
+            text-decoration: underline var(--colorsUtilityYin100);
+            text-decoration-thickness: 4px;
+            text-underline-offset: 3px;
+
+            -webkit-text-decoration: underline var(--colorsUtilityYin100);
+            -webkit-text-decoration-thickness: 4px;
+            -webkit-text-underline-offset: 3px;
           }
         }
 
         a:focus {
           top: var(--spacing100);
-          left: var(--spacing100);
+          left: 0;
         }
       `}
 

--- a/src/components/link/link.test.tsx
+++ b/src/components/link/link.test.tsx
@@ -6,41 +6,15 @@ import userEvent from "@testing-library/user-event";
 
 import Link from "./link.component";
 import MenuContext from "../menu/__internal__/menu.context";
-import { baseTheme } from "../../style/themes";
 
-describe("If `isSkipLink` provided", () => {
-  it("should render `Skip to main content` text inside of Link", () => {
-    render(
-      <Link href="#test" isSkipLink>
-        Test Content
-      </Link>
-    );
+test("should render `Skip to main content` text inside of Link when `isSkipLink` prop is provided", () => {
+  render(
+    <Link href="#test" isSkipLink>
+      Test Content
+    </Link>
+  );
 
-    expect(screen.getByText("Skip to main content")).toBeInTheDocument();
-  });
-
-  it("should render correct styling", () => {
-    render(
-      <Link href="#test" isSkipLink>
-        Test Content
-      </Link>
-    );
-
-    const linkElement = screen.getByTestId("link-anchor");
-
-    expect(linkElement).toHaveStyle({
-      position: "absolute",
-      paddingLeft: "var(--spacing300)",
-      paddingRight: "var(--spacing300)",
-      lineHeight: "36px",
-      fontSize: "var(--fontSizes200)",
-      left: "-999em",
-      color: "var(--colorsUtilityYin090)",
-      zIndex: `${baseTheme.zIndex.aboveAll}`,
-      boxShadow: "inset 0 0 0 var(--spacing025) var(--colorsActionMajor500)",
-      border: "var(--spacing025) solid var(--colorsUtilityYang100)",
-    });
-  });
+  expect(screen.getByText("Skip to main content")).toBeInTheDocument();
 });
 
 test("should not call the onClick function when `disabled` prop is true and clicked", async () => {


### PR DESCRIPTION
### Proposed behaviour

![Screenshot 2024-08-13 at 10 48 38](https://github.com/user-attachments/assets/10e60645-3a45-4ac8-a32f-b3e9b78adf11)

### Current behaviour

![Screenshot 2024-08-07 at 16 08 20](https://github.com/user-attachments/assets/8051b38c-d06e-4026-bf18-82082c0c25e9)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

I have removed the styling tests in RTL for the skip link variant. The tests used `toHaveStyle` assertion with token values and we have come to learn these tests don't really work as they always pass. These styles are better tested in Playwright, which we already had. 

### Testing instructions

- SkipLink should match the designs provided on the ticket.
- There should not be any other styling regressions with Link.