### PR TITLE
refactor(date, date-range, numeral-date): mock Tooltip due to latency issues in floating-ui

### DIFF
--- a/src/__internal__/validations/validation-icon.component.tsx
+++ b/src/__internal__/validations/validation-icon.component.tsx
@@ -129,6 +129,7 @@ export const ValidationIcon = ({
         if (onBlur) onBlur(e);
       }}
       isPartOfInput={isPartOfInput}
+      data-role={`validation-icon-${validationType}`}
       {...filterStyledSystemMarginProps(rest)}
     >
       <Icon

--- a/src/components/date-range/date-range.test.tsx
+++ b/src/components/date-range/date-range.test.tsx
@@ -5,6 +5,13 @@ import userEvent from "@testing-library/user-event";
 import DateRange, { DateRangeChangeEvent } from "./date-range.component";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
 import CarbonProvider from "../carbon-provider";
+import Tooltip from "../tooltip";
+
+jest.mock("../tooltip", () => {
+  return jest.fn(() => null);
+});
+
+const TooltipMock = Tooltip as jest.MockedFunction<typeof Tooltip>;
 
 testStyledSystemMargin((props) => (
   <DateRange
@@ -976,13 +983,16 @@ test("should only display the start input tooltip when the user hovers over it a
 
   const start = screen.getByRole("textbox", { name: "start" });
   await user.hover(start);
-  const startTooltip = await screen.findByRole("tooltip", {
-    name: "start error",
-  });
-  const endTooltip = screen.queryByRole("tooltip", { name: "end error" });
 
-  expect(startTooltip).toBeVisible();
-  expect(endTooltip).not.toBeInTheDocument();
+  expect(Tooltip).toHaveBeenCalledWith(
+    expect.objectContaining({ isVisible: true, message: "start error" }),
+    {}
+  );
+  expect(Tooltip).toHaveBeenCalledWith(
+    expect.objectContaining({ isVisible: false, message: "end error" }),
+    {}
+  );
+  TooltipMock.mockClear();
 });
 
 test("should only display the end input tooltip when the user hovers over it and both inputs have error strings passed with `validationRedesignOptIn` not set", async () => {
@@ -1002,11 +1012,16 @@ test("should only display the end input tooltip when the user hovers over it and
 
   const end = screen.getByRole("textbox", { name: "end" });
   await user.hover(end);
-  const tooltips = screen.getAllByRole("tooltip");
 
-  expect(tooltips).toHaveLength(1);
-  expect(tooltips[0]).toBeVisible();
-  expect(tooltips[0]).toHaveTextContent("end error");
+  expect(Tooltip).toHaveBeenCalledWith(
+    expect.objectContaining({ isVisible: false, message: "start error" }),
+    {}
+  );
+  expect(Tooltip).toHaveBeenCalledWith(
+    expect.objectContaining({ isVisible: true, message: "end error" }),
+    {}
+  );
+  TooltipMock.mockClear();
 });
 
 test("should display the error message for both inputs when strings are passed to the error props and `validationRedesignOptIn` is set", () => {

--- a/src/components/date/date.test.tsx
+++ b/src/components/date/date.test.tsx
@@ -16,6 +16,13 @@ import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-
 
 import DateInput, { DateChangeEvent } from "./date.component";
 import I18nProvider from "../i18n-provider";
+import Tooltip from "../tooltip";
+
+jest.mock("../tooltip", () => {
+  return jest.fn(() => null);
+});
+
+const TooltipMock = Tooltip as jest.MockedFunction<typeof Tooltip>;
 
 const ariaLabels = {
   nextMonthButton: () => "foo",
@@ -595,7 +602,11 @@ test("should render the help icon when the `labelHelp` prop is passed and displa
   const helpIcon = screen.getByRole("button", { name: "help" });
   await user.hover(helpIcon);
 
-  expect(screen.getByRole("tooltip")).toHaveTextContent("help text");
+  expect(Tooltip).toHaveBeenCalledWith(
+    expect.objectContaining({ isVisible: true, message: "help text" }),
+    {}
+  );
+  TooltipMock.mockClear();
 });
 
 test("should render the input with the expected required attribute when the `required` prop is true", () => {
@@ -1208,12 +1219,16 @@ describe("when the `validationRedesignOptIn` prop is falsy", () => {
       </CarbonProvider>
     );
     const input = screen.getByRole("textbox");
-    const icon = screen.getByTestId("icon-error");
+    const icon = screen.getByTestId("validation-icon-error");
     await user.hover(input);
 
     expect(input).toHaveAttribute("aria-invalid", "true");
     expect(icon).toBeInTheDocument();
-    expect(screen.getByRole("tooltip")).toHaveTextContent("error message");
+    expect(Tooltip).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true, message: "error message" }),
+      {}
+    );
+    TooltipMock.mockClear();
   });
 
   test("should render tooltip and validation icon when `validationOnLabel` is set and `error` is passed a string value and the user hovers the mouse over the input", async () => {
@@ -1232,7 +1247,11 @@ describe("when the `validationRedesignOptIn` prop is falsy", () => {
     const input = screen.getByRole("textbox");
     await user.hover(input);
 
-    expect(screen.getByRole("tooltip")).toHaveTextContent("error message");
+    expect(Tooltip).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true, message: "error message" }),
+      {}
+    );
+    TooltipMock.mockClear();
   });
 
   test("should render tooltip and validation icon when `validationOnLabel` is set and `error` is passed a string value and the user hovers the mouse over the label", async () => {
@@ -1251,7 +1270,11 @@ describe("when the `validationRedesignOptIn` prop is falsy", () => {
     const label = screen.getByText("label");
     await user.hover(label);
 
-    expect(screen.getByRole("tooltip")).toHaveTextContent("error message");
+    expect(Tooltip).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true, message: "error message" }),
+      {}
+    );
+    TooltipMock.mockClear();
   });
 
   test("should not render tooltip or validation icon when `error` is passed a boolean value", async () => {
@@ -1265,7 +1288,9 @@ describe("when the `validationRedesignOptIn` prop is falsy", () => {
     await user.hover(input);
 
     expect(input).toHaveAttribute("aria-invalid", "true");
-    expect(screen.queryByTestId("icon-error")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("validation-icon-error")
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 
@@ -1282,12 +1307,16 @@ describe("when the `validationRedesignOptIn` prop is falsy", () => {
       </CarbonProvider>
     );
     const input = screen.getByRole("textbox");
-    const icon = screen.getByTestId("icon-warning");
+    const icon = screen.getByTestId("validation-icon-warning");
     await user.hover(input);
 
     expect(input).toHaveAttribute("aria-invalid", "false");
     expect(icon).toBeInTheDocument();
-    expect(screen.getByRole("tooltip")).toHaveTextContent("warning message");
+    expect(Tooltip).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true, message: "warning message" }),
+      {}
+    );
+    TooltipMock.mockClear();
   });
 
   test("should not render tooltip or validation icon when `warning` is passed a boolean value", async () => {
@@ -1301,7 +1330,9 @@ describe("when the `validationRedesignOptIn` prop is falsy", () => {
     await user.hover(input);
 
     expect(input).toHaveAttribute("aria-invalid", "false");
-    expect(screen.queryByTestId("icon-warning")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("validation-icon-warning")
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 
@@ -1318,12 +1349,16 @@ describe("when the `validationRedesignOptIn` prop is falsy", () => {
       </CarbonProvider>
     );
     const input = screen.getByRole("textbox");
-    const icon = screen.getByTestId("icon-info");
+    const icon = screen.getByTestId("validation-icon-info");
     await user.hover(input);
 
     expect(input).toHaveAttribute("aria-invalid", "false");
     expect(icon).toBeInTheDocument();
-    expect(screen.getByRole("tooltip")).toHaveTextContent("info message");
+    expect(Tooltip).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true, message: "info message" }),
+      {}
+    );
+    TooltipMock.mockClear();
   });
 
   test("should not render tooltip or validation icon when `info` is passed a boolean value", async () => {
@@ -1337,7 +1372,9 @@ describe("when the `validationRedesignOptIn` prop is falsy", () => {
     await user.hover(input);
 
     expect(input).toHaveAttribute("aria-invalid", "false");
-    expect(screen.queryByTestId("icon-info")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("validation-icon-info")
+    ).not.toBeInTheDocument();
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 });

--- a/src/components/numeral-date/numeral-date.test.tsx
+++ b/src/components/numeral-date/numeral-date.test.tsx
@@ -7,6 +7,13 @@ import NumeralDate from "./numeral-date.component";
 import FormFieldStyle from "../../__internal__/form-field/form-field.style";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 import Logger from "../../__internal__/utils/logger";
+import Tooltip from "../tooltip";
+
+jest.mock("../tooltip", () => {
+  return jest.fn(() => null);
+});
+
+const TooltipMock = Tooltip as jest.MockedFunction<typeof Tooltip>;
 
 jest.mock("../../__internal__/utils/logger");
 
@@ -131,10 +138,14 @@ describe("when the `error` prop is passed a string value and `validationRedesign
     const dayInput = screen.getByRole("textbox", { name: "Day" });
     await user.hover(dayInput);
 
-    expect(await screen.findByRole("tooltip", { name: "error" })).toBeVisible();
+    expect(Tooltip).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true, message: "error" }),
+      {}
+    );
 
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
+    TooltipMock.mockClear();
   });
 
   it("should display the tooltip when the user hovers on the 'Month' input", async () => {
@@ -153,10 +164,14 @@ describe("when the `error` prop is passed a string value and `validationRedesign
     const monthInput = screen.getByRole("textbox", { name: "Month" });
     await user.hover(monthInput);
 
-    expect(await screen.findByRole("tooltip", { name: "error" })).toBeVisible();
+    expect(Tooltip).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true, message: "error" }),
+      {}
+    );
 
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
+    TooltipMock.mockClear();
   });
 
   it("should display the tooltip when the user hovers on the 'Year' input", async () => {
@@ -175,10 +190,14 @@ describe("when the `error` prop is passed a string value and `validationRedesign
     const yearInput = screen.getByRole("textbox", { name: "Year" });
     await user.hover(yearInput);
 
-    expect(await screen.findByRole("tooltip", { name: "error" })).toBeVisible();
+    expect(Tooltip).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true, message: "error" }),
+      {}
+    );
 
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
+    TooltipMock.mockClear();
   });
 });
 
@@ -307,12 +326,14 @@ describe("when the `warning` prop is passed a string value and `validationRedesi
     const dayInput = screen.getByRole("textbox", { name: "Day" });
     await user.hover(dayInput);
 
-    expect(
-      await screen.findByRole("tooltip", { name: "warning" })
-    ).toBeVisible();
+    expect(Tooltip).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true, message: "warning" }),
+      {}
+    );
 
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
+    TooltipMock.mockClear();
   });
 
   it("should display the tooltip when the user hovers on the 'Month' input", async () => {
@@ -331,12 +352,14 @@ describe("when the `warning` prop is passed a string value and `validationRedesi
     const monthInput = screen.getByRole("textbox", { name: "Month" });
     await user.hover(monthInput);
 
-    expect(
-      await screen.findByRole("tooltip", { name: "warning" })
-    ).toBeVisible();
+    expect(Tooltip).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true, message: "warning" }),
+      {}
+    );
 
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
+    TooltipMock.mockClear();
   });
 
   it("should display the tooltip when the user hovers on the 'Year' input", async () => {
@@ -355,12 +378,14 @@ describe("when the `warning` prop is passed a string value and `validationRedesi
     const yearInput = screen.getByRole("textbox", { name: "Year" });
     await user.hover(yearInput);
 
-    expect(
-      await screen.findByRole("tooltip", { name: "warning" })
-    ).toBeVisible();
+    expect(Tooltip).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true, message: "warning" }),
+      {}
+    );
 
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
+    TooltipMock.mockClear();
   });
 });
 
@@ -477,10 +502,14 @@ describe("when the `info` prop is passed a string value and `validationRedesignO
     const dayInput = screen.getByRole("textbox", { name: "Day" });
     await user.hover(dayInput);
 
-    expect(await screen.findByRole("tooltip", { name: "info" })).toBeVisible();
+    expect(Tooltip).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true, message: "info" }),
+      {}
+    );
 
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
+    TooltipMock.mockClear();
   });
 
   it("should display the tooltip when the user hovers on the 'Month' input", async () => {
@@ -499,10 +528,14 @@ describe("when the `info` prop is passed a string value and `validationRedesignO
     const monthInput = screen.getByRole("textbox", { name: "Month" });
     await user.hover(monthInput);
 
-    expect(await screen.findByRole("tooltip", { name: "info" })).toBeVisible();
+    expect(Tooltip).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true, message: "info" }),
+      {}
+    );
 
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
+    TooltipMock.mockClear();
   });
 
   it("should display the tooltip when the user hovers on the 'Year' input", async () => {
@@ -521,10 +554,14 @@ describe("when the `info` prop is passed a string value and `validationRedesignO
     const yearInput = screen.getByRole("textbox", { name: "Year" });
     await user.hover(yearInput);
 
-    expect(await screen.findByRole("tooltip", { name: "info" })).toBeVisible();
+    expect(Tooltip).toHaveBeenCalledWith(
+      expect.objectContaining({ isVisible: true, message: "info" }),
+      {}
+    );
 
     jest.runOnlyPendingTimers();
     jest.useRealTimers();
+    TooltipMock.mockClear();
   });
 });
 
@@ -726,12 +763,14 @@ test("should render the help icon and tooltip when `labelHelp` prop is set and `
   const labelHelp = screen.getByRole("button", { name: "help" });
   await user.hover(labelHelp);
 
-  expect(
-    await screen.findByRole("tooltip", { name: "labelHelp" })
-  ).toBeVisible();
+  expect(Tooltip).toHaveBeenCalledWith(
+    expect.objectContaining({ isVisible: true, message: "labelHelp" }),
+    {}
+  );
 
   jest.runOnlyPendingTimers();
   jest.useRealTimers();
+  TooltipMock.mockClear();
 });
 
 describe("when the `enableInternalError` prop is not set and `validationRedesignOptIn` is true", () => {


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Mocks tooltip visible tests in Date, DateRange and NumeralDate 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Tooltip visible tests not mocked

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Unit tests added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
