### PR TITLE
fix(action-popover): ensure that opening using the up arrow focuses last focusable element - FE-6793

### DIFF
--- a/src/components/action-popover/__internal__/action-popover-utils.tsx
+++ b/src/components/action-popover/__internal__/action-popover-utils.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { ActionPopoverItem } from "../action-popover-item/action-popover-item.component";
+
+// Reusable type alias for item types
+type ReactItem = React.ReactChild | React.ReactFragment | React.ReactPortal;
+
+export const getItems = (
+  children: React.ReactNode | React.ReactNode[]
+): ReactItem[] =>
+  React.Children.toArray(children).filter(
+    (child) => React.isValidElement(child) && child.type === ActionPopoverItem
+  );
+
+export const isItemDisabled = (item: ReactItem) =>
+  React.isValidElement(item) && !!item.props?.disabled;
+
+export const findFirstFocusableItem = (items: ReactItem[]): number =>
+  items.findIndex((_, index) => !isItemDisabled(items[index]));
+
+// FIX-ME: FE-6248
+// Once we no longer support Node 16, this function can be removed and `findLastIndex()` can be used in its place.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex
+export const findLastFocusableItem = (items: ReactItem[]): number => {
+  for (let i = items.length - 1; i >= 0; i--) {
+    if (!isItemDisabled(items[i])) {
+      return i;
+    }
+  }
+  return -1;
+};

--- a/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
+++ b/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
@@ -216,10 +216,13 @@ export const ActionPopoverItem = ({
     }
   }, [alignSubmenu, submenu]);
 
-  // focuses item on opening of actionPopover submenu
+  // Focuses item on opening of actionPopover submenu, but we want to do this once the Popover has finished opening
+  // We always want the focused item to be in the user's view for accessibility purposes, and without the initial unexpected scroll to top of page when used in a table.
   useEffect(() => {
     if (focusItem) {
-      ref.current?.focus({ preventScroll: true });
+      setTimeout(() => {
+        ref.current?.focus();
+      }, 0);
     }
   }, [focusItem]);
 

--- a/src/components/action-popover/action-popover-test.stories.tsx
+++ b/src/components/action-popover/action-popover-test.stories.tsx
@@ -17,10 +17,11 @@ import {
   FlatTableHeader,
   FlatTableCell,
 } from "../flat-table";
+import Box from "../box";
 
 export default {
   title: "Action Popover/Test",
-  includeStories: ["Default"],
+  includeStories: ["Default", "LongMenuExample"],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -704,5 +705,98 @@ export const ActionPopoverPropsComponentAllDisabled = (
       <ActionPopoverItem disabled>Item 6</ActionPopoverItem>
       <ActionPopoverItem disabled>Item 7</ActionPopoverItem>
     </ActionPopover>
+  );
+};
+
+export const LongMenuExample = () => {
+  const submenu = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 1</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 2</ActionPopoverItem>
+      <ActionPopoverItem disabled onClick={() => {}}>
+        Sub Menu 3
+      </ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+  const submenuWithIcons = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem icon="graph" onClick={() => {}}>
+        Sub Menu 1
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="add" onClick={() => {}}>
+        Sub Menu 2
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="print" disabled onClick={() => {}}>
+        Sub Menu 3
+      </ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+  return (
+    <Box mt={60} height={275}>
+      <ActionPopover onOpen={() => {}} onClose={() => {}}>
+        <ActionPopoverItem
+          disabled
+          icon="graph"
+          submenu={submenu}
+          onClick={() => {}}
+        >
+          Business
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="email" onClick={() => {}}>
+          Email Invoiceee
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="print" onClick={() => {}} submenu={submenu}>
+          Print Invoice
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="pdf" submenu={submenu} onClick={() => {}}>
+          Download PDF
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="csv" onClick={() => {}}>
+          Download CSV
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="email" onClick={() => {}}>
+          Email Invoiceee
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="print" onClick={() => {}} submenu={submenu}>
+          Print Invoice
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="pdf" submenu={submenu} onClick={() => {}}>
+          Download PDF
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="csv" onClick={() => {}}>
+          Download CSV
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="email" onClick={() => {}}>
+          Email Invoiceee
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="print" onClick={() => {}} submenu={submenu}>
+          Print Invoice
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="pdf" submenu={submenu} onClick={() => {}}>
+          Download PDF
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="csv" onClick={() => {}}>
+          Download CSV
+        </ActionPopoverItem>
+        <ActionPopoverDivider />
+        <ActionPopoverItem disabled icon="delete" onClick={() => {}}>
+          Delete
+        </ActionPopoverItem>
+      </ActionPopover>
+      <ActionPopover>
+        <ActionPopoverItem icon="csv" onClick={() => {}}>
+          Download CSV
+        </ActionPopoverItem>
+      </ActionPopover>
+      <ActionPopover>
+        <ActionPopoverItem
+          icon="csv"
+          submenu={submenuWithIcons}
+          onClick={() => {}}
+        >
+          Download CSV
+        </ActionPopoverItem>
+      </ActionPopover>
+    </Box>
   );
 };

--- a/src/components/action-popover/action-popover.pw.tsx
+++ b/src/components/action-popover/action-popover.pw.tsx
@@ -65,6 +65,7 @@ import {
   Submenu,
   SubmenuPositionedRight,
   ActionPopoverNestedInDialog,
+  LongMenuExample,
 } from "../../../src/components/action-popover/components.test-pw";
 
 const keyToTrigger = ["Enter", " ", "End", "ArrowDown", "ArrowUp"] as const;
@@ -101,6 +102,21 @@ test.describe("check functionality for ActionPopover component", () => {
       const focusedElement = await page.locator("*:focus");
       await expect(focusedElement).toContainText(elementText);
     });
+  });
+
+  test("should open and focus last element when up keyboard key is used to open menu", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<LongMenuExample />);
+    await page.setViewportSize({ width: 600, height: 600 });
+
+    const actionPopoverButtonElement = actionPopoverButton(page).first();
+    await actionPopoverButtonElement.press("ArrowUp");
+    const focusedElement = await page.locator("*:focus");
+
+    await expect(focusedElement).toContainText("Download CSV");
+    await expect(focusedElement).toBeVisible();
   });
 
   [keyToTrigger[0], keyToTrigger[1], keyToTrigger[3]].forEach((key) => {

--- a/src/components/action-popover/action-popover.stories.tsx
+++ b/src/components/action-popover/action-popover.stories.tsx
@@ -86,7 +86,7 @@ export const Default: Story = () => {
           Download CSV
         </ActionPopoverItem>
         <ActionPopoverDivider />
-        <ActionPopoverItem icon="delete" onClick={() => {}}>
+        <ActionPopoverItem disabled icon="delete" onClick={() => {}}>
           Delete
         </ActionPopoverItem>
       </ActionPopover>

--- a/src/components/action-popover/action-popover.test.tsx
+++ b/src/components/action-popover/action-popover.test.tsx
@@ -31,7 +31,7 @@ afterAll(() => {
 });
 
 afterEach(() => {
-  jest.runAllTimers();
+  jest.runOnlyPendingTimers();
 });
 
 testStyledSystemMarginRTL(
@@ -450,6 +450,7 @@ test("clicking the menu button focuses the first focusable element", async () =>
   );
 
   await user.click(screen.getByRole("button"));
+  jest.runOnlyPendingTimers();
 
   expect(screen.getByRole("button", { name: "example item" })).toBeFocused();
 });
@@ -524,6 +525,7 @@ test.each(["ArrowDown", "Space", "Enter", "ArrowUp"] as const)(
     screen.getByRole("button").focus();
     const userEventKeyCode = key === "Space" ? " " : `{${key}}`;
     await user.keyboard(userEventKeyCode);
+    jest.runOnlyPendingTimers();
 
     expect(screen.getByRole("list")).toBeVisible();
     expect(onOpen).toHaveBeenCalledTimes(1);
@@ -545,6 +547,7 @@ test.each(["ArrowDown", "Space", "Enter"] as const)(
     screen.getByRole("button").focus();
     const userEventKeyCode = key === "Space" ? " " : `{${key}}`;
     await user.keyboard(userEventKeyCode);
+    jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 1" })
@@ -552,9 +555,7 @@ test.each(["ArrowDown", "Space", "Enter"] as const)(
   }
 );
 
-// test left in, but skipped, pending investigation/decision on https://github.com/Sage/carbon/issues/6826
-// eslint-disable-next-line jest/no-disabled-tests
-test.skip("pressing ArrowUp key when focused on the menu button selects the last focusable item", async () => {
+test("pressing ArrowUp key when focused on the menu button selects the last focusable item", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
@@ -566,6 +567,7 @@ test.skip("pressing ArrowUp key when focused on the menu button selects the last
 
   screen.getByRole("button").focus();
   await user.keyboard("{ArrowUp}");
+  jest.runOnlyPendingTimers();
 
   expect(screen.getByRole("button", { name: "example item 2" })).toBeFocused();
 });
@@ -589,12 +591,17 @@ test.each([
 
     screen.getByRole("button").focus();
     await user.keyboard("{Enter}");
+    jest.runOnlyPendingTimers();
+
+    expect(
+      screen.getByRole("button", { name: "example item 1" })
+    ).toBeFocused();
 
     await user.keyboard(keycode);
+    jest.runOnlyPendingTimers();
 
     expect(screen.queryByRole("list")).not.toBeInTheDocument();
     expect(onClose).toHaveBeenCalledTimes(1);
-    // TODO - add test for correct element being focused if functionality is fixed (see FE-6424)
   }
 );
 
@@ -628,15 +635,19 @@ test("pressing the Down Arrow key when the menu is open focuses the next item an
   );
 
   await user.click(screen.getByRole("button"));
+  jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
 
   await user.keyboard("{ArrowDown}");
+  jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 2" })).toBeFocused();
 
   await user.keyboard("{ArrowDown}");
+  jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 3" })).toBeFocused();
 
   await user.keyboard("{ArrowDown}");
+  jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
 });
 
@@ -652,15 +663,19 @@ test("pressing the Up Arrow key when the menu is open focuses the previous item 
   );
 
   await user.click(screen.getByRole("button"));
+  jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
 
   await user.keyboard("{ArrowUp}");
+  jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 3" })).toBeFocused();
 
   await user.keyboard("{ArrowUp}");
+  jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 2" })).toBeFocused();
 
   await user.keyboard("{ArrowUp}");
+  jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
 });
 
@@ -677,24 +692,34 @@ test("pressing the Home key when the menu is open focuses the first item, no mat
   );
 
   await user.click(screen.getByRole("button"));
+  jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
 
   await user.keyboard("{ArrowDown}");
+  jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 2" })).toBeFocused();
   await user.keyboard("{Home}");
+  jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
 
   await user.keyboard("{ArrowDown}");
+  jest.runOnlyPendingTimers();
   await user.keyboard("{ArrowDown}");
+  jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 3" })).toBeFocused();
   await user.keyboard("{Home}");
+  jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
 
   await user.keyboard("{ArrowDown}");
+  jest.runOnlyPendingTimers();
   await user.keyboard("{ArrowDown}");
+  jest.runOnlyPendingTimers();
   await user.keyboard("{ArrowDown}");
+  jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 4" })).toBeFocused();
   await user.keyboard("{Home}");
+  jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
 });
 
@@ -711,20 +736,34 @@ test("pressing the End key when the menu is open focuses the last item, no matte
   );
 
   await user.click(screen.getByRole("button"));
+  jest.runOnlyPendingTimers();
+
   expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
 
   await user.keyboard("{End}");
+  jest.runOnlyPendingTimers();
+
   expect(screen.getByRole("button", { name: "example item 4" })).toBeFocused();
 
   await user.keyboard("{ArrowUp}");
+  jest.runOnlyPendingTimers();
+
   expect(screen.getByRole("button", { name: "example item 3" })).toBeFocused();
   await user.keyboard("{End}");
+  jest.runOnlyPendingTimers();
+
   expect(screen.getByRole("button", { name: "example item 4" })).toBeFocused();
 
   await user.keyboard("{ArrowUp}");
+  jest.runOnlyPendingTimers();
+
   await user.keyboard("{ArrowUp}");
+  jest.runOnlyPendingTimers();
+
   expect(screen.getByRole("button", { name: "example item 2" })).toBeFocused();
   await user.keyboard("{End}");
+  jest.runOnlyPendingTimers();
+
   expect(screen.getByRole("button", { name: "example item 4" })).toBeFocused();
 });
 
@@ -740,11 +779,13 @@ test("pressing Space when the menu is open does nothing", async () => {
   );
 
   await user.click(screen.getByRole("button"));
+  jest.runOnlyPendingTimers();
 
   expect(screen.getByRole("list")).toBeVisible();
   expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
 
   await user.keyboard(" ");
+  jest.runOnlyPendingTimers();
 
   expect(screen.getByRole("list")).toBeVisible();
   expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
@@ -764,21 +805,30 @@ test("pressing an alphabet character when the menu is open selects the next sele
     </ActionPopover>
   );
   await user.click(screen.getByRole("button"));
+  jest.runOnlyPendingTimers();
 
   // moves to first element starting with P
   await user.keyboard("p");
+  jest.runOnlyPendingTimers();
+
   expect(screen.getByRole("button", { name: "Print Invoice" })).toBeFocused();
 
   // moves to next element starting with D - noting that it skips the disabled "Disabled" item
   await user.keyboard("d");
+  jest.runOnlyPendingTimers();
+
   expect(screen.getByRole("button", { name: "Download CSV" })).toBeFocused();
 
   // moves to next element starting with D, it loops to the start
   await user.keyboard("d");
+  jest.runOnlyPendingTimers();
+
   expect(screen.getByRole("button", { name: "Download PDF" })).toBeFocused();
 
   // does nothing when there are no matches
   await user.keyboard("z");
+  jest.runOnlyPendingTimers();
+
   expect(screen.getByRole("button", { name: "Download PDF" })).toBeFocused();
 });
 
@@ -794,11 +844,13 @@ test("pressing a non-printable character key when the menu is open does nothing"
   );
 
   await user.click(screen.getByRole("button"));
+  jest.runOnlyPendingTimers();
 
   expect(screen.getByRole("list")).toBeVisible();
   expect(screen.getByRole("button", { name: "first item" })).toBeFocused();
 
   await user.keyboard("{F1}");
+  jest.runOnlyPendingTimers();
 
   expect(screen.getByRole("list")).toBeVisible();
   expect(screen.getByRole("button", { name: "first item" })).toBeFocused();
@@ -892,7 +944,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     );
 
     act(() => {
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
     });
 
     expect(
@@ -969,7 +1021,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
       screen.getByRole("button", { name: "example item with submenu" })
     );
     act(() => {
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
     });
 
     expect(
@@ -978,7 +1030,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
 
     await user.hover(screen.getByRole("button", { name: "example item 2" }));
     act(() => {
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
     });
 
     expect(
@@ -1056,9 +1108,11 @@ describe("when an item has a submenu with default (left) alignment", () => {
     );
 
     await user.click(screen.getByRole("button"));
+    jest.runOnlyPendingTimers();
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
     await user.keyboard("{ArrowLeft}");
+    jest.runOnlyPendingTimers();
 
     const firstItem = screen.getByRole("button", { name: "submenu item 1" });
     expect(firstItem).toBeVisible();
@@ -1127,15 +1181,18 @@ describe("when an item has a submenu with default (left) alignment", () => {
     );
 
     await user.click(screen.getByRole("button"));
+    jest.runOnlyPendingTimers();
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
     await user.keyboard("{ArrowLeft}");
+    jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "submenu item 1" })
     ).toBeVisible();
 
     await user.keyboard("z");
+    jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "submenu item 1" })
@@ -1166,9 +1223,11 @@ describe("when an item has a submenu with default (left) alignment", () => {
     );
 
     await user.click(screen.getByRole("button"));
+    jest.runOnlyPendingTimers();
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
     await user.keyboard("{Enter}");
+    jest.runOnlyPendingTimers();
 
     const firstItem = screen.getByRole("button", { name: "submenu item 1" });
     expect(firstItem).toBeVisible();
@@ -1227,14 +1286,20 @@ describe("when an item has a submenu with default (left) alignment", () => {
     );
 
     await user.click(screen.getByRole("button"));
+    jest.runOnlyPendingTimers();
+
     screen.getByRole("button", { name: "example item with submenu" }).focus();
 
     await user.keyboard("{ArrowLeft}");
+    jest.runOnlyPendingTimers();
+
     expect(
       screen.getByRole("button", { name: "submenu item 1" })
     ).toBeFocused();
 
     await user.keyboard("{Escape}");
+    jest.runOnlyPendingTimers();
+
     expect(screen.queryByRole("list")).not.toBeInTheDocument();
     expect(screen.getByRole("button")).toBeFocused();
   });
@@ -1271,7 +1336,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     );
 
     act(() => {
-      jest.runAllTimers();
+      jest.runOnlyPendingTimers();
     });
 
     expect(
@@ -1449,9 +1514,11 @@ describe("when there isn't enough space on the screen to render a submenu on the
     );
 
     await user.click(screen.getByRole("button"));
+    jest.runOnlyPendingTimers();
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
     await user.keyboard("{ArrowRight}");
+    jest.runOnlyPendingTimers();
 
     const firstItem = screen.getByRole("button", { name: "submenu item 1" });
     expect(firstItem).toBeVisible();
@@ -1556,9 +1623,11 @@ describe("when the submenuPosition prop is set to 'right'", () => {
     );
 
     await user.click(screen.getByRole("button"));
+    jest.runOnlyPendingTimers();
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
     await user.keyboard("{ArrowRight}");
+    jest.runOnlyPendingTimers();
 
     const firstItem = screen.getByRole("button", { name: "submenu item 1" });
     expect(firstItem).toBeVisible();
@@ -1680,9 +1749,11 @@ describe("when the submenuPosition prop is set to 'right' and there isn't enough
     );
 
     await user.click(screen.getByRole("button"));
+    jest.runOnlyPendingTimers();
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
     await user.keyboard("{ArrowLeft}");
+    jest.runOnlyPendingTimers();
 
     const firstItem = screen.getByRole("button", { name: "submenu item 1" });
     expect(firstItem).toBeVisible();
@@ -1858,11 +1929,13 @@ describe("When ActionPopoverMenu contains multiple disabled items", () => {
     );
 
     await user.click(screen.getByRole("button"));
+    jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 1" })
     ).toBeFocused();
     await user.keyboard("{ArrowDown}");
+    jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 4" })
@@ -1884,15 +1957,19 @@ describe("When ActionPopoverMenu contains multiple disabled items", () => {
     );
 
     await user.click(screen.getByRole("button"));
+    jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 1" })
     ).toBeFocused();
     await user.keyboard("{ArrowDown}");
+    jest.runOnlyPendingTimers();
+
     expect(
       screen.getByRole("button", { name: "example item 4" })
     ).toBeFocused();
     await user.keyboard("{ArrowUp}");
+    jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 1" })
@@ -1914,19 +1991,25 @@ describe("When ActionPopoverMenu contains multiple disabled items", () => {
     );
 
     await user.click(screen.getByRole("button"));
+    jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 2" })
     ).toBeFocused();
     await user.keyboard("{ArrowDown}");
+    jest.runOnlyPendingTimers();
+
     expect(
       screen.getByRole("button", { name: "example item 4" })
     ).toBeFocused();
     await user.keyboard("{ArrowDown}");
+    jest.runOnlyPendingTimers();
+
     expect(
       screen.getByRole("button", { name: "example item 5" })
     ).toBeFocused();
     await user.keyboard("{Home}");
+    jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 2" })
@@ -1948,11 +2031,13 @@ describe("When ActionPopoverMenu contains multiple disabled items", () => {
     );
 
     await user.click(screen.getByRole("button"));
+    jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 2" })
     ).toBeFocused();
     await user.keyboard("{End}");
+    jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 5" })

--- a/src/components/action-popover/components.test-pw.tsx
+++ b/src/components/action-popover/components.test-pw.tsx
@@ -1268,3 +1268,96 @@ export const ActionPopoverNestedInDialog = () => {
     </Dialog>
   );
 };
+
+export const LongMenuExample = () => {
+  const submenu = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 1</ActionPopoverItem>
+      <ActionPopoverItem onClick={() => {}}>Sub Menu 2</ActionPopoverItem>
+      <ActionPopoverItem disabled onClick={() => {}}>
+        Sub Menu 3
+      </ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+  const submenuWithIcons = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem icon="graph" onClick={() => {}}>
+        Sub Menu 1
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="add" onClick={() => {}}>
+        Sub Menu 2
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="print" disabled onClick={() => {}}>
+        Sub Menu 3
+      </ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+  return (
+    <Box mt={60} height={275}>
+      <ActionPopover onOpen={() => {}} onClose={() => {}}>
+        <ActionPopoverItem
+          disabled
+          icon="graph"
+          submenu={submenu}
+          onClick={() => {}}
+        >
+          Business
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="email" onClick={() => {}}>
+          Email Invoiceee
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="print" onClick={() => {}} submenu={submenu}>
+          Print Invoice
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="pdf" submenu={submenu} onClick={() => {}}>
+          Download PDF
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="csv" onClick={() => {}}>
+          Download CSV
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="email" onClick={() => {}}>
+          Email Invoiceee
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="print" onClick={() => {}} submenu={submenu}>
+          Print Invoice
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="pdf" submenu={submenu} onClick={() => {}}>
+          Download PDF
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="csv" onClick={() => {}}>
+          Download CSV
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="email" onClick={() => {}}>
+          Email Invoiceee
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="print" onClick={() => {}} submenu={submenu}>
+          Print Invoice
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="pdf" submenu={submenu} onClick={() => {}}>
+          Download PDF
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="csv" onClick={() => {}}>
+          Download CSV
+        </ActionPopoverItem>
+        <ActionPopoverDivider />
+        <ActionPopoverItem disabled icon="delete" onClick={() => {}}>
+          Delete
+        </ActionPopoverItem>
+      </ActionPopover>
+      <ActionPopover>
+        <ActionPopoverItem icon="csv" onClick={() => {}}>
+          Download CSV
+        </ActionPopoverItem>
+      </ActionPopover>
+      <ActionPopover>
+        <ActionPopoverItem
+          icon="csv"
+          submenu={submenuWithIcons}
+          onClick={() => {}}
+        >
+          Download CSV
+        </ActionPopoverItem>
+      </ActionPopover>
+    </Box>
+  );
+};


### PR DESCRIPTION
Currently, we have a bug whereby when a user presses the up arrow key, the first focusable item in the menu is focused. This appears to be a bug as we have code that specifically handles this behaviour but is overridden elsewhere in the code. This fix ensures that the last focusable item is focused.

fixes #6826

### Proposed behaviour

- Pressing the `Up Arrow` key should open the menu and focus the last focusable element.

https://github.com/user-attachments/assets/3505ce95-fa05-4d0b-960a-d61fd529141c

### Current behaviour

- Pressing the `Up Arrow` key opens the menu and focuses the first focusable element.

https://github.com/user-attachments/assets/d9fa3e32-da09-44ef-bc81-f9e7f9234d70

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Ensure that the `Up Arrow` key focuses on the last focusable element in the menu. 
- No other functionality-related regressions regarding keyboard navigation.
