### PR TITLE
Select virtualiser tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@floating-ui/react-dom": "~1.3.0",
         "@octokit/rest": "^18.12.0",
         "@styled-system/prop-types": "^5.1.5",
-        "@tanstack/react-virtual": "^3.0.0-beta.68",
+        "@tanstack/react-virtual": "^3.6.0",
         "@types/styled-system": "^5.1.22",
         "chalk": "^4.1.2",
         "ci-info": "^3.8.0",
@@ -6982,11 +6982,11 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.2.0.tgz",
-      "integrity": "sha512-OEdMByf2hEfDa6XDbGlZN8qO6bTjlNKqjM3im9JG+u3mCL8jALy0T/67oDI001raUUPh1Bdmfn4ZvPOV5knpcg==",
+      "version": "3.10.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.10.8.tgz",
+      "integrity": "sha512-VbzbVGSsZlQktyLrP5nxE+vE1ZR+U0NFAWPbJLoG2+DKPwd2D7dVICTVIIaYlJqX1ZCEnYDbaOpmMwbsyhBoIA==",
       "dependencies": {
-        "@tanstack/virtual-core": "3.2.0"
+        "@tanstack/virtual-core": "3.10.8"
       },
       "funding": {
         "type": "github",
@@ -6998,9 +6998,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.2.0.tgz",
-      "integrity": "sha512-P5XgYoAw/vfW65byBbJQCw+cagdXDT/qH6wmABiLt4v4YBT2q2vqCOhihe+D1Nt325F/S/0Tkv6C5z0Lv+VBQQ==",
+      "version": "3.10.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.10.8.tgz",
+      "integrity": "sha512-PBu00mtt95jbKFi6Llk9aik8bnR3tR/oQP1o3TSi+iG//+Q2RTIzCEgKkHG8BB86kxMNW6O8wku+Lmi+QFR6jA==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "@floating-ui/react-dom": "~1.3.0",
     "@octokit/rest": "^18.12.0",
     "@styled-system/prop-types": "^5.1.5",
-    "@tanstack/react-virtual": "^3.0.0-beta.68",
+    "@tanstack/react-virtual": "^3.10.8",
     "@types/styled-system": "^5.1.22",
     "chalk": "^4.1.2",
     "ci-info": "^3.8.0",

--- a/src/components/select/__internal__/select-list/select-list.component.tsx
+++ b/src/components/select/__internal__/select-list/select-list.component.tsx
@@ -291,11 +291,12 @@ const SelectList = React.forwardRef(
 
     const optionChildrenList = useMemo(
       () =>
-        childrenList.filter(
-          (child) =>
+        childrenList.filter((child) => {
+          return (
             React.isValidElement(child) &&
             (child.type === Option || child.type === OptionRow)
-        ),
+          );
+        }),
       [childrenList]
     );
 

--- a/src/components/select/__internal__/utils/with-filter.hoc.tsx
+++ b/src/components/select/__internal__/utils/with-filter.hoc.tsx
@@ -150,7 +150,9 @@ const withFilter = <T extends WrappedComponentProps>(
             }
 
             return (
-              <StyledOption>{noResultsMessage || noResultsText}</StyledOption>
+              <StyledOption isInteractive>
+                {noResultsMessage || noResultsText}
+              </StyledOption>
             );
           }
 

--- a/src/components/select/option/option.component.tsx
+++ b/src/components/select/option/option.component.tsx
@@ -16,11 +16,11 @@ export interface OptionProps
    */
   id?: string;
   /** The option's visible text, displayed within `<Textbox>` of `<Select>`, and used for filtering */
-  text: string;
-  /** Optional: alternative rendered content, displayed within `<SelectList>` of `<Select>` (eg: an icon, an image, etc) */
+  text?: string;
+  /** Alternative rendered content, displayed within `<SelectList>` of `<Select>` (eg: an icon, an image, etc) */
   children?: React.ReactNode;
-  /** The option's invisible internal value */
-  value: string | Record<string, unknown>;
+  /** The option's invisible internal value, if this is not passed the option will not be treated as interactive or selectable */
+  value?: string | Record<string, unknown>;
   /** MultiSelect only - custom Pill border color - provide any color from palette or any valid css color value. */
   borderColor?: string;
   /** MultiSelect only - fill Pill background with color */
@@ -69,12 +69,12 @@ const Option = React.forwardRef(
     let isSelected = selectListContext.currentOptionsListIndex === index;
     const internalIdRef = useRef(id || guid());
 
-    if (selectListContext.multiselectValues) {
+    if (selectListContext.multiselectValues && value) {
       isSelected = selectListContext.multiselectValues.includes(value);
     }
 
     function handleClick() {
-      if (disabled) {
+      if (disabled || !value) {
         return;
       }
       if (!onClick) {
@@ -97,6 +97,7 @@ const Option = React.forwardRef(
         role="option"
         hidden={hidden}
         style={style}
+        isInteractive={!!value}
         {...{ ...rest, fill: undefined }}
         data-component="option"
       >

--- a/src/components/select/option/option.style.ts
+++ b/src/components/select/option/option.style.ts
@@ -4,10 +4,10 @@ import { OptionProps } from ".";
 interface StyledOptionProps extends Pick<OptionProps, "id"> {
   isHighlighted?: boolean;
   isDisabled?: boolean;
+  isInteractive: boolean;
 }
 
 const StyledOption = styled.li<StyledOptionProps>`
-  cursor: pointer;
   box-sizing: border-box;
   line-height: 16px;
   padding: 12px 16px;
@@ -18,17 +18,20 @@ const StyledOption = styled.li<StyledOptionProps>`
   left: 0;
   width: 100%;
 
-  ${({ isHighlighted }) =>
-    isHighlighted &&
+  ${({ isInteractive, isHighlighted }) =>
+    isInteractive &&
     css`
-      background-color: var(--colorsUtilityMajor200);
+      cursor: pointer;
+      :hover {
+        background-color: var(--colorsUtilityMajor100);
+      }
+      ${isHighlighted &&
+      css`
+        background-color: var(--colorsUtilityMajor200);
+      `}
     `}
 
   ${({ hidden }) => hidden && "display: none;"}
-
-  :hover {
-    background-color: var(--colorsUtilityMajor100);
-  }
 
   ${({ isDisabled }) =>
     isDisabled &&

--- a/src/components/select/option/option.test.tsx
+++ b/src/components/select/option/option.test.tsx
@@ -81,6 +81,16 @@ test("should set `id` on the element when passed", () => {
   );
 });
 
+test("should not render with cursor style pointer when no value or text is passed", () => {
+  render(
+    <ul>
+      <Option>Foo</Option>
+    </ul>
+  );
+
+  expect(screen.getByRole("option")).not.toHaveStyle("cursor: pointer");
+});
+
 describe("when `disabled` prop is set", () => {
   it("should have expected style", () => {
     render(
@@ -202,6 +212,22 @@ describe("when `disabled` prop is not set", () => {
       text: "bar",
       value: "baz",
     });
+  });
+
+  it("should not call onClick and onSelect if both are passed but no value is set", async () => {
+    const user = userEvent.setup();
+    const onSelect = jest.fn();
+    const onClick = jest.fn();
+    const props = { text: "foo", onSelect, onClick };
+    render(
+      <ul>
+        <Option {...props}>Foo</Option>
+      </ul>
+    );
+    await user.click(screen.getByRole("option"));
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onClick).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/select/simple-select/components.test-pw.tsx
+++ b/src/components/select/simple-select/components.test-pw.tsx
@@ -629,3 +629,52 @@ export const ListWidth = ({
     </Box>
   );
 };
+
+export const ComplexCustomChildren = () => {
+  return (
+    <Box height={220}>
+      <Select
+        mb={0}
+        key="key"
+        id="id"
+        label="Select"
+        aria-label="aria label"
+        name="name"
+        value="value"
+        isLoading={false}
+        readOnly={false}
+        placeholder="placeholder"
+        onChange={() => {}}
+        onOpen={() => {}}
+        onListScrollBottom={() => {}}
+      >
+        <Option>
+          <Box
+            width="100%"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            mt={2}
+            mb={3}
+            flexDirection="column"
+            as="span"
+          >
+            <Box display="flex" mx={2}>
+              <Icon type="error" color="errorRed" />
+              <Box ml={1} width="100%">
+                <Box mb={1}>
+                  <Typography variant="b" color="errorRed">
+                    Something went wrong
+                  </Typography>
+                </Box>
+                <Typography variant="p" color="errorRed" mb={0}>
+                  We couldn't load the data. Please try again later.
+                </Typography>
+              </Box>
+            </Box>
+          </Box>
+        </Option>
+      </Select>
+    </Box>
+  );
+};

--- a/src/components/select/simple-select/simple-select-test.stories.tsx
+++ b/src/components/select/simple-select/simple-select-test.stories.tsx
@@ -663,3 +663,51 @@ export const SimpleSelectWithTruncatedText = () => {
     </Select>
   );
 };
+
+export const ComplexCustomChildren = () => {
+  return (
+    <Box height={220}>
+      <Select
+        mb={0}
+        key="key"
+        id="id"
+        label="Select"
+        aria-label="aria label"
+        name="name"
+        value="value"
+        isLoading={false}
+        readOnly={false}
+        placeholder="placeholder"
+        onChange={() => {}}
+        onOpen={() => {}}
+        onListScrollBottom={() => {}}
+      >
+        <Option>
+          <Box
+            width="100%"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            mt={2}
+            mb={3}
+            flexDirection="column"
+          >
+            <Box display="flex" mx={2}>
+              <Icon type="error" color="errorRed" />
+              <Box ml={1} width="100%">
+                <Box mb={1}>
+                  <Typography variant="b" color="errorRed">
+                    Something went wrong
+                  </Typography>
+                </Box>
+                <Typography variant="p" color="errorRed" mb={0}>
+                  We couldn't load the data. Please try again later.
+                </Typography>
+              </Box>
+            </Box>
+          </Box>
+        </Option>
+      </Select>
+    </Box>
+  );
+};

--- a/src/components/select/simple-select/simple-select.mdx
+++ b/src/components/select/simple-select/simple-select.mdx
@@ -127,6 +127,10 @@ This prop will be called every time a user scrolls to the bottom of the list.
 
 ### Custom Option content
 
+It is also possible to render non-interactive content within the `Option` component.
+This can be achieved by passing `children` with no `value` or `text` props set. However, 
+we recommend checking that there are no accessibility issues with this approach before using it.
+
 <Canvas of={SimpleSelectStories.CustomOptionChildren} />
 
 ### With multiple columns

--- a/src/components/select/simple-select/simple-select.pw.tsx
+++ b/src/components/select/simple-select/simple-select.pw.tsx
@@ -19,6 +19,7 @@ import {
   SimpleSelectControlled,
   WithObjectAsValue,
   ListWidth,
+  ComplexCustomChildren,
 } from "./components.test-pw";
 import {
   commonDataElementInputPreview,
@@ -1130,6 +1131,26 @@ test.describe("SimpleSelect component", () => {
 
     await expect(selectInput(page)).toHaveCSS("border-radius", "4px");
     await expect(selectListWrapper(page)).toHaveCSS("border-radius", "4px");
+  });
+
+  test("should display the custom option in full when list is opened", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<ComplexCustomChildren />);
+
+    await selectText(page).click();
+    const customOptionContent = selectListCustomChild(page, 1).nth(0);
+    const wrapper = selectListWrapper(page);
+    const customOptionHeight = await selectList(page)
+      .locator("li")
+      .evaluate((element) => element.getBoundingClientRect().height);
+    const wrapperHeight = await wrapper.evaluate(
+      (element) => element.getBoundingClientRect().height
+    );
+
+    await expect(customOptionContent).toBeVisible();
+    expect(wrapperHeight).toBe(customOptionHeight);
   });
 });
 


### PR DESCRIPTION
fix #6978
fix #6939

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Upgrades `@tanstack/react-virtual` to `3.10.8`

Updates `Option` interface to allow `value` and `text` to be optional to allow users to compose `children` for complex layouts. This ensures that `SelectList` height is set relatively when a custom option is passed as child so that there is no overflow (scrollbars). When no value is passed the option is treated as non-interactive (can't be clicked or selected) and is styled as such.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
`@tanstack/react-virtual` is `3.0.0-beta.68`
Option requires `value` and `text` to be set

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
