### PR TITLE
docs(storybook): fixes a number of accessibility issues in the documentation

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,10 @@
-import path from "path";
-import glob from "glob";
-import remarkGfm from "remark-gfm";
 import { StorybookConfig } from "@storybook/react-webpack5";
+
+import path from "path";
+
+import glob from "glob";
+
+import remarkGfm from "remark-gfm";
 
 const projectRoot = path.resolve(__dirname, "../");
 const ignoreTests = process.env.IGNORE_TESTS === "true";

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,7 +1,7 @@
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-<link rel="manifest" href="/site.webmanifest">
-<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
-<meta name="msapplication-TileColor" content="#da532c">
-<meta name="theme-color" content="#ffffff">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+<link rel="manifest" href="/site.webmanifest" />
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
+<meta name="msapplication-TileColor" content="#da532c" />
+<meta name="theme-color" content="#ffffff" />

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -29,3 +29,9 @@
   type="font/woff2"
   crossorigin="anonymous"
 />
+
+<style>
+  a.sbdocs-a {
+    text-decoration: underline !important;
+  }
+</style>

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,8 +1,31 @@
-<link rel="preload" href="/static/media/carbon-icons-webfont.woff2" as="font" type="font/woff2"
-  crossorigin="anonymous" />
+<link
+  rel="preload"
+  href="/static/media/carbon-icons-webfont.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
 
-<link rel="preload" href="/static/media/sageui-regular.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
+<link
+  rel="preload"
+  href="/static/media/sageui-regular.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
 
-<link rel="preload" href="/static/media/sageui-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
+<link
+  rel="preload"
+  href="/static/media/sageui-medium.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
 
-<link rel="preload" href="/static/media/sageui-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
+<link
+  rel="preload"
+  href="/static/media/sageui-bold.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,12 +1,13 @@
-import withGlobalStyles from "./with-global-styles";
-import { withThemeProvider, globalThemeProvider } from "./withThemeProvider";
-import withLocaleSelector from "./with-locale-selector";
-import withPortalProvider from "./with-portal-provider";
-import sageStorybookTheme from "./sage-storybook-theme";
+import { Preview } from "@storybook/react";
 
 import "../src/style/fonts.css";
+
 import isChromatic from "./isChromatic";
-import { Preview } from "@storybook/react";
+import sageStorybookTheme from "./sage-storybook-theme";
+import withGlobalStyles from "./with-global-styles";
+import withLocaleSelector from "./with-locale-selector";
+import withPortalProvider from "./with-portal-provider";
+import { withThemeProvider, globalThemeProvider } from "./withThemeProvider";
 
 const customViewports = {
   extraSmall: {

--- a/.storybook/sage-docs-theme.ts
+++ b/.storybook/sage-docs-theme.ts
@@ -4,7 +4,7 @@ export default create({
   base: "light",
 
   colorPrimary: "#007e45",
-  colorSecondary: "#8099A6",
+  colorSecondary: "#007e45",
 
   // UI
   appBg: "#FFFFFF",

--- a/.storybook/welcome-page/components-demo/component-heading/component-heading.component.js
+++ b/.storybook/welcome-page/components-demo/component-heading/component-heading.component.js
@@ -1,11 +1,26 @@
-import React from 'react';
-import { StyledComponentHeader, StyledHeading, StyledText } from './component-heading.style';
+import React from "react";
 
-const ComponentHeading = ({ centerAlign, title, titleSuffix, text, divider }) => (
-  <StyledComponentHeader centerAlign={ centerAlign }>
-    { title && <StyledHeading>{ title } { titleSuffix && <span>{ titleSuffix } </span> }</StyledHeading> }
-    { divider && <hr /> }
-    { text && <StyledText>{ text }</StyledText> }
+import {
+  StyledComponentHeader,
+  StyledHeading,
+  StyledText,
+} from "./component-heading.style";
+
+const ComponentHeading = ({
+  centerAlign,
+  title,
+  titleSuffix,
+  text,
+  divider,
+}) => (
+  <StyledComponentHeader centerAlign={centerAlign} title={title}>
+    {title && (
+      <StyledHeading>
+        {title} {titleSuffix && <span>{titleSuffix} </span>}
+      </StyledHeading>
+    )}
+    {divider && <hr />}
+    {text && <StyledText>{text}</StyledText>}
   </StyledComponentHeader>
 );
 

--- a/.storybook/welcome-page/components-demo/component-heading/component-heading.style.js
+++ b/.storybook/welcome-page/components-demo/component-heading/component-heading.style.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-export const StyledComponentHeader = styled.header`
+export const StyledComponentHeader = styled.div`
   align-items: ${({ centerAlign }) => (centerAlign ? "center" : "flex-start")};
   text-align: ${({ centerAlign }) => (centerAlign ? "center" : "left")};
   display: flex;

--- a/.storybook/welcome-page/components-demo/demo/demo-table/demo-table.component.js
+++ b/.storybook/welcome-page/components-demo/demo/demo-table/demo-table.component.js
@@ -1,4 +1,5 @@
 import React from "react";
+
 import {
   ActionPopover,
   ActionPopoverItem,
@@ -18,7 +19,7 @@ const DemoTable = () => (
       <FlatTableRow>
         <FlatTableHeader>First Name</FlatTableHeader>
         <FlatTableHeader>Second Name</FlatTableHeader>
-        <FlatTableHeader>&nbsp;</FlatTableHeader>
+        <FlatTableHeader align="center">Actions</FlatTableHeader>
       </FlatTableRow>
     </FlatTableHead>
     <FlatTableBody>

--- a/.storybook/welcome-page/components-demo/demo/demo.component.js
+++ b/.storybook/welcome-page/components-demo/demo/demo.component.js
@@ -1,19 +1,21 @@
 import React, { useState } from "react";
-import Button from "../../../../src/components/button";
-import Textbox from "../../../../src/components/textbox";
-import NumberInput from "../../../../src/components/number";
-import Decimal from "../../../../src/components/decimal";
-import { Select, Option } from "../../../../src/components/select";
+
+import Heading from "../component-heading";
 import { Wrapper, ContentWrapper } from "../../common.style";
+import Button from "../../../../src/components/button";
+import DateRange from "../../../../src/components/date-range";
+import Decimal from "../../../../src/components/decimal";
+import NumberInput from "../../../../src/components/number";
+import { Select, Option } from "../../../../src/components/select";
+import Textbox from "../../../../src/components/textbox";
+
+import DemoTable from "./demo-table";
 import {
   ComponentShowcaseWrapper,
   StyledDemoWrapper,
   StyledDemoRow,
   StyledComponentWrapper,
 } from "./demo.style";
-import DemoTable from "./demo-table";
-import DateRange from "../../../../src/components/date-range";
-import Heading from "../component-heading";
 
 const Demo = () => {
   const [numberValue, setNumberValue] = useState("0");
@@ -62,30 +64,50 @@ const Demo = () => {
             </StyledDemoRow>
             <StyledDemoRow styling={{ display: "flex" }}>
               <StyledComponentWrapper styling={{ width: "30%", padding: "1%" }}>
-                <Textbox placeholder="Carbon Textbox" inputIcon="search" />
+                <Textbox
+                  placeholder="Carbon Textbox"
+                  inputIcon="search"
+                  aria-label="An example textbox component with spyglass input icon"
+                />
               </StyledComponentWrapper>
               <StyledComponentWrapper styling={{ width: "30%", padding: "1%" }}>
                 <NumberInput
                   value={numberValue}
                   onChange={(e) => setNumberValue(e.target.value)}
+                  aria-label="An example numerical input component"
                 />
               </StyledComponentWrapper>
               <StyledComponentWrapper styling={{ width: "30%", padding: "1%" }}>
-                <Decimal />
+                <Decimal aria-label="An example decimal input component" />
               </StyledComponentWrapper>
             </StyledDemoRow>
             <StyledDemoRow styling={{ display: "flex" }}>
               <StyledComponentWrapper
                 styling={{ width: "100%", padding: "1.5%" }}
               >
-                <DateRange value={dateValue} onChange={handleDateChange} />
+                <DateRange
+                  value={dateValue}
+                  onChange={handleDateChange}
+                  endDateProps={{
+                    "aria-label":
+                      "The end date input of the example date range component",
+                  }}
+                  startDateProps={{
+                    "aria-label":
+                      "The start date input of the example date range component",
+                  }}
+                />
               </StyledComponentWrapper>
             </StyledDemoRow>
             <StyledDemoRow styling={{ display: "flex" }}>
               <StyledComponentWrapper
                 styling={{ width: "95%", padding: "1.5%" }}
               >
-                <Select defaultValue="" placeholder="Carbon Select">
+                <Select
+                  defaultValue=""
+                  placeholder="Carbon Select"
+                  aria-label="An example select component with two options"
+                >
                   <Option value="1" text="Red" />
                   <Option value="2" text="Blue" />
                 </Select>

--- a/.storybook/welcome-page/loves-carbon/loves-carbon.component.js
+++ b/.storybook/welcome-page/loves-carbon/loves-carbon.component.js
@@ -1,8 +1,10 @@
 import React from "react";
+
 import Heading from "../components-demo/component-heading";
-import { Wrapper, LovesCarbonWrapper, Image } from "./loves-carbon.style";
-import devices from "./devices.png";
 import Link from "../../../src/components/link";
+
+import devices from "./devices.png";
+import { Wrapper, LovesCarbonWrapper, Image } from "./loves-carbon.style";
 
 const LovesCarbon = () => (
   <LovesCarbonWrapper>
@@ -18,7 +20,10 @@ const LovesCarbon = () => (
           Learn more about Sage
         </Link>
       </div>
-      <Image src={devices} />
+      <Image
+        src={devices}
+        alt="Carbon in use across devices of varying sizes"
+      />
     </Wrapper>
   </LovesCarbonWrapper>
 );

--- a/.storybook/welcome-page/loves-carbon/loves-carbon.style.js
+++ b/.storybook/welcome-page/loves-carbon/loves-carbon.style.js
@@ -12,7 +12,6 @@ export const Wrapper = styled.div`
 `;
 
 export const LovesCarbonWrapper = styled.div`
-  /* background-color: #e6ebed; */
   width: 100%;
 
   && ${StyledLink} a {

--- a/.storybook/welcome-page/loves-carbon/loves-carbon.style.js
+++ b/.storybook/welcome-page/loves-carbon/loves-carbon.style.js
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { StyledComponentHeader } from "../components-demo/component-heading/component-heading.style";
 import { StyledLink } from "../../../src/components/link/link.style";
 
@@ -11,7 +12,7 @@ export const Wrapper = styled.div`
 `;
 
 export const LovesCarbonWrapper = styled.div`
-  background-color: #e6ebed;
+  /* background-color: #e6ebed; */
   width: 100%;
 
   && ${StyledLink} a {

--- a/.storybook/welcome-page/selling-points/selling-point-panel.component.js
+++ b/.storybook/welcome-page/selling-points/selling-point-panel.component.js
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Panel, Image, Heading, Text } from "./selling-points.style";
 
 const images = {
@@ -10,9 +11,23 @@ const images = {
   collaborate: require("../../../.assets/collaborate.svg"),
 };
 
+const imagesAltText = {
+  flexible:
+    "Carbon is beautiful out-of-the-box, down to colours, icons, and style.",
+  hammer: "Hundreds of thousands of users worldwide help Carbon evolve.",
+  plug:
+    "Carbon powers your app. Contribute your code, so you can power Carbon too.",
+  point:
+    "Over 50 components and 340 configurations bring your killer app to life.",
+  brush:
+    "Meet your users' needs with a simple, elegant, delightful experience.",
+  collaborate:
+    "With Carbon's UI Kit, designers and developers speak the same language.",
+};
+
 export default ({ icon, heading, text }) => (
   <Panel>
-    <Image src={images[icon]} />
+    <Image src={images[icon]} alt={imagesAltText[icon]} />
     <Heading>{heading}</Heading>
     <Text>{text}</Text>
   </Panel>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@floating-ui/react-dom": "~1.3.0",
         "@octokit/rest": "^18.12.0",
         "@styled-system/prop-types": "^5.1.5",
-        "@tanstack/react-virtual": "^3.6.0",
+        "@tanstack/react-virtual": "^3.10.8",
         "@types/styled-system": "^5.1.22",
         "chalk": "^4.1.2",
         "ci-info": "^3.8.0",

--- a/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof Breadcrumbs>;
 
 export const Default: Story = () => {
   return (
-    <Breadcrumbs>
+    <Breadcrumbs aria-label="Default breadcrumbs">
       <Crumb href="#">Breadcrumb 1</Crumb>
       <Crumb href="#">Breadcrumb 2</Crumb>
       <Crumb href="#">Breadcrumb 3</Crumb>
@@ -37,7 +37,10 @@ Default.storyName = "Default";
 export const OnDarkBackground: Story = () => {
   return (
     <Box p={2} bg="#000">
-      <Breadcrumbs isDarkBackground>
+      <Breadcrumbs
+        isDarkBackground
+        aria-label="Breadcrumbs on a dark background"
+      >
         <Crumb href="#">Breadcrumb 1</Crumb>
         <Crumb href="#">Breadcrumb 2</Crumb>
         <Crumb href="#">Breadcrumb 3</Crumb>

--- a/src/components/card/card.stories.tsx
+++ b/src/components/card/card.stories.tsx
@@ -63,7 +63,7 @@ export const DefaultStory: Story = {
             <Typography fontSize="16px" m={0} fontWeight="500">
               Body text
             </Typography>
-            <Heading title="More text" divider={false} />
+            <Heading title="More text" headingType="h2" divider={false} />
             <Typography>Even more text</Typography>
           </CardColumn>
         </CardRow>
@@ -103,7 +103,7 @@ export const SmallSpacing: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>
@@ -142,7 +142,7 @@ export const LargeSpacing: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>
@@ -181,7 +181,7 @@ export const WithWidthProvided: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>
@@ -220,7 +220,7 @@ export const WithCustomHeight: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>
@@ -259,7 +259,7 @@ export const WithExtraRoundness: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>
@@ -352,7 +352,7 @@ export const WithCustomBoxShadow: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>
@@ -390,7 +390,7 @@ export const DifferentCardRowPadding: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>
@@ -399,7 +399,7 @@ export const DifferentCardRowPadding: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>

--- a/src/components/definition-list/definition-list.stories.tsx
+++ b/src/components/definition-list/definition-list.stories.tsx
@@ -104,7 +104,7 @@ AsASingleColumn.storyName = "As a single column";
 export const MultipleSingleColumnsWithSegments: Story = () => (
   <Box width="65%" px={2} pt={4} pb={3}>
     <Box width="90%">
-      <Typography color="rgba(0,0,0,0.55)" variant="segment-subheader-alt">
+      <Typography color="rgba(0,0,0,0.55)" variant="h4">
         Segment Header
       </Typography>
       <Hr ml={0} mt={2} />

--- a/src/components/global-header/global-header.stories.tsx
+++ b/src/components/global-header/global-header.stories.tsx
@@ -39,14 +39,25 @@ export default meta;
 type Story = StoryObj<typeof GlobalHeader>;
 
 export const Default: Story = () => {
-  return <GlobalHeader>Example content</GlobalHeader>;
+  return (
+    <GlobalHeader aria-label="Default global header component">
+      Example content
+    </GlobalHeader>
+  );
 };
 Default.storyName = "Default";
 
 export const WithLogo: Story = () => {
   const Logo = () => <img height={28} src={carbonLogo} alt="Carbon logo" />;
 
-  return <GlobalHeader logo={<Logo />}>Example content</GlobalHeader>;
+  return (
+    <GlobalHeader
+      logo={<Logo />}
+      aria-label="Global header component with logo"
+    >
+      Example content
+    </GlobalHeader>
+  );
 };
 WithLogo.storyName = "With Logo";
 
@@ -54,7 +65,10 @@ export const BasicMenu: Story = () => {
   const Logo = () => <img height={28} src={carbonLogo} alt="Carbon logo" />;
 
   return (
-    <GlobalHeader logo={<Logo />}>
+    <GlobalHeader
+      logo={<Logo />}
+      aria-label="Global header component with basic menu"
+    >
       <Menu menuType="black" display="flex" flex="1">
         <MenuItem flex="1" submenu="Product Switcher">
           <MenuItem>Product A</MenuItem>
@@ -111,7 +125,10 @@ export const ResponsiveMenu: Story = () => {
   const Logo = () => <img height={28} src={carbonLogo} alt="Carbon logo" />;
 
   return (
-    <GlobalHeader logo={<Logo />}>
+    <GlobalHeader
+      logo={<Logo />}
+      aria-label="Global header component with responsive menu"
+    >
       <Menu menuType="black" display="flex" flex="1">
         {fullscreenViewBreakPoint ? (
           <>
@@ -144,8 +161,11 @@ export const GlobalLocalNavBarLayout: Story = () => {
 
   return (
     <>
-      <GlobalHeader logo={<Logo />}>
-        <Menu menuType="black" display="flex" flex="1">
+      <GlobalHeader
+        logo={<Logo />}
+        aria-label="Global header component with local nav bar"
+      >
+        <Menu menuType="black" display="flex" flex="1" aria-label="Menu bar">
           <MenuItem flex="1" submenu="Product Switcher">
             <MenuItem href="#">Product A</MenuItem>
           </MenuItem>
@@ -159,7 +179,12 @@ export const GlobalLocalNavBarLayout: Story = () => {
           </MenuItem>
         </Menu>
       </GlobalHeader>
-      <NavigationBar position="fixed" orientation="top" offset="40px">
+      <NavigationBar
+        position="fixed"
+        orientation="top"
+        offset="40px"
+        aria-label="Local nav bar"
+      >
         <Menu display="flex" flex="1">
           <MenuItem href="#" flex="1">
             Menu Item One

--- a/src/components/icon/icon.stories.tsx
+++ b/src/components/icon/icon.stories.tsx
@@ -41,6 +41,7 @@ export const WithTooltip: Story = () => {
         type="add"
         tooltipMessage="Hey I'm a default tooltip!"
         ariaLabel="Icon with tooltip"
+        role="img"
       />
       <Icon
         mr={8}
@@ -51,6 +52,7 @@ export const WithTooltip: Story = () => {
           </>
         }
         ariaLabel="Icon with tooltip"
+        role="img"
       />
       <Icon
         mr={8}
@@ -58,6 +60,7 @@ export const WithTooltip: Story = () => {
         tooltipMessage="Hey I'm a tooltip with a different position!"
         tooltipPosition="bottom"
         ariaLabel="Icon with tooltip"
+        role="img"
       />
       <Icon
         mr={8}
@@ -66,12 +69,14 @@ export const WithTooltip: Story = () => {
         tooltipBgColor="lightblue"
         tooltipFontColor="black"
         ariaLabel="Icon with tooltip"
+        role="img"
       />
       <Icon
         type="add"
         tooltipMessage="Hey I'm a tooltip with flip behaviour overrides!"
         tooltipFlipOverrides={["right", "left"]}
         ariaLabel="Icon with tooltip"
+        role="img"
       />
     </Box>
   );

--- a/src/components/link/link.stories.tsx
+++ b/src/components/link/link.stories.tsx
@@ -82,7 +82,7 @@ export const WithIsSkipLink: Story = () => {
         <MenuItem href="#">Menu Item 5</MenuItem>
       </Menu>
       <Box py={2} id="main-content">
-        <Typography mb={1} variant="h1">
+        <Typography mb={1} variant="h2">
           {" "}
           This is header of main content container{" "}
         </Typography>

--- a/src/components/pages/pages.stories.tsx
+++ b/src/components/pages/pages.stories.tsx
@@ -50,7 +50,12 @@ export const Default: Story = () => {
   return (
     <>
       <Button onClick={handleOpen}>Open Preview</Button>
-      <DialogFullScreen pagesStyling open={isOpen} onCancel={handleCancel}>
+      <DialogFullScreen
+        pagesStyling
+        open={isOpen}
+        onCancel={handleCancel}
+        aria-label="Full-screen dialog"
+      >
         <Pages pageIndex={pageIndex}>
           <Page title={<Heading title="My First Page" />}>
             <Button onClick={handleOnClick} disabled={isDisabled}>

--- a/src/components/pod/pod.stories.tsx
+++ b/src/components/pod/pod.stories.tsx
@@ -311,7 +311,7 @@ export const AddressExample: Story = () => {
   return (
     <Pod internalEditButton variant="tertiary">
       <Box>
-        <Typography variant="h5" fontWeight="500">
+        <Typography variant="h4" fontWeight="500">
           Unit 1
         </Typography>
         <Typography m={0}>South Nelson Industrial Estate</Typography>

--- a/src/components/popover-container/popover-container.mdx
+++ b/src/components/popover-container/popover-container.mdx
@@ -57,11 +57,11 @@ Use the `renderOpenComponent` and `renderCloseComponent` to render your own open
 
 These props use a render prop pattern - https://reactjs.org/docs/render-props.html
 
-##### Props passed through renderOpenComponent:
+#### Props passed through renderOpenComponent:
 
 <ArgTypes of={RenderOpenStories} />
 
-##### Props passed through renderCloseComponent:
+#### Props passed through renderCloseComponent:
 
 <ArgTypes of={RenderCloseStories} />
 

--- a/src/components/step-flow/step-flow.stories.tsx
+++ b/src/components/step-flow/step-flow.stories.tsx
@@ -51,7 +51,14 @@ export default meta;
 type Story = StoryObj<typeof StepFlow>;
 
 export const DefaultStory: Story = () => {
-  return <StepFlow title="Step title" currentStep={1} totalSteps={6} />;
+  return (
+    <StepFlow
+      title="Step title"
+      titleVariant="h2"
+      currentStep={1}
+      totalSteps={6}
+    />
+  );
 };
 DefaultStory.storyName = "Default";
 
@@ -63,7 +70,14 @@ export const TitleNodeStory: Story = () => {
     </Box>
   );
 
-  return <StepFlow title={titleNode} currentStep={1} totalSteps={6} />;
+  return (
+    <StepFlow
+      title={titleNode}
+      titleVariant="h2"
+      currentStep={1}
+      totalSteps={6}
+    />
+  );
 };
 TitleNodeStory.storyName = "Title Node";
 
@@ -71,6 +85,7 @@ export const TitleNodeStoryWithScreenReaderOnlyTitle: Story = () => {
   const titleNode = (
     <Box display="flex" alignItems="center">
       <StepFlowTitle
+        titleVariant="h2"
         titleString="Step title"
         screenReaderOnlyTitle="Step Title with a pointer image"
       />
@@ -93,6 +108,7 @@ export const CategoryStory: Story = () => {
       title="Step title"
       currentStep={1}
       totalSteps={6}
+      titleVariant="h2"
     />
   );
 };
@@ -106,6 +122,7 @@ export const ShowProgressIndicatorStory: Story = () => {
       currentStep={1}
       totalSteps={6}
       showProgressIndicator
+      titleVariant="h2"
     />
   );
 };
@@ -119,6 +136,7 @@ export const CurrentStepStory: Story = () => {
       currentStep={5}
       totalSteps={6}
       showProgressIndicator
+      titleVariant="h2"
     />
   );
 };
@@ -132,6 +150,7 @@ export const TotalStepsStory: Story = () => {
       currentStep={5}
       totalSteps={8}
       showProgressIndicator
+      titleVariant="h2"
     />
   );
 };
@@ -149,6 +168,7 @@ export const ShowCloseIconStory: Story = () => {
       totalSteps={6}
       showCloseIcon
       onDismiss={() => ""}
+      titleVariant="h2"
     />
   );
 };
@@ -191,6 +211,7 @@ export const ExampleImplementation: Story = () => {
             showCloseIcon
             onDismiss={() => setIsOpen(false)}
             mb="20px"
+            titleVariant="h2"
           />
         }
       >
@@ -265,6 +286,7 @@ export const ExampleImplementationWithTitleNode: Story = () => {
             showCloseIcon
             onDismiss={() => setIsOpen(false)}
             mb="20px"
+            titleVariant="h2"
           />
         }
       >

--- a/src/components/vertical-menu/vertical-menu.stories.tsx
+++ b/src/components/vertical-menu/vertical-menu.stories.tsx
@@ -63,7 +63,7 @@ const Link = ({ to, children, className }: LinkProps) => {
 
 export const Default: Story = () => (
   <Box height="100vh">
-    <VerticalMenu>
+    <VerticalMenu aria-label="Default vertical menu">
       <VerticalMenuItem
         iconType="analysis"
         adornment={(isOpen) =>
@@ -145,7 +145,11 @@ export const Default: Story = () => (
 Default.storyName = "Default";
 
 export const CustomWidthAndHeight: Story = () => (
-  <VerticalMenu width="500px" height="100vh">
+  <VerticalMenu
+    width="500px"
+    height="100vh"
+    aria-label="Vertical menu with custom width and height"
+  >
     <VerticalMenuItem
       iconType="analysis"
       adornment={
@@ -163,7 +167,7 @@ export const CustomWidthAndHeight: Story = () => (
 CustomWidthAndHeight.storyName = "Custom Width and Height";
 
 export const Adornment: Story = () => (
-  <VerticalMenu>
+  <VerticalMenu aria-label="Vertical menu with adornment">
     <VerticalMenuItem
       iconType="analysis"
       adornment={(isOpen) =>
@@ -191,7 +195,7 @@ export const Adornment: Story = () => (
 Adornment.storyName = "Adornment";
 
 export const Active: Story = () => (
-  <VerticalMenu>
+  <VerticalMenu aria-label="Active vertical menu">
     <VerticalMenuItem
       iconType="analysis"
       active={(isOpen) => !isOpen}
@@ -205,21 +209,21 @@ export const Active: Story = () => (
 Active.storyName = "Active";
 
 export const CustomItemPadding: Story = () => (
-  <VerticalMenu>
+  <VerticalMenu aria-label="Vertical menu with custom item padding">
     <VerticalMenuItem iconType="analysis" title="Item 1" padding="0 0 0 80px" />
   </VerticalMenu>
 );
 CustomItemPadding.storyName = "Custom Item Padding";
 
 export const CustomItemHeight: Story = () => (
-  <VerticalMenu>
+  <VerticalMenu aria-label="Vertical menu with custom item height">
     <VerticalMenuItem height="100px" iconType="analysis" title="Item 1" />
   </VerticalMenu>
 );
 CustomItemHeight.storyName = "Custom Item Height";
 
 export const CustomComponent: Story = () => (
-  <VerticalMenu>
+  <VerticalMenu aria-label="Custom vertical menu component">
     <VerticalMenuItem
       iconType="analysis"
       title="Item 1"
@@ -309,6 +313,10 @@ export const FullScreen: Story = () => {
     );
   }
 
-  return <VerticalMenu>{menuItems}</VerticalMenu>;
+  return (
+    <VerticalMenu aria-label="Full-screen vertical menu">
+      {menuItems}
+    </VerticalMenu>
+  );
 };
 FullScreen.storyName = "Full Screen";


### PR DESCRIPTION
### Proposed behaviour

The documentation offered by the storybook should be as accessible as possible. This PR aims to implement that by addressing a handful of issues:

- Changes the default secondary colour of the manager to the DS' Sage Green
- Fix the role assigned to the welcome page's headings
- Remove the duplicated `header` elements
- Add ARIA labels
- Add image alt text
- Replace blank table headings

### Current behaviour

A wide range of stories feature AXE failings, which results in a poor documentation experience for users who e.g. rely on assistive technologies.

### Checklist

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

The following issues are embedded within Storybook and can't be directly addressed:
- The Create a new story button throws a "Buttons must have discernible text" warning (only in localhost, live build is fine);
- The "Zooming and scaling" failure is due to Storybook's meta tag configuration which we can't override (so I've raised an issue with them to fix it)
- The accessibility control panel causes 4 landmark violations

### Testing instructions

Install Axe DevTools if not already installed. Open the documentation and then open the browser's inspector and switch to the DevTools tab. Run a full-page scan.
