### PR TITLE
fix(box): remove focus outline

### DIFF
--- a/src/components/box/box.pw.tsx
+++ b/src/components/box/box.pw.tsx
@@ -767,6 +767,21 @@ test.describe("should render Box component", () => {
       "rgba(0, 20, 30, 0.04) 0px 10px 40px 0px, rgba(0, 20, 30, 0.1) 0px 50px 80px 0px"
     );
   });
+
+  test("should render without a visible focus outline, when focused with a set `tabIndex`", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<Default tabIndex={0} />);
+    const boxElement = getDataElementByValue(page, "box");
+
+    await boxElement.focus();
+    await expect(boxElement).toBeFocused();
+    await expect(boxElement).toHaveCSS(
+      "outline",
+      "rgb(255, 255, 255) none 0px"
+    );
+  });
 });
 
 test.describe("Accessibility tests for Box", () => {

--- a/src/components/box/box.style.ts
+++ b/src/components/box/box.style.ts
@@ -30,6 +30,10 @@ const StyledBox = styled.div<BoxProps>`
   ${grid}
   ${calculatePosition}
 
+  :focus {
+    outline: none;
+  }
+
   ${({ theme, borderRadius = "borderRadius000" }) =>
     !theme.roundedCornersOptOut &&
     css`


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Removes all outlines when the component is focused, removes default browser outline when the component is focused with a set `tabIndex`.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, browsers apply a default outline when the component is focused with a set `tabIndex`.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
