### PR TITLE
fix(textarea): ensure expandable height shrinks when new lines are removed

### DIFF
--- a/src/components/textarea/textarea.component.tsx
+++ b/src/components/textarea/textarea.component.tsx
@@ -264,6 +264,8 @@ export const Textarea = React.forwardRef(
 
         const scrollPosition = scrollElement?.scrollTop;
 
+        // Reset height to allow shrinking when lines are removed
+        textarea.style.height = "auto";
         // Set the height so all content is shown
         textarea.style.height = `${Math.max(
           textarea.scrollHeight,

--- a/src/components/textarea/textarea.pw.tsx
+++ b/src/components/textarea/textarea.pw.tsx
@@ -673,17 +673,45 @@ test.describe("Props tests for Textarea component", () => {
       await mount(<TextareaComponent expandable={expandableValue} />);
 
       const textareaChildrenElement = textareaChildren(page);
-      await textareaChildrenElement.type("t");
+      await textareaChildrenElement.press("t");
       await textareaChildrenElement.press("Enter");
-      await textareaChildrenElement.type("e");
+      await textareaChildrenElement.press("e");
       await textareaChildrenElement.press("Enter");
-      await textareaChildrenElement.type("s");
+      await textareaChildrenElement.press("s");
       await textareaChildrenElement.press("Enter");
-      await textareaChildrenElement.type("t");
+      await textareaChildrenElement.press("t");
 
       await expect(textareaChildrenElement).toHaveCSS("height", `${height}px`);
     });
   });
+});
+
+test(`should verify expandable Textarea shrinks back to original height when lines are removed`, async ({
+  mount,
+  page,
+}) => {
+  await mount(<TextareaComponent expandable />);
+
+  const textareaChildrenElement = textareaChildren(page);
+  await textareaChildrenElement.press("t");
+  await textareaChildrenElement.press("Enter");
+  await textareaChildrenElement.press("e");
+  await textareaChildrenElement.press("Enter");
+  await textareaChildrenElement.press("s");
+  await textareaChildrenElement.press("Enter");
+  await textareaChildrenElement.press("t");
+
+  await expect(textareaChildrenElement).toHaveCSS("height", "92px");
+
+  await textareaChildrenElement.press("Backspace");
+  await textareaChildrenElement.press("Backspace");
+
+  await expect(textareaChildrenElement).toHaveCSS("height", "75px");
+
+  await textareaChildrenElement.press("Backspace");
+  await textareaChildrenElement.press("Backspace");
+
+  await expect(textareaChildrenElement).toHaveCSS("height", "64px");
 });
 
 test.describe("Event tests for Textarea component", () => {
@@ -702,7 +730,7 @@ test.describe("Event tests for Textarea component", () => {
     );
 
     const textareaChildrenElement = textareaChildren(page);
-    await textareaChildrenElement.type(inputValue);
+    await textareaChildrenElement.fill(inputValue);
 
     expect(callbackCount).toEqual(1);
   });
@@ -1042,7 +1070,7 @@ test("should not change the scroll position of a scrollable container when typin
   const textareaChildrenElement = textareaChildren(page);
   await textareaChildrenElement.click();
   await textareaChildrenElement.press("ArrowRight");
-  await textareaChildrenElement.type("foo");
+  await textareaChildrenElement.press("f");
 
   const scrollTop = await formContentElement.evaluate((el) => el.scrollTop);
 


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Expandable `Textarea` shrinks back to original height when new lines are removed. 

https://github.com/user-attachments/assets/1eec6d1b-97bc-4c5f-866c-75426d705b6d


### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Expandable `Textarea` increases in height when lines are added but does not shrink back to original height when new lines are removed. 

https://github.com/user-attachments/assets/d4b22b41-425a-405c-866e-0fd304ad709a

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

- Ensure `rows` and `minHeight` props still work as expected with an expandable `Textarea`.
