### PR TITLE
fix(checkbox, radio-button): restore support for `labelHelp` and `fieldHelp`

### DIFF
--- a/src/__internal__/checkable-input/checkable-input.component.tsx
+++ b/src/__internal__/checkable-input/checkable-input.component.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useContext } from "react";
+import React, { useRef } from "react";
 
 import {
   StyledCheckableInput,
@@ -12,7 +12,6 @@ import HiddenCheckableInput, {
 import guid from "../utils/helpers/guid";
 import useInputAccessibility from "../../hooks/__internal__/useInputAccessibility";
 import { ValidationProps } from "../validations";
-import NewValidationContext from "../../components/carbon-provider/__internal__/new-validation.context";
 
 export interface CommonCheckableInputProps
   extends ValidationProps,
@@ -21,10 +20,10 @@ export interface CommonCheckableInputProps
   disabled?: boolean;
   /** @private @ignore */
   loading?: boolean;
-  /** [Legacy] Help content to be displayed under an input */
+  /** Help content to be displayed under an input */
   fieldHelp?: React.ReactNode;
   /**
-   * [Legacy] If true, the FieldHelp will be displayed inline
+   * If true, the FieldHelp will be displayed inline
    * To be used with labelInline prop set to true
    */
   fieldHelpInline?: boolean;
@@ -34,7 +33,7 @@ export interface CommonCheckableInputProps
   inputWidth?: number;
   /** Label content */
   label?: React.ReactNode;
-  /** [Legacy] The content for the help tooltip, to appear next to the Label */
+  /** The content for the help tooltip, to appear next to the Label */
   labelHelp?: React.ReactNode;
   /** Spacing between label and a field for inline label, given number will be multiplied by base spacing unit (8) */
   labelSpacing?: 1 | 2;
@@ -101,7 +100,6 @@ const CheckableInput = React.forwardRef(
     ref: React.ForwardedRef<HTMLInputElement>
   ) => {
     const { current: id } = useRef(inputId || guid());
-    const { validationRedesignOptIn } = useContext(NewValidationContext);
 
     const {
       labelId,
@@ -139,7 +137,7 @@ const CheckableInput = React.forwardRef(
       // However, we still want the input element to receive the required prop
       isRequired: required,
       isOptional,
-      useValidationIcon: validationRedesignOptIn ? false : validationOnLabel,
+      useValidationIcon: validationOnLabel,
     };
 
     const inputProps = {

--- a/src/components/checkbox/checkbox-group/checkbox-group.component.tsx
+++ b/src/components/checkbox/checkbox-group/checkbox-group.component.tsx
@@ -17,8 +17,8 @@ export interface CheckboxGroupProps extends ValidationProps, MarginProps {
   /** The content for the CheckboxGroup Legend */
   legend?: string;
   /**
-   * The content for the CheckboxGroup hint text,
-   * will only be rendered when `validationRedesignOptIn` is true.
+   * The content for the CheckboxGroup Help tooltip,
+   * will be rendered as hint text when `validationRedesignOptIn` is true.
    */
   legendHelp?: string;
   /** [Legacy] When true, legend is placed inline with the checkboxes */
@@ -39,7 +39,7 @@ export interface CheckboxGroupProps extends ValidationProps, MarginProps {
   isOptional?: boolean;
   /** [Legacy] Overrides the default tooltip */
   tooltipPosition?: "top" | "bottom" | "left" | "right";
-  /** When true, Checkboxes are inline */
+  /** When true, Checkboxes are in line */
   inline?: boolean;
 }
 
@@ -69,8 +69,12 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
         <Fieldset
           legend={legend}
           inline={legendInline}
+          legendWidth={legendWidth}
+          legendAlign={legendAlign}
+          legendSpacing={legendSpacing}
           error={error}
           warning={warning}
+          info={info}
           isRequired={required}
           isOptional={isOptional}
           {...tagComponent("checkboxgroup", props)}
@@ -86,6 +90,7 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
             <StyledCheckboxGroup
               data-component="checkbox-group"
               data-role="checkbox-group"
+              legendInline={legendInline}
               inline={inline}
             >
               <CheckboxGroupContext.Provider
@@ -122,7 +127,6 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
               data-component="checkbox-group"
               data-role="checkbox-group"
               legendInline={legendInline}
-              inline={inline}
             >
               <CheckboxGroupContext.Provider
                 value={{

--- a/src/components/checkbox/checkbox-group/checkbox-group.test.tsx
+++ b/src/components/checkbox/checkbox-group/checkbox-group.test.tsx
@@ -121,27 +121,6 @@ test("should render with expected styles when inline is true", () => {
   });
 });
 
-test("should not render labelHelp and fieldHelp passed to children when validationRedesignOptIn is true", () => {
-  render(
-    <CarbonProvider validationRedesignOptIn>
-      <CheckboxGroup legend="legend">
-        <Checkbox
-          value="1"
-          label="label"
-          labelHelp="labelHelp"
-          fieldHelp="fieldHelp"
-          onChange={() => {}}
-        />
-      </CheckboxGroup>
-    </CarbonProvider>
-  );
-
-  expect(
-    screen.queryByRole("button", { name: "help" })
-  ).not.toBeInTheDocument();
-  expect(screen.queryByText("fieldHelp")).not.toBeInTheDocument();
-});
-
 testStyledSystemMargin((props) => (
   <CheckboxGroup legend="legend" {...props}>
     <Checkbox value="1" label="label" onChange={() => {}} />

--- a/src/components/checkbox/checkbox-test.stories.tsx
+++ b/src/components/checkbox/checkbox-test.stories.tsx
@@ -1,18 +1,12 @@
 import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
 
-import { Checkbox, CheckboxGroup, CheckboxGroupProps, CheckboxProps } from ".";
+import { Checkbox, CheckboxProps } from ".";
 import Box from "../box";
-import CarbonProvider from "../carbon-provider";
 
 export default {
   title: "Checkbox/Test",
-  includeStories: [
-    "Default",
-    "WithLongLabel",
-    "WithNewValidation",
-    "WithNewValidationGroup",
-  ],
+  includeStories: ["Default", "WithLongLabel"],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -116,43 +110,4 @@ WithLongLabel.storyName = "With long label";
 WithLongLabel.args = {
   label: "A really long description that will wrap onto the next line.",
   size: "",
-};
-
-export const WithNewValidation = (props: Partial<CheckboxProps>) => {
-  return (
-    <CarbonProvider validationRedesignOptIn>
-      <Checkbox label="Checkbox 1" {...props} />
-    </CarbonProvider>
-  );
-};
-
-WithNewValidation.args = {
-  error: "Error message",
-  warning: "",
-  fieldHelp: "field help text",
-  labelHelp: "label help text",
-  required: false,
-  checked: false,
-};
-
-export const WithNewValidationGroup = ({
-  ...props
-}: Partial<CheckboxGroupProps>) => {
-  return (
-    <CarbonProvider validationRedesignOptIn>
-      <CheckboxGroup legend="Checkbox legend" {...props}>
-        <Checkbox label="Checkbox 1" labelHelp="this shouldn't render" />
-        <Checkbox label="Checkbox 2" fieldHelp="this shouldn't render either" />
-        <Checkbox label="Checkbox 3" />
-      </CheckboxGroup>
-    </CarbonProvider>
-  );
-};
-
-WithNewValidationGroup.args = {
-  error: "Error message",
-  warning: "",
-  legendHelp: "Legend help text",
-  legendInline: false,
-  required: false,
 };

--- a/src/components/checkbox/checkbox.component.tsx
+++ b/src/components/checkbox/checkbox.component.tsx
@@ -24,13 +24,13 @@ export interface CheckboxProps extends CommonCheckableInputProps, MarginProps {
   "data-element"?: string;
   /** Identifier used for testing purposes, applied to the root element of the component. */
   "data-role"?: string;
-  /** [Legacy] Aria label for rendered help component */
+  /** Aria label for rendered help component */
   helpAriaLabel?: string;
   /** When true label is inline */
   labelInline?: boolean;
   /** Accepts a callback function which is triggered on click event */
   onClick?: (ev: React.MouseEvent<HTMLInputElement>) => void;
-  /** [Legacy] Overrides the default tooltip position */
+  /** Overrides the default tooltip position */
   tooltipPosition?: "top" | "bottom" | "left" | "right";
   /** The value of the checkbox, passed on form submit */
   value?: string;
@@ -97,15 +97,6 @@ export const Checkbox = React.forwardRef(
       );
     }
 
-    const commonProps = {
-      fieldHelpInline,
-      labelSpacing,
-      labelHelp,
-      fieldHelp,
-    };
-
-    const isInGroup = Object.keys(checkboxGroupContext).length !== 0;
-
     const inputProps = {
       ariaLabelledBy,
       onClick,
@@ -119,22 +110,27 @@ export const Checkbox = React.forwardRef(
       type: "checkbox",
       name,
       reverse: !reverse,
+      fieldHelp,
       autoFocus,
+      labelHelp,
+      labelSpacing,
       required,
       isOptional,
+      fieldHelpInline,
       checked,
       disabled,
       inputWidth,
       labelWidth,
       ref,
       ...rest,
-      ...(isInGroup && validationRedesignOptIn ? {} : { ...commonProps }),
     };
 
     const validationProps = {
       error: contextError || error,
       warning: contextWarning || warning,
-      info: contextInfo || info,
+      ...(validationRedesignOptIn
+        ? { validationOnLabel: false }
+        : { info: contextInfo || info }),
     };
 
     const marginProps = useFormSpacing(rest);

--- a/src/components/checkbox/checkbox.mdx
+++ b/src/components/checkbox/checkbox.mdx
@@ -63,6 +63,16 @@ import { Checkbox, CheckboxGroup } from "carbon-react/lib/components/checkbox";
 
 <Canvas of={CheckboxStories.Reversed} />
 
+### With fieldHelp
+
+<Canvas of={CheckboxStories.WithFieldHelp} />
+
+### With labelHelp
+
+**Note:** The `legendHelp` tooltip will be rendered as hint text if the `validationRedesignOptIn` flag on the `CarbonProvider` is true.
+
+<Canvas of={CheckboxStories.WithLabelHelp} />
+
 ### With custom labelWidth
 
 <Canvas of={CheckboxStories.WithCustomLabelWidth} />
@@ -71,11 +81,40 @@ import { Checkbox, CheckboxGroup } from "carbon-react/lib/components/checkbox";
 
 <Canvas of={CheckboxStories.CheckboxGroupStory} />
 
-### Inline Checkbock Group
+### With inline legend
 
-A `Checkbox` in a `CheckboxGroup` can be displayed inline using the `inline` prop. 
+The legend can be made inline by passing the `legendInline` prop to `CheckboxGroup`. Its width can be changed with the `legendWidth` prop and its text alignment with `legendAlign`.
 
-<Canvas of={CheckboxStories.NewInline} />
+The spacing between the legend and the checkboxes can be changed with the `legendSpacing` prop, this can be `1` or `2`, which is multiplied by the base theme spacing constant of `8px`, 
+so therefore `8px` or `16px`. The default is `2` for this prop.
+
+**Note:** The `legendInline` prop is not supported if the `validationRedesignOptIn` flag on the `CarbonProvider` is true. 
+
+<Canvas of={CheckboxStories.CheckboxGroupWithInlineLegend} />
+
+## Validations
+
+The folowing examples use the new validation pattern that is available by setting the `validationRedesignOptIn` flag on the `CarbonProvider` to true.
+
+For more information check our [Validations](../?path=/docs/documentation-validations--docs) documentation page.
+
+This is an example of `Checkbox` in a `CheckboxGroup` with validations passed as a string.
+
+**Note:** The `legendHelp` tooltip will be rendered as "Hint text".
+
+<Canvas of={ValidationStories.NewStringValidation} />
+
+This is an example of `Checkbox` in a `CheckboxGroup` displayed inline using the `inline` prop. 
+
+<Canvas of={ValidationStories.NewInline} />
+
+This is an example of `Checkbox` in a `CheckboxGroup` with validations passed as a string displayed inline.
+
+<Canvas of={ValidationStories.NewStringValidationInline} />
+
+This is an example of `Checkbox` with validations passed as boolean values.
+
+<Canvas of={ValidationStories.NewBooleanValidation} />
 
 ### Required
 
@@ -94,47 +133,6 @@ an individual checkbox input or on the group level.
 <Canvas of={CheckboxStories.IsOptional} />
 
 <Canvas of={CheckboxStories.CheckboxGroupIsOptional} />
-
-## Validations
-
-The folowing examples use the new validation pattern that is available by setting the `validationRedesignOptIn` flag on the `CarbonProvider` to true.
-
-For more information check our [Validations](../?path=/docs/documentation-validations--docs) documentation page.
-
-This is an example of `Checkbox` in a `CheckboxGroup` with validations passed as a string.
-
-You can use the `legendHelp` prop to provide a hint text for the group.
-
-**Note:** The `labelHelp` and/or `fieldHelp` props will not be supported if a `Checkbox` is within a group.
-
-<Canvas of={ValidationStories.NewStringValidation} />
-
-This is an example of `Checkbox` in a `CheckboxGroup` with validations passed as a string displayed inline.
-
-<Canvas of={ValidationStories.NewStringValidationInline} />
-
-This is an example of `Checkbox` with validations passed as boolean values.
-
-<Canvas of={ValidationStories.NewBooleanValidation} />
-
-### With inline legend
-
-The legend can be made inline by passing the `legendInline` prop to `CheckboxGroup`. Its width can be changed with the `legendWidth` prop and its text alignment with `legendAlign`.
-
-The spacing between the legend and the checkboxes can be changed with the `legendSpacing` prop, this can be `1` or `2`, which is multiplied by the base theme spacing constant of `8px`, 
-so therefore `8px` or `16px`. The default is `2` for this prop.
-
-**Note:** The `legendInline` prop is not supported if the `validationRedesignOptIn` flag on the `CarbonProvider` is true. 
-
-<Canvas of={CheckboxStories.CheckboxGroupWithInlineLegend} />
-
-### With fieldHelp
-
-<Canvas of={CheckboxStories.WithFieldHelp} />
-
-### With labelHelp
-
-<Canvas of={CheckboxStories.WithLabelHelp} />
 
 ## Props
 

--- a/src/components/checkbox/checkbox.stories.tsx
+++ b/src/components/checkbox/checkbox.stories.tsx
@@ -125,32 +125,6 @@ export const CheckboxGroupStory: Story = () => {
 };
 CheckboxGroupStory.storyName = "CheckboxGroup";
 
-export const NewInline: Story = () => {
-  return (
-    <CheckboxGroup legend="Label" inline>
-      <Checkbox
-        id="checkbox-one-new-inline"
-        key="checkbox-one-new-inline"
-        label="Example checkbox one"
-        name="checkbox-one-new-inline"
-      />
-      <Checkbox
-        id="checkbox-two-new-inline"
-        key="checkbox-two-new-inline"
-        label="Example checkbox two"
-        name="checkbox-two-new-inline"
-      />
-      <Checkbox
-        id="checkbox-three-new-inline"
-        key="checkbox-three-new-inline"
-        label="Example checkbox three"
-        name="checkbox-three-new-inline"
-      />
-    </CheckboxGroup>
-  );
-};
-NewInline.storyName = "Inline CheckboxGroup";
-
 export const CheckboxGroupWithInlineLegend: Story = () => {
   return (
     <CheckboxGroup

--- a/src/components/checkbox/checkbox.style.ts
+++ b/src/components/checkbox/checkbox.style.ts
@@ -59,13 +59,13 @@ const StyledCheckbox = styled.div<StyledCheckboxProps>`
       css`
         border: 1px solid var(--colorsUtilityMajor300);
 
+        ${info && `border: 1px solid var(--colorsSemanticInfo500);`}
+        ${warning && `border: 1px solid var(--colorsSemanticCaution500);`}
         ${error && `border: 2px solid var(--colorsSemanticNegative500);`}
 
-        ${!applyNewValidation &&
-        css`
-          ${info && `border: 1px solid var(--colorsSemanticInfo500);`}
-          ${warning && `border: 1px solid var(--colorsSemanticCaution500);`}
-        `}
+        ${warning &&
+        applyNewValidation &&
+        `border: 1px solid var(--colorsUtilityMajor300);`}
       `}
     }
 

--- a/src/components/checkbox/validations.stories.tsx
+++ b/src/components/checkbox/validations.stories.tsx
@@ -131,11 +131,39 @@ export const NewStringValidationInline: Story = () => {
 };
 NewStringValidationInline.storyName = "New String Validation Inline";
 
+export const NewInline: Story = () => {
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      <CheckboxGroup legend="Label" legendHelp="Hint Text" required inline>
+        <Checkbox
+          id="checkbox-one-new-inline"
+          key="checkbox-one-new-inline"
+          label="Example checkbox one"
+          name="checkbox-one-new-inline"
+        />
+        <Checkbox
+          id="checkbox-two-new-inline"
+          key="checkbox-two-new-inline"
+          label="Example checkbox two"
+          name="checkbox-two-new-inline"
+        />
+        <Checkbox
+          id="checkbox-three-new-inline"
+          key="checkbox-three-new-inline"
+          label="Example checkbox three"
+          name="checkbox-three-new-inline"
+        />
+      </CheckboxGroup>
+    </CarbonProvider>
+  );
+};
+NewInline.storyName = "New Inline";
+
 export const NewBooleanValidation: Story = () => {
   return (
     <CarbonProvider validationRedesignOptIn>
       <Checkbox
-        error
+        error="message"
         id="checkbox-one-error-boolean"
         key="checkbox-one-error-boolean"
         label="Example checkbox one - Error"

--- a/src/components/numeral-date/numeral-date.mdx
+++ b/src/components/numeral-date/numeral-date.mdx
@@ -55,7 +55,7 @@ For more information check our [Validations](../?path=/docs/documentation-valida
 
 The folowing examples use the new validation pattern that is available by setting the `validationRedesignOptIn` flag on the `CarbonProvider` to true.
 
-**Note:** The `labelHelp` tooltip will be rendered as "Hint text".
+**Note:** The `legendHelp` tooltip will be rendered as "Hint text".
 
 <Canvas of={NumeralDateStories.NewValidation} />
 
@@ -91,7 +91,7 @@ The inline label can change to be top aligned at a breakpoint. Enable this by pa
 
 ### With label help
 
-**Note:** The `labelHelp` tooltip will be rendered as hint text if the `validationRedesignOptIn` flag on the `CarbonProvider` is true.
+**Note:** The `legendHelp` tooltip will be rendered as hint text if the `validationRedesignOptIn` flag on the `CarbonProvider` is true.
 
 <Canvas of={NumeralDateStories.WithLabelHelp} />
 

--- a/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
+++ b/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
@@ -31,8 +31,8 @@ export interface RadioButtonGroupProps extends ValidationProps, MarginProps {
   /** The content for the RadioGroup Legend */
   legend?: string;
   /**
-   * The content for the RadioButtonGroup hint text,
-   * will only be rendered when `validationRedesignOptIn` is true.
+   * The content for the RadioButtonGroup Legend Help tooltip,
+   * will be rendered as hint text when `validationRedesignOptIn` is true.
    */
   legendHelp?: string;
   /** [Legacy] Text alignment of legend when inline */
@@ -120,7 +120,11 @@ export const RadioButtonGroup = (props: RadioButtonGroupProps) => {
           legend={legend}
           error={error}
           warning={warning}
+          info={info}
           inline={inlineLegend}
+          legendWidth={legendWidth}
+          legendAlign={legendAlign}
+          legendSpacing={legendSpacing}
           isRequired={required}
           isOptional={isOptional}
           {...tagComponent("radiogroup", props)}
@@ -142,6 +146,7 @@ export const RadioButtonGroup = (props: RadioButtonGroupProps) => {
               data-component="radio-button-group"
               role="radiogroup"
               inline={inline}
+              legendInline={inlineLegend}
             >
               <RadioButtonMapper
                 name={name}
@@ -159,6 +164,8 @@ export const RadioButtonGroup = (props: RadioButtonGroupProps) => {
                     labelSpacing,
                     error: !!error,
                     warning: !!warning,
+                    info: !!info,
+                    required,
                     ...child.props,
                   });
                 })}

--- a/src/components/radio-button/radio-button-group/radio-button-group.test.tsx
+++ b/src/components/radio-button/radio-button-group/radio-button-group.test.tsx
@@ -296,25 +296,4 @@ describe("when `validationRedesignOptIn` flag is true", () => {
     expect(screen.getAllByRole("radio")).toHaveLength(2);
     expect(screen.getByText("foo")).toBeVisible();
   });
-
-  test("should not render labelHelp and fieldHelp on children", () => {
-    render(
-      <CarbonProvider validationRedesignOptIn>
-        <RadioButtonGroup name="group" legend="legend">
-          <RadioButton
-            key="radio1"
-            value="radio1"
-            label="Radio Button 1"
-            labelHelp="labelHelp"
-            fieldHelp="fieldHelp"
-          />
-        </RadioButtonGroup>
-      </CarbonProvider>
-    );
-
-    expect(
-      screen.queryByRole("button", { name: "help" })
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText("fieldHelp")).not.toBeInTheDocument();
-  });
 });

--- a/src/components/radio-button/radio-button-test.stories.tsx
+++ b/src/components/radio-button/radio-button-test.stories.tsx
@@ -4,18 +4,15 @@ import { StoryFn } from "@storybook/react";
 import { RadioButtonGroup, RadioButton } from ".";
 import { RadioButtonGroupProps } from "./radio-button-group/radio-button-group.component";
 import { RadioButtonProps } from "./radio-button.component";
-import CarbonProvider from "../carbon-provider";
 
 export default {
   title: "Radio Button/Test",
   includeStories: [
-    "WithLabelHelp",
+    "Required",
     "WithValidationsOnButtons",
     "WithValidationsOnRadioGroup",
     "WithTooltipPosition",
     "WithTooltipPositionOnRadioGroup",
-    "WithNewValidation",
-    "WithNewValidationGroup",
   ],
   parameters: {
     info: { disable: true },
@@ -23,52 +20,23 @@ export default {
       disableSnapshot: true,
     },
   },
-  argTypes: {
-    labelSpacing: {
-      options: [1, 2],
-      control: {
-        type: "select",
-      },
-    },
-    size: {
-      options: ["small", "large"],
-      control: {
-        type: "select",
-      },
-    },
-  },
 };
 
-export const WithLabelHelp: StoryFn<typeof RadioButton> = () => (
-  <RadioButtonGroup name="labelHelp" legend="Radio group legend">
-    <RadioButton
-      id="radio-1"
-      value="radio1"
-      label="Radio Option 1"
-      labelHelp="Radio 1"
-    />
-    <RadioButton
-      id="radio-2"
-      value="radio2"
-      label="Radio Option 2"
-      labelHelp="Radio 2"
-    />
-    <RadioButton
-      id="radio-3"
-      value="radio3"
-      label="Radio Option 3"
-      labelHelp="Radio 3"
-    />
+export const Required: StoryFn<typeof RadioButton> = () => (
+  <RadioButtonGroup name="required" legend="Radio group legend" required>
+    <RadioButton id="radio-1" value="radio1" label="Radio Option 1" />
+    <RadioButton id="radio-2" value="radio2" label="Radio Option 2" />
+    <RadioButton id="radio-3" value="radio3" label="Radio Option 3" />
   </RadioButtonGroup>
 );
 
-WithLabelHelp.storyName = "with labelHelp";
+Required.storyName = "required";
 
-export const WithValidationsOnButtons = ({ ...args }) => (
+export const WithValidationsOnButtons: StoryFn<typeof RadioButton> = () => (
   <RadioButtonGroup
     name="validations-on-buttons-group"
     onChange={() => console.log("change")}
-    {...args}
+    legend="Radio group legend"
   >
     <RadioButton
       id="validations-on-buttons-radio-1"
@@ -93,18 +61,13 @@ export const WithValidationsOnButtons = ({ ...args }) => (
 );
 
 WithValidationsOnButtons.storyName = "with validations on RadioButton";
-WithValidationsOnButtons.args = {
-  legend: "Radio group legend",
-  legendInline: false,
-  required: false,
-  inline: false,
-};
 
-export const WithValidationsOnRadioGroup = ({ ...args }) => (
+export const WithValidationsOnRadioGroup: StoryFn<typeof RadioButton> = () => (
   <RadioButtonGroup
     name="validations-on-group"
     onChange={() => console.log("change")}
-    {...args}
+    legend="Radio group legend"
+    error="Error message"
   >
     <RadioButton
       id="validations-on-group-radio-1"
@@ -125,14 +88,6 @@ export const WithValidationsOnRadioGroup = ({ ...args }) => (
 );
 
 WithValidationsOnRadioGroup.storyName = "with validations on RadioGroup";
-WithValidationsOnRadioGroup.args = {
-  error: "Error message",
-  warning: "",
-  legend: "Radio group legend",
-  legendInline: false,
-  required: false,
-  inline: false,
-};
 
 export const WithTooltipPosition: StoryFn<typeof RadioButton> = () => (
   <RadioButtonGroup
@@ -183,52 +138,52 @@ export const WithTooltipPositionOnRadioGroup: StoryFn<
 WithTooltipPositionOnRadioGroup.storyName =
   "with tooltip position on RadioGroup";
 
-export const WithNewValidation = (props: Partial<RadioButtonProps>) => {
+const radioContainerWidth = 400;
+
+export const RadioButtonComponent = (props: Partial<RadioButtonProps>) => {
+  const [isChecked, setIsChecked] = React.useState(false);
   return (
-    <CarbonProvider validationRedesignOptIn>
+    <div
+      style={{
+        marginTop: "64px",
+        marginLeft: "64px",
+        width: radioContainerWidth,
+      }}
+    >
       <RadioButton
         id="radio-1"
         value="radio1"
         label="Radiobutton 1"
+        checked={isChecked}
+        onChange={(e) => setIsChecked(e.target.checked)}
         {...props}
       />
-    </CarbonProvider>
+    </div>
   );
 };
 
-WithNewValidation.args = {
-  error: "Error message",
-  warning: "",
-  fieldHelp: "",
-  labelHelp: "",
-  required: false,
-  checked: false,
-  labelSpacing: 1,
-};
-
-export const WithNewValidationGroup = ({
+export const RadioButtonGroupComponent = ({
+  children,
   ...props
 }: Partial<RadioButtonGroupProps>) => {
   return (
-    <CarbonProvider validationRedesignOptIn>
+    <div
+      style={{
+        marginTop: "64px",
+        marginLeft: "64px",
+      }}
+    >
       <RadioButtonGroup
-        name="radio-button-group"
+        name="radiobuttongroup"
         legend="Radio group legend"
         {...props}
       >
         <RadioButton id="radio-1" value="radio1" label="Yes" />
         <RadioButton id="radio-2" value="radio2" label="No" />
         <RadioButton id="radio-3" value="radio3" label="Maybe" />
-      </RadioButtonGroup>
-    </CarbonProvider>
-  );
-};
 
-WithNewValidationGroup.args = {
-  error: "Error message",
-  warning: "",
-  legendHelp: "Legend help text",
-  legendInline: false,
-  required: true,
-  inline: false,
+        {children}
+      </RadioButtonGroup>
+    </div>
+  );
 };

--- a/src/components/radio-button/radio-button.component.tsx
+++ b/src/components/radio-button/radio-button.component.tsx
@@ -26,9 +26,9 @@ export interface RadioButtonProps
   onClick?: (ev: React.MouseEvent<HTMLInputElement>) => void;
   /** the value of the Radio Button, passed on form submit */
   value: string;
-  /** [Legacy] Overrides the default tooltip position */
+  /** Overrides the default tooltip position */
   tooltipPosition?: "top" | "bottom" | "left" | "right";
-  /** [Legacy] Aria label for rendered help component */
+  /** Aria label for rendered help component */
   helpAriaLabel?: string;
 }
 
@@ -86,31 +86,34 @@ export const RadioButton = React.forwardRef<
     );
 
     const validationProps = {
+      disabled,
+      inputWidth,
       error,
       warning,
       info,
     };
 
     const commonProps = {
+      ...validationProps,
       fieldHelpInline,
-      labelHelp,
-      fieldHelp,
+      labelSpacing,
     };
 
     const inputProps = {
-      ...(!validationRedesignOptIn && { ...commonProps }),
+      ...(validationRedesignOptIn
+        ? { ...validationProps }
+        : { ...commonProps }),
       autoFocus,
       checked,
+      fieldHelp,
       name,
       onChange: handleChange,
       onBlur,
       onFocus,
       labelInline: true,
       labelWidth,
-      labelSpacing,
       label,
-      disabled,
-      inputWidth,
+      labelHelp,
       id,
       value,
       type: "radio",
@@ -139,14 +142,12 @@ export const RadioButton = React.forwardRef<
         inline={inline}
         reverse={reverse}
         size={size}
-        disabled={disabled}
-        inputWidth={inputWidth}
-        labelSpacing={labelSpacing}
-        fieldHelpInline={fieldHelpInline}
-        {...validationProps}
+        {...(validationRedesignOptIn
+          ? { ...validationProps }
+          : { ...commonProps, fieldHelp })}
         {...marginProps}
       >
-        <CheckableInput {...inputProps} {...validationProps}>
+        <CheckableInput {...inputProps}>
           <RadioButtonSvg />
         </CheckableInput>
       </RadioButtonStyle>

--- a/src/components/radio-button/radio-button.mdx
+++ b/src/components/radio-button/radio-button.mdx
@@ -54,11 +54,28 @@ A legend can be set for the group, and each radio button can have a label.
 
 <Canvas of={RadioButtonStories.WithLegendAndLabels} />
 
+### With inline legend
+
+The legend can be made inline. Its width can be changed with the `legendWidth` prop, its text alignment with `legendAlign`.
+
+The spacing between the legend and the radio buttons can be changed with the `legendSpacing` prop, this can be `1` or `2`, which is multiplied by the base theme spacing constant of `8px`, 
+so therefore `8px` or `16px`. The default is `2` for this prop.
+
+**Note:** The `legendInline` prop is not supported if the `validationRedesignOptIn` flag on the `CarbonProvider` is true. 
+
+<Canvas of={RadioButtonStories.WithInlineLegend} />
+
 ### With left margin
 
 A `ml` prop can be supplied to align the `RadioButtonGroup` with above and below components. This prop is a CSS string.
 
 <Canvas of={RadioButtonStories.WithLeftMargin} />
+
+### Enable adaptive behaviour
+
+Passing in the `adaptiveLegendBreakpoint` and `adaptiveSpacingBreakpoint` props will enable the adaptive behaviour.
+
+<Canvas of={RadioButtonStories.EnableAdaptiveBehaviour} />
 
 ### Different label spacing
 
@@ -68,7 +85,7 @@ The spacing between radio buttons and their labels can be changed with the `labe
 
 ### Inline radio buttons
 
-The radio buttons can be displayed inline with the `inline` prop.
+The radio buttons can be made inline with the `inline` prop.
 
 <Canvas of={RadioButtonStories.InlineRadioButtons} />
 
@@ -86,6 +103,12 @@ The radio buttons and labels can be disabled using the `disabled` prop on each r
 
 <Canvas of={RadioButtonStories.DisableRadioButtons} />
 
+### With field help
+
+Help text for each input can be added with the `fieldHelp` prop on `RadioButton`. This can be made inline with the `fieldHelpInline` prop.
+
+<Canvas of={RadioButtonStories.WithFieldHelp} />
+
 ### With large radio buttons
 
 Passing in `large` for the `size` prop on each radio button will increase the size of the button.
@@ -94,7 +117,7 @@ Passing in `large` for the `size` prop on each radio button will increase the si
 
 ### With custom styled labels
 
-The `label` prop can be set to a ReactNode to allow for custom styling of the label.
+Labels could be customized using the Typography Component
 
 <Canvas of={RadioButtonStories.WithCustomStyledLabels} />
 
@@ -118,7 +141,7 @@ For more information check our [Validations](../?path=/docs/documentation-valida
 
 This is an example of `RadioButton` in a `RadioButtonGroup` with validations passed as a string.
 
-You can use the `legendHelp` prop to provide a hint text for the group.
+**Note:** The `legendHelp` tooltip will be rendered as "Hint text".
 
 <Canvas of={RadioButtonStories.NewValidationDefaultGroup} />
 
@@ -129,31 +152,6 @@ This is an example of `RadioButton` in a `RadioButtonGroup` with validations pas
 This is an example of `RadioButton` with validations passed as boolean values.
 
 <Canvas of={RadioButtonStories.NewValidationDefault} />
-
-### With inline legend
-
-The legend can be made inline. Its width can be changed with the `legendWidth` prop, its text alignment with `legendAlign`.
-
-The spacing between the legend and the radio buttons can be changed with the `legendSpacing` prop, this can be `1` or `2`, which is multiplied by the base theme spacing constant of `8px`, 
-so therefore `8px` or `16px`. The default is `2` for this prop.
-
-**Note:** The `legendInline` prop is not supported if the `validationRedesignOptIn` flag on the `CarbonProvider` is true. 
-
-<Canvas of={RadioButtonStories.WithInlineLegend} />
-
-### Enable adaptive behaviour
-
-Passing in the `adaptiveLegendBreakpoint` and `adaptiveSpacingBreakpoint` props will enable the adaptive behaviour.
-
-<Canvas of={RadioButtonStories.EnableAdaptiveBehaviour} />
-
-### With field help
-
-Help text for each input can be added with the `fieldHelp` prop on `RadioButton`. This can be made inline with the `fieldHelpInline` prop.
-
-**Note**: The `fieldHelp` prop is not supported if the `validationRedesignOptIn` flag on the `CarbonProvider` is true.
-
-<Canvas of={RadioButtonStories.WithFieldHelp} />
 
 ## Props
 

--- a/src/components/radio-button/radio-button.stories.tsx
+++ b/src/components/radio-button/radio-button.stories.tsx
@@ -40,9 +40,24 @@ export const WithLegendAndLabels: Story = () => {
       onChange={() => console.log("change")}
       legend="Radio group legend"
     >
-      <RadioButton id="radio-1" value="radio1" label="Radio Option 1" />
-      <RadioButton id="radio-2" value="radio2" label="Radio Option 2" />
-      <RadioButton id="radio-3" value="radio3" label="Radio Option 3" />
+      <RadioButton
+        id="radio-1"
+        value="radio1"
+        label="Radio Option 1"
+        labelHelp="first option"
+      />
+      <RadioButton
+        id="radio-2"
+        value="radio2"
+        label="Radio Option 2"
+        labelHelp="second option"
+      />
+      <RadioButton
+        id="radio-3"
+        value="radio3"
+        label="Radio Option 3"
+        labelHelp="third option"
+      />
     </RadioButtonGroup>
   );
 };
@@ -270,18 +285,21 @@ export const WithLargeRadioButtons: Story = () => {
         value="radio1"
         label="Radio Option 1"
         size="large"
+        fieldHelp="Some help text for this input."
       />
       <RadioButton
         id="large-radio-2"
         value="radio2"
         label="Radio Option 2"
         size="large"
+        fieldHelp="Some help text for this input."
       />
       <RadioButton
         id="large-radio-3"
         value="radio3"
         label="Radio Option 3"
         size="large"
+        fieldHelp="Some help text for this input."
       />
     </RadioButtonGroup>
   );
@@ -367,7 +385,6 @@ export const NewValidationDefaultGroup: Story = () => {
           legendHelp="Hint Text"
           name="error-validations-group"
           error="Error Message (Fix is required)"
-          required
         >
           <RadioButton
             id="radio-one-1"
@@ -392,7 +409,6 @@ export const NewValidationDefaultGroup: Story = () => {
           legendHelp="Hint Text"
           name="warning-validations-group"
           warning="Warning Message (Fix is optional)"
-          required
         >
           <RadioButton
             id="radio-two-1"

--- a/src/components/switch/switch.mdx
+++ b/src/components/switch/switch.mdx
@@ -93,7 +93,7 @@ You can use the `isOptional` prop to indicate if the field is optional.
 
 ### With labelHelp
 
-**Note:** The `labelHelp` tooltip will be rendered as hint text if the `validationRedesignOptIn` flag on the `CarbonProvider` is true.
+**Note:** The `legendHelp` tooltip will be rendered as hint text if the `validationRedesignOptIn` flag on the `CarbonProvider` is true.
 
 <Canvas of={SwitchStories.WithLabelHelp} name="with labelHelp" />
 
@@ -155,7 +155,7 @@ It is possible to use the `tooltipPosition` to override the default placement of
 
 The folowing examples use the new validation pattern that is available by setting the `validationRedesignOptIn` flag on the `CarbonProvider` to true.
 
-**Note:** The `labelHelp` tooltip will be rendered as "Hint text".
+**Note:** The `legendHelp` tooltip will be rendered as "Hint text".
 
 <Canvas
   of={SwitchStories.NewValidationString}


### PR DESCRIPTION
### Proposed behaviour

- Reverts the following commits:
   - https://github.com/Sage/carbon/commit/2f2f340fcdfca1acb5b72bad6df7299eece3eb3e
   - https://github.com/Sage/carbon/commit/c9c4500b7177ffd6151a9a4fe6adbe576c4d2f9c

### Current behaviour

Support for `labelHelp` and `fieldHelp` props was removed from `Checkbox` and `RadioButton` when using the feature flag `validationRedesignOptIn`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
