### PR TITLE
fix(date): prevent multiple instances of date picker opening at the same time

### DIFF
--- a/src/components/date/date.component.tsx
+++ b/src/components/date/date.component.tsx
@@ -293,7 +293,9 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       isBlurBlocked.current = false;
 
       if (!open && !alreadyFocused.current) {
-        setOpen(true);
+        setTimeout(() => {
+          setOpen(true);
+        }, 0);
       } else {
         alreadyFocused.current = false;
       }
@@ -351,9 +353,13 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
 
       if (type !== "text") {
         alreadyFocused.current = true;
-        setOpen((prev) => !prev);
+        setTimeout(() => {
+          setOpen((prev) => !prev);
+        }, 0);
       } else if (!open) {
-        setOpen(true);
+        setTimeout(() => {
+          setOpen(true);
+        }, 0);
       }
     };
 

--- a/src/components/date/date.test.tsx
+++ b/src/components/date/date.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import enGBLocale from "date-fns/locale/en-GB";
@@ -157,11 +157,17 @@ test("should set ref to empty after unmount", () => {
   expect(ref.current).toBe(null);
 });
 
-test("should render with the input focused and picker visible when `autoFocus` is true", () => {
+test("should render with the input focused and picker visible when `autoFocus` is true", async () => {
   render(<DateInput label="label" autoFocus onChange={() => {}} value="" />);
 
+  act(() => {
+    jest.advanceTimersByTime(10);
+  });
+
   expect(screen.getByRole("textbox")).toHaveFocus();
-  expect(screen.getByRole("grid")).toBeVisible();
+  await waitFor(() => {
+    expect(screen.getByRole("grid")).toBeVisible();
+  });
 });
 
 test("should not render with the input focused or the picker visible when `autoFocus` is false", () => {
@@ -173,15 +179,20 @@ test("should not render with the input focused or the picker visible when `autoF
   expect(screen.queryByRole("grid")).not.toBeInTheDocument();
 });
 
-test("should open the picker and call the `onFocus` callback if one passed when the input is focused by the user", () => {
+test("should open the picker and call the `onFocus` callback if one passed when the input is focused by the user", async () => {
   const onFocus = jest.fn();
   render(
     <DateInput label="label" onChange={() => {}} value="" onFocus={onFocus} />
   );
   const input = screen.getByRole("textbox");
-  input.focus();
+  act(() => {
+    input.focus();
+    jest.advanceTimersByTime(10);
+  });
 
-  expect(screen.getByRole("grid")).toBeVisible();
+  await waitFor(() => {
+    expect(screen.getByRole("grid")).toBeVisible();
+  });
   expect(onFocus).toHaveBeenCalled();
 });
 
@@ -200,6 +211,7 @@ test("should open the picker and call the `onClick` and `onFocus` callbacks if p
   );
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
 
   expect(screen.getByRole("grid")).toBeVisible();
   expect(onFocus).toHaveBeenCalled();
@@ -214,6 +226,7 @@ test("should open the picker and call the `onClick` callback if passed when the 
   );
   const icon = screen.getByTestId("icon");
   await user.click(icon);
+  jest.advanceTimersByTime(10);
 
   expect(screen.getByRole("grid")).toBeVisible();
   expect(onClick).toHaveBeenCalled();
@@ -224,8 +237,13 @@ test("should close the picker if it is open and the user clicks on the input ico
   render(<DateInput label="label" onChange={() => {}} value="" />);
   const icon = screen.getByTestId("input-icon-toggle");
   await user.click(icon);
+  jest.advanceTimersByTime(10);
 
   expect(screen.getByRole("grid")).toBeVisible();
+
+  await user.click(icon);
+  jest.advanceTimersByTime(10);
+  expect(screen.queryByRole("grid")).not.toBeInTheDocument();
 });
 
 test("should not trigger a focus event when the user clicks on the input and `disabled` prop is set", async () => {
@@ -242,6 +260,7 @@ test("should not trigger a focus event when the user clicks on the input and `di
   );
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
 
   expect(screen.queryByRole("grid")).not.toBeInTheDocument();
   expect(onFocus).not.toHaveBeenCalled();
@@ -261,6 +280,7 @@ test("should not trigger a focus event when the user clicks on the input and `re
   );
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
 
   expect(screen.queryByRole("grid")).not.toBeInTheDocument();
   expect(onFocus).not.toHaveBeenCalled();
@@ -280,6 +300,7 @@ test("should call `onBlur` and `onChange` callbacks when the user clicks away fr
   );
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.click(document.body);
 
   expect(onBlur).toHaveBeenCalled();
@@ -295,6 +316,7 @@ test("should call `onBlur` but not `onChange` callbacks when the user clicks awa
   );
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.click(document.body);
 
   expect(onBlur).toHaveBeenCalled();
@@ -315,6 +337,7 @@ test("should call `onBlur` but not `onChange` callbacks when the user clicks awa
   );
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.click(document.body);
 
   expect(onBlur).toHaveBeenCalled();
@@ -336,6 +359,7 @@ test("should not call `onBlur` or `onChange` callbacks when user clicks away fro
   );
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.click(document.body);
 
   expect(onBlur).not.toHaveBeenCalled();
@@ -351,7 +375,9 @@ test("should not call `onBlur` when the user clicks on the input and then the in
   const input = screen.getByRole("textbox");
   const icon = screen.getByTestId("input-icon-toggle");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.click(icon);
+  jest.advanceTimersByTime(10);
 
   expect(onBlur).not.toHaveBeenCalled();
 });
@@ -362,6 +388,7 @@ test("should call `onChange` callback with expected values when user clicks away
   render(<MockComponent onChange={onChange} initialValue="" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.type(input, "12.12.69");
   await user.click(document.body);
 
@@ -378,6 +405,7 @@ test("should call `onChange` callback with expected values when user clicks away
   render(<MockComponent onChange={onChange} initialValue="" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.type(input, "12.12.20");
   await user.click(document.body);
 
@@ -394,6 +422,7 @@ test("should call `onChange` callback with expected values when user clicks away
   render(<MockComponent onChange={onChange} initialValue="" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.type(input, "12.12.00");
   await user.click(document.body);
 
@@ -416,6 +445,7 @@ test("should call `onChange` callback when user clears the input and clicks away
   );
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.clear(input);
   await user.click(document.body);
 
@@ -433,6 +463,7 @@ test("should not close the picker or call the `onChange` and `onBlur` callbacks 
   render(<DateInput onChange={onChange} onBlur={onBlur} value="04/04/2019" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   const picker = screen.getByRole("grid");
   await user.click(picker);
 
@@ -455,6 +486,7 @@ test("should not close the picker or call the `onChange` and `onBlur` callbacks 
   );
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.click(screen.getByRole("gridcell", { name: "Wed 3 Apr 2019" }));
 
   expect(screen.queryByRole("grid")).toBeVisible();
@@ -467,6 +499,7 @@ test("should close the open picker when a user presses the 'Escape' key", async 
   render(<DateInput onChange={() => {}} value="" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.keyboard("{Escape}");
 
   expect(screen.queryByRole("grid")).not.toBeInTheDocument();
@@ -477,6 +510,7 @@ test("should close the open picker when the user presses the 'Escape' key and fo
   render(<DateInput onChange={() => {}} value="" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.tab();
   await user.keyboard("{Escape}");
 
@@ -489,6 +523,7 @@ test("should call `onKeyDown` callback when the user types and the input is focu
   render(<DateInput onChange={() => {}} value="" onKeyDown={onKeyDown} />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.type(input, "12");
 
   expect(onKeyDown).toHaveBeenCalledTimes(2);
@@ -499,6 +534,7 @@ test("should keep the picker open and move focus to the previous month button wh
   render(<DateInput onChange={() => {}} value="" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.tab();
 
   expect(screen.getByRole("grid")).toBeVisible();
@@ -510,6 +546,7 @@ test("should keep the picker open and move focus to the previous month button wh
   render(<DateInput onChange={() => {}} value="" disablePortal />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.tab();
 
   expect(screen.getByRole("grid")).toBeVisible();
@@ -521,6 +558,7 @@ test("should close the picker when the user presses shift + tab and the input is
   render(<DateInput onChange={() => {}} value="" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
 
   expect(screen.getByRole("grid")).toBeVisible();
   await user.tab({ shift: true });
@@ -532,6 +570,7 @@ test("should close the picker when the user presses shift + tab and the previous
   render(<DateInput onChange={() => {}} value="" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.tab();
 
   expect(screen.getByRole("button", { name: "Previous month" })).toHaveFocus();
@@ -544,6 +583,7 @@ test("should not close the picker when the user presses shift + tab and neither 
   render(<DateInput onChange={() => {}} value="" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.tab();
   await user.tab();
 
@@ -557,6 +597,7 @@ test("should focus the next button and then the selected day element when the us
   render(<DateInput onChange={() => {}} value="04/04/2019" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.tab();
 
   expect(screen.getByRole("button", { name: "Previous month" })).toHaveFocus();
@@ -575,6 +616,7 @@ test("should close the picker, update the value and refocus the input element wh
   render(<MockComponent initialValue="04/04/2019" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.click(screen.getByRole("gridcell", { name: "Thu 11 Apr 2019" }));
 
   expect(screen.queryByRole("grid")).not.toBeInTheDocument();
@@ -612,6 +654,7 @@ test("should render the picker as a descendant of the main presentation element 
   );
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
 
   expect(
     within(screen.getAllByRole("presentation")[0]).getByRole("grid")
@@ -623,6 +666,7 @@ test("should not render the picker as a descendant of the main presentation elem
   render(<DateInput label="label" onChange={() => {}} value="" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
 
   expect(
     within(screen.getAllByRole("presentation")[0]).queryByRole("grid")
@@ -650,6 +694,7 @@ describe("when the `locale` is undefined", () => {
     );
     const input = screen.getByRole("textbox");
     await user.click(input);
+    jest.advanceTimersByTime(10);
     await user.tab();
 
     expect(input).toHaveValue("04/04/2019");
@@ -666,6 +711,7 @@ describe("when the `locale` is undefined", () => {
       );
       const input = screen.getByRole("textbox");
       await user.click(input);
+      jest.advanceTimersByTime(10);
       await user.type(input, inputString);
       await user.tab();
 
@@ -704,6 +750,7 @@ describe("when the `locale` is 'en-GB''", () => {
     );
     const input = screen.getByRole("textbox");
     await user.click(input);
+    jest.advanceTimersByTime(10);
     await user.tab();
 
     expect(input).toHaveValue("04/04/2019");
@@ -725,6 +772,7 @@ describe("when the `locale` is 'en-GB''", () => {
       );
       const input = screen.getByRole("textbox");
       await user.click(input);
+      jest.advanceTimersByTime(10);
       await user.type(input, inputString);
       await user.tab();
 
@@ -763,6 +811,7 @@ describe("when the `locale` is 'de-DE'", () => {
     );
     const input = screen.getByRole("textbox");
     await user.click(input);
+    jest.advanceTimersByTime(10);
     await user.tab();
 
     expect(input).toHaveValue("04.04.2019");
@@ -784,6 +833,7 @@ describe("when the `locale` is 'de-DE'", () => {
       );
       const input = screen.getByRole("textbox");
       await user.click(input);
+      jest.advanceTimersByTime(10);
       await user.type(input, inputString);
       await user.tab();
 
@@ -822,6 +872,7 @@ describe("when the `locale` is 'es'", () => {
     );
     const input = screen.getByRole("textbox");
     await user.click(input);
+    jest.advanceTimersByTime(10);
     await user.tab();
 
     expect(input).toHaveValue("04/04/2019");
@@ -843,6 +894,7 @@ describe("when the `locale` is 'es'", () => {
       );
       const input = screen.getByRole("textbox");
       await user.click(input);
+      jest.advanceTimersByTime(10);
       await user.type(input, inputString);
       await user.tab();
 
@@ -881,6 +933,7 @@ describe("when the `locale` is 'en-ZA'", () => {
     );
     const input = screen.getByRole("textbox");
     await user.click(input);
+    jest.advanceTimersByTime(10);
     await user.tab();
 
     expect(input).toHaveValue("04/04/2019");
@@ -902,6 +955,7 @@ describe("when the `locale` is 'en-ZA'", () => {
       );
       const input = screen.getByRole("textbox");
       await user.click(input);
+      jest.advanceTimersByTime(10);
       await user.type(input, inputString);
       await user.tab();
 
@@ -940,6 +994,7 @@ describe("when the `locale` is 'fr-FR'", () => {
     );
     const input = screen.getByRole("textbox");
     await user.click(input);
+    jest.advanceTimersByTime(10);
     await user.tab();
 
     expect(input).toHaveValue("04/04/2019");
@@ -961,6 +1016,7 @@ describe("when the `locale` is 'fr-FR'", () => {
       );
       const input = screen.getByRole("textbox");
       await user.click(input);
+      jest.advanceTimersByTime(10);
       await user.type(input, inputString);
       await user.tab();
 
@@ -999,6 +1055,7 @@ describe("when the `locale` is 'fr-CA'", () => {
     );
     const input = screen.getByRole("textbox");
     await user.click(input);
+    jest.advanceTimersByTime(10);
     await user.tab();
 
     expect(input).toHaveValue("04/04/2019");
@@ -1020,6 +1077,7 @@ describe("when the `locale` is 'fr-CA'", () => {
       );
       const input = screen.getByRole("textbox");
       await user.click(input);
+      jest.advanceTimersByTime(10);
       await user.type(input, inputString);
       await user.tab();
 
@@ -1058,6 +1116,7 @@ describe("when the `locale` is 'en-CA'", () => {
     );
     const input = screen.getByRole("textbox");
     await user.click(input);
+    jest.advanceTimersByTime(10);
     await user.tab();
 
     expect(input).toHaveValue("04/04/2019");
@@ -1079,6 +1138,7 @@ describe("when the `locale` is 'en-CA'", () => {
       );
       const input = screen.getByRole("textbox");
       await user.click(input);
+      jest.advanceTimersByTime(10);
       await user.type(input, inputString);
       await user.tab();
 
@@ -1117,6 +1177,7 @@ describe("when the `locale` is 'en-US'", () => {
     );
     const input = screen.getByRole("textbox");
     await user.click(input);
+    jest.advanceTimersByTime(10);
     await user.tab();
 
     expect(input).toHaveValue("04/04/2019");
@@ -1138,6 +1199,7 @@ describe("when the `locale` is 'en-US'", () => {
       );
       const input = screen.getByRole("textbox");
       await user.click(input);
+      jest.advanceTimersByTime(10);
       await user.type(input, inputString);
       await user.tab();
 
@@ -1152,6 +1214,7 @@ test("should update the input value and call `onChange` with expected parameters
   render(<MockComponent onChange={onChange} initialValue="" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.type(input, "29/02/2012");
   await user.tab();
 
@@ -1168,6 +1231,7 @@ test("should call `onChange` with expected parameters but not update the input v
   render(<MockComponent onChange={onChange} initialValue="" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.type(input, "29.02.2013");
   await user.tab();
 
@@ -1184,6 +1248,7 @@ test("should call `onChange` with expected parameters but not update the input v
   render(<MockComponent onChange={onChange} initialValue="" />);
   const input = screen.getByRole("textbox");
   await user.click(input);
+  jest.advanceTimersByTime(10);
   await user.type(input, "04.04/2019");
   await user.tab();
 


### PR DESCRIPTION
### Proposed behaviour

- remove the useClickAwayListener() hook call and replace with custom listeners purely for Date Picker

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

Currently it is possible to have two date pickers open at once if you click through them back and forth.

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
