### PR TITLE
chore: upgrade a transitive dependency

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,7 +9,7 @@
 .vscode
 CONTRIBUTING.md
 gulpfile.js
-jest.config.json
+jest.config.ts
 cla
 docs
 __mocks__

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,39 +1,35 @@
 {
-    // Use IntelliSense to learn about possible Node.js debug attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-
-      {
-        "name": "storybook",
-        "type": "chrome",
-        "request": "launch",
-        "url": "http://localhost:9001",
-        "webRoot": "${workspaceFolder}"
-      },
-      {
-        "name": "fixtures",
-        "type": "chrome",
-        "request": "launch",
-        "url": "http://localhost:9901",
-        "webRoot": "${workspaceFolder}"
-      },
-      {
-        "type": "node",
-        "request": "launch",
-        "name": "Run Current Spec",
-        "program": "${workspaceRoot}/node_modules/.bin/jest",
-        "args": [
-          "--config=./jest.config.json",
-          "${file}"
-        ],
-        "stopOnEntry": false,
-        "cwd": "${workspaceRoot}",
-        "sourceMaps": true,
-        "console": "integratedTerminal",
-        "internalConsoleOptions": "neverOpen",
-        "disableOptimisticBPs": true,
-      }
-    ]
-  }
+  // Use IntelliSense to learn about possible Node.js debug attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "storybook",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:9001",
+      "webRoot": "${workspaceFolder}"
+    },
+    {
+      "name": "fixtures",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:9901",
+      "webRoot": "${workspaceFolder}"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run Current Spec",
+      "program": "${workspaceRoot}/node_modules/.bin/jest",
+      "args": ["--config=./jest.config.ts", "${file}"],
+      "stopOnEntry": false,
+      "cwd": "${workspaceRoot}",
+      "sourceMaps": true,
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25457,12 +25457,13 @@
       ]
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {


### PR DESCRIPTION
### Proposed behaviour

- [ ] Upgrade `micromatch`
- [ ] Remove references to old jest config file

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
