### PR TITLE
feat(vertical-divider): add aria-hidden prop but prevent overriding when in menu

### DIFF
--- a/src/components/menu/__internal__/menu.context.tsx
+++ b/src/components/menu/__internal__/menu.context.tsx
@@ -5,7 +5,7 @@ export type MenuType = "light" | "dark" | "white" | "black";
 export interface MenuContextProps {
   menuType: MenuType;
   openSubmenuId: string | null;
-  inMenu: boolean;
+  inMenu?: boolean;
   inFullscreenView?: boolean;
   setOpenSubmenuId: (id: string | null) => void;
   registerItem?: (id: string) => void;
@@ -15,7 +15,6 @@ export interface MenuContextProps {
 
 export default React.createContext<MenuContextProps>({
   menuType: "light",
-  inMenu: false,
   openSubmenuId: null,
   setOpenSubmenuId: /* istanbul ignore next */ () => {},
 });

--- a/src/components/vertical-divider/vertical-divider.component.tsx
+++ b/src/components/vertical-divider/vertical-divider.component.tsx
@@ -117,6 +117,11 @@ export interface VerticalDividerProps extends SpaceProps {
   displayInline?: boolean;
   /** Custom tint of the divider, the supported rage is 1-100 */
   tint?: TintRange;
+  /**
+   * Set the divider to be hidden from screen readers.
+   * Please note that this cannot be overridden when inside a Menu.
+   * */
+  "aria-hidden"?: boolean;
 }
 
 export const VerticalDivider = ({
@@ -124,6 +129,7 @@ export const VerticalDivider = ({
   height,
   displayInline = false,
   tint = 80,
+  "aria-hidden": ariaHidden,
   ...props
 }: VerticalDividerProps): JSX.Element => {
   const { inMenu } = useContext(MenuContext);
@@ -137,7 +143,7 @@ export const VerticalDivider = ({
       displayInline={displayInline}
       {...props}
       as={inMenu ? "li" : "div"}
-      aria-hidden={!!inMenu}
+      aria-hidden={inMenu ?? ariaHidden}
     >
       <StyledDivider data-role="divider" tint={tint} />
     </StyledVerticalWrapper>

--- a/src/components/vertical-divider/vertical-divider.test.tsx
+++ b/src/components/vertical-divider/vertical-divider.test.tsx
@@ -61,3 +61,28 @@ test("should render as an `li` element with `aria-hidden` when inside a Menu", (
   expect(verticalDividerElement.tagName).toEqual("LI");
   expect(verticalDividerElement).toHaveAttribute("aria-hidden", "true");
 });
+
+test("should allow the `aria-hidden` attribute to be set when not in a menu", () => {
+  render(<VerticalDivider aria-hidden />);
+  const verticalDividerElement = screen.getByTestId("vertical-divider");
+
+  expect(verticalDividerElement).toHaveAttribute("aria-hidden", "true");
+});
+
+test("should not allow the `aria-hidden` attribute to be overridden when in a menu", () => {
+  render(
+    <MenuContext.Provider
+      value={{
+        menuType: "light",
+        inMenu: true,
+        openSubmenuId: null,
+        setOpenSubmenuId: () => {},
+      }}
+    >
+      <VerticalDivider aria-hidden={false} />
+    </MenuContext.Provider>
+  );
+  const verticalDividerElement = screen.getByTestId("vertical-divider");
+
+  expect(verticalDividerElement).toHaveAttribute("aria-hidden", "true");
+});


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Adds `aria-hidden` prop to VerticalDivider interface.
Ensure that it cannot be overridden when the divider is in Menu.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
aria-hidden is not part of VerticalDivider

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Unit tests added or updated if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
