### PR TITLE
feat(fonts): updated font weights for ds base token alignment

### DIFF
--- a/.storybook/welcome-page/components-demo/component-heading/component-heading.style.js
+++ b/.storybook/welcome-page/components-demo/component-heading/component-heading.style.js
@@ -1,8 +1,8 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
 export const StyledComponentHeader = styled.header`
-  align-items:${({ centerAlign }) => centerAlign ? 'center' : 'flex-start'};
-  text-align:${({ centerAlign }) => centerAlign ? 'center' : 'left'};
+  align-items: ${({ centerAlign }) => (centerAlign ? "center" : "flex-start")};
+  text-align: ${({ centerAlign }) => (centerAlign ? "center" : "left")};
   display: flex;
   flex-direction: column;
   margin-bottom: 60px;
@@ -23,7 +23,7 @@ export const StyledHeading = styled.h2`
 
   span {
     color: #000;
-    font-weight: 700;
+    font-weight: 500;
   }
 `;
 

--- a/.storybook/welcome-page/header/header.style.js
+++ b/.storybook/welcome-page/header/header.style.js
@@ -17,7 +17,7 @@ export const HeadingContentWrapper = styled.div`
   color: #fff;
 
   h1 {
-    font-weight: 900
+    font-weight: 700
     font-size: 40px;
     line-height: normal;
     margin: 0 auto;
@@ -25,7 +25,7 @@ export const HeadingContentWrapper = styled.div`
   }
 
   h2 {
-    font-weight: 700;
+    font-weight: 500;
     font-size: 22px;
     line-height: normal;
     margin-top: 16px;

--- a/.storybook/welcome-page/selling-points/selling-points.style.js
+++ b/.storybook/welcome-page/selling-points/selling-points.style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
 export const Wrapper = styled.div`
   margin: 0 auto;
@@ -55,7 +55,7 @@ export const Image = styled.img`
 
 export const Heading = styled.h3`
   font-size: 18px;
-  font-weight: 700;
+  font-weight: 500;
   line-height: 1.22em;
   margin-bottom: 0.5em;
 `;

--- a/src/__internal__/character-count/character-count.style.ts
+++ b/src/__internal__/character-count/character-count.style.ts
@@ -18,7 +18,7 @@ const StyledCharacterCount = styled.div<{ isOverLimit: boolean }>`
   ${({ isOverLimit }) =>
     isOverLimit &&
     css`
-      font-weight: var(--fontWeights700);
+      font-weight: var(--fontWeights500);
     `}
 `;
 

--- a/src/__internal__/fieldset/fieldset.style.ts
+++ b/src/__internal__/fieldset/fieldset.style.ts
@@ -36,7 +36,7 @@ const StyledLegendContent = styled.span<StyledLegendContentProps>`
         content: "*";
         line-height: 24px;
         color: var(--colorsSemanticNegative500);
-        font-weight: var(--fontWeights700);
+        font-weight: var(--fontWeights500);
         margin-left: var(--spacing050);
         position: relative;
         top: 1px;
@@ -76,7 +76,7 @@ const StyledLegend = styled.legend<StyledLegendProps>`
   align-items: center;
   margin-bottom: var(--spacing100);
   padding: 0;
-  font-weight: var(--fontWeights700);
+  font-weight: var(--fontWeights500);
   color: var(--colorsUtilityYin090);
   ${({ inline, width, align, rightPadding }) =>
     inline &&

--- a/src/__internal__/label/label.style.ts
+++ b/src/__internal__/label/label.style.ts
@@ -10,7 +10,7 @@ export interface StyledLabelProps {
 const StyledLabel = styled.label<StyledLabelProps>`
   color: var(--colorsUtilityYin090);
   display: block;
-  font-weight: var(--fontWeights700);
+  font-weight: var(--fontWeights500);
 
   ${({ isRequired }) =>
     isRequired &&
@@ -18,7 +18,7 @@ const StyledLabel = styled.label<StyledLabelProps>`
       ::after {
         content: "*";
         color: var(--colorsSemanticNegative500);
-        font-weight: var(--fontWeights700);
+        font-weight: var(--fontWeights500);
         margin-left: var(--spacing050);
       }
     `}

--- a/src/__internal__/validation-message/validation-message.style.ts
+++ b/src/__internal__/validation-message/validation-message.style.ts
@@ -9,7 +9,7 @@ const StyledValidationMessage = styled.p<StyledValidationMessageProps>`
     color: ${isWarning
       ? "var(--colorsSemanticCaution600)"
       : "var(--colorsSemanticNegative500)"};
-    font-weight: ${isWarning ? "normal" : "bold"};
+    font-weight: ${isWarning ? "normal" : "500"};
     margin-top: 0px;
     margin-bottom: 8px;
   `}

--- a/src/components/accordion/accordion.style.ts
+++ b/src/components/accordion/accordion.style.ts
@@ -71,7 +71,7 @@ const StyledAccordionTitle = styled.h3<StyledAccordionTitleProps>`
     size === "small" || variant === "subtle"
       ? "var(--fontSizes200)"
       : "var(--fontSizes400)"};
-  font-weight: 700;
+  font-weight: 500;
   line-height: 1;
   user-select: none;
   margin: 0;
@@ -213,7 +213,7 @@ const StyledAccordionTitleContainer = styled.div<StyledAccordionTitleContainerPr
     ${buttonHeading &&
     css`
       box-sizing: border-box;
-      font-weight: 600;
+      font-weight: 500;
       text-decoration: none;
       font-size: var(--fontSizes100);
       min-height: var(--spacing500);

--- a/src/components/action-popover/action-popover.style.ts
+++ b/src/components/action-popover/action-popover.style.ts
@@ -170,7 +170,7 @@ const StyledMenuItem = styled.button<Omit<StyledMenuItemProps, "variant">>`
   width: 100%;
   color: var(--colorsUtilityYin090);
   font-size: 14px;
-  font-weight: 700;
+  font-weight: 500;
 
   &:focus {
     ${({ theme }) =>

--- a/src/components/anchor-navigation/anchor-navigation-item/anchor-navigation-item.style.ts
+++ b/src/components/anchor-navigation/anchor-navigation-item/anchor-navigation-item.style.ts
@@ -19,7 +19,7 @@ const StyledNavigationItem = styled.li<StyledNavigationItemProps>`
     color: var(--colorsUtilityYin090);
     background-color: transparent;
     border-left: var(--sizing050) solid var(--colorsActionMinor100);
-    font-weight: 700;
+    font-weight: 500;
     padding: 12px 24px;
     border-top-right-radius: var(--borderRadius100);
     border-bottom-right-radius: var(--borderRadius100);

--- a/src/components/badge/badge.style.ts
+++ b/src/components/badge/badge.style.ts
@@ -22,7 +22,7 @@ const StyledBadgeWrapper = styled.div`
 `;
 
 const StyledCounter = styled.div`
-  font-weight: 700;
+  font-weight: 500;
   font-size: 12px;
   margin-top: -1px;
 `;

--- a/src/components/button-toggle/button-toggle.style.ts
+++ b/src/components/button-toggle/button-toggle.style.ts
@@ -71,7 +71,7 @@ const StyledButtonToggle = styled.button<StyledButtonToggleProps>`
   box-sizing: border-box;
   max-width: 100%;
 
-  font-weight: 700;
+  font-weight: 500;
   background-color: transparent;
   cursor: pointer;
   text-align: center;

--- a/src/components/button/button.style.ts
+++ b/src/components/button/button.style.ts
@@ -86,7 +86,7 @@ const StyledButton = styled.button<StyledButtonProps>`
     outline-offset: 0;
     border: 2px solid transparent;
     box-sizing: border-box;
-    font-weight: 600;
+    font-weight: 500;
     text-decoration: none;
     border-radius: var(--borderRadius400);
 

--- a/src/components/card/card-footer/card-footer.style.ts
+++ b/src/components/card/card-footer/card-footer.style.ts
@@ -34,7 +34,7 @@ const StyledCardFooter = styled.div<StyledCardFooterProps>`
     border-top-width: 1px;
     border-top-style: solid;
     font-size: 14px;
-    font-weight: 700;
+    font-weight: 500;
     margin: ${marginSizes[spacing]};
     display: flex;
     ${roundness === "default" &&

--- a/src/components/card/card.stories.tsx
+++ b/src/components/card/card.stories.tsx
@@ -60,7 +60,7 @@ export const DefaultStory: Story = {
         </CardRow>
         <CardRow>
           <CardColumn>
-            <Typography fontSize="16px" m={0} fontWeight="bold">
+            <Typography fontSize="16px" m={0} fontWeight="500">
               Body text
             </Typography>
             <Heading title="More text" divider={false} />
@@ -100,7 +100,7 @@ export const SmallSpacing: Story = () => {
       </CardRow>
       <CardRow>
         <CardColumn>
-          <Typography fontSize="16px" m={0} fontWeight="bold">
+          <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
           <Heading title="More text" divider={false} />
@@ -139,7 +139,7 @@ export const LargeSpacing: Story = () => {
       </CardRow>
       <CardRow>
         <CardColumn>
-          <Typography fontSize="16px" m={0} fontWeight="bold">
+          <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
           <Heading title="More text" divider={false} />
@@ -178,7 +178,7 @@ export const WithWidthProvided: Story = () => {
       </CardRow>
       <CardRow>
         <CardColumn>
-          <Typography fontSize="16px" m={0} fontWeight="bold">
+          <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
           <Heading title="More text" divider={false} />
@@ -217,7 +217,7 @@ export const WithCustomHeight: Story = () => {
       </CardRow>
       <CardRow>
         <CardColumn>
-          <Typography fontSize="16px" m={0} fontWeight="bold">
+          <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
           <Heading title="More text" divider={false} />
@@ -256,7 +256,7 @@ export const WithExtraRoundness: Story = () => {
       </CardRow>
       <CardRow>
         <CardColumn>
-          <Typography fontSize="16px" m={0} fontWeight="bold">
+          <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
           <Heading title="More text" divider={false} />
@@ -349,7 +349,7 @@ export const WithCustomBoxShadow: Story = () => {
       </CardRow>
       <CardRow>
         <CardColumn>
-          <Typography fontSize="16px" m={0} fontWeight="bold">
+          <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
           <Heading title="More text" divider={false} />
@@ -387,7 +387,7 @@ export const DifferentCardRowPadding: Story = () => {
       </CardRow>
       <CardRow pt={0} pb={4}>
         <CardColumn>
-          <Typography fontSize="16px" m={0} fontWeight="bold">
+          <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
           <Heading title="More text" divider={false} />
@@ -396,7 +396,7 @@ export const DifferentCardRowPadding: Story = () => {
       </CardRow>
       <CardRow pt={0} pb={4}>
         <CardColumn>
-          <Typography fontSize="16px" m={0} fontWeight="bold">
+          <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
           <Heading title="More text" divider={false} />
@@ -430,7 +430,7 @@ export const DifferentCardFooterPadding: Story = () => {
       >
         <CardRow>
           <CardColumn>
-            <Typography fontSize="16px" mt={2} mb={0} fontWeight="bold">
+            <Typography fontSize="16px" mt={2} mb={0} fontWeight="500">
               Here is some text
             </Typography>
           </CardColumn>
@@ -454,7 +454,7 @@ export const DifferentCardFooterPadding: Story = () => {
       >
         <CardRow>
           <CardColumn>
-            <Typography fontSize="16px" mt={2} mb={0} fontWeight="bold">
+            <Typography fontSize="16px" mt={2} mb={0} fontWeight="500">
               Here is some text
             </Typography>
           </CardColumn>
@@ -478,7 +478,7 @@ export const DifferentCardFooterPadding: Story = () => {
       >
         <CardRow>
           <CardColumn>
-            <Typography fontSize="16px" mt={2} mb={0} fontWeight="bold">
+            <Typography fontSize="16px" mt={2} mb={0} fontWeight="500">
               Here is some text
             </Typography>
           </CardColumn>
@@ -502,7 +502,7 @@ export const DifferentCardFooterPadding: Story = () => {
       >
         <CardRow>
           <CardColumn>
-            <Typography fontSize="16px" mt={2} mb={0} fontWeight="bold">
+            <Typography fontSize="16px" mt={2} mb={0} fontWeight="500">
               Here is some text
             </Typography>
           </CardColumn>
@@ -526,7 +526,7 @@ export const DifferentCardFooterPadding: Story = () => {
       >
         <CardRow>
           <CardColumn>
-            <Typography fontSize="16px" mt={2} mb={0} fontWeight="bold">
+            <Typography fontSize="16px" mt={2} mb={0} fontWeight="500">
               Here is some text
             </Typography>
           </CardColumn>
@@ -550,7 +550,7 @@ export const DifferentCardFooterPadding: Story = () => {
       >
         <CardRow>
           <CardColumn>
-            <Typography fontSize="16px" mt={2} mb={0} fontWeight="bold">
+            <Typography fontSize="16px" mt={2} mb={0} fontWeight="500">
               Here is some text
             </Typography>
           </CardColumn>
@@ -602,7 +602,7 @@ export const MoreExamplesOfCardFooter: Story = () => {
       >
         <CardRow>
           <CardColumn>
-            <Typography fontSize="16px" mt={2} mb={0} fontWeight="bold">
+            <Typography fontSize="16px" mt={2} mb={0} fontWeight="500">
               Here is some text
             </Typography>
           </CardColumn>
@@ -652,7 +652,7 @@ export const MoreExamplesOfCardFooter: Story = () => {
       >
         <CardRow>
           <CardColumn>
-            <Typography fontSize="16px" mt={2} mb={0} fontWeight="bold">
+            <Typography fontSize="16px" mt={2} mb={0} fontWeight="500">
               Here is some text
             </Typography>
           </CardColumn>
@@ -702,7 +702,7 @@ export const MoreExamplesOfCardFooter: Story = () => {
       >
         <CardRow>
           <CardColumn>
-            <Typography fontSize="16px" mt={2} mb={0} fontWeight="bold">
+            <Typography fontSize="16px" mt={2} mb={0} fontWeight="500">
               Here is some text
             </Typography>
           </CardColumn>
@@ -721,7 +721,7 @@ export const MoreExamplesOfCardFooter: Story = () => {
       >
         <CardRow>
           <CardColumn>
-            <Typography fontSize="16px" mt={2} mb={0} fontWeight="bold">
+            <Typography fontSize="16px" mt={2} mb={0} fontWeight="500">
               Here is some text
             </Typography>
           </CardColumn>

--- a/src/components/content/content.style.ts
+++ b/src/components/content/content.style.ts
@@ -52,7 +52,7 @@ const StyledContentTitle = styled.div<StyledContentTitleProps>`
   ${({ titleWidth, inline, variant, align }) => {
     return css`
       display: ${inline ? "inline-block" : "block"};
-      font-weight: bold;
+      font-weight: 500;
       width: ${titleWidth && `calc(${titleWidth}% - 30px)`};
       text-align: ${!inline && align};
 

--- a/src/components/date/__internal__/date-picker/day-picker.style.ts
+++ b/src/components/date/__internal__/date-picker/day-picker.style.ts
@@ -265,7 +265,7 @@ const StyledDayPicker = styled.div`
     border: none;
     //font-family: var(--fontFamiliesDefault); font assets to be updated part of FE-4975
     //font: var(--typographyDatePickerCalendarDateM); font assets to be updated part of FE-4975
-    font-weight: var(--fontWeights700);
+    font-weight: var(--fontWeights500);
     font-size: var(--fontSizes100);
     line-height: var(--lineHeights500);
     border-radius: var(--borderRadius400);

--- a/src/components/decimal/decimal.pw.tsx
+++ b/src/components/decimal/decimal.pw.tsx
@@ -265,7 +265,7 @@ test.describe("check Decimal input", () => {
       const textboxPrefixElement = textboxPrefix(page);
       await expect(textboxPrefixElement).toHaveText(prefix);
       await expect(textboxPrefixElement).toHaveCSS("font-size", "14px");
-      await expect(textboxPrefixElement).toHaveCSS("font-weight", "900");
+      await expect(textboxPrefixElement).toHaveCSS("font-weight", "700");
       await expect(textboxPrefixElement).toHaveCSS("margin-left", "12px");
     });
   });

--- a/src/components/definition-list/definition-list.style.ts
+++ b/src/components/definition-list/definition-list.style.ts
@@ -34,7 +34,7 @@ export const StyledDt = styled.dt<
 >`
   ${space}
   font-size: var(--fontSizes100);
-  font-weight: 700;
+  font-weight: 500;
   color: var(--colorsUtilityYin090);
   ${({ asSingleColumn }) =>
     !asSingleColumn &&

--- a/src/components/duelling-picklist/components.test-pw.tsx
+++ b/src/components/duelling-picklist/components.test-pw.tsx
@@ -123,7 +123,7 @@ export const DuellingPicklistComponent = (
           >
             <div style={{ display: "flex", width: "100%" }}>
               <div style={{ width: "50%" }}>
-                <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+                <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
                   {item.title}
                 </p>
               </div>
@@ -290,7 +290,7 @@ export const DuellingPicklistComponentAssigned = (
           >
             <div style={{ display: "flex", width: "100%" }}>
               <div style={{ width: "50%" }}>
-                <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+                <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
                   {item.title}
                 </p>
               </div>
@@ -444,7 +444,7 @@ export const AlternativeSearch = () => {
           <PicklistItem key={key} type={type} item={item} onChange={handler}>
             <div style={{ display: "flex", width: "100%" }}>
               <div style={{ width: "50%" }}>
-                <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+                <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
                   {item.title}
                 </p>
               </div>
@@ -583,7 +583,7 @@ export const Grouped = () => {
       return (
         <PicklistItem key={item.key} type={type} item={item} onChange={handler}>
           <div style={{ display: "flex", width: "100%" }}>
-            <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+            <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
               {item.title}
             </p>
           </div>
@@ -666,7 +666,7 @@ export const AddItem = () => (
     <PicklistItem type="add" item={1} onChange={() => null}>
       <div style={{ display: "flex", width: "100%" }}>
         <div style={{ width: "50%" }}>
-          <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+          <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
             Title for Item
           </p>
         </div>
@@ -680,7 +680,7 @@ export const RemoveItem = () => (
     <PicklistItem type="remove" item={1} onChange={() => null}>
       <div style={{ display: "flex", width: "100%" }}>
         <div style={{ width: "50%" }}>
-          <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+          <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
             Title for Item
           </p>
         </div>
@@ -694,7 +694,7 @@ export const Locked = () => (
     <PicklistItem type="add" item={1} onChange={() => null} locked>
       <div style={{ display: "flex", width: "100%" }}>
         <div style={{ width: "50%" }}>
-          <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+          <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
             Title for Item
           </p>
         </div>
@@ -714,7 +714,7 @@ export const CustomTooltipMessage = () => (
     >
       <div style={{ display: "flex", width: "100%" }}>
         <div style={{ width: "50%" }}>
-          <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+          <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
             Title for Item
           </p>
         </div>

--- a/src/components/duelling-picklist/duelling-picklist-test.stories.tsx
+++ b/src/components/duelling-picklist/duelling-picklist-test.stories.tsx
@@ -114,7 +114,7 @@ export const Default = () => {
           <PicklistItem key={key} type={type} item={item} onChange={handler}>
             <div style={{ display: "flex", width: "100%" }}>
               <div style={{ width: "50%" }}>
-                <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+                <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
                   {item.title}
                 </p>
               </div>

--- a/src/components/duelling-picklist/duelling-picklist.stories.tsx
+++ b/src/components/duelling-picklist/duelling-picklist.stories.tsx
@@ -128,7 +128,7 @@ export const Default = () => {
           <PicklistItem key={key} type={type} item={item} onChange={handler}>
             <div style={{ display: "flex", width: "100%" }}>
               <div style={{ width: "50%" }}>
-                <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+                <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
                   {item.title}
                 </p>
               </div>
@@ -276,7 +276,7 @@ export const AlternativeSearch: Story = () => {
           <PicklistItem key={key} type={type} item={item} onChange={handler}>
             <div style={{ display: "flex", width: "100%" }}>
               <div style={{ width: "50%" }}>
-                <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+                <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
                   {item.title}
                 </p>
               </div>
@@ -416,7 +416,7 @@ export const Grouped: Story = () => {
       return (
         <PicklistItem key={item.key} type={type} item={item} onChange={handler}>
           <div style={{ display: "flex", width: "100%" }}>
-            <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+            <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
               {item.title}
             </p>
           </div>
@@ -497,7 +497,7 @@ export const AddItem: Story = () => (
     <PicklistItem type="add" item={1} onChange={() => null}>
       <div style={{ display: "flex", width: "100%" }}>
         <div style={{ width: "50%" }}>
-          <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+          <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
             Title for Item
           </p>
         </div>
@@ -512,7 +512,7 @@ export const RemoveItem: Story = () => (
     <PicklistItem type="remove" item={1} onChange={() => null}>
       <div style={{ display: "flex", width: "100%" }}>
         <div style={{ width: "50%" }}>
-          <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+          <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
             Title for Item
           </p>
         </div>
@@ -527,7 +527,7 @@ export const Locked: Story = () => (
     <PicklistItem type="add" item={1} onChange={() => null} locked>
       <div style={{ display: "flex", width: "100%" }}>
         <div style={{ width: "50%" }}>
-          <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+          <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
             Title for Item
           </p>
         </div>
@@ -548,7 +548,7 @@ export const CustomTooltipMessage: Story = () => (
     >
       <div style={{ display: "flex", width: "100%" }}>
         <div style={{ width: "50%" }}>
-          <p style={{ fontWeight: 700, margin: 0, marginLeft: 24 }}>
+          <p style={{ fontWeight: 500, margin: 0, marginLeft: 24 }}>
             Title for Item
           </p>
         </div>

--- a/src/components/duelling-picklist/duelling-picklist.style.ts
+++ b/src/components/duelling-picklist/duelling-picklist.style.ts
@@ -31,7 +31,7 @@ const StyledLabelContainer = styled.div`
 `;
 
 const StyledLabel = styled.p`
-  font-weight: bold;
+  font-weight: 500;
   font-size: 12px;
   letter-spacing: 1;
   margin: 0;

--- a/src/components/fieldset/fieldset.style.ts
+++ b/src/components/fieldset/fieldset.style.ts
@@ -38,7 +38,7 @@ const StyledLegend = styled.legend<StyledFieldsetProps>`
   align-items: center;
   margin-bottom: 32px;
   font-size: 20px;
-  font-weight: var(--fontWeights700);
+  font-weight: var(--fontWeights500);
   color: var(--colorsUtilityYin090);
   line-height: 24px;
   margin-right: 4px;
@@ -50,7 +50,7 @@ const StyledLegend = styled.legend<StyledFieldsetProps>`
         content: "*";
         line-height: 24px;
         color: var(--colorsSemanticNegative500);
-        font-weight: var(--fontWeights700);
+        font-weight: var(--fontWeights500);
         margin-left: var(--spacing100);
         position: relative;
         top: 1px;

--- a/src/components/file-input/__internal__/file-upload-status/file-upload-status.style.tsx
+++ b/src/components/file-input/__internal__/file-upload-status/file-upload-status.style.tsx
@@ -87,7 +87,7 @@ export const StyledFileUploadStatus = styled.div<StyledFileUploadStatusProps>`
       ${hasError &&
       `&& ${StyledTypography} {
         color: var(--${colorToken});
-        font-weight: 500;
+        font-weight: 400;
       }`}
     `;
   }}

--- a/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.style.ts
+++ b/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.style.ts
@@ -38,7 +38,7 @@ const StyledFlatTableCheckbox = styled.td<StyledFlatTableCheckboxProps>`
       border-width: 0;
       border-bottom: 1px solid var(--colorsUtilityMajor100);
       box-sizing: border-box;
-      font-weight: 700;
+      font-weight: 500;
       left: auto;
       padding: 0;
       text-align: left;

--- a/src/components/flat-table/flat-table-head/flat-table-head.style.ts
+++ b/src/components/flat-table/flat-table-head/flat-table-head.style.ts
@@ -10,7 +10,7 @@ const StyledFlatTableHead = styled.thead`
       border-right: none;
     }
     ${StyledFlatTableRowHeader}, ${StyledFlatTableCheckbox} {
-      font-weight: 700;
+      font-weight: 500;
     }
   }
 `;

--- a/src/components/flat-table/flat-table-header/flat-table-header.style.ts
+++ b/src/components/flat-table/flat-table-header/flat-table-header.style.ts
@@ -41,7 +41,7 @@ const StyledFlatTableHeader = styled.th<StyledFlatTableHeaderProps>`
     background-color: transparent;
     border-width: 0;
     box-sizing: border-box;
-    font-weight: 700;
+    font-weight: 500;
     left: auto;
     text-align: ${align};
     user-select: none;

--- a/src/components/form/__internal__/form-summary.style.ts
+++ b/src/components/form/__internal__/form-summary.style.ts
@@ -11,7 +11,7 @@ export const StyledFormSummary = styled.div<StyledFormSummaryProps>`
   display: inline-flex;
   align-items: center;
   font-size: 13px;
-  font-weight: 700;
+  font-weight: 500;
   margin: -8px;
   padding: 8px;
   white-space: nowrap;

--- a/src/components/form/required-fields-indicator/required-fields-indicator.component.tsx
+++ b/src/components/form/required-fields-indicator/required-fields-indicator.component.tsx
@@ -15,7 +15,7 @@ const StyledIndicatorContainer = styled(Box)`
   ::after {
     content: "*";
     color: var(--colorsSemanticNegative500);
-    font-weight: 700;
+    font-weight: 500;
     margin-left: var(--spacing050);
   }
 `;

--- a/src/components/link-preview/link-preview.style.ts
+++ b/src/components/link-preview/link-preview.style.ts
@@ -74,7 +74,7 @@ const StyledPreviewWrapper = styled.div<{ isLoading: boolean }>`
 const StyledTitle = styled.div`
   white-space: nowrap;
   text-overflow: ellipsis;
-  font-weight: 700;
+  font-weight: 500;
   font-size: 14px;
   line-height: 21px;
 `;

--- a/src/components/loader-spinner/loader-spinner.component.tsx
+++ b/src/components/loader-spinner/loader-spinner.component.tsx
@@ -75,7 +75,7 @@ export const LoaderSpinner = ({
     <StyledLabel
       data-role="visible-label"
       variant="span"
-      fontWeight="500"
+      fontWeight="400"
       size={size}
       color={
         isLabelDark

--- a/src/components/loader-star/loader-star.component.tsx
+++ b/src/components/loader-star/loader-star.component.tsx
@@ -31,7 +31,7 @@ const LoaderStar = ({
   );
 
   const label = (
-    <StyledLabel data-role="visible-label" variant="span" fontWeight="500">
+    <StyledLabel data-role="visible-label" variant="span" fontWeight="400">
       {loaderStarLabel || locale.loaderStar.loading()}
     </StyledLabel>
   );

--- a/src/components/loader-star/loader-star.pw.tsx
+++ b/src/components/loader-star/loader-star.pw.tsx
@@ -27,7 +27,7 @@ test.describe("User prefers reduced motion", () => {
     await mount(<DefaultLoaderStar />);
 
     await expect(loaderStarVisibleLabel(page)).toHaveText("Loading...");
-    await expect(loaderStarVisibleLabel(page)).toHaveCSS("font-weight", "500");
+    await expect(loaderStarVisibleLabel(page)).toHaveCSS("font-weight", "400");
     await expect(loaderStarVisibleLabel(page)).toHaveCSS("display", "flex");
     await expect(loaderStarVisibleLabel(page)).toHaveCSS(
       "justify-content",

--- a/src/components/menu/menu-item/menu-item.style.ts
+++ b/src/components/menu/menu-item/menu-item.style.ts
@@ -102,7 +102,7 @@ const StyledMenuItemWrapper = styled.a.attrs({
     display: flex;
     align-items: center;
     font-size: 14px;
-    font-weight: 700;
+    font-weight: 500;
     min-height: 40px;
     position: relative;
     box-shadow: none;
@@ -270,7 +270,7 @@ const StyledMenuItemWrapper = styled.a.attrs({
       ${StyledLink} a,
       ${StyledLink} button,
       ${StyledLink} [data-component="icon"] {
-        font-weight: 700;
+        font-weight: 500;
         text-decoration: none;
         ${!hasInput && `color: ${menuConfigVariants[menuType].color};`}
       }

--- a/src/components/menu/menu-segment-title/menu-segment-title.style.ts
+++ b/src/components/menu/menu-segment-title/menu-segment-title.style.ts
@@ -14,7 +14,7 @@ const StyledTitle = styled.h2<StyledTitleProps>`
     margin: 0px;
     padding: 16px 16px 8px;
     font-size: 12px;
-    font-weight: 700;
+    font-weight: 500;
     text-transform: uppercase;
     line-height: 14px;
     cursor: default;

--- a/src/components/note/note.style.ts
+++ b/src/components/note/note.style.ts
@@ -46,7 +46,7 @@ const StyledInlineControl = styled.div`
 `;
 
 const StyledTitle = styled.header`
-  font-weight: 900;
+  font-weight: 700;
   font-size: 16px;
   line-height: 21px;
   padding-bottom: 16px;
@@ -55,7 +55,7 @@ const StyledTitle = styled.header`
 const StyledFooterContent = styled.div<{ hasName: boolean }>`
   line-height: 21px;
   align-items: baseline;
-  font-weight: bold;
+  font-weight: 500;
 
   ${({ hasName }) => css`
     margin-top: var(--spacing200);

--- a/src/components/pill/pill.style.ts
+++ b/src/components/pill/pill.style.ts
@@ -85,7 +85,7 @@ const StyledPill = styled.span<AllStyledPillProps>`
     return css`
       font-size: 12px;
       letter-spacing: 0.7px;
-      font-weight: 700;
+      font-weight: 500;
       position: relative;
       display: inline-flex;
       text-align: center;

--- a/src/components/pod/pod.stories.tsx
+++ b/src/components/pod/pod.stories.tsx
@@ -311,7 +311,7 @@ export const AddressExample: Story = () => {
   return (
     <Pod internalEditButton variant="tertiary">
       <Box>
-        <Typography variant="h5" fontWeight="700">
+        <Typography variant="h5" fontWeight="500">
           Unit 1
         </Typography>
         <Typography m={0}>South Nelson Industrial Estate</Typography>

--- a/src/components/pod/pod.style.ts
+++ b/src/components/pod/pod.style.ts
@@ -406,7 +406,7 @@ const StyledSubtitle = styled.h5`
 const StyledTitle = styled.h4`
   display: inline;
   font-size: 18px;
-  font-weight: 600;
+  font-weight: 500;
 `;
 
 StyledPod.defaultProps = {

--- a/src/components/popover-container/popover-container.style.ts
+++ b/src/components/popover-container/popover-container.style.ts
@@ -96,7 +96,7 @@ const PopoverContainerCloseIcon = styled(IconButton)<AdditionalIconButtonProps>`
 
 const PopoverContainerTitleStyle = styled.div`
   font-size: 16px;
-  font-weight: bold;
+  font-weight: 500;
 `;
 
 PopoverContainerContentStyle.defaultProps = {

--- a/src/components/portrait/portrait.style.tsx
+++ b/src/components/portrait/portrait.style.tsx
@@ -18,7 +18,7 @@ type StyledPortraitProps = {
 export const StyledPortraitInitials = styled.div<
   Pick<StyledPortraitProps, "size">
 >`
-  font-weight: bold;
+  font-weight: 500;
   font-size: ${({ size }) => profileConfigSizes[size].initialSize};
   display: flex;
   white-space: nowrap;

--- a/src/components/profile/profile.style.ts
+++ b/src/components/profile/profile.style.ts
@@ -14,7 +14,7 @@ interface ProfileSProps {
 }
 
 const ProfileNameStyle = styled.span<ProfileSProps>`
-  font-weight: bold;
+  font-weight: 500;
   font-size: ${({ size = "M" }) => profileConfigSizes[size].nameSize};
 `;
 

--- a/src/components/progress-tracker/progress-tracker.style.ts
+++ b/src/components/progress-tracker/progress-tracker.style.ts
@@ -77,7 +77,7 @@ const fontSizes = {
 
 const StyledValue = styled.span`
   display: inline-block;
-  font-weight: bold;
+  font-weight: 500;
 `;
 
 const StyledDescription = styled.span`

--- a/src/components/search/search.style.ts
+++ b/src/components/search/search.style.ts
@@ -41,7 +41,7 @@ const StyledSearch = styled.div<StyledSearchProps>`
       background-color: transparent;
       display: inline-flex;
       font-size: var(--fontSize100);
-      font-weight: 700;
+      font-weight: 500;
 
       ${!showSearchButton &&
       css`
@@ -138,7 +138,7 @@ const StyledSearch = styled.div<StyledSearchProps>`
 
         flex: 1;
         font-size: var(--fontSize100);
-        font-weight: 700;
+        font-weight: 500;
         padding-bottom: var(--spacing025);
         padding-top: 1px;
         cursor: pointer;

--- a/src/components/search/search.test.tsx
+++ b/src/components/search/search.test.tsx
@@ -381,7 +381,7 @@ test("applies the correct width specified by the user", () => {
 
   expect(screen.getByTestId("search")).toHaveStyle({
     display: "inline-flex",
-    "font-weight": "700",
+    "font-weight": "500",
     width: "400px",
   });
   expect(screen.getByTestId("search")).toHaveStyleRule(

--- a/src/components/select/__internal__/select-list/select-list.style.ts
+++ b/src/components/select/__internal__/select-list/select-list.style.ts
@@ -72,7 +72,7 @@ const StyledSelectListTableHeader = styled.thead<StyledSelectListTableHeaderProp
     padding: var(--spacing200);
     background-color: white;
     text-align: left;
-    font-weight: 900;
+    font-weight: 500;
     font-size: 12px;
     text-transform: uppercase;
     color: var(--colorsUtilityYin055);

--- a/src/components/select/__internal__/select-textbox/select-textbox.style.ts
+++ b/src/components/select/__internal__/select-textbox/select-textbox.style.ts
@@ -23,7 +23,7 @@ const StyledSelectText = styled.span<StyledSelectTextProps>`
 
     ${transparent &&
     css`
-      font-weight: 900;
+      font-weight: 500;
       text-align: right;
       flex-direction: row-reverse;
     `}

--- a/src/components/select/__internal__/select-textbox/select-textbox.test.tsx
+++ b/src/components/select/__internal__/select-textbox/select-textbox.test.tsx
@@ -264,7 +264,7 @@ describe("when hasTextCursor prop is false", () => {
 
     expect(screen.getByTestId("select-text")).toHaveStyle({
       textAlign: "right",
-      fontWeight: "900",
+      fontWeight: "500",
     });
   });
 });

--- a/src/components/select/__internal__/utils/highlight-part-of-text.test.tsx
+++ b/src/components/select/__internal__/utils/highlight-part-of-text.test.tsx
@@ -30,7 +30,7 @@ test("returns React element with a matching part highlighted", () => {
   const matchedText = screen.getByTestId("matching-text");
   expect(matchedText).toHaveTextContent("foo");
   expect(matchedText).toHaveStyle({
-    fontWeight: 700,
+    fontWeight: 500,
     textDecoration: "underline",
   });
 });

--- a/src/components/select/__internal__/utils/matching-text.style.ts
+++ b/src/components/select/__internal__/utils/matching-text.style.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 const MatchingText = styled.span`
-  font-weight: 700;
+  font-weight: 500;
   text-decoration: underline;
 `;
 

--- a/src/components/select/filterable-select/filterable-select.pw.tsx
+++ b/src/components/select/filterable-select/filterable-select.pw.tsx
@@ -971,7 +971,7 @@ test.describe("FilterableSelect component", () => {
         "text-decoration-style",
         "solid"
       );
-      await expect(highlightedValue).toHaveCSS("font-weight", "700");
+      await expect(highlightedValue).toHaveCSS("font-weight", "500");
     });
   });
 

--- a/src/components/select/filterable-select/filterable-select.spec.tsx
+++ b/src/components/select/filterable-select/filterable-select.spec.tsx
@@ -1265,7 +1265,7 @@ describe("FilterableSelect", () => {
         {
           content: '"*"',
           color: "var(--colorsSemanticNegative500)",
-          fontWeight: "var(--fontWeights700)",
+          fontWeight: "var(--fontWeights500)",
           marginLeft: "var(--spacing050)",
         },
         wrapper.find(StyledLabel),

--- a/src/components/select/multi-select/multi-select.pw.tsx
+++ b/src/components/select/multi-select/multi-select.pw.tsx
@@ -873,7 +873,7 @@ test.describe("MultiSelect component", () => {
         "text-decoration-style",
         "solid"
       );
-      await expect(highlightedValue).toHaveCSS("font-weight", "700");
+      await expect(highlightedValue).toHaveCSS("font-weight", "500");
     });
   });
 

--- a/src/components/select/multi-select/multi-select.spec.tsx
+++ b/src/components/select/multi-select/multi-select.spec.tsx
@@ -1231,7 +1231,7 @@ describe("MultiSelect", () => {
         {
           content: '"*"',
           color: "var(--colorsSemanticNegative500)",
-          fontWeight: "var(--fontWeights700)",
+          fontWeight: "var(--fontWeights500)",
           marginLeft: "var(--spacing050)",
         },
         wrapper.find(StyledLabel),

--- a/src/components/select/option-row/__snapshots__/option-row.spec.tsx.snap
+++ b/src/components/select/option-row/__snapshots__/option-row.spec.tsx.snap
@@ -20,7 +20,7 @@ exports[`OptionRow renders properly 1`] = `
 }
 
 .c0 td:first-child {
-  font-weight: 700;
+  font-weight: 500;
 }
 
 <table>

--- a/src/components/select/option-row/option-row.style.ts
+++ b/src/components/select/option-row/option-row.style.ts
@@ -30,7 +30,7 @@ const StyledOptionRow = styled.tr<StyledOptionRowProps>`
     padding: 12px 16px;
 
     &:first-child {
-      font-weight: 700;
+      font-weight: 500;
     }
   }
 

--- a/src/components/select/simple-select/simple-select.spec.tsx
+++ b/src/components/select/simple-select/simple-select.spec.tsx
@@ -987,7 +987,7 @@ describe("SimpleSelect", () => {
         {
           content: '"*"',
           color: "var(--colorsSemanticNegative500)",
-          fontWeight: "var(--fontWeights700)",
+          fontWeight: "var(--fontWeights500)",
           marginLeft: "var(--spacing050)",
         },
         wrapper.find(StyledLabel),

--- a/src/components/step-flow/step-flow-title/step-flow-title.component.tsx
+++ b/src/components/step-flow/step-flow-title/step-flow-title.component.tsx
@@ -44,7 +44,7 @@ export const StepFlowTitle = ({
         data-element="title-text"
       >
         <Typography
-          fontWeight="900"
+          fontWeight="700"
           fontSize="var(--fontSizes600)"
           lineHeight="var(--sizing375)"
           variant="span"

--- a/src/components/step-flow/step-flow.component.tsx
+++ b/src/components/step-flow/step-flow.component.tsx
@@ -185,7 +185,7 @@ export const StepFlow = forwardRef<StepFlowHandle, StepFlowProps>(
           {category ? (
             <StyledStepContentText>
               <Typography
-                fontWeight="500"
+                fontWeight="400"
                 fontSize="var(--fontSizes100)"
                 lineHeight="var(--sizing250)"
                 variant="span"

--- a/src/components/switch/__internal__/switch-slider.style.ts
+++ b/src/components/switch/__internal__/switch-slider.style.ts
@@ -26,7 +26,7 @@ const StyledSwitchSlider = styled.div`
   }: StyledSwitchSliderProps) => css`
     display: flex;
     font-size: 12px;
-    font-weight: bold;
+    font-weight: 500;
     height: 28px;
     left: 0;
     letter-spacing: 1px;

--- a/src/components/tabs/__internal__/tab-title/tab-title.spec.tsx
+++ b/src/components/tabs/__internal__/tab-title/tab-title.spec.tsx
@@ -60,7 +60,7 @@ describe("TabTitle", () => {
       {
         backgroundColor: "transparent",
         display: "inline-block",
-        fontWeight: "bold",
+        fontWeight: "500",
         height: "var(--sizing500)",
       },
       render({}, mount).find(StyledTabTitleButton)

--- a/src/components/tabs/__internal__/tab-title/tab-title.style.ts
+++ b/src/components/tabs/__internal__/tab-title/tab-title.style.ts
@@ -294,7 +294,7 @@ const tabTitleStyles = css<TabTitleProps>`
   display: inline-block;
   border-top-left-radius: var(--borderRadius100);
   border-top-right-radius: var(--borderRadius100);
-  font-weight: bold;
+  font-weight: 500;
   position: relative;
   border: none;
   cursor: pointer;

--- a/src/components/text-editor/__internal__/editor-link/editor-link.style.ts
+++ b/src/components/text-editor/__internal__/editor-link/editor-link.style.ts
@@ -6,7 +6,7 @@ const StyledEditorLink = styled(Link)`
 
   a {
     max-width: 100% span span span {
-      font-weight: 700;
+      font-weight: 500;
       font-style: normal;
     }
   }

--- a/src/components/textbox/__internal__/prefix.style.ts
+++ b/src/components/textbox/__internal__/prefix.style.ts
@@ -4,7 +4,7 @@ import { TextboxProps } from "../textbox.component";
 
 const StyledPrefix = styled.span<{ size: NonNullable<TextboxProps["size"]> }>`
   align-self: center;
-  font-weight: 900;
+  font-weight: 700;
   margin-left: ${({ size }) =>
     InputSizes[size]
       .horizontalPadding}; // margin must match the original component padding

--- a/src/components/textbox/textbox.pw.tsx
+++ b/src/components/textbox/textbox.pw.tsx
@@ -553,7 +553,7 @@ test.describe("Prop checks for Textbox component", () => {
 
       await expect(textboxPrefix(page)).toHaveText(prefix);
       await expect(textboxPrefix(page)).toHaveCSS("font-size", "14px");
-      await expect(textboxPrefix(page)).toHaveCSS("font-weight", "900");
+      await expect(textboxPrefix(page)).toHaveCSS("font-weight", "700");
       await expect(textboxPrefix(page)).toHaveCSS("margin-left", "12px");
     });
   });

--- a/src/components/tile-select/tile-select.style.ts
+++ b/src/components/tile-select/tile-select.style.ts
@@ -9,7 +9,7 @@ import addFocusStyling from "../../style/utils/add-focus-styling";
 
 const StyledTitle = styled.h3`
   font-size: 16px;
-  font-weight: 900;
+  font-weight: 700;
   margin: 0;
   margin-right: 16px;
   margin-bottom: 8px;
@@ -18,7 +18,7 @@ const StyledTitle = styled.h3`
 
 const StyledSubtitle = styled.h4`
   font-size: 14px;
-  font-weight: 700;
+  font-weight: 500;
   margin: 0;
   margin-right: 16px;
   margin-bottom: 8px;

--- a/src/components/tile/tile.stories.tsx
+++ b/src/components/tile/tile.stories.tsx
@@ -92,7 +92,7 @@ export const WithTileFooter: Story = () => {
     <Box>
       <Tile orientation="vertical" width={400}>
         <TileContent>
-          <Typography pb={2} variant="h4" fontWeight="bold">
+          <Typography pb={2} variant="h4" fontWeight="500">
             Example header
           </Typography>
           <Typography>
@@ -113,7 +113,7 @@ export const WithTileFooter: Story = () => {
       <Tile px={0} pb={0} orientation="vertical" width={400}>
         <TileContent>
           <Box px={3}>
-            <Typography pb={2} variant="h4" fontWeight="bold">
+            <Typography pb={2} variant="h4" fontWeight="500">
               Example header
             </Typography>
             <Typography>
@@ -135,7 +135,7 @@ export const WithTileFooter: Story = () => {
       <Tile px={0} pb={0} orientation="vertical" width={425}>
         <TileContent>
           <Box px={3}>
-            <Typography pb={2} variant="h4" fontWeight="bold">
+            <Typography pb={2} variant="h4" fontWeight="500">
               Example header
             </Typography>
             <Typography>Labore ipsum nostrud quis aliquip</Typography>
@@ -185,7 +185,7 @@ export const WithTileFooter: Story = () => {
       <Tile px={0} pb={0} orientation="vertical" width={400}>
         <TileContent>
           <Box px={3}>
-            <Typography pb={2} variant="h4" fontWeight="bold">
+            <Typography pb={2} variant="h4" fontWeight="500">
               Example header
             </Typography>
             <Typography>
@@ -202,7 +202,7 @@ export const WithTileFooter: Story = () => {
       <Tile px={0} pb={0} orientation="vertical" width={400}>
         <TileContent>
           <Box px={3}>
-            <Typography pb={2} variant="h4" fontWeight="bold">
+            <Typography pb={2} variant="h4" fontWeight="500">
               Example header
             </Typography>
             <Typography>
@@ -231,7 +231,7 @@ export const WithTileHeader: Story = () => (
           <Typography display="inline">Example text</Typography>
         </TileHeader>
         <Box pt={2}>
-          <Typography pb={2} variant="h4" fontWeight="bold">
+          <Typography pb={2} variant="h4" fontWeight="500">
             Example tile body
           </Typography>
           <Typography>
@@ -253,7 +253,7 @@ export const WithTileHeader: Story = () => (
           <Typography display="inline">Example text</Typography>
         </TileHeader>
         <Box px={3} pt={3}>
-          <Typography pb={2} variant="h4" fontWeight="bold">
+          <Typography pb={2} variant="h4" fontWeight="500">
             Example tile body
           </Typography>
           <Typography>
@@ -270,7 +270,7 @@ export const WithTileHeader: Story = () => (
       <TileContent>
         <TileHeader p={2} variant="black" />
         <Box px={3} pt={3}>
-          <Typography pb={2} variant="h4" fontWeight="bold">
+          <Typography pb={2} variant="h4" fontWeight="500">
             Example tile body
           </Typography>
           <Typography>
@@ -287,7 +287,7 @@ export const WithTileHeader: Story = () => (
       <TileContent>
         <TileHeader p={2} variant="grey" />
         <Box px={3} pt={3}>
-          <Typography pb={2} variant="h4" fontWeight="bold">
+          <Typography pb={2} variant="h4" fontWeight="500">
             Example tile body
           </Typography>
           <Typography>
@@ -328,7 +328,7 @@ export const WithButtonInTileHeader: Story = () => {
           </Button>
         </TileHeader>
         <Box px={3} pt={3}>
-          <Typography pb={2} variant="h4" fontWeight="bold">
+          <Typography pb={2} variant="h4" fontWeight="500">
             Example tile body
           </Typography>
           <Typography>{content1}</Typography>
@@ -441,7 +441,7 @@ export const CustomBorders: Story = () => {
         borderVariant="selected"
       >
         <TileContent>
-          <Typography pb={2} variant="h4" fontWeight="bold">
+          <Typography pb={2} variant="h4" fontWeight="500">
             Selected variant
           </Typography>
           <Typography>
@@ -460,7 +460,7 @@ export const CustomBorders: Story = () => {
         borderVariant="positive"
       >
         <TileContent>
-          <Typography pb={2} variant="h4" fontWeight="bold">
+          <Typography pb={2} variant="h4" fontWeight="500">
             Positive variant
           </Typography>
           <Typography>
@@ -479,7 +479,7 @@ export const CustomBorders: Story = () => {
         borderVariant="negative"
       >
         <TileContent>
-          <Typography pb={2} variant="h4" fontWeight="bold">
+          <Typography pb={2} variant="h4" fontWeight="500">
             Negative variant
           </Typography>
           <Typography>
@@ -498,7 +498,7 @@ export const CustomBorders: Story = () => {
         borderVariant="caution"
       >
         <TileContent>
-          <Typography pb={2} variant="h4" fontWeight="bold">
+          <Typography pb={2} variant="h4" fontWeight="500">
             Caution variant
           </Typography>
           <Typography>
@@ -512,7 +512,7 @@ export const CustomBorders: Story = () => {
       <Box my={3} />
       <Tile orientation="vertical" width={400} borderWidth="borderWidth100">
         <TileContent>
-          <Typography pb={2} variant="h4" fontWeight="bold">
+          <Typography pb={2} variant="h4" fontWeight="500">
             Default/neutral variant
           </Typography>
           <Typography>
@@ -531,7 +531,7 @@ export const CustomBorders: Story = () => {
         borderVariant="info"
       >
         <TileContent>
-          <Typography pb={2} variant="h4" fontWeight="bold">
+          <Typography pb={2} variant="h4" fontWeight="500">
             Info variant
           </Typography>
           <Typography>

--- a/src/components/time/time.style.ts
+++ b/src/components/time/time.style.ts
@@ -3,7 +3,7 @@ import Label from "../../__internal__/label";
 
 export const StyledLabel = styled(Label)`
   label {
-    font-weight: var(--fontWeights500);
+    font-weight: var(--fontWeights400);
   }
 `;
 

--- a/src/components/typography/typography.pw.tsx
+++ b/src/components/typography/typography.pw.tsx
@@ -125,7 +125,7 @@ const getWeight = (variant: VariantTypes) => {
     case "h1":
     case "segment-header":
     case "segment-header-small":
-      return "900";
+      return "700";
     case "h2":
     case "h3":
     case "segment-subheader":
@@ -133,7 +133,7 @@ const getWeight = (variant: VariantTypes) => {
     case "b":
     case "em":
     case "strong":
-      return "700";
+      return "500";
     case "h4":
     case "h5":
     case "p":

--- a/src/components/typography/typography.style.ts
+++ b/src/components/typography/typography.style.ts
@@ -93,7 +93,7 @@ const getWeight = (variant?: VariantTypes) => {
     case "h1":
     case "segment-header":
     case "segment-header-small":
-      return "900";
+      return "700";
     case "h2":
     case "h3":
     case "segment-subheader":
@@ -101,7 +101,7 @@ const getWeight = (variant?: VariantTypes) => {
     case "b":
     case "em":
     case "strong":
-      return "700";
+      return "500";
     case "h4":
     case "h5":
     case "p":

--- a/src/components/typography/typography.test.tsx
+++ b/src/components/typography/typography.test.tsx
@@ -22,7 +22,7 @@ test("should render with expected styles when variant is 'h1-large'", () => {
   expect(screen.getByText("Test")).toHaveStyle({
     fontSize: "32px",
     lineHeight: "40px",
-    fontWeight: "900",
+    fontWeight: "700",
     textTransform: "none",
     textDecoration: "none",
     margin: "0",
@@ -35,7 +35,7 @@ test("should render with expected styles when variant is 'h1'", () => {
   expect(screen.getByText("Test")).toHaveStyle({
     fontSize: "24px",
     lineHeight: "31px",
-    fontWeight: "900",
+    fontWeight: "700",
     textTransform: "none",
     textDecoration: "none",
     margin: "0",
@@ -48,7 +48,7 @@ test("should render with expected styles when variant is 'h2'", () => {
   expect(screen.getByText("Test")).toHaveStyle({
     fontSize: "22px",
     lineHeight: "29px",
-    fontWeight: "700",
+    fontWeight: "500",
     textTransform: "none",
     textDecoration: "none",
     margin: "0",
@@ -61,7 +61,7 @@ test("should render with expected styles when variant is 'h3'", () => {
   expect(screen.getByText("Test")).toHaveStyle({
     fontSize: "20px",
     lineHeight: "26px",
-    fontWeight: "700",
+    fontWeight: "500",
     textTransform: "none",
     textDecoration: "none",
     margin: "0",
@@ -100,7 +100,7 @@ test("should render with expected styles when variant is 'segment-header'", () =
   expect(screen.getByText("Test")).toHaveStyle({
     fontSize: "20px",
     lineHeight: "26px",
-    fontWeight: "900",
+    fontWeight: "700",
     textTransform: "none",
     textDecoration: "none",
     margin: "0",
@@ -113,7 +113,7 @@ test("should render with expected styles when variant is 'segment-header-small'"
   expect(screen.getByText("Test")).toHaveStyle({
     fontSize: "18px",
     lineHeight: "23px",
-    fontWeight: "900",
+    fontWeight: "700",
     textTransform: "none",
     textDecoration: "none",
     margin: "0",
@@ -126,7 +126,7 @@ test("should render with expected styles when variant is 'segment-subheader'", (
   expect(screen.getByText("Test")).toHaveStyle({
     fontSize: "16px",
     lineHeight: "31px",
-    fontWeight: "700",
+    fontWeight: "500",
     textTransform: "none",
     textDecoration: "none",
     margin: "0",
@@ -139,7 +139,7 @@ test("should render with expected styles when variant is 'segment-subheader-alt'
   expect(screen.getByText("Test")).toHaveStyle({
     fontSize: "14px",
     lineHeight: "21px",
-    fontWeight: "700",
+    fontWeight: "500",
     textTransform: "uppercase",
     textDecoration: "none",
     margin: "0",
@@ -219,7 +219,7 @@ test("should render with expected styles when variant is 'strong'", () => {
   expect(screen.getByText("Test")).toHaveStyle({
     fontSize: "14px",
     lineHeight: "21px",
-    fontWeight: "700",
+    fontWeight: "500",
     textTransform: "none",
     textDecoration: "none",
     margin: "0",
@@ -232,7 +232,7 @@ test("should render with expected styles when variant is 'b'", () => {
   expect(screen.getByText("Test")).toHaveStyle({
     fontSize: "14px",
     lineHeight: "21px",
-    fontWeight: "700",
+    fontWeight: "500",
     textTransform: "none",
     textDecoration: "none",
     margin: "0",
@@ -245,7 +245,7 @@ test("should render with expected styles when variant is 'em'", () => {
   expect(screen.getByText("Test")).toHaveStyle({
     fontSize: "14px",
     lineHeight: "21px",
-    fontWeight: "700",
+    fontWeight: "500",
     textTransform: "none",
     textDecoration: "underline",
     margin: "0",

--- a/src/components/vertical-menu/vertical-menu.style.ts
+++ b/src/components/vertical-menu/vertical-menu.style.ts
@@ -29,7 +29,7 @@ export const StyledVerticalMenuItem = styled.div<StyledVerticalMenuProps>`
   display: flex;
   border: none;
   align-items: center;
-  font-weight: 600;
+  font-weight: 500;
   font-size: 14px;
   cursor: pointer;
   color: var(--colorsComponentsLeftnavWinterStandardContent);
@@ -81,7 +81,7 @@ export const StyledVerticalMenuItem = styled.div<StyledVerticalMenuProps>`
 StyledVerticalMenuItem.defaultProps = { theme: baseTheme };
 
 export const StyledTitle = styled.h3`
-  font-weight: 600;
+  font-weight: 500;
   font-size: 14px;
   line-height: 21px;
   margin: 0;

--- a/src/style/fonts.css
+++ b/src/style/fonts.css
@@ -19,7 +19,7 @@
 @font-face {
   font-family: "Sage UI";
   font-style: normal;
-  font-weight: 700;
+  font-weight: 500;
   src: url("~@sage/design-tokens/assets/fonts/sageui-medium.woff2") format("woff2"),
     url("~@sage/design-tokens/assets/fonts/sageui-medium.woff") format("woff"),
     url("~@sage/design-tokens/assets/fonts/sageui-medium.ttf") format("truetype"),
@@ -29,7 +29,7 @@
 @font-face {
   font-family: "Sage UI";
   font-style: normal;
-  font-weight: 900;
+  font-weight: 700;
   src: url("~@sage/design-tokens/assets/fonts/sageui-bold.woff2") format("woff2"),
     url("~@sage/design-tokens/assets/fonts/sageui-bold.woff") format("woff"),
     url("~@sage/design-tokens/assets/fonts/sageui-bold.ttf") format("truetype"),

--- a/src/style/global-style.ts
+++ b/src/style/global-style.ts
@@ -19,12 +19,12 @@ const GlobalStyle = createGlobalStyle`
     font-family: inherit;
   }
 
-  h1, .h1 { font-size: 24px; font-weight: 900; line-height: 32px; }
-  h2, .h2 { font-size: 22px; font-weight: 700; margin-bottom: 26px; }
-  h3, .h3 { font-size: 20px; font-weight: 700; margin-bottom: 24px; }
-  h4, .h4 { font-size: 18px; font-weight: 700; margin-bottom: 22px; }
-  h5, .h5 { font-size: 16px; font-weight: 700; margin-bottom: 20px; }
-  h6, .h6 { font-size: 14px; font-weight: 700; margin-bottom: 18px; }
+  h1, .h1 { font-size: 24px; font-weight: 700; line-height: 32px; }
+  h2, .h2 { font-size: 22px; font-weight: 500; margin-bottom: 26px; }
+  h3, .h3 { font-size: 20px; font-weight: 500; margin-bottom: 24px; }
+  h4, .h4 { font-size: 18px; font-weight: 500; margin-bottom: 22px; }
+  h5, .h5 { font-size: 16px; font-weight: 500; margin-bottom: 20px; }
+  h6, .h6 { font-size: 14px; font-weight: 500; margin-bottom: 18px; }
 
   [data-element=${TAB_GUARD_TOP}], [data-element=${TAB_GUARD_BOTTOM}] {
     position: fixed;


### PR DESCRIPTION
### Proposed behaviour

Updating the fonts so that we see the following range:

- 700 - the new thickest weight relative number
- 500 - the new "bold" weight
- 400 - this is the same as currently implemented

### Current behaviour

The current weights are:

- 900
- 700
- 400

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

A note for QA - you should see NO DIFFERENCE with components. Though the title segments in Storybook might be thicker, not sure how we manage that, but no component should look different from what they do today, that is the QA part.

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
