### PR TITLE
feat(loader-star): create new loader-star component - FE-6752

### DIFF
--- a/playwright/components/loader-star/index.ts
+++ b/playwright/components/loader-star/index.ts
@@ -1,0 +1,19 @@
+import { Page } from "@playwright/test";
+import {
+  LOADER_STAR_HIDDEN_LABEL,
+  LOADER_STAR_SVG,
+  LOADER_STAR_VISIBLE_LABEL,
+  LOADER_STAR_WRAPPER,
+} from "./locators";
+
+// component preview locators
+export const loaderStarWrapper = (page: Page) =>
+  page.locator(LOADER_STAR_WRAPPER);
+
+export const loaderStarSvg = (page: Page) => page.locator(LOADER_STAR_SVG);
+
+export const loaderStarHiddenLabel = (page: Page) =>
+  page.locator(LOADER_STAR_HIDDEN_LABEL);
+
+export const loaderStarVisibleLabel = (page: Page) =>
+  page.locator(LOADER_STAR_VISIBLE_LABEL);

--- a/playwright/components/loader-star/locators.ts
+++ b/playwright/components/loader-star/locators.ts
@@ -1,0 +1,4 @@
+export const LOADER_STAR_WRAPPER = '[data-component="loader-star"]';
+export const LOADER_STAR_SVG = '[data-component="star"]';
+export const LOADER_STAR_VISIBLE_LABEL = '[data-role="visible-label"]';
+export const LOADER_STAR_HIDDEN_LABEL = '[data-role="hidden-label"]';

--- a/src/components/loader-star/components.test-pw.tsx
+++ b/src/components/loader-star/components.test-pw.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import LoaderStar, { LoaderStarProps } from "./loader-star.component";
+
+const DefaultLoaderStar = (props: LoaderStarProps) => {
+  return <LoaderStar {...props} />;
+};
+
+export default DefaultLoaderStar;

--- a/src/components/loader-star/index.ts
+++ b/src/components/loader-star/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./loader-star.component";
+export type { LoaderStarProps } from "./loader-star.component";

--- a/src/components/loader-star/internal/star.component.tsx
+++ b/src/components/loader-star/internal/star.component.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+
+import {
+  GradientStopBottom,
+  GradientStopTop,
+  StyledLoaderStarContainer,
+  StyledStarSVG,
+} from "./star.style";
+
+interface StarProps {
+  starContainerClassName: "star-1" | "star-2" | "star-3";
+  gradientId: "gradient1" | "gradient2" | "gradient3";
+}
+
+const Star = ({
+  starContainerClassName,
+  gradientId,
+}: StarProps): JSX.Element => {
+  return (
+    <StyledLoaderStarContainer
+      data-component="star"
+      role="presentation"
+      className={starContainerClassName}
+    >
+      <StyledStarSVG
+        className="ai-star-svg"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 217 216"
+      >
+        <path
+          className="ai-star-path"
+          fill="#000"
+          fillRule="evenodd"
+          d="M108.502 215.994c-.166.006-.334.006-.502.006-7.218 0-11.975-3.217-15.497-8.335-4.396-5.656-7.56-13.591-10.338-21.896l-.597-1.807-.667-2.063-.91-2.87-1.225-3.904c-1.831-5.82-3.65-11.42-5.751-16.135-1.456-2.661-3.075-5.078-4.921-7.146-.356-.391-.72-.777-1.094-1.156-4.054-4.038-9.808-7.093-16.262-9.726-14.49-4.937-33.33-8.698-43.486-17.634C2.766 119.712 0 114.918 0 108l.003-.413c.108-6.697 2.852-11.372 7.25-14.916 10.155-8.935 28.995-12.696 43.485-17.633C57.192 72.405 62.946 69.35 67 65.312c.373-.38.738-.765 1.094-1.156 1.846-2.068 3.465-4.485 4.922-7.145 2.567-5.764 4.713-12.849 6.976-20.04l.91-2.87.666-2.063.338-1.028c2.84-8.586 6.063-16.843 10.598-22.675C95.954 3.32 100.592.13 107.57.004L108 0c.168 0 .336 0 .502.006L109 0l.405.003c6.999.119 11.645 3.316 15.102 8.347 5.071 6.529 8.5 16.09 11.592 25.75l.335 1.054 2.362 7.501c1.645 5.178 3.304 10.125 5.19 14.358 1.456 2.66 3.074 5.075 4.92 7.142.356.392.72.778 1.094 1.157 4.054 4.038 9.808 7.093 16.262 9.726 14.49 4.937 33.33 8.698 43.486 17.634C214.234 96.288 217 101.082 217 108c0 6.918-2.766 11.712-7.252 15.328-10.156 8.936-28.996 12.697-43.486 17.634-6.454 2.633-12.208 5.688-16.262 9.726-.373.38-.738.765-1.094 1.157-1.846 2.067-3.464 4.482-4.92 7.142-1.886 4.233-3.545 9.18-5.19 14.358l-2.362 7.5-.335 1.054c-3.091 9.66-6.521 19.222-11.592 25.751-3.524 5.127-8.282 8.35-15.507 8.35l-.498-.006Z"
+        />
+        <defs>
+          <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="100%">
+            <GradientStopTop offset="0%" />
+            <GradientStopBottom offset="100%" />
+          </linearGradient>
+        </defs>
+      </StyledStarSVG>
+    </StyledLoaderStarContainer>
+  );
+};
+
+Star.displayName = "Star";
+export default Star;

--- a/src/components/loader-star/internal/star.style.ts
+++ b/src/components/loader-star/internal/star.style.ts
@@ -1,0 +1,134 @@
+import styled, { keyframes } from "styled-components";
+
+const animateStar = keyframes`
+  0% {
+    transform: translate3d(0px, 0px, 0px) scale(0.3);
+    opacity: 0;
+  }
+  10% {
+    transform: translate3d(0px, 0px, 0px) scale(0.3);
+    opacity: 0;
+  }
+  20% {
+    transform: translate3d(0px, 0px, 0px) scale(0.6);
+    opacity: 1;
+  }
+  35% {
+    transform: translate3d(0px, 0px, 0px) scale(0.6);
+    opacity: 1;
+  }
+  55% {
+    transform: translate3d(16px, -12px, 0px) scale(1.4);
+    opacity: 1;
+  }
+  60% {
+    transform: translate3d(16px, -12px, 0px) scale(1.4);
+    opacity: 1;
+  }
+  90% {
+    transform: translate3d(0px, -24px, 0px) scale(0.8);
+    opacity: 1;
+  }
+  100% {
+    transform: translate3d(0px, -24px, 0px) scale(0.6);
+    opacity: 0;
+  }
+`;
+
+const animateStopTop = keyframes`
+  0% { stop-color: #13a038; }
+  10% { stop-color: #13a038; }
+  50% { stop-color: #0092db; }
+  90% { stop-color: #8f49fe; }
+  100% { stop-color: #8f49fe; }
+`;
+
+const animateStopBottom = keyframes`
+  0% { stop-color: #13a038; }
+  10% { stop-color: #13a038; }
+  50% { stop-color: #13a038; }
+  90% { stop-color: #0092db; }
+  100% { stop-color: #0092db; }
+`;
+
+const time = "3s";
+
+export const StyledStarSVG = styled.svg`
+  animation: ${animateStar} ${time} ease-in-out forwards infinite;
+  height: var(--sizing200);
+  opacity: 0;
+  width: var(--sizing200);
+`;
+
+export const GradientStopTop = styled.stop`
+  animation: ${animateStopTop} ${time} ease-in-out forwards infinite;
+`;
+
+export const GradientStopBottom = styled.stop`
+  animation: ${animateStopBottom} ${time} ease-in-out forwards infinite;
+`;
+
+export const StyledLoaderStarContainer = styled.div`
+  bottom: 0;
+  height: var(--sizing200);
+  left: 0;
+  position: absolute;
+  width: var(--sizing200);
+
+  &.star-1 {
+    .ai-star-path {
+      fill: url(#gradient1);
+    }
+
+    ${StyledStarSVG} {
+      animation-delay: -2s;
+    }
+
+    #gradient1 {
+      ${GradientStopTop} {
+        animation-delay: -2s;
+      }
+      ${GradientStopBottom} {
+        animation-delay: -2s;
+      }
+    }
+  }
+
+  &.star-2 {
+    .ai-star-path {
+      fill: url(#gradient2);
+    }
+
+    ${StyledStarSVG} {
+      animation-delay: -1s;
+    }
+
+    #gradient2 {
+      ${GradientStopTop} {
+        animation-delay: -1s;
+      }
+      ${GradientStopBottom} {
+        animation-delay: -1s;
+      }
+    }
+  }
+
+  &.star-3 {
+    .ai-star-path {
+      fill: url(#gradient3);
+    }
+
+    ${StyledStarSVG} {
+      animation-delay: 0s;
+    }
+
+    #gradient3 {
+      ${GradientStopTop} {
+        animation-delay: 0s;
+      }
+      ${GradientStopBottom} {
+        animation-delay: 0s;
+      }
+    }
+  }
+`;

--- a/src/components/loader-star/loader-star-test.stories.tsx
+++ b/src/components/loader-star/loader-star-test.stories.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import Box from "../box";
+import LoaderStar, { LoaderStarProps } from ".";
+
+export default {
+  title: "Loader Star/Test",
+  includeStories: ["Default"],
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disableSnapshot: true,
+    },
+  },
+  argTypes: {
+    loaderStarLabel: {
+      control: {
+        type: "text",
+      },
+    },
+  },
+};
+
+export const Default = (props: Partial<LoaderStarProps>) => (
+  <Box m={3} width="100%" height="200px">
+    <LoaderStar {...props} />
+  </Box>
+);
+
+Default.storyName = "default";

--- a/src/components/loader-star/loader-star.component.tsx
+++ b/src/components/loader-star/loader-star.component.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import tagComponent, {
+  TagProps,
+} from "../../__internal__/utils/helpers/tags/tags";
+import {
+  StyledLoaderStarWrapper,
+  StyledLabel,
+  StyledStars,
+} from "./loader-star.style";
+import useLocale from "../../hooks/__internal__/useLocale";
+import useMediaQuery from "../../hooks/useMediaQuery";
+import Star from "./internal/star.component";
+import Typography from "../typography";
+
+export interface LoaderStarProps extends Omit<TagProps, "data-component"> {
+  /**
+   * The loaderStarLabel prop allows a specific label to be set.
+   * This label will be present if the user has `reduce-motion` enabled and will also be available to assistive technologies.
+   * By default the label will be `Loading...`.
+   */
+  loaderStarLabel?: string;
+}
+const LoaderStar = ({
+  loaderStarLabel,
+  ...rest
+}: LoaderStarProps): JSX.Element => {
+  const locale = useLocale();
+
+  const reduceMotion = !useMediaQuery(
+    "screen and (prefers-reduced-motion: no-preference)"
+  );
+
+  const label = (
+    <StyledLabel data-role="visible-label" variant="span" fontWeight="500">
+      {loaderStarLabel || locale.loaderStar.loading()}
+    </StyledLabel>
+  );
+
+  return (
+    <StyledLoaderStarWrapper
+      role="status"
+      {...tagComponent("loader-star", rest)}
+    >
+      {reduceMotion ? (
+        label
+      ) : (
+        <>
+          <StyledStars>
+            <Star starContainerClassName="star-1" gradientId="gradient1" />
+            <Star starContainerClassName="star-2" gradientId="gradient2" />
+            <Star starContainerClassName="star-3" gradientId="gradient3" />
+          </StyledStars>
+          <Typography data-role="hidden-label" variant="span" screenReaderOnly>
+            {loaderStarLabel || locale.loaderStar.loading()}
+          </Typography>
+        </>
+      )}
+    </StyledLoaderStarWrapper>
+  );
+};
+
+LoaderStar.displayName = "LoaderStar";
+export default LoaderStar;

--- a/src/components/loader-star/loader-star.mdx
+++ b/src/components/loader-star/loader-star.mdx
@@ -1,0 +1,56 @@
+import { Meta, ArgTypes, Canvas } from "@storybook/blocks";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
+
+import * as LoaderStarStories from "./loader-star.stories";
+
+<Meta of={LoaderStarStories} />
+
+# Loader Star
+
+Use the Loader Star component to let users know a task or loading data is still in progress.
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+- [Translation keys](#translation-keys)
+
+## Quick Start
+
+Import `LoaderStar` into the project.
+
+```javascript
+import LoaderStar from "carbon-react/lib/components/loader-star";
+```
+
+## Examples
+
+### Default
+
+This example of the Loader Star component demonstrates how it will appear as default.
+
+<Canvas of={LoaderStarStories.Default} />
+
+## Props
+
+### Loader Star
+
+<ArgTypes of={LoaderStarStories} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object
+to the [i18nProvider](../?path=/docs/documentation-i18n--docs).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "loaderStar.loading",
+      description:
+        "An accessible name for `LoaderStar`. This will also be used as alternative text to replace the loading animation - if the user requests for minimal motion-based animation (via their OS accessibility settings).",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
+/>

--- a/src/components/loader-star/loader-star.pw.tsx
+++ b/src/components/loader-star/loader-star.pw.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { test, expect } from "@playwright/experimental-ct-react17";
+import DefaultLoaderStar from "./components.test-pw";
+import {
+  loaderStarHiddenLabel,
+  loaderStarVisibleLabel,
+  loaderStarWrapper,
+} from "../../../playwright/components/loader-star/index";
+import { checkAccessibility } from "../../../playwright/support/helper";
+
+test.describe("User prefers reduced motion", () => {
+  test("when the 'LoaderStarLabel' prop is passed a custom string value it overrides the default visible label", async ({
+    mount,
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await mount(<DefaultLoaderStar loaderStarLabel="foo" />);
+
+    await expect(loaderStarVisibleLabel(page)).toHaveText("foo");
+  });
+
+  test("the expected styles are applied to the default visible label", async ({
+    mount,
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await mount(<DefaultLoaderStar />);
+
+    await expect(loaderStarVisibleLabel(page)).toHaveText("Loading...");
+    await expect(loaderStarVisibleLabel(page)).toHaveCSS("font-weight", "500");
+    await expect(loaderStarVisibleLabel(page)).toHaveCSS("display", "flex");
+    await expect(loaderStarVisibleLabel(page)).toHaveCSS(
+      "justify-content",
+      "center"
+    );
+  });
+});
+
+test.describe("User does not prefer reduced motion", () => {
+  test("when the 'LoaderStarLabel' prop is passed a custom string value it overrides the default hidden label", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<DefaultLoaderStar loaderStarLabel="bar" />);
+
+    await expect(loaderStarHiddenLabel(page)).toHaveText("bar");
+  });
+
+  test("the expected styles are applied to the component", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<DefaultLoaderStar />);
+
+    await expect(loaderStarWrapper(page)).toHaveCSS("height", "40px");
+    await expect(loaderStarWrapper(page)).toHaveCSS("width", "40px");
+    await expect(loaderStarWrapper(page)).toHaveCSS("position", "relative");
+  });
+});
+
+test.describe("Accessibility tests", () => {
+  test("should pass accessibility checks when component is rendered in its default state", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<DefaultLoaderStar />);
+
+    await checkAccessibility(page);
+  });
+
+  test("should pass accessibility checks when component is rendered and user prefers reduced motion", async ({
+    mount,
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await mount(<DefaultLoaderStar />);
+
+    await checkAccessibility(page);
+  });
+});

--- a/src/components/loader-star/loader-star.stories.tsx
+++ b/src/components/loader-star/loader-star.stories.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import LoaderStar from "./loader-star.component";
+
+const meta: Meta<typeof LoaderStar> = {
+  title: "Loader Star",
+  component: LoaderStar,
+  argTypes: {},
+  parameters: { chromatic: { disableSnapshot: true } },
+};
+
+export default meta;
+type Story = StoryObj<typeof LoaderStar>;
+
+export const Default: Story = () => {
+  return <LoaderStar />;
+};
+Default.storyName = "Default";

--- a/src/components/loader-star/loader-star.style.ts
+++ b/src/components/loader-star/loader-star.style.ts
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+import Typography from "../typography";
+import { LoaderStarProps } from "./loader-star.component";
+
+export const StyledLoaderStarWrapper = styled.div<LoaderStarProps>`
+  position: relative;
+  width: max-content;
+`;
+
+export const StyledLabel = styled(Typography)`
+  display: flex;
+  justify-content: center;
+  text-align: center;
+`;
+
+export const StyledStars = styled.div`
+  width: 40px;
+  height: 40px;
+`;

--- a/src/components/loader-star/loader-star.test.tsx
+++ b/src/components/loader-star/loader-star.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import LoaderStar from ".";
+import useMediaQuery from "../../hooks/useMediaQuery";
+
+jest.mock("../../hooks/useMediaQuery", () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnValue(true),
+}));
+
+test("should render with the expected data- attributes", () => {
+  render(<LoaderStar data-element="fish" data-role="chips" />);
+
+  const LoaderStarComponent = screen.getByRole("status");
+
+  expect(LoaderStarComponent).toHaveAttribute("data-element", "fish");
+  expect(LoaderStarComponent).toHaveAttribute("data-role", "chips");
+});
+
+test("component should have a visually hidden label for assistive technologies by default", () => {
+  render(<LoaderStar />);
+
+  const hiddenLabelElement = screen.getByTestId("hidden-label");
+
+  expect(hiddenLabelElement).toHaveTextContent("Loading...");
+});
+
+test("renders a custom visually hidden label for assistive technologies to use, when loaderStarLabel prop is provided", () => {
+  render(<LoaderStar loaderStarLabel="Responding..." />);
+
+  const hiddenLabelElement = screen.getByTestId("hidden-label");
+
+  expect(hiddenLabelElement).toHaveTextContent("Responding...");
+});
+
+describe("when the component is rendered and the user prefers reduced motion", () => {
+  it("should render the the LoaderStar label", () => {
+    const mockUseMediaQuery = useMediaQuery as jest.MockedFunction<
+      typeof useMediaQuery
+    >;
+    mockUseMediaQuery.mockReturnValueOnce(false);
+
+    render(<LoaderStar />);
+
+    const wrapperElement = screen.getByRole("status");
+    const visibleLabelElement = screen.getByTestId("visible-label");
+
+    expect(wrapperElement).toHaveTextContent("Loading...");
+    expect(visibleLabelElement).toBeVisible();
+  });
+
+  it("should not render the svg stars", () => {
+    const mockUseMediaQuery = useMediaQuery as jest.MockedFunction<
+      typeof useMediaQuery
+    >;
+    mockUseMediaQuery.mockReturnValueOnce(false);
+
+    render(<LoaderStar />);
+
+    const svgStarElement = screen.queryByRole("presentation");
+
+    expect(svgStarElement).not.toBeInTheDocument();
+  });
+});

--- a/src/locales/de-de.ts
+++ b/src/locales/de-de.ts
@@ -98,6 +98,9 @@ const deDE: Partial<Locale> = {
   loaderSpinner: {
     loading: () => "Laden...",
   },
+  loaderStar: {
+    loading: () => "Laden...",
+  },
   menuFullscreen: {
     ariaLabels: { closeButton: () => "Schließen" },
   },

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -107,6 +107,9 @@ const enGB: Locale = {
   loaderSpinner: {
     loading: () => "Loading...",
   },
+  loaderStar: {
+    loading: () => "Loading...",
+  },
   menuFullscreen: {
     ariaLabels: { closeButton: () => "Close" },
   },

--- a/src/locales/es-es.ts
+++ b/src/locales/es-es.ts
@@ -105,6 +105,9 @@ const esES: Partial<Locale> = {
   loaderSpinner: {
     loading: () => "Cargando...",
   },
+  loaderStar: {
+    loading: () => "Cargando...",
+  },
   menuFullscreen: {
     ariaLabels: { closeButton: () => "Cerrar" },
   },

--- a/src/locales/fr-ca.ts
+++ b/src/locales/fr-ca.ts
@@ -107,6 +107,9 @@ const frCA: Partial<Locale> = {
   loaderSpinner: {
     loading: () => "Chargement...",
   },
+  loaderStar: {
+    loading: () => "Chargement...",
+  },
   menuFullscreen: {
     ariaLabels: { closeButton: () => "Fermer" },
   },

--- a/src/locales/fr-fr.ts
+++ b/src/locales/fr-fr.ts
@@ -107,6 +107,9 @@ const frFR: Partial<Locale> = {
   loaderSpinner: {
     loading: () => "Téléhargement...",
   },
+  loaderStar: {
+    loading: () => "Téléhargement...",
+  },
   menuFullscreen: {
     ariaLabels: { closeButton: () => "Fermer" },
   },

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -82,6 +82,9 @@ interface Locale {
   loaderSpinner: {
     loading: () => string;
   };
+  loaderStar: {
+    loading: () => string;
+  };
   menuFullscreen: {
     ariaLabels: {
       closeButton: () => string;


### PR DESCRIPTION
### Proposed behaviour

Create a new component called `Loader Star`. 

**Component by default**
![LoaderStarGIF](https://github.com/user-attachments/assets/a80c4134-48b5-4bd8-a6ea-34f0876a9310)

**Component if user prefers `Reduce motion`**
![Screenshot 2024-08-19 at 13 27 29](https://github.com/user-attachments/assets/a61a4e97-ca35-44b8-8116-4ee930cb1372)

### Current behaviour

No component called `Loader Star` exists in Carbon.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Component should match designs and animation behaviour specified on the ticket.
- Component should display the expected message if the user prefers `Reduce motion`. 
- Ensure that Playwright tests are sufficient for testing the browser behaviour of this component.