### PR TITLE
fix(carbon-provider): add aria-hidden to token provider

### DIFF
--- a/src/components/carbon-provider/carbon-provider.component.tsx
+++ b/src/components/carbon-provider/carbon-provider.component.tsx
@@ -15,6 +15,7 @@ export interface CarbonProviderProps extends NewValidationContextProps {
   children: React.ReactNode;
   /** Theme which specifies styles to apply to all child components. Set to `sageTheme` by default. */
   theme?: Partial<ThemeObject>;
+  ariaHidden?: "true" | "false";
 }
 
 export const CarbonProvider = ({
@@ -23,6 +24,7 @@ export const CarbonProvider = ({
   validationRedesignOptIn = false,
   roundedCornersOptOut = false,
   focusRedesignOptOut = false,
+  ariaHidden = "false",
 }: CarbonProviderProps) => {
   const {
     roundedCornersOptOut: existingRoundedCornersOptOut,
@@ -41,7 +43,7 @@ export const CarbonProvider = ({
         focusRedesignOptOut: focusRedesignOptOutValue,
       }}
     >
-      <CarbonScopedTokensProvider>
+      <CarbonScopedTokensProvider aria-hidden={ariaHidden}>
         <NewValidationContext.Provider
           value={{
             validationRedesignOptIn,

--- a/src/components/carbon-provider/carbon-provider.test.tsx
+++ b/src/components/carbon-provider/carbon-provider.test.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import CarbonProvider from "../carbon-provider";
+import Button from "../button";
+
+describe("The CabronProvider component", () => {
+  test("renders with aria-hidden false if no ariaHidden prop is specified", () => {
+    render(
+      <CarbonProvider>
+        <Button buttonType="primary">Button</Button>
+      </CarbonProvider>
+    );
+
+    const button = screen.getByRole("button", {
+      name: "Button",
+    });
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const parent = button.closest("div");
+
+    expect(parent).toHaveAttribute("aria-hidden", "false");
+  });
+
+  test("renders with aria-hidden true if ariaHidden prop is specified as true", () => {
+    render(
+      <CarbonProvider ariaHidden="true">
+        <Button buttonType="primary">Button</Button>
+      </CarbonProvider>
+    );
+
+    const button = screen.getByText("Button");
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const parent = button.closest("div");
+
+    expect(parent).toHaveAttribute("aria-hidden", "true");
+  });
+});


### PR DESCRIPTION
### Proposed behaviour
Added an optional prop `ariaHidden?: "true" | "false"` to the `CarbonProvider` which is applied to the inner `CarbonScopedTokensProvider`
<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour
Currently there is no way to control the aria-hidden attribute for the `CarbonProvider` component.
<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
