### PR TITLE
chore(note): remove unnecessary invariant messages for required props - FE-6684

### DIFF
--- a/src/components/note/note.component.tsx
+++ b/src/components/note/note.component.tsx
@@ -61,10 +61,6 @@ export const Note = ({
   ...rest
 }: NoteProps) => {
   invariant(width > 0, "<Note> width must be greater than 0");
-  invariant(createdDate, "<Note> createdDate is required");
-  invariant(noteContent, "<Note> noteContent is required");
-  invariant(!status || status.text, "<Note> status.text is required");
-  invariant(!status || status.timeStamp, "<Note> status.timeStamp is required");
   invariant(
     !inlineControl ||
       (React.isValidElement(inlineControl) &&


### PR DESCRIPTION
### Proposed behaviour

Remove unnecessary invariant messages

### Current behaviour

Note has six invariant warnings, some for props that are `required` by TypeScript.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

There should be no regressions with the Note component.