### PR TITLE
chore: upgrade playwright to v1.47

### DIFF
--- a/.github/workflows/playwright-audit.yml
+++ b/.github/workflows/playwright-audit.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.43.0-jammy
+      image: mcr.microsoft.com/playwright:v1.47.0-jammy
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.43.0-jammy
+      image: mcr.microsoft.com/playwright:v1.47.0-jammy
     strategy:
       fail-fast: false
       matrix:

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "styled-system": "^5.1.5"
       },
       "devDependencies": {
-        "@axe-core/playwright": "~4.9.0",
+        "@axe-core/playwright": "~4.10.0",
         "@babel/cli": "^7.23.4",
         "@babel/core": "^7.23.3",
         "@babel/eslint-parser": "^7.23.3",
@@ -48,8 +48,8 @@
         "@babel/types": "^7.23.4",
         "@commitlint/cli": "^17.6.3",
         "@commitlint/config-conventional": "^17.6.3",
-        "@playwright/experimental-ct-react17": "~1.43.0",
-        "@playwright/test": "~1.43.0",
+        "@playwright/experimental-ct-react17": "~1.47.0",
+        "@playwright/test": "~1.47.0",
         "@sage/design-tokens": "~4.29.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^6.0.3",
@@ -196,12 +196,13 @@
       }
     },
     "node_modules/@axe-core/playwright": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.9.0.tgz",
-      "integrity": "sha512-Q1Lz75dNsX38jof+aev7RficDMdH/HLOLySkDdXR0fUoeFcLdw4UNgDO2CNNP4CTpoesEdfYRdd6VmDXjhBgbA==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.0.tgz",
+      "integrity": "sha512-kEr3JPEVUSnKIYp/egV2jvFj+chIjCjPp3K3zlpJMza/CB3TFw8UZNbI9agEC2uMz4YbgAOyzlbUy0QS+OofFA==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
-        "axe-core": "~4.9.0"
+        "axe-core": "~4.10.0"
       },
       "peerDependencies": {
         "playwright-core": ">= 1.0.0"
@@ -4439,51 +4440,51 @@
       }
     },
     "node_modules/@playwright/experimental-ct-core": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-core/-/experimental-ct-core-1.43.0.tgz",
-      "integrity": "sha512-kLYMqvHY0D30AsggB6xtit6KCnGtPLMIpfxqTqXFbbHUgfdrW3bberjzAN9sfuranbcgqwO4uxAvilo0fHXuWw==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-core/-/experimental-ct-core-1.47.0.tgz",
+      "integrity": "sha512-IgZBGLREGUqTEXwb8Kh0vEG+/CHHf7EtpivAVoaO8cPzEfZU0LMlyjBaQk0ry5LDD65BZ9DwhTfMYMekAqWXMg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.43.0",
-        "playwright-core": "1.43.0",
-        "vite": "^5.0.13"
-      },
-      "bin": {
-        "playwright": "cli.js"
+        "playwright": "1.47.0",
+        "playwright-core": "1.47.0",
+        "vite": "^5.2.8"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@playwright/experimental-ct-react17": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-react17/-/experimental-ct-react17-1.43.0.tgz",
-      "integrity": "sha512-4MZ88OJDCovPVIRUq4ejVlrTDGgQkw5n+CpInBwKg8fQkuVe+SLRgih8P/mujiz9a3rhAQTsXz+UEpqbzS24nA==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@playwright/experimental-ct-react17/-/experimental-ct-react17-1.47.0.tgz",
+      "integrity": "sha512-WOeEXx4PzZ2Qa6BYAw0c0gZFKBfYN4x1Jesf8Q9Tp6UA8Ye/7NgRjOfZzh7NqE8KWWyj4Dun4kZbFQr+lV5YQg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@playwright/experimental-ct-core": "1.43.0",
+        "@playwright/experimental-ct-core": "1.47.0",
         "@vitejs/plugin-react": "^4.2.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.0.tgz",
-      "integrity": "sha512-Ebw0+MCqoYflop7wVKj711ccbNlrwTBCtjY5rlbiY9kHL2bCYxq+qltK6uPsVBGGAOb033H2VO0YobcQVxoW7Q==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0.tgz",
+      "integrity": "sha512-SgAdlSwYVpToI4e/IH19IHHWvoijAYH5hu2MWSXptRypLSnzj51PcGD+rsOXFayde4P9ZLi+loXVwArg6IUkCA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.43.0"
+        "playwright": "1.47.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -8913,10 +8914,11 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.0.tgz",
-      "integrity": "sha512-H5orY+M2Fr56DWmMFpMrq5Ge93qjNdPVqzBv5gWK3aD1OvjBEJlEzxf09z93dGVQeI0LiW+aCMIx1QtShC/zUw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.0.tgz",
+      "integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
       "dev": true,
+      "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
       }
@@ -29795,33 +29797,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.0.tgz",
-      "integrity": "sha512-SiOKHbVjTSf6wHuGCbqrEyzlm6qvXcv7mENP+OZon1I07brfZLGdfWV0l/efAzVx7TF3Z45ov1gPEkku9q25YQ==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0.tgz",
+      "integrity": "sha512-jOWiRq2pdNAX/mwLiwFYnPHpEZ4rM+fRSQpRHwEwZlP2PUANvL3+aJOF/bvISMhFD30rqMxUB4RJx9aQbfh4Ww==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.43.0"
+        "playwright-core": "1.47.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.0.tgz",
-      "integrity": "sha512-iWFjyBUH97+pUFiyTqSLd8cDMMOS0r2ZYz2qEsPjH8/bX++sbIJT35MSwKnp1r/OQBAqC5XO99xFbJ9XClhf4w==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0.tgz",
+      "integrity": "sha512-1DyHT8OqkcfCkYUD9zzUTfg7EfTd+6a8MkD/NWOvjo0u/SCNd5YmY/lJwFvUZOxJbWNds+ei7ic2+R/cRz/PDg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/please-upgrade-node": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "styled-components": "^4.4.1"
   },
   "devDependencies": {
-    "@axe-core/playwright": "~4.9.0",
+    "@axe-core/playwright": "~4.10.0",
     "@babel/cli": "^7.23.4",
     "@babel/core": "^7.23.3",
     "@babel/eslint-parser": "^7.23.3",
@@ -69,8 +69,8 @@
     "@babel/types": "^7.23.4",
     "@commitlint/cli": "^17.6.3",
     "@commitlint/config-conventional": "^17.6.3",
-    "@playwright/experimental-ct-react17": "~1.43.0",
-    "@playwright/test": "~1.43.0",
+    "@playwright/experimental-ct-react17": "~1.47.0",
+    "@playwright/test": "~1.47.0",
     "@sage/design-tokens": "~4.29.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^6.0.3",


### PR DESCRIPTION
### Proposed behaviour

- Upgrade the following packages:
   - `@playwright/test` to version 1.47
   - `@playwright/experimental-ct-react17` to version 1.47
   - `@axe-core/playwright` to version 4.10
- Amend GitHub Actions workflows to upgrade Playwright image used 

### Current behaviour

- `@playwright/test` is on version 1.43
- `@playwright/experimental-ct-react17` is on version 1.43
- `@axe-core/playwright` is on version 4.9

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x]  Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

A bug was observed when running `npm run test:ct -- --ui` to run the [Playwright tests in UI mode](https://playwright.dev/docs/test-ui-mode), where the [results and timeline of a run test are wiped immediately after](https://github.com/microsoft/playwright/issues/30718). 

https://github.com/user-attachments/assets/cfe36bed-1e64-4d06-ad52-e3e49da27d07