### PR TITLE
docs(storybook): fixes a number of accessibility issues in the documentation

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,10 @@
-import path from "path";
-import glob from "glob";
-import remarkGfm from "remark-gfm";
 import { StorybookConfig } from "@storybook/react-webpack5";
+
+import path from "path";
+
+import glob from "glob";
+
+import remarkGfm from "remark-gfm";
 
 const projectRoot = path.resolve(__dirname, "../");
 const ignoreTests = process.env.IGNORE_TESTS === "true";

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,7 +1,7 @@
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-<link rel="manifest" href="/site.webmanifest">
-<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
-<meta name="msapplication-TileColor" content="#da532c">
-<meta name="theme-color" content="#ffffff">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+<link rel="manifest" href="/site.webmanifest" />
+<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
+<meta name="msapplication-TileColor" content="#da532c" />
+<meta name="theme-color" content="#ffffff" />

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,8 +1,37 @@
-<link rel="preload" href="/static/media/carbon-icons-webfont.woff2" as="font" type="font/woff2"
-  crossorigin="anonymous" />
+<link
+  rel="preload"
+  href="/static/media/carbon-icons-webfont.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
 
-<link rel="preload" href="/static/media/sageui-regular.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
+<link
+  rel="preload"
+  href="/static/media/sageui-regular.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
 
-<link rel="preload" href="/static/media/sageui-medium.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
+<link
+  rel="preload"
+  href="/static/media/sageui-medium.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
 
-<link rel="preload" href="/static/media/sageui-bold.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
+<link
+  rel="preload"
+  href="/static/media/sageui-bold.woff2"
+  as="font"
+  type="font/woff2"
+  crossorigin="anonymous"
+/>
+
+<style>
+  a.sbdocs-a {
+    text-decoration: underline !important;
+  }
+</style>

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,12 +1,13 @@
-import withGlobalStyles from "./with-global-styles";
-import { withThemeProvider, globalThemeProvider } from "./withThemeProvider";
-import withLocaleSelector from "./with-locale-selector";
-import withPortalProvider from "./with-portal-provider";
-import sageStorybookTheme from "./sage-storybook-theme";
+import { Preview } from "@storybook/react";
 
 import "../src/style/fonts.css";
+
 import isChromatic from "./isChromatic";
-import { Preview } from "@storybook/react";
+import sageStorybookTheme from "./sage-storybook-theme";
+import withGlobalStyles from "./with-global-styles";
+import withLocaleSelector from "./with-locale-selector";
+import withPortalProvider from "./with-portal-provider";
+import { withThemeProvider, globalThemeProvider } from "./withThemeProvider";
 
 const customViewports = {
   xsm: { name: "Extra small", styles: { width: "320px", height: "900px" } },

--- a/.storybook/sage-docs-theme.ts
+++ b/.storybook/sage-docs-theme.ts
@@ -4,7 +4,7 @@ export default create({
   base: "light",
 
   colorPrimary: "#007e45",
-  colorSecondary: "#8099A6",
+  colorSecondary: "#007e45",
 
   // UI
   appBg: "#FFFFFF",

--- a/.storybook/welcome-page/components-demo/component-heading/component-heading.component.js
+++ b/.storybook/welcome-page/components-demo/component-heading/component-heading.component.js
@@ -1,11 +1,26 @@
-import React from 'react';
-import { StyledComponentHeader, StyledHeading, StyledText } from './component-heading.style';
+import React from "react";
 
-const ComponentHeading = ({ centerAlign, title, titleSuffix, text, divider }) => (
-  <StyledComponentHeader centerAlign={ centerAlign }>
-    { title && <StyledHeading>{ title } { titleSuffix && <span>{ titleSuffix } </span> }</StyledHeading> }
-    { divider && <hr /> }
-    { text && <StyledText>{ text }</StyledText> }
+import {
+  StyledComponentHeader,
+  StyledHeading,
+  StyledText,
+} from "./component-heading.style";
+
+const ComponentHeading = ({
+  centerAlign,
+  title,
+  titleSuffix,
+  text,
+  divider,
+}) => (
+  <StyledComponentHeader centerAlign={centerAlign} title={title}>
+    {title && (
+      <StyledHeading>
+        {title} {titleSuffix && <span>{titleSuffix} </span>}
+      </StyledHeading>
+    )}
+    {divider && <hr />}
+    {text && <StyledText>{text}</StyledText>}
   </StyledComponentHeader>
 );
 

--- a/.storybook/welcome-page/components-demo/component-heading/component-heading.style.js
+++ b/.storybook/welcome-page/components-demo/component-heading/component-heading.style.js
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 
-export const StyledComponentHeader = styled.header`
+export const StyledComponentHeader = styled.div`
   align-items: ${({ centerAlign }) => (centerAlign ? "center" : "flex-start")};
   text-align: ${({ centerAlign }) => (centerAlign ? "center" : "left")};
   display: flex;

--- a/.storybook/welcome-page/components-demo/demo/demo-table/demo-table.component.js
+++ b/.storybook/welcome-page/components-demo/demo/demo-table/demo-table.component.js
@@ -1,4 +1,5 @@
 import React from "react";
+
 import {
   ActionPopover,
   ActionPopoverItem,
@@ -18,7 +19,7 @@ const DemoTable = () => (
       <FlatTableRow>
         <FlatTableHeader>First Name</FlatTableHeader>
         <FlatTableHeader>Second Name</FlatTableHeader>
-        <FlatTableHeader>&nbsp;</FlatTableHeader>
+        <FlatTableHeader align="center">Actions</FlatTableHeader>
       </FlatTableRow>
     </FlatTableHead>
     <FlatTableBody>

--- a/.storybook/welcome-page/components-demo/demo/demo.component.js
+++ b/.storybook/welcome-page/components-demo/demo/demo.component.js
@@ -1,19 +1,21 @@
 import React, { useState } from "react";
-import Button from "../../../../src/components/button";
-import Textbox from "../../../../src/components/textbox";
-import NumberInput from "../../../../src/components/number";
-import Decimal from "../../../../src/components/decimal";
-import { Select, Option } from "../../../../src/components/select";
+
+import Heading from "../component-heading";
 import { Wrapper, ContentWrapper } from "../../common.style";
+import Button from "../../../../src/components/button";
+import DateRange from "../../../../src/components/date-range";
+import Decimal from "../../../../src/components/decimal";
+import NumberInput from "../../../../src/components/number";
+import { Select, Option } from "../../../../src/components/select";
+import Textbox from "../../../../src/components/textbox";
+
+import DemoTable from "./demo-table";
 import {
   ComponentShowcaseWrapper,
   StyledDemoWrapper,
   StyledDemoRow,
   StyledComponentWrapper,
 } from "./demo.style";
-import DemoTable from "./demo-table";
-import DateRange from "../../../../src/components/date-range";
-import Heading from "../component-heading";
 
 const Demo = () => {
   const [numberValue, setNumberValue] = useState("0");
@@ -62,30 +64,50 @@ const Demo = () => {
             </StyledDemoRow>
             <StyledDemoRow styling={{ display: "flex" }}>
               <StyledComponentWrapper styling={{ width: "30%", padding: "1%" }}>
-                <Textbox placeholder="Carbon Textbox" inputIcon="search" />
+                <Textbox
+                  placeholder="Carbon Textbox"
+                  inputIcon="search"
+                  aria-label="An example textbox component with spyglass input icon"
+                />
               </StyledComponentWrapper>
               <StyledComponentWrapper styling={{ width: "30%", padding: "1%" }}>
                 <NumberInput
                   value={numberValue}
                   onChange={(e) => setNumberValue(e.target.value)}
+                  aria-label="An example numerical input component"
                 />
               </StyledComponentWrapper>
               <StyledComponentWrapper styling={{ width: "30%", padding: "1%" }}>
-                <Decimal />
+                <Decimal aria-label="An example decimal input component" />
               </StyledComponentWrapper>
             </StyledDemoRow>
             <StyledDemoRow styling={{ display: "flex" }}>
               <StyledComponentWrapper
                 styling={{ width: "100%", padding: "1.5%" }}
               >
-                <DateRange value={dateValue} onChange={handleDateChange} />
+                <DateRange
+                  value={dateValue}
+                  onChange={handleDateChange}
+                  endDateProps={{
+                    "aria-label":
+                      "The end date input of the example date range component",
+                  }}
+                  startDateProps={{
+                    "aria-label":
+                      "The start date input of the example date range component",
+                  }}
+                />
               </StyledComponentWrapper>
             </StyledDemoRow>
             <StyledDemoRow styling={{ display: "flex" }}>
               <StyledComponentWrapper
                 styling={{ width: "95%", padding: "1.5%" }}
               >
-                <Select defaultValue="" placeholder="Carbon Select">
+                <Select
+                  defaultValue=""
+                  placeholder="Carbon Select"
+                  aria-label="An example select component with two options"
+                >
                   <Option value="1" text="Red" />
                   <Option value="2" text="Blue" />
                 </Select>

--- a/.storybook/welcome-page/loves-carbon/loves-carbon.component.js
+++ b/.storybook/welcome-page/loves-carbon/loves-carbon.component.js
@@ -1,8 +1,10 @@
 import React from "react";
+
 import Heading from "../components-demo/component-heading";
-import { Wrapper, LovesCarbonWrapper, Image } from "./loves-carbon.style";
-import devices from "./devices.png";
 import Link from "../../../src/components/link";
+
+import devices from "./devices.png";
+import { Wrapper, LovesCarbonWrapper, Image } from "./loves-carbon.style";
 
 const LovesCarbon = () => (
   <LovesCarbonWrapper>
@@ -18,7 +20,10 @@ const LovesCarbon = () => (
           Learn more about Sage
         </Link>
       </div>
-      <Image src={devices} />
+      <Image
+        src={devices}
+        alt="Carbon in use across devices of varying sizes"
+      />
     </Wrapper>
   </LovesCarbonWrapper>
 );

--- a/.storybook/welcome-page/loves-carbon/loves-carbon.style.js
+++ b/.storybook/welcome-page/loves-carbon/loves-carbon.style.js
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+
 import { StyledComponentHeader } from "../components-demo/component-heading/component-heading.style";
 import { StyledLink } from "../../../src/components/link/link.style";
 
@@ -11,7 +12,6 @@ export const Wrapper = styled.div`
 `;
 
 export const LovesCarbonWrapper = styled.div`
-  background-color: #e6ebed;
   width: 100%;
 
   && ${StyledLink} a {

--- a/.storybook/welcome-page/selling-points/selling-point-panel.component.js
+++ b/.storybook/welcome-page/selling-points/selling-point-panel.component.js
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Panel, Image, Heading, Text } from "./selling-points.style";
 
 const images = {
@@ -10,9 +11,23 @@ const images = {
   collaborate: require("../../../.assets/collaborate.svg"),
 };
 
+const imagesAltText = {
+  flexible:
+    "Carbon is beautiful out-of-the-box, down to colours, icons, and style.",
+  hammer: "Hundreds of thousands of users worldwide help Carbon evolve.",
+  plug:
+    "Carbon powers your app. Contribute your code, so you can power Carbon too.",
+  point:
+    "Over 50 components and 340 configurations bring your killer app to life.",
+  brush:
+    "Meet your users' needs with a simple, elegant, delightful experience.",
+  collaborate:
+    "With Carbon's UI Kit, designers and developers speak the same language.",
+};
+
 export default ({ icon, heading, text }) => (
   <Panel>
-    <Image src={images[icon]} />
+    <Image src={images[icon]} alt={imagesAltText[icon]} />
     <Heading>{heading}</Heading>
     <Text>{text}</Text>
   </Panel>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6321 +61,5513 @@
 
 ### [144.0.1](https://github.com/Sage/carbon/compare/v144.0.0...v144.0.1) (2024-10-23)
 
-
 ### Bug Fixes
 
-* **dialog:** ensure height never exceeds 90% of the viewport height ([619a651](https://github.com/Sage/carbon/commit/619a6516ac3b0ac05e55219e79df529b491a9031))
-* prevent sticky footer form content from overflowing in Carbon modal components ([cb77fb7](https://github.com/Sage/carbon/commit/cb77fb78f72d866458df49964c08f567b971a110)), closes [#6969](https://github.com/Sage/carbon/issues/6969)
-* resolve layout issues with sticky footer forms inside Carbon modal components ([0fe249d](https://github.com/Sage/carbon/commit/0fe249db3d2e598f73eaccd3388e6feea61c2c80))
+- **dialog:** ensure height never exceeds 90% of the viewport height ([619a651](https://github.com/Sage/carbon/commit/619a6516ac3b0ac05e55219e79df529b491a9031))
+- prevent sticky footer form content from overflowing in Carbon modal components ([cb77fb7](https://github.com/Sage/carbon/commit/cb77fb78f72d866458df49964c08f567b971a110)), closes [#6969](https://github.com/Sage/carbon/issues/6969)
+- resolve layout issues with sticky footer forms inside Carbon modal components ([0fe249d](https://github.com/Sage/carbon/commit/0fe249db3d2e598f73eaccd3388e6feea61c2c80))
 
 ## [144.0.0](https://github.com/Sage/carbon/compare/v143.2.5...v144.0.0) (2024-10-21)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **menu, menu-item:** `Menu` no longer supports `height`, `minHeight`, `maxHeight`, `size`,
-`overflowY` and `display` props. `MenuItem` no longer supports `height`, `minHeight`,
-`maxHeight`, `size`, `verticalAlign`, `overflow`, `overflowY`, `overflowX` and
-`display` props.
+- **menu, menu-item:** `Menu` no longer supports `height`, `minHeight`, `maxHeight`, `size`,
+  `overflowY` and `display` props. `MenuItem` no longer supports `height`, `minHeight`,
+  `maxHeight`, `size`, `verticalAlign`, `overflow`, `overflowY`, `overflowX` and
+  `display` props.
 
 ### Bug Fixes
 
-* **menu-item:** ensure that it does not render children when `submenu` is an empty string ([975d5c6](https://github.com/Sage/carbon/commit/975d5c659ab99193bb94a194c3b8de834a94c0b6)), closes [#7010](https://github.com/Sage/carbon/issues/7010)
-* **menu, menu-item:** ensure that menu-items all remain the same height if any wrap to new lines ([501337c](https://github.com/Sage/carbon/commit/501337c4651d5bdd4713e986c207e453bb6beb68)), closes [#6934](https://github.com/Sage/carbon/issues/6934) [#7000](https://github.com/Sage/carbon/issues/7000)
+- **menu-item:** ensure that it does not render children when `submenu` is an empty string ([975d5c6](https://github.com/Sage/carbon/commit/975d5c659ab99193bb94a194c3b8de834a94c0b6)), closes [#7010](https://github.com/Sage/carbon/issues/7010)
+- **menu, menu-item:** ensure that menu-items all remain the same height if any wrap to new lines ([501337c](https://github.com/Sage/carbon/commit/501337c4651d5bdd4713e986c207e453bb6beb68)), closes [#6934](https://github.com/Sage/carbon/issues/6934) [#7000](https://github.com/Sage/carbon/issues/7000)
 
 ### [143.2.5](https://github.com/Sage/carbon/compare/v143.2.4...v143.2.5) (2024-10-18)
 
-
 ### Bug Fixes
 
-* **tile-select:** remove not allowed aria-expanded from accordion ([d43951d](https://github.com/Sage/carbon/commit/d43951d5b038da7019c974e7bbaa39cd21913bf1))
+- **tile-select:** remove not allowed aria-expanded from accordion ([d43951d](https://github.com/Sage/carbon/commit/d43951d5b038da7019c974e7bbaa39cd21913bf1))
 
 ### [143.2.4](https://github.com/Sage/carbon/compare/v143.2.3...v143.2.4) (2024-10-18)
 
-
 ### Bug Fixes
 
-* **action-popover:** ensure that opening using the up arrow focuses last element in the menu ([38aaed9](https://github.com/Sage/carbon/commit/38aaed9f7abaa7c5fe7750d9f9a61b60c3a3b0f3)), closes [#6826](https://github.com/Sage/carbon/issues/6826)
+- **action-popover:** ensure that opening using the up arrow focuses last element in the menu ([38aaed9](https://github.com/Sage/carbon/commit/38aaed9f7abaa7c5fe7750d9f9a61b60c3a3b0f3)), closes [#6826](https://github.com/Sage/carbon/issues/6826)
 
 ### [143.2.3](https://github.com/Sage/carbon/compare/v143.2.2...v143.2.3) (2024-10-18)
 
-
 ### Bug Fixes
 
-* downgrade @tanstack/react-virtual to version 3.10.1 ([b1cd42f](https://github.com/Sage/carbon/commit/b1cd42ffc258b9fda8db76009876128cd3b7c2bb))
+- downgrade @tanstack/react-virtual to version 3.10.1 ([b1cd42f](https://github.com/Sage/carbon/commit/b1cd42ffc258b9fda8db76009876128cd3b7c2bb))
 
 ### [143.2.2](https://github.com/Sage/carbon/compare/v143.2.1...v143.2.2) (2024-10-16)
 
-
 ### Bug Fixes
 
-* **switch:** fix screen reader announcements with new validation ([aed0ba0](https://github.com/Sage/carbon/commit/aed0ba027d8a640e8c253bce71f1911d40ce2b96)), closes [#6901](https://github.com/Sage/carbon/issues/6901)
+- **switch:** fix screen reader announcements with new validation ([aed0ba0](https://github.com/Sage/carbon/commit/aed0ba027d8a640e8c253bce71f1911d40ce2b96)), closes [#6901](https://github.com/Sage/carbon/issues/6901)
 
 ### [143.2.1](https://github.com/Sage/carbon/compare/v143.2.0...v143.2.1) (2024-10-16)
 
-
 ### Bug Fixes
 
-* **badge:** ensure badge does not appear under child components ([d88d3ec](https://github.com/Sage/carbon/commit/d88d3ec2d79419827aeacf27549b76e9c753c82b)), closes [#6765](https://github.com/Sage/carbon/issues/6765)
+- **badge:** ensure badge does not appear under child components ([d88d3ec](https://github.com/Sage/carbon/commit/d88d3ec2d79419827aeacf27549b76e9c753c82b)), closes [#6765](https://github.com/Sage/carbon/issues/6765)
 
 ## [143.2.0](https://github.com/Sage/carbon/compare/v143.1.0...v143.2.0) (2024-10-15)
 
-
 ### Features
 
-* **tile:** review changes - to be flattened ([8dc5a7c](https://github.com/Sage/carbon/commit/8dc5a7c9ae2d84caf646f1080949beabf935eba5))
+- **tile:** review changes - to be flattened ([8dc5a7c](https://github.com/Sage/carbon/commit/8dc5a7c9ae2d84caf646f1080949beabf935eba5))
 
 ## [143.1.0](https://github.com/Sage/carbon/compare/v143.0.2...v143.1.0) (2024-10-14)
 
-
 ### Features
 
-* **storybook:** upgrade storybook to 8.3 ([362e4e0](https://github.com/Sage/carbon/commit/362e4e0b91d0e59bb4e7e97a63e612251f5ae144))
+- **storybook:** upgrade storybook to 8.3 ([362e4e0](https://github.com/Sage/carbon/commit/362e4e0b91d0e59bb4e7e97a63e612251f5ae144))
 
 ### [143.0.2](https://github.com/Sage/carbon/compare/v143.0.1...v143.0.2) (2024-10-14)
 
-
 ### Bug Fixes
 
-* **action-popover-menu:** investigate focusIndex and setFocusIndex props on ActionPopoverMenu ([6d9cb82](https://github.com/Sage/carbon/commit/6d9cb82f3b0ff5f7fd3f5865c98b80455d3b81ba))
+- **action-popover-menu:** investigate focusIndex and setFocusIndex props on ActionPopoverMenu ([6d9cb82](https://github.com/Sage/carbon/commit/6d9cb82f3b0ff5f7fd3f5865c98b80455d3b81ba))
 
 ### [143.0.1](https://github.com/Sage/carbon/compare/v143.0.0...v143.0.1) (2024-10-14)
 
-
 ### Bug Fixes
 
-* **option:** makes `value` and `text` props optional ([fb37215](https://github.com/Sage/carbon/commit/fb372157e93cc171fa596ca9d74b299851db216c)), closes [#6939](https://github.com/Sage/carbon/issues/6939)
-* **select:** upgrade tanstack react-virtual to latest ([c51688f](https://github.com/Sage/carbon/commit/c51688fce6c25b7559e475fb09eef583689d1274)), closes [#6978](https://github.com/Sage/carbon/issues/6978)
+- **option:** makes `value` and `text` props optional ([fb37215](https://github.com/Sage/carbon/commit/fb372157e93cc171fa596ca9d74b299851db216c)), closes [#6939](https://github.com/Sage/carbon/issues/6939)
+- **select:** upgrade tanstack react-virtual to latest ([c51688f](https://github.com/Sage/carbon/commit/c51688fce6c25b7559e475fb09eef583689d1274)), closes [#6978](https://github.com/Sage/carbon/issues/6978)
 
 ## [143.0.0](https://github.com/Sage/carbon/compare/v142.13.5...v143.0.0) (2024-10-10)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **select:** `listPlacement` prop only supports `top` and `bottom` now
+- **select:** `listPlacement` prop only supports `top` and `bottom` now
 
 ### Features
 
-* **select, filterable-select, multi-select:** add support for overriding the list width ([c3853cd](https://github.com/Sage/carbon/commit/c3853cd139c229a7f73c787413efe61825426351)), closes [#6861](https://github.com/Sage/carbon/issues/6861)
-* **select:** remove support for rendering list to left and right of input ([4094117](https://github.com/Sage/carbon/commit/40941172da3ed07ae77ef145e9f777f55269f3a3))
+- **select, filterable-select, multi-select:** add support for overriding the list width ([c3853cd](https://github.com/Sage/carbon/commit/c3853cd139c229a7f73c787413efe61825426351)), closes [#6861](https://github.com/Sage/carbon/issues/6861)
+- **select:** remove support for rendering list to left and right of input ([4094117](https://github.com/Sage/carbon/commit/40941172da3ed07ae77ef145e9f777f55269f3a3))
 
 ### [142.13.5](https://github.com/Sage/carbon/compare/v142.13.4...v142.13.5) (2024-10-08)
 
-
 ### Bug Fixes
 
-* **textarea:** ensure expandable height shrinks when new lines are removed ([bdd32df](https://github.com/Sage/carbon/commit/bdd32df7017abfa75403fb9ad21b68386b019a3f))
+- **textarea:** ensure expandable height shrinks when new lines are removed ([bdd32df](https://github.com/Sage/carbon/commit/bdd32df7017abfa75403fb9ad21b68386b019a3f))
 
 ### [142.13.4](https://github.com/Sage/carbon/compare/v142.13.3...v142.13.4) (2024-10-07)
 
-
 ### Bug Fixes
 
-* **select:** prevent deprecation warning about uncontrolled textbox from being fired ([6de179c](https://github.com/Sage/carbon/commit/6de179cbae24f36ef8d7a7b122b7ccb8d13ec634)), closes [#6883](https://github.com/Sage/carbon/issues/6883)
+- **select:** prevent deprecation warning about uncontrolled textbox from being fired ([6de179c](https://github.com/Sage/carbon/commit/6de179cbae24f36ef8d7a7b122b7ccb8d13ec634)), closes [#6883](https://github.com/Sage/carbon/issues/6883)
 
 ### [142.13.3](https://github.com/Sage/carbon/compare/v142.13.2...v142.13.3) (2024-10-04)
 
-
 ### Bug Fixes
 
-* **badge:** investigate failing RTL test ([5e1d7d6](https://github.com/Sage/carbon/commit/5e1d7d6f6482b533c6fa9afe88f927293e3576c0))
+- **badge:** investigate failing RTL test ([5e1d7d6](https://github.com/Sage/carbon/commit/5e1d7d6f6482b533c6fa9afe88f927293e3576c0))
 
 ### [142.13.2](https://github.com/Sage/carbon/compare/v142.13.1...v142.13.2) (2024-10-04)
 
-
 ### Bug Fixes
 
-* **date:** add callback to be called when component blurs and picker is closed ([2a7e50e](https://github.com/Sage/carbon/commit/2a7e50e4551b0bff1848dd3fd7424d39eca6f196)), closes [#6788](https://github.com/Sage/carbon/issues/6788)
+- **date:** add callback to be called when component blurs and picker is closed ([2a7e50e](https://github.com/Sage/carbon/commit/2a7e50e4551b0bff1848dd3fd7424d39eca6f196)), closes [#6788](https://github.com/Sage/carbon/issues/6788)
 
 ### [142.13.1](https://github.com/Sage/carbon/compare/v142.13.0...v142.13.1) (2024-10-03)
 
-
 ### Bug Fixes
 
-* **form:** allow form-footer content to be responsive ([c7d55e1](https://github.com/Sage/carbon/commit/c7d55e14a44245609a5bd94df8993eb5a6f4b2ba)), closes [#6658](https://github.com/Sage/carbon/issues/6658)
+- **form:** allow form-footer content to be responsive ([c7d55e1](https://github.com/Sage/carbon/commit/c7d55e14a44245609a5bd94df8993eb5a6f4b2ba)), closes [#6658](https://github.com/Sage/carbon/issues/6658)
 
 ## [142.13.0](https://github.com/Sage/carbon/compare/v142.12.0...v142.13.0) (2024-10-02)
 
-
 ### Features
 
-* **fonts:** updated font weights for ds base token alignment ([58e89d8](https://github.com/Sage/carbon/commit/58e89d8255d2ff288adef2ddc03cb2679dabe481))
+- **fonts:** updated font weights for ds base token alignment ([58e89d8](https://github.com/Sage/carbon/commit/58e89d8255d2ff288adef2ddc03cb2679dabe481))
 
 ## [142.12.0](https://github.com/Sage/carbon/compare/v142.11.8...v142.12.0) (2024-09-26)
 
-
 ### Features
 
-* **version-picker:** reintroduce the version picker for storybook ([9d8ccf0](https://github.com/Sage/carbon/commit/9d8ccf040d32e09e10a806d5eb503438e60b7007))
+- **version-picker:** reintroduce the version picker for storybook ([9d8ccf0](https://github.com/Sage/carbon/commit/9d8ccf040d32e09e10a806d5eb503438e60b7007))
 
 ### [142.11.8](https://github.com/Sage/carbon/compare/v142.11.7...v142.11.8) (2024-09-26)
 
-
 ### Bug Fixes
 
-* **textarea:** ensure that correct height is applied when rows and expandable prop are used together ([835fac8](https://github.com/Sage/carbon/commit/835fac8b70e25b6bb4706c53fc9e96a91bd1558f)), closes [#6961](https://github.com/Sage/carbon/issues/6961)
+- **textarea:** ensure that correct height is applied when rows and expandable prop are used together ([835fac8](https://github.com/Sage/carbon/commit/835fac8b70e25b6bb4706c53fc9e96a91bd1558f)), closes [#6961](https://github.com/Sage/carbon/issues/6961)
 
 ### [142.11.7](https://github.com/Sage/carbon/compare/v142.11.6...v142.11.7) (2024-09-25)
 
-
 ### Bug Fixes
 
-* **loader:** translations for france ([e2f0a46](https://github.com/Sage/carbon/commit/e2f0a464139fb73e77b10be6c664223bf4258a5a))
+- **loader:** translations for france ([e2f0a46](https://github.com/Sage/carbon/commit/e2f0a464139fb73e77b10be6c664223bf4258a5a))
 
 ### [142.11.6](https://github.com/Sage/carbon/compare/v142.11.5...v142.11.6) (2024-09-23)
 
-
 ### Bug Fixes
 
-* **date:** prevent multiple instances of date picker opening at the same time ([d34c4e2](https://github.com/Sage/carbon/commit/d34c4e2053d7212705421aa9953ff61e3078421c))
+- **date:** prevent multiple instances of date picker opening at the same time ([d34c4e2](https://github.com/Sage/carbon/commit/d34c4e2053d7212705421aa9953ff61e3078421c))
 
 ### [142.11.5](https://github.com/Sage/carbon/compare/v142.11.4...v142.11.5) (2024-09-20)
 
-
 ### Bug Fixes
 
-* **navigation-bar:** move context provider to not wrap parent ([a265b1c](https://github.com/Sage/carbon/commit/a265b1cdc18d01c35c1ecf88299f9dc4fc76208c))
+- **navigation-bar:** move context provider to not wrap parent ([a265b1c](https://github.com/Sage/carbon/commit/a265b1cdc18d01c35c1ecf88299f9dc4fc76208c))
 
 ### [142.11.4](https://github.com/Sage/carbon/compare/v142.11.3...v142.11.4) (2024-09-20)
 
-
 ### Bug Fixes
 
-* **toast:** ensure closed toasts do not trigger axe warnings ([6183351](https://github.com/Sage/carbon/commit/6183351ff6ba00bd032506e3ef61f296f720b080))
+- **toast:** ensure closed toasts do not trigger axe warnings ([6183351](https://github.com/Sage/carbon/commit/6183351ff6ba00bd032506e3ef61f296f720b080))
 
 ### [142.11.3](https://github.com/Sage/carbon/compare/v142.11.2...v142.11.3) (2024-09-19)
 
-
 ### Bug Fixes
 
-* **tabs:** tab headers jump in width when navigating through them ([7c70261](https://github.com/Sage/carbon/commit/7c7026103f4f6b0f59b2c170f3f2523dd356832b)), closes [#6554](https://github.com/Sage/carbon/issues/6554)
+- **tabs:** tab headers jump in width when navigating through them ([7c70261](https://github.com/Sage/carbon/commit/7c7026103f4f6b0f59b2c170f3f2523dd356832b)), closes [#6554](https://github.com/Sage/carbon/issues/6554)
 
 ### [142.11.2](https://github.com/Sage/carbon/compare/v142.11.1...v142.11.2) (2024-09-19)
 
-
 ### Bug Fixes
 
-* **form, dialog:** tabbing in FireFox - focus incorrect ([43ff681](https://github.com/Sage/carbon/commit/43ff681be9365ba1ba4315bf50f04e79b9e88545))
+- **form, dialog:** tabbing in FireFox - focus incorrect ([43ff681](https://github.com/Sage/carbon/commit/43ff681be9365ba1ba4315bf50f04e79b9e88545))
 
 ### [142.11.1](https://github.com/Sage/carbon/compare/v142.11.0...v142.11.1) (2024-09-18)
 
-
 ### Bug Fixes
 
-* **checkbox:** restore support for `labelHelp` and `fieldHelp` props ([b2fea4a](https://github.com/Sage/carbon/commit/b2fea4ac84f96252d12e2a0bbfbffe677a304938))
-* **radio-button:** restore support for `labelHelp` and `fieldHelp` props ([81dfeb2](https://github.com/Sage/carbon/commit/81dfeb299bf89cf59a25009f1ace9b1a5938039a))
+- **checkbox:** restore support for `labelHelp` and `fieldHelp` props ([b2fea4a](https://github.com/Sage/carbon/commit/b2fea4ac84f96252d12e2a0bbfbffe677a304938))
+- **radio-button:** restore support for `labelHelp` and `fieldHelp` props ([81dfeb2](https://github.com/Sage/carbon/commit/81dfeb299bf89cf59a25009f1ace9b1a5938039a))
 
 ## [142.11.0](https://github.com/Sage/carbon/compare/v142.10.0...v142.11.0) (2024-09-18)
 
-
 ### Features
 
-* **flat-table:** add `hasOuterVerticalBorders` and `bottomBorderRadius` props ([866137a](https://github.com/Sage/carbon/commit/866137a13ddcad40be0ec2ca2da124eac400dd06))
+- **flat-table:** add `hasOuterVerticalBorders` and `bottomBorderRadius` props ([866137a](https://github.com/Sage/carbon/commit/866137a13ddcad40be0ec2ca2da124eac400dd06))
 
 ## [142.10.0](https://github.com/Sage/carbon/compare/v142.9.1...v142.10.0) (2024-09-16)
 
-
 ### Features
 
-* **preview:** add `shape` and `disableAnimation` props ([bd071fe](https://github.com/Sage/carbon/commit/bd071fe3347317ccfb0c4262e10566ad31443869))
+- **preview:** add `shape` and `disableAnimation` props ([bd071fe](https://github.com/Sage/carbon/commit/bd071fe3347317ccfb0c4262e10566ad31443869))
 
 ### [142.9.1](https://github.com/Sage/carbon/compare/v142.9.0...v142.9.1) (2024-09-12)
 
-
 ### Bug Fixes
 
-* **duelling-picklist:** fix data-element attribute of right controls ([ea07dc5](https://github.com/Sage/carbon/commit/ea07dc51080693fc2e07632e92a36bd65d3aded2))
+- **duelling-picklist:** fix data-element attribute of right controls ([ea07dc5](https://github.com/Sage/carbon/commit/ea07dc51080693fc2e07632e92a36bd65d3aded2))
 
 ## [142.9.0](https://github.com/Sage/carbon/compare/v142.8.1...v142.9.0) (2024-09-03)
 
-
 ### Features
 
-* **flex-tile-container:** add support for overriding the `overflow` styling ([64b0143](https://github.com/Sage/carbon/commit/64b014385afbd7b54430d2189f37dc482e165d77)), closes [#6868](https://github.com/Sage/carbon/issues/6868)
+- **flex-tile-container:** add support for overriding the `overflow` styling ([64b0143](https://github.com/Sage/carbon/commit/64b014385afbd7b54430d2189f37dc482e165d77)), closes [#6868](https://github.com/Sage/carbon/issues/6868)
 
 ### [142.8.1](https://github.com/Sage/carbon/compare/v142.8.0...v142.8.1) (2024-09-02)
 
-
 ### Reverts
 
-* Revert "refactor(date, date-range, numeral-date): mock Tooltip due to latency issues in floating-ui" ([ccf86a8](https://github.com/Sage/carbon/commit/ccf86a84de612995e02afb09d175d77e24d07f42))
+- Revert "refactor(date, date-range, numeral-date): mock Tooltip due to latency issues in floating-ui" ([ccf86a8](https://github.com/Sage/carbon/commit/ccf86a84de612995e02afb09d175d77e24d07f42))
 
 ## [142.8.0](https://github.com/Sage/carbon/compare/v142.7.0...v142.8.0) (2024-08-30)
 
-
 ### Features
 
-* **dialog:** add the "maximise" value to the `size` prop ([398ffb0](https://github.com/Sage/carbon/commit/398ffb0e18820d92ae1db7553f29d5b6bc516a6f))
+- **dialog:** add the "maximise" value to the `size` prop ([398ffb0](https://github.com/Sage/carbon/commit/398ffb0e18820d92ae1db7553f29d5b6bc516a6f))
 
 ## [142.7.0](https://github.com/Sage/carbon/compare/v142.6.0...v142.7.0) (2024-08-30)
 
-
 ### Features
 
-* **vertical-divider:** add aria-hidden prop but prevent overriding when in menu ([7da78ff](https://github.com/Sage/carbon/commit/7da78ff9c8bd8b04faa6ff44e9c333c8e73a41b6))
+- **vertical-divider:** add aria-hidden prop but prevent overriding when in menu ([7da78ff](https://github.com/Sage/carbon/commit/7da78ff9c8bd8b04faa6ff44e9c333c8e73a41b6))
 
 ## [142.6.0](https://github.com/Sage/carbon/compare/v142.5.1...v142.6.0) (2024-08-30)
 
-
 ### Features
 
-* **breadcrumbs:** add isDarkBackground prop ([25953d3](https://github.com/Sage/carbon/commit/25953d30e4cc5a2fba5d5ba3f7163c46a04d1121)), closes [#6724](https://github.com/Sage/carbon/issues/6724)
+- **breadcrumbs:** add isDarkBackground prop ([25953d3](https://github.com/Sage/carbon/commit/25953d30e4cc5a2fba5d5ba3f7163c46a04d1121)), closes [#6724](https://github.com/Sage/carbon/issues/6724)
 
 ### [142.5.1](https://github.com/Sage/carbon/compare/v142.5.0...v142.5.1) (2024-08-30)
 
-
 ### Bug Fixes
 
-* **textarea:** add minheight prop to Textarea ([cf1b651](https://github.com/Sage/carbon/commit/cf1b6514fdea19f7f70876158259eb18e3daa6ce)), closes [#6860](https://github.com/Sage/carbon/issues/6860)
+- **textarea:** add minheight prop to Textarea ([cf1b651](https://github.com/Sage/carbon/commit/cf1b6514fdea19f7f70876158259eb18e3daa6ce)), closes [#6860](https://github.com/Sage/carbon/issues/6860)
 
 ## [142.5.0](https://github.com/Sage/carbon/compare/v142.4.1...v142.5.0) (2024-08-28)
 
-
 ### Features
 
-* **tile:** add support for adding highlight border via the highlightVariant prop ([467ebcc](https://github.com/Sage/carbon/commit/467ebccd26e7fe59dc8709904ea6d45c52399171))
-
+- **tile:** add support for adding highlight border via the highlightVariant prop ([467ebcc](https://github.com/Sage/carbon/commit/467ebccd26e7fe59dc8709904ea6d45c52399171))
 
 ### Bug Fixes
 
-* **tile:** ensure border radius is only set on children when not in TileContent ([86f5cbd](https://github.com/Sage/carbon/commit/86f5cbdc7e14807e0e0208df7bc97266dc75ba26))
+- **tile:** ensure border radius is only set on children when not in TileContent ([86f5cbd](https://github.com/Sage/carbon/commit/86f5cbdc7e14807e0e0208df7bc97266dc75ba26))
 
 ### [142.4.1](https://github.com/Sage/carbon/compare/v142.4.0...v142.4.1) (2024-08-28)
 
-
 ### Bug Fixes
 
-* **menu-item, submenu:** remove min-width when submenuMaxWidth prop is set ([002c37d](https://github.com/Sage/carbon/commit/002c37d59611d18285b95b02ca316af1645277b0))
+- **menu-item, submenu:** remove min-width when submenuMaxWidth prop is set ([002c37d](https://github.com/Sage/carbon/commit/002c37d59611d18285b95b02ca316af1645277b0))
 
 ## [142.4.0](https://github.com/Sage/carbon/compare/v142.3.2...v142.4.0) (2024-08-27)
 
-
 ### Features
 
-* **loader-star:** create new loader-star component ([5ffe0e4](https://github.com/Sage/carbon/commit/5ffe0e41ec7fa673522c1e2f966a398c08a0c287))
+- **loader-star:** create new loader-star component ([5ffe0e4](https://github.com/Sage/carbon/commit/5ffe0e41ec7fa673522c1e2f966a398c08a0c287))
 
 ### [142.3.2](https://github.com/Sage/carbon/compare/v142.3.1...v142.3.2) (2024-08-23)
 
-
 ### Bug Fixes
 
-* **checkbox:** prevent labelHelp and fieldHelp from rendering in a group with new validation ([2f2f340](https://github.com/Sage/carbon/commit/2f2f340fcdfca1acb5b72bad6df7299eece3eb3e))
-* **radio-button:** prevent labelHelp and fieldHelp from rendering with new validation ([c9c4500](https://github.com/Sage/carbon/commit/c9c4500b7177ffd6151a9a4fe6adbe576c4d2f9c))
+- **checkbox:** prevent labelHelp and fieldHelp from rendering in a group with new validation ([2f2f340](https://github.com/Sage/carbon/commit/2f2f340fcdfca1acb5b72bad6df7299eece3eb3e))
+- **radio-button:** prevent labelHelp and fieldHelp from rendering with new validation ([c9c4500](https://github.com/Sage/carbon/commit/c9c4500b7177ffd6151a9a4fe6adbe576c4d2f9c))
 
 ### [142.3.1](https://github.com/Sage/carbon/compare/v142.3.0...v142.3.1) (2024-08-22)
 
-
 ### Bug Fixes
 
-* **menu-item:** ensure correct alignment when onClick and icon props are set ([afa2759](https://github.com/Sage/carbon/commit/afa2759adac7b401708802d3fc0b759ba95246b1))
+- **menu-item:** ensure correct alignment when onClick and icon props are set ([afa2759](https://github.com/Sage/carbon/commit/afa2759adac7b401708802d3fc0b759ba95246b1))
 
 ## [142.3.0](https://github.com/Sage/carbon/compare/v142.2.2...v142.3.0) (2024-08-21)
 
-
 ### Features
 
-* **menu-item:** add `submenuMaxWidth` prop to allow setting of `max-width` on submenus ([0d57505](https://github.com/Sage/carbon/commit/0d575052a15fb8c065c0c24971aee42eeed80872))
-* **menu-item:** update so custom padding is set on the button or anchor element ([7a4f540](https://github.com/Sage/carbon/commit/7a4f540c0238bf0c80e142410bec81a57031365e))
+- **menu-item:** add `submenuMaxWidth` prop to allow setting of `max-width` on submenus ([0d57505](https://github.com/Sage/carbon/commit/0d575052a15fb8c065c0c24971aee42eeed80872))
+- **menu-item:** update so custom padding is set on the button or anchor element ([7a4f540](https://github.com/Sage/carbon/commit/7a4f540c0238bf0c80e142410bec81a57031365e))
 
 ### [142.2.2](https://github.com/Sage/carbon/compare/v142.2.1...v142.2.2) (2024-08-20)
 
-
 ### Bug Fixes
 
-* **batch-selection:** children are still clickable when hidden prop is true ([7364fb5](https://github.com/Sage/carbon/commit/7364fb52834f703498b56372948bcc06620cc2dd)), closes [#6858](https://github.com/Sage/carbon/issues/6858)
+- **batch-selection:** children are still clickable when hidden prop is true ([7364fb5](https://github.com/Sage/carbon/commit/7364fb52834f703498b56372948bcc06620cc2dd)), closes [#6858](https://github.com/Sage/carbon/issues/6858)
 
 ### [142.2.1](https://github.com/Sage/carbon/compare/v142.2.0...v142.2.1) (2024-08-19)
 
-
 ### Bug Fixes
 
-* **icon:** ensure tooltip does not render when component is disabled ([c1cfd50](https://github.com/Sage/carbon/commit/c1cfd50c68efffafb72afffaae64662c24edb44d))
+- **icon:** ensure tooltip does not render when component is disabled ([c1cfd50](https://github.com/Sage/carbon/commit/c1cfd50c68efffafb72afffaae64662c24edb44d))
 
 ## [142.2.0](https://github.com/Sage/carbon/compare/v142.1.0...v142.2.0) (2024-08-16)
 
-
 ### Features
 
-* **hr:** add the aria-hidden prop ([d84e37f](https://github.com/Sage/carbon/commit/d84e37f05b36889f33b59c7f842ea876f1cd7c5d))
+- **hr:** add the aria-hidden prop ([d84e37f](https://github.com/Sage/carbon/commit/d84e37f05b36889f33b59c7f842ea876f1cd7c5d))
 
 ## [142.1.0](https://github.com/Sage/carbon/compare/v142.0.4...v142.1.0) (2024-08-16)
 
-
 ### Features
 
-* **link:** update styling of skip link variant ([79e44c9](https://github.com/Sage/carbon/commit/79e44c97b8df4ff544e8dc40b84ce3a884762244))
+- **link:** update styling of skip link variant ([79e44c9](https://github.com/Sage/carbon/commit/79e44c97b8df4ff544e8dc40b84ce3a884762244))
 
 ### [142.0.4](https://github.com/Sage/carbon/compare/v142.0.3...v142.0.4) (2024-08-15)
 
-
 ### Bug Fixes
 
-* **select:** consolidate hitbox across all Select variants ([297ce84](https://github.com/Sage/carbon/commit/297ce84f141ae5f3eae6f99c582e37c9dfe55816)), closes [#6841](https://github.com/Sage/carbon/issues/6841)
+- **select:** consolidate hitbox across all Select variants ([297ce84](https://github.com/Sage/carbon/commit/297ce84f141ae5f3eae6f99c582e37c9dfe55816)), closes [#6841](https://github.com/Sage/carbon/issues/6841)
 
 ### [142.0.3](https://github.com/Sage/carbon/compare/v142.0.2...v142.0.3) (2024-08-14)
 
-
 ### Bug Fixes
 
-* **simple-color-picker, advanced-color-picker:** ensure blur blocking works when switching colors ([c4434bb](https://github.com/Sage/carbon/commit/c4434bba81405cf1d200911a5a13107c9c4624a0)), closes [#6850](https://github.com/Sage/carbon/issues/6850)
+- **simple-color-picker, advanced-color-picker:** ensure blur blocking works when switching colors ([c4434bb](https://github.com/Sage/carbon/commit/c4434bba81405cf1d200911a5a13107c9c4624a0)), closes [#6850](https://github.com/Sage/carbon/issues/6850)
 
 ### [142.0.2](https://github.com/Sage/carbon/compare/v142.0.1...v142.0.2) (2024-08-14)
 
-
 ### Bug Fixes
 
-* **menu:** variant type mismatch MenuItem and Link ([f3da8b4](https://github.com/Sage/carbon/commit/f3da8b41899ee59aa75539d96d16cbdfdb72c171)), closes [#6829](https://github.com/Sage/carbon/issues/6829)
+- **menu:** variant type mismatch MenuItem and Link ([f3da8b4](https://github.com/Sage/carbon/commit/f3da8b41899ee59aa75539d96d16cbdfdb72c171)), closes [#6829](https://github.com/Sage/carbon/issues/6829)
 
 ### [142.0.1](https://github.com/Sage/carbon/compare/v142.0.0...v142.0.1) (2024-08-13)
 
-
 ### Bug Fixes
 
-* **heading:** ensure back link focus styling is consistent when rendered as a link or button ([5991d48](https://github.com/Sage/carbon/commit/5991d48bedcc400bf20c26a534f3071069dd66fb))
-* **heading:** ensure back link wrapper does not have additional focus styling ([041ff54](https://github.com/Sage/carbon/commit/041ff54345a5f0a60db1e0df8ab912501cb24bc1))
+- **heading:** ensure back link focus styling is consistent when rendered as a link or button ([5991d48](https://github.com/Sage/carbon/commit/5991d48bedcc400bf20c26a534f3071069dd66fb))
+- **heading:** ensure back link wrapper does not have additional focus styling ([041ff54](https://github.com/Sage/carbon/commit/041ff54345a5f0a60db1e0df8ab912501cb24bc1))
 
 ## [142.0.0](https://github.com/Sage/carbon/compare/v141.4.4...v142.0.0) (2024-08-09)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **message:** `MessageContent` and `TypeIcon` subcomponents have been moved to an `__internal__`
-directory
-* **progress-tracker:** Aria attribute and `showDefaultLabel` props have been removed from
-`ProgressTracker`. This component can no longer be used without labels, default labels will
-now always be displayed if no valid `currentProgressLabel` is provided.
+- **message:** `MessageContent` and `TypeIcon` subcomponents have been moved to an `__internal__`
+  directory
+- **progress-tracker:** Aria attribute and `showDefaultLabel` props have been removed from
+  `ProgressTracker`. This component can no longer be used without labels, default labels will
+  now always be displayed if no valid `currentProgressLabel` is provided.
 
 ### Features
 
-* **progress-tracker:** remove aria- attribute and showDefaultLabel  props ([8edfd4c](https://github.com/Sage/carbon/commit/8edfd4c0e67b166f7e4fcf9a60b821826b92b349)), closes [#6755](https://github.com/Sage/carbon/issues/6755)
-
+- **progress-tracker:** remove aria- attribute and showDefaultLabel props ([8edfd4c](https://github.com/Sage/carbon/commit/8edfd4c0e67b166f7e4fcf9a60b821826b92b349)), closes [#6755](https://github.com/Sage/carbon/issues/6755)
 
 ### Miscellaneous Chores
 
-* **message:** move subcomponents into an internal directory ([4f602c2](https://github.com/Sage/carbon/commit/4f602c275ee5f2ae7f816aac9b0124bfd5ffe526))
+- **message:** move subcomponents into an internal directory ([4f602c2](https://github.com/Sage/carbon/commit/4f602c275ee5f2ae7f816aac9b0124bfd5ffe526))
 
 ### [141.4.4](https://github.com/Sage/carbon/compare/v141.4.3...v141.4.4) (2024-08-07)
 
-
 ### Bug Fixes
 
-* **switch:** visual overflow with longer translation strings ([baf21b1](https://github.com/Sage/carbon/commit/baf21b12065973406b05722cd0dd27a644160f88))
+- **switch:** visual overflow with longer translation strings ([baf21b1](https://github.com/Sage/carbon/commit/baf21b12065973406b05722cd0dd27a644160f88))
 
 ### [141.4.3](https://github.com/Sage/carbon/compare/v141.4.2...v141.4.3) (2024-08-02)
 
-
 ### Bug Fixes
 
-* **multi-select:** ensure unique keys when options passed object values with duplicate text property ([5c3fd8c](https://github.com/Sage/carbon/commit/5c3fd8ce86cea9a49cdc9b5a78a28dd364901a58)), closes [#6843](https://github.com/Sage/carbon/issues/6843)
+- **multi-select:** ensure unique keys when options passed object values with duplicate text property ([5c3fd8c](https://github.com/Sage/carbon/commit/5c3fd8ce86cea9a49cdc9b5a78a28dd364901a58)), closes [#6843](https://github.com/Sage/carbon/issues/6843)
 
 ### [141.4.2](https://github.com/Sage/carbon/compare/v141.4.1...v141.4.2) (2024-08-02)
 
-
 ### Bug Fixes
 
-* **batch-selection:** ensure all button children are disabled when inside a disabled BatchSelection ([9ab48ab](https://github.com/Sage/carbon/commit/9ab48ab4ecf948f5016333098640b6449465916c))
+- **batch-selection:** ensure all button children are disabled when inside a disabled BatchSelection ([9ab48ab](https://github.com/Sage/carbon/commit/9ab48ab4ecf948f5016333098640b6449465916c))
 
 ### [141.4.1](https://github.com/Sage/carbon/compare/v141.4.0...v141.4.1) (2024-08-02)
 
-
 ### Reverts
 
-* Revert "chore(storybook): disable version picker addon" ([4a3269a](https://github.com/Sage/carbon/commit/4a3269a0ba37eff8779fbbf145401b8be05e065e))
+- Revert "chore(storybook): disable version picker addon" ([4a3269a](https://github.com/Sage/carbon/commit/4a3269a0ba37eff8779fbbf145401b8be05e065e))
 
 ## [141.4.0](https://github.com/Sage/carbon/compare/v141.3.1...v141.4.0) (2024-08-01)
 
-
 ### Features
 
-* **search:** add `triggerOnClear` prop to allow clicking `cross` icon to trigger `onClick` ([a77afe5](https://github.com/Sage/carbon/commit/a77afe55bf47f9b52befa3356c3affc755651b29)), closes [#6768](https://github.com/Sage/carbon/issues/6768)
+- **search:** add `triggerOnClear` prop to allow clicking `cross` icon to trigger `onClick` ([a77afe5](https://github.com/Sage/carbon/commit/a77afe55bf47f9b52befa3356c3affc755651b29)), closes [#6768](https://github.com/Sage/carbon/issues/6768)
 
 ### [141.3.1](https://github.com/Sage/carbon/compare/v141.3.0...v141.3.1) (2024-08-01)
 
-
 ### Bug Fixes
 
-* **heading:** the heading separator incorrectly has 1px black colour at the leftmost position ([b31fb1e](https://github.com/Sage/carbon/commit/b31fb1ea7ef0b59c87e885d61e8ec622ff1a0fa3))
+- **heading:** the heading separator incorrectly has 1px black colour at the leftmost position ([b31fb1e](https://github.com/Sage/carbon/commit/b31fb1ea7ef0b59c87e885d61e8ec622ff1a0fa3))
 
 ## [141.3.0](https://github.com/Sage/carbon/compare/v141.2.1...v141.3.0) (2024-07-31)
 
-
 ### Features
 
-* **toast:** improve component screen reader behaviour ([5e945e3](https://github.com/Sage/carbon/commit/5e945e3003202867bc3962a68a8423db64ae2c57)), closes [#6729](https://github.com/Sage/carbon/issues/6729)
+- **toast:** improve component screen reader behaviour ([5e945e3](https://github.com/Sage/carbon/commit/5e945e3003202867bc3962a68a8423db64ae2c57)), closes [#6729](https://github.com/Sage/carbon/issues/6729)
 
 ### [141.2.1](https://github.com/Sage/carbon/compare/v141.2.0...v141.2.1) (2024-07-30)
 
-
 ### Bug Fixes
 
-* **flat-table:** flat table contents visible behind sticky header/footer ([4f84514](https://github.com/Sage/carbon/commit/4f845144d3f44376529bf8c2d706179a59b63534))
+- **flat-table:** flat table contents visible behind sticky header/footer ([4f84514](https://github.com/Sage/carbon/commit/4f845144d3f44376529bf8c2d706179a59b63534))
 
 ## [141.2.0](https://github.com/Sage/carbon/compare/v141.1.1...v141.2.0) (2024-07-29)
 
-
 ### Features
 
-* **step-flow:** allow component title to be compositional ([4d5d808](https://github.com/Sage/carbon/commit/4d5d808982e1557a7b0f2c964e302a7c30715cb6)), closes [#6732](https://github.com/Sage/carbon/issues/6732)
+- **step-flow:** allow component title to be compositional ([4d5d808](https://github.com/Sage/carbon/commit/4d5d808982e1557a7b0f2c964e302a7c30715cb6)), closes [#6732](https://github.com/Sage/carbon/issues/6732)
 
 ### [141.1.1](https://github.com/Sage/carbon/compare/v141.1.0...v141.1.1) (2024-07-26)
 
-
 ### Bug Fixes
 
-* **flat-table-row-header:** focus border partially covered in expanded rows ([d97caa8](https://github.com/Sage/carbon/commit/d97caa8ef195b485948b45a5f373731d477ad973)), closes [#6561](https://github.com/Sage/carbon/issues/6561)
+- **flat-table-row-header:** focus border partially covered in expanded rows ([d97caa8](https://github.com/Sage/carbon/commit/d97caa8ef195b485948b45a5f373731d477ad973)), closes [#6561](https://github.com/Sage/carbon/issues/6561)
 
 ## [141.1.0](https://github.com/Sage/carbon/compare/v141.0.8...v141.1.0) (2024-07-25)
 
-
 ### Features
 
-* **option-group-header:** add support for children to be passed to component ([9629f93](https://github.com/Sage/carbon/commit/9629f9388328626caab6ffad6f90694aa02eadd9)), closes [#6823](https://github.com/Sage/carbon/issues/6823)
+- **option-group-header:** add support for children to be passed to component ([9629f93](https://github.com/Sage/carbon/commit/9629f9388328626caab6ffad6f90694aa02eadd9)), closes [#6823](https://github.com/Sage/carbon/issues/6823)
 
 ### [141.0.8](https://github.com/Sage/carbon/compare/v141.0.7...v141.0.8) (2024-07-25)
 
-
 ### Bug Fixes
 
-* **popover-container:** popover position re-renders with controlled multiselect ([2783ace](https://github.com/Sage/carbon/commit/2783aceed1b13b5bdaee9cc7ec87ab8fea118b94)), closes [#6793](https://github.com/Sage/carbon/issues/6793)
+- **popover-container:** popover position re-renders with controlled multiselect ([2783ace](https://github.com/Sage/carbon/commit/2783aceed1b13b5bdaee9cc7ec87ab8fea118b94)), closes [#6793](https://github.com/Sage/carbon/issues/6793)
 
 ### [141.0.7](https://github.com/Sage/carbon/compare/v141.0.6...v141.0.7) (2024-07-25)
 
-
 ### Bug Fixes
 
-* **button-toggle:** long text overflows button and update large icon padding ([265ff49](https://github.com/Sage/carbon/commit/265ff4992492341f550684a79e37986eb1c06de7)), closes [#6799](https://github.com/Sage/carbon/issues/6799)
+- **button-toggle:** long text overflows button and update large icon padding ([265ff49](https://github.com/Sage/carbon/commit/265ff4992492341f550684a79e37986eb1c06de7)), closes [#6799](https://github.com/Sage/carbon/issues/6799)
 
 ### [141.0.6](https://github.com/Sage/carbon/compare/v141.0.5...v141.0.6) (2024-07-22)
 
-
 ### Bug Fixes
 
-* **numeral-date:** ensure that enter key triggers default behaviour ([7c2f997](https://github.com/Sage/carbon/commit/7c2f99705cee55dd6ed000965e7f304c27c79273)), closes [#6832](https://github.com/Sage/carbon/issues/6832)
+- **numeral-date:** ensure that enter key triggers default behaviour ([7c2f997](https://github.com/Sage/carbon/commit/7c2f99705cee55dd6ed000965e7f304c27c79273)), closes [#6832](https://github.com/Sage/carbon/issues/6832)
 
 ### [141.0.5](https://github.com/Sage/carbon/compare/v141.0.4...v141.0.5) (2024-07-19)
 
-
 ### Bug Fixes
 
-* **alert:** fix data-component for alert component ([8f8530f](https://github.com/Sage/carbon/commit/8f8530f7d42b8c701fc10c865835629db6e0e0a9))
+- **alert:** fix data-component for alert component ([8f8530f](https://github.com/Sage/carbon/commit/8f8530f7d42b8c701fc10c865835629db6e0e0a9))
 
 ### [141.0.4](https://github.com/Sage/carbon/compare/v141.0.3...v141.0.4) (2024-07-19)
 
-
 ### Bug Fixes
 
-* **menu-item:** ensure hover styling does not overlap focus outlines ([1e673b3](https://github.com/Sage/carbon/commit/1e673b3b4cccb7169ac80768122699d0d238a61b)), closes [#6781](https://github.com/Sage/carbon/issues/6781)
+- **menu-item:** ensure hover styling does not overlap focus outlines ([1e673b3](https://github.com/Sage/carbon/commit/1e673b3b4cccb7169ac80768122699d0d238a61b)), closes [#6781](https://github.com/Sage/carbon/issues/6781)
 
 ### [141.0.3](https://github.com/Sage/carbon/compare/v141.0.2...v141.0.3) (2024-07-19)
 
-
 ### Bug Fixes
 
-* **dialog-full-screen:** fix flex title layout ([73c41e7](https://github.com/Sage/carbon/commit/73c41e795bcf468362bf111e5f0e1a319e2187d9)), closes [#6740](https://github.com/Sage/carbon/issues/6740)
+- **dialog-full-screen:** fix flex title layout ([73c41e7](https://github.com/Sage/carbon/commit/73c41e795bcf468362bf111e5f0e1a319e2187d9)), closes [#6740](https://github.com/Sage/carbon/issues/6740)
 
 ### [141.0.2](https://github.com/Sage/carbon/compare/v141.0.1...v141.0.2) (2024-07-19)
 
-
 ### Bug Fixes
 
-* **file-input:** ensure that long file names are truncated correctly ([e4986a0](https://github.com/Sage/carbon/commit/e4986a0ba91fa5c977a18019c0aa8297b9ce3afc))
+- **file-input:** ensure that long file names are truncated correctly ([e4986a0](https://github.com/Sage/carbon/commit/e4986a0ba91fa5c977a18019c0aa8297b9ce3afc))
 
 ### [141.0.1](https://github.com/Sage/carbon/compare/v141.0.0...v141.0.1) (2024-07-18)
 
-
 ### Bug Fixes
 
-* **link:** ensure focus styles are removed when underlying element loses focus ([0c68b5e](https://github.com/Sage/carbon/commit/0c68b5eb45f79f8a24089057557646a394fdb548)), closes [#6808](https://github.com/Sage/carbon/issues/6808) [#6688](https://github.com/Sage/carbon/issues/6688)
+- **link:** ensure focus styles are removed when underlying element loses focus ([0c68b5e](https://github.com/Sage/carbon/commit/0c68b5eb45f79f8a24089057557646a394fdb548)), closes [#6808](https://github.com/Sage/carbon/issues/6808) [#6688](https://github.com/Sage/carbon/issues/6688)
 
 ## [141.0.0](https://github.com/Sage/carbon/compare/v140.2.0...v141.0.0) (2024-07-12)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **menu:** Removed support for consuming `MenuContext`
-* **icon-button:** Remove onAction prop in favour of onClick
-* **sidebar:** Custom `data-element` and `data-role` tags are now placed on
-the main sidebar element that has a dialog role
+- **menu:** Removed support for consuming `MenuContext`
+- **icon-button:** Remove onAction prop in favour of onClick
+- **sidebar:** Custom `data-element` and `data-role` tags are now placed on
+  the main sidebar element that has a dialog role
 
 ### Bug Fixes
 
-* **menu:** remove export for internal context ([4cf8852](https://github.com/Sage/carbon/commit/4cf88527aa60282f99284700b96f8534b6b27590))
-* **sidebar:** ensure data tag props are set on the correct internal element ([e5465b7](https://github.com/Sage/carbon/commit/e5465b71ec9dec5a2ff210316fcd77b136ee5c8b))
-
+- **menu:** remove export for internal context ([4cf8852](https://github.com/Sage/carbon/commit/4cf88527aa60282f99284700b96f8534b6b27590))
+- **sidebar:** ensure data tag props are set on the correct internal element ([e5465b7](https://github.com/Sage/carbon/commit/e5465b71ec9dec5a2ff210316fcd77b136ee5c8b))
 
 ### Code Refactoring
 
-* **icon-button:** remove deprecated onAction prop ([22dff44](https://github.com/Sage/carbon/commit/22dff445ec3b5c54a76146e42605d85dc7557745))
+- **icon-button:** remove deprecated onAction prop ([22dff44](https://github.com/Sage/carbon/commit/22dff445ec3b5c54a76146e42605d85dc7557745))
 
 ## [140.2.0](https://github.com/Sage/carbon/compare/v140.1.1...v140.2.0) (2024-07-09)
 
-
 ### Features
 
-* **portrait, profile:** deprecate the gravatar prop ([bb22e16](https://github.com/Sage/carbon/commit/bb22e169e4d3241658ba31be12ace5043d1e8494))
+- **portrait, profile:** deprecate the gravatar prop ([bb22e16](https://github.com/Sage/carbon/commit/bb22e169e4d3241658ba31be12ace5043d1e8494))
 
 ### [140.1.1](https://github.com/Sage/carbon/compare/v140.1.0...v140.1.1) (2024-07-04)
 
-
 ### Bug Fixes
 
-* **character-count:** prevent screen reader announcing value when submitting a form ([17ff11f](https://github.com/Sage/carbon/commit/17ff11fedff78093d0a671f30f5786c01fd55798)), closes [#6181](https://github.com/Sage/carbon/issues/6181)
+- **character-count:** prevent screen reader announcing value when submitting a form ([17ff11f](https://github.com/Sage/carbon/commit/17ff11fedff78093d0a671f30f5786c01fd55798)), closes [#6181](https://github.com/Sage/carbon/issues/6181)
 
 ## [140.1.0](https://github.com/Sage/carbon/compare/v140.0.1...v140.1.0) (2024-07-01)
 
-
 ### Features
 
-* **progress-tracker:** deprecate aria- attribute props ([9403d08](https://github.com/Sage/carbon/commit/9403d08d5db10342ccd5d39ac54d9a794a571a46))
+- **progress-tracker:** deprecate aria- attribute props ([9403d08](https://github.com/Sage/carbon/commit/9403d08d5db10342ccd5d39ac54d9a794a571a46))
 
 ### [140.0.1](https://github.com/Sage/carbon/compare/v140.0.0...v140.0.1) (2024-07-01)
 
-
 ### Bug Fixes
 
-* **progress-tracker:** apply box sizing of border box to the inner styled bar ([06e7379](https://github.com/Sage/carbon/commit/06e7379132d4b8c9b8c67052567804d802e087a0)), closes [#6779](https://github.com/Sage/carbon/issues/6779)
+- **progress-tracker:** apply box sizing of border box to the inner styled bar ([06e7379](https://github.com/Sage/carbon/commit/06e7379132d4b8c9b8c67052567804d802e087a0)), closes [#6779](https://github.com/Sage/carbon/issues/6779)
 
 ## [140.0.0](https://github.com/Sage/carbon/compare/v139.0.0...v140.0.0) (2024-06-27)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **dialog:** Removed `data-component` prop
-* **dialog:** Custom `data-element` and `data-role` tags are now placed on the
-main dialog element when provided
+- **dialog:** Removed `data-component` prop
+- **dialog:** Custom `data-element` and `data-role` tags are now placed on the
+  main dialog element when provided
 
 ### Bug Fixes
 
-* **dialog:** ensure data tag props are set on the correct internal element ([fba4db0](https://github.com/Sage/carbon/commit/fba4db0cfc92ba90371dbd812407fc9c34899bc4))
+- **dialog:** ensure data tag props are set on the correct internal element ([fba4db0](https://github.com/Sage/carbon/commit/fba4db0cfc92ba90371dbd812407fc9c34899bc4))
 
 ## [139.0.0](https://github.com/Sage/carbon/compare/v138.2.2...v139.0.0) (2024-06-27)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **action-popover:** `ActionPopoverContext is now in an internal directory
-* **carbon-provider:** contexts have been moved to an internal directory
-* **vertical-menu:** moves `VerticalMenuFullScreenContext`and `MenuItemContext` into
-internal directories
-* **text-editor:** moves `EditorContext` into an internal directory
-* **tab:** moves `TabContext` and `TabTitleContext` to internal directory
-* **sidebar:** The context is no longer exposed as part of the public interface of `Sidebar`
-* **select:** `SelectList`, `ListActionButton`, `SelectTextbox` and utils
-have been moved to `__internal__` directory
-* **portal:** The context is no longer exposed as part of the public
-interface of `Portal`
-* **numeral-date:** The context is no longer exposed as part of the public interface
-of `NumeralDate`
-* **flat-table:** The context is no longer exposed as part of the public
-interface of `FlatTableHead`
-* **navigation-bar:** The context is no longer exposed as part of the public
-interface of `NavigationBar`
-* **modal:** The context is no longer exposed as part of the public interface of `Modal`
-* **menu:** The context is no longer exposed as part of the public interface of `Menu`
-* **flat-table:** The context is no longer exposed as part of the public interface
-of `FlatTable`
-* **duelling-picklist:** The context is no longer exposed as part of the public interface of
-`DuellingPicklist`
-* **drawer:** The context is no longer exposed as part of the public interface of `Drawer`
-* **date-range:** The context is no longer exposed as part of the public interface of `DateRange`
-* **checkbox-group:** The context is no longer exposed as part of the public interface of `CheckboxGroup`
-* **button-toggle-group:** The context is no longer exposed as part of the public interface of `ButtonBar`
-* **button-bar:** The context is no longer exposed as part of the public interface of `ButtonBar`
-* **spec_helper:** Majority of `spec_helper` functions are now private
+- **action-popover:** `ActionPopoverContext is now in an internal directory
+- **carbon-provider:** contexts have been moved to an internal directory
+- **vertical-menu:** moves `VerticalMenuFullScreenContext`and `MenuItemContext` into
+  internal directories
+- **text-editor:** moves `EditorContext` into an internal directory
+- **tab:** moves `TabContext` and `TabTitleContext` to internal directory
+- **sidebar:** The context is no longer exposed as part of the public interface of `Sidebar`
+- **select:** `SelectList`, `ListActionButton`, `SelectTextbox` and utils
+  have been moved to `__internal__` directory
+- **portal:** The context is no longer exposed as part of the public
+  interface of `Portal`
+- **numeral-date:** The context is no longer exposed as part of the public interface
+  of `NumeralDate`
+- **flat-table:** The context is no longer exposed as part of the public
+  interface of `FlatTableHead`
+- **navigation-bar:** The context is no longer exposed as part of the public
+  interface of `NavigationBar`
+- **modal:** The context is no longer exposed as part of the public interface of `Modal`
+- **menu:** The context is no longer exposed as part of the public interface of `Menu`
+- **flat-table:** The context is no longer exposed as part of the public interface
+  of `FlatTable`
+- **duelling-picklist:** The context is no longer exposed as part of the public interface of
+  `DuellingPicklist`
+- **drawer:** The context is no longer exposed as part of the public interface of `Drawer`
+- **date-range:** The context is no longer exposed as part of the public interface of `DateRange`
+- **checkbox-group:** The context is no longer exposed as part of the public interface of `CheckboxGroup`
+- **button-toggle-group:** The context is no longer exposed as part of the public interface of `ButtonBar`
+- **button-bar:** The context is no longer exposed as part of the public interface of `ButtonBar`
+- **spec_helper:** Majority of `spec_helper` functions are now private
 
 ### Build System
 
-* **spec_helper:** move private spec helpers to internal directory and ignore them in build script ([f5e351d](https://github.com/Sage/carbon/commit/f5e351d2178f76000cc85e69736ac932fee8e022))
-
+- **spec_helper:** move private spec helpers to internal directory and ignore them in build script ([f5e351d](https://github.com/Sage/carbon/commit/f5e351d2178f76000cc85e69736ac932fee8e022))
 
 ### Code Refactoring
 
-* **action-popover:** move context to an internal directory ([95ddb3b](https://github.com/Sage/carbon/commit/95ddb3b14c2da80b040cace876c0bd1e0c203bf7))
-* **button-bar:** move context into an internal directory ([a595244](https://github.com/Sage/carbon/commit/a5952447224a23b506c1bc0c94dffcae692b1653))
-* **button-toggle-group:** move context into an internal directory ([2154dff](https://github.com/Sage/carbon/commit/2154dff0574d46030c8a6ad1e6eac21fafcc5571))
-* **carbon-provider:** move contexts into an internal directory ([725f8fe](https://github.com/Sage/carbon/commit/725f8fee72098f14713356f4e849d3bba2817379))
-* **checkbox-group:** move context into an internal directory ([816ddcb](https://github.com/Sage/carbon/commit/816ddcbf2fdd11e5ae4ed96f9b9a817aff1678c2))
-* **date-range:** move context into an internal directory ([2e678a6](https://github.com/Sage/carbon/commit/2e678a6220e247c122cecf641858c41168d2bb7a))
-* **drawer:** move context into an internal directory ([96909c6](https://github.com/Sage/carbon/commit/96909c6cd8586d7df10d6fa72433d0ef968e6f82))
-* **duelling-picklist:** move context into an internal directory ([88bf483](https://github.com/Sage/carbon/commit/88bf483d45bfe9bd3493ab680554c5c247410382))
-* **flat-table:** move context into an internal directory ([ab9bfed](https://github.com/Sage/carbon/commit/ab9bfed0908737af069a310950b95ea31c88ea50))
-* **flat-table:** move context into an internal directory ([442d414](https://github.com/Sage/carbon/commit/442d4146aec6a860d52a7ee36256d706ab1158b8))
-* **menu:** move context into an internal directory ([6585a93](https://github.com/Sage/carbon/commit/6585a93c3d06d82823816ac12b1c4798f5fb7621))
-* **modal:** move context into an internal directory ([f442020](https://github.com/Sage/carbon/commit/f44202049eb8c0eb61a67944a9921b095a17dc3e))
-* **navigation-bar:** move context into an internal directory ([db5e40c](https://github.com/Sage/carbon/commit/db5e40cc015c0cc158ab43873ead15282d365a3c))
-* **numeral-date:** move context into an internal directory ([65a1ef4](https://github.com/Sage/carbon/commit/65a1ef4ce3881f9ea37a23a86ce340263003556d))
-* **portal:** move context into an internal directory ([3e1d3ce](https://github.com/Sage/carbon/commit/3e1d3ce563fd748762905a59024a0faebba77208))
-* **select:** move sub-components and utils into internal directory ([ededad1](https://github.com/Sage/carbon/commit/ededad1414f13bdd438adf342129b0ecaa315051))
-* **sidebar:** move context into an internal directory ([579907f](https://github.com/Sage/carbon/commit/579907f8a258495cd4fbe1442358c946e4b5011f))
-* **tab:** move context into an internal directory ([ae0c0d8](https://github.com/Sage/carbon/commit/ae0c0d8cf50a14c3cc7d3d526db92259beade2ce))
-* **text-editor:** move context into an internal directory ([d5ffbbb](https://github.com/Sage/carbon/commit/d5ffbbbdda4358bc83b7f311a847e9ad6c14047d))
-* **vertical-menu:** move context into an internal directory ([aaa95ef](https://github.com/Sage/carbon/commit/aaa95efd54a4b795b9aa09b4f92dfd49e897171a))
+- **action-popover:** move context to an internal directory ([95ddb3b](https://github.com/Sage/carbon/commit/95ddb3b14c2da80b040cace876c0bd1e0c203bf7))
+- **button-bar:** move context into an internal directory ([a595244](https://github.com/Sage/carbon/commit/a5952447224a23b506c1bc0c94dffcae692b1653))
+- **button-toggle-group:** move context into an internal directory ([2154dff](https://github.com/Sage/carbon/commit/2154dff0574d46030c8a6ad1e6eac21fafcc5571))
+- **carbon-provider:** move contexts into an internal directory ([725f8fe](https://github.com/Sage/carbon/commit/725f8fee72098f14713356f4e849d3bba2817379))
+- **checkbox-group:** move context into an internal directory ([816ddcb](https://github.com/Sage/carbon/commit/816ddcbf2fdd11e5ae4ed96f9b9a817aff1678c2))
+- **date-range:** move context into an internal directory ([2e678a6](https://github.com/Sage/carbon/commit/2e678a6220e247c122cecf641858c41168d2bb7a))
+- **drawer:** move context into an internal directory ([96909c6](https://github.com/Sage/carbon/commit/96909c6cd8586d7df10d6fa72433d0ef968e6f82))
+- **duelling-picklist:** move context into an internal directory ([88bf483](https://github.com/Sage/carbon/commit/88bf483d45bfe9bd3493ab680554c5c247410382))
+- **flat-table:** move context into an internal directory ([ab9bfed](https://github.com/Sage/carbon/commit/ab9bfed0908737af069a310950b95ea31c88ea50))
+- **flat-table:** move context into an internal directory ([442d414](https://github.com/Sage/carbon/commit/442d4146aec6a860d52a7ee36256d706ab1158b8))
+- **menu:** move context into an internal directory ([6585a93](https://github.com/Sage/carbon/commit/6585a93c3d06d82823816ac12b1c4798f5fb7621))
+- **modal:** move context into an internal directory ([f442020](https://github.com/Sage/carbon/commit/f44202049eb8c0eb61a67944a9921b095a17dc3e))
+- **navigation-bar:** move context into an internal directory ([db5e40c](https://github.com/Sage/carbon/commit/db5e40cc015c0cc158ab43873ead15282d365a3c))
+- **numeral-date:** move context into an internal directory ([65a1ef4](https://github.com/Sage/carbon/commit/65a1ef4ce3881f9ea37a23a86ce340263003556d))
+- **portal:** move context into an internal directory ([3e1d3ce](https://github.com/Sage/carbon/commit/3e1d3ce563fd748762905a59024a0faebba77208))
+- **select:** move sub-components and utils into internal directory ([ededad1](https://github.com/Sage/carbon/commit/ededad1414f13bdd438adf342129b0ecaa315051))
+- **sidebar:** move context into an internal directory ([579907f](https://github.com/Sage/carbon/commit/579907f8a258495cd4fbe1442358c946e4b5011f))
+- **tab:** move context into an internal directory ([ae0c0d8](https://github.com/Sage/carbon/commit/ae0c0d8cf50a14c3cc7d3d526db92259beade2ce))
+- **text-editor:** move context into an internal directory ([d5ffbbb](https://github.com/Sage/carbon/commit/d5ffbbbdda4358bc83b7f311a847e9ad6c14047d))
+- **vertical-menu:** move context into an internal directory ([aaa95ef](https://github.com/Sage/carbon/commit/aaa95efd54a4b795b9aa09b4f92dfd49e897171a))
 
 ### [138.2.2](https://github.com/Sage/carbon/compare/v138.2.1...v138.2.2) (2024-06-25)
 
-
 ### Bug Fixes
 
-* **profile:** accessibility violation when no email is provided ([77523e8](https://github.com/Sage/carbon/commit/77523e8770716aa88e86f930e38ecb152888527f)), closes [#6754](https://github.com/Sage/carbon/issues/6754)
+- **profile:** accessibility violation when no email is provided ([77523e8](https://github.com/Sage/carbon/commit/77523e8770716aa88e86f930e38ecb152888527f)), closes [#6754](https://github.com/Sage/carbon/issues/6754)
 
 ### [138.2.1](https://github.com/Sage/carbon/compare/v138.2.0...v138.2.1) (2024-06-20)
 
-
 ### Bug Fixes
 
-* **action-popover:** right arrow in menu item with submenu not aligned with text in safari ([3884642](https://github.com/Sage/carbon/commit/388464237431635dd9c957d9529ea8ef73ad38d4))
+- **action-popover:** right arrow in menu item with submenu not aligned with text in safari ([3884642](https://github.com/Sage/carbon/commit/388464237431635dd9c957d9529ea8ef73ad38d4))
 
 ## [138.2.0](https://github.com/Sage/carbon/compare/v138.1.1...v138.2.0) (2024-06-18)
 
-
 ### Features
 
-* **select-list:** ensure virtualised Select list container always has at least 1 pixel of height ([99bdeaf](https://github.com/Sage/carbon/commit/99bdeafd632fd3b97aef18b4bc22b07847d62723))
+- **select-list:** ensure virtualised Select list container always has at least 1 pixel of height ([99bdeaf](https://github.com/Sage/carbon/commit/99bdeafd632fd3b97aef18b4bc22b07847d62723))
 
 ### [138.1.1](https://github.com/Sage/carbon/compare/v138.1.0...v138.1.1) (2024-06-18)
 
-
 ### Bug Fixes
 
-* **menu:** ensure scrollbars meet colour contrast guidelines ([98244cd](https://github.com/Sage/carbon/commit/98244cd29099c48600d84e88b4181e0f28463743))
+- **menu:** ensure scrollbars meet colour contrast guidelines ([98244cd](https://github.com/Sage/carbon/commit/98244cd29099c48600d84e88b4181e0f28463743))
 
 ## [138.1.0](https://github.com/Sage/carbon/compare/v138.0.2...v138.1.0) (2024-06-14)
 
-
 ### Features
 
-* **button-minor:** add forward ref to component ([8816286](https://github.com/Sage/carbon/commit/88162866493fd62fe92c6a4eaf52801d3ff384b5))
+- **button-minor:** add forward ref to component ([8816286](https://github.com/Sage/carbon/commit/88162866493fd62fe92c6a4eaf52801d3ff384b5))
 
 ### [138.0.2](https://github.com/Sage/carbon/compare/v138.0.1...v138.0.2) (2024-06-13)
 
-
 ### Bug Fixes
 
-* **pill:** fix button background position on hover for small pill ([f690834](https://github.com/Sage/carbon/commit/f69083463489b2e25bfe00dde080aeff681251b1))
+- **pill:** fix button background position on hover for small pill ([f690834](https://github.com/Sage/carbon/commit/f69083463489b2e25bfe00dde080aeff681251b1))
 
 ### [138.0.1](https://github.com/Sage/carbon/compare/v138.0.0...v138.0.1) (2024-06-11)
 
-
 ### Bug Fixes
 
-* component MenuFullScreen and MenuItem not truncating topic ([c939148](https://github.com/Sage/carbon/commit/c93914878f5310b8ed9117ceec3b192207e891a6)), closes [#6666](https://github.com/Sage/carbon/issues/6666)
+- component MenuFullScreen and MenuItem not truncating topic ([c939148](https://github.com/Sage/carbon/commit/c93914878f5310b8ed9117ceec3b192207e891a6)), closes [#6666](https://github.com/Sage/carbon/issues/6666)
 
 ## [138.0.0](https://github.com/Sage/carbon/compare/v137.0.0...v138.0.0) (2024-06-11)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **button-toggle, button-toggle-group:** `name` prop has been removed, `onChange` prop type as also been updated as a
-result.
-* **button-toggle:** `checked` prop has been removed, `pressed` should be used instead.
+- **button-toggle, button-toggle-group:** `name` prop has been removed, `onChange` prop type as also been updated as a
+  result.
+- **button-toggle:** `checked` prop has been removed, `pressed` should be used instead.
 
 ### Miscellaneous Chores
 
-* **button-toggle, button-toggle-group:** remove name prop ([1b812fa](https://github.com/Sage/carbon/commit/1b812fad68328697c941f03418e8161577eedd3a))
-* **button-toggle:** remove checked prop ([974f337](https://github.com/Sage/carbon/commit/974f33712bb01028da2f07f08604fc69260a801e))
+- **button-toggle, button-toggle-group:** remove name prop ([1b812fa](https://github.com/Sage/carbon/commit/1b812fad68328697c941f03418e8161577eedd3a))
+- **button-toggle:** remove checked prop ([974f337](https://github.com/Sage/carbon/commit/974f33712bb01028da2f07f08604fc69260a801e))
 
 ## [137.0.0](https://github.com/Sage/carbon/compare/v136.0.4...v137.0.0) (2024-06-07)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **en-gb:** Changes the named export of the en-gb locale from EnGb to enGB
+- **en-gb:** Changes the named export of the en-gb locale from EnGb to enGB
 
 ### Features
 
-* add support for the de-DE locale ([ff4fbe4](https://github.com/Sage/carbon/commit/ff4fbe439195809c3f3aa8e836b6f8b491848362))
-* add support for the en-CA locale ([d6c5529](https://github.com/Sage/carbon/commit/d6c55295edc6deec98a9c885cf204075e680b027))
-* add support for the en-US locale ([9802dd1](https://github.com/Sage/carbon/commit/9802dd110587db1b4ff1a2157ecdf6a553ce87dc))
-* add support for the es-ES locale ([9296a18](https://github.com/Sage/carbon/commit/9296a1867b6fcaefc12389ea04836e0348ef7aae))
-* add support for the fr-CA locale ([d88ba34](https://github.com/Sage/carbon/commit/d88ba34c55087311bd9c8b1bbab2664cfc453040))
-* add support for the fr-FR locale ([32e72eb](https://github.com/Sage/carbon/commit/32e72ebd7d3c440967e0bd17d5d037d360585cb4))
-
+- add support for the de-DE locale ([ff4fbe4](https://github.com/Sage/carbon/commit/ff4fbe439195809c3f3aa8e836b6f8b491848362))
+- add support for the en-CA locale ([d6c5529](https://github.com/Sage/carbon/commit/d6c55295edc6deec98a9c885cf204075e680b027))
+- add support for the en-US locale ([9802dd1](https://github.com/Sage/carbon/commit/9802dd110587db1b4ff1a2157ecdf6a553ce87dc))
+- add support for the es-ES locale ([9296a18](https://github.com/Sage/carbon/commit/9296a1867b6fcaefc12389ea04836e0348ef7aae))
+- add support for the fr-CA locale ([d88ba34](https://github.com/Sage/carbon/commit/d88ba34c55087311bd9c8b1bbab2664cfc453040))
+- add support for the fr-FR locale ([32e72eb](https://github.com/Sage/carbon/commit/32e72ebd7d3c440967e0bd17d5d037d360585cb4))
 
 ### Miscellaneous Chores
 
-* **en-gb:** change named export from EnGb to enGB ([1191ac5](https://github.com/Sage/carbon/commit/1191ac50f0dd4b8f0c1364084338fb1774fca10f))
+- **en-gb:** change named export from EnGb to enGB ([1191ac5](https://github.com/Sage/carbon/commit/1191ac50f0dd4b8f0c1364084338fb1774fca10f))
 
 ### [136.0.4](https://github.com/Sage/carbon/compare/v136.0.3...v136.0.4) (2024-06-06)
 
-
 ### Bug Fixes
 
-* **text-editor:** content overflows in small viewports ([c985d5d](https://github.com/Sage/carbon/commit/c985d5d81ec2ccbe520ca65006978a9efd73fe0a)), closes [#6707](https://github.com/Sage/carbon/issues/6707)
+- **text-editor:** content overflows in small viewports ([c985d5d](https://github.com/Sage/carbon/commit/c985d5d81ec2ccbe520ca65006978a9efd73fe0a)), closes [#6707](https://github.com/Sage/carbon/issues/6707)
 
 ### [136.0.3](https://github.com/Sage/carbon/compare/v136.0.2...v136.0.3) (2024-06-05)
 
-
 ### Bug Fixes
 
-* **dialog-full-screen:** prevent horizontal overflow due to a child Form with a sticky footer ([4fea1d5](https://github.com/Sage/carbon/commit/4fea1d5582a83b0916dd9973ab647032d075b71c)), closes [#6719](https://github.com/Sage/carbon/issues/6719)
+- **dialog-full-screen:** prevent horizontal overflow due to a child Form with a sticky footer ([4fea1d5](https://github.com/Sage/carbon/commit/4fea1d5582a83b0916dd9973ab647032d075b71c)), closes [#6719](https://github.com/Sage/carbon/issues/6719)
 
 ### [136.0.2](https://github.com/Sage/carbon/compare/v136.0.1...v136.0.2) (2024-05-30)
 
-
 ### Bug Fixes
 
-* **icon-button:** allow aria-label prop to be applied and then default to icon type ([fdac494](https://github.com/Sage/carbon/commit/fdac494cdb95cb5ac2a7390dc5474d9c190b428b))
+- **icon-button:** allow aria-label prop to be applied and then default to icon type ([fdac494](https://github.com/Sage/carbon/commit/fdac494cdb95cb5ac2a7390dc5474d9c190b428b))
 
 ### [136.0.1](https://github.com/Sage/carbon/compare/v136.0.0...v136.0.1) (2024-05-29)
 
-
 ### Bug Fixes
 
-* **card:** ensure that focus outline wraps all card content when `height` prop is set ([5b73495](https://github.com/Sage/carbon/commit/5b734956bb949e41d1aea818a3afb5ec66c08dc7)), closes [#6741](https://github.com/Sage/carbon/issues/6741)
+- **card:** ensure that focus outline wraps all card content when `height` prop is set ([5b73495](https://github.com/Sage/carbon/commit/5b734956bb949e41d1aea818a3afb5ec66c08dc7)), closes [#6741](https://github.com/Sage/carbon/issues/6741)
 
 ## [136.0.0](https://github.com/Sage/carbon/compare/v135.1.3...v136.0.0) (2024-05-24)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **textarea:** removed cols, size and tooltipMessage props from the TextArea
-component as they were no longer doing anything
+- **textarea:** removed cols, size and tooltipMessage props from the TextArea
+  component as they were no longer doing anything
 
 ### Features
 
-* **textarea:** remove redundant props ([21a701c](https://github.com/Sage/carbon/commit/21a701c281ac8a3c2a63fa3bec8f0a0e001aa9bf)), closes [#6107](https://github.com/Sage/carbon/issues/6107)
+- **textarea:** remove redundant props ([21a701c](https://github.com/Sage/carbon/commit/21a701c281ac8a3c2a63fa3bec8f0a0e001aa9bf)), closes [#6107](https://github.com/Sage/carbon/issues/6107)
 
 ### [135.1.3](https://github.com/Sage/carbon/compare/v135.1.2...v135.1.3) (2024-05-24)
 
-
 ### Bug Fixes
 
-* **accordion:** ensure disableContentPadding works with subtle variant ([8a6d5f8](https://github.com/Sage/carbon/commit/8a6d5f8ba90c45b9ae281c5ccda6a4095ff00a18)), closes [#6723](https://github.com/Sage/carbon/issues/6723)
+- **accordion:** ensure disableContentPadding works with subtle variant ([8a6d5f8](https://github.com/Sage/carbon/commit/8a6d5f8ba90c45b9ae281c5ccda6a4095ff00a18)), closes [#6723](https://github.com/Sage/carbon/issues/6723)
 
 ### [135.1.2](https://github.com/Sage/carbon/compare/v135.1.1...v135.1.2) (2024-05-22)
 
-
 ### Bug Fixes
 
-* **scrollable-block:** ensure border-styling is applied when appropriate to do so ([14b0b21](https://github.com/Sage/carbon/commit/14b0b21c1a8d013e59089e783dcdef1c838cbe46))
+- **scrollable-block:** ensure border-styling is applied when appropriate to do so ([14b0b21](https://github.com/Sage/carbon/commit/14b0b21c1a8d013e59089e783dcdef1c838cbe46))
 
 ### [135.1.1](https://github.com/Sage/carbon/compare/v135.1.0...v135.1.1) (2024-05-20)
 
-
 ### Bug Fixes
 
-* **toast:** margin-top on notice variant prevents elements being clicked ([1732886](https://github.com/Sage/carbon/commit/173288609effca75ae07c3e04ec30df35a250643)), closes [#6730](https://github.com/Sage/carbon/issues/6730)
+- **toast:** margin-top on notice variant prevents elements being clicked ([1732886](https://github.com/Sage/carbon/commit/173288609effca75ae07c3e04ec30df35a250643)), closes [#6730](https://github.com/Sage/carbon/issues/6730)
 
 ## [135.1.0](https://github.com/Sage/carbon/compare/v135.0.0...v135.1.0) (2024-05-16)
 
-
 ### Features
 
-* **multi-action-button:** add position prop ([0a152b5](https://github.com/Sage/carbon/commit/0a152b55a810b419fd5c81091094250e6ccc96e2)), closes [#6705](https://github.com/Sage/carbon/issues/6705)
-* **split-button:** add position prop ([716bed3](https://github.com/Sage/carbon/commit/716bed3dbd671ededcd9da4b96a8c96160558569))
+- **multi-action-button:** add position prop ([0a152b5](https://github.com/Sage/carbon/commit/0a152b55a810b419fd5c81091094250e6ccc96e2)), closes [#6705](https://github.com/Sage/carbon/issues/6705)
+- **split-button:** add position prop ([716bed3](https://github.com/Sage/carbon/commit/716bed3dbd671ededcd9da4b96a8c96160558569))
 
 ## [135.0.0](https://github.com/Sage/carbon/compare/v134.2.0...v135.0.0) (2024-05-15)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **step-sequence:** `StepSequence` and `StepSequenceItem` have been removed `StepFlow` should be
-used instead
-* **carousel:** The `Carousel` component no longer exists in Carbon
-* **toast:** Deprecated `isCenter` prop has been removed
+- **step-sequence:** `StepSequence` and `StepSequenceItem` have been removed `StepFlow` should be
+  used instead
+- **carousel:** The `Carousel` component no longer exists in Carbon
+- **toast:** Deprecated `isCenter` prop has been removed
 
 ### Bug Fixes
 
-* **toast:** remove default value on isCenter prop, add default value of "center" to align prop ([1fc80cd](https://github.com/Sage/carbon/commit/1fc80cdf30ad9b1700dc54195a65b34d6ea32f0e))
-* **toast:** remove the isCenter prop ([a803f0e](https://github.com/Sage/carbon/commit/a803f0eaa66fc89111d6216a69de90c16428f9c5))
-
+- **toast:** remove default value on isCenter prop, add default value of "center" to align prop ([1fc80cd](https://github.com/Sage/carbon/commit/1fc80cdf30ad9b1700dc54195a65b34d6ea32f0e))
+- **toast:** remove the isCenter prop ([a803f0e](https://github.com/Sage/carbon/commit/a803f0eaa66fc89111d6216a69de90c16428f9c5))
 
 ### Miscellaneous Chores
 
-* **carousel:** remove component ([7a2bea3](https://github.com/Sage/carbon/commit/7a2bea39f2a4869a6bf59cdc72993e892d0a271e))
-* **step-sequence:** remove component ([915a0d8](https://github.com/Sage/carbon/commit/915a0d815a80955e65a2c80630c28cb39c876938))
+- **carousel:** remove component ([7a2bea3](https://github.com/Sage/carbon/commit/7a2bea39f2a4869a6bf59cdc72993e892d0a271e))
+- **step-sequence:** remove component ([915a0d8](https://github.com/Sage/carbon/commit/915a0d815a80955e65a2c80630c28cb39c876938))
 
 ## [134.2.0](https://github.com/Sage/carbon/compare/v134.1.2...v134.2.0) (2024-05-15)
 
-
 ### Features
 
-* **typography:** add support for wordBreak property ([d257da5](https://github.com/Sage/carbon/commit/d257da5002d0a587edf5e0bd230cf1dd2863c714))
+- **typography:** add support for wordBreak property ([d257da5](https://github.com/Sage/carbon/commit/d257da5002d0a587edf5e0bd230cf1dd2863c714))
 
 ### [134.1.2](https://github.com/Sage/carbon/compare/v134.1.1...v134.1.2) (2024-05-15)
 
-
 ### Bug Fixes
 
-* **action-popover:** submenu is left aligned in the 'with submenu aligned right' story ([6e17163](https://github.com/Sage/carbon/commit/6e171631f0ed654837fc85b7611eb383c397788c)), closes [#6000](https://github.com/Sage/carbon/issues/6000)
+- **action-popover:** submenu is left aligned in the 'with submenu aligned right' story ([6e17163](https://github.com/Sage/carbon/commit/6e171631f0ed654837fc85b7611eb383c397788c)), closes [#6000](https://github.com/Sage/carbon/issues/6000)
 
 ### [134.1.1](https://github.com/Sage/carbon/compare/v134.1.0...v134.1.1) (2024-05-14)
 
-
 ### Bug Fixes
 
-* **filterable-select, simple-select:** ensure an ellipsis is shown during text overflow ([3eb5364](https://github.com/Sage/carbon/commit/3eb5364ed71a166fa9b1840db72d9bf80dc5fed8)), closes [#6641](https://github.com/Sage/carbon/issues/6641)
+- **filterable-select, simple-select:** ensure an ellipsis is shown during text overflow ([3eb5364](https://github.com/Sage/carbon/commit/3eb5364ed71a166fa9b1840db72d9bf80dc5fed8)), closes [#6641](https://github.com/Sage/carbon/issues/6641)
 
 ## [134.1.0](https://github.com/Sage/carbon/compare/v134.0.4...v134.1.0) (2024-05-10)
 
-
 ### Features
 
-* **multi-action-button:** remove open menu on hover ([56d79ba](https://github.com/Sage/carbon/commit/56d79ba2955401781757970d627415fea3ea272e))
-* **split-button:** remove open menu on hover ([8a2822d](https://github.com/Sage/carbon/commit/8a2822da6ea587c976faadc55420b53b5333aeb5))
-
+- **multi-action-button:** remove open menu on hover ([56d79ba](https://github.com/Sage/carbon/commit/56d79ba2955401781757970d627415fea3ea272e))
+- **split-button:** remove open menu on hover ([8a2822d](https://github.com/Sage/carbon/commit/8a2822da6ea587c976faadc55420b53b5333aeb5))
 
 ### Bug Fixes
 
-* **multi-action-button, split-button:** popup menu covers the trigger button focus border ([d4f6155](https://github.com/Sage/carbon/commit/d4f615547a437fc8d3fbc2be2ab1ac0ee8a198a4))
-* **popover-container:** popup menu covers trigger button focus border ([c9ec79a](https://github.com/Sage/carbon/commit/c9ec79a05c5e036b84235b83c5f2ad4f7cea84f5))
+- **multi-action-button, split-button:** popup menu covers the trigger button focus border ([d4f6155](https://github.com/Sage/carbon/commit/d4f615547a437fc8d3fbc2be2ab1ac0ee8a198a4))
+- **popover-container:** popup menu covers trigger button focus border ([c9ec79a](https://github.com/Sage/carbon/commit/c9ec79a05c5e036b84235b83c5f2ad4f7cea84f5))
 
 ### [134.0.4](https://github.com/Sage/carbon/compare/v134.0.3...v134.0.4) (2024-05-09)
 
-
 ### Bug Fixes
 
-* **typography:** textOverflow prop has no effect when the truncate prop is set ([ee95a2b](https://github.com/Sage/carbon/commit/ee95a2ba35a626023b4dd2c5cfd6f9df6db70d03)), closes [#6098](https://github.com/Sage/carbon/issues/6098)
+- **typography:** textOverflow prop has no effect when the truncate prop is set ([ee95a2b](https://github.com/Sage/carbon/commit/ee95a2ba35a626023b4dd2c5cfd6f9df6db70d03)), closes [#6098](https://github.com/Sage/carbon/issues/6098)
 
 ### [134.0.3](https://github.com/Sage/carbon/compare/v134.0.2...v134.0.3) (2024-05-09)
 
-
 ### Bug Fixes
 
-* **loader-spinner:** allow components label to extend longer than the svg wrapper ([bd87c52](https://github.com/Sage/carbon/commit/bd87c52547e959bf06a24f2f4e127386b1e6b7b1)), closes [#6702](https://github.com/Sage/carbon/issues/6702)
+- **loader-spinner:** allow components label to extend longer than the svg wrapper ([bd87c52](https://github.com/Sage/carbon/commit/bd87c52547e959bf06a24f2f4e127386b1e6b7b1)), closes [#6702](https://github.com/Sage/carbon/issues/6702)
 
 ### [134.0.2](https://github.com/Sage/carbon/compare/v134.0.1...v134.0.2) (2024-05-08)
 
-
 ### Bug Fixes
 
-* **link:** ensure styling overrides apply to open button when popover-container renders in menu ([4b9ea02](https://github.com/Sage/carbon/commit/4b9ea02d7294ec3b25679174dd5ad8a3388088c8)), closes [#6725](https://github.com/Sage/carbon/issues/6725)
+- **link:** ensure styling overrides apply to open button when popover-container renders in menu ([4b9ea02](https://github.com/Sage/carbon/commit/4b9ea02d7294ec3b25679174dd5ad8a3388088c8)), closes [#6725](https://github.com/Sage/carbon/issues/6725)
 
 ### [134.0.1](https://github.com/Sage/carbon/compare/v134.0.0...v134.0.1) (2024-05-08)
 
-
 ### Bug Fixes
 
-* **simple-select:** prevent select list from opening via enter key when component is focused ([aade7da](https://github.com/Sage/carbon/commit/aade7dac7dad70e92596127b028d9e5f5e123857))
+- **simple-select:** prevent select list from opening via enter key when component is focused ([aade7da](https://github.com/Sage/carbon/commit/aade7dac7dad70e92596127b028d9e5f5e123857))
 
 ## [134.0.0](https://github.com/Sage/carbon/compare/v133.2.0...v134.0.0) (2024-05-02)
 
-
 ### ⚠ BREAKING CHANGES
 
-* Carbon no longer re-exports the `date-fns` locales.
-Consuming projects need to import the locales directly from `date-fns`.
+- Carbon no longer re-exports the `date-fns` locales.
+  Consuming projects need to import the locales directly from `date-fns`.
 
 closes: SBS-84395
 
 ### Bug Fixes
 
-* ensure tree-shaking works with date-fns package ([ed4ba2f](https://github.com/Sage/carbon/commit/ed4ba2f677b5542ec30be527a0cbf0d585ef2bd9))
+- ensure tree-shaking works with date-fns package ([ed4ba2f](https://github.com/Sage/carbon/commit/ed4ba2f677b5542ec30be527a0cbf0d585ef2bd9))
 
 ## [133.2.0](https://github.com/Sage/carbon/compare/v133.1.1...v133.2.0) (2024-05-02)
 
-
 ### Features
 
-* **icon:** 3 new icons added and tick update ([eec42ec](https://github.com/Sage/carbon/commit/eec42ec04bd8d80c546e0b931ae8790b5ff3cfd1))
+- **icon:** 3 new icons added and tick update ([eec42ec](https://github.com/Sage/carbon/commit/eec42ec04bd8d80c546e0b931ae8790b5ff3cfd1))
 
 ### [133.1.1](https://github.com/Sage/carbon/compare/v133.1.0...v133.1.1) (2024-04-30)
 
-
 ### Bug Fixes
 
-* **popover-container:** allow fullWidth button to be rendered as renderOpenComponent ([dbbbe2d](https://github.com/Sage/carbon/commit/dbbbe2d2767223d616e5172e544054a66720528c)), closes [#5784](https://github.com/Sage/carbon/issues/5784)
+- **popover-container:** allow fullWidth button to be rendered as renderOpenComponent ([dbbbe2d](https://github.com/Sage/carbon/commit/dbbbe2d2767223d616e5172e544054a66720528c)), closes [#5784](https://github.com/Sage/carbon/issues/5784)
 
 ## [133.1.0](https://github.com/Sage/carbon/compare/v133.0.5...v133.1.0) (2024-04-26)
 
-
 ### Features
 
-* **loader-spinner:** add spinnerLabel prop to override the default loading label with custom text ([60b7209](https://github.com/Sage/carbon/commit/60b720946418c75a43463d1daaa2cd01ab63df47)), closes [#6694](https://github.com/Sage/carbon/issues/6694)
+- **loader-spinner:** add spinnerLabel prop to override the default loading label with custom text ([60b7209](https://github.com/Sage/carbon/commit/60b720946418c75a43463d1daaa2cd01ab63df47)), closes [#6694](https://github.com/Sage/carbon/issues/6694)
 
 ### [133.0.5](https://github.com/Sage/carbon/compare/v133.0.4...v133.0.5) (2024-04-25)
 
-
 ### Bug Fixes
 
-* **select:** input element extends outside textbox in smaller screens ([1696470](https://github.com/Sage/carbon/commit/1696470360a3035987eaf3f6710d6be09db6f335)), closes [#6490](https://github.com/Sage/carbon/issues/6490)
+- **select:** input element extends outside textbox in smaller screens ([1696470](https://github.com/Sage/carbon/commit/1696470360a3035987eaf3f6710d6be09db6f335)), closes [#6490](https://github.com/Sage/carbon/issues/6490)
 
 ### [133.0.4](https://github.com/Sage/carbon/compare/v133.0.3...v133.0.4) (2024-04-25)
 
-
 ### Bug Fixes
 
-* **select:** option remaining highlighted after clearing value ([1672900](https://github.com/Sage/carbon/commit/1672900a093e27b48f6f84dcc6debb923d971611)), closes [#6669](https://github.com/Sage/carbon/issues/6669)
+- **select:** option remaining highlighted after clearing value ([1672900](https://github.com/Sage/carbon/commit/1672900a093e27b48f6f84dcc6debb923d971611)), closes [#6669](https://github.com/Sage/carbon/issues/6669)
 
 ### [133.0.3](https://github.com/Sage/carbon/compare/v133.0.2...v133.0.3) (2024-04-24)
 
-
 ### Bug Fixes
 
-* **button-toggle:** ensure the first button toggle in a group is focusable via mouse click on Safari ([0df7688](https://github.com/Sage/carbon/commit/0df76888641a5da5d2fe8fde6036344111ff55a8))
+- **button-toggle:** ensure the first button toggle in a group is focusable via mouse click on Safari ([0df7688](https://github.com/Sage/carbon/commit/0df76888641a5da5d2fe8fde6036344111ff55a8))
 
 ### [133.0.2](https://github.com/Sage/carbon/compare/v133.0.1...v133.0.2) (2024-04-23)
 
-
 ### Bug Fixes
 
-* **checkbox:** fix reduced spacing between label and large checkbox ([1a20aa4](https://github.com/Sage/carbon/commit/1a20aa48be3892c9dcfab6d049e4eb84127cd200)), closes [#6683](https://github.com/Sage/carbon/issues/6683)
+- **checkbox:** fix reduced spacing between label and large checkbox ([1a20aa4](https://github.com/Sage/carbon/commit/1a20aa48be3892c9dcfab6d049e4eb84127cd200)), closes [#6683](https://github.com/Sage/carbon/issues/6683)
 
 ### [133.0.1](https://github.com/Sage/carbon/compare/v133.0.0...v133.0.1) (2024-04-23)
 
-
 ### Bug Fixes
 
-* **filterable-select:** ensure no runtime error is triggered when component has a single option ([4926092](https://github.com/Sage/carbon/commit/4926092ec619fc18629cf2ddf8f03e359ceae85c)), closes [#6654](https://github.com/Sage/carbon/issues/6654)
-* **multi-select:** ensure console error is not fired when component has a single option ([1914940](https://github.com/Sage/carbon/commit/19149402b1892d839af5d3233370ed10f0c009cc))
+- **filterable-select:** ensure no runtime error is triggered when component has a single option ([4926092](https://github.com/Sage/carbon/commit/4926092ec619fc18629cf2ddf8f03e359ceae85c)), closes [#6654](https://github.com/Sage/carbon/issues/6654)
+- **multi-select:** ensure console error is not fired when component has a single option ([1914940](https://github.com/Sage/carbon/commit/19149402b1892d839af5d3233370ed10f0c009cc))
 
 ## [133.0.0](https://github.com/Sage/carbon/compare/v132.2.1...v133.0.0) (2024-04-18)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **input:** `inputRef` prop has been removed from input components, use `ref` instead.
-* **button:** "dashed" variant has been removed from `buttonType`.
-* **button:** `forwardRef` has been removed, use `ref` instead.
+- **input:** `inputRef` prop has been removed from input components, use `ref` instead.
+- **button:** "dashed" variant has been removed from `buttonType`.
+- **button:** `forwardRef` has been removed, use `ref` instead.
 
 ### Miscellaneous Chores
 
-* **button:** remove dashed buttonType ([997cfdc](https://github.com/Sage/carbon/commit/997cfdcb947f1192b01275ec190c0e88822b3aab))
-* **button:** remove forwardRef prop ([c14d300](https://github.com/Sage/carbon/commit/c14d30059621eac684b6f4979181e109d330856e))
-* **input:** remove inputRef prop ([6db6202](https://github.com/Sage/carbon/commit/6db620261d7dcf80d9f61d4a60a9529d2fdfa322))
+- **button:** remove dashed buttonType ([997cfdc](https://github.com/Sage/carbon/commit/997cfdcb947f1192b01275ec190c0e88822b3aab))
+- **button:** remove forwardRef prop ([c14d300](https://github.com/Sage/carbon/commit/c14d30059621eac684b6f4979181e109d330856e))
+- **input:** remove inputRef prop ([6db6202](https://github.com/Sage/carbon/commit/6db620261d7dcf80d9f61d4a60a9529d2fdfa322))
 
 ### [132.2.1](https://github.com/Sage/carbon/compare/v132.2.0...v132.2.1) (2024-04-15)
 
-
 ### Bug Fixes
 
-* **submenu:** ensure last child in segment title has correct styling ([a6ab6aa](https://github.com/Sage/carbon/commit/a6ab6aa563e25fa4d9cc155b314fc26855601170)), closes [#6488](https://github.com/Sage/carbon/issues/6488)
+- **submenu:** ensure last child in segment title has correct styling ([a6ab6aa](https://github.com/Sage/carbon/commit/a6ab6aa563e25fa4d9cc155b314fc26855601170)), closes [#6488](https://github.com/Sage/carbon/issues/6488)
 
 ## [132.2.0](https://github.com/Sage/carbon/compare/v132.1.0...v132.2.0) (2024-04-11)
 
-
 ### Features
 
-* **loader-spinner:** add new component ([53d9d67](https://github.com/Sage/carbon/commit/53d9d6738f8c5b9c67202268700502f18e29899f))
+- **loader-spinner:** add new component ([53d9d67](https://github.com/Sage/carbon/commit/53d9d6738f8c5b9c67202268700502f18e29899f))
 
 ## [132.1.0](https://github.com/Sage/carbon/compare/v132.0.0...v132.1.0) (2024-04-11)
 
-
 ### Features
 
-* **file-input:** update default component size and progress/loader bar size ([6957bc3](https://github.com/Sage/carbon/commit/6957bc30a0aa6237eedcd519965096ca325408bf))
+- **file-input:** update default component size and progress/loader bar size ([6957bc3](https://github.com/Sage/carbon/commit/6957bc30a0aa6237eedcd519965096ca325408bf))
 
 ## [132.0.0](https://github.com/Sage/carbon/compare/v131.1.0...v132.0.0) (2024-04-11)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **theme:** This change removes the mint theme. Please use the
-'sage' theme instead.
-* **theme:** This change removes the aegean theme. Please use the
-'sage' theme instead.
+- **theme:** This change removes the mint theme. Please use the
+  'sage' theme instead.
+- **theme:** This change removes the aegean theme. Please use the
+  'sage' theme instead.
 
 ### Features
 
-* **theme:** remove aegean theme ([ebe0ddb](https://github.com/Sage/carbon/commit/ebe0ddb9981581497ff01603eaf9017d5fc1ecdb))
-* **theme:** remove mint theme ([04f81f8](https://github.com/Sage/carbon/commit/04f81f8e19748761cb88581d6ad1e786424dd6f2))
+- **theme:** remove aegean theme ([ebe0ddb](https://github.com/Sage/carbon/commit/ebe0ddb9981581497ff01603eaf9017d5fc1ecdb))
+- **theme:** remove mint theme ([04f81f8](https://github.com/Sage/carbon/commit/04f81f8e19748761cb88581d6ad1e786424dd6f2))
 
 ## [131.1.0](https://github.com/Sage/carbon/compare/v131.0.1...v131.1.0) (2024-04-10)
 
-
 ### Features
 
-* **icon:** added woff2 format of the icon font ([1ebd58f](https://github.com/Sage/carbon/commit/1ebd58f6d82ee5c05cad5277a25c6074112c1ab2))
-* **icon:** updated references of icon font for woff2 ([d2c8c77](https://github.com/Sage/carbon/commit/d2c8c77790094687a94f0b0b6813e8055af332f9))
+- **icon:** added woff2 format of the icon font ([1ebd58f](https://github.com/Sage/carbon/commit/1ebd58f6d82ee5c05cad5277a25c6074112c1ab2))
+- **icon:** updated references of icon font for woff2 ([d2c8c77](https://github.com/Sage/carbon/commit/d2c8c77790094687a94f0b0b6813e8055af332f9))
 
 ### [131.0.1](https://github.com/Sage/carbon/compare/v131.0.0...v131.0.1) (2024-04-09)
 
-
 ### Bug Fixes
 
-* **select:** objects as value fix ([451d74b](https://github.com/Sage/carbon/commit/451d74bf25a0227cf3f3de04f544eeb2b28cf93f)), closes [#6600](https://github.com/Sage/carbon/issues/6600)
+- **select:** objects as value fix ([451d74b](https://github.com/Sage/carbon/commit/451d74bf25a0227cf3f3de04f544eeb2b28cf93f)), closes [#6600](https://github.com/Sage/carbon/issues/6600)
 
 ## [131.0.0](https://github.com/Sage/carbon/compare/v130.0.0...v131.0.0) (2024-04-09)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **fieldset:** The `inline` prop has been removed from the `Fieldset` component.
+- **fieldset:** The `inline` prop has been removed from the `Fieldset` component.
 
 ### Bug Fixes
 
-* **fieldset:** invalid fieldset HTML fix ([8c45cc5](https://github.com/Sage/carbon/commit/8c45cc56ff26f30fe7b525f3c1a60ef69549fc3f))
+- **fieldset:** invalid fieldset HTML fix ([8c45cc5](https://github.com/Sage/carbon/commit/8c45cc56ff26f30fe7b525f3c1a60ef69549fc3f))
 
 ## [130.0.0](https://github.com/Sage/carbon/compare/v129.0.0...v130.0.0) (2024-04-08)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **sort:** the potential type of false has been removed from the sortType prop. The type for
-the components children has also been changed from a react node to just a string
+- **sort:** the potential type of false has been removed from the sortType prop. The type for
+  the components children has also been changed from a react node to just a string
 
 ### Features
 
-* **sort:** add the accessibleName prop to ensure consumers can pass a custom accessible name ([39229b1](https://github.com/Sage/carbon/commit/39229b1fb9aaa6df8f6f61032b01276e604c825d))
-* **sort:** add translation support for the accessible name of the component ([b0f99cb](https://github.com/Sage/carbon/commit/b0f99cbedfa4fb6f560795ab63a3f6a2b2b273bf))
+- **sort:** add the accessibleName prop to ensure consumers can pass a custom accessible name ([39229b1](https://github.com/Sage/carbon/commit/39229b1fb9aaa6df8f6f61032b01276e604c825d))
+- **sort:** add translation support for the accessible name of the component ([b0f99cb](https://github.com/Sage/carbon/commit/b0f99cbedfa4fb6f560795ab63a3f6a2b2b273bf))
 
 ## [129.0.0](https://github.com/Sage/carbon/compare/v128.4.1...v129.0.0) (2024-04-08)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **search:** Ref is `SearchHandle` type and only supports calling focus on the input
-* **search:** The `inputRef` is no more
-* **search:** The `threshold` prop has been removed as it no longer does anything in the
-redesigned component
+- **search:** Ref is `SearchHandle` type and only supports calling focus on the input
+- **search:** The `inputRef` is no more
+- **search:** The `threshold` prop has been removed as it no longer does anything in the
+  redesigned component
 
 ### Features
 
-* **search:** add imperative handle to allow passing a ref and programmatically focus input ([c592372](https://github.com/Sage/carbon/commit/c592372b412bbf0d8b7a51a0ca4321074ae77b01))
-* **search:** search button is rendered at all times when `searchButton` prop is set ([deadf2a](https://github.com/Sage/carbon/commit/deadf2aa111d7e313fd4f6dc1a7e224ac45614f0)), closes [#6581](https://github.com/Sage/carbon/issues/6581)
-
+- **search:** add imperative handle to allow passing a ref and programmatically focus input ([c592372](https://github.com/Sage/carbon/commit/c592372b412bbf0d8b7a51a0ca4321074ae77b01))
+- **search:** search button is rendered at all times when `searchButton` prop is set ([deadf2a](https://github.com/Sage/carbon/commit/deadf2aa111d7e313fd4f6dc1a7e224ac45614f0)), closes [#6581](https://github.com/Sage/carbon/issues/6581)
 
 ### Bug Fixes
 
-* **search:** deprecate `inputRef` prop ([eae130f](https://github.com/Sage/carbon/commit/eae130f1cbce4590f46ea8e65d58e97ff66f29b2))
+- **search:** deprecate `inputRef` prop ([eae130f](https://github.com/Sage/carbon/commit/eae130f1cbce4590f46ea8e65d58e97ff66f29b2))
 
 ### [128.4.1](https://github.com/Sage/carbon/compare/v128.4.0...v128.4.1) (2024-04-05)
 
-
 ### Bug Fixes
 
-* **text-editor:** ensure the input is focused when toolbar buttons are activated or deactivated ([c7c616c](https://github.com/Sage/carbon/commit/c7c616c7ea037c24613a13949eca5aa49f280301))
+- **text-editor:** ensure the input is focused when toolbar buttons are activated or deactivated ([c7c616c](https://github.com/Sage/carbon/commit/c7c616c7ea037c24613a13949eca5aa49f280301))
 
 ## [128.4.0](https://github.com/Sage/carbon/compare/v128.3.1...v128.4.0) (2024-04-05)
 
-
 ### Features
 
-* **dialog:** allow subtitle prop to accept a node ([5620e3d](https://github.com/Sage/carbon/commit/5620e3d2443b96ef668a936dde63884df65734e2)), closes [#5844](https://github.com/Sage/carbon/issues/5844)
+- **dialog:** allow subtitle prop to accept a node ([5620e3d](https://github.com/Sage/carbon/commit/5620e3d2443b96ef668a936dde63884df65734e2)), closes [#5844](https://github.com/Sage/carbon/issues/5844)
 
 ### [128.3.1](https://github.com/Sage/carbon/compare/v128.3.0...v128.3.1) (2024-04-04)
 
-
 ### Bug Fixes
 
-* **profile:** ensure ProfileProps extend MarginProps ([8bf062f](https://github.com/Sage/carbon/commit/8bf062f7d01f8a3262605fce382075d8000d5cae)), closes [#6622](https://github.com/Sage/carbon/issues/6622)
+- **profile:** ensure ProfileProps extend MarginProps ([8bf062f](https://github.com/Sage/carbon/commit/8bf062f7d01f8a3262605fce382075d8000d5cae)), closes [#6622](https://github.com/Sage/carbon/issues/6622)
 
 ## [128.3.0](https://github.com/Sage/carbon/compare/v128.2.0...v128.3.0) (2024-04-04)
 
-
 ### Features
 
-* **menu-fullscreen:** add translation key 'menuFullscreen.ariaLabels.closeButton' ([4117997](https://github.com/Sage/carbon/commit/4117997f40e2a04d66cbf58bfe07b6c0bb14fe4d))
-
+- **menu-fullscreen:** add translation key 'menuFullscreen.ariaLabels.closeButton' ([4117997](https://github.com/Sage/carbon/commit/4117997f40e2a04d66cbf58bfe07b6c0bb14fe4d))
 
 ### Bug Fixes
 
-* **menu-fullscreen:** amend typing of onClose prop ([2fb540e](https://github.com/Sage/carbon/commit/2fb540e2d12898ab312a104012923b9189bbae4e))
-* **menu-fullscreen:** ensure menu has aria properties required for dialogs ([7ca7223](https://github.com/Sage/carbon/commit/7ca7223c3119f66392b60209c50f8e49fb25df29))
+- **menu-fullscreen:** amend typing of onClose prop ([2fb540e](https://github.com/Sage/carbon/commit/2fb540e2d12898ab312a104012923b9189bbae4e))
+- **menu-fullscreen:** ensure menu has aria properties required for dialogs ([7ca7223](https://github.com/Sage/carbon/commit/7ca7223c3119f66392b60209c50f8e49fb25df29))
 
 ## [128.2.0](https://github.com/Sage/carbon/compare/v128.1.2...v128.2.0) (2024-04-04)
 
-
 ### Features
 
-* **decimal:** add support for isOptional ([1cdde56](https://github.com/Sage/carbon/commit/1cdde56a6dcf89c5b6c0f24011edc348d92ec300))
-* **fieldset:** add support for required and isOptional ([c22c6f3](https://github.com/Sage/carbon/commit/c22c6f31dd509f36e0f527f97662991940c363c7))
-* **file-input:** add support for isOptional ([a622805](https://github.com/Sage/carbon/commit/a6228056254aa50041a2204d433be19f890205d9))
-* **form:** add component to indicate when there is required fields ([f168805](https://github.com/Sage/carbon/commit/f16880552f5e3e750d2872bdd83fce07c9622104))
-* **inline-inputs:** add support for required and isOptional ([a4819e4](https://github.com/Sage/carbon/commit/a4819e4382bf04b3b52af450952f670b1009bbdb))
-* **numeral-date:** add support for isOptional ([e03384b](https://github.com/Sage/carbon/commit/e03384bf38f7fb52b3ca1e2f22b79f2c75990ef5))
-* **radio-button, checkbox, switch:** add support for required and isOptional ([bafa070](https://github.com/Sage/carbon/commit/bafa070847929e8ac317794e552b20c90e745b85))
-* **select:** add support for isOptional ([1c14041](https://github.com/Sage/carbon/commit/1c14041879141246b30885c44ef085880430e11e))
-* **text-editor:** add support for required and isOptional ([6f78219](https://github.com/Sage/carbon/commit/6f78219e7f8ff732e90d10f70afa311fe20b1e0f))
-* **textarea:** add support for isOptional ([2958d46](https://github.com/Sage/carbon/commit/2958d46ba4b5e9284978f44e6af329c3401868eb))
-
+- **decimal:** add support for isOptional ([1cdde56](https://github.com/Sage/carbon/commit/1cdde56a6dcf89c5b6c0f24011edc348d92ec300))
+- **fieldset:** add support for required and isOptional ([c22c6f3](https://github.com/Sage/carbon/commit/c22c6f31dd509f36e0f527f97662991940c363c7))
+- **file-input:** add support for isOptional ([a622805](https://github.com/Sage/carbon/commit/a6228056254aa50041a2204d433be19f890205d9))
+- **form:** add component to indicate when there is required fields ([f168805](https://github.com/Sage/carbon/commit/f16880552f5e3e750d2872bdd83fce07c9622104))
+- **inline-inputs:** add support for required and isOptional ([a4819e4](https://github.com/Sage/carbon/commit/a4819e4382bf04b3b52af450952f670b1009bbdb))
+- **numeral-date:** add support for isOptional ([e03384b](https://github.com/Sage/carbon/commit/e03384bf38f7fb52b3ca1e2f22b79f2c75990ef5))
+- **radio-button, checkbox, switch:** add support for required and isOptional ([bafa070](https://github.com/Sage/carbon/commit/bafa070847929e8ac317794e552b20c90e745b85))
+- **select:** add support for isOptional ([1c14041](https://github.com/Sage/carbon/commit/1c14041879141246b30885c44ef085880430e11e))
+- **text-editor:** add support for required and isOptional ([6f78219](https://github.com/Sage/carbon/commit/6f78219e7f8ff732e90d10f70afa311fe20b1e0f))
+- **textarea:** add support for isOptional ([2958d46](https://github.com/Sage/carbon/commit/2958d46ba4b5e9284978f44e6af329c3401868eb))
 
 ### Bug Fixes
 
-* **fieldset, label:** update font weight and colour of label text to use tokens ([f28611d](https://github.com/Sage/carbon/commit/f28611dd726bde5e09152921edf39697c648d9c9))
-* update font weight of required and optional label markers to use tokens ([a63c293](https://github.com/Sage/carbon/commit/a63c293246bf814186cd569bfd56b159334295f4))
-* update spacing for required indicator and colour of optional indicator appended to input labels ([6e5f992](https://github.com/Sage/carbon/commit/6e5f9923156049aec150aa525a4cb8030c227f25))
+- **fieldset, label:** update font weight and colour of label text to use tokens ([f28611d](https://github.com/Sage/carbon/commit/f28611dd726bde5e09152921edf39697c648d9c9))
+- update font weight of required and optional label markers to use tokens ([a63c293](https://github.com/Sage/carbon/commit/a63c293246bf814186cd569bfd56b159334295f4))
+- update spacing for required indicator and colour of optional indicator appended to input labels ([6e5f992](https://github.com/Sage/carbon/commit/6e5f9923156049aec150aa525a4cb8030c227f25))
 
 ### [128.1.2](https://github.com/Sage/carbon/compare/v128.1.1...v128.1.2) (2024-04-03)
 
-
 ### Bug Fixes
 
-* exclude docs/ directory in TS build config ([2d88106](https://github.com/Sage/carbon/commit/2d88106ced3df3eff3ebb8a2a301b8c4f929af5a))
+- exclude docs/ directory in TS build config ([2d88106](https://github.com/Sage/carbon/commit/2d88106ced3df3eff3ebb8a2a301b8c4f929af5a))
 
 ### [128.1.1](https://github.com/Sage/carbon/compare/v128.1.0...v128.1.1) (2024-04-02)
 
-
 ### ⚠ NOTE
 
 **This version was not published. Please use version 128.1.2.**
 
 ### Bug Fixes
 
-* **pager:** use activation trigger for onkeydown and onclick ([664a43b](https://github.com/Sage/carbon/commit/664a43b4fb3675dcc8a999ef866192b916f0fcdd)), closes [#6289](https://github.com/Sage/carbon/issues/6289)
+- **pager:** use activation trigger for onkeydown and onclick ([664a43b](https://github.com/Sage/carbon/commit/664a43b4fb3675dcc8a999ef866192b916f0fcdd)), closes [#6289](https://github.com/Sage/carbon/issues/6289)
 
 ## [128.1.0](https://github.com/Sage/carbon/compare/v128.0.0...v128.1.0) (2024-04-02)
 
-
 ### ⚠ NOTE
 
 **This version was not published. Please use version 128.1.2.**
 
 ### Features
 
-* **dialog:** add closeButtonDataProps prop ([b9b3054](https://github.com/Sage/carbon/commit/b9b3054118c6d8bd0c9a7e2866a89cb538a2e80d)), closes [#6603](https://github.com/Sage/carbon/issues/6603)
+- **dialog:** add closeButtonDataProps prop ([b9b3054](https://github.com/Sage/carbon/commit/b9b3054118c6d8bd0c9a7e2866a89cb538a2e80d)), closes [#6603](https://github.com/Sage/carbon/issues/6603)
 
 ## [128.0.0](https://github.com/Sage/carbon/compare/v127.1.1...v128.0.0) (2024-03-28)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **select:** The `disablePortal` prop has been removed from all 3 Select variants. It is no
-longer needed as the component now always behaves as it did before with this prop added.
+- **select:** The `disablePortal` prop has been removed from all 3 Select variants. It is no
+  longer needed as the component now always behaves as it did before with this prop added.
 
 ### Bug Fixes
 
-* **select:** render select list in DOM order rather than in a portal ([5099120](https://github.com/Sage/carbon/commit/50991201124ce1c62ebf2055d2088e704cac2387)), closes [#5171](https://github.com/Sage/carbon/issues/5171)
+- **select:** render select list in DOM order rather than in a portal ([5099120](https://github.com/Sage/carbon/commit/50991201124ce1c62ebf2055d2088e704cac2387)), closes [#5171](https://github.com/Sage/carbon/issues/5171)
 
 ### [127.1.1](https://github.com/Sage/carbon/compare/v127.1.0...v127.1.1) (2024-03-28)
 
-
 ### Bug Fixes
 
-* **filterable-select, multi-select:** ensure whitespace is trimmed from the input when filtering ([98a91ef](https://github.com/Sage/carbon/commit/98a91ef38390018b0379420205735a8354d4b6fc)), closes [#6446](https://github.com/Sage/carbon/issues/6446)
+- **filterable-select, multi-select:** ensure whitespace is trimmed from the input when filtering ([98a91ef](https://github.com/Sage/carbon/commit/98a91ef38390018b0379420205735a8354d4b6fc)), closes [#6446](https://github.com/Sage/carbon/issues/6446)
 
 ## [127.1.0](https://github.com/Sage/carbon/compare/v127.0.4...v127.1.0) (2024-03-28)
 
-
 ### Features
 
-* **action-popover:** add aria-label prop ([8d69273](https://github.com/Sage/carbon/commit/8d69273abe90f0ef022e3f078088d1aa1ef4098a))
-* **action-popover:** remove aria-label from menu items that open a submenu ([faf6292](https://github.com/Sage/carbon/commit/faf6292085a4ea62cabd50fddf3897738d7b9738))
-* **action-popover:** remove menu roles and use semantic html ([da74523](https://github.com/Sage/carbon/commit/da7452383393aa98023b07c19758d31636412a3b))
-* **split-button, multi-action-button:** remove menu roles and use semantic html lists ([dfd3a4c](https://github.com/Sage/carbon/commit/dfd3a4c819d18b0710f2f4e13dfcaf3d3f1ef383))
+- **action-popover:** add aria-label prop ([8d69273](https://github.com/Sage/carbon/commit/8d69273abe90f0ef022e3f078088d1aa1ef4098a))
+- **action-popover:** remove aria-label from menu items that open a submenu ([faf6292](https://github.com/Sage/carbon/commit/faf6292085a4ea62cabd50fddf3897738d7b9738))
+- **action-popover:** remove menu roles and use semantic html ([da74523](https://github.com/Sage/carbon/commit/da7452383393aa98023b07c19758d31636412a3b))
+- **split-button, multi-action-button:** remove menu roles and use semantic html lists ([dfd3a4c](https://github.com/Sage/carbon/commit/dfd3a4c819d18b0710f2f4e13dfcaf3d3f1ef383))
 
 ### [127.0.4](https://github.com/Sage/carbon/compare/v127.0.3...v127.0.4) (2024-03-27)
 
-
 ### Bug Fixes
 
-* **select:** remove list action button from scrollable area in select list ([d95770e](https://github.com/Sage/carbon/commit/d95770e9a4be9680c2e846c51afbce61f512fc13)), closes [#6541](https://github.com/Sage/carbon/issues/6541)
+- **select:** remove list action button from scrollable area in select list ([d95770e](https://github.com/Sage/carbon/commit/d95770e9a4be9680c2e846c51afbce61f512fc13)), closes [#6541](https://github.com/Sage/carbon/issues/6541)
 
 ### [127.0.3](https://github.com/Sage/carbon/compare/v127.0.2...v127.0.3) (2024-03-25)
 
-
 ### Bug Fixes
 
-* **advanced-color-picker:** address translation inconsistencies ([48d6b2d](https://github.com/Sage/carbon/commit/48d6b2db269d707cee1f48c793003c84afe2e8ea))
-* **password:** address translation inconsistencies ([606100a](https://github.com/Sage/carbon/commit/606100aa793f3a8c3faa8da68fa808a4b1c94c57))
+- **advanced-color-picker:** address translation inconsistencies ([48d6b2d](https://github.com/Sage/carbon/commit/48d6b2db269d707cee1f48c793003c84afe2e8ea))
+- **password:** address translation inconsistencies ([606100a](https://github.com/Sage/carbon/commit/606100aa793f3a8c3faa8da68fa808a4b1c94c57))
 
 ### [127.0.2](https://github.com/Sage/carbon/compare/v127.0.1...v127.0.2) (2024-03-25)
 
-
 ### Bug Fixes
 
-* **flat-table:** sort icon color fix ([ddf4d84](https://github.com/Sage/carbon/commit/ddf4d84d1d3ab28776f470e0cd78da9437f4525c)), closes [#6523](https://github.com/Sage/carbon/issues/6523)
+- **flat-table:** sort icon color fix ([ddf4d84](https://github.com/Sage/carbon/commit/ddf4d84d1d3ab28776f470e0cd78da9437f4525c)), closes [#6523](https://github.com/Sage/carbon/issues/6523)
 
 ### [127.0.1](https://github.com/Sage/carbon/compare/v127.0.0...v127.0.1) (2024-03-25)
 
-
 ### Bug Fixes
 
-* **input:** insufficient colour contrast in input placeholder ([cb30557](https://github.com/Sage/carbon/commit/cb30557a84f6b6abf3c69df16717f3074e942c72)), closes [#6587](https://github.com/Sage/carbon/issues/6587)
+- **input:** insufficient colour contrast in input placeholder ([cb30557](https://github.com/Sage/carbon/commit/cb30557a84f6b6abf3c69df16717f3074e942c72)), closes [#6587](https://github.com/Sage/carbon/issues/6587)
 
 ## [127.0.0](https://github.com/Sage/carbon/compare/v126.10.1...v127.0.0) (2024-03-14)
 
-
 ### ⚠ BREAKING CHANGES
 
-* Carbon components will no longer expose `propTypes` in production builds - any
-functionality that relies on reading the `propTypes` of a component will break
+- Carbon components will no longer expose `propTypes` in production builds - any
+  functionality that relies on reading the `propTypes` of a component will break
 
 ### Build System
 
-* remove proptypes from production bundles ([1929f14](https://github.com/Sage/carbon/commit/1929f14f7fe38d760ab6b51a38c22b53247eeef9))
+- remove proptypes from production bundles ([1929f14](https://github.com/Sage/carbon/commit/1929f14f7fe38d760ab6b51a38c22b53247eeef9))
 
 ### [126.10.1](https://github.com/Sage/carbon/compare/v126.10.0...v126.10.1) (2024-03-13)
 
-
 ### Bug Fixes
 
-* **action-popover:** add preventScroll to the focus method responsible for focusing each menu item ([55a241f](https://github.com/Sage/carbon/commit/55a241fdf472e4f83ae1fb624a19d68b41fbf892)), closes [#6485](https://github.com/Sage/carbon/issues/6485)
+- **action-popover:** add preventScroll to the focus method responsible for focusing each menu item ([55a241f](https://github.com/Sage/carbon/commit/55a241fdf472e4f83ae1fb624a19d68b41fbf892)), closes [#6485](https://github.com/Sage/carbon/issues/6485)
 
 ## [126.10.0](https://github.com/Sage/carbon/compare/v126.9.1...v126.10.0) (2024-03-13)
 
-
 ### Features
 
-* **button-toggle-group:** add support for aria-describedby ([4097833](https://github.com/Sage/carbon/commit/40978336dd36fc647f89838a7ed5410c14d30544))
-* **button, button-minor:** add aria-labelledby and aria-describedby props ([fd017ca](https://github.com/Sage/carbon/commit/fd017ca9e8065c1f1316076f00e27127d324e1ec))
+- **button-toggle-group:** add support for aria-describedby ([4097833](https://github.com/Sage/carbon/commit/40978336dd36fc647f89838a7ed5410c14d30544))
+- **button, button-minor:** add aria-labelledby and aria-describedby props ([fd017ca](https://github.com/Sage/carbon/commit/fd017ca9e8065c1f1316076f00e27127d324e1ec))
 
 ### [126.9.1](https://github.com/Sage/carbon/compare/v126.9.0...v126.9.1) (2024-02-29)
 
-
 ### Bug Fixes
 
-* **tabs:** remove negative margin to resolve scrollbar appearing ([02c2de5](https://github.com/Sage/carbon/commit/02c2de53b969b3ad03ef6717e695977374fcb03c)), closes [#6511](https://github.com/Sage/carbon/issues/6511)
+- **tabs:** remove negative margin to resolve scrollbar appearing ([02c2de5](https://github.com/Sage/carbon/commit/02c2de53b969b3ad03ef6717e695977374fcb03c)), closes [#6511](https://github.com/Sage/carbon/issues/6511)
 
 ## [126.9.0](https://github.com/Sage/carbon/compare/v126.8.0...v126.9.0) (2024-02-29)
 
-
 ### Features
 
-* **textarea:** add prop to hide borders ([cfbff30](https://github.com/Sage/carbon/commit/cfbff309ab433fdda5a46a4803561641846293d6))
+- **textarea:** add prop to hide borders ([cfbff30](https://github.com/Sage/carbon/commit/cfbff309ab433fdda5a46a4803561641846293d6))
 
 ## [126.8.0](https://github.com/Sage/carbon/compare/v126.7.1...v126.8.0) (2024-02-29)
 
-
 ### Features
 
-* **button-toggle:** update styles ([f5cdf09](https://github.com/Sage/carbon/commit/f5cdf09cc1d9d2ac9d0d8699c819b266daa6bf46))
+- **button-toggle:** update styles ([f5cdf09](https://github.com/Sage/carbon/commit/f5cdf09cc1d9d2ac9d0d8699c819b266daa6bf46))
 
 ### [126.7.1](https://github.com/Sage/carbon/compare/v126.7.0...v126.7.1) (2024-02-28)
 
-
 ### Bug Fixes
 
-* **tile:** ensure borderVariant overrides border color associated to variant prop ([53170b0](https://github.com/Sage/carbon/commit/53170b017341c60ac9481f5ee8daa1dbfb518ecc))
+- **tile:** ensure borderVariant overrides border color associated to variant prop ([53170b0](https://github.com/Sage/carbon/commit/53170b017341c60ac9481f5ee8daa1dbfb518ecc))
 
 ## [126.7.0](https://github.com/Sage/carbon/compare/v126.6.0...v126.7.0) (2024-02-26)
 
-
 ### Features
 
-* **dismissible-box:** allows a custom data role to close button and translations to aria label ([2c59569](https://github.com/Sage/carbon/commit/2c59569523a9aa36cc1b7af9557970f69c854186)), closes [#6487](https://github.com/Sage/carbon/issues/6487)
+- **dismissible-box:** allows a custom data role to close button and translations to aria label ([2c59569](https://github.com/Sage/carbon/commit/2c59569523a9aa36cc1b7af9557970f69c854186)), closes [#6487](https://github.com/Sage/carbon/issues/6487)
 
 ## [126.6.0](https://github.com/Sage/carbon/compare/v126.5.3...v126.6.0) (2024-02-26)
 
-
 ### Features
 
-* **icon:** 2 icons added to the icon font ([949282a](https://github.com/Sage/carbon/commit/949282aafca3ea33ca2448e77570754e10d24827))
+- **icon:** 2 icons added to the icon font ([949282a](https://github.com/Sage/carbon/commit/949282aafca3ea33ca2448e77570754e10d24827))
 
 ### [126.5.3](https://github.com/Sage/carbon/compare/v126.5.2...v126.5.3) (2024-02-23)
 
-
 ### Bug Fixes
 
-* **form:** remove 4px margin bottom from Textarea FormField ([4011182](https://github.com/Sage/carbon/commit/401118288af1503e5a974903960cd3c7a993884e))
+- **form:** remove 4px margin bottom from Textarea FormField ([4011182](https://github.com/Sage/carbon/commit/401118288af1503e5a974903960cd3c7a993884e))
 
 ### [126.5.2](https://github.com/Sage/carbon/compare/v126.5.1...v126.5.2) (2024-02-23)
 
-
 ### Bug Fixes
 
-* **icon:** bgSize and fontSize bug fix ([6eb59d1](https://github.com/Sage/carbon/commit/6eb59d111bd9e9a8add9c275e94807b08305b4a8)), closes [#5812](https://github.com/Sage/carbon/issues/5812)
+- **icon:** bgSize and fontSize bug fix ([6eb59d1](https://github.com/Sage/carbon/commit/6eb59d111bd9e9a8add9c275e94807b08305b4a8)), closes [#5812](https://github.com/Sage/carbon/issues/5812)
 
 ### [126.5.1](https://github.com/Sage/carbon/compare/v126.5.0...v126.5.1) (2024-02-22)
 
-
 ### Bug Fixes
 
-* **filterable-select:** ensure onchange called when deleting text ([10e5834](https://github.com/Sage/carbon/commit/10e5834aff5bc9fcbd257c6605af74dc618d4137))
+- **filterable-select:** ensure onchange called when deleting text ([10e5834](https://github.com/Sage/carbon/commit/10e5834aff5bc9fcbd257c6605af74dc618d4137))
 
 ## [126.5.0](https://github.com/Sage/carbon/compare/v126.4.3...v126.5.0) (2024-02-21)
 
-
 ### Features
 
-* **image:** add padding props ([9448170](https://github.com/Sage/carbon/commit/9448170d0b5523feeb63bbb02d062d92ac2ee67d)), closes [#6232](https://github.com/Sage/carbon/issues/6232)
+- **image:** add padding props ([9448170](https://github.com/Sage/carbon/commit/9448170d0b5523feeb63bbb02d062d92ac2ee67d)), closes [#6232](https://github.com/Sage/carbon/issues/6232)
 
 ### [126.4.3](https://github.com/Sage/carbon/compare/v126.4.2...v126.4.3) (2024-02-20)
 
-
 ### Bug Fixes
 
-* **filterable-select:** ensure selectionConfirmed is false when enter pressed with no match ([fef9f08](https://github.com/Sage/carbon/commit/fef9f0803ed71215c14da3521231d59b34f2f480)), closes [#6518](https://github.com/Sage/carbon/issues/6518)
+- **filterable-select:** ensure selectionConfirmed is false when enter pressed with no match ([fef9f08](https://github.com/Sage/carbon/commit/fef9f0803ed71215c14da3521231d59b34f2f480)), closes [#6518](https://github.com/Sage/carbon/issues/6518)
 
 ### [126.4.2](https://github.com/Sage/carbon/compare/v126.4.1...v126.4.2) (2024-02-20)
 
-
 ### Bug Fixes
 
-* **textarea, textbox:** ensure enterkeyhint attribute can be set ([95a30a7](https://github.com/Sage/carbon/commit/95a30a794be05d0fb92ba644346fece4ed29081c)), closes [#6525](https://github.com/Sage/carbon/issues/6525)
+- **textarea, textbox:** ensure enterkeyhint attribute can be set ([95a30a7](https://github.com/Sage/carbon/commit/95a30a794be05d0fb92ba644346fece4ed29081c)), closes [#6525](https://github.com/Sage/carbon/issues/6525)
 
 ### [126.4.1](https://github.com/Sage/carbon/compare/v126.4.0...v126.4.1) (2024-02-20)
 
-
 ### Bug Fixes
 
-* **checkbox, toast:** fix bugs in stories ([94053ad](https://github.com/Sage/carbon/commit/94053ad11396790772b4aa3dfbdd41300ff3e575))
+- **checkbox, toast:** fix bugs in stories ([94053ad](https://github.com/Sage/carbon/commit/94053ad11396790772b4aa3dfbdd41300ff3e575))
 
 ## [126.4.0](https://github.com/Sage/carbon/compare/v126.3.1...v126.4.0) (2024-02-19)
 
-
 ### Features
 
-* **tile:** add "small" roundness option ([56ec960](https://github.com/Sage/carbon/commit/56ec960b82c176a4312c409903665d399dd48924))
-* **tile:** add grey variant ([c8a8d7e](https://github.com/Sage/carbon/commit/c8a8d7edd196fba83fad5fcbc56545dea7768929))
-* **tile:** add new tile-header subcomponent ([9428174](https://github.com/Sage/carbon/commit/9428174a4fc1d9545a9a482bc5c390e5100b4e64))
-
+- **tile:** add "small" roundness option ([56ec960](https://github.com/Sage/carbon/commit/56ec960b82c176a4312c409903665d399dd48924))
+- **tile:** add grey variant ([c8a8d7e](https://github.com/Sage/carbon/commit/c8a8d7edd196fba83fad5fcbc56545dea7768929))
+- **tile:** add new tile-header subcomponent ([9428174](https://github.com/Sage/carbon/commit/9428174a4fc1d9545a9a482bc5c390e5100b4e64))
 
 ### Bug Fixes
 
-* **tile:** remove `overflow: hidden` from tile container ([5373176](https://github.com/Sage/carbon/commit/5373176e67f7ce19f4b6318af07f66e28333d95c))
+- **tile:** remove `overflow: hidden` from tile container ([5373176](https://github.com/Sage/carbon/commit/5373176e67f7ce19f4b6318af07f66e28333d95c))
 
 ### [126.3.1](https://github.com/Sage/carbon/compare/v126.3.0...v126.3.1) (2024-02-19)
 
-
 ### Bug Fixes
 
-* **popover-container:** ensure styling is correct when rendered as a child of menu ([ee672d2](https://github.com/Sage/carbon/commit/ee672d2eae2fd31a4fdbd6273ed05c6c7e70c17a)), closes [#6538](https://github.com/Sage/carbon/issues/6538)
+- **popover-container:** ensure styling is correct when rendered as a child of menu ([ee672d2](https://github.com/Sage/carbon/commit/ee672d2eae2fd31a4fdbd6273ed05c6c7e70c17a)), closes [#6538](https://github.com/Sage/carbon/issues/6538)
 
 ## [126.3.0](https://github.com/Sage/carbon/compare/v126.2.1...v126.3.0) (2024-02-16)
 
-
 ### Features
 
-* **loader:** add gradient color to component ([8166ac7](https://github.com/Sage/carbon/commit/8166ac79f9868d773d55e729ac78b1c91054f026))
+- **loader:** add gradient color to component ([8166ac7](https://github.com/Sage/carbon/commit/8166ac79f9868d773d55e729ac78b1c91054f026))
 
 ### [126.2.1](https://github.com/Sage/carbon/compare/v126.2.0...v126.2.1) (2024-02-16)
 
-
 ### Bug Fixes
 
-* **pager:** increase margin so focus style does not overlap text ([4508254](https://github.com/Sage/carbon/commit/4508254e759e3eb7acf43aa29fd153c36d6f0bc6))
+- **pager:** increase margin so focus style does not overlap text ([4508254](https://github.com/Sage/carbon/commit/4508254e759e3eb7acf43aa29fd153c36d6f0bc6))
 
 ## [126.2.0](https://github.com/Sage/carbon/compare/v126.1.0...v126.2.0) (2024-02-15)
 
-
 ### Features
 
-* **button:** add new `gradient-white` and `gradient-grey` buttonTypes ([36dea2a](https://github.com/Sage/carbon/commit/36dea2a14856cea465256e939bde68f53f46809c))
+- **button:** add new `gradient-white` and `gradient-grey` buttonTypes ([36dea2a](https://github.com/Sage/carbon/commit/36dea2a14856cea465256e939bde68f53f46809c))
 
 ## [126.1.0](https://github.com/Sage/carbon/compare/v126.0.1...v126.1.0) (2024-02-14)
 
-
 ### Features
 
-* **textarea:** add new borderRadius prop ([5ff228b](https://github.com/Sage/carbon/commit/5ff228b07ff969c0e54b7cfcad1973f8f4f71ecb))
+- **textarea:** add new borderRadius prop ([5ff228b](https://github.com/Sage/carbon/commit/5ff228b07ff969c0e54b7cfcad1973f8f4f71ecb))
 
 ### [126.0.1](https://github.com/Sage/carbon/compare/v126.0.0...v126.0.1) (2024-02-13)
 
-
 ### Bug Fixes
 
-* **message:** reduce left padding of content for `transparent` variant ([31feba5](https://github.com/Sage/carbon/commit/31feba518ff1bfcaee1b9b499691a5ad52655815)), closes [#6552](https://github.com/Sage/carbon/issues/6552)
+- **message:** reduce left padding of content for `transparent` variant ([31feba5](https://github.com/Sage/carbon/commit/31feba518ff1bfcaee1b9b499691a5ad52655815)), closes [#6552](https://github.com/Sage/carbon/issues/6552)
 
 ## [126.0.0](https://github.com/Sage/carbon/compare/v125.13.0...v126.0.0) (2024-02-13)
 
-
 ### ⚠ BREAKING CHANGES
 
-* The `labelAlign` prop has been removed from `ButtonToggle`, `Checkbox`,
-`RadioButton` and `Switch` components.
+- The `labelAlign` prop has been removed from `ButtonToggle`, `Checkbox`,
+  `RadioButton` and `Switch` components.
 
 ### Bug Fixes
 
-* remove unused labelAlign prop from checkable inputs ([037dcc9](https://github.com/Sage/carbon/commit/037dcc923fbd53b3edd49f97103a18e6dfba633e))
+- remove unused labelAlign prop from checkable inputs ([037dcc9](https://github.com/Sage/carbon/commit/037dcc923fbd53b3edd49f97103a18e6dfba633e))
 
 ## [125.13.0](https://github.com/Sage/carbon/compare/v125.12.2...v125.13.0) (2024-02-12)
 
-
 ### Features
 
-* **portal:** add inertOptOut prop to keep the content interactable when a modal opens ([250ba58](https://github.com/Sage/carbon/commit/250ba5853545218b175c97a66fcbe71f0e44b115))
+- **portal:** add inertOptOut prop to keep the content interactable when a modal opens ([250ba58](https://github.com/Sage/carbon/commit/250ba5853545218b175c97a66fcbe71f0e44b115))
 
 ### [125.12.2](https://github.com/Sage/carbon/compare/v125.12.1...v125.12.2) (2024-02-09)
 
-
 ### Bug Fixes
 
-* **date:** prevent dialog from closing if esc is pressed and date picker is open ([f28f361](https://github.com/Sage/carbon/commit/f28f3618a015046272ff6df36ecad7581d2efaa3))
+- **date:** prevent dialog from closing if esc is pressed and date picker is open ([f28f361](https://github.com/Sage/carbon/commit/f28f3618a015046272ff6df36ecad7581d2efaa3))
 
 ### [125.12.1](https://github.com/Sage/carbon/compare/v125.12.0...v125.12.1) (2024-02-08)
 
-
 ### Bug Fixes
 
-* **split-button:** fix style when href is passed to a button ([8dd1645](https://github.com/Sage/carbon/commit/8dd1645e78f9607ae56d05a8995acc10a04335c0))
+- **split-button:** fix style when href is passed to a button ([8dd1645](https://github.com/Sage/carbon/commit/8dd1645e78f9607ae56d05a8995acc10a04335c0))
 
 ## [125.12.0](https://github.com/Sage/carbon/compare/v125.11.1...v125.12.0) (2024-02-07)
 
-
 ### Features
 
-* **text-editor:** make container of `toolbarElements` a flex container for responsiveness ([305bf69](https://github.com/Sage/carbon/commit/305bf6902a2fc7c7e480c72d2376d25e6cbb538a)), closes [#6530](https://github.com/Sage/carbon/issues/6530)
-* **text-editor:** update dimensions and active background colour of toolbar buttons ([446b327](https://github.com/Sage/carbon/commit/446b327483af70e5fc59b2ba4f174dde52ec770b))
+- **text-editor:** make container of `toolbarElements` a flex container for responsiveness ([305bf69](https://github.com/Sage/carbon/commit/305bf6902a2fc7c7e480c72d2376d25e6cbb538a)), closes [#6530](https://github.com/Sage/carbon/issues/6530)
+- **text-editor:** update dimensions and active background colour of toolbar buttons ([446b327](https://github.com/Sage/carbon/commit/446b327483af70e5fc59b2ba4f174dde52ec770b))
 
 ### [125.11.1](https://github.com/Sage/carbon/compare/v125.11.0...v125.11.1) (2024-02-07)
 
-
 ### Bug Fixes
 
-* **select:** maintain option ids according to key when children count changes ([144583b](https://github.com/Sage/carbon/commit/144583ba10c284209e9f4dc8e4d081ee1da4b332)), closes [#6378](https://github.com/Sage/carbon/issues/6378)
+- **select:** maintain option ids according to key when children count changes ([144583b](https://github.com/Sage/carbon/commit/144583ba10c284209e9f4dc8e4d081ee1da4b332)), closes [#6378](https://github.com/Sage/carbon/issues/6378)
 
 ## [125.11.0](https://github.com/Sage/carbon/compare/v125.10.0...v125.11.0) (2024-02-06)
 
-
 ### Features
 
-* **step-flow:** add new component ([707ef4f](https://github.com/Sage/carbon/commit/707ef4f30b02c68c6595eea6590c968d6456eebf))
+- **step-flow:** add new component ([707ef4f](https://github.com/Sage/carbon/commit/707ef4f30b02c68c6595eea6590c968d6456eebf))
 
 ## [125.10.0](https://github.com/Sage/carbon/compare/v125.9.3...v125.10.0) (2024-02-06)
 
-
 ### Features
 
-* **pill:** add dark background color variants ([8f4b697](https://github.com/Sage/carbon/commit/8f4b69735a96cececfaef7c74cb8fc1d5c48d0a0))
-* **pill:** add information variant ([dcf30bd](https://github.com/Sage/carbon/commit/dcf30bd2ebb1997e84eabb616b8008b350764608))
+- **pill:** add dark background color variants ([8f4b697](https://github.com/Sage/carbon/commit/8f4b69735a96cececfaef7c74cb8fc1d5c48d0a0))
+- **pill:** add information variant ([dcf30bd](https://github.com/Sage/carbon/commit/dcf30bd2ebb1997e84eabb616b8008b350764608))
 
 ### [125.9.3](https://github.com/Sage/carbon/compare/v125.9.2...v125.9.3) (2024-02-01)
 
-
 ### Bug Fixes
 
-* **pages:** maintain height of content when page slides in ([b97dfb1](https://github.com/Sage/carbon/commit/b97dfb16889be2d91e5aeb028894e8c7c1f9d071)), closes [#6492](https://github.com/Sage/carbon/issues/6492)
+- **pages:** maintain height of content when page slides in ([b97dfb1](https://github.com/Sage/carbon/commit/b97dfb16889be2d91e5aeb028894e8c7c1f9d071)), closes [#6492](https://github.com/Sage/carbon/issues/6492)
 
 ### [125.9.2](https://github.com/Sage/carbon/compare/v125.9.1...v125.9.2) (2024-02-01)
 
-
 ### Bug Fixes
 
-* **numeral-date:** ensure it uses static validation when no month value passed ([b70086a](https://github.com/Sage/carbon/commit/b70086a99f8ffdd07e02c5a8ee7590c554fd419a))
+- **numeral-date:** ensure it uses static validation when no month value passed ([b70086a](https://github.com/Sage/carbon/commit/b70086a99f8ffdd07e02c5a8ee7590c554fd419a))
 
 ### [125.9.1](https://github.com/Sage/carbon/compare/v125.9.0...v125.9.1) (2024-01-31)
 
-
 ### Bug Fixes
 
-* **dialog + icon + tabs:** fix color for modal, dialog responsive size and added new icon minimise ([5c9e559](https://github.com/Sage/carbon/commit/5c9e55959fb227240b81a605376783f75e79c0a7))
+- **dialog + icon + tabs:** fix color for modal, dialog responsive size and added new icon minimise ([5c9e559](https://github.com/Sage/carbon/commit/5c9e55959fb227240b81a605376783f75e79c0a7))
 
 ## [125.9.0](https://github.com/Sage/carbon/compare/v125.8.0...v125.9.0) (2024-01-30)
 
-
 ### Features
 
-* **image:** add position prop to component ([8e20a4f](https://github.com/Sage/carbon/commit/8e20a4f67afa1065e22ae1488e133648c36a0380))
+- **image:** add position prop to component ([8e20a4f](https://github.com/Sage/carbon/commit/8e20a4f67afa1065e22ae1488e133648c36a0380))
 
 ## [125.8.0](https://github.com/Sage/carbon/compare/v125.7.0...v125.8.0) (2024-01-29)
 
-
 ### Features
 
-* **time:** add new component ([27dc669](https://github.com/Sage/carbon/commit/27dc669de37dab9d0549a5405b8eab17ef473121))
+- **time:** add new component ([27dc669](https://github.com/Sage/carbon/commit/27dc669de37dab9d0549a5405b8eab17ef473121))
 
 ## [125.7.0](https://github.com/Sage/carbon/compare/v125.6.0...v125.7.0) (2024-01-29)
 
-
 ### Features
 
-* **accordion:** add subtle variant and update default styles ([91a2be0](https://github.com/Sage/carbon/commit/91a2be0b76bdb49a00596728d2c159bd2b639415))
+- **accordion:** add subtle variant and update default styles ([91a2be0](https://github.com/Sage/carbon/commit/91a2be0b76bdb49a00596728d2c159bd2b639415))
 
 ## [125.6.0](https://github.com/Sage/carbon/compare/v125.5.1...v125.6.0) (2024-01-26)
 
-
 ### Features
 
-* **preview:** add rounded corners styling to component ([e3af885](https://github.com/Sage/carbon/commit/e3af8855f37f6b56e4c89eba591e6fbbda7bc5ab)), closes [#6174](https://github.com/Sage/carbon/issues/6174)
+- **preview:** add rounded corners styling to component ([e3af885](https://github.com/Sage/carbon/commit/e3af8855f37f6b56e4c89eba591e6fbbda7bc5ab)), closes [#6174](https://github.com/Sage/carbon/issues/6174)
 
 ### [125.5.1](https://github.com/Sage/carbon/compare/v125.5.0...v125.5.1) (2024-01-25)
 
-
 ### Bug Fixes
 
-* **flat-table:** ensure that focus size is correctly applied in Safari ([cd1c3e3](https://github.com/Sage/carbon/commit/cd1c3e361500761d2a5bc98201650448beffc102)), closes [#6496](https://github.com/Sage/carbon/issues/6496)
+- **flat-table:** ensure that focus size is correctly applied in Safari ([cd1c3e3](https://github.com/Sage/carbon/commit/cd1c3e361500761d2a5bc98201650448beffc102)), closes [#6496](https://github.com/Sage/carbon/issues/6496)
 
 ## [125.5.0](https://github.com/Sage/carbon/compare/v125.4.0...v125.5.0) (2024-01-25)
 
-
 ### Features
 
-* **inline-inputs:** add labelAlign prop ([55a485d](https://github.com/Sage/carbon/commit/55a485d6da6b1d94edb79291c14b108a721e1002))
+- **inline-inputs:** add labelAlign prop ([55a485d](https://github.com/Sage/carbon/commit/55a485d6da6b1d94edb79291c14b108a721e1002))
 
 ## [125.4.0](https://github.com/Sage/carbon/compare/v125.3.0...v125.4.0) (2024-01-25)
 
-
 ### Features
 
-* **filterable-select:** add disableDefaultFiltering prop ([11c9a1f](https://github.com/Sage/carbon/commit/11c9a1fee723c55de1a0f82046eb740a751c86f8))
+- **filterable-select:** add disableDefaultFiltering prop ([11c9a1f](https://github.com/Sage/carbon/commit/11c9a1fee723c55de1a0f82046eb740a751c86f8))
 
 ## [125.3.0](https://github.com/Sage/carbon/compare/v125.2.2...v125.3.0) (2024-01-23)
 
-
 ### Features
 
-* **option, option-row:** add disabled prop ([465f5f0](https://github.com/Sage/carbon/commit/465f5f0a3cf0f13670baeb672ca96b9f0f248710))
+- **option, option-row:** add disabled prop ([465f5f0](https://github.com/Sage/carbon/commit/465f5f0a3cf0f13670baeb672ca96b9f0f248710))
 
 ### [125.2.2](https://github.com/Sage/carbon/compare/v125.2.1...v125.2.2) (2024-01-22)
 
-
 ### Bug Fixes
 
-* **link:** focus underline fix ([5edad27](https://github.com/Sage/carbon/commit/5edad27df0f9a69d8e164fae58309056f9f22545)), closes [#6434](https://github.com/Sage/carbon/issues/6434)
+- **link:** focus underline fix ([5edad27](https://github.com/Sage/carbon/commit/5edad27df0f9a69d8e164fae58309056f9f22545)), closes [#6434](https://github.com/Sage/carbon/issues/6434)
 
 ### [125.2.1](https://github.com/Sage/carbon/compare/v125.2.0...v125.2.1) (2024-01-22)
 
-
 ### Bug Fixes
 
-* **flat-table:** ensure that pressing arrow and space keys scroll table when it is scrollable ([b7614e3](https://github.com/Sage/carbon/commit/b7614e38c192d4e05d75b87f3f754e9d36f18052)), closes [#6425](https://github.com/Sage/carbon/issues/6425)
+- **flat-table:** ensure that pressing arrow and space keys scroll table when it is scrollable ([b7614e3](https://github.com/Sage/carbon/commit/b7614e38c192d4e05d75b87f3f754e9d36f18052)), closes [#6425](https://github.com/Sage/carbon/issues/6425)
 
 ## [125.2.0](https://github.com/Sage/carbon/compare/v125.1.0...v125.2.0) (2024-01-19)
 
-
 ### Features
 
-* **popover-container:** ensure that container behaves like a modal when open button is covered ([dcf655a](https://github.com/Sage/carbon/commit/dcf655a9d538492a704c6ce73f51fbe1cb074959)), closes [#6307](https://github.com/Sage/carbon/issues/6307)
+- **popover-container:** ensure that container behaves like a modal when open button is covered ([dcf655a](https://github.com/Sage/carbon/commit/dcf655a9d538492a704c6ce73f51fbe1cb074959)), closes [#6307](https://github.com/Sage/carbon/issues/6307)
 
 ## [125.1.0](https://github.com/Sage/carbon/compare/v125.0.2...v125.1.0) (2024-01-18)
 
-
 ### Features
 
-* **popover-container:** add prop to disable animation ([2a6a12c](https://github.com/Sage/carbon/commit/2a6a12c15a0d6cf725bfffde09673eb29db499a0)), closes [#6002](https://github.com/Sage/carbon/issues/6002)
+- **popover-container:** add prop to disable animation ([2a6a12c](https://github.com/Sage/carbon/commit/2a6a12c15a0d6cf725bfffde09673eb29db499a0)), closes [#6002](https://github.com/Sage/carbon/issues/6002)
 
 ### [125.0.2](https://github.com/Sage/carbon/compare/v125.0.1...v125.0.2) (2024-01-15)
 
-
 ### Bug Fixes
 
-* **numeral-date:** ensure internal validation uses given month and year values where possible ([24648d2](https://github.com/Sage/carbon/commit/24648d29d729c73e1dda837180f48fb16b21dabf)), closes [#6438](https://github.com/Sage/carbon/issues/6438)
+- **numeral-date:** ensure internal validation uses given month and year values where possible ([24648d2](https://github.com/Sage/carbon/commit/24648d29d729c73e1dda837180f48fb16b21dabf)), closes [#6438](https://github.com/Sage/carbon/issues/6438)
 
 ### [125.0.1](https://github.com/Sage/carbon/compare/v125.0.0...v125.0.1) (2024-01-11)
 
-
 ### Bug Fixes
 
-* **menu-fullscreen:** ensure that custom padding is applied to submenu items inside menu fullscreen ([d80f902](https://github.com/Sage/carbon/commit/d80f902e07f277ee166a2923dc5ed3b83e660bd2)), closes [#6325](https://github.com/Sage/carbon/issues/6325)
+- **menu-fullscreen:** ensure that custom padding is applied to submenu items inside menu fullscreen ([d80f902](https://github.com/Sage/carbon/commit/d80f902e07f277ee166a2923dc5ed3b83e660bd2)), closes [#6325](https://github.com/Sage/carbon/issues/6325)
 
 ## [125.0.0](https://github.com/Sage/carbon/compare/v124.6.1...v125.0.0) (2024-01-11)
 
-
 ### ⚠ BREAKING CHANGES
 
-* The `pl-pl` translation files have been moved to an internal directory
-* **card:** Removes `action` and `interactive` props. Renames `cardWidth` prop to `width`.
-* **card:** `dataRole` has been deprecated use `data-role` instead
-* **card, card-row, card-footer:** The `spacing` prop is no longer surfaced on `CardRowProps` and `CardFooterProps`
-interfaces
+- The `pl-pl` translation files have been moved to an internal directory
+- **card:** Removes `action` and `interactive` props. Renames `cardWidth` prop to `width`.
+- **card:** `dataRole` has been deprecated use `data-role` instead
+- **card, card-row, card-footer:** The `spacing` prop is no longer surfaced on `CardRowProps` and `CardFooterProps`
+  interfaces
 
 ### Features
 
-* **card, card-row, card-footer:** replace cloning and mapping of children with context ([18cdb4b](https://github.com/Sage/carbon/commit/18cdb4bbbf11c4cb0e2b66704cca9fb8a4ea9a6c))
-* **card:** ensure card action can be triggered by correct key presses when it is a button or link ([c81092d](https://github.com/Sage/carbon/commit/c81092d483d37b27daf8704d04dd961fa49cd310)), closes [#4800](https://github.com/Sage/carbon/issues/4800)
-* move Polish translation files into an internal directory ([416e94c](https://github.com/Sage/carbon/commit/416e94c316d8631a7906298b77958ddf7d0fb23d))
-
+- **card, card-row, card-footer:** replace cloning and mapping of children with context ([18cdb4b](https://github.com/Sage/carbon/commit/18cdb4bbbf11c4cb0e2b66704cca9fb8a4ea9a6c))
+- **card:** ensure card action can be triggered by correct key presses when it is a button or link ([c81092d](https://github.com/Sage/carbon/commit/c81092d483d37b27daf8704d04dd961fa49cd310)), closes [#4800](https://github.com/Sage/carbon/issues/4800)
+- move Polish translation files into an internal directory ([416e94c](https://github.com/Sage/carbon/commit/416e94c316d8631a7906298b77958ddf7d0fb23d))
 
 ### Miscellaneous Chores
 
-* **card:** deprecate old dataRole prop ([5328423](https://github.com/Sage/carbon/commit/53284236f06153da26f15973f345ce4c1bfd2d1c))
+- **card:** deprecate old dataRole prop ([5328423](https://github.com/Sage/carbon/commit/53284236f06153da26f15973f345ce4c1bfd2d1c))
 
 ### [124.6.1](https://github.com/Sage/carbon/compare/v124.6.0...v124.6.1) (2024-01-11)
 
-
 ### Bug Fixes
 
-* **select:** stop list scrolling to selected option unless it has changed ([93de140](https://github.com/Sage/carbon/commit/93de140349cd85fe80a7db49595d9bbf17536e17)), closes [#6461](https://github.com/Sage/carbon/issues/6461)
+- **select:** stop list scrolling to selected option unless it has changed ([93de140](https://github.com/Sage/carbon/commit/93de140349cd85fe80a7db49595d9bbf17536e17)), closes [#6461](https://github.com/Sage/carbon/issues/6461)
 
 ## [124.6.0](https://github.com/Sage/carbon/compare/v124.5.0...v124.6.0) (2024-01-05)
 
-
 ### Features
 
-* **progress-tracker:** add inline label and label width prop ([5742c81](https://github.com/Sage/carbon/commit/5742c8199cbabe91fc4f561aba232d46dad3a4b1))
+- **progress-tracker:** add inline label and label width prop ([5742c81](https://github.com/Sage/carbon/commit/5742c8199cbabe91fc4f561aba232d46dad3a4b1))
 
 ## [124.5.0](https://github.com/Sage/carbon/compare/v124.4.1...v124.5.0) (2024-01-04)
 
-
 ### Features
 
-* **numeral-date:** add date format and update to align with DS ([a292c86](https://github.com/Sage/carbon/commit/a292c86cc0eda7b363e545965b7fdc39b5ddfd1c))
+- **numeral-date:** add date format and update to align with DS ([a292c86](https://github.com/Sage/carbon/commit/a292c86cc0eda7b363e545965b7fdc39b5ddfd1c))
 
 ### [124.4.1](https://github.com/Sage/carbon/compare/v124.4.0...v124.4.1) (2023-12-19)
 
-
 ### Bug Fixes
 
-* **filterable-select, multi-select:** no error when input has non-matched filter and arrow key press ([2a4c9ef](https://github.com/Sage/carbon/commit/2a4c9efb9a297202491bfd6ac901fd358c0f7c16)), closes [#6459](https://github.com/Sage/carbon/issues/6459)
-* **filterable-select, simple-select:** ensure onListScrollBottom is not called when option selected ([00158dc](https://github.com/Sage/carbon/commit/00158dccbbf7fe4baef22f9a3a40d5b25d368814)), closes [#6285](https://github.com/Sage/carbon/issues/6285)
+- **filterable-select, multi-select:** no error when input has non-matched filter and arrow key press ([2a4c9ef](https://github.com/Sage/carbon/commit/2a4c9efb9a297202491bfd6ac901fd358c0f7c16)), closes [#6459](https://github.com/Sage/carbon/issues/6459)
+- **filterable-select, simple-select:** ensure onListScrollBottom is not called when option selected ([00158dc](https://github.com/Sage/carbon/commit/00158dccbbf7fe4baef22f9a3a40d5b25d368814)), closes [#6285](https://github.com/Sage/carbon/issues/6285)
 
 ## [124.4.0](https://github.com/Sage/carbon/compare/v124.3.1...v124.4.0) (2023-12-19)
 
-
 ### Features
 
-* responsive tile ([79f2476](https://github.com/Sage/carbon/commit/79f247632ad15d482ef72f0cfe3ce306c9f2dc8e))
+- responsive tile ([79f2476](https://github.com/Sage/carbon/commit/79f247632ad15d482ef72f0cfe3ce306c9f2dc8e))
 
 ### [124.3.1](https://github.com/Sage/carbon/compare/v124.3.0...v124.3.1) (2023-12-15)
 
-
 ### Bug Fixes
 
-* **select:** auto-scroll to top when reopening, to fix Safari ([3735c6c](https://github.com/Sage/carbon/commit/3735c6cf6ce40a8f81fe4c69a41b4957fb0b69d0))
-* **select:** ensure re-opening the select resets scroll position to the top ([0ce2847](https://github.com/Sage/carbon/commit/0ce2847c42bfe79ba34192725af77d8ed6a31c6b)), closes [#6399](https://github.com/Sage/carbon/issues/6399)
+- **select:** auto-scroll to top when reopening, to fix Safari ([3735c6c](https://github.com/Sage/carbon/commit/3735c6cf6ce40a8f81fe4c69a41b4957fb0b69d0))
+- **select:** ensure re-opening the select resets scroll position to the top ([0ce2847](https://github.com/Sage/carbon/commit/0ce2847c42bfe79ba34192725af77d8ed6a31c6b)), closes [#6399](https://github.com/Sage/carbon/issues/6399)
 
 ## [124.3.0](https://github.com/Sage/carbon/compare/v124.2.2...v124.3.0) (2023-12-13)
 
-
 ### Features
 
-* add new file-input component ([947eaa1](https://github.com/Sage/carbon/commit/947eaa1d8276dfcbf6ffc70e61d0f92e741d51e0))
-* ensure text of long file name does not overflow container ([8cdabc9](https://github.com/Sage/carbon/commit/8cdabc93daab76f34964e080309a275ad2bc97c6))
-* **file-input:** make upload status message into aria-live region ([adb1e83](https://github.com/Sage/carbon/commit/adb1e83dab5da19ed26d20ee6783e4a7ad285d7b))
-
+- add new file-input component ([947eaa1](https://github.com/Sage/carbon/commit/947eaa1d8276dfcbf6ffc70e61d0f92e741d51e0))
+- ensure text of long file name does not overflow container ([8cdabc9](https://github.com/Sage/carbon/commit/8cdabc93daab76f34964e080309a275ad2bc97c6))
+- **file-input:** make upload status message into aria-live region ([adb1e83](https://github.com/Sage/carbon/commit/adb1e83dab5da19ed26d20ee6783e4a7ad285d7b))
 
 ### Bug Fixes
 
-* correct default min-width and fix docs ([f5172ca](https://github.com/Sage/carbon/commit/f5172cac47af36382ff120eea38e158b0fd12907))
-* css syntax for text opacity ([6339e5e](https://github.com/Sage/carbon/commit/6339e5e2a09c0b952aa02fe129d4652357daf811))
-* **file-input:** fix outer background color of loaderbar ([fc0c807](https://github.com/Sage/carbon/commit/fc0c807af71f241da2c1983ce36850b5223ff2be))
-* link focus styling ([5a75d03](https://github.com/Sage/carbon/commit/5a75d0339b04d21c9a0052a75c16ff5dd8369e8e))
+- correct default min-width and fix docs ([f5172ca](https://github.com/Sage/carbon/commit/f5172cac47af36382ff120eea38e158b0fd12907))
+- css syntax for text opacity ([6339e5e](https://github.com/Sage/carbon/commit/6339e5e2a09c0b952aa02fe129d4652357daf811))
+- **file-input:** fix outer background color of loaderbar ([fc0c807](https://github.com/Sage/carbon/commit/fc0c807af71f241da2c1983ce36850b5223ff2be))
+- link focus styling ([5a75d03](https://github.com/Sage/carbon/commit/5a75d0339b04d21c9a0052a75c16ff5dd8369e8e))
 
 ### [124.2.2](https://github.com/Sage/carbon/compare/v124.2.1...v124.2.2) (2023-12-11)
 
-
 ### Bug Fixes
 
-* **filterable-select:** ensure list does not reopen when user clicks option and openOnFocus prop set ([e143aaa](https://github.com/Sage/carbon/commit/e143aaad13c821a9ee6bfb9ce1a64494c81ce23b)), closes [#6462](https://github.com/Sage/carbon/issues/6462)
+- **filterable-select:** ensure list does not reopen when user clicks option and openOnFocus prop set ([e143aaa](https://github.com/Sage/carbon/commit/e143aaad13c821a9ee6bfb9ce1a64494c81ce23b)), closes [#6462](https://github.com/Sage/carbon/issues/6462)
 
 ### [124.2.1](https://github.com/Sage/carbon/compare/v124.2.0...v124.2.1) (2023-12-08)
 
-
 ### Bug Fixes
 
-* **textbox:** ensure no action is triggered when disabled or readOnly input or input icon is clicked ([0f028f9](https://github.com/Sage/carbon/commit/0f028f9a9e3e8268e978c9ccb1b94e7db84bcc9c)), closes [#6471](https://github.com/Sage/carbon/issues/6471)
+- **textbox:** ensure no action is triggered when disabled or readOnly input or input icon is clicked ([0f028f9](https://github.com/Sage/carbon/commit/0f028f9a9e3e8268e978c9ccb1b94e7db84bcc9c)), closes [#6471](https://github.com/Sage/carbon/issues/6471)
 
 ## [124.2.0](https://github.com/Sage/carbon/compare/v124.1.0...v124.2.0) (2023-12-06)
 
-
 ### Features
 
-* **button-toggle:** add minor child ([864f005](https://github.com/Sage/carbon/commit/864f005fd608514390a5cfb2d89f2714826b0b53))
+- **button-toggle:** add minor child ([864f005](https://github.com/Sage/carbon/commit/864f005fd608514390a5cfb2d89f2714826b0b53))
 
 ## [124.1.0](https://github.com/Sage/carbon/compare/v124.0.0...v124.1.0) (2023-12-04)
 
-
 ### Features
 
-* **dialog:** add greyBackground prop ([416b0cf](https://github.com/Sage/carbon/commit/416b0cf5bdc475ac3f1d5a0e48143b865c0a712e)), closes [#6257](https://github.com/Sage/carbon/issues/6257)
+- **dialog:** add greyBackground prop ([416b0cf](https://github.com/Sage/carbon/commit/416b0cf5bdc475ac3f1d5a0e48143b865c0a712e)), closes [#6257](https://github.com/Sage/carbon/issues/6257)
 
 ## [124.0.0](https://github.com/Sage/carbon/compare/v123.11.2...v124.0.0) (2023-12-01)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **show-edit-pod:** `ShowEditPod` no longer exists
-* **menu-segment-title:** You will need to pass any associated list items as children of the
-`MenuSegmentTitle` so they are rendered in a sublist with the segment heading
+- **show-edit-pod:** `ShowEditPod` no longer exists
+- **menu-segment-title:** You will need to pass any associated list items as children of the
+  `MenuSegmentTitle` so they are rendered in a sublist with the segment heading
 
 ### Bug Fixes
 
-* **menu-item:** ensure that icons rendered in menu item have display inline-block ([a937011](https://github.com/Sage/carbon/commit/a93701171e9f2931ddba25eee09d3681557fa7fc))
-* **menu-segment-title:** ensure segment titles are rendered as part of sublist with associated items ([9f4a6ff](https://github.com/Sage/carbon/commit/9f4a6ffd91c9cf6b8a308b11362ebf7671adfd46)), closes [#6010](https://github.com/Sage/carbon/issues/6010)
-
+- **menu-item:** ensure that icons rendered in menu item have display inline-block ([a937011](https://github.com/Sage/carbon/commit/a93701171e9f2931ddba25eee09d3681557fa7fc))
+- **menu-segment-title:** ensure segment titles are rendered as part of sublist with associated items ([9f4a6ff](https://github.com/Sage/carbon/commit/9f4a6ffd91c9cf6b8a308b11362ebf7671adfd46)), closes [#6010](https://github.com/Sage/carbon/issues/6010)
 
 ### Miscellaneous Chores
 
-* **show-edit-pod:** deprecate component ([3183e6c](https://github.com/Sage/carbon/commit/3183e6c2b046b8894e6f190fcb88b2bb1c54b744))
+- **show-edit-pod:** deprecate component ([3183e6c](https://github.com/Sage/carbon/commit/3183e6c2b046b8894e6f190fcb88b2bb1c54b744))
 
 ### [123.11.2](https://github.com/Sage/carbon/compare/v123.11.1...v123.11.2) (2023-11-27)
 
-
 ### Bug Fixes
 
-* **input:** ensure focus styles removed when becoming inert ([40ba27a](https://github.com/Sage/carbon/commit/40ba27a6c5e67d6eb49440e7108541dc2f0c972c)), closes [#6415](https://github.com/Sage/carbon/issues/6415)
+- **input:** ensure focus styles removed when becoming inert ([40ba27a](https://github.com/Sage/carbon/commit/40ba27a6c5e67d6eb49440e7108541dc2f0c972c)), closes [#6415](https://github.com/Sage/carbon/issues/6415)
 
 ### [123.11.1](https://github.com/Sage/carbon/compare/v123.11.0...v123.11.1) (2023-11-23)
 
-
 ### Bug Fixes
 
-* **menu-full-screen:** fix keys in rendering of children ([5c17f15](https://github.com/Sage/carbon/commit/5c17f15757bac9e7fb1134ba84ea75e66de63434))
+- **menu-full-screen:** fix keys in rendering of children ([5c17f15](https://github.com/Sage/carbon/commit/5c17f15757bac9e7fb1134ba84ea75e66de63434))
 
 ## [123.11.0](https://github.com/Sage/carbon/compare/v123.10.3...v123.11.0) (2023-11-23)
 
-
 ### Features
 
-* **badge:** add color prop ([4a5750d](https://github.com/Sage/carbon/commit/4a5750d8eb64486095347836279c56f588c46b9f)), closes [#5839](https://github.com/Sage/carbon/issues/5839)
+- **badge:** add color prop ([4a5750d](https://github.com/Sage/carbon/commit/4a5750d8eb64486095347836279c56f588c46b9f)), closes [#5839](https://github.com/Sage/carbon/issues/5839)
 
 ### [123.10.3](https://github.com/Sage/carbon/compare/v123.10.2...v123.10.3) (2023-11-23)
 
-
 ### Bug Fixes
 
-* **tabs:** error border partially hidden fix ([6aa62e1](https://github.com/Sage/carbon/commit/6aa62e16f3a385fa631052a87d7025c7a725a402)), closes [#6314](https://github.com/Sage/carbon/issues/6314)
+- **tabs:** error border partially hidden fix ([6aa62e1](https://github.com/Sage/carbon/commit/6aa62e16f3a385fa631052a87d7025c7a725a402)), closes [#6314](https://github.com/Sage/carbon/issues/6314)
 
 ### [123.10.2](https://github.com/Sage/carbon/compare/v123.10.1...v123.10.2) (2023-11-23)
 
-
 ### Bug Fixes
 
-* **note:** inlineControl button and note content overlap fix ([f196759](https://github.com/Sage/carbon/commit/f19675955261019ff32f339a08edc9eee31be52a)), closes [#6228](https://github.com/Sage/carbon/issues/6228)
+- **note:** inlineControl button and note content overlap fix ([f196759](https://github.com/Sage/carbon/commit/f19675955261019ff32f339a08edc9eee31be52a)), closes [#6228](https://github.com/Sage/carbon/issues/6228)
 
 ### [123.10.1](https://github.com/Sage/carbon/compare/v123.10.0...v123.10.1) (2023-11-23)
 
-
 ### Bug Fixes
 
-* ensure any auto-focused element is focused first when a child of a focus trapped component ([f34eca4](https://github.com/Sage/carbon/commit/f34eca46693e487d20c77dd1892dfaad5a830742)), closes [#6384](https://github.com/Sage/carbon/issues/6384)
+- ensure any auto-focused element is focused first when a child of a focus trapped component ([f34eca4](https://github.com/Sage/carbon/commit/f34eca46693e487d20c77dd1892dfaad5a830742)), closes [#6384](https://github.com/Sage/carbon/issues/6384)
 
 ## [123.10.0](https://github.com/Sage/carbon/compare/v123.9.1...v123.10.0) (2023-11-22)
 
-
 ### Features
 
-* add support for manually overriding stacking order of modals ([9d4252a](https://github.com/Sage/carbon/commit/9d4252a4ad69274be2eff6bc11d5f0f240ec6ffc)), closes [#6402](https://github.com/Sage/carbon/issues/6402) [#6410](https://github.com/Sage/carbon/issues/6410)
+- add support for manually overriding stacking order of modals ([9d4252a](https://github.com/Sage/carbon/commit/9d4252a4ad69274be2eff6bc11d5f0f240ec6ffc)), closes [#6402](https://github.com/Sage/carbon/issues/6402) [#6410](https://github.com/Sage/carbon/issues/6410)
 
 ### [123.9.1](https://github.com/Sage/carbon/compare/v123.9.0...v123.9.1) (2023-11-16)
 
-
 ### Bug Fixes
 
-* **crumb:** ensure LinkProps are correctly extended so component has the correct interface ([0889433](https://github.com/Sage/carbon/commit/0889433994205f7aa2403b297ea46f2850f3558b)), closes [#6133](https://github.com/Sage/carbon/issues/6133)
+- **crumb:** ensure LinkProps are correctly extended so component has the correct interface ([0889433](https://github.com/Sage/carbon/commit/0889433994205f7aa2403b297ea46f2850f3558b)), closes [#6133](https://github.com/Sage/carbon/issues/6133)
 
 ## [123.9.0](https://github.com/Sage/carbon/compare/v123.8.0...v123.9.0) (2023-11-15)
 
-
 ### Features
 
-* **portrait, profile:** align with design system and reduce code complexity ([c37c6c1](https://github.com/Sage/carbon/commit/c37c6c1e9cec1308a36b2daced831df0a5d77a46)), closes [#6191](https://github.com/Sage/carbon/issues/6191)
+- **portrait, profile:** align with design system and reduce code complexity ([c37c6c1](https://github.com/Sage/carbon/commit/c37c6c1e9cec1308a36b2daced831df0a5d77a46)), closes [#6191](https://github.com/Sage/carbon/issues/6191)
 
 ## [123.8.0](https://github.com/Sage/carbon/compare/v123.7.2...v123.8.0) (2023-11-15)
 
-
 ### Features
 
-* **split-button:** add aria-label prop and locale support for aria-label ([aedafe8](https://github.com/Sage/carbon/commit/aedafe83ec461406631b590f092d0a4d3f19cfb3))
-
+- **split-button:** add aria-label prop and locale support for aria-label ([aedafe8](https://github.com/Sage/carbon/commit/aedafe83ec461406631b590f092d0a4d3f19cfb3))
 
 ### Bug Fixes
 
-* **multi-action-button:** remove unnecessary aria-label ([942f43a](https://github.com/Sage/carbon/commit/942f43a09487bb57d264c397588cc6e219aececb)), closes [#6397](https://github.com/Sage/carbon/issues/6397)
+- **multi-action-button:** remove unnecessary aria-label ([942f43a](https://github.com/Sage/carbon/commit/942f43a09487bb57d264c397588cc6e219aececb)), closes [#6397](https://github.com/Sage/carbon/issues/6397)
 
 ### [123.7.2](https://github.com/Sage/carbon/compare/v123.7.1...v123.7.2) (2023-11-10)
 
-
 ### Bug Fixes
 
-* **switch:** fix alignment issue with component when no new validation is applied ([af416ac](https://github.com/Sage/carbon/commit/af416acecb365988d2be2ebf5c8688ccf8d60faa)), closes [#6303](https://github.com/Sage/carbon/issues/6303)
+- **switch:** fix alignment issue with component when no new validation is applied ([af416ac](https://github.com/Sage/carbon/commit/af416acecb365988d2be2ebf5c8688ccf8d60faa)), closes [#6303](https://github.com/Sage/carbon/issues/6303)
 
 ### [123.7.1](https://github.com/Sage/carbon/compare/v123.7.0...v123.7.1) (2023-11-09)
 
-
 ### Bug Fixes
 
-* **popover-container:** ensure that component is closed when Esc key is pressed ([4c33cd3](https://github.com/Sage/carbon/commit/4c33cd3ee4ff002d6e706e90d7233828c5088107)), closes [#6195](https://github.com/Sage/carbon/issues/6195)
+- **popover-container:** ensure that component is closed when Esc key is pressed ([4c33cd3](https://github.com/Sage/carbon/commit/4c33cd3ee4ff002d6e706e90d7233828c5088107)), closes [#6195](https://github.com/Sage/carbon/issues/6195)
 
 ## [123.7.0](https://github.com/Sage/carbon/compare/v123.6.0...v123.7.0) (2023-11-08)
 
-
 ### Features
 
-* **select:** add selectionConfirmed property to event emitted on change ([748a17b](https://github.com/Sage/carbon/commit/748a17b8185a2d9a2bd58843efbd4a10739c2e8d)), closes [#6330](https://github.com/Sage/carbon/issues/6330)
-
+- **select:** add selectionConfirmed property to event emitted on change ([748a17b](https://github.com/Sage/carbon/commit/748a17b8185a2d9a2bd58843efbd4a10739c2e8d)), closes [#6330](https://github.com/Sage/carbon/issues/6330)
 
 ### Bug Fixes
 
-* **filterable-select, multi-select:** handle when filter text has no match and enter pressed ([84ebef7](https://github.com/Sage/carbon/commit/84ebef7df4573d3205db9ebd424d88c2a26f4c3e))
-* **option:** ensure fill prop is not passed to underlying DOM element ([2a8cfc1](https://github.com/Sage/carbon/commit/2a8cfc11bae33c52496a65741ad02a339989beff))
+- **filterable-select, multi-select:** handle when filter text has no match and enter pressed ([84ebef7](https://github.com/Sage/carbon/commit/84ebef7df4573d3205db9ebd424d88c2a26f4c3e))
+- **option:** ensure fill prop is not passed to underlying DOM element ([2a8cfc1](https://github.com/Sage/carbon/commit/2a8cfc11bae33c52496a65741ad02a339989beff))
 
 ## [123.6.0](https://github.com/Sage/carbon/compare/v123.5.1...v123.6.0) (2023-11-08)
 
-
 ### Features
 
-* **toast:** add alignY prop to allow vertical alignment to be configurable ([64203e1](https://github.com/Sage/carbon/commit/64203e1a618294c9c8c71964963377ae2891e134)), closes [#6301](https://github.com/Sage/carbon/issues/6301)
+- **toast:** add alignY prop to allow vertical alignment to be configurable ([64203e1](https://github.com/Sage/carbon/commit/64203e1a618294c9c8c71964963377ae2891e134)), closes [#6301](https://github.com/Sage/carbon/issues/6301)
 
 ### [123.5.1](https://github.com/Sage/carbon/compare/v123.5.0...v123.5.1) (2023-11-08)
 
-
 ### Bug Fixes
 
-* **multi-action-button, split-button:** fix aria role ([c16a1e4](https://github.com/Sage/carbon/commit/c16a1e4357518a122681675875999d61408a60b8)), closes [#6383](https://github.com/Sage/carbon/issues/6383)
+- **multi-action-button, split-button:** fix aria role ([c16a1e4](https://github.com/Sage/carbon/commit/c16a1e4357518a122681675875999d61408a60b8)), closes [#6383](https://github.com/Sage/carbon/issues/6383)
 
 ## [123.5.0](https://github.com/Sage/carbon/compare/v123.4.4...v123.5.0) (2023-11-07)
 
-
 ### Features
 
-* **icon:** 4 icons added to the icon font ([33f979a](https://github.com/Sage/carbon/commit/33f979ad1690fba0229a73e5999744168814378b))
+- **icon:** 4 icons added to the icon font ([33f979a](https://github.com/Sage/carbon/commit/33f979ad1690fba0229a73e5999744168814378b))
 
 ### [123.4.4](https://github.com/Sage/carbon/compare/v123.4.3...v123.4.4) (2023-11-06)
 
-
 ### Bug Fixes
 
-* **textarea, textbox:** display icon when component is disabled or readOnly ([6afe2d4](https://github.com/Sage/carbon/commit/6afe2d4ec5e4063f52fde0355e301aab8d0fdefb))
+- **textarea, textbox:** display icon when component is disabled or readOnly ([6afe2d4](https://github.com/Sage/carbon/commit/6afe2d4ec5e4063f52fde0355e301aab8d0fdefb))
 
 ### [123.4.3](https://github.com/Sage/carbon/compare/v123.4.2...v123.4.3) (2023-11-06)
 
-
 ### Bug Fixes
 
-* **button:** correct the width and height of icons inside buttons ([0ea3b36](https://github.com/Sage/carbon/commit/0ea3b367b56f5a5a548b65a2c89a3eb224b29010))
+- **button:** correct the width and height of icons inside buttons ([0ea3b36](https://github.com/Sage/carbon/commit/0ea3b367b56f5a5a548b65a2c89a3eb224b29010))
 
 ### [123.4.2](https://github.com/Sage/carbon/compare/v123.4.1...v123.4.2) (2023-11-03)
 
-
 ### Bug Fixes
 
-* **badge:** change the position and size of counter ([d247e71](https://github.com/Sage/carbon/commit/d247e71617e61865df510d1349e64838444255e0))
+- **badge:** change the position and size of counter ([d247e71](https://github.com/Sage/carbon/commit/d247e71617e61865df510d1349e64838444255e0))
 
 ### [123.4.1](https://github.com/Sage/carbon/compare/v123.4.0...v123.4.1) (2023-11-03)
 
-
 ### Bug Fixes
 
-* **loader-bar:** loaderBar height fix ([233782e](https://github.com/Sage/carbon/commit/233782ef1a7290e4582ac44a20fa425584570723)), closes [#5999](https://github.com/Sage/carbon/issues/5999)
+- **loader-bar:** loaderBar height fix ([233782e](https://github.com/Sage/carbon/commit/233782ef1a7290e4582ac44a20fa425584570723)), closes [#5999](https://github.com/Sage/carbon/issues/5999)
 
 ## [123.4.0](https://github.com/Sage/carbon/compare/v123.3.0...v123.4.0) (2023-11-02)
 
-
 ### Features
 
-* **date:** add support for keyboard navigation in picker ([11d1853](https://github.com/Sage/carbon/commit/11d185306a6cf30e67e1efcf31c7985366594b78)), closes [#6324](https://github.com/Sage/carbon/issues/6324) [#3969](https://github.com/Sage/carbon/issues/3969)
-
+- **date:** add support for keyboard navigation in picker ([11d1853](https://github.com/Sage/carbon/commit/11d185306a6cf30e67e1efcf31c7985366594b78)), closes [#6324](https://github.com/Sage/carbon/issues/6324) [#3969](https://github.com/Sage/carbon/issues/3969)
 
 ### Bug Fixes
 
-* **date:** add aria labels to picker navigation buttons and fix other accessibility issues ([b5eb150](https://github.com/Sage/carbon/commit/b5eb150bcc5760f548db60610f70c5ccd6a7db18)), closes [#5804](https://github.com/Sage/carbon/issues/5804)
+- **date:** add aria labels to picker navigation buttons and fix other accessibility issues ([b5eb150](https://github.com/Sage/carbon/commit/b5eb150bcc5760f548db60610f70c5ccd6a7db18)), closes [#5804](https://github.com/Sage/carbon/issues/5804)
 
 ## [123.3.0](https://github.com/Sage/carbon/compare/v123.2.2...v123.3.0) (2023-11-02)
 
-
 ### Features
 
-* **message:** remove role of status from component ([f09ef5e](https://github.com/Sage/carbon/commit/f09ef5ecf76ae1551a6e01dac1c45be56583df2b)), closes [#6013](https://github.com/Sage/carbon/issues/6013)
+- **message:** remove role of status from component ([f09ef5e](https://github.com/Sage/carbon/commit/f09ef5ecf76ae1551a6e01dac1c45be56583df2b)), closes [#6013](https://github.com/Sage/carbon/issues/6013)
 
 ### [123.2.2](https://github.com/Sage/carbon/compare/v123.2.1...v123.2.2) (2023-11-02)
 
-
 ### Bug Fixes
 
-* **action-popover:** fix issue with stories not rendering in storybook ([437ee03](https://github.com/Sage/carbon/commit/437ee03386d82c9d32799efce05ea009cc7feb6f))
+- **action-popover:** fix issue with stories not rendering in storybook ([437ee03](https://github.com/Sage/carbon/commit/437ee03386d82c9d32799efce05ea009cc7feb6f))
 
 ### [123.2.1](https://github.com/Sage/carbon/compare/v123.2.0...v123.2.1) (2023-11-01)
 
-
 ### Bug Fixes
 
-* **navigation-bar:** stop ResizeObserver errors being thrown on render ([d80db16](https://github.com/Sage/carbon/commit/d80db16272daf24579c0619ec68bb119e19bcd78)), closes [#6259](https://github.com/Sage/carbon/issues/6259)
+- **navigation-bar:** stop ResizeObserver errors being thrown on render ([d80db16](https://github.com/Sage/carbon/commit/d80db16272daf24579c0619ec68bb119e19bcd78)), closes [#6259](https://github.com/Sage/carbon/issues/6259)
 
 ## [123.2.0](https://github.com/Sage/carbon/compare/v123.1.0...v123.2.0) (2023-10-30)
 
-
 ### Features
 
-* **confirm:** make data tag props available on cancel and confirm buttons ([2c69101](https://github.com/Sage/carbon/commit/2c691011688c5186a7d20f8af7e6acd768e5a0e8)), closes [#6374](https://github.com/Sage/carbon/issues/6374)
+- **confirm:** make data tag props available on cancel and confirm buttons ([2c69101](https://github.com/Sage/carbon/commit/2c691011688c5186a7d20f8af7e6acd768e5a0e8)), closes [#6374](https://github.com/Sage/carbon/issues/6374)
 
 ## [123.1.0](https://github.com/Sage/carbon/compare/v123.0.1...v123.1.0) (2023-10-27)
 
-
 ### Features
 
-* **action-popover:** disabled items can no longer be focused ([208148b](https://github.com/Sage/carbon/commit/208148b2d5009db64fa3ce4d8ad86250c860c523))
+- **action-popover:** disabled items can no longer be focused ([208148b](https://github.com/Sage/carbon/commit/208148b2d5009db64fa3ce4d8ad86250c860c523))
 
 ### [123.0.1](https://github.com/Sage/carbon/compare/v123.0.0...v123.0.1) (2023-10-27)
 
-
 ### Bug Fixes
 
-* **textarea, textbox:** ensure inputHint and labelHelp props do not render two seperate DOM elements ([607c649](https://github.com/Sage/carbon/commit/607c64906dce77ee763425abdc2f9463947f8de0))
+- **textarea, textbox:** ensure inputHint and labelHelp props do not render two seperate DOM elements ([607c649](https://github.com/Sage/carbon/commit/607c64906dce77ee763425abdc2f9463947f8de0))
 
 ## [123.0.0](https://github.com/Sage/carbon/compare/v122.0.1...v123.0.0) (2023-10-24)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **tile:** You will need to wrap children in `TileContent` to achieve the
-layouts of the
-previous component where they receive padding relative to that of the `Tile`
-parent's.
+- **tile:** You will need to wrap children in `TileContent` to achieve the
+  layouts of the
+  previous component where they receive padding relative to that of the `Tile`
+  parent's.
 
 ### Features
 
-* **tile:** refactor component to support more flexible composition of children ([f5742c0](https://github.com/Sage/carbon/commit/f5742c0529ccf90f0d51cc811719540caa1fc07b)), closes [#5760](https://github.com/Sage/carbon/issues/5760)
+- **tile:** refactor component to support more flexible composition of children ([f5742c0](https://github.com/Sage/carbon/commit/f5742c0529ccf90f0d51cc811719540caa1fc07b)), closes [#5760](https://github.com/Sage/carbon/issues/5760)
 
 ### [122.0.1](https://github.com/Sage/carbon/compare/v122.0.0...v122.0.1) (2023-10-24)
 
-
 ### Bug Fixes
 
-* **link:** ensure Icon in component has inline display property to respect dimensions of the parent ([be0a33c](https://github.com/Sage/carbon/commit/be0a33c07b18cc36633ad65369915f2256e54ae2)), closes [#6295](https://github.com/Sage/carbon/issues/6295)
+- **link:** ensure Icon in component has inline display property to respect dimensions of the parent ([be0a33c](https://github.com/Sage/carbon/commit/be0a33c07b18cc36633ad65369915f2256e54ae2)), closes [#6295](https://github.com/Sage/carbon/issues/6295)
 
 ## [122.0.0](https://github.com/Sage/carbon/compare/v121.2.0...v122.0.0) (2023-10-23)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **pod:** The onEdit prop is now restricted to being an event handler function - the options
-for it to be a string or an object have been removed.
+- **pod:** The onEdit prop is now restricted to being an event handler function - the options
+  for it to be a string or an object have been removed.
 
 ### Bug Fixes
 
-* **pod:** make edit button an HTML button rather than an anchor tag ([98d8bde](https://github.com/Sage/carbon/commit/98d8bde579b6a14a081e87d4e7b38501335370bb))
+- **pod:** make edit button an HTML button rather than an anchor tag ([98d8bde](https://github.com/Sage/carbon/commit/98d8bde579b6a14a081e87d4e7b38501335370bb))
 
 ## [121.2.0](https://github.com/Sage/carbon/compare/v121.1.0...v121.2.0) (2023-10-17)
 
-
 ### Features
 
-* **typography:** add support for span as a support variant ([e181c44](https://github.com/Sage/carbon/commit/e181c4452f0d315968abe40c124ea66d0014240a))
-* **typography:** add text-align prop ([553d854](https://github.com/Sage/carbon/commit/553d854b46ca06314de07bbf2eb9b5da6ca1dd1d))
+- **typography:** add support for span as a support variant ([e181c44](https://github.com/Sage/carbon/commit/e181c4452f0d315968abe40c124ea66d0014240a))
+- **typography:** add text-align prop ([553d854](https://github.com/Sage/carbon/commit/553d854b46ca06314de07bbf2eb9b5da6ca1dd1d))
 
 ## [121.1.0](https://github.com/Sage/carbon/compare/v121.0.2...v121.1.0) (2023-10-17)
 
-
 ### Features
 
-* **character-count:** increase font size to 14px and update styles to use relevant tokens ([3e690ad](https://github.com/Sage/carbon/commit/3e690ada80d5a59ba2192b194409c77c8022d490))
-* **text-editor:** add support for new validation designs ([91bb986](https://github.com/Sage/carbon/commit/91bb986f0714a6e1267ab558469578ee2b210554))
+- **character-count:** increase font size to 14px and update styles to use relevant tokens ([3e690ad](https://github.com/Sage/carbon/commit/3e690ada80d5a59ba2192b194409c77c8022d490))
+- **text-editor:** add support for new validation designs ([91bb986](https://github.com/Sage/carbon/commit/91bb986f0714a6e1267ab558469578ee2b210554))
 
 ### [121.0.2](https://github.com/Sage/carbon/compare/v121.0.1...v121.0.2) (2023-10-12)
 
-
 ### Bug Fixes
 
-* **pager:** make top corners rounded ([7ea657a](https://github.com/Sage/carbon/commit/7ea657a283ff08ceb9801dfe5c45692f1ceee450))
+- **pager:** make top corners rounded ([7ea657a](https://github.com/Sage/carbon/commit/7ea657a283ff08ceb9801dfe5c45692f1ceee450))
 
 ### [121.0.1](https://github.com/Sage/carbon/compare/v121.0.0...v121.0.1) (2023-10-11)
 
-
 ### Bug Fixes
 
-* **link:** refactor styles to remove focus-within due to issues with JSDOM ([b9065af](https://github.com/Sage/carbon/commit/b9065afb342d359949910212b2ed33d09a5c866e)), closes [#6320](https://github.com/Sage/carbon/issues/6320)
+- **link:** refactor styles to remove focus-within due to issues with JSDOM ([b9065af](https://github.com/Sage/carbon/commit/b9065afb342d359949910212b2ed33d09a5c866e)), closes [#6320](https://github.com/Sage/carbon/issues/6320)
 
 ## [121.0.0](https://github.com/Sage/carbon/compare/v120.6.1...v121.0.0) (2023-10-06)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **textarea, textbox:** The `enforceCharacterLimit` prop has been completely removed and is no longer
-supported. We recommend providing adequate feedback to users when they have exceeded the set
-`characterLimit` instead
-* **locale:** As the `hintString` translation key is public facing, its removal will mean a
-type / compile error may be thrown in consumers TypeScript projects
+- **textarea, textbox:** The `enforceCharacterLimit` prop has been completely removed and is no longer
+  supported. We recommend providing adequate feedback to users when they have exceeded the set
+  `characterLimit` instead
+- **locale:** As the `hintString` translation key is public facing, its removal will mean a
+  type / compile error may be thrown in consumers TypeScript projects
 
 ### Bug Fixes
 
-* **locale:** remove `hintString` translation key ([b0042c4](https://github.com/Sage/carbon/commit/b0042c4e4589f76fc03476de24d00a3e7e26a36d))
-* **textarea, textbox:** improve character count accessibility and align with design system ([0e59173](https://github.com/Sage/carbon/commit/0e59173ab3c50426337f53919fd9888a01a8c632))
-* **textarea, textbox:** remove `enforceCharacterLimit` from textbox based inputs and textarea ([55d5dbf](https://github.com/Sage/carbon/commit/55d5dbf2f9c30faeddf837fe17dc26a0a4d6b4bf))
+- **locale:** remove `hintString` translation key ([b0042c4](https://github.com/Sage/carbon/commit/b0042c4e4589f76fc03476de24d00a3e7e26a36d))
+- **textarea, textbox:** improve character count accessibility and align with design system ([0e59173](https://github.com/Sage/carbon/commit/0e59173ab3c50426337f53919fd9888a01a8c632))
+- **textarea, textbox:** remove `enforceCharacterLimit` from textbox based inputs and textarea ([55d5dbf](https://github.com/Sage/carbon/commit/55d5dbf2f9c30faeddf837fe17dc26a0a4d6b4bf))
 
 ### [120.6.1](https://github.com/Sage/carbon/compare/v120.6.0...v120.6.1) (2023-10-05)
 
-
 ### Bug Fixes
 
-* **multi-action-button:** update styling to ensure corrext spacing when child buttons have icons ([a6b382a](https://github.com/Sage/carbon/commit/a6b382abd2e6ffaca0a54ab920da581f57fb763b)), closes [#6214](https://github.com/Sage/carbon/issues/6214)
+- **multi-action-button:** update styling to ensure corrext spacing when child buttons have icons ([a6b382a](https://github.com/Sage/carbon/commit/a6b382abd2e6ffaca0a54ab920da581f57fb763b)), closes [#6214](https://github.com/Sage/carbon/issues/6214)
 
 ## [120.6.0](https://github.com/Sage/carbon/compare/v120.5.0...v120.6.0) (2023-10-04)
 
-
 ### Features
 
-* **dialog:** expose focus method of root dom node via a ref handle ([4811e82](https://github.com/Sage/carbon/commit/4811e82205ae24f2efcb199640d1e0f129eee694)), closes [#6250](https://github.com/Sage/carbon/issues/6250)
+- **dialog:** expose focus method of root dom node via a ref handle ([4811e82](https://github.com/Sage/carbon/commit/4811e82205ae24f2efcb199640d1e0f129eee694)), closes [#6250](https://github.com/Sage/carbon/issues/6250)
 
 ## [120.5.0](https://github.com/Sage/carbon/compare/v120.4.0...v120.5.0) (2023-10-02)
 
-
 ### Features
 
-* **tile:** add support for passing custom height to component ([123630b](https://github.com/Sage/carbon/commit/123630b62c53b264606298a28f99a65cd136a39a)), closes [#6240](https://github.com/Sage/carbon/issues/6240)
+- **tile:** add support for passing custom height to component ([123630b](https://github.com/Sage/carbon/commit/123630b62c53b264606298a28f99a65cd136a39a)), closes [#6240](https://github.com/Sage/carbon/issues/6240)
 
 ## [120.4.0](https://github.com/Sage/carbon/compare/v120.3.1...v120.4.0) (2023-09-27)
 
-
 ### Features
 
-* **toast, message:** update component to align with Design System ([eb0c29d](https://github.com/Sage/carbon/commit/eb0c29d2003e4638868bf91f91dff41c5c9b8ae9))
+- **toast, message:** update component to align with Design System ([eb0c29d](https://github.com/Sage/carbon/commit/eb0c29d2003e4638868bf91f91dff41c5c9b8ae9))
 
 ### [120.3.1](https://github.com/Sage/carbon/compare/v120.3.0...v120.3.1) (2023-09-22)
 
-
 ### Bug Fixes
 
-* **flat-table:** ensure tabindex is set on clickable elements when table has pager and loading state ([847c7c3](https://github.com/Sage/carbon/commit/847c7c3dd7cd7fb11ebbe26f575c85dfffec5c5e))
+- **flat-table:** ensure tabindex is set on clickable elements when table has pager and loading state ([847c7c3](https://github.com/Sage/carbon/commit/847c7c3dd7cd7fb11ebbe26f575c85dfffec5c5e))
 
 ## [120.3.0](https://github.com/Sage/carbon/compare/v120.2.1...v120.3.0) (2023-09-22)
 
-
 ### Features
 
-* **definition-list:** allow children to be wrapped ([70092e8](https://github.com/Sage/carbon/commit/70092e862cb24334d1384c0ca9d37de610d610a7)), closes [#6216](https://github.com/Sage/carbon/issues/6216) [#6243](https://github.com/Sage/carbon/issues/6243)
+- **definition-list:** allow children to be wrapped ([70092e8](https://github.com/Sage/carbon/commit/70092e862cb24334d1384c0ca9d37de610d610a7)), closes [#6216](https://github.com/Sage/carbon/issues/6216) [#6243](https://github.com/Sage/carbon/issues/6243)
 
 ### [120.2.1](https://github.com/Sage/carbon/compare/v120.2.0...v120.2.1) (2023-09-21)
 
-
 ### Bug Fixes
 
-* **menu-item:** address aria role accessibility error with icon only menu items ([c891d45](https://github.com/Sage/carbon/commit/c891d45aaae69457def7ef9d989ae89e8edf6cb1)), closes [#6175](https://github.com/Sage/carbon/issues/6175)
+- **menu-item:** address aria role accessibility error with icon only menu items ([c891d45](https://github.com/Sage/carbon/commit/c891d45aaae69457def7ef9d989ae89e8edf6cb1)), closes [#6175](https://github.com/Sage/carbon/issues/6175)
 
 ## [120.2.0](https://github.com/Sage/carbon/compare/v120.1.0...v120.2.0) (2023-09-08)
 
-
 ### Features
 
-* **typography:** add a prop to support text that is for screen readers only ([17c8e24](https://github.com/Sage/carbon/commit/17c8e2486f96dc74d734d76d27467c1e16d9d944))
+- **typography:** add a prop to support text that is for screen readers only ([17c8e24](https://github.com/Sage/carbon/commit/17c8e2486f96dc74d734d76d27467c1e16d9d944))
 
 ## [120.1.0](https://github.com/Sage/carbon/compare/v120.0.0...v120.1.0) (2023-08-30)
 
-
 ### Features
 
-* **flat-table, flat-table-row:** components can now be wrapped, subRows no longer need to ([ea27a57](https://github.com/Sage/carbon/commit/ea27a57734ed75301a07d855fbd303a4a1686ce0)), closes [#6219](https://github.com/Sage/carbon/issues/6219)
+- **flat-table, flat-table-row:** components can now be wrapped, subRows no longer need to ([ea27a57](https://github.com/Sage/carbon/commit/ea27a57734ed75301a07d855fbd303a4a1686ce0)), closes [#6219](https://github.com/Sage/carbon/issues/6219)
 
 ## [120.0.0](https://github.com/Sage/carbon/compare/v119.12.2...v120.0.0) (2023-08-29)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **typography:** types for the Typography component are now properly listed and therefore
-undocumented props will no longer be supported
-* **box:** types for the Box component are now properly listed and therefore undocumented
-props will no longer be supported
+- **typography:** types for the Typography component are now properly listed and therefore
+  undocumented props will no longer be supported
+- **box:** types for the Box component are now properly listed and therefore undocumented
+  props will no longer be supported
 
 ### Features
 
-* **box:** add support for css grid within box ([8f0308b](https://github.com/Sage/carbon/commit/8f0308ba33ccdddc9a4b9eb9eb782afd06a6cc43))
-
+- **box:** add support for css grid within box ([8f0308b](https://github.com/Sage/carbon/commit/8f0308ba33ccdddc9a4b9eb9eb782afd06a6cc43))
 
 ### Code Refactoring
 
-* **box:** convert from styled component to a standard component ([64420a3](https://github.com/Sage/carbon/commit/64420a3f282bab1680b186afbecab20169d30d77))
-* **typography:** convert from styled component to a standard component ([e73eab0](https://github.com/Sage/carbon/commit/e73eab0acbb6e69059f6ab2797e6a0e38f2db7a3))
+- **box:** convert from styled component to a standard component ([64420a3](https://github.com/Sage/carbon/commit/64420a3f282bab1680b186afbecab20169d30d77))
+- **typography:** convert from styled component to a standard component ([e73eab0](https://github.com/Sage/carbon/commit/e73eab0acbb6e69059f6ab2797e6a0e38f2db7a3))
 
 ### [119.12.2](https://github.com/Sage/carbon/compare/v119.12.1...v119.12.2) (2023-08-24)
 
-
 ### Bug Fixes
 
-* **text-editor:** update typo to ensure focused toolbar button has relative position ([25bcaf6](https://github.com/Sage/carbon/commit/25bcaf66b7dcfc023700bdd01b2683765a478d06))
+- **text-editor:** update typo to ensure focused toolbar button has relative position ([25bcaf6](https://github.com/Sage/carbon/commit/25bcaf66b7dcfc023700bdd01b2683765a478d06))
 
 ### [119.12.1](https://github.com/Sage/carbon/compare/v119.12.0...v119.12.1) (2023-08-22)
 
-
 ### Bug Fixes
 
-* **menu-item:** allow fixed padding on StyledMenuItem to be configurable when in full screen view ([721bcf6](https://github.com/Sage/carbon/commit/721bcf61b1adb96b00f523558e407fec22ad4815)), closes [#6058](https://github.com/Sage/carbon/issues/6058)
+- **menu-item:** allow fixed padding on StyledMenuItem to be configurable when in full screen view ([721bcf6](https://github.com/Sage/carbon/commit/721bcf61b1adb96b00f523558e407fec22ad4815)), closes [#6058](https://github.com/Sage/carbon/issues/6058)
 
 ## [119.12.0](https://github.com/Sage/carbon/compare/v119.11.0...v119.12.0) (2023-08-21)
 
-
 ### Features
 
-* **pod:** allow title and subtitle to be passed as a node ([efdc827](https://github.com/Sage/carbon/commit/efdc827fd549ae0f3307cdaa03674274b4c0b95f)), closes [#4607](https://github.com/Sage/carbon/issues/4607)
+- **pod:** allow title and subtitle to be passed as a node ([efdc827](https://github.com/Sage/carbon/commit/efdc827fd549ae0f3307cdaa03674274b4c0b95f)), closes [#4607](https://github.com/Sage/carbon/issues/4607)
 
 ## [119.11.0](https://github.com/Sage/carbon/compare/v119.10.2...v119.11.0) (2023-08-09)
 
-
 ### Features
 
-* **focus-styling:** implement new focus styling ([ae68d8d](https://github.com/Sage/carbon/commit/ae68d8debbfcfa4239096569e738de95773d3d16))
+- **focus-styling:** implement new focus styling ([ae68d8d](https://github.com/Sage/carbon/commit/ae68d8debbfcfa4239096569e738de95773d3d16))
 
 ### [119.10.2](https://github.com/Sage/carbon/compare/v119.10.1...v119.10.2) (2023-08-08)
 
-
 ### Bug Fixes
 
-* set rootDir to src in tsconfig ([b805293](https://github.com/Sage/carbon/commit/b805293285e1a038b8f9c4389d9a3180a9b207ea))
+- set rootDir to src in tsconfig ([b805293](https://github.com/Sage/carbon/commit/b805293285e1a038b8f9c4389d9a3180a9b207ea))
 
 ### [119.10.1](https://github.com/Sage/carbon/compare/v119.10.0...v119.10.1) (2023-08-07)
 
-
 ### Bug Fixes
 
-* **select:** fix accessible name ([f9abcfa](https://github.com/Sage/carbon/commit/f9abcfaf077a6d727fe306ab955d8006722e5b3a)), closes [#5945](https://github.com/Sage/carbon/issues/5945)
+- **select:** fix accessible name ([f9abcfa](https://github.com/Sage/carbon/commit/f9abcfaf077a6d727fe306ab955d8006722e5b3a)), closes [#5945](https://github.com/Sage/carbon/issues/5945)
 
 ## [119.10.0](https://github.com/Sage/carbon/compare/v119.9.3...v119.10.0) (2023-08-04)
 
-
 ### Features
 
-* **checkbox:** add support for new validation ([05d137d](https://github.com/Sage/carbon/commit/05d137d42be0e7939fce53bc4cf7575a9f826a2d))
+- **checkbox:** add support for new validation ([05d137d](https://github.com/Sage/carbon/commit/05d137d42be0e7939fce53bc4cf7575a9f826a2d))
 
 ### [119.9.3](https://github.com/Sage/carbon/compare/v119.9.2...v119.9.3) (2023-08-04)
 
-
 ### Bug Fixes
 
-* **split-button, multi-action-button:** remove children iteration ([a8631bc](https://github.com/Sage/carbon/commit/a8631bcaeba1e5357158c8c7e9bc75e71c697da5)), closes [#4784](https://github.com/Sage/carbon/issues/4784)
+- **split-button, multi-action-button:** remove children iteration ([a8631bc](https://github.com/Sage/carbon/commit/a8631bcaeba1e5357158c8c7e9bc75e71c697da5)), closes [#4784](https://github.com/Sage/carbon/issues/4784)
 
 ### [119.9.2](https://github.com/Sage/carbon/compare/v119.9.1...v119.9.2) (2023-08-04)
 
-
 ### Bug Fixes
 
-* **portrait:** rewrite types and add invariant for gravatar and src props ([0ed96d6](https://github.com/Sage/carbon/commit/0ed96d6381887d070363cca88df7c1f5a4313dac))
+- **portrait:** rewrite types and add invariant for gravatar and src props ([0ed96d6](https://github.com/Sage/carbon/commit/0ed96d6381887d070363cca88df7c1f5a4313dac))
 
 ### [119.9.1](https://github.com/Sage/carbon/compare/v119.9.0...v119.9.1) (2023-08-03)
 
-
 ### Bug Fixes
 
-* **textarea:** attempted fix for font-loading issue observed on codesandbox ([32e6cc1](https://github.com/Sage/carbon/commit/32e6cc14b72681d9b62b4e94aa79eeca6acb945f))
-* **textarea:** stop unwanted scroll of container when expandable ([0acf935](https://github.com/Sage/carbon/commit/0acf935395fca4105e10bd95140c753d74e28953)), closes [#6088](https://github.com/Sage/carbon/issues/6088)
+- **textarea:** attempted fix for font-loading issue observed on codesandbox ([32e6cc1](https://github.com/Sage/carbon/commit/32e6cc14b72681d9b62b4e94aa79eeca6acb945f))
+- **textarea:** stop unwanted scroll of container when expandable ([0acf935](https://github.com/Sage/carbon/commit/0acf935395fca4105e10bd95140c753d74e28953)), closes [#6088](https://github.com/Sage/carbon/issues/6088)
 
 ## [119.9.0](https://github.com/Sage/carbon/compare/v119.8.0...v119.9.0) (2023-08-02)
 
-
 ### Features
 
-* **action-popover:** align component with design system ([d411789](https://github.com/Sage/carbon/commit/d41178916d337964ada0953f90c6dd2605e1740f)), closes [#5801](https://github.com/Sage/carbon/issues/5801)
+- **action-popover:** align component with design system ([d411789](https://github.com/Sage/carbon/commit/d41178916d337964ada0953f90c6dd2605e1740f)), closes [#5801](https://github.com/Sage/carbon/issues/5801)
 
 ## [119.8.0](https://github.com/Sage/carbon/compare/v119.7.2...v119.8.0) (2023-08-02)
 
-
 ### Features
 
-* **option-group-header, option-row, option:** allow custom IDs and surface data selectors ([04b11c5](https://github.com/Sage/carbon/commit/04b11c54b1e589ea818088faac8ea36b84c19ddc)), closes [#6126](https://github.com/Sage/carbon/issues/6126) [#5810](https://github.com/Sage/carbon/issues/5810)
+- **option-group-header, option-row, option:** allow custom IDs and surface data selectors ([04b11c5](https://github.com/Sage/carbon/commit/04b11c54b1e589ea818088faac8ea36b84c19ddc)), closes [#6126](https://github.com/Sage/carbon/issues/6126) [#5810](https://github.com/Sage/carbon/issues/5810)
 
 ### [119.7.2](https://github.com/Sage/carbon/compare/v119.7.1...v119.7.2) (2023-07-27)
 
-
 ### Bug Fixes
 
-* **switch:** ensure invariant is not thrown when loading and validation is set ([df9b89e](https://github.com/Sage/carbon/commit/df9b89e2619d0d4957a37237c427e2015527818a))
+- **switch:** ensure invariant is not thrown when loading and validation is set ([df9b89e](https://github.com/Sage/carbon/commit/df9b89e2619d0d4957a37237c427e2015527818a))
 
 ### [119.7.1](https://github.com/Sage/carbon/compare/v119.7.0...v119.7.1) (2023-07-27)
 
-
 ### Bug Fixes
 
-* **dialog, sidebar:** use aria-hidden and inert to hide non-modal elements ([a35680e](https://github.com/Sage/carbon/commit/a35680e41444e613f2b7c60318fd2fc3b2d7209b)), closes [#5920](https://github.com/Sage/carbon/issues/5920)
+- **dialog, sidebar:** use aria-hidden and inert to hide non-modal elements ([a35680e](https://github.com/Sage/carbon/commit/a35680e41444e613f2b7c60318fd2fc3b2d7209b)), closes [#5920](https://github.com/Sage/carbon/issues/5920)
 
 ## [119.7.0](https://github.com/Sage/carbon/compare/v119.6.4...v119.7.0) (2023-07-26)
 
-
 ### Features
 
-* **radio-button:** add support for new validation ([da5d4ad](https://github.com/Sage/carbon/commit/da5d4add046e9a321e3454726be7a1415e704186))
+- **radio-button:** add support for new validation ([da5d4ad](https://github.com/Sage/carbon/commit/da5d4add046e9a321e3454726be7a1415e704186))
 
 ### [119.6.4](https://github.com/Sage/carbon/compare/v119.6.3...v119.6.4) (2023-07-26)
 
-
 ### Bug Fixes
 
-* **menu:** ensure menu remains open when enter is pressed on search ([8040505](https://github.com/Sage/carbon/commit/80405055621e53b2b19c29b7bb867efbc1b64be7)), closes [#6146](https://github.com/Sage/carbon/issues/6146)
+- **menu:** ensure menu remains open when enter is pressed on search ([8040505](https://github.com/Sage/carbon/commit/80405055621e53b2b19c29b7bb867efbc1b64be7)), closes [#6146](https://github.com/Sage/carbon/issues/6146)
 
 ### [119.6.3](https://github.com/Sage/carbon/compare/v119.6.2...v119.6.3) (2023-07-24)
 
-
 ### Bug Fixes
 
-* icon alignments and pill updates ([b55433f](https://github.com/Sage/carbon/commit/b55433fcfb6989641ad8f742cf70913ee0cee9a4))
+- icon alignments and pill updates ([b55433f](https://github.com/Sage/carbon/commit/b55433fcfb6989641ad8f742cf70913ee0cee9a4))
 
 ### [119.6.2](https://github.com/Sage/carbon/compare/v119.6.1...v119.6.2) (2023-07-20)
 
-
 ### Bug Fixes
 
-* **decimal:** replace row-reverse with row when text is right aligned ([ceb04e1](https://github.com/Sage/carbon/commit/ceb04e16f1b2cddfb202593592532518f974a0b4)), closes [#6109](https://github.com/Sage/carbon/issues/6109)
+- **decimal:** replace row-reverse with row when text is right aligned ([ceb04e1](https://github.com/Sage/carbon/commit/ceb04e16f1b2cddfb202593592532518f974a0b4)), closes [#6109](https://github.com/Sage/carbon/issues/6109)
 
 ### [119.6.1](https://github.com/Sage/carbon/compare/v119.6.0...v119.6.1) (2023-07-12)
 
-
 ### Bug Fixes
 
-* **menu-fullscreen:** fix focus when menu closed ([516cb5a](https://github.com/Sage/carbon/commit/516cb5ab29e6beaca9399bd06c91ade584b1a1e7)), closes [#6037](https://github.com/Sage/carbon/issues/6037)
+- **menu-fullscreen:** fix focus when menu closed ([516cb5a](https://github.com/Sage/carbon/commit/516cb5ab29e6beaca9399bd06c91ade584b1a1e7)), closes [#6037](https://github.com/Sage/carbon/issues/6037)
 
 ## [119.6.0](https://github.com/Sage/carbon/compare/v119.5.1...v119.6.0) (2023-07-06)
 
-
 ### Features
 
-* **switch:** add support for new validation ([800841f](https://github.com/Sage/carbon/commit/800841f7ada21f3b34b001115c48c1c10149a217))
-
+- **switch:** add support for new validation ([800841f](https://github.com/Sage/carbon/commit/800841f7ada21f3b34b001115c48c1c10149a217))
 
 ### Bug Fixes
 
-* **validation-message:** fix incorrect syntax for font-weight ([69d02ca](https://github.com/Sage/carbon/commit/69d02cae8f9b4c892f550a01579c4db7a4ac75c6))
+- **validation-message:** fix incorrect syntax for font-weight ([69d02ca](https://github.com/Sage/carbon/commit/69d02cae8f9b4c892f550a01579c4db7a4ac75c6))
 
 ### [119.5.1](https://github.com/Sage/carbon/compare/v119.5.0...v119.5.1) (2023-07-06)
 
-
 ### Bug Fixes
 
-* **menu-full-screen:** ensure menu-divider is not rendered for empty children ([6c3b08e](https://github.com/Sage/carbon/commit/6c3b08eac539827aa8f584092e63e7b5ec6a2d64)), closes [#6099](https://github.com/Sage/carbon/issues/6099)
+- **menu-full-screen:** ensure menu-divider is not rendered for empty children ([6c3b08e](https://github.com/Sage/carbon/commit/6c3b08eac539827aa8f584092e63e7b5ec6a2d64)), closes [#6099](https://github.com/Sage/carbon/issues/6099)
 
 ## [119.5.0](https://github.com/Sage/carbon/compare/v119.4.2...v119.5.0) (2023-07-05)
 
-
 ### Features
 
-* **button bar:** add support for rendering button minor children ([1386c52](https://github.com/Sage/carbon/commit/1386c528a97e8b9b231ed15068e9fc94667be77b))
+- **button bar:** add support for rendering button minor children ([1386c52](https://github.com/Sage/carbon/commit/1386c528a97e8b9b231ed15068e9fc94667be77b))
 
 ### [119.4.2](https://github.com/Sage/carbon/compare/v119.4.1...v119.4.2) (2023-07-05)
 
-
 ### Bug Fixes
 
-* **flat-table:** convert all files in directory to typescript ([eb0b473](https://github.com/Sage/carbon/commit/eb0b473b839865426ab61f5a4fc88d756e1d3c50)), closes [#5979](https://github.com/Sage/carbon/issues/5979)
+- **flat-table:** convert all files in directory to typescript ([eb0b473](https://github.com/Sage/carbon/commit/eb0b473b839865426ab61f5a4fc88d756e1d3c50)), closes [#5979](https://github.com/Sage/carbon/issues/5979)
 
 ### [119.4.1](https://github.com/Sage/carbon/compare/v119.4.0...v119.4.1) (2023-07-04)
 
-
 ### Bug Fixes
 
-* **menu:** make submenu scrollable when inside a fixed navigation bar ([dc685b5](https://github.com/Sage/carbon/commit/dc685b59900005a9efb052d765b711a9dce409cb)), closes [#6009](https://github.com/Sage/carbon/issues/6009)
+- **menu:** make submenu scrollable when inside a fixed navigation bar ([dc685b5](https://github.com/Sage/carbon/commit/dc685b59900005a9efb052d765b711a9dce409cb)), closes [#6009](https://github.com/Sage/carbon/issues/6009)
 
 ## [119.4.0](https://github.com/Sage/carbon/compare/v119.3.4...v119.4.0) (2023-07-03)
 
-
 ### Features
 
-* **icon:** 28 new icons added to the icon font ([fd9caca](https://github.com/Sage/carbon/commit/fd9caca93823b45f66c920401871d23e2dc33172))
+- **icon:** 28 new icons added to the icon font ([fd9caca](https://github.com/Sage/carbon/commit/fd9caca93823b45f66c920401871d23e2dc33172))
 
 ### [119.3.4](https://github.com/Sage/carbon/compare/v119.3.3...v119.3.4) (2023-06-29)
 
-
 ### Bug Fixes
 
-* **flat-table:** ensure window does not scroll when using up and down arrow keys to navigate rows ([ea89c65](https://github.com/Sage/carbon/commit/ea89c65aa13f17fa42806da56eda08b838963612)), closes [#6152](https://github.com/Sage/carbon/issues/6152)
+- **flat-table:** ensure window does not scroll when using up and down arrow keys to navigate rows ([ea89c65](https://github.com/Sage/carbon/commit/ea89c65aa13f17fa42806da56eda08b838963612)), closes [#6152](https://github.com/Sage/carbon/issues/6152)
 
 ### [119.3.3](https://github.com/Sage/carbon/compare/v119.3.2...v119.3.3) (2023-06-29)
 
-
 ### Bug Fixes
 
-* **decimal:** ensure empty value is formatted correctly ([284cabc](https://github.com/Sage/carbon/commit/284cabc6015f6319b97380f549074019f8a188d7)), closes [#6012](https://github.com/Sage/carbon/issues/6012)
+- **decimal:** ensure empty value is formatted correctly ([284cabc](https://github.com/Sage/carbon/commit/284cabc6015f6319b97380f549074019f8a188d7)), closes [#6012](https://github.com/Sage/carbon/issues/6012)
 
 ### [119.3.2](https://github.com/Sage/carbon/compare/v119.3.1...v119.3.2) (2023-06-20)
 
-
 ### Bug Fixes
 
-* **button:** render falsy children ([587c728](https://github.com/Sage/carbon/commit/587c728a0bf1bd90aba3bb5550f74103c0a69cf8)), closes [#6108](https://github.com/Sage/carbon/issues/6108)
+- **button:** render falsy children ([587c728](https://github.com/Sage/carbon/commit/587c728a0bf1bd90aba3bb5550f74103c0a69cf8)), closes [#6108](https://github.com/Sage/carbon/issues/6108)
 
 ### [119.3.1](https://github.com/Sage/carbon/compare/v119.3.0...v119.3.1) (2023-06-20)
 
-
 ### Bug Fixes
 
-* **flat-table:** fix sticky footer no longer at the foot of the table ([209af5e](https://github.com/Sage/carbon/commit/209af5eef7ae4475224155ea9d45308f0c90fd9f))
+- **flat-table:** fix sticky footer no longer at the foot of the table ([209af5e](https://github.com/Sage/carbon/commit/209af5eef7ae4475224155ea9d45308f0c90fd9f))
 
 ## [119.3.0](https://github.com/Sage/carbon/compare/v119.2.0...v119.3.0) (2023-06-15)
 
-
 ### Features
 
-* **search:** add searchButtonAriaLabel prop to component ([5de15f0](https://github.com/Sage/carbon/commit/5de15f0b0e0f63d6ee92a704d84a9466d93a918d))
+- **search:** add searchButtonAriaLabel prop to component ([5de15f0](https://github.com/Sage/carbon/commit/5de15f0b0e0f63d6ee92a704d84a9466d93a918d))
 
 ## [119.2.0](https://github.com/Sage/carbon/compare/v119.1.1...v119.2.0) (2023-06-14)
 
-
 ### Features
 
-* **message:** add mechanism to focus component ([b4b7ff4](https://github.com/Sage/carbon/commit/b4b7ff4f7fddb28e18407aa7bf06e123f2fc5b05)), closes [#5924](https://github.com/Sage/carbon/issues/5924)
+- **message:** add mechanism to focus component ([b4b7ff4](https://github.com/Sage/carbon/commit/b4b7ff4f7fddb28e18407aa7bf06e123f2fc5b05)), closes [#5924](https://github.com/Sage/carbon/issues/5924)
 
 ### [119.1.1](https://github.com/Sage/carbon/compare/v119.1.0...v119.1.1) (2023-06-13)
 
-
 ### Bug Fixes
 
-* **numeral-date:** remove superfluous css from component ([dce29cb](https://github.com/Sage/carbon/commit/dce29cbed15b7056b23421576bd42f3aa18ea6dd)), closes [#6024](https://github.com/Sage/carbon/issues/6024)
+- **numeral-date:** remove superfluous css from component ([dce29cb](https://github.com/Sage/carbon/commit/dce29cbed15b7056b23421576bd42f3aa18ea6dd)), closes [#6024](https://github.com/Sage/carbon/issues/6024)
 
 ## [119.1.0](https://github.com/Sage/carbon/compare/v119.0.1...v119.1.0) (2023-06-12)
 
-
 ### Features
 
-* **flat-table:** update keyboard navigation behaviour when rows are ([b688349](https://github.com/Sage/carbon/commit/b688349eb84775d4955a66120ebc1510444ff9db))
-
+- **flat-table:** update keyboard navigation behaviour when rows are ([b688349](https://github.com/Sage/carbon/commit/b688349eb84775d4955a66120ebc1510444ff9db))
 
 ### Bug Fixes
 
-* **flat-table-row:** overrides user agent focus styling ([55e4aa0](https://github.com/Sage/carbon/commit/55e4aa0586bdb4d180ec70406784093a5c9d4919)), closes [#5991](https://github.com/Sage/carbon/issues/5991)
+- **flat-table-row:** overrides user agent focus styling ([55e4aa0](https://github.com/Sage/carbon/commit/55e4aa0586bdb4d180ec70406784093a5c9d4919)), closes [#5991](https://github.com/Sage/carbon/issues/5991)
 
 ### [119.0.1](https://github.com/Sage/carbon/compare/v119.0.0...v119.0.1) (2023-06-12)
 
-
 ### Bug Fixes
 
-* **popover-container:** prevent click outside calling onclose when container is not open ([cba4e17](https://github.com/Sage/carbon/commit/cba4e1714c326d771129a6c9f75d1fb5f8c761c3)), closes [#6066](https://github.com/Sage/carbon/issues/6066)
+- **popover-container:** prevent click outside calling onclose when container is not open ([cba4e17](https://github.com/Sage/carbon/commit/cba4e1714c326d771129a6c9f75d1fb5f8c761c3)), closes [#6066](https://github.com/Sage/carbon/issues/6066)
 
 ## [119.0.0](https://github.com/Sage/carbon/compare/v118.6.0...v119.0.0) (2023-06-12)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **button-toggle, button-toggle-group:** Changes to props in the ButtonToggle component:
-- `defaultChecked`, `guid` and `onChange` have been removed
+- **button-toggle, button-toggle-group:** Changes to props in the ButtonToggle component:
+
+* `defaultChecked`, `guid` and `onChange` have been removed
+
 - `onClick`, `onBlur` and `onFocus` have new types
-Changes to props in the ButtonToggleGroup component:
+  Changes to props in the ButtonToggleGroup component:
 - all validation-related props (`validationOnLabel`, `error`, `warning` and `info`) have been
-removed
+  removed
 - `onBlur` has also been removed (the main purpose of this will have been to perform validation)
 - the `onChange` prop has a new type. The event argument now has an HTML `button` as its target,
-with the `value` and `name` props of the corresponding `ButtonToggle` component passed as optional
-second and third arguments
-Other important changes to be aware of:
+  with the `value` and `name` props of the corresponding `ButtonToggle` component passed as optional
+  second and third arguments
+  Other important changes to be aware of:
 - import paths changed: both components are now named exports from `components/button-toggle`
 - these components can no longer be used in an "uncontrolled" fashion, the state of which button
-(if any) has been selected must be managed by consumers using React
+  (if any) has been selected must be managed by consumers using React
 - the `name` prop on ButtonToggleGroup is no longer mandatory. Both this and the corresponding
-prop on ButtonToggle now provide nothing except an internal label which can be used in an
-`onChange` handler. These have been kept for backwards compatibility and will soon be removed
+  prop on ButtonToggle now provide nothing except an internal label which can be used in an
+  `onChange` handler. These have been kept for backwards compatibility and will soon be removed
 - the `checked` prop on ButtonToggle has likewise been kept only temporarily for backwards
-compatibility, and is an alias for the new `pressed` prop which sets the `aria-pressed`
-attribute on the underlying HTML button
+  compatibility, and is an alias for the new `pressed` prop which sets the `aria-pressed`
+  attribute on the underlying HTML button
 
 ### Features
 
-* **button-toggle, button-toggle-group:** update HTML for accessibility ([d621521](https://github.com/Sage/carbon/commit/d62152131ec87704df7dff6980e76b46f770f2f1))
-
+- **button-toggle, button-toggle-group:** update HTML for accessibility ([d621521](https://github.com/Sage/carbon/commit/d62152131ec87704df7dff6980e76b46f770f2f1))
 
 ### Bug Fixes
 
-* **button-toggle:** ensure id is consistent between renders ([55c40d0](https://github.com/Sage/carbon/commit/55c40d0b62e71cf3ec999c68f092d71c50abc923))
+- **button-toggle:** ensure id is consistent between renders ([55c40d0](https://github.com/Sage/carbon/commit/55c40d0b62e71cf3ec999c68f092d71c50abc923))
 
 ## [118.6.0](https://github.com/Sage/carbon/compare/v118.5.2...v118.6.0) (2023-06-09)
 
-
 ### Features
 
-* **breadcrumbs:** add padding and margin interfaces to component ([9de6f0b](https://github.com/Sage/carbon/commit/9de6f0b2f923046dd54d9ab48d4aaddeccb906fc)), closes [#6096](https://github.com/Sage/carbon/issues/6096)
-
+- **breadcrumbs:** add padding and margin interfaces to component ([9de6f0b](https://github.com/Sage/carbon/commit/9de6f0b2f923046dd54d9ab48d4aaddeccb906fc)), closes [#6096](https://github.com/Sage/carbon/issues/6096)
 
 ### Bug Fixes
 
-* **crumb:** ensure all props in interface are passed down and remove href as required prop ([dab8805](https://github.com/Sage/carbon/commit/dab88055fc7fc6ce091e53ac0d5aea38412102bc)), closes [#6105](https://github.com/Sage/carbon/issues/6105)
+- **crumb:** ensure all props in interface are passed down and remove href as required prop ([dab8805](https://github.com/Sage/carbon/commit/dab88055fc7fc6ce091e53ac0d5aea38412102bc)), closes [#6105](https://github.com/Sage/carbon/issues/6105)
 
 ### [118.5.2](https://github.com/Sage/carbon/compare/v118.5.1...v118.5.2) (2023-06-07)
 
-
 ### Bug Fixes
 
-* **menu:** ensure onSubmenuOpen only fires once when submenu opens ([b0fbfd7](https://github.com/Sage/carbon/commit/b0fbfd73af363eafc2bf154ce9cdff0af3a4b0a7))
+- **menu:** ensure onSubmenuOpen only fires once when submenu opens ([b0fbfd7](https://github.com/Sage/carbon/commit/b0fbfd73af363eafc2bf154ce9cdff0af3a4b0a7))
 
 ### [118.5.1](https://github.com/Sage/carbon/compare/v118.5.0...v118.5.1) (2023-06-06)
 
-
 ### Bug Fixes
 
-* **multi-action-button:** remove unused props from interface ([b4fd915](https://github.com/Sage/carbon/commit/b4fd9152a358860e59d551c1c850f6e55467818f)), closes [#6059](https://github.com/Sage/carbon/issues/6059)
+- **multi-action-button:** remove unused props from interface ([b4fd915](https://github.com/Sage/carbon/commit/b4fd9152a358860e59d551c1c850f6e55467818f)), closes [#6059](https://github.com/Sage/carbon/issues/6059)
 
 ## [118.5.0](https://github.com/Sage/carbon/compare/v118.4.1...v118.5.0) (2023-06-01)
 
-
 ### Features
 
-* **icon:** new icon font added with 20px size and 2 new icons added to the icon font ([fbab091](https://github.com/Sage/carbon/commit/fbab091a851046b976fcf5b34610b19cb0a28aec))
+- **icon:** new icon font added with 20px size and 2 new icons added to the icon font ([fbab091](https://github.com/Sage/carbon/commit/fbab091a851046b976fcf5b34610b19cb0a28aec))
 
 ### [118.4.1](https://github.com/Sage/carbon/compare/v118.4.0...v118.4.1) (2023-05-30)
 
-
 ### Bug Fixes
 
-* **action-popover:** change html structure so buttons are not nested inside buttons ([3a1bb50](https://github.com/Sage/carbon/commit/3a1bb50393c0ec45bfffaa6c7a255e0211498f1f))
+- **action-popover:** change html structure so buttons are not nested inside buttons ([3a1bb50](https://github.com/Sage/carbon/commit/3a1bb50393c0ec45bfffaa6c7a255e0211498f1f))
 
 ## [118.4.0](https://github.com/Sage/carbon/compare/v118.3.3...v118.4.0) (2023-05-23)
 
-
 ### Features
 
-* add feature flag to allow consumers to opt out of rounded corners update ([ab11660](https://github.com/Sage/carbon/commit/ab116604a60104ca15241750558a211f4c326d0b))
+- add feature flag to allow consumers to opt out of rounded corners update ([ab11660](https://github.com/Sage/carbon/commit/ab116604a60104ca15241750558a211f4c326d0b))
 
 ### [118.3.3](https://github.com/Sage/carbon/compare/v118.3.2...v118.3.3) (2023-05-17)
 
-
 ### Bug Fixes
 
-* **focus-trap:** prevent scroll to bottom when tabbing through ([472d58e](https://github.com/Sage/carbon/commit/472d58ea9fc54682802a1e7b122038075932f388)), closes [#5986](https://github.com/Sage/carbon/issues/5986)
+- **focus-trap:** prevent scroll to bottom when tabbing through ([472d58e](https://github.com/Sage/carbon/commit/472d58ea9fc54682802a1e7b122038075932f388)), closes [#5986](https://github.com/Sage/carbon/issues/5986)
 
 ### [118.3.2](https://github.com/Sage/carbon/compare/v118.3.1...v118.3.2) (2023-05-16)
 
-
 ### Bug Fixes
 
-* **submenu:** ensure that the search cross icon is centred when focused ([94bbfa2](https://github.com/Sage/carbon/commit/94bbfa24248ac637f1e17cefdb83077e555d30db)), closes [#FE-5694](https://github.com/Sage/carbon/issues/FE-5694)
+- **submenu:** ensure that the search cross icon is centred when focused ([94bbfa2](https://github.com/Sage/carbon/commit/94bbfa24248ac637f1e17cefdb83077e555d30db)), closes [#FE-5694](https://github.com/Sage/carbon/issues/FE-5694)
 
 ### [118.3.1](https://github.com/Sage/carbon/compare/v118.3.0...v118.3.1) (2023-05-15)
 
-
 ### Bug Fixes
 
-* **select:** reset height and width after closing ([dfe70bf](https://github.com/Sage/carbon/commit/dfe70bf623b74c011d1b0e75ad2a6f28e566dc85)), closes [#5981](https://github.com/Sage/carbon/issues/5981)
+- **select:** reset height and width after closing ([dfe70bf](https://github.com/Sage/carbon/commit/dfe70bf623b74c011d1b0e75ad2a6f28e566dc85)), closes [#5981](https://github.com/Sage/carbon/issues/5981)
 
 ## [118.3.0](https://github.com/Sage/carbon/compare/v118.2.1...v118.3.0) (2023-05-12)
 
-
 ### Features
 
-* **password:** add new component ([f141b72](https://github.com/Sage/carbon/commit/f141b7273f10883318a9f9a660849663a9534d91)), closes [#5614](https://github.com/Sage/carbon/issues/5614)
+- **password:** add new component ([f141b72](https://github.com/Sage/carbon/commit/f141b7273f10883318a9f9a660849663a9534d91)), closes [#5614](https://github.com/Sage/carbon/issues/5614)
 
 ### [118.2.1](https://github.com/Sage/carbon/compare/v118.2.0...v118.2.1) (2023-05-05)
 
-
 ### Bug Fixes
 
-* **menu-fullscreen:** ensure correct tab order when Search with button rendered as a child ([ddabef9](https://github.com/Sage/carbon/commit/ddabef96a12165bc5e3d5e44140e303ee1e6a715)), closes [#5959](https://github.com/Sage/carbon/issues/5959)
-* **menu-item:** ensure text colour is correct when item is focused in full screen view ([82b543b](https://github.com/Sage/carbon/commit/82b543b4ba7f6ed342bede80be1fe03bf13651fa))
+- **menu-fullscreen:** ensure correct tab order when Search with button rendered as a child ([ddabef9](https://github.com/Sage/carbon/commit/ddabef96a12165bc5e3d5e44140e303ee1e6a715)), closes [#5959](https://github.com/Sage/carbon/issues/5959)
+- **menu-item:** ensure text colour is correct when item is focused in full screen view ([82b543b](https://github.com/Sage/carbon/commit/82b543b4ba7f6ed342bede80be1fe03bf13651fa))
 
 ## [118.2.0](https://github.com/Sage/carbon/compare/v118.1.1...v118.2.0) (2023-05-05)
 
-
 ### Features
 
-* **action-popover:** add rounded corner styling to component ([11a287d](https://github.com/Sage/carbon/commit/11a287d3940c61a4f2d5434ffea277112950a2df))
-* add border radius styling to text based input components ([20888fb](https://github.com/Sage/carbon/commit/20888fbed3691077105ea664679d0ce60ea5ba01))
-* add rounded corner styling to button components ([13a1dfb](https://github.com/Sage/carbon/commit/13a1dfb8c44d342b6f0da0edfadf6d41aa1b4332))
-* **advanced-color-picker:** add rounded corner styling to component ([0848dca](https://github.com/Sage/carbon/commit/0848dca44766e0cb37ef993862bd57e77ba4616c))
-* **anchor-navigation:** add rounded corner styling to component ([b21debd](https://github.com/Sage/carbon/commit/b21debdcb3185b1e4d2ecbf6c4ba72c561fbf433))
-* **badge:** add rounded corner styling to component ([07170e4](https://github.com/Sage/carbon/commit/07170e4717049f91518f4750bf2278f9d89d0d5e))
-* **batch-selection:** add rounded corner styling to component ([58a64d6](https://github.com/Sage/carbon/commit/58a64d6a48eadadc3aa9da737fd916cbfedc4a3a))
-* **box, dismissible-box:** add `borderRadius` prop to support rounded corner styling ([75bfce1](https://github.com/Sage/carbon/commit/75bfce1ad6c06811bc5c1c8b28e522c2ed74dfd2))
-* **button-bar:** add rounded corner styling to component ([f6155d2](https://github.com/Sage/carbon/commit/f6155d2327dbe8a4bece7878c56c394ac8d5b546))
-* **button-toggle:** add rounded corner styling to component ([6bccc24](https://github.com/Sage/carbon/commit/6bccc240c8e6ea578cbd9061912418d196771ca9))
-* **card:** add support for configuring rounded corners on component ([c5af888](https://github.com/Sage/carbon/commit/c5af8881709334daba8dd20f3166b6253b1258d3))
-* **carousel:** add rounded corner styling to component ([dbc4465](https://github.com/Sage/carbon/commit/dbc4465a822c6be273b820d314a956f57592afaa))
-* **checkbox:** add radius styling to component ([5a0bfa8](https://github.com/Sage/carbon/commit/5a0bfa88b563c2cf589130fcd16565025fc04df3))
-* **dialog, alert, confirm:** add rounded corner styling to components ([63edf2a](https://github.com/Sage/carbon/commit/63edf2aa7b06ff6c8f06e2b177ba91f2b0fdbdd9))
-* **drawer:** add rounded corner styling to component ([71888e6](https://github.com/Sage/carbon/commit/71888e6e13a513d2121009340e805ca4f39952d0))
-* **duelling-picklist:** add rounded corner styling to component ([0b6bad6](https://github.com/Sage/carbon/commit/0b6bad6b074de505e15015b43bf8f936bc17ed53))
-* **flat-table:** add rounded corner styling to component ([0262a68](https://github.com/Sage/carbon/commit/0262a686a251800bafa52c40fa61b182c003abca))
-* **icon-button:** add rounded corner styling to component ([5625db2](https://github.com/Sage/carbon/commit/5625db247406beb6167cb3f417c7d0573816b6d7))
-* **inline-inputs:** add rounded corner styling to component ([d57a271](https://github.com/Sage/carbon/commit/d57a2711fda5f46dfc61c699f98d0576edb52014))
-* **link-preview:** add rounded corner styling to component ([889a47c](https://github.com/Sage/carbon/commit/889a47cd1805e59920b78c2334df4d0b7f22e85c))
-* **link:** add rounded corner styling to component ([8a300c6](https://github.com/Sage/carbon/commit/8a300c6915231193433ff8d6744e843ea3112613))
-* **loader-bar:** add rounded corner styling to component ([04bbea3](https://github.com/Sage/carbon/commit/04bbea32cbf2b5b59fdd9d62ba9e5209994e9279))
-* **loader:** add rounded corner styling to component ([9738dd6](https://github.com/Sage/carbon/commit/9738dd62ee6c5e0ed0fafd74bfccc9f7111ed40c))
-* **menu:** add rounded corner styling to submenu component ([2578358](https://github.com/Sage/carbon/commit/2578358d9a5b3f6b990531b718f71fa98cba6a77))
-* **message, toast:** add rounded corner styling to components ([b7b100c](https://github.com/Sage/carbon/commit/b7b100c9831273c94da43c8127061b6236ca2079))
-* **note:** add rounded corner styling to component ([9fc6d7f](https://github.com/Sage/carbon/commit/9fc6d7fc0aa10ef60ac9bf7e11cdae0c64d1c03c))
-* **pager:** add rounded corner styling to component ([0e6f4d8](https://github.com/Sage/carbon/commit/0e6f4d85e2add626fec94210e6ce44bfa223eee9))
-* **pill:** add rounded corner styling to component ([2caf52b](https://github.com/Sage/carbon/commit/2caf52bc4aed0429c3f896ad0bf05733a5343820))
-* **pod, show-edit-pod:** add rounded corner styling to components ([0fdb957](https://github.com/Sage/carbon/commit/0fdb9573f9beaa41c8b6ff0749b567a058f3d7ad))
-* **popover-container:** add rounded corner styling to component ([fc43813](https://github.com/Sage/carbon/commit/fc43813afe3b9b6f97cbc2ce46c6ad4dfa269b60))
-* **portrait, profile:** add rounded corner styling to components ([b653c72](https://github.com/Sage/carbon/commit/b653c7251b742a32b87d6abb0d877ceaef47ce70))
-* **progress-tracker:** add rounded corner styling to component ([ece764d](https://github.com/Sage/carbon/commit/ece764dfed19ef09c387b1b7c2cddbb39a596d82))
-* **radio-button:** add rounded corner styling to component ([03a5a42](https://github.com/Sage/carbon/commit/03a5a427a8311a0724cb4b51f61a13f657e1e48d))
-* **switch:** add radius styling to component ([402c6fa](https://github.com/Sage/carbon/commit/402c6fa140696b24c5baabaf50f2ad0ce2056b71))
-* **tabs:** add rounded corner styling to component ([a88bdb3](https://github.com/Sage/carbon/commit/a88bdb380fc1895cf60c88ef035499aa732f4f75))
-* **text-editor:** add rounded corner styling to component ([18f210d](https://github.com/Sage/carbon/commit/18f210df01b5c6fb20ddfd371dfc0ede2bba586a))
-* **tile-select:** add rounded corner styling to component ([b07610f](https://github.com/Sage/carbon/commit/b07610fde4b7491539bd97c65dd7b259d716a594))
-* **tile:** add support for configuring rounded corners on component ([a87687f](https://github.com/Sage/carbon/commit/a87687fad04675d985bd0ef0279a3d350eecc92d))
-* **tooltip:** add rounded corner styling to component ([5ddd2fa](https://github.com/Sage/carbon/commit/5ddd2fab48c9c8a824dbec4a983cdbe5d674edaf))
-* **vertical-menu:** add rounded corner styling to component ([24b88e4](https://github.com/Sage/carbon/commit/24b88e44bf5c080b7e10bf3e21219efdee61fab2))
+- **action-popover:** add rounded corner styling to component ([11a287d](https://github.com/Sage/carbon/commit/11a287d3940c61a4f2d5434ffea277112950a2df))
+- add border radius styling to text based input components ([20888fb](https://github.com/Sage/carbon/commit/20888fbed3691077105ea664679d0ce60ea5ba01))
+- add rounded corner styling to button components ([13a1dfb](https://github.com/Sage/carbon/commit/13a1dfb8c44d342b6f0da0edfadf6d41aa1b4332))
+- **advanced-color-picker:** add rounded corner styling to component ([0848dca](https://github.com/Sage/carbon/commit/0848dca44766e0cb37ef993862bd57e77ba4616c))
+- **anchor-navigation:** add rounded corner styling to component ([b21debd](https://github.com/Sage/carbon/commit/b21debdcb3185b1e4d2ecbf6c4ba72c561fbf433))
+- **badge:** add rounded corner styling to component ([07170e4](https://github.com/Sage/carbon/commit/07170e4717049f91518f4750bf2278f9d89d0d5e))
+- **batch-selection:** add rounded corner styling to component ([58a64d6](https://github.com/Sage/carbon/commit/58a64d6a48eadadc3aa9da737fd916cbfedc4a3a))
+- **box, dismissible-box:** add `borderRadius` prop to support rounded corner styling ([75bfce1](https://github.com/Sage/carbon/commit/75bfce1ad6c06811bc5c1c8b28e522c2ed74dfd2))
+- **button-bar:** add rounded corner styling to component ([f6155d2](https://github.com/Sage/carbon/commit/f6155d2327dbe8a4bece7878c56c394ac8d5b546))
+- **button-toggle:** add rounded corner styling to component ([6bccc24](https://github.com/Sage/carbon/commit/6bccc240c8e6ea578cbd9061912418d196771ca9))
+- **card:** add support for configuring rounded corners on component ([c5af888](https://github.com/Sage/carbon/commit/c5af8881709334daba8dd20f3166b6253b1258d3))
+- **carousel:** add rounded corner styling to component ([dbc4465](https://github.com/Sage/carbon/commit/dbc4465a822c6be273b820d314a956f57592afaa))
+- **checkbox:** add radius styling to component ([5a0bfa8](https://github.com/Sage/carbon/commit/5a0bfa88b563c2cf589130fcd16565025fc04df3))
+- **dialog, alert, confirm:** add rounded corner styling to components ([63edf2a](https://github.com/Sage/carbon/commit/63edf2aa7b06ff6c8f06e2b177ba91f2b0fdbdd9))
+- **drawer:** add rounded corner styling to component ([71888e6](https://github.com/Sage/carbon/commit/71888e6e13a513d2121009340e805ca4f39952d0))
+- **duelling-picklist:** add rounded corner styling to component ([0b6bad6](https://github.com/Sage/carbon/commit/0b6bad6b074de505e15015b43bf8f936bc17ed53))
+- **flat-table:** add rounded corner styling to component ([0262a68](https://github.com/Sage/carbon/commit/0262a686a251800bafa52c40fa61b182c003abca))
+- **icon-button:** add rounded corner styling to component ([5625db2](https://github.com/Sage/carbon/commit/5625db247406beb6167cb3f417c7d0573816b6d7))
+- **inline-inputs:** add rounded corner styling to component ([d57a271](https://github.com/Sage/carbon/commit/d57a2711fda5f46dfc61c699f98d0576edb52014))
+- **link-preview:** add rounded corner styling to component ([889a47c](https://github.com/Sage/carbon/commit/889a47cd1805e59920b78c2334df4d0b7f22e85c))
+- **link:** add rounded corner styling to component ([8a300c6](https://github.com/Sage/carbon/commit/8a300c6915231193433ff8d6744e843ea3112613))
+- **loader-bar:** add rounded corner styling to component ([04bbea3](https://github.com/Sage/carbon/commit/04bbea32cbf2b5b59fdd9d62ba9e5209994e9279))
+- **loader:** add rounded corner styling to component ([9738dd6](https://github.com/Sage/carbon/commit/9738dd62ee6c5e0ed0fafd74bfccc9f7111ed40c))
+- **menu:** add rounded corner styling to submenu component ([2578358](https://github.com/Sage/carbon/commit/2578358d9a5b3f6b990531b718f71fa98cba6a77))
+- **message, toast:** add rounded corner styling to components ([b7b100c](https://github.com/Sage/carbon/commit/b7b100c9831273c94da43c8127061b6236ca2079))
+- **note:** add rounded corner styling to component ([9fc6d7f](https://github.com/Sage/carbon/commit/9fc6d7fc0aa10ef60ac9bf7e11cdae0c64d1c03c))
+- **pager:** add rounded corner styling to component ([0e6f4d8](https://github.com/Sage/carbon/commit/0e6f4d85e2add626fec94210e6ce44bfa223eee9))
+- **pill:** add rounded corner styling to component ([2caf52b](https://github.com/Sage/carbon/commit/2caf52bc4aed0429c3f896ad0bf05733a5343820))
+- **pod, show-edit-pod:** add rounded corner styling to components ([0fdb957](https://github.com/Sage/carbon/commit/0fdb9573f9beaa41c8b6ff0749b567a058f3d7ad))
+- **popover-container:** add rounded corner styling to component ([fc43813](https://github.com/Sage/carbon/commit/fc43813afe3b9b6f97cbc2ce46c6ad4dfa269b60))
+- **portrait, profile:** add rounded corner styling to components ([b653c72](https://github.com/Sage/carbon/commit/b653c7251b742a32b87d6abb0d877ceaef47ce70))
+- **progress-tracker:** add rounded corner styling to component ([ece764d](https://github.com/Sage/carbon/commit/ece764dfed19ef09c387b1b7c2cddbb39a596d82))
+- **radio-button:** add rounded corner styling to component ([03a5a42](https://github.com/Sage/carbon/commit/03a5a427a8311a0724cb4b51f61a13f657e1e48d))
+- **switch:** add radius styling to component ([402c6fa](https://github.com/Sage/carbon/commit/402c6fa140696b24c5baabaf50f2ad0ce2056b71))
+- **tabs:** add rounded corner styling to component ([a88bdb3](https://github.com/Sage/carbon/commit/a88bdb380fc1895cf60c88ef035499aa732f4f75))
+- **text-editor:** add rounded corner styling to component ([18f210d](https://github.com/Sage/carbon/commit/18f210df01b5c6fb20ddfd371dfc0ede2bba586a))
+- **tile-select:** add rounded corner styling to component ([b07610f](https://github.com/Sage/carbon/commit/b07610fde4b7491539bd97c65dd7b259d716a594))
+- **tile:** add support for configuring rounded corners on component ([a87687f](https://github.com/Sage/carbon/commit/a87687fad04675d985bd0ef0279a3d350eecc92d))
+- **tooltip:** add rounded corner styling to component ([5ddd2fa](https://github.com/Sage/carbon/commit/5ddd2fab48c9c8a824dbec4a983cdbe5d674edaf))
+- **vertical-menu:** add rounded corner styling to component ([24b88e4](https://github.com/Sage/carbon/commit/24b88e44bf5c080b7e10bf3e21219efdee61fab2))
 
 ### [118.1.1](https://github.com/Sage/carbon/compare/v118.1.0...v118.1.1) (2023-05-02)
 
-
 ### Bug Fixes
 
-* **tabs:** add type="button" to tab title ([ad352ae](https://github.com/Sage/carbon/commit/ad352aefdcbbe0dbe7cf0fc178968db692797cf3)), closes [#5740](https://github.com/Sage/carbon/issues/5740)
+- **tabs:** add type="button" to tab title ([ad352ae](https://github.com/Sage/carbon/commit/ad352aefdcbbe0dbe7cf0fc178968db692797cf3)), closes [#5740](https://github.com/Sage/carbon/issues/5740)
 
 ## [118.1.0](https://github.com/Sage/carbon/compare/v118.0.0...v118.1.0) (2023-04-24)
 
-
 ### Features
 
-* **minor-button:** add position: absolute property to icon when component is icon only ([72af0f4](https://github.com/Sage/carbon/commit/72af0f441d98e6647d64a77e10f8675ce8b4b1f3)), closes [#5946](https://github.com/Sage/carbon/issues/5946)
+- **minor-button:** add position: absolute property to icon when component is icon only ([72af0f4](https://github.com/Sage/carbon/commit/72af0f441d98e6647d64a77e10f8675ce8b4b1f3)), closes [#5946](https://github.com/Sage/carbon/issues/5946)
 
 ## [118.0.0](https://github.com/Sage/carbon/compare/v117.7.1...v118.0.0) (2023-04-20)
 
-
 ### ⚠ BREAKING CHANGES
 
-* Please see updated LICENSE file.
+- Please see updated LICENSE file.
 
 ### Miscellaneous Chores
 
-* update copyright holder ([0ea7d05](https://github.com/Sage/carbon/commit/0ea7d059ce33f2a96107ead5e6f9b402fa67b100))
+- update copyright holder ([0ea7d05](https://github.com/Sage/carbon/commit/0ea7d059ce33f2a96107ead5e6f9b402fa67b100))
 
 ### [117.7.1](https://github.com/Sage/carbon/compare/v117.7.0...v117.7.1) (2023-04-20)
 
-
 ### Bug Fixes
 
-* **link:** ensure button has a type when used ([065c206](https://github.com/Sage/carbon/commit/065c20694bce9c59188218e2780a746a7af3299e)), closes [#5676](https://github.com/Sage/carbon/issues/5676)
+- **link:** ensure button has a type when used ([065c206](https://github.com/Sage/carbon/commit/065c20694bce9c59188218e2780a746a7af3299e)), closes [#5676](https://github.com/Sage/carbon/issues/5676)
 
 ## [117.7.0](https://github.com/Sage/carbon/compare/v117.6.1...v117.7.0) (2023-04-19)
 
-
 ### Features
 
-* add white-space: nowrap CSS property to visually hidden class ([b8fd55e](https://github.com/Sage/carbon/commit/b8fd55e11d26b1f35c0e4857d65b902024073f3f))
+- add white-space: nowrap CSS property to visually hidden class ([b8fd55e](https://github.com/Sage/carbon/commit/b8fd55e11d26b1f35c0e4857d65b902024073f3f))
 
 ### [117.6.1](https://github.com/Sage/carbon/compare/v117.6.0...v117.6.1) (2023-04-12)
 
-
 ### Bug Fixes
 
-* **message:** add conditional padding based on the showCloseIcon props truth value ([cf8d7b2](https://github.com/Sage/carbon/commit/cf8d7b272b00011463d945268ba26f9e94d526bf)), closes [#5904](https://github.com/Sage/carbon/issues/5904)
+- **message:** add conditional padding based on the showCloseIcon props truth value ([cf8d7b2](https://github.com/Sage/carbon/commit/cf8d7b272b00011463d945268ba26f9e94d526bf)), closes [#5904](https://github.com/Sage/carbon/issues/5904)
 
 ## [117.6.0](https://github.com/Sage/carbon/compare/v117.5.0...v117.6.0) (2023-04-12)
 
-
 ### Features
 
-* add tag props interface to all public Menu components ([8f04b2d](https://github.com/Sage/carbon/commit/8f04b2d354b99eb1938b2474414d55a3d4b5958a))
-* **menu-item:** add padding interface to menu item ([1ada0ec](https://github.com/Sage/carbon/commit/1ada0ec2c4ba4debe98a21f66b67aa001016ab11))
-
+- add tag props interface to all public Menu components ([8f04b2d](https://github.com/Sage/carbon/commit/8f04b2d354b99eb1938b2474414d55a3d4b5958a))
+- **menu-item:** add padding interface to menu item ([1ada0ec](https://github.com/Sage/carbon/commit/1ada0ec2c4ba4debe98a21f66b67aa001016ab11))
 
 ### Bug Fixes
 
-* **menu-item:** ensure icons have correct colour when items are focused ([ee34138](https://github.com/Sage/carbon/commit/ee3413800923dc09696cdcf5f6a3e870641f6829)), closes [#5613](https://github.com/Sage/carbon/issues/5613)
-* **submenu:** ensure keyboard navigation order is correct when children update ([9148868](https://github.com/Sage/carbon/commit/9148868c8ff718c82295c0b76251b0742d2a16f6)), closes [#5916](https://github.com/Sage/carbon/issues/5916)
+- **menu-item:** ensure icons have correct colour when items are focused ([ee34138](https://github.com/Sage/carbon/commit/ee3413800923dc09696cdcf5f6a3e870641f6829)), closes [#5613](https://github.com/Sage/carbon/issues/5613)
+- **submenu:** ensure keyboard navigation order is correct when children update ([9148868](https://github.com/Sage/carbon/commit/9148868c8ff718c82295c0b76251b0742d2a16f6)), closes [#5916](https://github.com/Sage/carbon/issues/5916)
 
 ## [117.5.0](https://github.com/Sage/carbon/compare/v117.4.1...v117.5.0) (2023-04-11)
 
-
 ### Features
 
-* **vertical-menu:** add default open state to menu item ([aae55b8](https://github.com/Sage/carbon/commit/aae55b816279f24b8168536f9b876fa87a28722f)), closes [#5822](https://github.com/Sage/carbon/issues/5822)
+- **vertical-menu:** add default open state to menu item ([aae55b8](https://github.com/Sage/carbon/commit/aae55b816279f24b8168536f9b876fa87a28722f)), closes [#5822](https://github.com/Sage/carbon/issues/5822)
 
 ### [117.4.1](https://github.com/Sage/carbon/compare/v117.4.0...v117.4.1) (2023-04-11)
 
-
 ### Bug Fixes
 
-* **switch:** fix styling defect caused by box-sizing border-box css ([9228a3f](https://github.com/Sage/carbon/commit/9228a3fd2f0fc48121a4005295d2cc7eb81085f2))
+- **switch:** fix styling defect caused by box-sizing border-box css ([9228a3f](https://github.com/Sage/carbon/commit/9228a3fd2f0fc48121a4005295d2cc7eb81085f2))
 
 ## [117.4.0](https://github.com/Sage/carbon/compare/v117.3.0...v117.4.0) (2023-04-11)
 
-
 ### Features
 
-* add internal useThrottle hook ([26c7a56](https://github.com/Sage/carbon/commit/26c7a565da42ca6bc647ef960ac4242c42ff0f18))
-* **tabs:** enhance tabs component ([eb003a2](https://github.com/Sage/carbon/commit/eb003a2db720aef25abbfefef384489f03378857))
+- add internal useThrottle hook ([26c7a56](https://github.com/Sage/carbon/commit/26c7a565da42ca6bc647ef960ac4242c42ff0f18))
+- **tabs:** enhance tabs component ([eb003a2](https://github.com/Sage/carbon/commit/eb003a2db720aef25abbfefef384489f03378857))
 
 ## [117.3.0](https://github.com/Sage/carbon/compare/v117.2.2...v117.3.0) (2023-04-05)
 
-
 ### Features
 
-* **pager:** surface interactivePageNumber prop to ensure selecting page number is optional ([b1ef242](https://github.com/Sage/carbon/commit/b1ef242936073f8794932beab566b26c35d2c215)), closes [#5674](https://github.com/Sage/carbon/issues/5674)
+- **pager:** surface interactivePageNumber prop to ensure selecting page number is optional ([b1ef242](https://github.com/Sage/carbon/commit/b1ef242936073f8794932beab566b26c35d2c215)), closes [#5674](https://github.com/Sage/carbon/issues/5674)
 
 ### [117.2.2](https://github.com/Sage/carbon/compare/v117.2.1...v117.2.2) (2023-04-04)
 
-
 ### Bug Fixes
 
-* **fieldset:** ensure Fieldset components accept custom margin values ([f35af48](https://github.com/Sage/carbon/commit/f35af4866ec8aac1a9be48fdf8788e54875ddf49)), closes [#5902](https://github.com/Sage/carbon/issues/5902)
+- **fieldset:** ensure Fieldset components accept custom margin values ([f35af48](https://github.com/Sage/carbon/commit/f35af4866ec8aac1a9be48fdf8788e54875ddf49)), closes [#5902](https://github.com/Sage/carbon/issues/5902)
 
 ### [117.2.1](https://github.com/Sage/carbon/compare/v117.2.0...v117.2.1) (2023-04-04)
 
-
 ### Bug Fixes
 
-* **advanced-color-picker:** add visually hidden description list to describe selected color ([8b5d433](https://github.com/Sage/carbon/commit/8b5d4334d0039b56758217b73298e2fc09fc088d))
+- **advanced-color-picker:** add visually hidden description list to describe selected color ([8b5d433](https://github.com/Sage/carbon/commit/8b5d4334d0039b56758217b73298e2fc09fc088d))
 
 ## [117.2.0](https://github.com/Sage/carbon/compare/v117.1.2...v117.2.0) (2023-04-03)
 
-
 ### Features
 
-* **breadcrumbs:** new component ([f7dde02](https://github.com/Sage/carbon/commit/f7dde02f8d50892e32e66cae37792bbdd2afa034))
+- **breadcrumbs:** new component ([f7dde02](https://github.com/Sage/carbon/commit/f7dde02f8d50892e32e66cae37792bbdd2afa034))
 
 ### [117.1.2](https://github.com/Sage/carbon/compare/v117.1.1...v117.1.2) (2023-03-31)
 
-
 ### Bug Fixes
 
-* **textarea:** add missing error message id ([d2d3bea](https://github.com/Sage/carbon/commit/d2d3bead736a90e385f76b0b0b8c1629f2baacfa))
-* **textbox, textarea, checkbox, radio-button:** fix ARIA descriptions ([1989d4a](https://github.com/Sage/carbon/commit/1989d4afd2f3d5bb776cc990e404473e280aad9a))
-* **validations:** add aria-describedby to validation icon ([d5a5892](https://github.com/Sage/carbon/commit/d5a589293493a9c39adf51d13dfea96fb0e40f6f)), closes [#5498](https://github.com/Sage/carbon/issues/5498) [#5411](https://github.com/Sage/carbon/issues/5411) [#5594](https://github.com/Sage/carbon/issues/5594)
-* **validations:** add error anouncement for redesigned validations ([1ea2bbe](https://github.com/Sage/carbon/commit/1ea2bbed1c45126d99cfa73ad9764de8caf6df23)), closes [#5828](https://github.com/Sage/carbon/issues/5828)
+- **textarea:** add missing error message id ([d2d3bea](https://github.com/Sage/carbon/commit/d2d3bead736a90e385f76b0b0b8c1629f2baacfa))
+- **textbox, textarea, checkbox, radio-button:** fix ARIA descriptions ([1989d4a](https://github.com/Sage/carbon/commit/1989d4afd2f3d5bb776cc990e404473e280aad9a))
+- **validations:** add aria-describedby to validation icon ([d5a5892](https://github.com/Sage/carbon/commit/d5a589293493a9c39adf51d13dfea96fb0e40f6f)), closes [#5498](https://github.com/Sage/carbon/issues/5498) [#5411](https://github.com/Sage/carbon/issues/5411) [#5594](https://github.com/Sage/carbon/issues/5594)
+- **validations:** add error anouncement for redesigned validations ([1ea2bbe](https://github.com/Sage/carbon/commit/1ea2bbed1c45126d99cfa73ad9764de8caf6df23)), closes [#5828](https://github.com/Sage/carbon/issues/5828)
 
 ### [117.1.1](https://github.com/Sage/carbon/compare/v117.1.0...v117.1.1) (2023-03-31)
 
-
 ### Bug Fixes
 
-* **date:** add missing ref TS type ([d27984b](https://github.com/Sage/carbon/commit/d27984ba97c856398bcf7cf0505ac0e883b4d38c)), closes [#5929](https://github.com/Sage/carbon/issues/5929)
+- **date:** add missing ref TS type ([d27984b](https://github.com/Sage/carbon/commit/d27984ba97c856398bcf7cf0505ac0e883b4d38c)), closes [#5929](https://github.com/Sage/carbon/issues/5929)
 
 ## [117.1.0](https://github.com/Sage/carbon/compare/v117.0.0...v117.1.0) (2023-03-30)
 
-
 ### Features
 
-* **filterable-select:** add aria-label and aria-labelledby props ([e656d2b](https://github.com/Sage/carbon/commit/e656d2b65d6e6dee26fa2ff6c9c68cc674696582))
-* **multi-select:** add aria-label and aria-labelledby props ([422627f](https://github.com/Sage/carbon/commit/422627f3b4ad7ad231a9c05e746cbb824ca316d8))
-* **select:** add aria-label and aria-labelledby props ([f4e11d2](https://github.com/Sage/carbon/commit/f4e11d22f22980cb777170086b50bcf6befab883))
+- **filterable-select:** add aria-label and aria-labelledby props ([e656d2b](https://github.com/Sage/carbon/commit/e656d2b65d6e6dee26fa2ff6c9c68cc674696582))
+- **multi-select:** add aria-label and aria-labelledby props ([422627f](https://github.com/Sage/carbon/commit/422627f3b4ad7ad231a9c05e746cbb824ca316d8))
+- **select:** add aria-label and aria-labelledby props ([f4e11d2](https://github.com/Sage/carbon/commit/f4e11d22f22980cb777170086b50bcf6befab883))
 
 ## [117.0.0](https://github.com/Sage/carbon/compare/v116.2.2...v117.0.0) (2023-03-30)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **textarea, textbox:** The `warnOverLimit` prop is no longer consumed by both components and the styling
-the prop applied has now been made the default. Also the type of the `characterLimit` prop has been
-changed to solely a number opposed to a number or a string.
+- **textarea, textbox:** The `warnOverLimit` prop is no longer consumed by both components and the styling
+  the prop applied has now been made the default. Also the type of the `characterLimit` prop has been
+  changed to solely a number opposed to a number or a string.
 
 ### Bug Fixes
 
-* **textarea, textbox:** accessibility refactor of character count functionality ([182afc9](https://github.com/Sage/carbon/commit/182afc9ef94b3cd127d43ab3362b6374633dc64c)), closes [#5717](https://github.com/Sage/carbon/issues/5717)
+- **textarea, textbox:** accessibility refactor of character count functionality ([182afc9](https://github.com/Sage/carbon/commit/182afc9ef94b3cd127d43ab3362b6374633dc64c)), closes [#5717](https://github.com/Sage/carbon/issues/5717)
 
 ### [116.2.2](https://github.com/Sage/carbon/compare/v116.2.1...v116.2.2) (2023-03-30)
 
-
 ### Bug Fixes
 
-* **check_rfcs:** ship the index file in the published package ([ca9665e](https://github.com/Sage/carbon/commit/ca9665e288b5c37ae2fabd536cefe53535fa981e))
+- **check_rfcs:** ship the index file in the published package ([ca9665e](https://github.com/Sage/carbon/commit/ca9665e288b5c37ae2fabd536cefe53535fa981e))
 
 ### [116.2.1](https://github.com/Sage/carbon/compare/v116.2.0...v116.2.1) (2023-03-28)
 
-
 ### Bug Fixes
 
-* **select:** stop select list triggering refocus if closed inside a modal ([2505dc4](https://github.com/Sage/carbon/commit/2505dc4eed3d19ca154aa13bc59929cbcd223d5a)), closes [#5898](https://github.com/Sage/carbon/issues/5898)
+- **select:** stop select list triggering refocus if closed inside a modal ([2505dc4](https://github.com/Sage/carbon/commit/2505dc4eed3d19ca154aa13bc59929cbcd223d5a)), closes [#5898](https://github.com/Sage/carbon/issues/5898)
 
 ## [116.2.0](https://github.com/Sage/carbon/compare/v116.1.3...v116.2.0) (2023-03-24)
 
-
 ### Features
 
-* **accordion:** allow buttonWidth to accept string values ([34aa10c](https://github.com/Sage/carbon/commit/34aa10c46af31aea3d9d81d081362d18e2127833)), closes [#5897](https://github.com/Sage/carbon/issues/5897)
+- **accordion:** allow buttonWidth to accept string values ([34aa10c](https://github.com/Sage/carbon/commit/34aa10c46af31aea3d9d81d081362d18e2127833)), closes [#5897](https://github.com/Sage/carbon/issues/5897)
 
 ### [116.1.3](https://github.com/Sage/carbon/compare/v116.1.2...v116.1.3) (2023-03-23)
 
-
 ### Bug Fixes
 
-* **date:** enable width customization ([8807c18](https://github.com/Sage/carbon/commit/8807c183b840094c4822330b68f70c747b191fa7)), closes [#5787](https://github.com/Sage/carbon/issues/5787)
+- **date:** enable width customization ([8807c18](https://github.com/Sage/carbon/commit/8807c183b840094c4822330b68f70c747b191fa7)), closes [#5787](https://github.com/Sage/carbon/issues/5787)
 
 ### [116.1.2](https://github.com/Sage/carbon/compare/v116.1.1...v116.1.2) (2023-03-21)
 
-
 ### Bug Fixes
 
-* **button-toggle:** ensure text wraps correctly ([243badb](https://github.com/Sage/carbon/commit/243badbe6709d7d5cc669dfe951468859436d1c7)), closes [#FE-5682](https://github.com/Sage/carbon/issues/FE-5682)
+- **button-toggle:** ensure text wraps correctly ([243badb](https://github.com/Sage/carbon/commit/243badbe6709d7d5cc669dfe951468859436d1c7)), closes [#FE-5682](https://github.com/Sage/carbon/issues/FE-5682)
 
 ### [116.1.1](https://github.com/Sage/carbon/compare/v116.1.0...v116.1.1) (2023-03-21)
 
-
 ### Bug Fixes
 
-* **focus-trap:** ensure focus trap behaviour does not work except in the top modal ([de53a06](https://github.com/Sage/carbon/commit/de53a060c05d1346623ee8fbc17cf99c572358cc)), closes [#5754](https://github.com/Sage/carbon/issues/5754)
-* **focus-trap:** utilise tab guards to avoid calling preventDefault except when necessary ([9fadf91](https://github.com/Sage/carbon/commit/9fadf911a41de72dfa324f8c078ed55492c80791)), closes [#5749](https://github.com/Sage/carbon/issues/5749)
+- **focus-trap:** ensure focus trap behaviour does not work except in the top modal ([de53a06](https://github.com/Sage/carbon/commit/de53a060c05d1346623ee8fbc17cf99c572358cc)), closes [#5754](https://github.com/Sage/carbon/issues/5754)
+- **focus-trap:** utilise tab guards to avoid calling preventDefault except when necessary ([9fadf91](https://github.com/Sage/carbon/commit/9fadf911a41de72dfa324f8c078ed55492c80791)), closes [#5749](https://github.com/Sage/carbon/issues/5749)
 
 ## [116.1.0](https://github.com/Sage/carbon/compare/v116.0.1...v116.1.0) (2023-03-20)
 
-
 ### Features
 
-* **badge:** allow component to be display only ([856ecc2](https://github.com/Sage/carbon/commit/856ecc2a1681705051250ac6c27aba4a5f62e585)), closes [#5706](https://github.com/Sage/carbon/issues/5706)
+- **badge:** allow component to be display only ([856ecc2](https://github.com/Sage/carbon/commit/856ecc2a1681705051250ac6c27aba4a5f62e585)), closes [#5706](https://github.com/Sage/carbon/issues/5706)
 
 ### [116.0.1](https://github.com/Sage/carbon/compare/v116.0.0...v116.0.1) (2023-03-15)
 
-
 ### Bug Fixes
 
-* **select:** prevent crash when the value does not match any child ([a184f95](https://github.com/Sage/carbon/commit/a184f95e2c1c6eb1a8be0d7a4d7130ed067ba518)), closes [#5905](https://github.com/Sage/carbon/issues/5905)
+- **select:** prevent crash when the value does not match any child ([a184f95](https://github.com/Sage/carbon/commit/a184f95e2c1c6eb1a8be0d7a4d7130ed067ba518)), closes [#5905](https://github.com/Sage/carbon/issues/5905)
 
 ## [116.0.0](https://github.com/Sage/carbon/compare/v115.0.2...v116.0.0) (2023-03-14)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **tile-select:** The name prop is now required for
-TileSelect. Additionally, the onChange handler in TileSelect and
-TileSelectGroup components has been updated to properly
-type arguments, including custom events. Also inputRef prop has been removed.
+- **tile-select:** The name prop is now required for
+  TileSelect. Additionally, the onChange handler in TileSelect and
+  TileSelectGroup components has been updated to properly
+  type arguments, including custom events. Also inputRef prop has been removed.
 
 ### Code Refactoring
 
-* **tile-select:** convert component to typescript ([382ef95](https://github.com/Sage/carbon/commit/382ef95c38c6805bb97dad33efb70db6780a5528))
+- **tile-select:** convert component to typescript ([382ef95](https://github.com/Sage/carbon/commit/382ef95c38c6805bb97dad33efb70db6780a5528))
 
 ### [115.0.2](https://github.com/Sage/carbon/compare/v115.0.1...v115.0.2) (2023-03-14)
 
-
 ### Bug Fixes
 
-* **multi-action-button, split-button:** open menu on click ([3c01e7b](https://github.com/Sage/carbon/commit/3c01e7ba98eec26700f9676843440f928dab576b)), closes [#5615](https://github.com/Sage/carbon/issues/5615)
+- **multi-action-button, split-button:** open menu on click ([3c01e7b](https://github.com/Sage/carbon/commit/3c01e7ba98eec26700f9676843440f928dab576b)), closes [#5615](https://github.com/Sage/carbon/issues/5615)
 
 ### [115.0.1](https://github.com/Sage/carbon/compare/v115.0.0...v115.0.1) (2023-03-13)
 
-
 ### Bug Fixes
 
-* **action-popover:** resolve issue with Select component closing parent Dialog on escape key press ([e942dbf](https://github.com/Sage/carbon/commit/e942dbf57b3aa77b6b0afe2f158234c2abc9e08c))
+- **action-popover:** resolve issue with Select component closing parent Dialog on escape key press ([e942dbf](https://github.com/Sage/carbon/commit/e942dbf57b3aa77b6b0afe2f158234c2abc9e08c))
 
 ## [115.0.0](https://github.com/Sage/carbon/compare/v114.18.2...v115.0.0) (2023-03-13)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **textbox, textarea, checkbox, inline-inputs:** inline inputs are no longer automatically labelled
-by the label prop, please use aria-label or aria-labelledby directly
-on components passed as InlineInputs children.
-* **textbox:** labelId prop is removed
+- **textbox, textarea, checkbox, inline-inputs:** inline inputs are no longer automatically labelled
+  by the label prop, please use aria-label or aria-labelledby directly
+  on components passed as InlineInputs children.
+- **textbox:** labelId prop is removed
 
 ### Bug Fixes
 
-* **textbox, textarea, checkbox, inline-inputs:** allow aria-labelledby to be passed to the input ([f62ade2](https://github.com/Sage/carbon/commit/f62ade2dae47ed35be5a47071279ab169ef50f05))
-
+- **textbox, textarea, checkbox, inline-inputs:** allow aria-labelledby to be passed to the input ([f62ade2](https://github.com/Sage/carbon/commit/f62ade2dae47ed35be5a47071279ab169ef50f05))
 
 ### Code Refactoring
 
-* **textbox:** remove labelId prop ([85aa922](https://github.com/Sage/carbon/commit/85aa92250edcd6480b578d30bae5a50fb87a6441))
+- **textbox:** remove labelId prop ([85aa922](https://github.com/Sage/carbon/commit/85aa92250edcd6480b578d30bae5a50fb87a6441))
 
 ### [114.18.2](https://github.com/Sage/carbon/compare/v114.18.1...v114.18.2) (2023-03-09)
 
-
 ### Bug Fixes
 
-* **multi-action-button:** resolve an issue with styles being overriden in child buttons ([b581624](https://github.com/Sage/carbon/commit/b581624ac6a9fffb53cf74c8e3bbdaad48b85122))
-* **split-button:** resolve an issue with styles being overriden in child buttons ([0e27765](https://github.com/Sage/carbon/commit/0e27765e8aedf4c7e6de44ccfd3f6db0b2cb8fdd))
+- **multi-action-button:** resolve an issue with styles being overriden in child buttons ([b581624](https://github.com/Sage/carbon/commit/b581624ac6a9fffb53cf74c8e3bbdaad48b85122))
+- **split-button:** resolve an issue with styles being overriden in child buttons ([0e27765](https://github.com/Sage/carbon/commit/0e27765e8aedf4c7e6de44ccfd3f6db0b2cb8fdd))
 
 ### [114.18.1](https://github.com/Sage/carbon/compare/v114.18.0...v114.18.1) (2023-03-08)
 
-
 ### Bug Fixes
 
-* workaround to generate valid `icon-unicodes.d.ts` ([42752d7](https://github.com/Sage/carbon/commit/42752d73bd4c809d6b2e0a7705c773d12a1e59fe))
+- workaround to generate valid `icon-unicodes.d.ts` ([42752d7](https://github.com/Sage/carbon/commit/42752d73bd4c809d6b2e0a7705c773d12a1e59fe))
 
 ## [114.18.0](https://github.com/Sage/carbon/compare/v114.17.6...v114.18.0) (2023-03-08)
 
-
 ### Features
 
-* **inline-inputs:** add margin interface ([681a284](https://github.com/Sage/carbon/commit/681a2848ec947537eef54a39eb325e5947009922))
-
+- **inline-inputs:** add margin interface ([681a284](https://github.com/Sage/carbon/commit/681a2848ec947537eef54a39eb325e5947009922))
 
 ### Bug Fixes
 
-* **form:** ensure any custom margin-bottom applied to inputs override fieldSpacing ([96a1222](https://github.com/Sage/carbon/commit/96a12222426d9107dde0d911371faf0cfe506978)), closes [#5681](https://github.com/Sage/carbon/issues/5681)
+- **form:** ensure any custom margin-bottom applied to inputs override fieldSpacing ([96a1222](https://github.com/Sage/carbon/commit/96a12222426d9107dde0d911371faf0cfe506978)), closes [#5681](https://github.com/Sage/carbon/issues/5681)
 
 ### [114.17.6](https://github.com/Sage/carbon/compare/v114.17.5...v114.17.6) (2023-03-03)
 
-
 ### Bug Fixes
 
-* **deps:** move esbuild to dev dependency ([7c55ec6](https://github.com/Sage/carbon/commit/7c55ec612a331e0254e25ff928b426bb3e115220))
+- **deps:** move esbuild to dev dependency ([7c55ec6](https://github.com/Sage/carbon/commit/7c55ec612a331e0254e25ff928b426bb3e115220))
 
 ### [114.17.5](https://github.com/Sage/carbon/compare/v114.17.4...v114.17.5) (2023-03-03)
 
-
 ### Bug Fixes
 
-* **page:** remove additional box padding ([6554158](https://github.com/Sage/carbon/commit/655415881af57651d9b0956846b0ed254acaa447)), closes [#5857](https://github.com/Sage/carbon/issues/5857)
+- **page:** remove additional box padding ([6554158](https://github.com/Sage/carbon/commit/655415881af57651d9b0956846b0ed254acaa447)), closes [#5857](https://github.com/Sage/carbon/issues/5857)
 
 ### [114.17.4](https://github.com/Sage/carbon/compare/v114.17.3...v114.17.4) (2023-03-02)
 
-
 ### Bug Fixes
 
-* make internal menu keyboard navigation hook use useModalManager ([cf004c9](https://github.com/Sage/carbon/commit/cf004c92c4e1a9370037040a9f1c8850e855591a))
-* **multi-action-button:** resolve issue with component closing parent Dialog on escape key press ([1bed27c](https://github.com/Sage/carbon/commit/1bed27ca6210547410da0ed7bd01d4fdc2110e2f))
-* **split-button:** resolve issue with component closing parent Dialog on escape key press ([cb7900a](https://github.com/Sage/carbon/commit/cb7900a7ed1ded14e7d19a6f54735c08553257e5))
+- make internal menu keyboard navigation hook use useModalManager ([cf004c9](https://github.com/Sage/carbon/commit/cf004c92c4e1a9370037040a9f1c8850e855591a))
+- **multi-action-button:** resolve issue with component closing parent Dialog on escape key press ([1bed27c](https://github.com/Sage/carbon/commit/1bed27ca6210547410da0ed7bd01d4fdc2110e2f))
+- **split-button:** resolve issue with component closing parent Dialog on escape key press ([cb7900a](https://github.com/Sage/carbon/commit/cb7900a7ed1ded14e7d19a6f54735c08553257e5))
 
 ### [114.17.3](https://github.com/Sage/carbon/compare/v114.17.2...v114.17.3) (2023-03-01)
 
-
 ### Bug Fixes
 
-* **submenu:** ensure focus order is correct when submenu parent item is clicked first ([2377e5a](https://github.com/Sage/carbon/commit/2377e5ab15ee892dfa846022bdc933ffc426cfa2)), closes [#5850](https://github.com/Sage/carbon/issues/5850)
+- **submenu:** ensure focus order is correct when submenu parent item is clicked first ([2377e5a](https://github.com/Sage/carbon/commit/2377e5ab15ee892dfa846022bdc933ffc426cfa2)), closes [#5850](https://github.com/Sage/carbon/issues/5850)
 
 ### [114.17.2](https://github.com/Sage/carbon/compare/v114.17.1...v114.17.2) (2023-02-28)
 
-
 ### Bug Fixes
 
-* **select:** resolve issue with Select component closing parent Dialog on escape key press ([eeaba5f](https://github.com/Sage/carbon/commit/eeaba5f349cf5b9175929500a5bafb51b181f85a))
+- **select:** resolve issue with Select component closing parent Dialog on escape key press ([eeaba5f](https://github.com/Sage/carbon/commit/eeaba5f349cf5b9175929500a5bafb51b181f85a))
 
 ### [114.17.1](https://github.com/Sage/carbon/compare/v114.17.0...v114.17.1) (2023-02-23)
 
-
 ### Bug Fixes
 
-* **menu-item:** maintain focus order when submenu child item is clicked ([a9c7d06](https://github.com/Sage/carbon/commit/a9c7d063922fe3e757f3afd556152d6a7ef7d5b3)), closes [#5850](https://github.com/Sage/carbon/issues/5850)
-* **submenu:** ensure first submenu child item is not focused when opened via mouseover ([d429c0f](https://github.com/Sage/carbon/commit/d429c0fc9cd0f31b7b4b07ed3594cad9346afbc4))
+- **menu-item:** maintain focus order when submenu child item is clicked ([a9c7d06](https://github.com/Sage/carbon/commit/a9c7d063922fe3e757f3afd556152d6a7ef7d5b3)), closes [#5850](https://github.com/Sage/carbon/issues/5850)
+- **submenu:** ensure first submenu child item is not focused when opened via mouseover ([d429c0f](https://github.com/Sage/carbon/commit/d429c0fc9cd0f31b7b4b07ed3594cad9346afbc4))
 
 ## [114.17.0](https://github.com/Sage/carbon/compare/v114.16.0...v114.17.0) (2023-02-22)
 
-
 ### Features
 
-* **simple-color-picker:** add forwardRef that returns all color inputs ([ea29b7c](https://github.com/Sage/carbon/commit/ea29b7cdff61776298bbb4556e5c6433252b8934))
+- **simple-color-picker:** add forwardRef that returns all color inputs ([ea29b7c](https://github.com/Sage/carbon/commit/ea29b7cdff61776298bbb4556e5c6433252b8934))
 
 ## [114.16.0](https://github.com/Sage/carbon/compare/v114.15.0...v114.16.0) (2023-02-21)
 
-
 ### Features
 
-* **settings-row,heading:** surface headingType prop on components ([7f53917](https://github.com/Sage/carbon/commit/7f53917b6aeafe57f534bbd493afec2c676e2ac7)), closes [#5723](https://github.com/Sage/carbon/issues/5723)
+- **settings-row,heading:** surface headingType prop on components ([7f53917](https://github.com/Sage/carbon/commit/7f53917b6aeafe57f534bbd493afec2c676e2ac7)), closes [#5723](https://github.com/Sage/carbon/issues/5723)
 
 ## [114.15.0](https://github.com/Sage/carbon/compare/v114.14.1...v114.15.0) (2023-02-21)
 
-
 ### Features
 
-* add internal useStableCallback hook ([d1e96bc](https://github.com/Sage/carbon/commit/d1e96bc348dd9cd8aeaa15d16fa6ce5104944756))
-
+- add internal useStableCallback hook ([d1e96bc](https://github.com/Sage/carbon/commit/d1e96bc348dd9cd8aeaa15d16fa6ce5104944756))
 
 ### Bug Fixes
 
-* **filterable-select:** resolve issue with multiple execution of onOpen and onFilterChange callbacks ([65a9cef](https://github.com/Sage/carbon/commit/65a9cef560723f9c23220ca8db0be69b7bf6b77c))
-* **multi-select:** resolve issue with multiple execution of onFilterChange callback ([f0112a7](https://github.com/Sage/carbon/commit/f0112a72f73a4a56b748d12e10be4546bf381c41))
+- **filterable-select:** resolve issue with multiple execution of onOpen and onFilterChange callbacks ([65a9cef](https://github.com/Sage/carbon/commit/65a9cef560723f9c23220ca8db0be69b7bf6b77c))
+- **multi-select:** resolve issue with multiple execution of onFilterChange callback ([f0112a7](https://github.com/Sage/carbon/commit/f0112a72f73a4a56b748d12e10be4546bf381c41))
 
 ### [114.14.1](https://github.com/Sage/carbon/compare/v114.14.0...v114.14.1) (2023-02-16)
 
-
 ### Bug Fixes
 
-* **link:** change display to inline so that text can wrap ([aa35ee5](https://github.com/Sage/carbon/commit/aa35ee52dd78e00945a3308972ca06ca1ab1c7ee)), closes [#5774](https://github.com/Sage/carbon/issues/5774)
-* types in MenuContext provider in link test ([4c51a6c](https://github.com/Sage/carbon/commit/4c51a6cff00be815c05dc99e805e8f4e455256cf))
+- **link:** change display to inline so that text can wrap ([aa35ee5](https://github.com/Sage/carbon/commit/aa35ee52dd78e00945a3308972ca06ca1ab1c7ee)), closes [#5774](https://github.com/Sage/carbon/issues/5774)
+- types in MenuContext provider in link test ([4c51a6c](https://github.com/Sage/carbon/commit/4c51a6cff00be815c05dc99e805e8f4e455256cf))
 
 ## [114.14.0](https://github.com/Sage/carbon/compare/v114.13.2...v114.14.0) (2023-02-15)
 
-
 ### Features
 
-* **select:** add virtual scrolling support ([a1048d7](https://github.com/Sage/carbon/commit/a1048d779b6fe81dd9930202cbaa443fd9ee153c)), closes [#5492](https://github.com/Sage/carbon/issues/5492)
-
+- **select:** add virtual scrolling support ([a1048d7](https://github.com/Sage/carbon/commit/a1048d779b6fe81dd9930202cbaa443fd9ee153c)), closes [#5492](https://github.com/Sage/carbon/issues/5492)
 
 ### Bug Fixes
 
-* **select:** ensure IDs of select options remain stable on prop changes ([c35fe3f](https://github.com/Sage/carbon/commit/c35fe3f2a54b1b0c55b4046dbc9dc2193c9f3ef4))
+- **select:** ensure IDs of select options remain stable on prop changes ([c35fe3f](https://github.com/Sage/carbon/commit/c35fe3f2a54b1b0c55b4046dbc9dc2193c9f3ef4))
 
 ### [114.13.2](https://github.com/Sage/carbon/compare/v114.13.1...v114.13.2) (2023-02-15)
 
-
 ### Bug Fixes
 
-* **menu, submenu:** refactor components to remove children iteration and cloning ([5530a8f](https://github.com/Sage/carbon/commit/5530a8ffc9d00008217a55d9446fb2b71e6dfbeb)), closes [#5592](https://github.com/Sage/carbon/issues/5592)
+- **menu, submenu:** refactor components to remove children iteration and cloning ([5530a8f](https://github.com/Sage/carbon/commit/5530a8ffc9d00008217a55d9446fb2b71e6dfbeb)), closes [#5592](https://github.com/Sage/carbon/issues/5592)
 
 ### [114.13.1](https://github.com/Sage/carbon/compare/v114.13.0...v114.13.1) (2023-02-14)
 
-
 ### Bug Fixes
 
-* trigger release ([e2c853b](https://github.com/Sage/carbon/commit/e2c853bf32fa5200e4ba916e0311a40ae4be85eb))
+- trigger release ([e2c853b](https://github.com/Sage/carbon/commit/e2c853bf32fa5200e4ba916e0311a40ae4be85eb))
 
 ## [114.13.0](https://github.com/Sage/carbon/compare/v114.12.4...v114.13.0) (2023-02-14)
 
-
 ### Features
 
-* **anchor-navigation:** changed behaviour to improve accessibility ([251bd9c](https://github.com/Sage/carbon/commit/251bd9cf7d8e075ae51714bcd8d814944ab7e853)), closes [#5283](https://github.com/Sage/carbon/issues/5283)
+- **anchor-navigation:** changed behaviour to improve accessibility ([251bd9c](https://github.com/Sage/carbon/commit/251bd9cf7d8e075ae51714bcd8d814944ab7e853)), closes [#5283](https://github.com/Sage/carbon/issues/5283)
 
 ### [114.12.4](https://github.com/Sage/carbon/compare/v114.12.3...v114.12.4) (2023-02-13)
 
-
 ### Bug Fixes
 
-* **date:** update abbreviated day translations in picker component for German locale ([fef59f0](https://github.com/Sage/carbon/commit/fef59f0477da6a4aecc81c7804da7a45038d68f0)), closes [#5786](https://github.com/Sage/carbon/issues/5786)
+- **date:** update abbreviated day translations in picker component for German locale ([fef59f0](https://github.com/Sage/carbon/commit/fef59f0477da6a4aecc81c7804da7a45038d68f0)), closes [#5786](https://github.com/Sage/carbon/issues/5786)
 
 ### [114.12.3](https://github.com/Sage/carbon/compare/v114.12.2...v114.12.3) (2023-02-10)
 
-
 ### Bug Fixes
 
-* **multi-select:** fix onchange callback being called twice on option select ([d1b8581](https://github.com/Sage/carbon/commit/d1b858133147a1b76132202feaad701da0405750))
+- **multi-select:** fix onchange callback being called twice on option select ([d1b8581](https://github.com/Sage/carbon/commit/d1b858133147a1b76132202feaad701da0405750))
 
 ### [114.12.2](https://github.com/Sage/carbon/compare/v114.12.1...v114.12.2) (2023-02-10)
 
-
 ### Bug Fixes
 
-* **box:** ensure z-index is set when sticky or fixed positioned ([7385e53](https://github.com/Sage/carbon/commit/7385e53a8f7137a9e907ae568de19b80cfb9ee00)), closes [#5572](https://github.com/Sage/carbon/issues/5572)
+- **box:** ensure z-index is set when sticky or fixed positioned ([7385e53](https://github.com/Sage/carbon/commit/7385e53a8f7137a9e907ae568de19b80cfb9ee00)), closes [#5572](https://github.com/Sage/carbon/issues/5572)
 
 ### [114.12.1](https://github.com/Sage/carbon/compare/v114.12.0...v114.12.1) (2023-02-09)
 
-
 ### Bug Fixes
 
-* **icon-button:** use onClick instead of onAction to ensure keyboard behaviour is handled by default ([ed31161](https://github.com/Sage/carbon/commit/ed3116154c4ffc263bdaaf2398db6f906ff369b9)), closes [#5791](https://github.com/Sage/carbon/issues/5791)
+- **icon-button:** use onClick instead of onAction to ensure keyboard behaviour is handled by default ([ed31161](https://github.com/Sage/carbon/commit/ed3116154c4ffc263bdaaf2398db6f906ff369b9)), closes [#5791](https://github.com/Sage/carbon/issues/5791)
 
 ## [114.12.0](https://github.com/Sage/carbon/compare/v114.11.0...v114.12.0) (2023-02-09)
 
-
 ### Features
 
-* **image:** add decorative prop to component ([166e859](https://github.com/Sage/carbon/commit/166e8590f59ef6b129bba6fce867f31b4e378e62))
+- **image:** add decorative prop to component ([166e859](https://github.com/Sage/carbon/commit/166e8590f59ef6b129bba6fce867f31b4e378e62))
 
 ## [114.11.0](https://github.com/Sage/carbon/compare/v114.10.1...v114.11.0) (2023-02-08)
 
-
 ### Features
 
-* **minor-button:** add new MinorButton component ([c032d2e](https://github.com/Sage/carbon/commit/c032d2e0797371c9650871e93ecd79e53e6f76c3))
+- **minor-button:** add new MinorButton component ([c032d2e](https://github.com/Sage/carbon/commit/c032d2e0797371c9650871e93ecd79e53e6f76c3))
 
 ### [114.10.1](https://github.com/Sage/carbon/compare/v114.10.0...v114.10.1) (2023-02-08)
 
-
 ### Bug Fixes
 
-* **flat-table:** fix misaligned pager ([4bda19a](https://github.com/Sage/carbon/commit/4bda19adb0a00f56e63b4f11edf911f4fb232a05))
+- **flat-table:** fix misaligned pager ([4bda19a](https://github.com/Sage/carbon/commit/4bda19adb0a00f56e63b4f11edf911f4fb232a05))
 
 ## [114.10.0](https://github.com/Sage/carbon/compare/v114.9.1...v114.10.0) (2023-02-07)
 
-
 ### Features
 
-* **draggable:** adds dragged item id to getColumns callback of draggable component ([8355480](https://github.com/Sage/carbon/commit/835548046223f1c297d58713f45379e394fe0af3))
+- **draggable:** adds dragged item id to getColumns callback of draggable component ([8355480](https://github.com/Sage/carbon/commit/835548046223f1c297d58713f45379e394fe0af3))
 
 ### [114.9.1](https://github.com/Sage/carbon/compare/v114.9.0...v114.9.1) (2023-02-06)
 
-
 ### Bug Fixes
 
-* **popover:** prevent from crashing when rendered in sidebar ([a03c84f](https://github.com/Sage/carbon/commit/a03c84f1d540cdff51d9b5c305e64e286743d4f7))
+- **popover:** prevent from crashing when rendered in sidebar ([a03c84f](https://github.com/Sage/carbon/commit/a03c84f1d540cdff51d9b5c305e64e286743d4f7))
 
 ## [114.9.0](https://github.com/Sage/carbon/compare/v114.8.0...v114.9.0) (2023-02-06)
 
-
 ### Features
 
-* **tab:** introduce titleProps for passing props to corresponding title ([3a0c4e7](https://github.com/Sage/carbon/commit/3a0c4e783f2c49dd2abaebb84e09c6e4f08ff87d))
+- **tab:** introduce titleProps for passing props to corresponding title ([3a0c4e7](https://github.com/Sage/carbon/commit/3a0c4e783f2c49dd2abaebb84e09c6e4f08ff87d))
 
 ## [114.8.0](https://github.com/Sage/carbon/compare/v114.7.1...v114.8.0) (2023-02-03)
 
-
 ### Features
 
-* **checkbox:** use React.forwardRef and deprecate inputRef prop ([9817fe6](https://github.com/Sage/carbon/commit/9817fe61784e7d9b4413995a38115c16c2d149dd)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
-* **date-range:** add startRef and endRef props ([656662e](https://github.com/Sage/carbon/commit/656662e5db4e5464c6f493717049cd3e823994bd)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
-* **date:** use React.forwardRef and deprecate inputRef prop ([fdaf540](https://github.com/Sage/carbon/commit/fdaf54066c62c7b6b01295417f94d00c7cab68d1)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
-* **decimal:** useReact.forwardRef and deprecate inputRef prop ([d1876d3](https://github.com/Sage/carbon/commit/d1876d32bbc4040326f50f0c4aa2732e5fe9727e)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
-* **grouped-character:** use React.forwardRef and deprecate inputRef prop ([3737d54](https://github.com/Sage/carbon/commit/3737d540200ffa3156095b6053109c0e94c78ef2)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
-* **number:** use React.forwardRef and deprecate inputRef prop ([8d0215d](https://github.com/Sage/carbon/commit/8d0215d4de4cf6d8ec41c708c7d91007e07bc03b)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
-* **numeral-date:** add props to give refs to each input ([df20e7d](https://github.com/Sage/carbon/commit/df20e7defc2cad9b9d039fbd81db857504d8cde7)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
-* **radio-button:** deprecate inputRef prop ([171daa7](https://github.com/Sage/carbon/commit/171daa70581e5e281872c8151c9b85b1867ed5e7)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
-* **search:** use React.forwardRef and deprecate inputRef prop ([832c44d](https://github.com/Sage/carbon/commit/832c44dc8a136e6ae843e4d53854f645d7c776bf)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
-* **select:** deprecate inputRef prop ([708cd10](https://github.com/Sage/carbon/commit/708cd10895564588251f61b27d474185e333146b))
-* **switch:** use React.forwardRef and deprecate inputRef prop ([e2f2945](https://github.com/Sage/carbon/commit/e2f29455f748ae0b32570fe1192eb26efaa8380d)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
-* **textarea:** use React.forwardRef and deprecate inputRef prop ([afce55f](https://github.com/Sage/carbon/commit/afce55f6f4c31d7e3d0f1a1ea8a63c263894b3d7)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
-* **textbox:** use React.forwardRef and deprecate inputRef prop ([17c9e2e](https://github.com/Sage/carbon/commit/17c9e2e0a1914953e9aaef581febc44e23dc9c0a)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
-* **tile-select:** use React.forwardRef and deprecate inputRef prop ([774aa1a](https://github.com/Sage/carbon/commit/774aa1aac9d5a8bce84a4456eb3a186eeeda9d61)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
-
+- **checkbox:** use React.forwardRef and deprecate inputRef prop ([9817fe6](https://github.com/Sage/carbon/commit/9817fe61784e7d9b4413995a38115c16c2d149dd)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
+- **date-range:** add startRef and endRef props ([656662e](https://github.com/Sage/carbon/commit/656662e5db4e5464c6f493717049cd3e823994bd)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
+- **date:** use React.forwardRef and deprecate inputRef prop ([fdaf540](https://github.com/Sage/carbon/commit/fdaf54066c62c7b6b01295417f94d00c7cab68d1)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
+- **decimal:** useReact.forwardRef and deprecate inputRef prop ([d1876d3](https://github.com/Sage/carbon/commit/d1876d32bbc4040326f50f0c4aa2732e5fe9727e)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
+- **grouped-character:** use React.forwardRef and deprecate inputRef prop ([3737d54](https://github.com/Sage/carbon/commit/3737d540200ffa3156095b6053109c0e94c78ef2)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
+- **number:** use React.forwardRef and deprecate inputRef prop ([8d0215d](https://github.com/Sage/carbon/commit/8d0215d4de4cf6d8ec41c708c7d91007e07bc03b)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
+- **numeral-date:** add props to give refs to each input ([df20e7d](https://github.com/Sage/carbon/commit/df20e7defc2cad9b9d039fbd81db857504d8cde7)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
+- **radio-button:** deprecate inputRef prop ([171daa7](https://github.com/Sage/carbon/commit/171daa70581e5e281872c8151c9b85b1867ed5e7)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
+- **search:** use React.forwardRef and deprecate inputRef prop ([832c44d](https://github.com/Sage/carbon/commit/832c44dc8a136e6ae843e4d53854f645d7c776bf)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
+- **select:** deprecate inputRef prop ([708cd10](https://github.com/Sage/carbon/commit/708cd10895564588251f61b27d474185e333146b))
+- **switch:** use React.forwardRef and deprecate inputRef prop ([e2f2945](https://github.com/Sage/carbon/commit/e2f29455f748ae0b32570fe1192eb26efaa8380d)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
+- **textarea:** use React.forwardRef and deprecate inputRef prop ([afce55f](https://github.com/Sage/carbon/commit/afce55f6f4c31d7e3d0f1a1ea8a63c263894b3d7)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
+- **textbox:** use React.forwardRef and deprecate inputRef prop ([17c9e2e](https://github.com/Sage/carbon/commit/17c9e2e0a1914953e9aaef581febc44e23dc9c0a)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
+- **tile-select:** use React.forwardRef and deprecate inputRef prop ([774aa1a](https://github.com/Sage/carbon/commit/774aa1aac9d5a8bce84a4456eb3a186eeeda9d61)), closes [#5564](https://github.com/Sage/carbon/issues/5564)
 
 ### Bug Fixes
 
-* remove internal use of inputRef prop in components ([3745ade](https://github.com/Sage/carbon/commit/3745ade5d3ada3b3ab507d526913354e863ca3b3))
+- remove internal use of inputRef prop in components ([3745ade](https://github.com/Sage/carbon/commit/3745ade5d3ada3b3ab507d526913354e863ca3b3))
 
 ### [114.7.1](https://github.com/Sage/carbon/compare/v114.7.0...v114.7.1) (2023-02-01)
 
-
 ### Bug Fixes
 
-* **button-bar, button, icon-button:** remove invariant and implement context to pass props ([da29af1](https://github.com/Sage/carbon/commit/da29af1c08365c1b18ebed8763c8ab9ab0fb54a4)), closes [#5669](https://github.com/Sage/carbon/issues/5669)
+- **button-bar, button, icon-button:** remove invariant and implement context to pass props ([da29af1](https://github.com/Sage/carbon/commit/da29af1c08365c1b18ebed8763c8ab9ab0fb54a4)), closes [#5669](https://github.com/Sage/carbon/issues/5669)
 
 ## [114.7.0](https://github.com/Sage/carbon/compare/v114.6.1...v114.7.0) (2023-01-27)
 
-
 ### Features
 
-* **loader-bar:** display loading message if reduced motion preference is detected ([0b2c0c1](https://github.com/Sage/carbon/commit/0b2c0c133eafb618c02ff22a523de40df4a02ede))
-* **loader:** add locale translation for loading message ([1b50d3b](https://github.com/Sage/carbon/commit/1b50d3b663537b0b4e825f0b666f19494ffffffb))
-* **loader:** display loading message if reduced motion preference is detected ([e9d2192](https://github.com/Sage/carbon/commit/e9d2192102d3f22ce605e6a27b4a418b39858750))
+- **loader-bar:** display loading message if reduced motion preference is detected ([0b2c0c1](https://github.com/Sage/carbon/commit/0b2c0c133eafb618c02ff22a523de40df4a02ede))
+- **loader:** add locale translation for loading message ([1b50d3b](https://github.com/Sage/carbon/commit/1b50d3b663537b0b4e825f0b666f19494ffffffb))
+- **loader:** display loading message if reduced motion preference is detected ([e9d2192](https://github.com/Sage/carbon/commit/e9d2192102d3f22ce605e6a27b4a418b39858750))
 
 ### [114.6.1](https://github.com/Sage/carbon/compare/v114.6.0...v114.6.1) (2023-01-27)
 
-
 ### Bug Fixes
 
-* **text-editor:** add tabIndex 0 to editor container and update types for value and onChange ([61ab635](https://github.com/Sage/carbon/commit/61ab635575f0b95f9e53366657e547e64f16b862)), closes [#5685](https://github.com/Sage/carbon/issues/5685)
+- **text-editor:** add tabIndex 0 to editor container and update types for value and onChange ([61ab635](https://github.com/Sage/carbon/commit/61ab635575f0b95f9e53366657e547e64f16b862)), closes [#5685](https://github.com/Sage/carbon/issues/5685)
 
 ## [114.6.0](https://github.com/Sage/carbon/compare/v114.5.1...v114.6.0) (2023-01-26)
 
-
 ### Features
 
-* add new VerticalMenu component ([819d65d](https://github.com/Sage/carbon/commit/819d65d077b4c28d216cf96f753b1fcc6ee96b61))
+- add new VerticalMenu component ([819d65d](https://github.com/Sage/carbon/commit/819d65d077b4c28d216cf96f753b1fcc6ee96b61))
 
 ### [114.5.1](https://github.com/Sage/carbon/compare/v114.5.0...v114.5.1) (2023-01-26)
 
-
 ### Bug Fixes
 
-* **dialog:** remove left offset on small screens ([1b8d9ec](https://github.com/Sage/carbon/commit/1b8d9ecce0e4579de5c11a309819915992a4f633)), closes [#5549](https://github.com/Sage/carbon/issues/5549)
+- **dialog:** remove left offset on small screens ([1b8d9ec](https://github.com/Sage/carbon/commit/1b8d9ecce0e4579de5c11a309819915992a4f633)), closes [#5549](https://github.com/Sage/carbon/issues/5549)
 
 ## [114.5.0](https://github.com/Sage/carbon/compare/v114.4.0...v114.5.0) (2023-01-26)
 
-
 ### Features
 
-* **icon:** 20 new icons added to the icon font ([5b343c9](https://github.com/Sage/carbon/commit/5b343c9814506a5bdfec1a005735ee172a4cc1ca))
+- **icon:** 20 new icons added to the icon font ([5b343c9](https://github.com/Sage/carbon/commit/5b343c9814506a5bdfec1a005735ee172a4cc1ca))
 
 ## [114.4.0](https://github.com/Sage/carbon/compare/v114.3.0...v114.4.0) (2023-01-25)
 
-
 ### Features
 
-* **pager:** surface hideDisabledElements prop to ensure disabled elements are hidden ([8dc34d5](https://github.com/Sage/carbon/commit/8dc34d5d0cd21a34c3fac84c6bbade11d5773034))
+- **pager:** surface hideDisabledElements prop to ensure disabled elements are hidden ([8dc34d5](https://github.com/Sage/carbon/commit/8dc34d5d0cd21a34c3fac84c6bbade11d5773034))
 
 ## [114.3.0](https://github.com/Sage/carbon/compare/v114.2.1...v114.3.0) (2023-01-24)
 
-
 ### Features
 
-* **pill:** add functionality to define custom aria-label in remove button ([4225f09](https://github.com/Sage/carbon/commit/4225f0959c3cc5012ed6ab826613be5ba58383da)), closes [#5715](https://github.com/Sage/carbon/issues/5715)
+- **pill:** add functionality to define custom aria-label in remove button ([4225f09](https://github.com/Sage/carbon/commit/4225f0959c3cc5012ed6ab826613be5ba58383da)), closes [#5715](https://github.com/Sage/carbon/issues/5715)
 
 ### [114.2.1](https://github.com/Sage/carbon/compare/v114.2.0...v114.2.1) (2023-01-24)
 
-
 ### Bug Fixes
 
-* **note:** fix text overlapping inlineControl button ([7d92187](https://github.com/Sage/carbon/commit/7d92187383d0f53dc071833e2f885fab8748d025)), closes [#5734](https://github.com/Sage/carbon/issues/5734)
+- **note:** fix text overlapping inlineControl button ([7d92187](https://github.com/Sage/carbon/commit/7d92187383d0f53dc071833e2f885fab8748d025)), closes [#5734](https://github.com/Sage/carbon/issues/5734)
 
 ## [114.2.0](https://github.com/Sage/carbon/compare/v114.1.0...v114.2.0) (2023-01-18)
 
-
 ### Features
 
-* **inline-inputs:** add required prop ([d1b12a2](https://github.com/Sage/carbon/commit/d1b12a2db05fbb910e581c73878b694bc492b1ea)), closes [#4625](https://github.com/Sage/carbon/issues/4625)
+- **inline-inputs:** add required prop ([d1b12a2](https://github.com/Sage/carbon/commit/d1b12a2db05fbb910e581c73878b694bc492b1ea)), closes [#4625](https://github.com/Sage/carbon/issues/4625)
 
 ## [114.1.0](https://github.com/Sage/carbon/compare/v114.0.0...v114.1.0) (2023-01-18)
 
-
 ### Features
 
-* **pod:** deprecate support for passing strings and objects to the `onEdit` prop ([ce3b46e](https://github.com/Sage/carbon/commit/ce3b46e771718e37d055cfc63e22a3c361554db6))
-
+- **pod:** deprecate support for passing strings and objects to the `onEdit` prop ([ce3b46e](https://github.com/Sage/carbon/commit/ce3b46e771718e37d055cfc63e22a3c361554db6))
 
 ### Bug Fixes
 
-* **pod:** add accessible names to delete and undo buttons ([abb9025](https://github.com/Sage/carbon/commit/abb90257c986b6ae57cd7d0ec9ef908f8fa8ec10))
-* **pod:** remove footer aligning when alignTitle is set ([20f3532](https://github.com/Sage/carbon/commit/20f3532f5f53be91c8a3003a36b802e9b1c2ee0d))
+- **pod:** add accessible names to delete and undo buttons ([abb9025](https://github.com/Sage/carbon/commit/abb90257c986b6ae57cd7d0ec9ef908f8fa8ec10))
+- **pod:** remove footer aligning when alignTitle is set ([20f3532](https://github.com/Sage/carbon/commit/20f3532f5f53be91c8a3003a36b802e9b1c2ee0d))
 
 ## [114.0.0](https://github.com/Sage/carbon/compare/v113.0.3...v114.0.0) (2023-01-17)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **progress-tracker:** The orientation and direction props of the component are no longer available.
-The component is now meant to be used only in a horizontal.
+- **progress-tracker:** The orientation and direction props of the component are no longer available.
+  The component is now meant to be used only in a horizontal.
 
 ### Features
 
-* **progress-tracker:** implement component redesign ([7c0e936](https://github.com/Sage/carbon/commit/7c0e936b132ee74521068ec48b4063757efdeb62))
+- **progress-tracker:** implement component redesign ([7c0e936](https://github.com/Sage/carbon/commit/7c0e936b132ee74521068ec48b4063757efdeb62))
 
 ### [113.0.3](https://github.com/Sage/carbon/compare/v113.0.2...v113.0.3) (2023-01-13)
 
-
 ### Bug Fixes
 
-* **tile-select-group:** implement conditional rendering for the description prop ([f271d25](https://github.com/Sage/carbon/commit/f271d258133e4ac69e00b357b0483052a3dc4933)), closes [#5699](https://github.com/Sage/carbon/issues/5699)
+- **tile-select-group:** implement conditional rendering for the description prop ([f271d25](https://github.com/Sage/carbon/commit/f271d258133e4ac69e00b357b0483052a3dc4933)), closes [#5699](https://github.com/Sage/carbon/issues/5699)
 
 ### [113.0.2](https://github.com/Sage/carbon/compare/v113.0.1...v113.0.2) (2023-01-12)
 
-
 ### Bug Fixes
 
-* **form:** update onSubmit type ([03fd976](https://github.com/Sage/carbon/commit/03fd976504c8943ada57df92d1b0d6537a7e4c76)), closes [#5659](https://github.com/Sage/carbon/issues/5659)
+- **form:** update onSubmit type ([03fd976](https://github.com/Sage/carbon/commit/03fd976504c8943ada57df92d1b0d6537a7e4c76)), closes [#5659](https://github.com/Sage/carbon/issues/5659)
 
 ### [113.0.1](https://github.com/Sage/carbon/compare/v113.0.0...v113.0.1) (2023-01-11)
 
-
 ### Bug Fixes
 
-* **dialog:** fix incorrect focus trap behaviour when ag-grid is rendered inside ([d44b2d9](https://github.com/Sage/carbon/commit/d44b2d99d1c6f591d4bdd2473117da5d2c6e1dd3))
+- **dialog:** fix incorrect focus trap behaviour when ag-grid is rendered inside ([d44b2d9](https://github.com/Sage/carbon/commit/d44b2d99d1c6f591d4bdd2473117da5d2c6e1dd3))
 
 ## [113.0.0](https://github.com/Sage/carbon/compare/v112.0.4...v113.0.0) (2023-01-11)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **tooltip:** jest versions lower than 27 are no longer supported and might break unit tests
+- **tooltip:** jest versions lower than 27 are no longer supported and might break unit tests
 
 ### Code Refactoring
 
-* **tooltip:** make tooltips use floating-ui package ([afc5bf5](https://github.com/Sage/carbon/commit/afc5bf53f6a037512350177937c5f5509a452a2d))
+- **tooltip:** make tooltips use floating-ui package ([afc5bf5](https://github.com/Sage/carbon/commit/afc5bf53f6a037512350177937c5f5509a452a2d))
 
 ### [112.0.4](https://github.com/Sage/carbon/compare/v112.0.3...v112.0.4) (2023-01-10)
 
-
 ### Bug Fixes
 
-* **tab-title:** ensure focus outline is present when Tabs are used within Drawer ([1f191dc](https://github.com/Sage/carbon/commit/1f191dc2438ac685a2201df9751ce3da2f356244)), closes [#5598](https://github.com/Sage/carbon/issues/5598)
+- **tab-title:** ensure focus outline is present when Tabs are used within Drawer ([1f191dc](https://github.com/Sage/carbon/commit/1f191dc2438ac685a2201df9751ce3da2f356244)), closes [#5598](https://github.com/Sage/carbon/issues/5598)
 
 ### [112.0.3](https://github.com/Sage/carbon/compare/v112.0.2...v112.0.3) (2023-01-10)
 
-
 ### Bug Fixes
 
-* **page:** replace incorrect article tag with div ([3622ed9](https://github.com/Sage/carbon/commit/3622ed99046f986aceba8f0e0b5c144689526b60))
+- **page:** replace incorrect article tag with div ([3622ed9](https://github.com/Sage/carbon/commit/3622ed99046f986aceba8f0e0b5c144689526b60))
 
 ### [112.0.2](https://github.com/Sage/carbon/compare/v112.0.1...v112.0.2) (2023-01-09)
 
-
 ### Bug Fixes
 
-* **textbox:** fix incorrect margin on prefix ([7a4200a](https://github.com/Sage/carbon/commit/7a4200a694a9a1b243e699339f5a3b9f6aac4942)), closes [#5646](https://github.com/Sage/carbon/issues/5646)
+- **textbox:** fix incorrect margin on prefix ([7a4200a](https://github.com/Sage/carbon/commit/7a4200a694a9a1b243e699339f5a3b9f6aac4942)), closes [#5646](https://github.com/Sage/carbon/issues/5646)
 
 ### [112.0.1](https://github.com/Sage/carbon/compare/v112.0.0...v112.0.1) (2023-01-09)
 
-
 ### Bug Fixes
 
-* **tabs:** ensure arrow navigation is correct when Tabs are used within Drawer ([150d67e](https://github.com/Sage/carbon/commit/150d67e4d443ce18f1d0b8f3767825e361adf24b)), closes [#5597](https://github.com/Sage/carbon/issues/5597)
+- **tabs:** ensure arrow navigation is correct when Tabs are used within Drawer ([150d67e](https://github.com/Sage/carbon/commit/150d67e4d443ce18f1d0b8f3767825e361adf24b)), closes [#5597](https://github.com/Sage/carbon/issues/5597)
 
 ## [112.0.0](https://github.com/Sage/carbon/compare/v111.22.4...v112.0.0) (2023-01-09)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **pager:** onNext, onFirst, OnPrevious and onLast Pager prop types have been changed
+- **pager:** onNext, onFirst, OnPrevious and onLast Pager prop types have been changed
 
 ### Code Refactoring
 
-* **pager:** convert component to typescript ([3233d4c](https://github.com/Sage/carbon/commit/3233d4ce6b7e0d5acfeddbc45025c8d359c23d7b))
+- **pager:** convert component to typescript ([3233d4c](https://github.com/Sage/carbon/commit/3233d4ce6b7e0d5acfeddbc45025c8d359c23d7b))
 
 ### [111.22.4](https://github.com/Sage/carbon/compare/v111.22.3...v111.22.4) (2023-01-06)
 
-
 ### Bug Fixes
 
-* **progress-tracker:** add deprecation warnings for orientation and direction props ([db4d936](https://github.com/Sage/carbon/commit/db4d93635f88dbaa273174994491362ef4019df1))
+- **progress-tracker:** add deprecation warnings for orientation and direction props ([db4d936](https://github.com/Sage/carbon/commit/db4d93635f88dbaa273174994491362ef4019df1))
 
 ### [111.22.3](https://github.com/Sage/carbon/compare/v111.22.2...v111.22.3) (2023-01-04)
 
-
 ### Bug Fixes
 
-* **menu-full-screen:** ensure no crash when clicking outside a submenu ([c1f2bdb](https://github.com/Sage/carbon/commit/c1f2bdbe8ef28be5de2f79398091876cfc491255)), closes [#5682](https://github.com/Sage/carbon/issues/5682)
+- **menu-full-screen:** ensure no crash when clicking outside a submenu ([c1f2bdb](https://github.com/Sage/carbon/commit/c1f2bdbe8ef28be5de2f79398091876cfc491255)), closes [#5682](https://github.com/Sage/carbon/issues/5682)
 
 ### [111.22.2](https://github.com/Sage/carbon/compare/v111.22.1...v111.22.2) (2022-12-23)
 
-
 ### Bug Fixes
 
-* **simple-color-picker:** make simple-color ids unique ([678d838](https://github.com/Sage/carbon/commit/678d8388aff4a1264e266265cec2f487f938b399))
+- **simple-color-picker:** make simple-color ids unique ([678d838](https://github.com/Sage/carbon/commit/678d8388aff4a1264e266265cec2f487f938b399))
 
 ### [111.22.1](https://github.com/Sage/carbon/compare/v111.22.0...v111.22.1) (2022-12-21)
 
-
 ### Bug Fixes
 
-* **tabs:** fix an issue with infinite rerender when numeral date is rendered as a child ([0b046f0](https://github.com/Sage/carbon/commit/0b046f0d507d43e1bf050394c53e5913dfbfe383))
+- **tabs:** fix an issue with infinite rerender when numeral date is rendered as a child ([0b046f0](https://github.com/Sage/carbon/commit/0b046f0d507d43e1bf050394c53e5913dfbfe383))
 
 ## [111.22.0](https://github.com/Sage/carbon/compare/v111.21.1...v111.22.0) (2022-12-19)
 
-
 ### Features
 
-* **icon:** 1 new icon added dashboard ([9dec617](https://github.com/Sage/carbon/commit/9dec617f963d521a1ee7cff32df155809031a5e6))
+- **icon:** 1 new icon added dashboard ([9dec617](https://github.com/Sage/carbon/commit/9dec617f963d521a1ee7cff32df155809031a5e6))
 
 ### [111.21.1](https://github.com/Sage/carbon/compare/v111.21.0...v111.21.1) (2022-12-16)
 
-
 ### Bug Fixes
 
-* **pager:** correctly associate labels to input fields ([8407813](https://github.com/Sage/carbon/commit/84078135ba6f67cddb7f081597781d93e1687a2b)), closes [#5284](https://github.com/Sage/carbon/issues/5284) [#5632](https://github.com/Sage/carbon/issues/5632)
+- **pager:** correctly associate labels to input fields ([8407813](https://github.com/Sage/carbon/commit/84078135ba6f67cddb7f081597781d93e1687a2b)), closes [#5284](https://github.com/Sage/carbon/issues/5284) [#5632](https://github.com/Sage/carbon/issues/5632)
 
 ## [111.21.0](https://github.com/Sage/carbon/compare/v111.20.0...v111.21.0) (2022-12-16)
 
-
 ### Features
 
-* **multi-action-button:** surface width prop to allow width to be set for component ([0056bbe](https://github.com/Sage/carbon/commit/0056bbe5f743b78ebfafacbb0befc69f3883a991)), closes [#5547](https://github.com/Sage/carbon/issues/5547) [#5672](https://github.com/Sage/carbon/issues/5672)
+- **multi-action-button:** surface width prop to allow width to be set for component ([0056bbe](https://github.com/Sage/carbon/commit/0056bbe5f743b78ebfafacbb0befc69f3883a991)), closes [#5547](https://github.com/Sage/carbon/issues/5547) [#5672](https://github.com/Sage/carbon/issues/5672)
 
 ## [111.20.0](https://github.com/Sage/carbon/compare/v111.19.0...v111.20.0) (2022-12-14)
 
-
 ### Features
 
-* **icon-button:** add padding interface to component ([2aba921](https://github.com/Sage/carbon/commit/2aba9219ef4f233b8b0ac023d26f4a6c8dabd873))
-
+- **icon-button:** add padding interface to component ([2aba921](https://github.com/Sage/carbon/commit/2aba9219ef4f233b8b0ac023d26f4a6c8dabd873))
 
 ### Bug Fixes
 
-* **menu-item:** prevent default padding on button/anchor inside MenuItem if no onClick/href set ([45195c6](https://github.com/Sage/carbon/commit/45195c6926da7a679b4898c9c2187ac9d7d32595)), closes [#5640](https://github.com/Sage/carbon/issues/5640)
+- **menu-item:** prevent default padding on button/anchor inside MenuItem if no onClick/href set ([45195c6](https://github.com/Sage/carbon/commit/45195c6926da7a679b4898c9c2187ac9d7d32595)), closes [#5640](https://github.com/Sage/carbon/issues/5640)
 
 ## [111.19.0](https://github.com/Sage/carbon/compare/v111.18.0...v111.19.0) (2022-12-13)
 
-
 ### Features
 
-* **tabs:** add showValidationsSummary prop to support rendering a summary of validation failures ([bce64c6](https://github.com/Sage/carbon/commit/bce64c66d22087dff89dc738a94ea2e7da756ee0)), closes [#5618](https://github.com/Sage/carbon/issues/5618)
-
+- **tabs:** add showValidationsSummary prop to support rendering a summary of validation failures ([bce64c6](https://github.com/Sage/carbon/commit/bce64c66d22087dff89dc738a94ea2e7da756ee0)), closes [#5618](https://github.com/Sage/carbon/issues/5618)
 
 ### Bug Fixes
 
-* **tab:** ensure that validation failures are no longer reported when children unmount ([4b67d47](https://github.com/Sage/carbon/commit/4b67d4738c8ed4ff603b9f6e61fcd0fccb05c8b6)), closes [#5591](https://github.com/Sage/carbon/issues/5591)
+- **tab:** ensure that validation failures are no longer reported when children unmount ([4b67d47](https://github.com/Sage/carbon/commit/4b67d4738c8ed4ff603b9f6e61fcd0fccb05c8b6)), closes [#5591](https://github.com/Sage/carbon/issues/5591)
 
 ## [111.18.0](https://github.com/Sage/carbon/compare/v111.17.0...v111.18.0) (2022-12-13)
 
-
 ### Features
 
-* **card:** add height prop ([e8d7d21](https://github.com/Sage/carbon/commit/e8d7d21900d3f81aca4a197a98cab034c7de6373))
+- **card:** add height prop ([e8d7d21](https://github.com/Sage/carbon/commit/e8d7d21900d3f81aca4a197a98cab034c7de6373))
 
 ## [111.17.0](https://github.com/Sage/carbon/compare/v111.16.0...v111.17.0) (2022-12-12)
 
-
 ### Features
 
-* **tile:** add black variant to footer and add border options to component ([06c7dcf](https://github.com/Sage/carbon/commit/06c7dcf4734733cec20d48ac225c6b2d54c71149))
+- **tile:** add black variant to footer and add border options to component ([06c7dcf](https://github.com/Sage/carbon/commit/06c7dcf4734733cec20d48ac225c6b2d54c71149))
 
 ## [111.16.0](https://github.com/Sage/carbon/compare/v111.15.0...v111.16.0) (2022-12-07)
 
-
 ### Features
 
-* **form:** surface padding interface on Form footer via footerPadding prop ([1c29e01](https://github.com/Sage/carbon/commit/1c29e018e0fdca033e2f9b860e8f7c2b5f22ab69))
-* **sidebar:** add support for overriding the padding in header ([0040efb](https://github.com/Sage/carbon/commit/0040efba3db1e44ac32bc5a674b6fe63bde1e4a8))
+- **form:** surface padding interface on Form footer via footerPadding prop ([1c29e01](https://github.com/Sage/carbon/commit/1c29e018e0fdca033e2f9b860e8f7c2b5f22ab69))
+- **sidebar:** add support for overriding the padding in header ([0040efb](https://github.com/Sage/carbon/commit/0040efba3db1e44ac32bc5a674b6fe63bde1e4a8))
 
 ## [111.15.0](https://github.com/Sage/carbon/compare/v111.14.0...v111.15.0) (2022-12-07)
 
-
 ### Features
 
-* **box:** add props for custom box shadow ([3bc3f6d](https://github.com/Sage/carbon/commit/3bc3f6dd95ab410463c43a509f23f07edf4cfb2c))
-* **card:** add props for custom box shadows ([17f1931](https://github.com/Sage/carbon/commit/17f193180b402d79b063f4ebb433b2461e973f49))
+- **box:** add props for custom box shadow ([3bc3f6d](https://github.com/Sage/carbon/commit/3bc3f6dd95ab410463c43a509f23f07edf4cfb2c))
+- **card:** add props for custom box shadows ([17f1931](https://github.com/Sage/carbon/commit/17f193180b402d79b063f4ebb433b2461e973f49))
 
 ## [111.14.0](https://github.com/Sage/carbon/compare/v111.13.2...v111.14.0) (2022-12-07)
 
-
 ### Features
 
-* **button-toggle-group:** surface fullWidth prop to ensure children flex to container width ([b41324c](https://github.com/Sage/carbon/commit/b41324c9f077ac34f0401ddc0ed9182601b3aed9)), closes [#5490](https://github.com/Sage/carbon/issues/5490)
+- **button-toggle-group:** surface fullWidth prop to ensure children flex to container width ([b41324c](https://github.com/Sage/carbon/commit/b41324c9f077ac34f0401ddc0ed9182601b3aed9)), closes [#5490](https://github.com/Sage/carbon/issues/5490)
 
 ### [111.13.2](https://github.com/Sage/carbon/compare/v111.13.1...v111.13.2) (2022-12-07)
 
-
 ### Bug Fixes
 
-* **pager:** fix bottom margin of number input when inside a form ([242d29c](https://github.com/Sage/carbon/commit/242d29c9a5f49b1979547d57a20f3ddb117ffce0)), closes [#5650](https://github.com/Sage/carbon/issues/5650)
+- **pager:** fix bottom margin of number input when inside a form ([242d29c](https://github.com/Sage/carbon/commit/242d29c9a5f49b1979547d57a20f3ddb117ffce0)), closes [#5650](https://github.com/Sage/carbon/issues/5650)
 
 ### [111.13.1](https://github.com/Sage/carbon/compare/v111.13.0...v111.13.1) (2022-12-05)
 
-
 ### Bug Fixes
 
-* **pager:** ensure there is no margin-bottom on page number input ([f5f1637](https://github.com/Sage/carbon/commit/f5f1637e822ec102fac7761c9e4a35e39642426f)), closes [#5650](https://github.com/Sage/carbon/issues/5650)
+- **pager:** ensure there is no margin-bottom on page number input ([f5f1637](https://github.com/Sage/carbon/commit/f5f1637e822ec102fac7761c9e4a35e39642426f)), closes [#5650](https://github.com/Sage/carbon/issues/5650)
 
 ## [111.13.0](https://github.com/Sage/carbon/compare/v111.12.7...v111.13.0) (2022-12-02)
 
-
 ### Features
 
-* **textarea, textbox:** surface maxWidth prop on components ([544a050](https://github.com/Sage/carbon/commit/544a050142b0e437aabccfdc78e8c31872795115)), closes [#5494](https://github.com/Sage/carbon/issues/5494) [#5234](https://github.com/Sage/carbon/issues/5234)
+- **textarea, textbox:** surface maxWidth prop on components ([544a050](https://github.com/Sage/carbon/commit/544a050142b0e437aabccfdc78e8c31872795115)), closes [#5494](https://github.com/Sage/carbon/issues/5494) [#5234](https://github.com/Sage/carbon/issues/5234)
 
 ### [111.12.7](https://github.com/Sage/carbon/compare/v111.12.6...v111.12.7) (2022-12-02)
 
-
 ### Bug Fixes
 
-* added missing focus trap props to sidebar and full-width-dialog ([a0335bc](https://github.com/Sage/carbon/commit/a0335bc38b9f0d42d2b59a353e00d574c4082393))
+- added missing focus trap props to sidebar and full-width-dialog ([a0335bc](https://github.com/Sage/carbon/commit/a0335bc38b9f0d42d2b59a353e00d574c4082393))
 
 ### [111.12.6](https://github.com/Sage/carbon/compare/v111.12.5...v111.12.6) (2022-12-01)
 
-
 ### Bug Fixes
 
-* **date-range:** update styles so validation and label text wrap if they exceed input width ([014a5b3](https://github.com/Sage/carbon/commit/014a5b311cdaf770472801b6981069a00fe3ba9e)), closes [#5431](https://github.com/Sage/carbon/issues/5431)
+- **date-range:** update styles so validation and label text wrap if they exceed input width ([014a5b3](https://github.com/Sage/carbon/commit/014a5b311cdaf770472801b6981069a00fe3ba9e)), closes [#5431](https://github.com/Sage/carbon/issues/5431)
 
 ### [111.12.5](https://github.com/Sage/carbon/compare/v111.12.4...v111.12.5) (2022-11-30)
 
-
 ### Bug Fixes
 
-* **cypress:** update accessibility tests to ignore  mdx docs on contributing ([0a53d49](https://github.com/Sage/carbon/commit/0a53d494685fc43ce521bd5896b18a6da873c35a))
+- **cypress:** update accessibility tests to ignore mdx docs on contributing ([0a53d49](https://github.com/Sage/carbon/commit/0a53d494685fc43ce521bd5896b18a6da873c35a))
 
 ### [111.12.4](https://github.com/Sage/carbon/compare/v111.12.3...v111.12.4) (2022-11-24)
 
-
 ### Bug Fixes
 
-* **date-picker:** correct css variable for disabled state and current date disable styling ([52de6e4](https://github.com/Sage/carbon/commit/52de6e452fe9f8bd57f195952b9a66f0af4c3c8a))
+- **date-picker:** correct css variable for disabled state and current date disable styling ([52de6e4](https://github.com/Sage/carbon/commit/52de6e452fe9f8bd57f195952b9a66f0af4c3c8a))
 
 ### [111.12.3](https://github.com/Sage/carbon/compare/v111.12.2...v111.12.3) (2022-11-24)
 
-
 ### Bug Fixes
 
-* **loader-utils:** bumps version to remove critical security vulnerability ([4b0efb7](https://github.com/Sage/carbon/commit/4b0efb7635697cb9a99d71e6aafca563f7bbb6b5))
+- **loader-utils:** bumps version to remove critical security vulnerability ([4b0efb7](https://github.com/Sage/carbon/commit/4b0efb7635697cb9a99d71e6aafca563f7bbb6b5))
 
 ### [111.12.2](https://github.com/Sage/carbon/compare/v111.12.1...v111.12.2) (2022-11-23)
 
-
 ### Bug Fixes
 
-* **accordion:** update margin-left spacing values to use tokens when buttonHeading is used ([e4804e8](https://github.com/Sage/carbon/commit/e4804e813d4ad3ee4bf603ed8729eb526bf5a42c))
+- **accordion:** update margin-left spacing values to use tokens when buttonHeading is used ([e4804e8](https://github.com/Sage/carbon/commit/e4804e813d4ad3ee4bf603ed8729eb526bf5a42c))
 
 ### [111.12.1](https://github.com/Sage/carbon/compare/v111.12.0...v111.12.1) (2022-11-23)
 
-
 ### Bug Fixes
 
-* **toast:** ensure toast component has first focus when opened ([81d87fe](https://github.com/Sage/carbon/commit/81d87fe8e1c541c0aeb7185bd984defa6c50c5e6))
+- **toast:** ensure toast component has first focus when opened ([81d87fe](https://github.com/Sage/carbon/commit/81d87fe8e1c541c0aeb7185bd984defa6c50c5e6))
 
 ## [111.12.0](https://github.com/Sage/carbon/compare/v111.11.0...v111.12.0) (2022-11-21)
 
-
 ### Features
 
-* **step-sequence-item:** add new dashed line for incomplete steps ([4379f68](https://github.com/Sage/carbon/commit/4379f68aa97bc72b3890984e03ede7024b5d70fc))
-* **step-sequence:** remove default padding and add support for padding props interface ([a3d3c28](https://github.com/Sage/carbon/commit/a3d3c28c56ba8eeaf15088aa63ace41f2f689b82))
-
+- **step-sequence-item:** add new dashed line for incomplete steps ([4379f68](https://github.com/Sage/carbon/commit/4379f68aa97bc72b3890984e03ede7024b5d70fc))
+- **step-sequence:** remove default padding and add support for padding props interface ([a3d3c28](https://github.com/Sage/carbon/commit/a3d3c28c56ba8eeaf15088aa63ace41f2f689b82))
 
 ### Bug Fixes
 
-* **step-sequence:** ensure elements flex to full height of container when vertically orientated ([2329cbe](https://github.com/Sage/carbon/commit/2329cbe00086bcf0ed13d041d8da2f5f4da97d46))
+- **step-sequence:** ensure elements flex to full height of container when vertically orientated ([2329cbe](https://github.com/Sage/carbon/commit/2329cbe00086bcf0ed13d041d8da2f5f4da97d46))
 
 ## [111.11.0](https://github.com/Sage/carbon/compare/v111.10.0...v111.11.0) (2022-11-21)
 
-
 ### Features
 
-* **icon:** 3 new icons, box_arrow_left, u_turn_left and u_turn_right ([eac6021](https://github.com/Sage/carbon/commit/eac60215e0bb0214898a77764ce1659638c66a87))
+- **icon:** 3 new icons, box_arrow_left, u_turn_left and u_turn_right ([eac6021](https://github.com/Sage/carbon/commit/eac60215e0bb0214898a77764ce1659638c66a87))
 
 ## [111.10.0](https://github.com/Sage/carbon/compare/v111.9.1...v111.10.0) (2022-11-21)
 
-
 ### Features
 
-* **sidebar:** add support for setting custom width ([f2995f8](https://github.com/Sage/carbon/commit/f2995f8564fb9d40ab2ee399dd972166d82aabbb))
+- **sidebar:** add support for setting custom width ([f2995f8](https://github.com/Sage/carbon/commit/f2995f8564fb9d40ab2ee399dd972166d82aabbb))
 
 ### [111.9.1](https://github.com/Sage/carbon/compare/v111.9.0...v111.9.1) (2022-11-14)
 
-
 ### Bug Fixes
 
-* **dialog, sidebar:** fix tabbing in nested modals ([ae82ef2](https://github.com/Sage/carbon/commit/ae82ef2c99d6d81b10fc222d350620634e50d171)), closes [#5445](https://github.com/Sage/carbon/issues/5445)
+- **dialog, sidebar:** fix tabbing in nested modals ([ae82ef2](https://github.com/Sage/carbon/commit/ae82ef2c99d6d81b10fc222d350620634e50d171)), closes [#5445](https://github.com/Sage/carbon/issues/5445)
 
 ## [111.9.0](https://github.com/Sage/carbon/compare/v111.8.5...v111.9.0) (2022-11-10)
 
-
 ### Features
 
-* **flat-table-header:** add support for overriding the colour of the right border ([7267b56](https://github.com/Sage/carbon/commit/7267b56b11f076f202fbf8e8ddc8c392797bf9dc))
-* **flat-table-row-header:** add support for rendering a second right hand side sticky column ([70f1a3c](https://github.com/Sage/carbon/commit/70f1a3c73c72f659c2e9eae5bdc23d92bf384be5))
-
+- **flat-table-header:** add support for overriding the colour of the right border ([7267b56](https://github.com/Sage/carbon/commit/7267b56b11f076f202fbf8e8ddc8c392797bf9dc))
+- **flat-table-row-header:** add support for rendering a second right hand side sticky column ([70f1a3c](https://github.com/Sage/carbon/commit/70f1a3c73c72f659c2e9eae5bdc23d92bf384be5))
 
 ### Bug Fixes
 
-* **flat-table:** ensure all table head is sticky when isStickyHead is used with rowSpan ([1733915](https://github.com/Sage/carbon/commit/1733915ab006591053bd1f9b90b5e210fc603826)), closes [#5576](https://github.com/Sage/carbon/issues/5576)
-* **flat-table:** ensure th elements within sticky thead overlap tbody elements when scrolling ([03340d4](https://github.com/Sage/carbon/commit/03340d4070d42bdd78b2a31a68424fef37ec2b17)), closes [#5459](https://github.com/Sage/carbon/issues/5459)
+- **flat-table:** ensure all table head is sticky when isStickyHead is used with rowSpan ([1733915](https://github.com/Sage/carbon/commit/1733915ab006591053bd1f9b90b5e210fc603826)), closes [#5576](https://github.com/Sage/carbon/issues/5576)
+- **flat-table:** ensure th elements within sticky thead overlap tbody elements when scrolling ([03340d4](https://github.com/Sage/carbon/commit/03340d4070d42bdd78b2a31a68424fef37ec2b17)), closes [#5459](https://github.com/Sage/carbon/issues/5459)
 
 ### [111.8.5](https://github.com/Sage/carbon/compare/v111.8.4...v111.8.5) (2022-11-09)
 
-
 ### Bug Fixes
 
-* **form:** fix form styling when inside a sidebar ([055b15d](https://github.com/Sage/carbon/commit/055b15d2e41c7fe8186768f60cdf831607be3b67)), closes [#5404](https://github.com/Sage/carbon/issues/5404)
+- **form:** fix form styling when inside a sidebar ([055b15d](https://github.com/Sage/carbon/commit/055b15d2e41c7fe8186768f60cdf831607be3b67)), closes [#5404](https://github.com/Sage/carbon/issues/5404)
 
 ### [111.8.4](https://github.com/Sage/carbon/compare/v111.8.3...v111.8.4) (2022-11-07)
 
-
 ### Bug Fixes
 
-* **textbox:** fix issue with click action not triggered when the component is slightly out of view ([6bef71b](https://github.com/Sage/carbon/commit/6bef71bf056a1d4326057247db1e38697fb444b9))
+- **textbox:** fix issue with click action not triggered when the component is slightly out of view ([6bef71b](https://github.com/Sage/carbon/commit/6bef71bf056a1d4326057247db1e38697fb444b9))
 
 ### [111.8.3](https://github.com/Sage/carbon/compare/v111.8.2...v111.8.3) (2022-11-03)
 
-
 ### Bug Fixes
 
-* **menu:** ensure only one submenu can be open at any one time ([285f6b4](https://github.com/Sage/carbon/commit/285f6b44e851f4ab65600db5aa7aad19d7d46d1a)), closes [#5229](https://github.com/Sage/carbon/issues/5229)
+- **menu:** ensure only one submenu can be open at any one time ([285f6b4](https://github.com/Sage/carbon/commit/285f6b44e851f4ab65600db5aa7aad19d7d46d1a)), closes [#5229](https://github.com/Sage/carbon/issues/5229)
 
 ### [111.8.2](https://github.com/Sage/carbon/compare/v111.8.1...v111.8.2) (2022-10-31)
 
-
 ### Bug Fixes
 
-* **select:** fix select list positioning issues ([942c31b](https://github.com/Sage/carbon/commit/942c31b7839593e66b785420e86079d06d5c78d5))
+- **select:** fix select list positioning issues ([942c31b](https://github.com/Sage/carbon/commit/942c31b7839593e66b785420e86079d06d5c78d5))
 
 ### [111.8.1](https://github.com/Sage/carbon/compare/v111.8.0...v111.8.1) (2022-10-27)
 
-
 ### Bug Fixes
 
-* **definition-list:** correct font styling of dt and dd elements ([6a6f628](https://github.com/Sage/carbon/commit/6a6f628b75672a7c8b64ef8d869778c3a216c3e1))
+- **definition-list:** correct font styling of dt and dd elements ([6a6f628](https://github.com/Sage/carbon/commit/6a6f628b75672a7c8b64ef8d869778c3a216c3e1))
 
 ## [111.8.0](https://github.com/Sage/carbon/compare/v111.7.0...v111.8.0) (2022-10-24)
 
-
 ### Features
 
-* **menuitem:** add `rel` prop to be passed down to HTML anchor ([1544e79](https://github.com/Sage/carbon/commit/1544e79c75460aefc2c17eddac639a446594503c)), closes [#5464](https://github.com/Sage/carbon/issues/5464)
+- **menuitem:** add `rel` prop to be passed down to HTML anchor ([1544e79](https://github.com/Sage/carbon/commit/1544e79c75460aefc2c17eddac639a446594503c)), closes [#5464](https://github.com/Sage/carbon/issues/5464)
 
 ## [111.7.0](https://github.com/Sage/carbon/compare/v111.6.0...v111.7.0) (2022-10-21)
 
-
 ### Features
 
-* **focus-trap:** custom selector for focusable elements ([f5f3ce3](https://github.com/Sage/carbon/commit/f5f3ce38bfa6b4336f318575055ef73c4f403d19))
+- **focus-trap:** custom selector for focusable elements ([f5f3ce3](https://github.com/Sage/carbon/commit/f5f3ce38bfa6b4336f318575055ef73c4f403d19))
 
 ## [111.6.0](https://github.com/Sage/carbon/compare/v111.5.3...v111.6.0) (2022-10-21)
 
-
 ### Features
 
-* **image:** add hidden prop ([2d89615](https://github.com/Sage/carbon/commit/2d89615e542fc285f9dda6e3545325020a059df9))
+- **image:** add hidden prop ([2d89615](https://github.com/Sage/carbon/commit/2d89615e542fc285f9dda6e3545325020a059df9))
 
 ### [111.5.3](https://github.com/Sage/carbon/compare/v111.5.2...v111.5.3) (2022-10-21)
 
-
 ### Bug Fixes
 
-* upgrade node-fetch dependency to version 3 ([0f20144](https://github.com/Sage/carbon/commit/0f201440a122a0ee2bafeca10d43350fb64aeb16))
+- upgrade node-fetch dependency to version 3 ([0f20144](https://github.com/Sage/carbon/commit/0f201440a122a0ee2bafeca10d43350fb64aeb16))
 
 ### [111.5.2](https://github.com/Sage/carbon/compare/v111.5.1...v111.5.2) (2022-10-20)
 
-
 ### Bug Fixes
 
-* **dialog, sidebar:** ensure aria-modal is only added to top modal ([e6bcf92](https://github.com/Sage/carbon/commit/e6bcf920b1dbc35a3931ab5cd911c767df9b5065)), closes [#5303](https://github.com/Sage/carbon/issues/5303)
+- **dialog, sidebar:** ensure aria-modal is only added to top modal ([e6bcf92](https://github.com/Sage/carbon/commit/e6bcf920b1dbc35a3931ab5cd911c767df9b5065)), closes [#5303](https://github.com/Sage/carbon/issues/5303)
 
 ### [111.5.1](https://github.com/Sage/carbon/compare/v111.5.0...v111.5.1) (2022-10-19)
 
-
 ### Bug Fixes
 
-* **tags:** update TagProps interface so only the data tag types are exported ([e6d14ba](https://github.com/Sage/carbon/commit/e6d14ba32c033a47955a08abee2799d343c0e988)), closes [#5534](https://github.com/Sage/carbon/issues/5534)
+- **tags:** update TagProps interface so only the data tag types are exported ([e6d14ba](https://github.com/Sage/carbon/commit/e6d14ba32c033a47955a08abee2799d343c0e988)), closes [#5534](https://github.com/Sage/carbon/issues/5534)
 
 ## [111.5.0](https://github.com/Sage/carbon/compare/v111.4.2...v111.5.0) (2022-10-19)
 
-
 ### Features
 
-* **card:** deprecate dataRole prop, replace with functionality with data-role ([6fff828](https://github.com/Sage/carbon/commit/6fff8280972db3a1b219c2b9a6e55d5489bd4117))
+- **card:** deprecate dataRole prop, replace with functionality with data-role ([6fff828](https://github.com/Sage/carbon/commit/6fff8280972db3a1b219c2b9a6e55d5489bd4117))
 
 ### [111.4.2](https://github.com/Sage/carbon/compare/v111.4.1...v111.4.2) (2022-10-18)
 
-
 ### Bug Fixes
 
-* **multi-action-button:** fix safari styling for right alignment ([abee168](https://github.com/Sage/carbon/commit/abee168019229c103c37c8b2141616f77b399cd5))
+- **multi-action-button:** fix safari styling for right alignment ([abee168](https://github.com/Sage/carbon/commit/abee168019229c103c37c8b2141616f77b399cd5))
 
 ### [111.4.1](https://github.com/Sage/carbon/compare/v111.4.0...v111.4.1) (2022-10-17)
 
-
 ### Bug Fixes
 
-* fix typescript errors in declaration files ([ae9a447](https://github.com/Sage/carbon/commit/ae9a447ada1bd6b1433eb92944b2ac0389c26335)), closes [#5478](https://github.com/Sage/carbon/issues/5478)
+- fix typescript errors in declaration files ([ae9a447](https://github.com/Sage/carbon/commit/ae9a447ada1bd6b1433eb92944b2ac0389c26335)), closes [#5478](https://github.com/Sage/carbon/issues/5478)
 
 ## [111.4.0](https://github.com/Sage/carbon/compare/v111.3.3...v111.4.0) (2022-10-14)
 
-
 ### Features
 
-* **dialog:** introduce DialogSizes type ([872627c](https://github.com/Sage/carbon/commit/872627c900befe2caea9557dcbfb880067d5b954)), closes [#5516](https://github.com/Sage/carbon/issues/5516)
+- **dialog:** introduce DialogSizes type ([872627c](https://github.com/Sage/carbon/commit/872627c900befe2caea9557dcbfb880067d5b954)), closes [#5516](https://github.com/Sage/carbon/issues/5516)
 
 ### [111.3.3](https://github.com/Sage/carbon/compare/v111.3.2...v111.3.3) (2022-10-13)
 
-
 ### Bug Fixes
 
-* **tab:** prevent title prop being set as an attribute on the DOM element ([6169a7f](https://github.com/Sage/carbon/commit/6169a7fa9523c8287f2e7882645aff59b8349f3b)), closes [#5480](https://github.com/Sage/carbon/issues/5480)
-* **tabs:** ensure that the selected Tab does not update when children update ([dccf8ed](https://github.com/Sage/carbon/commit/dccf8edd9c40875441ac4a64a19b49973fa1919f)), closes [#5527](https://github.com/Sage/carbon/issues/5527)
+- **tab:** prevent title prop being set as an attribute on the DOM element ([6169a7f](https://github.com/Sage/carbon/commit/6169a7fa9523c8287f2e7882645aff59b8349f3b)), closes [#5480](https://github.com/Sage/carbon/issues/5480)
+- **tabs:** ensure that the selected Tab does not update when children update ([dccf8ed](https://github.com/Sage/carbon/commit/dccf8edd9c40875441ac4a64a19b49973fa1919f)), closes [#5527](https://github.com/Sage/carbon/issues/5527)
 
 ### [111.3.2](https://github.com/Sage/carbon/compare/v111.3.1...v111.3.2) (2022-10-13)
 
-
 ### Bug Fixes
 
-* move cypress preprocessor dependencies to devDependencies ([efca508](https://github.com/Sage/carbon/commit/efca50845702f47bec393ad5c29e296c262a01fd))
+- move cypress preprocessor dependencies to devDependencies ([efca508](https://github.com/Sage/carbon/commit/efca50845702f47bec393ad5c29e296c262a01fd))
 
 ### [111.3.1](https://github.com/Sage/carbon/compare/v111.3.0...v111.3.1) (2022-10-13)
 
-
 ### Bug Fixes
 
-* **multi-action-button:** fix styling bug when a href is passed to a button ([cffbdf7](https://github.com/Sage/carbon/commit/cffbdf7604b7badcbc1b4790646678a42864a7dd)), closes [#5483](https://github.com/Sage/carbon/issues/5483)
+- **multi-action-button:** fix styling bug when a href is passed to a button ([cffbdf7](https://github.com/Sage/carbon/commit/cffbdf7604b7badcbc1b4790646678a42864a7dd)), closes [#5483](https://github.com/Sage/carbon/issues/5483)
 
 ## [111.3.0](https://github.com/Sage/carbon/compare/v111.2.0...v111.3.0) (2022-10-10)
 
-
 ### Features
 
-* **box:** add support for the gap css property when component is displayed flex or inline-flex ([b751e26](https://github.com/Sage/carbon/commit/b751e26a0136a586a0f225081fc5f6bf7c21ee32)), closes [#5434](https://github.com/Sage/carbon/issues/5434)
+- **box:** add support for the gap css property when component is displayed flex or inline-flex ([b751e26](https://github.com/Sage/carbon/commit/b751e26a0136a586a0f225081fc5f6bf7c21ee32)), closes [#5434](https://github.com/Sage/carbon/issues/5434)
 
 ## [111.2.0](https://github.com/Sage/carbon/compare/v111.1.0...v111.2.0) (2022-10-07)
 
-
 ### Features
 
-* **sidebar, drawer and dialogs:** adjust background of modal headers to be white instead of grey ([2126172](https://github.com/Sage/carbon/commit/21261720fadf628479d3e2b2edb18a5e22663eeb))
+- **sidebar, drawer and dialogs:** adjust background of modal headers to be white instead of grey ([2126172](https://github.com/Sage/carbon/commit/21261720fadf628479d3e2b2edb18a5e22663eeb))
 
 ## [111.1.0](https://github.com/Sage/carbon/compare/v111.0.3...v111.1.0) (2022-10-06)
 
-
 ### Features
 
-* **toast:** add notice variant ([f177de5](https://github.com/Sage/carbon/commit/f177de563a53544b64f08641e314a685d4af8f65))
+- **toast:** add notice variant ([f177de5](https://github.com/Sage/carbon/commit/f177de563a53544b64f08641e314a685d4af8f65))
 
 ### [111.0.3](https://github.com/Sage/carbon/compare/v111.0.2...v111.0.3) (2022-10-04)
 
-
 ### Bug Fixes
 
-* **multi-select:** ensure aria-selected has the correct value ([0e1f314](https://github.com/Sage/carbon/commit/0e1f31427293731f1301aad0ff2a8fac1a4059e4)), closes [#5272](https://github.com/Sage/carbon/issues/5272)
+- **multi-select:** ensure aria-selected has the correct value ([0e1f314](https://github.com/Sage/carbon/commit/0e1f31427293731f1301aad0ff2a8fac1a4059e4)), closes [#5272](https://github.com/Sage/carbon/issues/5272)
 
 ### [111.0.2](https://github.com/Sage/carbon/compare/v111.0.1...v111.0.2) (2022-09-29)
 
-
 ### Bug Fixes
 
-* **menu:** ensure submenu closes when enter key is pressed ([04f5045](https://github.com/Sage/carbon/commit/04f504507e1f0a826806012301c7b5ee142cc98e)), closes [#4792](https://github.com/Sage/carbon/issues/4792)
+- **menu:** ensure submenu closes when enter key is pressed ([04f5045](https://github.com/Sage/carbon/commit/04f504507e1f0a826806012301c7b5ee142cc98e)), closes [#4792](https://github.com/Sage/carbon/issues/4792)
 
 ### [111.0.1](https://github.com/Sage/carbon/compare/v111.0.0...v111.0.1) (2022-09-29)
 
-
 ### Bug Fixes
 
-* **flat-table:** correct alignment of focus outline ([87f464b](https://github.com/Sage/carbon/commit/87f464b5f40f4c0d379a00f06f25a78469af29c6)), closes [#5403](https://github.com/Sage/carbon/issues/5403)
+- **flat-table:** correct alignment of focus outline ([87f464b](https://github.com/Sage/carbon/commit/87f464b5f40f4c0d379a00f06f25a78469af29c6)), closes [#5403](https://github.com/Sage/carbon/issues/5403)
 
 ## [111.0.0](https://github.com/Sage/carbon/compare/v110.11.1...v111.0.0) (2022-09-29)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **select:** listPlacement prop interface on all Select components has been changed -
- only `top`, `bottom`, `left` and `right` are valid values now
+- **select:** listPlacement prop interface on all Select components has been changed -
+  only `top`, `bottom`, `left` and `right` are valid values now
 
 ### Features
 
-* add internal useFloating hook ([cd73ec8](https://github.com/Sage/carbon/commit/cd73ec8b58d5887b0297fa0c0c0604879c8c313b))
-
+- add internal useFloating hook ([cd73ec8](https://github.com/Sage/carbon/commit/cd73ec8b58d5887b0297fa0c0c0604879c8c313b))
 
 ### Bug Fixes
 
-* **select:** fix issue with list not updating position after layout change ([f3b22d9](https://github.com/Sage/carbon/commit/f3b22d9538d65c2fdb26d8dee1b8f417fd1e42ef))
+- **select:** fix issue with list not updating position after layout change ([f3b22d9](https://github.com/Sage/carbon/commit/f3b22d9538d65c2fdb26d8dee1b8f417fd1e42ef))
 
 ### [110.11.1](https://github.com/Sage/carbon/compare/v110.11.0...v110.11.1) (2022-09-28)
 
-
 ### Bug Fixes
 
-* **multi-action-button:** ensure that enter and space keys trigger onClick callback ([6d0f6e8](https://github.com/Sage/carbon/commit/6d0f6e8dd18f0b5ee908b7f94fb1776a00d217d2)), closes [#5472](https://github.com/Sage/carbon/issues/5472)
+- **multi-action-button:** ensure that enter and space keys trigger onClick callback ([6d0f6e8](https://github.com/Sage/carbon/commit/6d0f6e8dd18f0b5ee908b7f94fb1776a00d217d2)), closes [#5472](https://github.com/Sage/carbon/issues/5472)
 
 ## [110.11.0](https://github.com/Sage/carbon/compare/v110.10.3...v110.11.0) (2022-09-27)
 
-
 ### Features
 
-* **progress-tracker:** add default value for aria-valuenow ([434911d](https://github.com/Sage/carbon/commit/434911d8e8c5a82df5b600f3d1eb32b9deed0964))
+- **progress-tracker:** add default value for aria-valuenow ([434911d](https://github.com/Sage/carbon/commit/434911d8e8c5a82df5b600f3d1eb32b9deed0964))
 
 ### [110.10.3](https://github.com/Sage/carbon/compare/v110.10.2...v110.10.3) (2022-09-23)
 
-
 ### Bug Fixes
 
-* **tabs:** update type definition for validationStatusOverride prop ([19bb18f](https://github.com/Sage/carbon/commit/19bb18f16fbfbca6342825d395a2f73c63597472))
+- **tabs:** update type definition for validationStatusOverride prop ([19bb18f](https://github.com/Sage/carbon/commit/19bb18f16fbfbca6342825d395a2f73c63597472))
 
 ### [110.10.2](https://github.com/Sage/carbon/compare/v110.10.1...v110.10.2) (2022-09-22)
 
-
 ### Bug Fixes
 
-* **popover-container:** fix positioning with renderOpenComponent prop ([ab2fa46](https://github.com/Sage/carbon/commit/ab2fa46b98a5d36668ffff47a97722340af610fd))
+- **popover-container:** fix positioning with renderOpenComponent prop ([ab2fa46](https://github.com/Sage/carbon/commit/ab2fa46b98a5d36668ffff47a97722340af610fd))
 
 ### [110.10.1](https://github.com/Sage/carbon/compare/v110.10.0...v110.10.1) (2022-09-22)
 
-
 ### Bug Fixes
 
-* **dialog, dialog-full-screen, sidebar, form:** ensure focused elements are displayed on screen ([172d64c](https://github.com/Sage/carbon/commit/172d64c5fff2aa85bfe1d536781019bef3888d0a)), closes [#5278](https://github.com/Sage/carbon/issues/5278)
+- **dialog, dialog-full-screen, sidebar, form:** ensure focused elements are displayed on screen ([172d64c](https://github.com/Sage/carbon/commit/172d64c5fff2aa85bfe1d536781019bef3888d0a)), closes [#5278](https://github.com/Sage/carbon/issues/5278)
 
 ## [110.10.0](https://github.com/Sage/carbon/compare/v110.9.1...v110.10.0) (2022-09-21)
 
-
 ### Features
 
-* **tile:** add support for active variant styling ([e1ed353](https://github.com/Sage/carbon/commit/e1ed353821c2f0b431ada65bb3f6b8242bf5ccd5)), closes [#5444](https://github.com/Sage/carbon/issues/5444)
+- **tile:** add support for active variant styling ([e1ed353](https://github.com/Sage/carbon/commit/e1ed353821c2f0b431ada65bb3f6b8242bf5ccd5)), closes [#5444](https://github.com/Sage/carbon/issues/5444)
 
 ### [110.9.1](https://github.com/Sage/carbon/compare/v110.9.0...v110.9.1) (2022-09-21)
 
-
 ### Bug Fixes
 
-* **confirm:** update DialogProps import path to ensure interface is extended correctly ([f5f2004](https://github.com/Sage/carbon/commit/f5f2004769368f73be4412a2e9563b96f2bd4014))
+- **confirm:** update DialogProps import path to ensure interface is extended correctly ([f5f2004](https://github.com/Sage/carbon/commit/f5f2004769368f73be4412a2e9563b96f2bd4014))
 
 ## [110.9.0](https://github.com/Sage/carbon/compare/v110.8.0...v110.9.0) (2022-09-16)
 
-
 ### Features
 
-* **filterable-select:** add listMaxHeight prop support ([d37346f](https://github.com/Sage/carbon/commit/d37346ff217b3f57b549c9116283f9434e9b7daa))
-* **multi-select:** add listMaxHeight prop support ([140199e](https://github.com/Sage/carbon/commit/140199e6604961c7f5320edb23d71c1a7864db8c))
-* **simple-select:** add listMaxHeight prop support ([dc2bb43](https://github.com/Sage/carbon/commit/dc2bb439f0d56519cf1e7895a4fffd17c557dce3))
+- **filterable-select:** add listMaxHeight prop support ([d37346f](https://github.com/Sage/carbon/commit/d37346ff217b3f57b549c9116283f9434e9b7daa))
+- **multi-select:** add listMaxHeight prop support ([140199e](https://github.com/Sage/carbon/commit/140199e6604961c7f5320edb23d71c1a7864db8c))
+- **simple-select:** add listMaxHeight prop support ([dc2bb43](https://github.com/Sage/carbon/commit/dc2bb439f0d56519cf1e7895a4fffd17c557dce3))
 
 ## [110.8.0](https://github.com/Sage/carbon/compare/v110.7.0...v110.8.0) (2022-09-15)
 
-
 ### Features
 
-* **link:** add support for negative and neutral states and better contrast on dark backgrounds ([7c5e4e0](https://github.com/Sage/carbon/commit/7c5e4e0eca2746fe8604c0cbd96168701f13acbe)), closes [#5407](https://github.com/Sage/carbon/issues/5407)
+- **link:** add support for negative and neutral states and better contrast on dark backgrounds ([7c5e4e0](https://github.com/Sage/carbon/commit/7c5e4e0eca2746fe8604c0cbd96168701f13acbe)), closes [#5407](https://github.com/Sage/carbon/issues/5407)
 
 ## [110.7.0](https://github.com/Sage/carbon/compare/v110.6.1...v110.7.0) (2022-09-14)
 
-
 ### Features
 
-* **form:** add support for full width buttons ([5b132fa](https://github.com/Sage/carbon/commit/5b132faf74fa9879be7b8ef910e63322731e19e4)), closes [#4206](https://github.com/Sage/carbon/issues/4206)
+- **form:** add support for full width buttons ([5b132fa](https://github.com/Sage/carbon/commit/5b132faf74fa9879be7b8ef910e63322731e19e4)), closes [#4206](https://github.com/Sage/carbon/issues/4206)
 
 ### [110.6.1](https://github.com/Sage/carbon/compare/v110.6.0...v110.6.1) (2022-09-12)
 
-
 ### Bug Fixes
 
-* **button:** always pass aria-label down to the html element ([286f668](https://github.com/Sage/carbon/commit/286f66851bf70a1e2f4b00acfbd8c0a3dd1cd1f9)), closes [#5311](https://github.com/Sage/carbon/issues/5311)
+- **button:** always pass aria-label down to the html element ([286f668](https://github.com/Sage/carbon/commit/286f66851bf70a1e2f4b00acfbd8c0a3dd1cd1f9)), closes [#5311](https://github.com/Sage/carbon/issues/5311)
 
 ## [110.6.0](https://github.com/Sage/carbon/compare/v110.5.2...v110.6.0) (2022-09-12)
 
-
 ### Features
 
-* **icon:** 3 new icons, alert_on, palm_tree and tick_thick ([c35a8d7](https://github.com/Sage/carbon/commit/c35a8d767289104bd0dd1e2cc9bd5364867fe59b))
+- **icon:** 3 new icons, alert_on, palm_tree and tick_thick ([c35a8d7](https://github.com/Sage/carbon/commit/c35a8d767289104bd0dd1e2cc9bd5364867fe59b))
 
 ### [110.5.2](https://github.com/Sage/carbon/compare/v110.5.1...v110.5.2) (2022-09-12)
 
-
 ### Bug Fixes
 
-* **flat-table-header:** alternative color not changing according theme ([ce6e48c](https://github.com/Sage/carbon/commit/ce6e48c5a26084a96bfe29cf9cd7dcd62d3935e6))
+- **flat-table-header:** alternative color not changing according theme ([ce6e48c](https://github.com/Sage/carbon/commit/ce6e48c5a26084a96bfe29cf9cd7dcd62d3935e6))
 
 ### [110.5.1](https://github.com/Sage/carbon/compare/v110.5.0...v110.5.1) (2022-09-12)
 
-
 ### Bug Fixes
 
-* **tabs, icon:** override behaviour of icon with tooltip when rendered inside tab title ([235e6d9](https://github.com/Sage/carbon/commit/235e6d95c626c1b88050363b02a71a2117bccf94)), closes [#4663](https://github.com/Sage/carbon/issues/4663)
+- **tabs, icon:** override behaviour of icon with tooltip when rendered inside tab title ([235e6d9](https://github.com/Sage/carbon/commit/235e6d95c626c1b88050363b02a71a2117bccf94)), closes [#4663](https://github.com/Sage/carbon/issues/4663)
 
 ## [110.5.0](https://github.com/Sage/carbon/compare/v110.4.1...v110.5.0) (2022-09-09)
 
-
 ### Features
 
-* **search:** add validation props ([04dad45](https://github.com/Sage/carbon/commit/04dad45336168ebdb45ad21f68f2f41fb306efd2)), closes [#5236](https://github.com/Sage/carbon/issues/5236)
+- **search:** add validation props ([04dad45](https://github.com/Sage/carbon/commit/04dad45336168ebdb45ad21f68f2f41fb306efd2)), closes [#5236](https://github.com/Sage/carbon/issues/5236)
 
 ### [110.4.1](https://github.com/Sage/carbon/compare/v110.4.0...v110.4.1) (2022-09-07)
 
-
 ### Bug Fixes
 
-* **select:** ensure aria-activedescendant is always valid ([327b134](https://github.com/Sage/carbon/commit/327b134a05a494ef149d0edcc40331107b470ae3)), closes [#5289](https://github.com/Sage/carbon/issues/5289)
+- **select:** ensure aria-activedescendant is always valid ([327b134](https://github.com/Sage/carbon/commit/327b134a05a494ef149d0edcc40331107b470ae3)), closes [#5289](https://github.com/Sage/carbon/issues/5289)
 
 ## [110.4.0](https://github.com/Sage/carbon/compare/v110.3.0...v110.4.0) (2022-09-07)
 
-
 ### Features
 
-* **button-toggle:** add invariant for childless and iconless buttons ([3a2b631](https://github.com/Sage/carbon/commit/3a2b631546ac213f17ebd2a64994b3c206baa290))
-* **radio-button-mapper:** define types for component props ([c6bce8c](https://github.com/Sage/carbon/commit/c6bce8caafc929d54bdb210693b24fabfec77d0a))
+- **button-toggle:** add invariant for childless and iconless buttons ([3a2b631](https://github.com/Sage/carbon/commit/3a2b631546ac213f17ebd2a64994b3c206baa290))
+- **radio-button-mapper:** define types for component props ([c6bce8c](https://github.com/Sage/carbon/commit/c6bce8caafc929d54bdb210693b24fabfec77d0a))
 
 ## [110.3.0](https://github.com/Sage/carbon/compare/v110.2.4...v110.3.0) (2022-09-06)
 
-
 ### Features
 
-* **scrollable-block:** add parent prop and fix rendered HTML ([c7537f0](https://github.com/Sage/carbon/commit/c7537f012a88e86ec727000bd5e1b89e56112168))
+- **scrollable-block:** add parent prop and fix rendered HTML ([c7537f0](https://github.com/Sage/carbon/commit/c7537f012a88e86ec727000bd5e1b89e56112168))
 
 ### [110.2.4](https://github.com/Sage/carbon/compare/v110.2.3...v110.2.4) (2022-09-05)
 
-
 ### Bug Fixes
 
-* **definition-list:** ensure component has valid displayName ([84ad499](https://github.com/Sage/carbon/commit/84ad4995b6ec5fc698ea0bcca267d2cbff7952ef))
+- **definition-list:** ensure component has valid displayName ([84ad499](https://github.com/Sage/carbon/commit/84ad4995b6ec5fc698ea0bcca267d2cbff7952ef))
 
 ### [110.2.3](https://github.com/Sage/carbon/compare/v110.2.2...v110.2.3) (2022-09-05)
 
-
 ### Bug Fixes
 
-* **flat-table-row:** allow click actions inside interactive row ([536ec5a](https://github.com/Sage/carbon/commit/536ec5a2c393dd906dcaf6939ce5c1dc3e459b72)), closes [#5402](https://github.com/Sage/carbon/issues/5402)
+- **flat-table-row:** allow click actions inside interactive row ([536ec5a](https://github.com/Sage/carbon/commit/536ec5a2c393dd906dcaf6939ce5c1dc3e459b72)), closes [#5402](https://github.com/Sage/carbon/issues/5402)
 
 ### [110.2.2](https://github.com/Sage/carbon/compare/v110.2.1...v110.2.2) (2022-09-02)
 
-
 ### Bug Fixes
 
-* **popover-container:** remove incorrect role attribute ([dfc9ac1](https://github.com/Sage/carbon/commit/dfc9ac1668f3353fa25b0f066610514ccbf4e8d9))
+- **popover-container:** remove incorrect role attribute ([dfc9ac1](https://github.com/Sage/carbon/commit/dfc9ac1668f3353fa25b0f066610514ccbf4e8d9))
 
 ### [110.2.1](https://github.com/Sage/carbon/compare/v110.2.0...v110.2.1) (2022-09-01)
 
-
 ### Bug Fixes
 
-* **select:** ensure select list always has correct height to fit content ([f1d966b](https://github.com/Sage/carbon/commit/f1d966bb96645d91fa989f3f40fb2fd8173e8951)), closes [#5341](https://github.com/Sage/carbon/issues/5341)
+- **select:** ensure select list always has correct height to fit content ([f1d966b](https://github.com/Sage/carbon/commit/f1d966bb96645d91fa989f3f40fb2fd8173e8951)), closes [#5341](https://github.com/Sage/carbon/issues/5341)
 
 ## [110.2.0](https://github.com/Sage/carbon/compare/v110.1.3...v110.2.0) (2022-08-30)
 
-
 ### Features
 
-* **box:** add styled-system position props ([52f065f](https://github.com/Sage/carbon/commit/52f065fbedf5eadf36f970faab96d191bddc4fdc)), closes [#5345](https://github.com/Sage/carbon/issues/5345)
-* **box:** add tabIndex prop ([79a20f2](https://github.com/Sage/carbon/commit/79a20f2ccb9903586c4721ed5313895fa53e67d4))
+- **box:** add styled-system position props ([52f065f](https://github.com/Sage/carbon/commit/52f065fbedf5eadf36f970faab96d191bddc4fdc)), closes [#5345](https://github.com/Sage/carbon/issues/5345)
+- **box:** add tabIndex prop ([79a20f2](https://github.com/Sage/carbon/commit/79a20f2ccb9903586c4721ed5313895fa53e67d4))
 
 ### [110.1.3](https://github.com/Sage/carbon/compare/v110.1.2...v110.1.3) (2022-08-26)
 
-
 ### Bug Fixes
 
-* **form-field:** modify typing of data props ([52a1e57](https://github.com/Sage/carbon/commit/52a1e579054b02f32f777b962cabe9e4514401ff))
+- **form-field:** modify typing of data props ([52a1e57](https://github.com/Sage/carbon/commit/52a1e579054b02f32f777b962cabe9e4514401ff))
 
 ### [110.1.2](https://github.com/Sage/carbon/compare/v110.1.1...v110.1.2) (2022-08-25)
 
-
 ### Bug Fixes
 
-* **date:** ensure selectedDays prop receives a valid value on initial render ([3c8d6da](https://github.com/Sage/carbon/commit/3c8d6daf936dda6e8c5c3ed312f429c2770625eb)), closes [#5333](https://github.com/Sage/carbon/issues/5333)
+- **date:** ensure selectedDays prop receives a valid value on initial render ([3c8d6da](https://github.com/Sage/carbon/commit/3c8d6daf936dda6e8c5c3ed312f429c2770625eb)), closes [#5333](https://github.com/Sage/carbon/issues/5333)
 
 ### [110.1.1](https://github.com/Sage/carbon/compare/v110.1.0...v110.1.1) (2022-08-18)
 
-
 ### Bug Fixes
 
-* **definition-list:** ensure links are styled correctly ([288b85a](https://github.com/Sage/carbon/commit/288b85a438f0347c0bacbb439fa06eefdd1666ce)), closes [#5240](https://github.com/Sage/carbon/issues/5240)
+- **definition-list:** ensure links are styled correctly ([288b85a](https://github.com/Sage/carbon/commit/288b85a438f0347c0bacbb439fa06eefdd1666ce)), closes [#5240](https://github.com/Sage/carbon/issues/5240)
 
 ## [110.1.0](https://github.com/Sage/carbon/compare/v110.0.4...v110.1.0) (2022-08-17)
 
-
 ### Features
 
-* **sidebar:** add padding props for customising content container ([4f7a7bf](https://github.com/Sage/carbon/commit/4f7a7bf92213e0ba74c6e0a72e3242e240f5cfe2))
+- **sidebar:** add padding props for customising content container ([4f7a7bf](https://github.com/Sage/carbon/commit/4f7a7bf92213e0ba74c6e0a72e3242e240f5cfe2))
 
 ### [110.0.4](https://github.com/Sage/carbon/compare/v110.0.3...v110.0.4) (2022-08-17)
 
-
 ### Bug Fixes
 
-* **focus-trap:** keydown listener is now registered in capture phase ([7f4d2e2](https://github.com/Sage/carbon/commit/7f4d2e2b15cb2a692f2e3b1c178675322ce2ade2)), closes [#5295](https://github.com/Sage/carbon/issues/5295)
-* **sidebar:** ensure sidebar wrapper does not have outline when focused ([bbdcd5d](https://github.com/Sage/carbon/commit/bbdcd5d2b747dbe206171b25bd85023a15d95fa9))
+- **focus-trap:** keydown listener is now registered in capture phase ([7f4d2e2](https://github.com/Sage/carbon/commit/7f4d2e2b15cb2a692f2e3b1c178675322ce2ade2)), closes [#5295](https://github.com/Sage/carbon/issues/5295)
+- **sidebar:** ensure sidebar wrapper does not have outline when focused ([bbdcd5d](https://github.com/Sage/carbon/commit/bbdcd5d2b747dbe206171b25bd85023a15d95fa9))
 
 ### [110.0.3](https://github.com/Sage/carbon/compare/v110.0.2...v110.0.3) (2022-08-16)
 
-
 ### Bug Fixes
 
-* **modal:** remove propTypes from component ([b9994e5](https://github.com/Sage/carbon/commit/b9994e52d3b00423f959bb520afe66901a16a3f3)), closes [#5376](https://github.com/Sage/carbon/issues/5376)
+- **modal:** remove propTypes from component ([b9994e5](https://github.com/Sage/carbon/commit/b9994e52d3b00423f959bb520afe66901a16a3f3)), closes [#5376](https://github.com/Sage/carbon/issues/5376)
 
 ### [110.0.2](https://github.com/Sage/carbon/compare/v110.0.1...v110.0.2) (2022-08-16)
 
-
 ### Bug Fixes
 
-* **flat-table:** fix cut outline of selected row ([51c7a33](https://github.com/Sage/carbon/commit/51c7a3352d63107c8a9f4b31a9ad007402dc26e6))
-
+- **flat-table:** fix cut outline of selected row ([51c7a33](https://github.com/Sage/carbon/commit/51c7a3352d63107c8a9f4b31a9ad007402dc26e6))
 
 ### Reverts
 
-* **node, npm:** revert relaxing of node and npm versions ([a5ce6cc](https://github.com/Sage/carbon/commit/a5ce6cce5140b7f65cab7308be131b378977b5cc)), closes [#5364](https://github.com/Sage/carbon/issues/5364)
+- **node, npm:** revert relaxing of node and npm versions ([a5ce6cc](https://github.com/Sage/carbon/commit/a5ce6cce5140b7f65cab7308be131b378977b5cc)), closes [#5364](https://github.com/Sage/carbon/issues/5364)
 
 ### [110.0.1](https://github.com/Sage/carbon/compare/v110.0.0...v110.0.1) (2022-08-10)
 
-
 ### Bug Fixes
 
-* **popover-container:** ensure clicks inside popover do not close it ([48808bc](https://github.com/Sage/carbon/commit/48808bc32b4437729a2d3aa74f1f1013ea354c8e))
+- **popover-container:** ensure clicks inside popover do not close it ([48808bc](https://github.com/Sage/carbon/commit/48808bc32b4437729a2d3aa74f1f1013ea354c8e))
 
 ## [110.0.0](https://github.com/Sage/carbon/compare/v109.7.1...v110.0.0) (2022-08-09)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **link:** The tabbable prop has been removed and can no longer be used.
-Link component renders either an anchor or a button,
-both of these HTML elements are already tabbable by default,
-however anchors without href and disabled buttons are not,
-making this prop redundant.
+- **link:** The tabbable prop has been removed and can no longer be used.
+  Link component renders either an anchor or a button,
+  both of these HTML elements are already tabbable by default,
+  however anchors without href and disabled buttons are not,
+  making this prop redundant.
 
 ### Bug Fixes
 
-* **menu:** force submenu wrapper to render as a button ([460449c](https://github.com/Sage/carbon/commit/460449c2a6df409437ffc08ae0c9c48622f0c79d))
-
+- **menu:** force submenu wrapper to render as a button ([460449c](https://github.com/Sage/carbon/commit/460449c2a6df409437ffc08ae0c9c48622f0c79d))
 
 ### Code Refactoring
 
-* **link:** remove tabbable prop ([f087214](https://github.com/Sage/carbon/commit/f087214c6ee867646375088c250f2c4679467d5f))
+- **link:** remove tabbable prop ([f087214](https://github.com/Sage/carbon/commit/f087214c6ee867646375088c250f2c4679467d5f))
 
 ### [109.7.1](https://github.com/Sage/carbon/compare/v109.7.0...v109.7.1) (2022-08-08)
 
-
 ### Bug Fixes
 
-* **grid-container:** add support for wrapping GridItems in fragments ([bb57e85](https://github.com/Sage/carbon/commit/bb57e850335ecf24e3ea81eeca21ee0b68f81cbc)), closes [#5325](https://github.com/Sage/carbon/issues/5325)
+- **grid-container:** add support for wrapping GridItems in fragments ([bb57e85](https://github.com/Sage/carbon/commit/bb57e850335ecf24e3ea81eeca21ee0b68f81cbc)), closes [#5325](https://github.com/Sage/carbon/issues/5325)
 
 ## [109.7.0](https://github.com/Sage/carbon/compare/v109.6.0...v109.7.0) (2022-08-04)
 
-
 ### Features
 
-* add new GlobalHeader component ([0d920b6](https://github.com/Sage/carbon/commit/0d920b6902618f5f13066328d91fde72e684ba5f))
-
+- add new GlobalHeader component ([0d920b6](https://github.com/Sage/carbon/commit/0d920b6902618f5f13066328d91fde72e684ba5f))
 
 ### Bug Fixes
 
-* **menu:** modify typing to extend flexbox props from styled-system ([67a2450](https://github.com/Sage/carbon/commit/67a24509fa3739e022f03a1a90b7191540239bc4))
+- **menu:** modify typing to extend flexbox props from styled-system ([67a2450](https://github.com/Sage/carbon/commit/67a24509fa3739e022f03a1a90b7191540239bc4))
 
 ## [109.6.0](https://github.com/Sage/carbon/compare/v109.5.2...v109.6.0) (2022-08-03)
 
-
 ### Features
 
-* **modal:** convert to typescript ([1e4b5cf](https://github.com/Sage/carbon/commit/1e4b5cf4aa0f191c283c1d40a97847ad7e2dd963))
+- **modal:** convert to typescript ([1e4b5cf](https://github.com/Sage/carbon/commit/1e4b5cf4aa0f191c283c1d40a97847ad7e2dd963))
 
 ### [109.5.2](https://github.com/Sage/carbon/compare/v109.5.1...v109.5.2) (2022-08-02)
 
-
 ### Bug Fixes
 
-* **loader:** ensure correct colours are applied to loader when in a button ([f2ff159](https://github.com/Sage/carbon/commit/f2ff1598f73390c9aea2512add6c7accac6becc3)), closes [#5226](https://github.com/Sage/carbon/issues/5226)
+- **loader:** ensure correct colours are applied to loader when in a button ([f2ff159](https://github.com/Sage/carbon/commit/f2ff1598f73390c9aea2512add6c7accac6becc3)), closes [#5226](https://github.com/Sage/carbon/issues/5226)
 
 ### [109.5.1](https://github.com/Sage/carbon/compare/v109.5.0...v109.5.1) (2022-08-01)
 
-
 ### Bug Fixes
 
-* **button-toggle-group:** add missing id prop to type definition ([51c1e70](https://github.com/Sage/carbon/commit/51c1e7099559ef21edc50ae6e4d3f3de97ec3548)), closes [#5314](https://github.com/Sage/carbon/issues/5314)
-* **tab:** make typing of props in TabContextProps interface optional ([673a809](https://github.com/Sage/carbon/commit/673a8097a9fed1af1f1903efca75df6b27a2e1f7))
+- **button-toggle-group:** add missing id prop to type definition ([51c1e70](https://github.com/Sage/carbon/commit/51c1e7099559ef21edc50ae6e4d3f3de97ec3548)), closes [#5314](https://github.com/Sage/carbon/issues/5314)
+- **tab:** make typing of props in TabContextProps interface optional ([673a809](https://github.com/Sage/carbon/commit/673a8097a9fed1af1f1903efca75df6b27a2e1f7))
 
 ## [109.5.0](https://github.com/Sage/carbon/compare/v109.4.0...v109.5.0) (2022-07-28)
 
-
 ### Features
 
-* **icon-button:** convert to typescript ([65dca20](https://github.com/Sage/carbon/commit/65dca20bb17cf535c3e3279cff3726a8322748b3))
-
+- **icon-button:** convert to typescript ([65dca20](https://github.com/Sage/carbon/commit/65dca20bb17cf535c3e3279cff3726a8322748b3))
 
 ### Bug Fixes
 
-* **pill:** fix event handlers types ([d655206](https://github.com/Sage/carbon/commit/d6552066a75bf5e1dc607ca75be3a1ce512c030f))
-* **popover-container:** fix event handlers types ([51d1091](https://github.com/Sage/carbon/commit/51d109197319af83da869bc73768993b9cc6f57b))
+- **pill:** fix event handlers types ([d655206](https://github.com/Sage/carbon/commit/d6552066a75bf5e1dc607ca75be3a1ce512c030f))
+- **popover-container:** fix event handlers types ([51d1091](https://github.com/Sage/carbon/commit/51d109197319af83da869bc73768993b9cc6f57b))
 
 ## [109.4.0](https://github.com/Sage/carbon/compare/v109.3.5...v109.4.0) (2022-07-27)
 
-
 ### Features
 
-* **page:** add padding interface to content container ([74233e2](https://github.com/Sage/carbon/commit/74233e2f5d7f38bdb7525e77bd4a68d69a07d2f0)), closes [#5302](https://github.com/Sage/carbon/issues/5302)
+- **page:** add padding interface to content container ([74233e2](https://github.com/Sage/carbon/commit/74233e2f5d7f38bdb7525e77bd4a68d69a07d2f0)), closes [#5302](https://github.com/Sage/carbon/issues/5302)
 
 ### [109.3.5](https://github.com/Sage/carbon/compare/v109.3.4...v109.3.5) (2022-07-27)
 
-
 ### Bug Fixes
 
-* **multiselect:** ensure value prop is always used when controlled ([0ec8fa9](https://github.com/Sage/carbon/commit/0ec8fa96c30a5076ff581020a26af3be6f265fb6)), closes [#5259](https://github.com/Sage/carbon/issues/5259)
+- **multiselect:** ensure value prop is always used when controlled ([0ec8fa9](https://github.com/Sage/carbon/commit/0ec8fa96c30a5076ff581020a26af3be6f265fb6)), closes [#5259](https://github.com/Sage/carbon/issues/5259)
 
 ### [109.3.4](https://github.com/Sage/carbon/compare/v109.3.3...v109.3.4) (2022-07-26)
 
-
 ### Bug Fixes
 
-* **pager:** change styles so all items are exposed to accessibility tree ([67a3846](https://github.com/Sage/carbon/commit/67a3846306dd8fe13db20f54c14d9b675573aaa4)), closes [#4637](https://github.com/Sage/carbon/issues/4637)
+- **pager:** change styles so all items are exposed to accessibility tree ([67a3846](https://github.com/Sage/carbon/commit/67a3846306dd8fe13db20f54c14d9b675573aaa4)), closes [#4637](https://github.com/Sage/carbon/issues/4637)
 
 ### [109.3.3](https://github.com/Sage/carbon/compare/v109.3.2...v109.3.3) (2022-07-25)
 
-
 ### Bug Fixes
 
-* **select:** fix column alignment in multi column mode ([6897637](https://github.com/Sage/carbon/commit/6897637f08fa32bfb3fee861aeb79a104c453e6b))
+- **select:** fix column alignment in multi column mode ([6897637](https://github.com/Sage/carbon/commit/6897637f08fa32bfb3fee861aeb79a104c453e6b))
 
 ### [109.3.2](https://github.com/Sage/carbon/compare/v109.3.1...v109.3.2) (2022-07-21)
 
-
 ### Bug Fixes
 
-* **filterableselect, multiselect:** fix filter for nested components ([65bc094](https://github.com/Sage/carbon/commit/65bc0943269774f5a87f482cafc26c90a9095dfd)), closes [#5242](https://github.com/Sage/carbon/issues/5242)
+- **filterableselect, multiselect:** fix filter for nested components ([65bc094](https://github.com/Sage/carbon/commit/65bc0943269774f5a87f482cafc26c90a9095dfd)), closes [#5242](https://github.com/Sage/carbon/issues/5242)
 
 ### [109.3.1](https://github.com/Sage/carbon/compare/v109.3.0...v109.3.1) (2022-07-19)
 
-
 ### Bug Fixes
 
-* **multi-action-button:** add new keyboard functionality to component ([a76819b](https://github.com/Sage/carbon/commit/a76819b39e888ec926b74d94f63f7c3c631399bd)), closes [#4522](https://github.com/Sage/carbon/issues/4522)
-* **split-button:** add new keyboard functionality to component ([5121f6a](https://github.com/Sage/carbon/commit/5121f6af4521a9658e937cecff91676cffdf4f86)), closes [#4522](https://github.com/Sage/carbon/issues/4522)
+- **multi-action-button:** add new keyboard functionality to component ([a76819b](https://github.com/Sage/carbon/commit/a76819b39e888ec926b74d94f63f7c3c631399bd)), closes [#4522](https://github.com/Sage/carbon/issues/4522)
+- **split-button:** add new keyboard functionality to component ([5121f6a](https://github.com/Sage/carbon/commit/5121f6af4521a9658e937cecff91676cffdf4f86)), closes [#4522](https://github.com/Sage/carbon/issues/4522)
 
 ## [109.3.0](https://github.com/Sage/carbon/compare/v109.2.4...v109.3.0) (2022-07-19)
 
-
 ### Features
 
-* **dialog, dialog-full-screen, sidebar:** allow more tab control ([e497fb1](https://github.com/Sage/carbon/commit/e497fb1d29f75b77995234995bcc8f16b39b94e1)), closes [#5092](https://github.com/Sage/carbon/issues/5092)
-* **toast:** autofocus dismiss button unless disableAutoFocus prop set ([2c0ff36](https://github.com/Sage/carbon/commit/2c0ff3681c5a171ed1e294a778642a07d585ba42)), closes [#5092](https://github.com/Sage/carbon/issues/5092)
-* **toast:** return focus when closing toast after autofocus ([517682e](https://github.com/Sage/carbon/commit/517682e5f9d604cb5d1a44dccc63e250c7687cbd))
-
+- **dialog, dialog-full-screen, sidebar:** allow more tab control ([e497fb1](https://github.com/Sage/carbon/commit/e497fb1d29f75b77995234995bcc8f16b39b94e1)), closes [#5092](https://github.com/Sage/carbon/issues/5092)
+- **toast:** autofocus dismiss button unless disableAutoFocus prop set ([2c0ff36](https://github.com/Sage/carbon/commit/2c0ff3681c5a171ed1e294a778642a07d585ba42)), closes [#5092](https://github.com/Sage/carbon/issues/5092)
+- **toast:** return focus when closing toast after autofocus ([517682e](https://github.com/Sage/carbon/commit/517682e5f9d604cb5d1a44dccc63e250c7687cbd))
 
 ### Bug Fixes
 
-* **focus-trap:** fix behaviour with radio buttons ([c6e55e7](https://github.com/Sage/carbon/commit/c6e55e7c8f5b072764e733fa50abfef694a7b34d)), closes [#5224](https://github.com/Sage/carbon/issues/5224)
+- **focus-trap:** fix behaviour with radio buttons ([c6e55e7](https://github.com/Sage/carbon/commit/c6e55e7c8f5b072764e733fa50abfef694a7b34d)), closes [#5224](https://github.com/Sage/carbon/issues/5224)
 
 ### [109.2.4](https://github.com/Sage/carbon/compare/v109.2.3...v109.2.4) (2022-07-18)
 
-
 ### Bug Fixes
 
-* **use-scroll-block:** calc the scroll width each time the clientWidth value of document changes ([5744ec4](https://github.com/Sage/carbon/commit/5744ec42239213be365ebf8450b6ebe188e3fbe9)), closes [#5220](https://github.com/Sage/carbon/issues/5220)
+- **use-scroll-block:** calc the scroll width each time the clientWidth value of document changes ([5744ec4](https://github.com/Sage/carbon/commit/5744ec42239213be365ebf8450b6ebe188e3fbe9)), closes [#5220](https://github.com/Sage/carbon/issues/5220)
 
 ### [109.2.3](https://github.com/Sage/carbon/compare/v109.2.2...v109.2.3) (2022-07-15)
 
-
 ### Bug Fixes
 
-* **menu-full-screen:** pass onClick to menu item ([839cd55](https://github.com/Sage/carbon/commit/839cd557f18c70957b375ae0962ac00e04f44dfe)), closes [#5313](https://github.com/Sage/carbon/issues/5313)
+- **menu-full-screen:** pass onClick to menu item ([839cd55](https://github.com/Sage/carbon/commit/839cd557f18c70957b375ae0962ac00e04f44dfe)), closes [#5313](https://github.com/Sage/carbon/issues/5313)
 
 ### [109.2.2](https://github.com/Sage/carbon/compare/v109.2.1...v109.2.2) (2022-07-14)
 
-
 ### Bug Fixes
 
-* **button:** fix forwardRef type isssues ([a2ec6ff](https://github.com/Sage/carbon/commit/a2ec6ff05483d9c77d0369f0b171a2144f7d816e))
+- **button:** fix forwardRef type isssues ([a2ec6ff](https://github.com/Sage/carbon/commit/a2ec6ff05483d9c77d0369f0b171a2144f7d816e))
 
 ### [109.2.1](https://github.com/Sage/carbon/compare/v109.2.0...v109.2.1) (2022-07-13)
 
-
 ### Bug Fixes
 
-* **search:** update icon colour and hover colour in default variant ([2912a74](https://github.com/Sage/carbon/commit/2912a74f16514c52fe478408ad8bb675f8f8a7ae))
+- **search:** update icon colour and hover colour in default variant ([2912a74](https://github.com/Sage/carbon/commit/2912a74f16514c52fe478408ad8bb675f8f8a7ae))
 
 ## [109.2.0](https://github.com/Sage/carbon/compare/v109.1.3...v109.2.0) (2022-07-12)
 
-
 ### Features
 
-* **pill:** add text wrapping and max width support to component ([9fc65bc](https://github.com/Sage/carbon/commit/9fc65bcc9bb29771503dc7fdba3d931248ae627c))
-
+- **pill:** add text wrapping and max width support to component ([9fc65bc](https://github.com/Sage/carbon/commit/9fc65bcc9bb29771503dc7fdba3d931248ae627c))
 
 ### Bug Fixes
 
-* **multi-select:** prevent pills with long text strings from overflowing the input ([4beabcf](https://github.com/Sage/carbon/commit/4beabcfd0862c8a7c3a30388a44c498e0e8ee59b)), closes [#5192](https://github.com/Sage/carbon/issues/5192)
+- **multi-select:** prevent pills with long text strings from overflowing the input ([4beabcf](https://github.com/Sage/carbon/commit/4beabcfd0862c8a7c3a30388a44c498e0e8ee59b)), closes [#5192](https://github.com/Sage/carbon/issues/5192)
 
 ### [109.1.3](https://github.com/Sage/carbon/compare/v109.1.2...v109.1.3) (2022-07-08)
 
-
 ### Bug Fixes
 
-* **popover-container:** position automatically depending on available space ([4b63a17](https://github.com/Sage/carbon/commit/4b63a17caf8517f2de44c2442be49155d46d30ce))
+- **popover-container:** position automatically depending on available space ([4b63a17](https://github.com/Sage/carbon/commit/4b63a17caf8517f2de44c2442be49155d46d30ce))
 
 ### [109.1.2](https://github.com/Sage/carbon/compare/v109.1.1...v109.1.2) (2022-07-06)
 
-
 ### Bug Fixes
 
-* **flat-table/sort:** fix color of sort arrows ([a892359](https://github.com/Sage/carbon/commit/a892359a3159fba1a89c6f0301210868c63caeb6)), closes [#4984](https://github.com/Sage/carbon/issues/4984)
+- **flat-table/sort:** fix color of sort arrows ([a892359](https://github.com/Sage/carbon/commit/a892359a3159fba1a89c6f0301210868c63caeb6)), closes [#4984](https://github.com/Sage/carbon/issues/4984)
 
 ### [109.1.1](https://github.com/Sage/carbon/compare/v109.1.0...v109.1.1) (2022-07-05)
 
-
 ### Bug Fixes
 
-* **use-click-away-listener:** rewrite ClickAwayWrapper component as a custom hook ([b7a37f8](https://github.com/Sage/carbon/commit/b7a37f807645870210ed1e750a553de75df5f6ad)), closes [#5245](https://github.com/Sage/carbon/issues/5245)
+- **use-click-away-listener:** rewrite ClickAwayWrapper component as a custom hook ([b7a37f8](https://github.com/Sage/carbon/commit/b7a37f807645870210ed1e750a553de75df5f6ad)), closes [#5245](https://github.com/Sage/carbon/issues/5245)
 
 ## [109.1.0](https://github.com/Sage/carbon/compare/v109.0.2...v109.1.0) (2022-07-01)
 
-
 ### Features
 
-* **inline-inputs:** add adaptiveLabelBreakpoint prop to component ([0ffdde6](https://github.com/Sage/carbon/commit/0ffdde63dd08e0c130ac176074fec74b49cf9c1a)), closes [#5099](https://github.com/Sage/carbon/issues/5099)
+- **inline-inputs:** add adaptiveLabelBreakpoint prop to component ([0ffdde6](https://github.com/Sage/carbon/commit/0ffdde63dd08e0c130ac176074fec74b49cf9c1a)), closes [#5099](https://github.com/Sage/carbon/issues/5099)
 
 ### [109.0.2](https://github.com/Sage/carbon/compare/v109.0.1...v109.0.2) (2022-07-01)
 
-
 ### Bug Fixes
 
-* **form:** fix tabs focus outline not rendering correctly ([f4e56fe](https://github.com/Sage/carbon/commit/f4e56fe482a57567b62ee125018f2d3f5c49eae1)), closes [#5161](https://github.com/Sage/carbon/issues/5161)
+- **form:** fix tabs focus outline not rendering correctly ([f4e56fe](https://github.com/Sage/carbon/commit/f4e56fe482a57567b62ee125018f2d3f5c49eae1)), closes [#5161](https://github.com/Sage/carbon/issues/5161)
 
 ### [109.0.1](https://github.com/Sage/carbon/compare/v109.0.0...v109.0.1) (2022-07-01)
 
-
 ### Bug Fixes
 
-* **flat-table:** fix border bottom colour in light theme ([9932367](https://github.com/Sage/carbon/commit/99323674d86a3a637b1389d81017d621f9e977bc)), closes [#5175](https://github.com/Sage/carbon/issues/5175)
+- **flat-table:** fix border bottom colour in light theme ([9932367](https://github.com/Sage/carbon/commit/99323674d86a3a637b1389d81017d621f9e977bc)), closes [#5175](https://github.com/Sage/carbon/issues/5175)
 
 ## [109.0.0](https://github.com/Sage/carbon/compare/v108.0.0...v109.0.0) (2022-07-01)
 
-
 ### ⚠ BREAKING CHANGES
 
-* react 16 is no longer supported
+- react 16 is no longer supported
 
 ### Features
 
-* upgrade to react 17 ([831dcd8](https://github.com/Sage/carbon/commit/831dcd8daeebc463fb4a129d45afde634af75a43))
+- upgrade to react 17 ([831dcd8](https://github.com/Sage/carbon/commit/831dcd8daeebc463fb4a129d45afde634af75a43))
 
 ## [108.0.0](https://github.com/Sage/carbon/compare/v107.2.1...v108.0.0) (2022-06-23)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **popover-container:** dataElement and ariaLabel props have been renamed
-to data-element and aria-label in both renderOpenComponent and
-renderCloseComponent render prop methods
+- **popover-container:** dataElement and ariaLabel props have been renamed
+  to data-element and aria-label in both renderOpenComponent and
+  renderCloseComponent render prop methods
 
 ### Code Refactoring
 
-* **popover-container:** convert to ts ([58a95eb](https://github.com/Sage/carbon/commit/58a95ebcb28292d511f2d4d18b32537bdbd54d4e))
+- **popover-container:** convert to ts ([58a95eb](https://github.com/Sage/carbon/commit/58a95ebcb28292d511f2d4d18b32537bdbd54d4e))
 
 ### [107.2.1](https://github.com/Sage/carbon/compare/v107.2.0...v107.2.1) (2022-06-22)
 
-
 ### Bug Fixes
 
-* **heading:** add aria-label to back button ([b3473de](https://github.com/Sage/carbon/commit/b3473de80e3f40a168486393df00df06b5cfa61b)), closes [#4876](https://github.com/Sage/carbon/issues/4876)
-* **help:** add aria-label when help is a link ([4882e13](https://github.com/Sage/carbon/commit/4882e134bdec67625c85640dd7f4d9a1f1863dc8))
+- **heading:** add aria-label to back button ([b3473de](https://github.com/Sage/carbon/commit/b3473de80e3f40a168486393df00df06b5cfa61b)), closes [#4876](https://github.com/Sage/carbon/issues/4876)
+- **help:** add aria-label when help is a link ([4882e13](https://github.com/Sage/carbon/commit/4882e134bdec67625c85640dd7f4d9a1f1863dc8))
 
 ## [107.2.0](https://github.com/Sage/carbon/compare/v107.1.8...v107.2.0) (2022-06-21)
 
-
 ### Features
 
-* **modal:** add typing for and export ModalContext from modal module ([c4155bd](https://github.com/Sage/carbon/commit/c4155bd171f42b05ce22d7080bf30f6e588623a2))
-
+- **modal:** add typing for and export ModalContext from modal module ([c4155bd](https://github.com/Sage/carbon/commit/c4155bd171f42b05ce22d7080bf30f6e588623a2))
 
 ### Bug Fixes
 
-* **form:** prevent two scrollbars appearing when content overflows inside modal ([085a9cf](https://github.com/Sage/carbon/commit/085a9cf75988237555ccd59a474f3729aecdf75e))
+- **form:** prevent two scrollbars appearing when content overflows inside modal ([085a9cf](https://github.com/Sage/carbon/commit/085a9cf75988237555ccd59a474f3729aecdf75e))
 
 ### [107.1.8](https://github.com/Sage/carbon/compare/v107.1.7...v107.1.8) (2022-06-21)
 
-
 ### Bug Fixes
 
-* **submenu:** make menu open on click even when clickToOpen prop missing ([040c276](https://github.com/Sage/carbon/commit/040c2762719c04f9fae499b277c1d5729fac04ad)), closes [#4797](https://github.com/Sage/carbon/issues/4797)
+- **submenu:** make menu open on click even when clickToOpen prop missing ([040c276](https://github.com/Sage/carbon/commit/040c2762719c04f9fae499b277c1d5729fac04ad)), closes [#4797](https://github.com/Sage/carbon/issues/4797)
 
 ### [107.1.7](https://github.com/Sage/carbon/compare/v107.1.6...v107.1.7) (2022-06-20)
 
-
 ### Bug Fixes
 
-* **date:** ensure that contrast ratio for weekday meets AA standards ([5de5ff9](https://github.com/Sage/carbon/commit/5de5ff953a06ba3627ef97dd97b1b1f71a5c3ccc)), closes [#5173](https://github.com/Sage/carbon/issues/5173)
+- **date:** ensure that contrast ratio for weekday meets AA standards ([5de5ff9](https://github.com/Sage/carbon/commit/5de5ff953a06ba3627ef97dd97b1b1f71a5c3ccc)), closes [#5173](https://github.com/Sage/carbon/issues/5173)
 
 ### [107.1.6](https://github.com/Sage/carbon/compare/v107.1.5...v107.1.6) (2022-06-17)
 
-
 ### Bug Fixes
 
-* **flat-table-row:** update sticky column functionality to support wrapping row headers ([d15cb0d](https://github.com/Sage/carbon/commit/d15cb0da02f4428bd550ad8a7709325f33113390)), closes [#5208](https://github.com/Sage/carbon/issues/5208)
+- **flat-table-row:** update sticky column functionality to support wrapping row headers ([d15cb0d](https://github.com/Sage/carbon/commit/d15cb0da02f4428bd550ad8a7709325f33113390)), closes [#5208](https://github.com/Sage/carbon/issues/5208)
 
 ### [107.1.5](https://github.com/Sage/carbon/compare/v107.1.4...v107.1.5) (2022-06-16)
 
-
 ### Bug Fixes
 
-* **date:** ensure that event contains input name and id when picker is used to change date ([7376122](https://github.com/Sage/carbon/commit/7376122249f374eba87870359c5cd24da5459613)), closes [#5193](https://github.com/Sage/carbon/issues/5193)
+- **date:** ensure that event contains input name and id when picker is used to change date ([7376122](https://github.com/Sage/carbon/commit/7376122249f374eba87870359c5cd24da5459613)), closes [#5193](https://github.com/Sage/carbon/issues/5193)
 
 ### [107.1.4](https://github.com/Sage/carbon/compare/v107.1.3...v107.1.4) (2022-06-15)
 
-
 ### Bug Fixes
 
-* **tabs:** fix issue with two tab titles being highlited simultaneously ([659ef2a](https://github.com/Sage/carbon/commit/659ef2ab4c6d07c276a8bf0ca2d95f2e7b8b6db1))
+- **tabs:** fix issue with two tab titles being highlited simultaneously ([659ef2a](https://github.com/Sage/carbon/commit/659ef2ab4c6d07c276a8bf0ca2d95f2e7b8b6db1))
 
 ### [107.1.3](https://github.com/Sage/carbon/compare/v107.1.2...v107.1.3) (2022-06-15)
 
-
 ### Bug Fixes
 
-* **heading:** fix typings ([a53482e](https://github.com/Sage/carbon/commit/a53482ef5c258eb10712cd1339e6384cf7475c16))
+- **heading:** fix typings ([a53482e](https://github.com/Sage/carbon/commit/a53482ef5c258eb10712cd1339e6384cf7475c16))
 
 ### [107.1.2](https://github.com/Sage/carbon/compare/v107.1.1...v107.1.2) (2022-06-14)
 
-
 ### Bug Fixes
 
-* **button-toggle-group:** ensure that id prop is passed to FormField ([0b81a5e](https://github.com/Sage/carbon/commit/0b81a5e044f5b32913b7735c77cd71ad3304c07c))
+- **button-toggle-group:** ensure that id prop is passed to FormField ([0b81a5e](https://github.com/Sage/carbon/commit/0b81a5e044f5b32913b7735c77cd71ad3304c07c))
 
 ### [107.1.1](https://github.com/Sage/carbon/compare/v107.1.0...v107.1.1) (2022-06-14)
 
-
 ### Bug Fixes
 
-* **date-range:** change startDateProps and endDateProps to ensure all props are optional ([83ed1b9](https://github.com/Sage/carbon/commit/83ed1b9ed3760d7e788b31cb092623ee7c3a0e7e)), closes [#5185](https://github.com/Sage/carbon/issues/5185)
+- **date-range:** change startDateProps and endDateProps to ensure all props are optional ([83ed1b9](https://github.com/Sage/carbon/commit/83ed1b9ed3760d7e788b31cb092623ee7c3a0e7e)), closes [#5185](https://github.com/Sage/carbon/issues/5185)
 
 ## [107.1.0](https://github.com/Sage/carbon/compare/v107.0.0...v107.1.0) (2022-06-13)
 
-
 ### Features
 
-* **click-away-wrapper:** add ClickAwayWrapper component to internal directory ([091f0a4](https://github.com/Sage/carbon/commit/091f0a48a7dd0963fe493c82044d591521a093bb))
-* **popover-container:** add ClickAwayWrapper to close popover when click outside detected ([5ba1522](https://github.com/Sage/carbon/commit/5ba1522d09cc0301fd1aee7aad71d49f53e19fda)), closes [#5017](https://github.com/Sage/carbon/issues/5017) [#5158](https://github.com/Sage/carbon/issues/5158)
+- **click-away-wrapper:** add ClickAwayWrapper component to internal directory ([091f0a4](https://github.com/Sage/carbon/commit/091f0a48a7dd0963fe493c82044d591521a093bb))
+- **popover-container:** add ClickAwayWrapper to close popover when click outside detected ([5ba1522](https://github.com/Sage/carbon/commit/5ba1522d09cc0301fd1aee7aad71d49f53e19fda)), closes [#5017](https://github.com/Sage/carbon/issues/5017) [#5158](https://github.com/Sage/carbon/issues/5158)
 
 ## [107.0.0](https://github.com/Sage/carbon/compare/v106.7.0...v107.0.0) (2022-06-13)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **menu:** The deprecated `SubmenuBlock` component has now been removed
-and can no longer be used. Please use the `MenuItem` component with the
-`submenu` prop instead.
-* **navigation-bar:** The deprecated props `stickyPosition` and `stickyOffset` have been
-removed and can no longer be used. Please use the `position`, `offset` and `orientation`
-props to achieve the same layout. The following codemods are available to help with
-updating your code:
-https://github.com/Sage/carbon-codemod/tree/master/transforms/remove-prop
-https://github.com/Sage/carbon-codemod/tree/master/transforms/add-prop
-* **multi-action-button:** The deprecated `as` prop has been removed and can no longer
-be used. Please use the `buttonType` prop to achieve the same styling.
-A codemod is available to help with updating your code:
-https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop
-* **split-button:** The deprecated `as` prop has been removed and can no longer
-be used. Please use the `buttonType` prop to achieve the same styling.
-A codemod is available for updating your code:
-https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop
-* **toast:** The deprecated `as` prop has now been removed and can no
-longer be used. Please use the `variant` prop to achieve the same styling.
-A codemod is available to help with updating your code:
-https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop
-* **tile:** The deprecated `as` prop has been removed and can no
-longer be used. Please use the `variant` prop to achieve the same
-styling. A codemod is available to help with updating your code and can be found
-here:
-https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop
-* The deprecated `ScrollableList` component has been removed and can no
-longer be used.
-* The deprecated `MultiStepWizard` component has been removed and can no
-longer be used. Please use the `StepSequence` component instead.
-* The deprecated `MountInApp` component has been removed
-and can no longer be used.
-* **confirm:** The deprecated `destructive` prop has been removed and can no
-longer be used. Please use `cancelButtonDestructive` and `confirmButtonDestructive` props
-instead. A codemod is available to help with renaming props and can be found here:
-https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop
-* **button:** The deprecated `as` prop has now been removed and can no
-longer be used. Please use the `buttonType` prop instead which has similar
-functionality. A codemod is available to help with renaming props and can be found
-here: https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop
-* The deprecated `AppWrapper` component has now been removed
-and can no longer be used. Please use the `Box` component instead.
-* **radio-button:** `RadioButtonMapper` is now an internal component and can no longer be
-imported by consuming apps.
-* **heading:** `Heading` has been refactored from a class-based to a functional-based
-component - therefore cannot be extended anymore.
+- **menu:** The deprecated `SubmenuBlock` component has now been removed
+  and can no longer be used. Please use the `MenuItem` component with the
+  `submenu` prop instead.
+- **navigation-bar:** The deprecated props `stickyPosition` and `stickyOffset` have been
+  removed and can no longer be used. Please use the `position`, `offset` and `orientation`
+  props to achieve the same layout. The following codemods are available to help with
+  updating your code:
+  <https://github.com/Sage/carbon-codemod/tree/master/transforms/remove-prop>
+  <https://github.com/Sage/carbon-codemod/tree/master/transforms/add-prop>
+- **multi-action-button:** The deprecated `as` prop has been removed and can no longer
+  be used. Please use the `buttonType` prop to achieve the same styling.
+  A codemod is available to help with updating your code:
+  <https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop>
+- **split-button:** The deprecated `as` prop has been removed and can no longer
+  be used. Please use the `buttonType` prop to achieve the same styling.
+  A codemod is available for updating your code:
+  <https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop>
+- **toast:** The deprecated `as` prop has now been removed and can no
+  longer be used. Please use the `variant` prop to achieve the same styling.
+  A codemod is available to help with updating your code:
+  <https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop>
+- **tile:** The deprecated `as` prop has been removed and can no
+  longer be used. Please use the `variant` prop to achieve the same
+  styling. A codemod is available to help with updating your code and can be found
+  here:
+  <https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop>
+- The deprecated `ScrollableList` component has been removed and can no
+  longer be used.
+- The deprecated `MultiStepWizard` component has been removed and can no
+  longer be used. Please use the `StepSequence` component instead.
+- The deprecated `MountInApp` component has been removed
+  and can no longer be used.
+- **confirm:** The deprecated `destructive` prop has been removed and can no
+  longer be used. Please use `cancelButtonDestructive` and `confirmButtonDestructive` props
+  instead. A codemod is available to help with renaming props and can be found here:
+  <https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop>
+- **button:** The deprecated `as` prop has now been removed and can no
+  longer be used. Please use the `buttonType` prop instead which has similar
+  functionality. A codemod is available to help with renaming props and can be found
+  here: <https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop>
+- The deprecated `AppWrapper` component has now been removed
+  and can no longer be used. Please use the `Box` component instead.
+- **radio-button:** `RadioButtonMapper` is now an internal component and can no longer be
+  imported by consuming apps.
+- **heading:** `Heading` has been refactored from a class-based to a functional-based
+  component - therefore cannot be extended anymore.
 
 ### Code Refactoring
 
-* **button:** remove deprecated `as` prop ([660b699](https://github.com/Sage/carbon/commit/660b69991ff1753d197ec0ed731a30dc27c34c8f))
-* **confirm:** remove deprecated `destructive` prop ([c4edbf2](https://github.com/Sage/carbon/commit/c4edbf2afa2c0be5b8197f4e098e0bcc26cffb54))
-* **heading:** convert to functional component ([2f8aa70](https://github.com/Sage/carbon/commit/2f8aa709d282533098dedec6a15cab3034350ffe))
-* **menu:** remove deprecated `SubmenuBlock` component ([bc4a3e0](https://github.com/Sage/carbon/commit/bc4a3e078ca9023bc4b216a5d62d80ee00e61e1f))
-* **multi-action-button:** remove deprecated `as` prop ([f9128e6](https://github.com/Sage/carbon/commit/f9128e65326f497661e852eca2a4379b60bcb2d3))
-* **navigation-bar:** remove deprecated `stickyPosition` and `stickyOffset` props ([c0a7381](https://github.com/Sage/carbon/commit/c0a73814b9b5a2ba748bda16a3010f18f7175a8e))
-* **radio-button:** prevent consumption of RadioButtonMapper component ([20043a6](https://github.com/Sage/carbon/commit/20043a6cd42ecc8a0ea00fa07f99ea2b02f27534))
-* remove deprecated `AppWrapper` component ([d26dece](https://github.com/Sage/carbon/commit/d26decef5a0778e5fc7d3c169908f6793bc5f6c8))
-* remove deprecated `MountInApp` component ([7766355](https://github.com/Sage/carbon/commit/77663552812d574e60c72da2c94a9855ae6745fd))
-* remove deprecated `ScrollableList` component ([ef85639](https://github.com/Sage/carbon/commit/ef85639a6b515481d648240aa6839d9adfd7693f))
-* removed deprecated `MultiStepWizard` component ([a2ecb9c](https://github.com/Sage/carbon/commit/a2ecb9c55eef4584c2b833b2c8ec10409aae7457))
-* **split-button:** remove deprecated `as` prop ([b4c1762](https://github.com/Sage/carbon/commit/b4c176254522bdc042a63d28fdca0fb65013f6c4))
-* **tile:** remove deprecated `as` prop ([98d466e](https://github.com/Sage/carbon/commit/98d466e15d3547867f432c891cec3bd229297588))
-* **toast:** remove deprecated `as` prop ([85690a6](https://github.com/Sage/carbon/commit/85690a60564883f0167521ffd0284ac0f14b62f0))
+- **button:** remove deprecated `as` prop ([660b699](https://github.com/Sage/carbon/commit/660b69991ff1753d197ec0ed731a30dc27c34c8f))
+- **confirm:** remove deprecated `destructive` prop ([c4edbf2](https://github.com/Sage/carbon/commit/c4edbf2afa2c0be5b8197f4e098e0bcc26cffb54))
+- **heading:** convert to functional component ([2f8aa70](https://github.com/Sage/carbon/commit/2f8aa709d282533098dedec6a15cab3034350ffe))
+- **menu:** remove deprecated `SubmenuBlock` component ([bc4a3e0](https://github.com/Sage/carbon/commit/bc4a3e078ca9023bc4b216a5d62d80ee00e61e1f))
+- **multi-action-button:** remove deprecated `as` prop ([f9128e6](https://github.com/Sage/carbon/commit/f9128e65326f497661e852eca2a4379b60bcb2d3))
+- **navigation-bar:** remove deprecated `stickyPosition` and `stickyOffset` props ([c0a7381](https://github.com/Sage/carbon/commit/c0a73814b9b5a2ba748bda16a3010f18f7175a8e))
+- **radio-button:** prevent consumption of RadioButtonMapper component ([20043a6](https://github.com/Sage/carbon/commit/20043a6cd42ecc8a0ea00fa07f99ea2b02f27534))
+- remove deprecated `AppWrapper` component ([d26dece](https://github.com/Sage/carbon/commit/d26decef5a0778e5fc7d3c169908f6793bc5f6c8))
+- remove deprecated `MountInApp` component ([7766355](https://github.com/Sage/carbon/commit/77663552812d574e60c72da2c94a9855ae6745fd))
+- remove deprecated `ScrollableList` component ([ef85639](https://github.com/Sage/carbon/commit/ef85639a6b515481d648240aa6839d9adfd7693f))
+- removed deprecated `MultiStepWizard` component ([a2ecb9c](https://github.com/Sage/carbon/commit/a2ecb9c55eef4584c2b833b2c8ec10409aae7457))
+- **split-button:** remove deprecated `as` prop ([b4c1762](https://github.com/Sage/carbon/commit/b4c176254522bdc042a63d28fdca0fb65013f6c4))
+- **tile:** remove deprecated `as` prop ([98d466e](https://github.com/Sage/carbon/commit/98d466e15d3547867f432c891cec3bd229297588))
+- **toast:** remove deprecated `as` prop ([85690a6](https://github.com/Sage/carbon/commit/85690a60564883f0167521ffd0284ac0f14b62f0))
 
 ## [106.7.0](https://github.com/Sage/carbon/compare/v106.6.10...v106.7.0) (2022-06-10)
 
-
 ### Features
 
-* **dialog, sidebar:** set focus to dialog container on open ([0a6a2b0](https://github.com/Sage/carbon/commit/0a6a2b0ac438d9bcdae8986959a4c2c2575cd3c0)), closes [#4975](https://github.com/Sage/carbon/issues/4975)
-* **sidebar:** add aria-labelledby referencing title if not provided ([a2c795a](https://github.com/Sage/carbon/commit/a2c795a280615a34c07530f3183edcae0c9152b1))
-
+- **dialog, sidebar:** set focus to dialog container on open ([0a6a2b0](https://github.com/Sage/carbon/commit/0a6a2b0ac438d9bcdae8986959a4c2c2575cd3c0)), closes [#4975](https://github.com/Sage/carbon/issues/4975)
+- **sidebar:** add aria-labelledby referencing title if not provided ([a2c795a](https://github.com/Sage/carbon/commit/a2c795a280615a34c07530f3183edcae0c9152b1))
 
 ### Bug Fixes
 
-* **menu-full-screen:** fix for new FocusTrap behavior ([0c4b8b5](https://github.com/Sage/carbon/commit/0c4b8b5d7de210e0cdef597fe16b258ac08567fc))
+- **menu-full-screen:** fix for new FocusTrap behavior ([0c4b8b5](https://github.com/Sage/carbon/commit/0c4b8b5d7de210e0cdef597fe16b258ac08567fc))
 
 ### [106.6.10](https://github.com/Sage/carbon/compare/v106.6.9...v106.6.10) (2022-06-10)
 
-
 ### Bug Fixes
 
-* **date:** ensure months and days are capitalised and formatted correctly for all locales ([b759d45](https://github.com/Sage/carbon/commit/b759d45bc98864234561087b2476fdff69a6cd24)), closes [#5181](https://github.com/Sage/carbon/issues/5181)
+- **date:** ensure months and days are capitalised and formatted correctly for all locales ([b759d45](https://github.com/Sage/carbon/commit/b759d45bc98864234561087b2476fdff69a6cd24)), closes [#5181](https://github.com/Sage/carbon/issues/5181)
 
 ### [106.6.9](https://github.com/Sage/carbon/compare/v106.6.8...v106.6.9) (2022-06-10)
 
-
 ### Bug Fixes
 
-* fix missing type declarations ([6fa87a6](https://github.com/Sage/carbon/commit/6fa87a6541430390b7facc685529fa1ec0ce4f74))
+- fix missing type declarations ([6fa87a6](https://github.com/Sage/carbon/commit/6fa87a6541430390b7facc685529fa1ec0ce4f74))
 
 ### [106.6.8](https://github.com/Sage/carbon/compare/v106.6.7...v106.6.8) (2022-06-01)
 
-
 ### Bug Fixes
 
-* **decimal:** ensure that value prop is reliably displayed ([5130b96](https://github.com/Sage/carbon/commit/5130b96e7f5f7cac18962c7c6f4ecd60f89e014c))
+- **decimal:** ensure that value prop is reliably displayed ([5130b96](https://github.com/Sage/carbon/commit/5130b96e7f5f7cac18962c7c6f4ecd60f89e014c))
 
 ### [106.6.7](https://github.com/Sage/carbon/compare/v106.6.6...v106.6.7) (2022-05-31)
 
-
 ### Bug Fixes
 
-* **menu:** change passive menu item background color ([a05a3ad](https://github.com/Sage/carbon/commit/a05a3add1b854a1dca4a6fcf19c1df0ce78a3efb)), closes [#5064](https://github.com/Sage/carbon/issues/5064)
+- **menu:** change passive menu item background color ([a05a3ad](https://github.com/Sage/carbon/commit/a05a3add1b854a1dca4a6fcf19c1df0ce78a3efb)), closes [#5064](https://github.com/Sage/carbon/issues/5064)
 
 ### [106.6.6](https://github.com/Sage/carbon/compare/v106.6.5...v106.6.6) (2022-05-24)
 
-
 ### Bug Fixes
 
-* **button:** stop icon from wrapping when nowrap prop set ([0711c3f](https://github.com/Sage/carbon/commit/0711c3fc57d45167ce51e2e64e1ac9cda7c950b4)), closes [#5101](https://github.com/Sage/carbon/issues/5101)
+- **button:** stop icon from wrapping when nowrap prop set ([0711c3f](https://github.com/Sage/carbon/commit/0711c3fc57d45167ce51e2e64e1ac9cda7c950b4)), closes [#5101](https://github.com/Sage/carbon/issues/5101)
 
 ### [106.6.5](https://github.com/Sage/carbon/compare/v106.6.4...v106.6.5) (2022-05-23)
 
-
 ### Bug Fixes
 
-* **heading:** remove doc comments to fix type definitions ([9903e45](https://github.com/Sage/carbon/commit/9903e45586141eca5f7d1afc2de7349932d755e4))
+- **heading:** remove doc comments to fix type definitions ([9903e45](https://github.com/Sage/carbon/commit/9903e45586141eca5f7d1afc2de7349932d755e4))
 
 ### [106.6.4](https://github.com/Sage/carbon/compare/v106.6.3...v106.6.4) (2022-05-19)
 
-
 ### Bug Fixes
 
-* **menu, link:** ensure correct semantic HTML for menu items and links ([d505ffb](https://github.com/Sage/carbon/commit/d505ffbf0f5f304b23a6c7f41f4072822ca32078)), closes [#4922](https://github.com/Sage/carbon/issues/4922)
-* **menu:** announce the menu as a list when using a screenreader ([175e1f3](https://github.com/Sage/carbon/commit/175e1f3b624db51e9b5ad68ca1cb36d6c9000c12))
-* **scrollable-block:** add role to fix scrollable submenu ([a4ef5af](https://github.com/Sage/carbon/commit/a4ef5af27c50233a82371e0cbee861df0185e4cd))
+- **menu, link:** ensure correct semantic HTML for menu items and links ([d505ffb](https://github.com/Sage/carbon/commit/d505ffbf0f5f304b23a6c7f41f4072822ca32078)), closes [#4922](https://github.com/Sage/carbon/issues/4922)
+- **menu:** announce the menu as a list when using a screenreader ([175e1f3](https://github.com/Sage/carbon/commit/175e1f3b624db51e9b5ad68ca1cb36d6c9000c12))
+- **scrollable-block:** add role to fix scrollable submenu ([a4ef5af](https://github.com/Sage/carbon/commit/a4ef5af27c50233a82371e0cbee861df0185e4cd))
 
 ### [106.6.3](https://github.com/Sage/carbon/compare/v106.6.2...v106.6.3) (2022-05-19)
 
-
 ### Bug Fixes
 
-* **toast:** fix escape key behaviour when toast launched from dialog ([6b9037d](https://github.com/Sage/carbon/commit/6b9037df288ae0498a05de5ce6762ffd34b75b6e)), closes [#5079](https://github.com/Sage/carbon/issues/5079)
+- **toast:** fix escape key behaviour when toast launched from dialog ([6b9037d](https://github.com/Sage/carbon/commit/6b9037df288ae0498a05de5ce6762ffd34b75b6e)), closes [#5079](https://github.com/Sage/carbon/issues/5079)
 
 ### [106.6.2](https://github.com/Sage/carbon/compare/v106.6.1...v106.6.2) (2022-05-17)
 
-
 ### Bug Fixes
 
-* **form:** only render footer when it has content ([14bc4b2](https://github.com/Sage/carbon/commit/14bc4b2fa709a8b88aac3e46aea7935745b05926)), closes [#5065](https://github.com/Sage/carbon/issues/5065)
+- **form:** only render footer when it has content ([14bc4b2](https://github.com/Sage/carbon/commit/14bc4b2fa709a8b88aac3e46aea7935745b05926)), closes [#5065](https://github.com/Sage/carbon/issues/5065)
 
 ### [106.6.1](https://github.com/Sage/carbon/compare/v106.6.0...v106.6.1) (2022-05-16)
 
-
 ### Bug Fixes
 
-* **select:** ensure select list appends to body if no element with role dialog exists ([4b2e4da](https://github.com/Sage/carbon/commit/4b2e4da21e181fb34d28bb76ac83f05b2acff778)), closes [#5135](https://github.com/Sage/carbon/issues/5135)
+- **select:** ensure select list appends to body if no element with role dialog exists ([4b2e4da](https://github.com/Sage/carbon/commit/4b2e4da21e181fb34d28bb76ac83f05b2acff778)), closes [#5135](https://github.com/Sage/carbon/issues/5135)
 
 ## [106.6.0](https://github.com/Sage/carbon/compare/v106.5.0...v106.6.0) (2022-05-16)
 
-
 ### Features
 
-* **multi-action-button:** close button list when clicked ([5a2d2e4](https://github.com/Sage/carbon/commit/5a2d2e47603a51f2f90ac2928de8786d26daed2b))
-* **split-button:** close button list when clicked ([dbd7edd](https://github.com/Sage/carbon/commit/dbd7edd9e6a86aff741ce976532ec06369968999))
+- **multi-action-button:** close button list when clicked ([5a2d2e4](https://github.com/Sage/carbon/commit/5a2d2e47603a51f2f90ac2928de8786d26daed2b))
+- **split-button:** close button list when clicked ([dbd7edd](https://github.com/Sage/carbon/commit/dbd7edd9e6a86aff741ce976532ec06369968999))
 
 ## [106.5.0](https://github.com/Sage/carbon/compare/v106.4.2...v106.5.0) (2022-05-16)
 
-
 ### Features
 
-* **textarea:** modify padding to use design tokens ([f4d5e71](https://github.com/Sage/carbon/commit/f4d5e71460916ab8a3e12ad2b95f672c20696459))
+- **textarea:** modify padding to use design tokens ([f4d5e71](https://github.com/Sage/carbon/commit/f4d5e71460916ab8a3e12ad2b95f672c20696459))
 
 ### [106.4.2](https://github.com/Sage/carbon/compare/v106.4.1...v106.4.2) (2022-05-16)
 
-
 ### Bug Fixes
 
-* **portrait:** ensure background fills consistently when zoom is greater than 100% ([f2b4a60](https://github.com/Sage/carbon/commit/f2b4a60278fc8ea93bb665ff0b740ed632e305db)), closes [#4939](https://github.com/Sage/carbon/issues/4939)
+- **portrait:** ensure background fills consistently when zoom is greater than 100% ([f2b4a60](https://github.com/Sage/carbon/commit/f2b4a60278fc8ea93bb665ff0b740ed632e305db)), closes [#4939](https://github.com/Sage/carbon/issues/4939)
 
 ### [106.4.1](https://github.com/Sage/carbon/compare/v106.4.0...v106.4.1) (2022-05-13)
 
-
 ### Bug Fixes
 
-* **menu:** fix incorrect scrollable block background ([a066c10](https://github.com/Sage/carbon/commit/a066c10d5bbee78980c159a26999dd3a9ff49a30))
+- **menu:** fix incorrect scrollable block background ([a066c10](https://github.com/Sage/carbon/commit/a066c10d5bbee78980c159a26999dd3a9ff49a30))
 
 ## [106.4.0](https://github.com/Sage/carbon/compare/v106.3.2...v106.4.0) (2022-05-13)
 
-
 ### Features
 
-* **select:** make select list respond to pageup/pagedown keys ([3c08c12](https://github.com/Sage/carbon/commit/3c08c127136ec30be60d86e087867791600b569b))
+- **select:** make select list respond to pageup/pagedown keys ([3c08c12](https://github.com/Sage/carbon/commit/3c08c127136ec30be60d86e087867791600b569b))
 
 ### [106.3.2](https://github.com/Sage/carbon/compare/v106.3.1...v106.3.2) (2022-05-13)
 
-
 ### Bug Fixes
 
-* **alert:** export alert props interface from index ([228ed28](https://github.com/Sage/carbon/commit/228ed28db99f660134859f89df8462c632613678))
-* **hr:** export prop interface from index ([0723453](https://github.com/Sage/carbon/commit/0723453e1fef283e0166f0d2c3c2673942c83577))
-* **link:** export prop interface from index ([72acd10](https://github.com/Sage/carbon/commit/72acd10cdc03d1c682b374b52409dec1bf7df854)), closes [#5132](https://github.com/Sage/carbon/issues/5132)
-* **navigation-bar:** export prop interface from index ([5748e36](https://github.com/Sage/carbon/commit/5748e36d02fb85a5db20524d01bd74b6cbf3b1ab))
-* **vertical-divider:** export prop interface from index ([9fd4f3b](https://github.com/Sage/carbon/commit/9fd4f3b539d47b4acfbfa513e1bd69c2e4dcba7e))
+- **alert:** export alert props interface from index ([228ed28](https://github.com/Sage/carbon/commit/228ed28db99f660134859f89df8462c632613678))
+- **hr:** export prop interface from index ([0723453](https://github.com/Sage/carbon/commit/0723453e1fef283e0166f0d2c3c2673942c83577))
+- **link:** export prop interface from index ([72acd10](https://github.com/Sage/carbon/commit/72acd10cdc03d1c682b374b52409dec1bf7df854)), closes [#5132](https://github.com/Sage/carbon/issues/5132)
+- **navigation-bar:** export prop interface from index ([5748e36](https://github.com/Sage/carbon/commit/5748e36d02fb85a5db20524d01bd74b6cbf3b1ab))
+- **vertical-divider:** export prop interface from index ([9fd4f3b](https://github.com/Sage/carbon/commit/9fd4f3b539d47b4acfbfa513e1bd69c2e4dcba7e))
 
 ### [106.3.1](https://github.com/Sage/carbon/compare/v106.3.0...v106.3.1) (2022-05-11)
 
-
 ### Bug Fixes
 
-* **date:** prevent calling onChange when input is blurred and value has not changed ([b2c9467](https://github.com/Sage/carbon/commit/b2c9467b764389eead3cd57d8b81688b7dfdc18d)), closes [#5120](https://github.com/Sage/carbon/issues/5120)
+- **date:** prevent calling onChange when input is blurred and value has not changed ([b2c9467](https://github.com/Sage/carbon/commit/b2c9467b764389eead3cd57d8b81688b7dfdc18d)), closes [#5120](https://github.com/Sage/carbon/issues/5120)
 
 ## [106.3.0](https://github.com/Sage/carbon/compare/v106.2.2...v106.3.0) (2022-05-10)
 
-
 ### Features
 
-* **progress-tracker:** add length prop ([51c0d46](https://github.com/Sage/carbon/commit/51c0d462e2e85bc99a58fc1347bebaa48d155589)), closes [#5106](https://github.com/Sage/carbon/issues/5106)
+- **progress-tracker:** add length prop ([51c0d46](https://github.com/Sage/carbon/commit/51c0d462e2e85bc99a58fc1347bebaa48d155589)), closes [#5106](https://github.com/Sage/carbon/issues/5106)
 
 ### [106.2.2](https://github.com/Sage/carbon/compare/v106.2.1...v106.2.2) (2022-05-10)
 
-
 ### Bug Fixes
 
-* **dialog-full-screen:** update contentRef prop to be optional in type definition ([c1616a9](https://github.com/Sage/carbon/commit/c1616a9e4fe3f6c4c36cf23597f4095186d9c576)), closes [#5121](https://github.com/Sage/carbon/issues/5121)
+- **dialog-full-screen:** update contentRef prop to be optional in type definition ([c1616a9](https://github.com/Sage/carbon/commit/c1616a9e4fe3f6c4c36cf23597f4095186d9c576)), closes [#5121](https://github.com/Sage/carbon/issues/5121)
 
 ### [106.2.1](https://github.com/Sage/carbon/compare/v106.2.0...v106.2.1) (2022-05-10)
 
-
 ### Bug Fixes
 
-* **form:** apply margin correctly to textarea component in a form ([dd40877](https://github.com/Sage/carbon/commit/dd40877aedf588dfd9c6ac28ba53b9c6e9fdceff)), closes [#5074](https://github.com/Sage/carbon/issues/5074)
+- **form:** apply margin correctly to textarea component in a form ([dd40877](https://github.com/Sage/carbon/commit/dd40877aedf588dfd9c6ac28ba53b9c6e9fdceff)), closes [#5074](https://github.com/Sage/carbon/issues/5074)
 
 ## [106.2.0](https://github.com/Sage/carbon/compare/v106.1.7...v106.2.0) (2022-05-06)
 
-
 ### Features
 
-* **typography:** change strong font weight to 700 ([aba57bd](https://github.com/Sage/carbon/commit/aba57bdd8ea21a04f511da5ab2d73c8402c6f852))
+- **typography:** change strong font weight to 700 ([aba57bd](https://github.com/Sage/carbon/commit/aba57bdd8ea21a04f511da5ab2d73c8402c6f852))
 
 ### [106.1.7](https://github.com/Sage/carbon/compare/v106.1.6...v106.1.7) (2022-05-06)
 
-
 ### Bug Fixes
 
-* **flat-table:** ensure no hover background change when FlatTableCheckbox is a th and isZebra is set ([f2fbd1c](https://github.com/Sage/carbon/commit/f2fbd1cc5d0ac54a7b8a5cfdf5e1cc7da6817daf)), closes [#5102](https://github.com/Sage/carbon/issues/5102)
-* **flat-table:** ensure z-index sticky footer is higher than FlatTableRowHeader ([a380428](https://github.com/Sage/carbon/commit/a38042878cb4c783b54d61a2bc9e6f4fdf6c955a)), closes [#5091](https://github.com/Sage/carbon/issues/5091)
+- **flat-table:** ensure no hover background change when FlatTableCheckbox is a th and isZebra is set ([f2fbd1c](https://github.com/Sage/carbon/commit/f2fbd1cc5d0ac54a7b8a5cfdf5e1cc7da6817daf)), closes [#5102](https://github.com/Sage/carbon/issues/5102)
+- **flat-table:** ensure z-index sticky footer is higher than FlatTableRowHeader ([a380428](https://github.com/Sage/carbon/commit/a38042878cb4c783b54d61a2bc9e6f4fdf6c955a)), closes [#5091](https://github.com/Sage/carbon/issues/5091)
 
 ### [106.1.6](https://github.com/Sage/carbon/compare/v106.1.5...v106.1.6) (2022-05-06)
 
-
 ### Bug Fixes
 
-* **date:** ensure correct output format and input formats are used for given locale ([2e9247e](https://github.com/Sage/carbon/commit/2e9247efc08d5d057a96965b37cca1ff6a89b5f8)), closes [#4966](https://github.com/Sage/carbon/issues/4966)
-* **date:** ensure onBlur callback is called when the input blurs ([6b00554](https://github.com/Sage/carbon/commit/6b005548be4e278edab28f881ca2f85fc6d9f994)), closes [#5072](https://github.com/Sage/carbon/issues/5072)
-* **date:** ensure rawValue emits correct value when year string is only 2 digits ([8d6afa7](https://github.com/Sage/carbon/commit/8d6afa707b32dfef66cd2a3d7b97c02c204f3391)), closes [#5119](https://github.com/Sage/carbon/issues/5119)
+- **date:** ensure correct output format and input formats are used for given locale ([2e9247e](https://github.com/Sage/carbon/commit/2e9247efc08d5d057a96965b37cca1ff6a89b5f8)), closes [#4966](https://github.com/Sage/carbon/issues/4966)
+- **date:** ensure onBlur callback is called when the input blurs ([6b00554](https://github.com/Sage/carbon/commit/6b005548be4e278edab28f881ca2f85fc6d9f994)), closes [#5072](https://github.com/Sage/carbon/issues/5072)
+- **date:** ensure rawValue emits correct value when year string is only 2 digits ([8d6afa7](https://github.com/Sage/carbon/commit/8d6afa707b32dfef66cd2a3d7b97c02c204f3391)), closes [#5119](https://github.com/Sage/carbon/issues/5119)
 
 ### [106.1.5](https://github.com/Sage/carbon/compare/v106.1.4...v106.1.5) (2022-05-06)
 
-
 ### Bug Fixes
 
-* **validations:** ensure VaidationProps are correctly imported by components extending its interface ([2f5e59b](https://github.com/Sage/carbon/commit/2f5e59bdf41537d5bb7f201c27c53c6d49ff0b3f)), closes [#5115](https://github.com/Sage/carbon/issues/5115)
+- **validations:** ensure VaidationProps are correctly imported by components extending its interface ([2f5e59b](https://github.com/Sage/carbon/commit/2f5e59bdf41537d5bb7f201c27c53c6d49ff0b3f)), closes [#5115](https://github.com/Sage/carbon/issues/5115)
 
 ### [106.1.4](https://github.com/Sage/carbon/compare/v106.1.3...v106.1.4) (2022-05-04)
 
-
 ### Bug Fixes
 
-* **accordion:** fix accordion content height issue ([2f76a18](https://github.com/Sage/carbon/commit/2f76a18120d5b4fe7ff26af7a040ad1d5558e5f4))
+- **accordion:** fix accordion content height issue ([2f76a18](https://github.com/Sage/carbon/commit/2f76a18120d5b4fe7ff26af7a040ad1d5558e5f4))
 
 ### [106.1.3](https://github.com/Sage/carbon/compare/v106.1.2...v106.1.3) (2022-05-03)
 
-
 ### Bug Fixes
 
-* **link:** apply correct colour to icon on hover ([be66093](https://github.com/Sage/carbon/commit/be660935ac5e153bb55da770f03e6d3d0090cd09)), closes [#5088](https://github.com/Sage/carbon/issues/5088)
+- **link:** apply correct colour to icon on hover ([be66093](https://github.com/Sage/carbon/commit/be660935ac5e153bb55da770f03e6d3d0090cd09)), closes [#5088](https://github.com/Sage/carbon/issues/5088)
 
 ### [106.1.2](https://github.com/Sage/carbon/compare/v106.1.1...v106.1.2) (2022-04-29)
 
-
 ### Bug Fixes
 
-* **dialog:** fix component not displayed in react 17 ([e311304](https://github.com/Sage/carbon/commit/e311304c0937c586f028b1aa954f2b0589711f5f)), closes [#4585](https://github.com/Sage/carbon/issues/4585)
-* **modal:** resolve findDOMNode deprecation warning in React 17 projects ([1d44633](https://github.com/Sage/carbon/commit/1d44633f63124f9f93f8a221440eaaf87a9a0053))
+- **dialog:** fix component not displayed in react 17 ([e311304](https://github.com/Sage/carbon/commit/e311304c0937c586f028b1aa954f2b0589711f5f)), closes [#4585](https://github.com/Sage/carbon/issues/4585)
+- **modal:** resolve findDOMNode deprecation warning in React 17 projects ([1d44633](https://github.com/Sage/carbon/commit/1d44633f63124f9f93f8a221440eaaf87a9a0053))
 
 ### [106.1.1](https://github.com/Sage/carbon/compare/v106.1.0...v106.1.1) (2022-04-28)
 
-
 ### Bug Fixes
 
-* **simple-select:** stop key filtering when command/control pressed ([167b068](https://github.com/Sage/carbon/commit/167b068f5273d15e538e050c732620e0417c4856))
+- **simple-select:** stop key filtering when command/control pressed ([167b068](https://github.com/Sage/carbon/commit/167b068f5273d15e538e050c732620e0417c4856))
 
 ## [106.1.0](https://github.com/Sage/carbon/compare/v106.0.3...v106.1.0) (2022-04-26)
 
-
 ### Features
 
-* consume Sage UI font from @sage/design-tokens package ([1d27c5f](https://github.com/Sage/carbon/commit/1d27c5f8b1cb334132c86b6864ae19690295f36d))
+- consume Sage UI font from @sage/design-tokens package ([1d27c5f](https://github.com/Sage/carbon/commit/1d27c5f8b1cb334132c86b6864ae19690295f36d))
 
 ### [106.0.3](https://github.com/Sage/carbon/compare/v106.0.2...v106.0.3) (2022-04-25)
 
-
 ### Bug Fixes
 
-* **decimal:** ensure id prop is passed to input ([a66fe0d](https://github.com/Sage/carbon/commit/a66fe0d6a541341a325772c7090c24feae920672)), closes [#5035](https://github.com/Sage/carbon/issues/5035)
+- **decimal:** ensure id prop is passed to input ([a66fe0d](https://github.com/Sage/carbon/commit/a66fe0d6a541341a325772c7090c24feae920672)), closes [#5035](https://github.com/Sage/carbon/issues/5035)
 
 ### [106.0.2](https://github.com/Sage/carbon/compare/v106.0.1...v106.0.2) (2022-04-19)
 
-
 ### Bug Fixes
 
-* **split-button:** ensure prop type definition is exported from index.d.ts file ([85b96c5](https://github.com/Sage/carbon/commit/85b96c58acd1fb257633237c9313b0d39c56cde1)), closes [#5049](https://github.com/Sage/carbon/issues/5049)
+- **split-button:** ensure prop type definition is exported from index.d.ts file ([85b96c5](https://github.com/Sage/carbon/commit/85b96c58acd1fb257633237c9313b0d39c56cde1)), closes [#5049](https://github.com/Sage/carbon/issues/5049)
 
 ### [106.0.1](https://github.com/Sage/carbon/compare/v106.0.0...v106.0.1) (2022-04-12)
 
-
 ### Bug Fixes
 
-* **tabs:** update background colour to improve contrast for selected Tab in alternate variant ([2af38b7](https://github.com/Sage/carbon/commit/2af38b7821fab7c0374bae3a765ab460a1f00310)), closes [#5030](https://github.com/Sage/carbon/issues/5030)
+- **tabs:** update background colour to improve contrast for selected Tab in alternate variant ([2af38b7](https://github.com/Sage/carbon/commit/2af38b7821fab7c0374bae3a765ab460a1f00310)), closes [#5030](https://github.com/Sage/carbon/issues/5030)
 
 ## [106.0.0](https://github.com/Sage/carbon/compare/v105.2.0...v106.0.0) (2022-04-08)
 
-
 ### ⚠ BREAKING CHANGES
 
-* @sage/design-tokens package is now a peer dependency
-instead of a built-in dependency.
+- @sage/design-tokens package is now a peer dependency
+  instead of a built-in dependency.
 
 ### Features
 
-* add support for Sage UI typeface ([f207ca1](https://github.com/Sage/carbon/commit/f207ca1394a609963aa2c8303868c7ebc20ba985))
+- add support for Sage UI typeface ([f207ca1](https://github.com/Sage/carbon/commit/f207ca1394a609963aa2c8303868c7ebc20ba985))
 
 ## [105.2.0](https://github.com/Sage/carbon/compare/v105.1.2...v105.2.0) (2022-04-07)
 
-
 ### Features
 
-* **multi-action-button:** pass props down to main button ([9d06db2](https://github.com/Sage/carbon/commit/9d06db2f42fb3acb66fbbe2511e9fa5ce738f64f))
-* **split-button:** pass props down to main button ([81d2510](https://github.com/Sage/carbon/commit/81d25103fe0cde086c0aff7bcaf2ff098af7efa0)), closes [#4972](https://github.com/Sage/carbon/issues/4972)
+- **multi-action-button:** pass props down to main button ([9d06db2](https://github.com/Sage/carbon/commit/9d06db2f42fb3acb66fbbe2511e9fa5ce738f64f))
+- **split-button:** pass props down to main button ([81d2510](https://github.com/Sage/carbon/commit/81d25103fe0cde086c0aff7bcaf2ff098af7efa0)), closes [#4972](https://github.com/Sage/carbon/issues/4972)
 
 ### [105.1.2](https://github.com/Sage/carbon/compare/v105.1.1...v105.1.2) (2022-04-04)
 
-
 ### Bug Fixes
 
-* **select:** fix incorrect option children prop type definition ([26305f0](https://github.com/Sage/carbon/commit/26305f0be0fd493b19d5ced73b7acebdaf4cd075))
+- **select:** fix incorrect option children prop type definition ([26305f0](https://github.com/Sage/carbon/commit/26305f0be0fd493b19d5ced73b7acebdaf4cd075))
 
 ### [105.1.1](https://github.com/Sage/carbon/compare/v105.1.0...v105.1.1) (2022-04-04)
 
-
 ### Bug Fixes
 
-* **flat-table:** correct cursor when using draggable rows ([636b191](https://github.com/Sage/carbon/commit/636b191b7bbf23f0c93f5bfa97f779ed9efc65a9))
+- **flat-table:** correct cursor when using draggable rows ([636b191](https://github.com/Sage/carbon/commit/636b191b7bbf23f0c93f5bfa97f779ed9efc65a9))
 
 ## [105.1.0](https://github.com/Sage/carbon/compare/v105.0.2...v105.1.0) (2022-03-30)
 
-
 ### Features
 
-* **tile:** surface variant prop and add deprecation warning for as prop ([e5670e3](https://github.com/Sage/carbon/commit/e5670e37f1dd95d59d1c6d02962734620fea8d03))
+- **tile:** surface variant prop and add deprecation warning for as prop ([e5670e3](https://github.com/Sage/carbon/commit/e5670e37f1dd95d59d1c6d02962734620fea8d03))
 
 ### [105.0.2](https://github.com/Sage/carbon/compare/v105.0.1...v105.0.2) (2022-03-29)
 
-
 ### Bug Fixes
 
-* **popover:** attach portal to dialog root when inside dialog ([1304481](https://github.com/Sage/carbon/commit/1304481d25953adfcab9135138b8b55dbd3e6934)), closes [#4880](https://github.com/Sage/carbon/issues/4880)
-* **select:** fix openOnFocus behaviour when clicked ([fab0bfe](https://github.com/Sage/carbon/commit/fab0bfe8e87e3eab6b70c4c0c7fa001215dafbd1))
+- **popover:** attach portal to dialog root when inside dialog ([1304481](https://github.com/Sage/carbon/commit/1304481d25953adfcab9135138b8b55dbd3e6934)), closes [#4880](https://github.com/Sage/carbon/issues/4880)
+- **select:** fix openOnFocus behaviour when clicked ([fab0bfe](https://github.com/Sage/carbon/commit/fab0bfe8e87e3eab6b70c4c0c7fa001215dafbd1))
 
 ### [105.0.1](https://github.com/Sage/carbon/compare/v105.0.0...v105.0.1) (2022-03-29)
 
-
 ### Bug Fixes
 
-* **vertical-divider:** render component as li element if it is a child of Menu ([3ebfc0b](https://github.com/Sage/carbon/commit/3ebfc0b27b83d1c739ad0a1d0d21bd5011066d31)), closes [#4951](https://github.com/Sage/carbon/issues/4951)
+- **vertical-divider:** render component as li element if it is a child of Menu ([3ebfc0b](https://github.com/Sage/carbon/commit/3ebfc0b27b83d1c739ad0a1d0d21bd5011066d31)), closes [#4951](https://github.com/Sage/carbon/issues/4951)
 
 ## [105.0.0](https://github.com/Sage/carbon/compare/v104.58.8...v105.0.0) (2022-03-29)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **row, column:** Row and Column components are deprecated
-and could no longer be used, please use the GridContainer and GridItem components instead.
-To help with migration please use our codemod `npx carbon-codemod replace-row-column-with-grid`
+- **row, column:** Row and Column components are deprecated
+  and could no longer be used, please use the GridContainer and GridItem components instead.
+  To help with migration please use our codemod `npx carbon-codemod replace-row-column-with-grid`
 
 ### Code Refactoring
 
-* **row, column:** remove deprecated components ([c5b9bb0](https://github.com/Sage/carbon/commit/c5b9bb0be702cf95decda448937c5df6dc3c8a06))
+- **row, column:** remove deprecated components ([c5b9bb0](https://github.com/Sage/carbon/commit/c5b9bb0be702cf95decda448937c5df6dc3c8a06))
 
 ### [104.58.8](https://github.com/Sage/carbon/compare/v104.58.7...v104.58.8) (2022-03-28)
 
-
 ### Bug Fixes
 
-* **message:** remove unused variants ([670281d](https://github.com/Sage/carbon/commit/670281d632736ee19f31156028d7d86418b983df))
-* **toast:** remove unused variants ([5638ced](https://github.com/Sage/carbon/commit/5638ced343a4ae578144446bd829a88a74209ae7))
+- **message:** remove unused variants ([670281d](https://github.com/Sage/carbon/commit/670281d632736ee19f31156028d7d86418b983df))
+- **toast:** remove unused variants ([5638ced](https://github.com/Sage/carbon/commit/5638ced343a4ae578144446bd829a88a74209ae7))
 
 ### [104.58.7](https://github.com/Sage/carbon/compare/v104.58.6...v104.58.7) (2022-03-28)
 
-
 ### Bug Fixes
 
-* **pager:** remove id from page size select ([6999ab1](https://github.com/Sage/carbon/commit/6999ab1e0ee0ef4aa6d47376d3a088e561a7d624)), closes [#4947](https://github.com/Sage/carbon/issues/4947)
+- **pager:** remove id from page size select ([6999ab1](https://github.com/Sage/carbon/commit/6999ab1e0ee0ef4aa6d47376d3a088e561a7d624)), closes [#4947](https://github.com/Sage/carbon/issues/4947)
 
 ### [104.58.6](https://github.com/Sage/carbon/compare/v104.58.5...v104.58.6) (2022-03-25)
 
-
 ### Bug Fixes
 
-* **textarea:** allow row and expandable props to be used together ([a9b64ca](https://github.com/Sage/carbon/commit/a9b64cadffc30aaff1212da5593ec245f5b5e5aa)), closes [#4959](https://github.com/Sage/carbon/issues/4959)
+- **textarea:** allow row and expandable props to be used together ([a9b64ca](https://github.com/Sage/carbon/commit/a9b64cadffc30aaff1212da5593ec245f5b5e5aa)), closes [#4959](https://github.com/Sage/carbon/issues/4959)
 
 ### [104.58.5](https://github.com/Sage/carbon/compare/v104.58.4...v104.58.5) (2022-03-24)
 
-
 ### Bug Fixes
 
-* **select:** fix page scrolling to the top issue ([3433027](https://github.com/Sage/carbon/commit/3433027b1a373b967319871c63534af7ec560ac3))
+- **select:** fix page scrolling to the top issue ([3433027](https://github.com/Sage/carbon/commit/3433027b1a373b967319871c63534af7ec560ac3))
 
 ### [104.58.4](https://github.com/Sage/carbon/compare/v104.58.3...v104.58.4) (2022-03-24)
 
-
 ### Bug Fixes
 
-* **multi-action-button:** fix incorrect hover color ([cca48c5](https://github.com/Sage/carbon/commit/cca48c5e257804d62f742a757e34246ffb23fbde))
+- **multi-action-button:** fix incorrect hover color ([cca48c5](https://github.com/Sage/carbon/commit/cca48c5e257804d62f742a757e34246ffb23fbde))
 
 ### [104.58.3](https://github.com/Sage/carbon/compare/v104.58.2...v104.58.3) (2022-03-22)
 
-
 ### Bug Fixes
 
-* **menu-item:** prevent setting maxWidth when items are rendered in MenuFullscreen ([8bf5887](https://github.com/Sage/carbon/commit/8bf5887fd7b8bee17c6d42b9b5996937c98e1bee)), closes [#4961](https://github.com/Sage/carbon/issues/4961)
+- **menu-item:** prevent setting maxWidth when items are rendered in MenuFullscreen ([8bf5887](https://github.com/Sage/carbon/commit/8bf5887fd7b8bee17c6d42b9b5996937c98e1bee)), closes [#4961](https://github.com/Sage/carbon/issues/4961)
 
 ### [104.58.2](https://github.com/Sage/carbon/compare/v104.58.1...v104.58.2) (2022-03-22)
 
-
 ### Bug Fixes
 
-* **tabs:** move onclick handler to button element ([6d63414](https://github.com/Sage/carbon/commit/6d63414d1293c10b36ce73dde6b9580f494da020)), closes [#4883](https://github.com/Sage/carbon/issues/4883)
+- **tabs:** move onclick handler to button element ([6d63414](https://github.com/Sage/carbon/commit/6d63414d1293c10b36ce73dde6b9580f494da020)), closes [#4883](https://github.com/Sage/carbon/issues/4883)
 
 ### [104.58.1](https://github.com/Sage/carbon/compare/v104.58.0...v104.58.1) (2022-03-21)
 
-
 ### Bug Fixes
 
-* **select:** ensure textbox placeholder can be set when passed as prop ([4905d48](https://github.com/Sage/carbon/commit/4905d481e4fcb13e077bbbd5412c72696431a4be))
+- **select:** ensure textbox placeholder can be set when passed as prop ([4905d48](https://github.com/Sage/carbon/commit/4905d481e4fcb13e077bbbd5412c72696431a4be))
 
 ## [104.58.0](https://github.com/Sage/carbon/compare/v104.57.0...v104.58.0) (2022-03-17)
 
-
 ### Features
 
-* **icon:** add id prop ([14cfc46](https://github.com/Sage/carbon/commit/14cfc4678841bc08d40154eff01fae5a0ab00d59))
-
+- **icon:** add id prop ([14cfc46](https://github.com/Sage/carbon/commit/14cfc4678841bc08d40154eff01fae5a0ab00d59))
 
 ### Bug Fixes
 
-* **validation-icon:** fix accessibility issue ([b8285bc](https://github.com/Sage/carbon/commit/b8285bc48dcc85fcb7f7ecb36bde2d03f8e83671))
+- **validation-icon:** fix accessibility issue ([b8285bc](https://github.com/Sage/carbon/commit/b8285bc48dcc85fcb7f7ecb36bde2d03f8e83671))
 
 ## [104.57.0](https://github.com/Sage/carbon/compare/v104.56.0...v104.57.0) (2022-03-17)
 
-
 ### Features
 
-* **carbon-provider:** add support for passing new validation flag via context ([de42a45](https://github.com/Sage/carbon/commit/de42a45fb36e0637d84400010036bc7f639b95e9))
-* **date-range:** add new validation style support ([957037f](https://github.com/Sage/carbon/commit/957037f4a7c1905ea1c807942055d9bbe10534b3))
-* **date:** add new validation style support ([b5fcfc8](https://github.com/Sage/carbon/commit/b5fcfc8156c8a99b9f939c095ee551da71054e1a))
-* **decimal:** add new validation style support ([7929926](https://github.com/Sage/carbon/commit/7929926b8c046091cb0c5d470fa5e1b70769f2a1))
-* **filterable-select:** add new validation style support ([1908bca](https://github.com/Sage/carbon/commit/1908bca40b3e667788a831aa017a5bb1b8913884))
-* **grouped-character:** add new validation style support ([578e308](https://github.com/Sage/carbon/commit/578e3081761a87894408bb54f0b429de14ecfa1f))
-* **multi-select:** add new validation style support ([3bb38ba](https://github.com/Sage/carbon/commit/3bb38baa2138d5c54ee457cbb8ac60f724563f94))
-* **number:** add new validation style support ([0f5b343](https://github.com/Sage/carbon/commit/0f5b343df7e1490ebc2e31f5807eed89d62c770c))
-* **numeral-date:** add new validation style support ([eb537f9](https://github.com/Sage/carbon/commit/eb537f9c9325d1593e52030363f542b00c61eda0))
-* **select:** add new validation style support ([5dcb7d3](https://github.com/Sage/carbon/commit/5dcb7d33156c7b3e627a745442f9a9ce6e78afae))
-* **textarea:** add new validation style support ([af48d7a](https://github.com/Sage/carbon/commit/af48d7a65c92c3558424bab029a4811b9480925e))
-* **textbox:** add support for new validation design and different size inputs ([462c6c6](https://github.com/Sage/carbon/commit/462c6c659a62b22153747ca9155712057ef94162))
-* **validation-message:** describe validation message component with design-tokens ([0acc714](https://github.com/Sage/carbon/commit/0acc714a672d5693f06bb891a25b94a1315f902e))
-* **validation-message:** internal component for validation messages ([ed0e148](https://github.com/Sage/carbon/commit/ed0e148bf08b960b2bd9538cd994ec0faae0611a))
-
+- **carbon-provider:** add support for passing new validation flag via context ([de42a45](https://github.com/Sage/carbon/commit/de42a45fb36e0637d84400010036bc7f639b95e9))
+- **date-range:** add new validation style support ([957037f](https://github.com/Sage/carbon/commit/957037f4a7c1905ea1c807942055d9bbe10534b3))
+- **date:** add new validation style support ([b5fcfc8](https://github.com/Sage/carbon/commit/b5fcfc8156c8a99b9f939c095ee551da71054e1a))
+- **decimal:** add new validation style support ([7929926](https://github.com/Sage/carbon/commit/7929926b8c046091cb0c5d470fa5e1b70769f2a1))
+- **filterable-select:** add new validation style support ([1908bca](https://github.com/Sage/carbon/commit/1908bca40b3e667788a831aa017a5bb1b8913884))
+- **grouped-character:** add new validation style support ([578e308](https://github.com/Sage/carbon/commit/578e3081761a87894408bb54f0b429de14ecfa1f))
+- **multi-select:** add new validation style support ([3bb38ba](https://github.com/Sage/carbon/commit/3bb38baa2138d5c54ee457cbb8ac60f724563f94))
+- **number:** add new validation style support ([0f5b343](https://github.com/Sage/carbon/commit/0f5b343df7e1490ebc2e31f5807eed89d62c770c))
+- **numeral-date:** add new validation style support ([eb537f9](https://github.com/Sage/carbon/commit/eb537f9c9325d1593e52030363f542b00c61eda0))
+- **select:** add new validation style support ([5dcb7d3](https://github.com/Sage/carbon/commit/5dcb7d33156c7b3e627a745442f9a9ce6e78afae))
+- **textarea:** add new validation style support ([af48d7a](https://github.com/Sage/carbon/commit/af48d7a65c92c3558424bab029a4811b9480925e))
+- **textbox:** add support for new validation design and different size inputs ([462c6c6](https://github.com/Sage/carbon/commit/462c6c659a62b22153747ca9155712057ef94162))
+- **validation-message:** describe validation message component with design-tokens ([0acc714](https://github.com/Sage/carbon/commit/0acc714a672d5693f06bb891a25b94a1315f902e))
+- **validation-message:** internal component for validation messages ([ed0e148](https://github.com/Sage/carbon/commit/ed0e148bf08b960b2bd9538cd994ec0faae0611a))
 
 ### Bug Fixes
 
-* **input:** change warning colour based on context ([e0a1826](https://github.com/Sage/carbon/commit/e0a182679c8af304172f15a05c0ea52c501bb048))
+- **input:** change warning colour based on context ([e0a1826](https://github.com/Sage/carbon/commit/e0a182679c8af304172f15a05c0ea52c501bb048))
 
 ## [104.56.0](https://github.com/Sage/carbon/compare/v104.55.0...v104.56.0) (2022-03-16)
 
-
 ### Features
 
-* **hidden-checkable-input:** surface role prop ([8fe6e73](https://github.com/Sage/carbon/commit/8fe6e730db2b3c5b2f07b26b1ec82abe9ffd49d0))
-
+- **hidden-checkable-input:** surface role prop ([8fe6e73](https://github.com/Sage/carbon/commit/8fe6e730db2b3c5b2f07b26b1ec82abe9ffd49d0))
 
 ### Bug Fixes
 
-* **switch:** ensure the input has the correct role ([3d012a2](https://github.com/Sage/carbon/commit/3d012a253fc2900a621a2373bf82852fdd4f8b53))
+- **switch:** ensure the input has the correct role ([3d012a2](https://github.com/Sage/carbon/commit/3d012a253fc2900a621a2373bf82852fdd4f8b53))
 
 ## [104.55.0](https://github.com/Sage/carbon/compare/v104.54.4...v104.55.0) (2022-03-16)
 
-
 ### Features
 
-* **modal-manager:** enable global management of modal lists ([7d640a1](https://github.com/Sage/carbon/commit/7d640a11b948580108826c635cf0c4335aa00697)), closes [#4170](https://github.com/Sage/carbon/issues/4170)
+- **modal-manager:** enable global management of modal lists ([7d640a1](https://github.com/Sage/carbon/commit/7d640a11b948580108826c635cf0c4335aa00697)), closes [#4170](https://github.com/Sage/carbon/issues/4170)
 
 ### [104.54.4](https://github.com/Sage/carbon/compare/v104.54.3...v104.54.4) (2022-03-16)
 
-
 ### Bug Fixes
 
-* **select:** remove incorrect props ([a755a8f](https://github.com/Sage/carbon/commit/a755a8f7ea34ac49ebcb168f71a7f34161ed986c)), closes [#4840](https://github.com/Sage/carbon/issues/4840)
+- **select:** remove incorrect props ([a755a8f](https://github.com/Sage/carbon/commit/a755a8f7ea34ac49ebcb168f71a7f34161ed986c)), closes [#4840](https://github.com/Sage/carbon/issues/4840)
 
 ### [104.54.3](https://github.com/Sage/carbon/compare/v104.54.2...v104.54.3) (2022-03-15)
 
-
 ### Bug Fixes
 
-* **action-popover-item:** prevent popover staying open when using keyboard nav ([6c03ae3](https://github.com/Sage/carbon/commit/6c03ae377c388f6b27c209047267ee3872bd19b3)), closes [#4662](https://github.com/Sage/carbon/issues/4662)
+- **action-popover-item:** prevent popover staying open when using keyboard nav ([6c03ae3](https://github.com/Sage/carbon/commit/6c03ae377c388f6b27c209047267ee3872bd19b3)), closes [#4662](https://github.com/Sage/carbon/issues/4662)
 
 ### [104.54.2](https://github.com/Sage/carbon/compare/v104.54.1...v104.54.2) (2022-03-14)
 
-
 ### Bug Fixes
 
-* **multi-action-button:** fix tabbing order issues ([fd24b7a](https://github.com/Sage/carbon/commit/fd24b7a5205a219c10d9f13792825e402ed7faea))
-* **split-button:** fix tabbing order issues ([a7b631f](https://github.com/Sage/carbon/commit/a7b631f0f1414fe454fa8af53916a5fe980fcc6e))
+- **multi-action-button:** fix tabbing order issues ([fd24b7a](https://github.com/Sage/carbon/commit/fd24b7a5205a219c10d9f13792825e402ed7faea))
+- **split-button:** fix tabbing order issues ([a7b631f](https://github.com/Sage/carbon/commit/a7b631f0f1414fe454fa8af53916a5fe980fcc6e))
 
 ### [104.54.1](https://github.com/Sage/carbon/compare/v104.54.0...v104.54.1) (2022-03-14)
 
-
 ### Bug Fixes
 
-* **pager:** fix incorrect styling when open ([4acfe02](https://github.com/Sage/carbon/commit/4acfe02c58b77a0a0df65a93373ec21dcca03026))
+- **pager:** fix incorrect styling when open ([4acfe02](https://github.com/Sage/carbon/commit/4acfe02c58b77a0a0df65a93373ec21dcca03026))
 
 ## [104.54.0](https://github.com/Sage/carbon/compare/v104.53.4...v104.54.0) (2022-03-11)
 
-
 ### Features
 
-* **flat-table:** add width prop ([4266db4](https://github.com/Sage/carbon/commit/4266db484c17f9a1de5f72fff49dad894749d5cd)), closes [#4822](https://github.com/Sage/carbon/issues/4822)
+- **flat-table:** add width prop ([4266db4](https://github.com/Sage/carbon/commit/4266db484c17f9a1de5f72fff49dad894749d5cd)), closes [#4822](https://github.com/Sage/carbon/issues/4822)
 
 ### [104.53.4](https://github.com/Sage/carbon/compare/v104.53.3...v104.53.4) (2022-03-11)
 
-
 ### Bug Fixes
 
-* **textbox:** prevent axe issue when the validation string is empty ([84f026f](https://github.com/Sage/carbon/commit/84f026f5e15c2f9e9b98b255a53b7706c929abea)), closes [#4839](https://github.com/Sage/carbon/issues/4839)
+- **textbox:** prevent axe issue when the validation string is empty ([84f026f](https://github.com/Sage/carbon/commit/84f026f5e15c2f9e9b98b255a53b7706c929abea)), closes [#4839](https://github.com/Sage/carbon/issues/4839)
 
 ### [104.53.3](https://github.com/Sage/carbon/compare/v104.53.2...v104.53.3) (2022-03-11)
 
-
 ### Bug Fixes
 
-* **tooltip:** fix tooltip repositioning ([f3a3943](https://github.com/Sage/carbon/commit/f3a394393df10b34588573ecd3120f267bda49ab))
+- **tooltip:** fix tooltip repositioning ([f3a3943](https://github.com/Sage/carbon/commit/f3a394393df10b34588573ecd3120f267bda49ab))
 
 ### [104.53.2](https://github.com/Sage/carbon/compare/v104.53.1...v104.53.2) (2022-03-10)
 
-
 ### Bug Fixes
 
-* **flat-table-row:** update styles to ensure that icon color can be customised via prop ([e4cd58c](https://github.com/Sage/carbon/commit/e4cd58c5a112af790ebff019eb55b5d6c2f746b0)), closes [#4904](https://github.com/Sage/carbon/issues/4904)
+- **flat-table-row:** update styles to ensure that icon color can be customised via prop ([e4cd58c](https://github.com/Sage/carbon/commit/e4cd58c5a112af790ebff019eb55b5d6c2f746b0)), closes [#4904](https://github.com/Sage/carbon/issues/4904)
 
 ### [104.53.1](https://github.com/Sage/carbon/compare/v104.53.0...v104.53.1) (2022-03-10)
 
-
 ### Bug Fixes
 
-* **multi-select:** prevent component calling onChange on first render when uncontrolled ([51f1e93](https://github.com/Sage/carbon/commit/51f1e93719a4961cfb4a5c41c2cf3985d925e29e)), closes [#4727](https://github.com/Sage/carbon/issues/4727)
+- **multi-select:** prevent component calling onChange on first render when uncontrolled ([51f1e93](https://github.com/Sage/carbon/commit/51f1e93719a4961cfb4a5c41c2cf3985d925e29e)), closes [#4727](https://github.com/Sage/carbon/issues/4727)
 
 ## [104.53.0](https://github.com/Sage/carbon/compare/v104.52.2...v104.53.0) (2022-03-09)
 
-
 ### Features
 
-* **space:** swap space values for values described by tokens ([ec0c2d4](https://github.com/Sage/carbon/commit/ec0c2d4521eba4649e3863d335390b612ff99994))
+- **space:** swap space values for values described by tokens ([ec0c2d4](https://github.com/Sage/carbon/commit/ec0c2d4521eba4649e3863d335390b612ff99994))
 
 ### [104.52.2](https://github.com/Sage/carbon/compare/v104.52.1...v104.52.2) (2022-03-09)
 
-
 ### Bug Fixes
 
-* **storybook:** fix theme selector functionality ([ccfbd50](https://github.com/Sage/carbon/commit/ccfbd50a0415c9c99767136a8e64a2b8ccaccf85))
+- **storybook:** fix theme selector functionality ([ccfbd50](https://github.com/Sage/carbon/commit/ccfbd50a0415c9c99767136a8e64a2b8ccaccf85))
 
 ### [104.52.1](https://github.com/Sage/carbon/compare/v104.52.0...v104.52.1) (2022-03-08)
 
-
 ### Bug Fixes
 
-* **filterable-select:** prevent passing a non-existent label id to children ([da6c470](https://github.com/Sage/carbon/commit/da6c4703a19593fa0f78715e09d1e2b2e8cf823a))
+- **filterable-select:** prevent passing a non-existent label id to children ([da6c470](https://github.com/Sage/carbon/commit/da6c4703a19593fa0f78715e09d1e2b2e8cf823a))
 
 ## [104.52.0](https://github.com/Sage/carbon/compare/v104.51.0...v104.52.0) (2022-03-08)
 
-
 ### Features
 
-* **flat-table:** add ability to use data-xxx props on flat table components ([11b365d](https://github.com/Sage/carbon/commit/11b365daf701d5c29acb60b923e5a7f3317b1327)), closes [#4862](https://github.com/Sage/carbon/issues/4862)
+- **flat-table:** add ability to use data-xxx props on flat table components ([11b365d](https://github.com/Sage/carbon/commit/11b365daf701d5c29acb60b923e5a7f3317b1327)), closes [#4862](https://github.com/Sage/carbon/issues/4862)
 
 ## [104.51.0](https://github.com/Sage/carbon/compare/v104.50.0...v104.51.0) (2022-03-08)
 
-
 ### Features
 
-* extend toColor function by design tokens ([1d17860](https://github.com/Sage/carbon/commit/1d17860cf82f3b7bbe779fb75f93744f36e311a2))
+- extend toColor function by design tokens ([1d17860](https://github.com/Sage/carbon/commit/1d17860cf82f3b7bbe779fb75f93744f36e311a2))
 
 ## [104.50.0](https://github.com/Sage/carbon/compare/v104.49.0...v104.50.0) (2022-03-07)
 
-
 ### Features
 
-* **character-count:** describe character-count component using design tokens, update tests ([8e5d184](https://github.com/Sage/carbon/commit/8e5d18443ba277de85bf6a853e23da216d851b03))
-* **checkable-input:** describe checkable-input component using design tokens, update tests ([14b924c](https://github.com/Sage/carbon/commit/14b924cc41d71a82ac4815389a04ffcc113ac24b))
-* **input-icon-toggle:** describe input-icon-toggle component using design tokens ([f82f7bf](https://github.com/Sage/carbon/commit/f82f7bffcca1927f3ecaf08ee2dc506eb96812af))
-* **input-presentation:** describe input-presentation component using design tokens, update tests ([a65fa6b](https://github.com/Sage/carbon/commit/a65fa6b53a57c6faef8863526a943f4580aba9d6))
+- **character-count:** describe character-count component using design tokens, update tests ([8e5d184](https://github.com/Sage/carbon/commit/8e5d18443ba277de85bf6a853e23da216d851b03))
+- **checkable-input:** describe checkable-input component using design tokens, update tests ([14b924c](https://github.com/Sage/carbon/commit/14b924cc41d71a82ac4815389a04ffcc113ac24b))
+- **input-icon-toggle:** describe input-icon-toggle component using design tokens ([f82f7bf](https://github.com/Sage/carbon/commit/f82f7bffcca1927f3ecaf08ee2dc506eb96812af))
+- **input-presentation:** describe input-presentation component using design tokens, update tests ([a65fa6b](https://github.com/Sage/carbon/commit/a65fa6b53a57c6faef8863526a943f4580aba9d6))
 
 ## [104.49.0](https://github.com/Sage/carbon/compare/v104.48.1...v104.49.0) (2022-03-07)
 
-
 ### Features
 
-* **scrollable-list-item, select-list-container:** describe components using tokens ([2d4bcbd](https://github.com/Sage/carbon/commit/2d4bcbde12a34b2b660a841ba3204b04762ae90c))
+- **scrollable-list-item, select-list-container:** describe components using tokens ([2d4bcbd](https://github.com/Sage/carbon/commit/2d4bcbde12a34b2b660a841ba3204b04762ae90c))
 
 ### [104.48.1](https://github.com/Sage/carbon/compare/v104.48.0...v104.48.1) (2022-03-07)
 
-
 ### Bug Fixes
 
-* **icon:** update icon colors token to match  design decisions ([af356c2](https://github.com/Sage/carbon/commit/af356c2691699eb9e02f61869d01f41f8f5510b4))
+- **icon:** update icon colors token to match design decisions ([af356c2](https://github.com/Sage/carbon/commit/af356c2691699eb9e02f61869d01f41f8f5510b4))
 
 ## [104.48.0](https://github.com/Sage/carbon/compare/v104.47.0...v104.48.0) (2022-03-04)
 
-
 ### Features
 
-* **sidebar-header:** describe sidebar-header using design tokens, update tests ([1adde4b](https://github.com/Sage/carbon/commit/1adde4badabb9f460237cf52b55b8297d9fa8220))
+- **sidebar-header:** describe sidebar-header using design tokens, update tests ([1adde4b](https://github.com/Sage/carbon/commit/1adde4badabb9f460237cf52b55b8297d9fa8220))
 
 ## [104.47.0](https://github.com/Sage/carbon/compare/v104.46.0...v104.47.0) (2022-03-04)
 
-
 ### Features
 
-* **box:** describe box component using design tokens, update tests ([2494d24](https://github.com/Sage/carbon/commit/2494d24bbe9a26a1b142ad2177295ed7a34a2554))
-* **content:** describe content component using design tokens, update tests ([f096852](https://github.com/Sage/carbon/commit/f096852391735ceeed37ea7e910bc78c11e62b5e))
-* **dismissible-box:** describe dissmisible-box component using design tokens, update tests ([4c3158a](https://github.com/Sage/carbon/commit/4c3158a586b211622b70f44ceebffc7f625987a0))
+- **box:** describe box component using design tokens, update tests ([2494d24](https://github.com/Sage/carbon/commit/2494d24bbe9a26a1b142ad2177295ed7a34a2554))
+- **content:** describe content component using design tokens, update tests ([f096852](https://github.com/Sage/carbon/commit/f096852391735ceeed37ea7e910bc78c11e62b5e))
+- **dismissible-box:** describe dissmisible-box component using design tokens, update tests ([4c3158a](https://github.com/Sage/carbon/commit/4c3158a586b211622b70f44ceebffc7f625987a0))
 
 ## [104.46.0](https://github.com/Sage/carbon/compare/v104.45.0...v104.46.0) (2022-03-04)
 
-
 ### Features
 
-* **date-range, date-input:** describe using design tokens ([605a81a](https://github.com/Sage/carbon/commit/605a81ab76744c098d7c4fcab1bfada78e5eeed3))
+- **date-range, date-input:** describe using design tokens ([605a81a](https://github.com/Sage/carbon/commit/605a81ab76744c098d7c4fcab1bfada78e5eeed3))
 
 ## [104.45.0](https://github.com/Sage/carbon/compare/v104.44.0...v104.45.0) (2022-03-04)
 
-
 ### Features
 
-* **detail:** describe detail component using design tokens, update tests ([ba90819](https://github.com/Sage/carbon/commit/ba90819ad00c03939b26620158563ca4b53f8289))
+- **detail:** describe detail component using design tokens, update tests ([ba90819](https://github.com/Sage/carbon/commit/ba90819ad00c03939b26620158563ca4b53f8289))
 
 ## [104.44.0](https://github.com/Sage/carbon/compare/v104.43.1...v104.44.0) (2022-03-04)
 
-
 ### Features
 
-* **setting-row:** describe setting-row component using design tokens, update tests ([f4808f5](https://github.com/Sage/carbon/commit/f4808f5ebedb07db8d224ae608e4a9888c9c4db1))
+- **setting-row:** describe setting-row component using design tokens, update tests ([f4808f5](https://github.com/Sage/carbon/commit/f4808f5ebedb07db8d224ae608e4a9888c9c4db1))
 
 ### [104.43.1](https://github.com/Sage/carbon/compare/v104.43.0...v104.43.1) (2022-03-03)
 
-
 ### Bug Fixes
 
-* **help:** resolve aria issues ([efc5645](https://github.com/Sage/carbon/commit/efc56451d510bc4f50ee381144e4107e4763b74c))
-* **icon:** resolve aria issues ([fa75f2a](https://github.com/Sage/carbon/commit/fa75f2a571adbba83b1dbfc082ad226597dcd2f3))
-* **tooltip:** fix incorrect icon with tooltip focusability ([32644bc](https://github.com/Sage/carbon/commit/32644bc4d68557527c6f8915482838fe08d6902a))
+- **help:** resolve aria issues ([efc5645](https://github.com/Sage/carbon/commit/efc56451d510bc4f50ee381144e4107e4763b74c))
+- **icon:** resolve aria issues ([fa75f2a](https://github.com/Sage/carbon/commit/fa75f2a571adbba83b1dbfc082ad226597dcd2f3))
+- **tooltip:** fix incorrect icon with tooltip focusability ([32644bc](https://github.com/Sage/carbon/commit/32644bc4d68557527c6f8915482838fe08d6902a))
 
 ## [104.43.0](https://github.com/Sage/carbon/compare/v104.42.0...v104.43.0) (2022-03-03)
 
-
 ### Features
 
-* **grid:** add styled-system props ([446f477](https://github.com/Sage/carbon/commit/446f47782a2ef2967ccce810e0fcc025779a16ec))
+- **grid:** add styled-system props ([446f477](https://github.com/Sage/carbon/commit/446f47782a2ef2967ccce810e0fcc025779a16ec))
 
 ## [104.42.0](https://github.com/Sage/carbon/compare/v104.41.0...v104.42.0) (2022-03-03)
 
-
 ### Features
 
-* **help:** describe component using design tokens ([a102cdf](https://github.com/Sage/carbon/commit/a102cdf4e736784a796b17994d627dd69bc5dcaf))
+- **help:** describe component using design tokens ([a102cdf](https://github.com/Sage/carbon/commit/a102cdf4e736784a796b17994d627dd69bc5dcaf))
 
 ## [104.41.0](https://github.com/Sage/carbon/compare/v104.40.0...v104.41.0) (2022-03-03)
 
-
 ### Features
 
-* **link-preview, preview:** describe link-preview & preview using design tokens ([b62e6f3](https://github.com/Sage/carbon/commit/b62e6f3c53bfb085d2da8d876c00da6da0fa3362))
+- **link-preview, preview:** describe link-preview & preview using design tokens ([b62e6f3](https://github.com/Sage/carbon/commit/b62e6f3c53bfb085d2da8d876c00da6da0fa3362))
 
 ## [104.40.0](https://github.com/Sage/carbon/compare/v104.39.0...v104.40.0) (2022-03-03)
 
-
 ### Features
 
-* **grid:** change getSpacing function to design tokens ([ef54b92](https://github.com/Sage/carbon/commit/ef54b92d91ca70ff15158a500b585c60ab708078))
+- **grid:** change getSpacing function to design tokens ([ef54b92](https://github.com/Sage/carbon/commit/ef54b92d91ca70ff15158a500b585c60ab708078))
 
 ## [104.39.0](https://github.com/Sage/carbon/compare/v104.38.2...v104.39.0) (2022-03-03)
 
-
 ### Features
 
-* **draggable:** describe draggable using design tokens, update tests ([a70b1b1](https://github.com/Sage/carbon/commit/a70b1b16eb6c9d3cab16bd539246409ddc8aced6))
-* **popover-container:** describe popover-container using design tokens, update tests ([7ff7197](https://github.com/Sage/carbon/commit/7ff719766be0a6278dc0022bc04d8b6b968e59f6))
+- **draggable:** describe draggable using design tokens, update tests ([a70b1b1](https://github.com/Sage/carbon/commit/a70b1b16eb6c9d3cab16bd539246409ddc8aced6))
+- **popover-container:** describe popover-container using design tokens, update tests ([7ff7197](https://github.com/Sage/carbon/commit/7ff719766be0a6278dc0022bc04d8b6b968e59f6))
 
 ### [104.38.2](https://github.com/Sage/carbon/compare/v104.38.1...v104.38.2) (2022-03-02)
 
-
 ### Bug Fixes
 
-* **select-list:** replace colorsComponentsNavigation token ([ec27917](https://github.com/Sage/carbon/commit/ec279175486d6588ba1b13892697f9acf2a03641))
+- **select-list:** replace colorsComponentsNavigation token ([ec27917](https://github.com/Sage/carbon/commit/ec279175486d6588ba1b13892697f9acf2a03641))
 
 ### [104.38.1](https://github.com/Sage/carbon/compare/v104.38.0...v104.38.1) (2022-03-02)
 
-
 ### Bug Fixes
 
-* **button:** fix incorrect forwardref behaviour ([5e69003](https://github.com/Sage/carbon/commit/5e6900398ed167d487df2d330827887e3ff7847d))
-* **icon-button:** fix incorrect ref behaviour ([13cffb9](https://github.com/Sage/carbon/commit/13cffb9b3580b3acb88ca63c102267b9bcaeb557))
+- **button:** fix incorrect forwardref behaviour ([5e69003](https://github.com/Sage/carbon/commit/5e6900398ed167d487df2d330827887e3ff7847d))
+- **icon-button:** fix incorrect ref behaviour ([13cffb9](https://github.com/Sage/carbon/commit/13cffb9b3580b3acb88ca63c102267b9bcaeb557))
 
 ## [104.38.0](https://github.com/Sage/carbon/compare/v104.37.0...v104.38.0) (2022-03-01)
 
-
 ### Features
 
-* **hr:** describe component using design tokens ([f464a08](https://github.com/Sage/carbon/commit/f464a084d9f3c202efa5e0cb1694701153e5c018))
-* **tile-select:** describe accordion footer with token ([dae33f7](https://github.com/Sage/carbon/commit/dae33f70458f5c50e7ccd45f8248a576893bde52))
+- **hr:** describe component using design tokens ([f464a08](https://github.com/Sage/carbon/commit/f464a084d9f3c202efa5e0cb1694701153e5c018))
+- **tile-select:** describe accordion footer with token ([dae33f7](https://github.com/Sage/carbon/commit/dae33f70458f5c50e7ccd45f8248a576893bde52))
 
 ## [104.37.0](https://github.com/Sage/carbon/compare/v104.36.0...v104.37.0) (2022-03-01)
 
-
 ### Features
 
-* **confirm:** describe confirm component using design tokens, update tests ([504e1ac](https://github.com/Sage/carbon/commit/504e1ac4d93978f2cd8726359ddb5da1a5026e92))
+- **confirm:** describe confirm component using design tokens, update tests ([504e1ac](https://github.com/Sage/carbon/commit/504e1ac4d93978f2cd8726359ddb5da1a5026e92))
 
 ## [104.36.0](https://github.com/Sage/carbon/compare/v104.35.0...v104.36.0) (2022-03-01)
 
-
 ### Features
 
-* **field-help:** describe field-help using design tokens, update tests ([97b5cc0](https://github.com/Sage/carbon/commit/97b5cc0ba1d6d9e3cfbfd53f20c7a2842563ad53))
-* **fieldset:** describe fieldset using design tokens, update tests ([a7095e5](https://github.com/Sage/carbon/commit/a7095e5fd4f12677851341f9c95e1ec2873abca8))
+- **field-help:** describe field-help using design tokens, update tests ([97b5cc0](https://github.com/Sage/carbon/commit/97b5cc0ba1d6d9e3cfbfd53f20c7a2842563ad53))
+- **fieldset:** describe fieldset using design tokens, update tests ([a7095e5](https://github.com/Sage/carbon/commit/a7095e5fd4f12677851341f9c95e1ec2873abca8))
 
 ## [104.35.0](https://github.com/Sage/carbon/compare/v104.34.1...v104.35.0) (2022-03-01)
 
-
 ### Features
 
-* enable tree shaking ([07d2b8a](https://github.com/Sage/carbon/commit/07d2b8a85a7f5ae452c876e65224a4b8dd27501e))
+- enable tree shaking ([07d2b8a](https://github.com/Sage/carbon/commit/07d2b8a85a7f5ae452c876e65224a4b8dd27501e))
 
 ### [104.34.1](https://github.com/Sage/carbon/compare/v104.34.0...v104.34.1) (2022-02-28)
 
-
 ### Bug Fixes
 
-* **card:** fix incorrect headers ([4c4d5fa](https://github.com/Sage/carbon/commit/4c4d5fa3f45885af72464a7d7d65ddcce84c17f2))
+- **card:** fix incorrect headers ([4c4d5fa](https://github.com/Sage/carbon/commit/4c4d5fa3f45885af72464a7d7d65ddcce84c17f2))
 
 ## [104.34.0](https://github.com/Sage/carbon/compare/v104.33.1...v104.34.0) (2022-02-28)
 
-
 ### Features
 
-* **icon-button:** describe icon-button component using design tokens, update tests ([ca5a296](https://github.com/Sage/carbon/commit/ca5a2968fe0f482d1734a5bc2c360fa6d3a52cee))
+- **icon-button:** describe icon-button component using design tokens, update tests ([ca5a296](https://github.com/Sage/carbon/commit/ca5a2968fe0f482d1734a5bc2c360fa6d3a52cee))
 
 ### [104.33.1](https://github.com/Sage/carbon/compare/v104.33.0...v104.33.1) (2022-02-28)
 
-
 ### Bug Fixes
 
-* **draggable:** prevent crash when dragging item from one container to another ([def7ef7](https://github.com/Sage/carbon/commit/def7ef7fae2593b1e4830af776f5737960a55c69))
-* **flat-table-draggable:** prevent crash when dragging item from one table to another ([57e8b62](https://github.com/Sage/carbon/commit/57e8b62fdd2051ba72f16e1adb9fabec7e778034)), closes [#4857](https://github.com/Sage/carbon/issues/4857)
+- **draggable:** prevent crash when dragging item from one container to another ([def7ef7](https://github.com/Sage/carbon/commit/def7ef7fae2593b1e4830af776f5737960a55c69))
+- **flat-table-draggable:** prevent crash when dragging item from one table to another ([57e8b62](https://github.com/Sage/carbon/commit/57e8b62fdd2051ba72f16e1adb9fabec7e778034)), closes [#4857](https://github.com/Sage/carbon/issues/4857)
 
 ## [104.33.0](https://github.com/Sage/carbon/compare/v104.32.0...v104.33.0) (2022-02-25)
 
-
 ### Features
 
-* **navigation-bar:** add position, offset and orientation props to enable fixed or sticky positions ([a2e8467](https://github.com/Sage/carbon/commit/a2e846774d6bcd7f0a7e9da6ae1b67450eddd4c4)), closes [#4691](https://github.com/Sage/carbon/issues/4691)
+- **navigation-bar:** add position, offset and orientation props to enable fixed or sticky positions ([a2e8467](https://github.com/Sage/carbon/commit/a2e846774d6bcd7f0a7e9da6ae1b67450eddd4c4)), closes [#4691](https://github.com/Sage/carbon/issues/4691)
 
 ## [104.32.0](https://github.com/Sage/carbon/compare/v104.31.1...v104.32.0) (2022-02-25)
 
-
 ### Features
 
-* **step-sequence-item:** support hiding indicator ([460ba0d](https://github.com/Sage/carbon/commit/460ba0dcbb4fb7cefc995cced58380611677cb4a))
+- **step-sequence-item:** support hiding indicator ([460ba0d](https://github.com/Sage/carbon/commit/460ba0dcbb4fb7cefc995cced58380611677cb4a))
 
 ### [104.31.1](https://github.com/Sage/carbon/compare/v104.31.0...v104.31.1) (2022-02-25)
 
-
 ### Bug Fixes
 
-* **tab-title:** ensure icon color can be overridden when rendered in TabTitle ([29a5bb7](https://github.com/Sage/carbon/commit/29a5bb700dc0d1ff39d6e26dd2839f5081d0d531)), closes [#4875](https://github.com/Sage/carbon/issues/4875)
-* **tab-title:** remove additional error border and prevent content jumping when has siblings ([3d29834](https://github.com/Sage/carbon/commit/3d2983401aeab9f20c61fb4c5e805780cf3fc7f3)), closes [#4833](https://github.com/Sage/carbon/issues/4833)
+- **tab-title:** ensure icon color can be overridden when rendered in TabTitle ([29a5bb7](https://github.com/Sage/carbon/commit/29a5bb700dc0d1ff39d6e26dd2839f5081d0d531)), closes [#4875](https://github.com/Sage/carbon/issues/4875)
+- **tab-title:** remove additional error border and prevent content jumping when has siblings ([3d29834](https://github.com/Sage/carbon/commit/3d2983401aeab9f20c61fb4c5e805780cf3fc7f3)), closes [#4833](https://github.com/Sage/carbon/issues/4833)
 
 ## [104.31.0](https://github.com/Sage/carbon/compare/v104.30.0...v104.31.0) (2022-02-25)
 
-
 ### Features
 
-* **definition-list:** descirbe DefinitionList component using design tokens ([17f3e84](https://github.com/Sage/carbon/commit/17f3e8450a1d3c44f615cab305900894c7ad78b8))
-* **select:** describe select component using design tokens ([6fa3b76](https://github.com/Sage/carbon/commit/6fa3b766171500afbf5ce4571bd171ef327c24aa))
+- **definition-list:** descirbe DefinitionList component using design tokens ([17f3e84](https://github.com/Sage/carbon/commit/17f3e8450a1d3c44f615cab305900894c7ad78b8))
+- **select:** describe select component using design tokens ([6fa3b76](https://github.com/Sage/carbon/commit/6fa3b766171500afbf5ce4571bd171ef327c24aa))
 
 ## [104.30.0](https://github.com/Sage/carbon/compare/v104.29.0...v104.30.0) (2022-02-23)
 
-
 ### Features
 
-* **form:** describe form using design tokens, update tests ([ab4d386](https://github.com/Sage/carbon/commit/ab4d38692ae2d26284e9888a880736b09e1e7ee5))
+- **form:** describe form using design tokens, update tests ([ab4d386](https://github.com/Sage/carbon/commit/ab4d38692ae2d26284e9888a880736b09e1e7ee5))
 
 ## [104.29.0](https://github.com/Sage/carbon/compare/v104.28.0...v104.29.0) (2022-02-23)
 
-
 ### Features
 
-* **drawer:** add padding to sticky footer ([c662801](https://github.com/Sage/carbon/commit/c6628018340169589b632b726491d4575608c51b))
-* **drawer:** describe using design tokens ([9a9d6f4](https://github.com/Sage/carbon/commit/9a9d6f47dc47d80c4d5e434592e21769de81887d))
+- **drawer:** add padding to sticky footer ([c662801](https://github.com/Sage/carbon/commit/c6628018340169589b632b726491d4575608c51b))
+- **drawer:** describe using design tokens ([9a9d6f4](https://github.com/Sage/carbon/commit/9a9d6f47dc47d80c4d5e434592e21769de81887d))
 
 ## [104.28.0](https://github.com/Sage/carbon/compare/v104.27.0...v104.28.0) (2022-02-23)
 
-
 ### Features
 
-* **pod:** describe pod using design tokens, update tests ([efe366a](https://github.com/Sage/carbon/commit/efe366a3e873ea9b8fa86d09dbb32ec10bc93058))
-* **show-edit-pod:** describe show-edit-pod using design tokens, update tests ([bcb30be](https://github.com/Sage/carbon/commit/bcb30be673d9bbf71c7bc4cb767b54b97688138b))
+- **pod:** describe pod using design tokens, update tests ([efe366a](https://github.com/Sage/carbon/commit/efe366a3e873ea9b8fa86d09dbb32ec10bc93058))
+- **show-edit-pod:** describe show-edit-pod using design tokens, update tests ([bcb30be](https://github.com/Sage/carbon/commit/bcb30be673d9bbf71c7bc4cb767b54b97688138b))
 
 ## [104.27.0](https://github.com/Sage/carbon/compare/v104.26.1...v104.27.0) (2022-02-23)
 
-
 ### Features
 
-* **advanced-color-picker:** describe advanced-color-picker using design tokens ([38954ac](https://github.com/Sage/carbon/commit/38954ac9932aea8a4b5a01b4e3b7923b0c31814e))
-* **simple-color-picker:** describe simple-color-picker using design tokens, update tests ([57b347e](https://github.com/Sage/carbon/commit/57b347e8bd9758242f3d543b72671da948a57625))
+- **advanced-color-picker:** describe advanced-color-picker using design tokens ([38954ac](https://github.com/Sage/carbon/commit/38954ac9932aea8a4b5a01b4e3b7923b0c31814e))
+- **simple-color-picker:** describe simple-color-picker using design tokens, update tests ([57b347e](https://github.com/Sage/carbon/commit/57b347e8bd9758242f3d543b72671da948a57625))
 
 ### [104.26.1](https://github.com/Sage/carbon/compare/v104.26.0...v104.26.1) (2022-02-22)
 
-
 ### Bug Fixes
 
-* **search:** fix onchange callback fired twice ([f25602f](https://github.com/Sage/carbon/commit/f25602f197ccf8575b0e27441af7871dd37ec19e))
+- **search:** fix onchange callback fired twice ([f25602f](https://github.com/Sage/carbon/commit/f25602f197ccf8575b0e27441af7871dd37ec19e))
 
 ## [104.26.0](https://github.com/Sage/carbon/compare/v104.25.0...v104.26.0) (2022-02-22)
 
-
 ### Features
 
-* **duelling-picklist:** describe duelling picklist component using design tokens ([4dd37c0](https://github.com/Sage/carbon/commit/4dd37c0b68bc0bd89f0100876b6052ea6b8eb285))
+- **duelling-picklist:** describe duelling picklist component using design tokens ([4dd37c0](https://github.com/Sage/carbon/commit/4dd37c0b68bc0bd89f0100876b6052ea6b8eb285))
 
 ## [104.25.0](https://github.com/Sage/carbon/compare/v104.24.1...v104.25.0) (2022-02-22)
 
-
 ### Features
 
-* **flat-table:** describe table using design tokens, update tests ([ac5331f](https://github.com/Sage/carbon/commit/ac5331f2a9b600038ebcac1afd38dba348693349))
+- **flat-table:** describe table using design tokens, update tests ([ac5331f](https://github.com/Sage/carbon/commit/ac5331f2a9b600038ebcac1afd38dba348693349))
 
 ### [104.24.1](https://github.com/Sage/carbon/compare/v104.24.0...v104.24.1) (2022-02-22)
 
-
 ### Bug Fixes
 
-* **accordion:** add role button to control to ensure aria-expanded use is valid ([37f7230](https://github.com/Sage/carbon/commit/37f7230f1c98c6050c24cf146313b8f19f2eabbd))
-* **dialog-full-screen:** aria-modal only set if role is dialog and set dialog as default role value ([28d5263](https://github.com/Sage/carbon/commit/28d526340aad2e30733c1366683944bfbb9b6905))
-* **drawer:** prevent overflow-y being set on sidebar container unless expanded ([79ac06b](https://github.com/Sage/carbon/commit/79ac06b08e7783c7d2b5d315a7c548e1ff7d7e66))
-* **popover-container:** set id on the control if render prop is used and container is closed ([2b77d56](https://github.com/Sage/carbon/commit/2b77d5634d3ff758a3164942f8866f475dba7a84))
-* **textbox:** prevent setting labelId when no label value passed in ([be510cb](https://github.com/Sage/carbon/commit/be510cbf1bbe034c241fbceb33dbbc9ceef37c0f))
+- **accordion:** add role button to control to ensure aria-expanded use is valid ([37f7230](https://github.com/Sage/carbon/commit/37f7230f1c98c6050c24cf146313b8f19f2eabbd))
+- **dialog-full-screen:** aria-modal only set if role is dialog and set dialog as default role value ([28d5263](https://github.com/Sage/carbon/commit/28d526340aad2e30733c1366683944bfbb9b6905))
+- **drawer:** prevent overflow-y being set on sidebar container unless expanded ([79ac06b](https://github.com/Sage/carbon/commit/79ac06b08e7783c7d2b5d315a7c548e1ff7d7e66))
+- **popover-container:** set id on the control if render prop is used and container is closed ([2b77d56](https://github.com/Sage/carbon/commit/2b77d5634d3ff758a3164942f8866f475dba7a84))
+- **textbox:** prevent setting labelId when no label value passed in ([be510cb](https://github.com/Sage/carbon/commit/be510cbf1bbe034c241fbceb33dbbc9ceef37c0f))
 
 ## [104.24.0](https://github.com/Sage/carbon/compare/v104.23.1...v104.24.0) (2022-02-22)
 
-
 ### Features
 
-* **text-editor:** describe text-editor using design tokens ([eb4aa90](https://github.com/Sage/carbon/commit/eb4aa906614ebf1ae0ea42ad5db0d87900feee8a))
+- **text-editor:** describe text-editor using design tokens ([eb4aa90](https://github.com/Sage/carbon/commit/eb4aa906614ebf1ae0ea42ad5db0d87900feee8a))
 
 ### [104.23.1](https://github.com/Sage/carbon/compare/v104.23.0...v104.23.1) (2022-02-22)
 
-
 ### Bug Fixes
 
-* **flat-table-checkbox:** fix incorrect event propagation ([816f8d8](https://github.com/Sage/carbon/commit/816f8d8b44dbe2e1ca8a9be40050bc81ce856155))
+- **flat-table-checkbox:** fix incorrect event propagation ([816f8d8](https://github.com/Sage/carbon/commit/816f8d8b44dbe2e1ca8a9be40050bc81ce856155))
 
 ## [104.23.0](https://github.com/Sage/carbon/compare/v104.22.0...v104.23.0) (2022-02-22)
 
-
 ### Features
 
-* **menu:** describe menu using design-tokens, update tests ([9392569](https://github.com/Sage/carbon/commit/9392569e254a7d01874d3279a0ed792023a08671))
+- **menu:** describe menu using design-tokens, update tests ([9392569](https://github.com/Sage/carbon/commit/9392569e254a7d01874d3279a0ed792023a08671))
 
 ## [104.22.0](https://github.com/Sage/carbon/compare/v104.21.1...v104.22.0) (2022-02-21)
 
-
 ### Features
 
-* **full-screen-heading:** describe FullScreenHeading using design tokens ([68236f3](https://github.com/Sage/carbon/commit/68236f37122ba062b783e0ade49d060cf98c62fb))
-* **heading:** describe heading component using design tokens ([1b2329e](https://github.com/Sage/carbon/commit/1b2329ef7a3a1a490bf9bf1a2271b09bd3710af6))
+- **full-screen-heading:** describe FullScreenHeading using design tokens ([68236f3](https://github.com/Sage/carbon/commit/68236f37122ba062b783e0ade49d060cf98c62fb))
+- **heading:** describe heading component using design tokens ([1b2329e](https://github.com/Sage/carbon/commit/1b2329ef7a3a1a490bf9bf1a2271b09bd3710af6))
 
 ### [104.21.1](https://github.com/Sage/carbon/compare/v104.21.0...v104.21.1) (2022-02-21)
 
-
 ### Bug Fixes
 
-* remove border style from input when disabled ([737eaaf](https://github.com/Sage/carbon/commit/737eaaf3ad9f4812ed4c6987368abd094f7a4541)), closes [#4769](https://github.com/Sage/carbon/issues/4769)
+- remove border style from input when disabled ([737eaaf](https://github.com/Sage/carbon/commit/737eaaf3ad9f4812ed4c6987368abd094f7a4541)), closes [#4769](https://github.com/Sage/carbon/issues/4769)
 
 ## [104.21.0](https://github.com/Sage/carbon/compare/v104.20.0...v104.21.0) (2022-02-21)
 
-
 ### Features
 
-* **pager:** describe pager using design tokens, update tests ([fce8144](https://github.com/Sage/carbon/commit/fce81440e1662974c88f7a66ed0560ed6d894807))
+- **pager:** describe pager using design tokens, update tests ([fce8144](https://github.com/Sage/carbon/commit/fce81440e1662974c88f7a66ed0560ed6d894807))
 
 ## [104.20.0](https://github.com/Sage/carbon/compare/v104.19.2...v104.20.0) (2022-02-18)
 
-
 ### Features
 
-* **date-navbar:** describe using design tokens ([1183494](https://github.com/Sage/carbon/commit/118349459b8fdc5a877105ad8223a462ab74e05a))
-* **date-picker:** describe using design tokens ([1cec2ae](https://github.com/Sage/carbon/commit/1cec2aebb28a3ccfad8aafcd27dfd73b1c16d5e9))
-* **date-weekday:** describe using design tokens ([a3f2b60](https://github.com/Sage/carbon/commit/a3f2b60c88bc43b273199ecef9c5896179c14000))
+- **date-navbar:** describe using design tokens ([1183494](https://github.com/Sage/carbon/commit/118349459b8fdc5a877105ad8223a462ab74e05a))
+- **date-picker:** describe using design tokens ([1cec2ae](https://github.com/Sage/carbon/commit/1cec2aebb28a3ccfad8aafcd27dfd73b1c16d5e9))
+- **date-weekday:** describe using design tokens ([a3f2b60](https://github.com/Sage/carbon/commit/a3f2b60c88bc43b273199ecef9c5896179c14000))
 
 ### [104.19.2](https://github.com/Sage/carbon/compare/v104.19.1...v104.19.2) (2022-02-18)
 
-
 ### Bug Fixes
 
-* **button-toggle-group:** proper style for info variant ([4ee2305](https://github.com/Sage/carbon/commit/4ee2305f51fce41a2abc6299ce245a94192034f6))
+- **button-toggle-group:** proper style for info variant ([4ee2305](https://github.com/Sage/carbon/commit/4ee2305f51fce41a2abc6299ce245a94192034f6))
 
 ### [104.19.1](https://github.com/Sage/carbon/compare/v104.19.0...v104.19.1) (2022-02-18)
 
-
 ### Bug Fixes
 
-* **date:** ensure day value is validated against format with the month value included ([61b429e](https://github.com/Sage/carbon/commit/61b429eb59a585f612b9e754d994e2b577c5d996)), closes [#4853](https://github.com/Sage/carbon/issues/4853)
+- **date:** ensure day value is validated against format with the month value included ([61b429e](https://github.com/Sage/carbon/commit/61b429eb59a585f612b9e754d994e2b577c5d996)), closes [#4853](https://github.com/Sage/carbon/issues/4853)
 
 ## [104.19.0](https://github.com/Sage/carbon/compare/v104.18.1...v104.19.0) (2022-02-18)
 
-
 ### Features
 
-* **batch-selection:** describe batch-selection component using design tokens ([a493a72](https://github.com/Sage/carbon/commit/a493a72e2d6a101b52e327d5b7ddeb600f8fbf98))
+- **batch-selection:** describe batch-selection component using design tokens ([a493a72](https://github.com/Sage/carbon/commit/a493a72e2d6a101b52e327d5b7ddeb600f8fbf98))
 
 ### [104.18.1](https://github.com/Sage/carbon/compare/v104.18.0...v104.18.1) (2022-02-16)
 
-
 ### Bug Fixes
 
-* **icon-button:** fix background color when component is disabled ([7e0572e](https://github.com/Sage/carbon/commit/7e0572e6352722fcd14e1e7c7366e4736b4f6367))
+- **icon-button:** fix background color when component is disabled ([7e0572e](https://github.com/Sage/carbon/commit/7e0572e6352722fcd14e1e7c7366e4736b4f6367))
 
 ## [104.18.0](https://github.com/Sage/carbon/compare/v104.17.0...v104.18.0) (2022-02-16)
 
-
 ### Features
 
-* **portrait, profile:** describe portrait and profile using design tokens, update tests ([1d5730d](https://github.com/Sage/carbon/commit/1d5730d26fa1b47e317c45efcd714f85b032e2dc))
+- **portrait, profile:** describe portrait and profile using design tokens, update tests ([1d5730d](https://github.com/Sage/carbon/commit/1d5730d26fa1b47e317c45efcd714f85b032e2dc))
 
 ## [104.17.0](https://github.com/Sage/carbon/compare/v104.16.1...v104.17.0) (2022-02-16)
 
-
 ### Features
 
-* **tabs:** describe tabs using design tokens, update tests ([9bea1df](https://github.com/Sage/carbon/commit/9bea1df85f84e3341d661a8d3e8457ffb1d36c81))
-* **validation-icon:** describe validation-icon using design tokens ([4cc893d](https://github.com/Sage/carbon/commit/4cc893d74ef9e2db5f90dd53ba62ee5b1c54fa22))
+- **tabs:** describe tabs using design tokens, update tests ([9bea1df](https://github.com/Sage/carbon/commit/9bea1df85f84e3341d661a8d3e8457ffb1d36c81))
+- **validation-icon:** describe validation-icon using design tokens ([4cc893d](https://github.com/Sage/carbon/commit/4cc893d74ef9e2db5f90dd53ba62ee5b1c54fa22))
 
 ### [104.16.1](https://github.com/Sage/carbon/compare/v104.16.0...v104.16.1) (2022-02-15)
 
-
 ### Bug Fixes
 
-* **decimal:** fix precision console error firing when no precision prop specified ([dc8f454](https://github.com/Sage/carbon/commit/dc8f454f74f81b0a7d481e8c4a8dadff96dd7f72)), closes [#4826](https://github.com/Sage/carbon/issues/4826)
+- **decimal:** fix precision console error firing when no precision prop specified ([dc8f454](https://github.com/Sage/carbon/commit/dc8f454f74f81b0a7d481e8c4a8dadff96dd7f72)), closes [#4826](https://github.com/Sage/carbon/issues/4826)
 
 ## [104.16.0](https://github.com/Sage/carbon/compare/v104.15.0...v104.16.0) (2022-02-15)
 
-
 ### Features
 
-* **button-bar:** describe Button Bar component using design tokens ([8425dba](https://github.com/Sage/carbon/commit/8425dbad3d908ba05dcba5934e3f1d718047328f))
+- **button-bar:** describe Button Bar component using design tokens ([8425dba](https://github.com/Sage/carbon/commit/8425dbad3d908ba05dcba5934e3f1d718047328f))
 
 ## [104.15.0](https://github.com/Sage/carbon/compare/v104.14.0...v104.15.0) (2022-02-14)
 
-
 ### Features
 
-* **note:** describe note using design tokens, update tests ([1626581](https://github.com/Sage/carbon/commit/162658126b496bc6886261cd3908759b9d4963f5))
+- **note:** describe note using design tokens, update tests ([1626581](https://github.com/Sage/carbon/commit/162658126b496bc6886261cd3908759b9d4963f5))
 
 ## [104.14.0](https://github.com/Sage/carbon/compare/v104.13.0...v104.14.0) (2022-02-11)
 
-
 ### Features
 
-* **select:** block scroll while select is open ([362c7ef](https://github.com/Sage/carbon/commit/362c7efbe6146c0dc9f7a08dbf267fdf9bcd0975))
+- **select:** block scroll while select is open ([362c7ef](https://github.com/Sage/carbon/commit/362c7efbe6146c0dc9f7a08dbf267fdf9bcd0975))
 
 ## [104.13.0](https://github.com/Sage/carbon/compare/v104.12.2...v104.13.0) (2022-02-11)
 
-
 ### Features
 
-* **button-toggle:** describe ButtonToggle and ButtonToggleGroup components usign design tokens ([683f607](https://github.com/Sage/carbon/commit/683f607a896924f8099ddaafffa16632cfb7ee45))
+- **button-toggle:** describe ButtonToggle and ButtonToggleGroup components usign design tokens ([683f607](https://github.com/Sage/carbon/commit/683f607a896924f8099ddaafffa16632cfb7ee45))
 
 ### [104.12.2](https://github.com/Sage/carbon/compare/v104.12.1...v104.12.2) (2022-02-11)
 
-
 ### Bug Fixes
 
-* **toast:** make toast position fixed to top of viewport ([ca8a778](https://github.com/Sage/carbon/commit/ca8a778244bf43062ff0d8b281f1ef25e9e1e472)), closes [#4730](https://github.com/Sage/carbon/issues/4730)
+- **toast:** make toast position fixed to top of viewport ([ca8a778](https://github.com/Sage/carbon/commit/ca8a778244bf43062ff0d8b281f1ef25e9e1e472)), closes [#4730](https://github.com/Sage/carbon/issues/4730)
 
 ### [104.12.1](https://github.com/Sage/carbon/compare/v104.12.0...v104.12.1) (2022-02-10)
 
-
 ### Bug Fixes
 
-* **docs:** sort versions by semver in picker ([a9cbf95](https://github.com/Sage/carbon/commit/a9cbf9542c9e1a7af7bcae6055951f7c121c1d9f))
+- **docs:** sort versions by semver in picker ([a9cbf95](https://github.com/Sage/carbon/commit/a9cbf9542c9e1a7af7bcae6055951f7c121c1d9f))
 
 ## [104.12.0](https://github.com/Sage/carbon/compare/v104.11.0...v104.12.0) (2022-02-10)
 
-
 ### Features
 
-* **navigation bar:** describe navigation bar using design tokens, update tests ([168301c](https://github.com/Sage/carbon/commit/168301cf53559a5a08f437a3e04409fb2463f14f))
+- **navigation bar:** describe navigation bar using design tokens, update tests ([168301c](https://github.com/Sage/carbon/commit/168301cf53559a5a08f437a3e04409fb2463f14f))
 
 ## [104.11.0](https://github.com/Sage/carbon/compare/v104.10.2...v104.11.0) (2022-02-10)
 
-
 ### Features
 
-* **search:** describe search component using design tokens ([4d7c6e5](https://github.com/Sage/carbon/commit/4d7c6e506692c78d535b4db89aa565ff063e3620))
+- **search:** describe search component using design tokens ([4d7c6e5](https://github.com/Sage/carbon/commit/4d7c6e506692c78d535b4db89aa565ff063e3620))
 
 ### [104.10.2](https://github.com/Sage/carbon/compare/v104.10.1...v104.10.2) (2022-02-10)
 
-
 ### Bug Fixes
 
-* **filterable-select:** add missing aria attributes ([64d15d8](https://github.com/Sage/carbon/commit/64d15d881b2c8cbb7e829fa2d6995e5f6e4b18e7))
-* **multi-select:** add missing aria attributes ([2d9d11a](https://github.com/Sage/carbon/commit/2d9d11a6b8e153e7266a155425249166845f9160))
+- **filterable-select:** add missing aria attributes ([64d15d8](https://github.com/Sage/carbon/commit/64d15d881b2c8cbb7e829fa2d6995e5f6e4b18e7))
+- **multi-select:** add missing aria attributes ([2d9d11a](https://github.com/Sage/carbon/commit/2d9d11a6b8e153e7266a155425249166845f9160))
 
 ### [104.10.1](https://github.com/Sage/carbon/compare/v104.10.0...v104.10.1) (2022-02-09)
 
-
 ### Bug Fixes
 
-* **icon:** fix tooltip visible logic when disabled ([0a1fdb4](https://github.com/Sage/carbon/commit/0a1fdb4fd091fdde782c1787e8b3ba179abfb6d1)), closes [#4745](https://github.com/Sage/carbon/issues/4745)
+- **icon:** fix tooltip visible logic when disabled ([0a1fdb4](https://github.com/Sage/carbon/commit/0a1fdb4fd091fdde782c1787e8b3ba179abfb6d1)), closes [#4745](https://github.com/Sage/carbon/issues/4745)
 
 ## [104.10.0](https://github.com/Sage/carbon/compare/v104.9.0...v104.10.0) (2022-02-08)
 
-
 ### Features
 
-* **dialog:** surface contentPadding prop to allow overriding default padding values dialog content ([a6f0d7c](https://github.com/Sage/carbon/commit/a6f0d7ce82c734ac8e2ad79802f4acf8189d8535))
+- **dialog:** surface contentPadding prop to allow overriding default padding values dialog content ([a6f0d7c](https://github.com/Sage/carbon/commit/a6f0d7ce82c734ac8e2ad79802f4acf8189d8535))
 
 ## [104.9.0](https://github.com/Sage/carbon/compare/v104.8.0...v104.9.0) (2022-02-08)
 
-
 ### Features
 
-* **anchor-navigation:** describe anchor navigation using design tokens, update tests ([eb78718](https://github.com/Sage/carbon/commit/eb7871881d18dd14d8165153e349b0a3b1484e06))
+- **anchor-navigation:** describe anchor navigation using design tokens, update tests ([eb78718](https://github.com/Sage/carbon/commit/eb7871881d18dd14d8165153e349b0a3b1484e06))
 
 ## [104.8.0](https://github.com/Sage/carbon/compare/v104.7.3...v104.8.0) (2022-02-08)
 
-
 ### Features
 
-* **dialog-full-screen:** add close button aria label translation ([3e312db](https://github.com/Sage/carbon/commit/3e312db132b7d26dcb22cc67ca0580a9134da9be))
-* **dialog:** add close button aria label translation ([aacca1b](https://github.com/Sage/carbon/commit/aacca1b8d1cbd5d506ddd7e9f4e3381c91f73072))
-* **sidebar:** add close button aria label translation ([8f09f74](https://github.com/Sage/carbon/commit/8f09f745fdc32f105bd14bb16d839a746e9cc38b))
-* **toast:** add close button aria label translation ([6eebf87](https://github.com/Sage/carbon/commit/6eebf87e699266e36a13f880595eb85ee89b7306))
+- **dialog-full-screen:** add close button aria label translation ([3e312db](https://github.com/Sage/carbon/commit/3e312db132b7d26dcb22cc67ca0580a9134da9be))
+- **dialog:** add close button aria label translation ([aacca1b](https://github.com/Sage/carbon/commit/aacca1b8d1cbd5d506ddd7e9f4e3381c91f73072))
+- **sidebar:** add close button aria label translation ([8f09f74](https://github.com/Sage/carbon/commit/8f09f745fdc32f105bd14bb16d839a746e9cc38b))
+- **toast:** add close button aria label translation ([6eebf87](https://github.com/Sage/carbon/commit/6eebf87e699266e36a13f880595eb85ee89b7306))
 
 ### [104.7.3](https://github.com/Sage/carbon/compare/v104.7.2...v104.7.3) (2022-02-08)
 
-
 ### Bug Fixes
 
-* **menu-full-screen:** fix heights and widths and remove horizontal scroll bar ([8a73083](https://github.com/Sage/carbon/commit/8a73083689b26e690d28f6b3fdcfd4f2c3623161)), closes [#4473](https://github.com/Sage/carbon/issues/4473) [#4674](https://github.com/Sage/carbon/issues/4674)
-* **menu-full-screen:** fix search styling within full screen menu ([19b609e](https://github.com/Sage/carbon/commit/19b609ed58763567f8a01676f5f4de26829be908)), closes [#4675](https://github.com/Sage/carbon/issues/4675)
+- **menu-full-screen:** fix heights and widths and remove horizontal scroll bar ([8a73083](https://github.com/Sage/carbon/commit/8a73083689b26e690d28f6b3fdcfd4f2c3623161)), closes [#4473](https://github.com/Sage/carbon/issues/4473) [#4674](https://github.com/Sage/carbon/issues/4674)
+- **menu-full-screen:** fix search styling within full screen menu ([19b609e](https://github.com/Sage/carbon/commit/19b609ed58763567f8a01676f5f4de26829be908)), closes [#4675](https://github.com/Sage/carbon/issues/4675)
 
 ### [104.7.2](https://github.com/Sage/carbon/compare/v104.7.1...v104.7.2) (2022-02-08)
 
-
 ### Bug Fixes
 
-* **accessibility:** fix incorrect aria-describedby on input ([c03fdef](https://github.com/Sage/carbon/commit/c03fdef9e9bc224c924d132a1be1f827c7cf0611)), closes [#4689](https://github.com/Sage/carbon/issues/4689)
-
+- **accessibility:** fix incorrect aria-describedby on input ([c03fdef](https://github.com/Sage/carbon/commit/c03fdef9e9bc224c924d132a1be1f827c7cf0611)), closes [#4689](https://github.com/Sage/carbon/issues/4689)
 
 ### Reverts
 
-* Revert "fix(radio-button, label): when help prop is provided, pass input context values to children" ([b7a9064](https://github.com/Sage/carbon/commit/b7a90647d6479d72c9eb0463dbcf6cc5c246fff1)), closes [#4725](https://github.com/Sage/carbon/issues/4725)
+- Revert "fix(radio-button, label): when help prop is provided, pass input context values to children" ([b7a9064](https://github.com/Sage/carbon/commit/b7a90647d6479d72c9eb0463dbcf6cc5c246fff1)), closes [#4725](https://github.com/Sage/carbon/issues/4725)
 
 ### [104.7.1](https://github.com/Sage/carbon/compare/v104.7.0...v104.7.1) (2022-02-08)
 
-
 ### Bug Fixes
 
-* **navigation-bar:** add z-index so NavigationBar stacks just below Modals ([ef5c465](https://github.com/Sage/carbon/commit/ef5c465468f486bd4525e86756b8bc55d59102b1)), closes [#4690](https://github.com/Sage/carbon/issues/4690)
+- **navigation-bar:** add z-index so NavigationBar stacks just below Modals ([ef5c465](https://github.com/Sage/carbon/commit/ef5c465468f486bd4525e86756b8bc55d59102b1)), closes [#4690](https://github.com/Sage/carbon/issues/4690)
 
 ## [104.7.0](https://github.com/Sage/carbon/compare/v104.6.0...v104.7.0) (2022-02-08)
 
-
 ### Features
 
-* **dialog:** describe dialog and dialog full screen with design tokens ([ad1171f](https://github.com/Sage/carbon/commit/ad1171f6ff9067282c16c66d9542bcb3ccbda464))
+- **dialog:** describe dialog and dialog full screen with design tokens ([ad1171f](https://github.com/Sage/carbon/commit/ad1171f6ff9067282c16c66d9542bcb3ccbda464))
 
 ## [104.6.0](https://github.com/Sage/carbon/compare/v104.5.0...v104.6.0) (2022-02-08)
 
-
 ### Features
 
-* **sidebar:** use design tokens to describe sidebar ([d8445d6](https://github.com/Sage/carbon/commit/d8445d6c3959c97e8421dae3beb3723eac0513bf))
+- **sidebar:** use design tokens to describe sidebar ([d8445d6](https://github.com/Sage/carbon/commit/d8445d6c3959c97e8421dae3beb3723eac0513bf))
 
 ## [104.5.0](https://github.com/Sage/carbon/compare/v104.4.0...v104.5.0) (2022-02-08)
 
-
 ### Features
 
-* **tile-select:** describe tile select using design tokens ([6b563f6](https://github.com/Sage/carbon/commit/6b563f6f605c5cebeba26584046fa632680953b8))
-* **tile-select:** remove color and fill on disabled ([d8ce33d](https://github.com/Sage/carbon/commit/d8ce33dfc00e47eb311e583524f220f1c2cee5ed))
+- **tile-select:** describe tile select using design tokens ([6b563f6](https://github.com/Sage/carbon/commit/6b563f6f605c5cebeba26584046fa632680953b8))
+- **tile-select:** remove color and fill on disabled ([d8ce33d](https://github.com/Sage/carbon/commit/d8ce33dfc00e47eb311e583524f220f1c2cee5ed))
 
 ## [104.4.0](https://github.com/Sage/carbon/compare/v104.3.0...v104.4.0) (2022-02-08)
 
-
 ### Features
 
-* **dialog, dialog-full-screen, confirm:** generate IDs dynamically ([d5e07d9](https://github.com/Sage/carbon/commit/d5e07d978236711ef010d7ae2e050e2a734bc5f6))
-
+- **dialog, dialog-full-screen, confirm:** generate IDs dynamically ([d5e07d9](https://github.com/Sage/carbon/commit/d5e07d978236711ef010d7ae2e050e2a734bc5f6))
 
 ### Bug Fixes
 
-* **dialog, dialog-full-screen:** address axe violations ([53167d8](https://github.com/Sage/carbon/commit/53167d8007ec5a8c6e2fa020acbb7dc16cec713e))
+- **dialog, dialog-full-screen:** address axe violations ([53167d8](https://github.com/Sage/carbon/commit/53167d8007ec5a8c6e2fa020acbb7dc16cec713e))
 
 ## [104.3.0](https://github.com/Sage/carbon/compare/v104.2.0...v104.3.0) (2022-02-08)
 
-
 ### Features
 
-* **accordion:** describe accordion using design tokens, update of tests after changes ([03f30d0](https://github.com/Sage/carbon/commit/03f30d041614d66738b20b6e8e72ce52a38ecb23))
+- **accordion:** describe accordion using design tokens, update of tests after changes ([03f30d0](https://github.com/Sage/carbon/commit/03f30d041614d66738b20b6e8e72ce52a38ecb23))
 
 ## [104.2.0](https://github.com/Sage/carbon/compare/v104.1.1...v104.2.0) (2022-02-07)
 
-
 ### Features
 
-* **tooltip:** add target prop ([f1a868b](https://github.com/Sage/carbon/commit/f1a868bb9ad934baf282c56d1f8240b8880a2792))
-
+- **tooltip:** add target prop ([f1a868b](https://github.com/Sage/carbon/commit/f1a868bb9ad934baf282c56d1f8240b8880a2792))
 
 ### Bug Fixes
 
-* **button:** fix tooltip accessibility issue ([7ff2229](https://github.com/Sage/carbon/commit/7ff2229e699ac81a968c50152124e1f17be33e53))
-* **icon-button:** fix tooltip accessibility issue ([4d14ef0](https://github.com/Sage/carbon/commit/4d14ef06820287f03249fbe4983ba187fc1e6f5f))
+- **button:** fix tooltip accessibility issue ([7ff2229](https://github.com/Sage/carbon/commit/7ff2229e699ac81a968c50152124e1f17be33e53))
+- **icon-button:** fix tooltip accessibility issue ([4d14ef0](https://github.com/Sage/carbon/commit/4d14ef06820287f03249fbe4983ba187fc1e6f5f))
 
 ### [104.1.1](https://github.com/Sage/carbon/compare/v104.1.0...v104.1.1) (2022-02-07)
 
-
 ### Bug Fixes
 
-* **design-tokens:** fix scoped tokens in mfe ([5d2788e](https://github.com/Sage/carbon/commit/5d2788e554ea4c610cc8c07c8245a80f2d04bb5a))
+- **design-tokens:** fix scoped tokens in mfe ([5d2788e](https://github.com/Sage/carbon/commit/5d2788e554ea4c610cc8c07c8245a80f2d04bb5a))
 
 ## [104.1.0](https://github.com/Sage/carbon/compare/v104.0.0...v104.1.0) (2022-01-28)
 
-
 ### Features
 
-* **step-sequence:** describe step sequence using design tokens, update tests ([97be3fe](https://github.com/Sage/carbon/commit/97be3fe4fb291c60dd5dfdfe85fc41e9f3643d44))
+- **step-sequence:** describe step sequence using design tokens, update tests ([97be3fe](https://github.com/Sage/carbon/commit/97be3fe4fb291c60dd5dfdfe85fc41e9f3643d44))
 
 ## [104.0.0](https://github.com/Sage/carbon/compare/v103.2.0...v104.0.0) (2022-01-27)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **date, date-range:** Date component is no longer class based so any previous extension of it will no
-longer work. It also now only works as a controlled component and requires both `value` and
-`onChange` props to work: the `onChange` handler should also use the `formattedValue` to set the
-value state and `rawValue` for validation and storing in the backend. The `DateRange` can now only
-be used as a controlled component, `value` and `onChange` are required and `formattedValue` should
-be used to update the state.
+- **date, date-range:** Date component is no longer class based so any previous extension of it will no
+  longer work. It also now only works as a controlled component and requires both `value` and
+  `onChange` props to work: the `onChange` handler should also use the `formattedValue` to set the
+  value state and `rawValue` for validation and storing in the backend. The `DateRange` can now only
+  be used as a controlled component, `value` and `onChange` are required and `formattedValue` should
+  be used to update the state.
 
 ### Features
 
-* **date, date-range:** rewrite Date component using date-fns and remove uncontrolled support ([b9f3a5f](https://github.com/Sage/carbon/commit/b9f3a5f6ca44264bb6a1b0e7b7b5106f1b4ce51d)), closes [#2996](https://github.com/Sage/carbon/issues/2996) [#4458](https://github.com/Sage/carbon/issues/4458)
+- **date, date-range:** rewrite Date component using date-fns and remove uncontrolled support ([b9f3a5f](https://github.com/Sage/carbon/commit/b9f3a5f6ca44264bb6a1b0e7b7b5106f1b4ce51d)), closes [#2996](https://github.com/Sage/carbon/issues/2996) [#4458](https://github.com/Sage/carbon/issues/4458)
 
 ## [103.2.0](https://github.com/Sage/carbon/compare/v103.1.0...v103.2.0) (2022-01-27)
 
-
 ### Features
 
-* **badge:** describe component using design tokens ([16664f5](https://github.com/Sage/carbon/commit/16664f59788e386ae3deba511a2d31cf8d532d3c))
+- **badge:** describe component using design tokens ([16664f5](https://github.com/Sage/carbon/commit/16664f59788e386ae3deba511a2d31cf8d532d3c))
 
 ## [103.1.0](https://github.com/Sage/carbon/compare/v103.0.0...v103.1.0) (2022-01-25)
 
-
 ### Features
 
-* **progress tracker:** add accessibility props to component ([cf52243](https://github.com/Sage/carbon/commit/cf5224323479232e0d5d58cfe85c3b76c4de8615)), closes [#FE-4699](https://github.com/Sage/carbon/issues/FE-4699)
+- **progress tracker:** add accessibility props to component ([cf52243](https://github.com/Sage/carbon/commit/cf5224323479232e0d5d58cfe85c3b76c4de8615)), closes [#FE-4699](https://github.com/Sage/carbon/issues/FE-4699)
 
 ## [103.0.0](https://github.com/Sage/carbon/compare/v102.22.1...v103.0.0) (2022-01-24)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **progress-tracker:** Variant prop has been deprecated from the component.
+- **progress-tracker:** Variant prop has been deprecated from the component.
 
 ### Features
 
-* **progress-tracker:** describe progress-tracker using design tokens, remove variant prop ([d29dc79](https://github.com/Sage/carbon/commit/d29dc799d9f5115f7679459b2b5c591c22a1f172))
+- **progress-tracker:** describe progress-tracker using design tokens, remove variant prop ([d29dc79](https://github.com/Sage/carbon/commit/d29dc799d9f5115f7679459b2b5c591c22a1f172))
 
 ### [102.22.1](https://github.com/Sage/carbon/compare/v102.22.0...v102.22.1) (2022-01-24)
 
-
 ### Bug Fixes
 
-* **loader:** give loader the correct role and aria-label prop ([41f76e1](https://github.com/Sage/carbon/commit/41f76e15d09f66cb193d4a0c084a4a7bc1073f0a)), closes [#4644](https://github.com/Sage/carbon/issues/4644)
+- **loader:** give loader the correct role and aria-label prop ([41f76e1](https://github.com/Sage/carbon/commit/41f76e15d09f66cb193d4a0c084a4a7bc1073f0a)), closes [#4644](https://github.com/Sage/carbon/issues/4644)
 
 ## [102.22.0](https://github.com/Sage/carbon/compare/v102.21.0...v102.22.0) (2022-01-24)
 
-
 ### Features
 
-* **split-button:** describe split button using design tokens ([34137ed](https://github.com/Sage/carbon/commit/34137ed3935769b185b95bd291becbe6076cd6f0))
-* **split-button:** remove margin on buttons within container, add box-shadow to container ([88dc3cb](https://github.com/Sage/carbon/commit/88dc3cb9715d4db2f68cc85a8ba0ac5c11b7219d))
+- **split-button:** describe split button using design tokens ([34137ed](https://github.com/Sage/carbon/commit/34137ed3935769b185b95bd291becbe6076cd6f0))
+- **split-button:** remove margin on buttons within container, add box-shadow to container ([88dc3cb](https://github.com/Sage/carbon/commit/88dc3cb9715d4db2f68cc85a8ba0ac5c11b7219d))
 
 ## [102.21.0](https://github.com/Sage/carbon/compare/v102.20.1...v102.21.0) (2022-01-24)
 
-
 ### Features
 
-* **multi-action-button:** describe multi action button using design tokens ([078be83](https://github.com/Sage/carbon/commit/078be833e956bf682d0432c007150569d9f05c84))
+- **multi-action-button:** describe multi action button using design tokens ([078be83](https://github.com/Sage/carbon/commit/078be833e956bf682d0432c007150569d9f05c84))
 
 ### [102.20.1](https://github.com/Sage/carbon/compare/v102.20.0...v102.20.1) (2022-01-21)
 
-
 ### Bug Fixes
 
-* **confirm:** fix incorrect button margin ([bae20b3](https://github.com/Sage/carbon/commit/bae20b34fd183f64759c61efd77ea59ecae0c022))
+- **confirm:** fix incorrect button margin ([bae20b3](https://github.com/Sage/carbon/commit/bae20b34fd183f64759c61efd77ea59ecae0c022))
 
 ## [102.20.0](https://github.com/Sage/carbon/compare/v102.19.1...v102.20.0) (2022-01-21)
 
-
 ### Features
 
-* **action-popover:** describe action popover using design tokens, update of the tests after changes ([2b3457a](https://github.com/Sage/carbon/commit/2b3457a96848e9431f87507a93a2424fec23ae05))
+- **action-popover:** describe action popover using design tokens, update of the tests after changes ([2b3457a](https://github.com/Sage/carbon/commit/2b3457a96848e9431f87507a93a2424fec23ae05))
 
 ### [102.19.1](https://github.com/Sage/carbon/compare/v102.19.0...v102.19.1) (2022-01-21)
 
-
 ### Bug Fixes
 
-* **tabs-header:** set cursor to default in adjacent blank areas (FE-4715) ([4d4a6c1](https://github.com/Sage/carbon/commit/4d4a6c1cc0d86aad0c3595907e00e98ef978e273))
+- **tabs-header:** set cursor to default in adjacent blank areas (FE-4715) ([4d4a6c1](https://github.com/Sage/carbon/commit/4d4a6c1cc0d86aad0c3595907e00e98ef978e273))
 
 ## [102.19.0](https://github.com/Sage/carbon/compare/v102.18.0...v102.19.0) (2022-01-21)
 
-
 ### Features
 
-* **switch:** describe switch using design tokens ([aeb011b](https://github.com/Sage/carbon/commit/aeb011bbb7f338caf4f84b1da5df1b58860254d0))
+- **switch:** describe switch using design tokens ([aeb011b](https://github.com/Sage/carbon/commit/aeb011bbb7f338caf4f84b1da5df1b58860254d0))
 
 ## [102.18.0](https://github.com/Sage/carbon/compare/v102.17.0...v102.18.0) (2022-01-20)
 
-
 ### Features
 
-* **select:** describe select component using tokens ([5223f36](https://github.com/Sage/carbon/commit/5223f36b879623a88ee2a73dc61d34f3cd98d2e2))
+- **select:** describe select component using tokens ([5223f36](https://github.com/Sage/carbon/commit/5223f36b879623a88ee2a73dc61d34f3cd98d2e2))
 
 ## [102.17.0](https://github.com/Sage/carbon/compare/v102.16.1...v102.17.0) (2022-01-20)
 
-
 ### Features
 
-* **carousel:** describe Carousel using design tokens (FE-4721) ([dee97ea](https://github.com/Sage/carbon/commit/dee97eabb265e73c777269ba9f6c4ed0e0f78a80))
+- **carousel:** describe Carousel using design tokens (FE-4721) ([dee97ea](https://github.com/Sage/carbon/commit/dee97eabb265e73c777269ba9f6c4ed0e0f78a80))
 
 ### [102.16.1](https://github.com/Sage/carbon/compare/v102.16.0...v102.16.1) (2022-01-19)
 
-
 ### Bug Fixes
 
-* **drawer:** add toggleAnimation call to useEffect listening for changes to expanded prop ([e478562](https://github.com/Sage/carbon/commit/e478562a7724a9d38b0500ba00afd43cd91b9e17)), closes [#4688](https://github.com/Sage/carbon/issues/4688)
+- **drawer:** add toggleAnimation call to useEffect listening for changes to expanded prop ([e478562](https://github.com/Sage/carbon/commit/e478562a7724a9d38b0500ba00afd43cd91b9e17)), closes [#4688](https://github.com/Sage/carbon/issues/4688)
 
 ## [102.16.0](https://github.com/Sage/carbon/compare/v102.15.0...v102.16.0) (2022-01-18)
 
-
 ### Features
 
-* **pill:** describe pill using tokens, update of tests after changes ([e57f8a2](https://github.com/Sage/carbon/commit/e57f8a284ffb27b16ed537a6a9b32101e62b3f16))
+- **pill:** describe pill using tokens, update of tests after changes ([e57f8a2](https://github.com/Sage/carbon/commit/e57f8a284ffb27b16ed537a6a9b32101e62b3f16))
 
 ## [102.15.0](https://github.com/Sage/carbon/compare/v102.14.0...v102.15.0) (2022-01-18)
 
-
 ### Features
 
-* **card:** describe card using design tokens, update of tests after changes ([824c240](https://github.com/Sage/carbon/commit/824c2402f7318f2bfd69f3c37d44e2950462f74d))
+- **card:** describe card using design tokens, update of tests after changes ([824c240](https://github.com/Sage/carbon/commit/824c2402f7318f2bfd69f3c37d44e2950462f74d))
 
 ## [102.14.0](https://github.com/Sage/carbon/compare/v102.13.2...v102.14.0) (2022-01-18)
 
-
 ### Features
 
-* **textbox:** describe textbox component using design-tokens ([04100c1](https://github.com/Sage/carbon/commit/04100c1a497ae746ec806a53159d93855a987564))
+- **textbox:** describe textbox component using design-tokens ([04100c1](https://github.com/Sage/carbon/commit/04100c1a497ae746ec806a53159d93855a987564))
 
 ### [102.13.2](https://github.com/Sage/carbon/compare/v102.13.1...v102.13.2) (2022-01-17)
 
-
 ### Bug Fixes
 
-* **dialog-fullscreen:** add missing aria-modal attribute ([d07dce4](https://github.com/Sage/carbon/commit/d07dce4a59b621785e888b91cecfc3c38c1f4143)), closes [#4687](https://github.com/Sage/carbon/issues/4687)
+- **dialog-fullscreen:** add missing aria-modal attribute ([d07dce4](https://github.com/Sage/carbon/commit/d07dce4a59b621785e888b91cecfc3c38c1f4143)), closes [#4687](https://github.com/Sage/carbon/issues/4687)
 
 ### [102.13.1](https://github.com/Sage/carbon/compare/v102.13.0...v102.13.1) (2022-01-17)
 
-
 ### Bug Fixes
 
-* remove border style when the input is disabled ([98658dc](https://github.com/Sage/carbon/commit/98658dca0ae1aca13c767f44d117272fa79eeaa4)), closes [#4631](https://github.com/Sage/carbon/issues/4631)
+- remove border style when the input is disabled ([98658dc](https://github.com/Sage/carbon/commit/98658dca0ae1aca13c767f44d117272fa79eeaa4)), closes [#4631](https://github.com/Sage/carbon/issues/4631)
 
 ## [102.13.0](https://github.com/Sage/carbon/compare/v102.12.0...v102.13.0) (2022-01-17)
 
-
 ### Features
 
-* **checkbox:** change spacing to match radio button group ([50a6ab4](https://github.com/Sage/carbon/commit/50a6ab4fb9c3036d9d192abbff5d300d3854dc12)), closes [#4670](https://github.com/Sage/carbon/issues/4670)
+- **checkbox:** change spacing to match radio button group ([50a6ab4](https://github.com/Sage/carbon/commit/50a6ab4fb9c3036d9d192abbff5d300d3854dc12)), closes [#4670](https://github.com/Sage/carbon/issues/4670)
 
 ## [102.12.0](https://github.com/Sage/carbon/compare/v102.11.0...v102.12.0) (2022-01-17)
 
-
 ### Features
 
-* **menu:** add white and black themes ([cd6b276](https://github.com/Sage/carbon/commit/cd6b276e25235566472738a9de7d45db70dbec04))
-* **navigation-bar:** add white and black themes ([1663dfd](https://github.com/Sage/carbon/commit/1663dfdb7feaf27bfaae7be3fe15472efd30dba0))
+- **menu:** add white and black themes ([cd6b276](https://github.com/Sage/carbon/commit/cd6b276e25235566472738a9de7d45db70dbec04))
+- **navigation-bar:** add white and black themes ([1663dfd](https://github.com/Sage/carbon/commit/1663dfdb7feaf27bfaae7be3fe15472efd30dba0))
 
 ## [102.11.0](https://github.com/Sage/carbon/compare/v102.10.2...v102.11.0) (2022-01-17)
 
-
 ### Features
 
-* **tile:** describe tile and tile-footer components with design tokens ([78dac46](https://github.com/Sage/carbon/commit/78dac465abf477d9ee60d6afe382e4d888a1f446))
+- **tile:** describe tile and tile-footer components with design tokens ([78dac46](https://github.com/Sage/carbon/commit/78dac465abf477d9ee60d6afe382e4d888a1f446))
 
 ### [102.10.2](https://github.com/Sage/carbon/compare/v102.10.1...v102.10.2) (2022-01-14)
 
-
 ### Bug Fixes
 
-* **tabs, tab-title:** remove onFocus to stop firing callback twice and tabs activate onmouseup ([56d54da](https://github.com/Sage/carbon/commit/56d54da056f93dafec33ae252584d96fe824bddf)), closes [#4640](https://github.com/Sage/carbon/issues/4640) [#4611](https://github.com/Sage/carbon/issues/4611)
+- **tabs, tab-title:** remove onFocus to stop firing callback twice and tabs activate onmouseup ([56d54da](https://github.com/Sage/carbon/commit/56d54da056f93dafec33ae252584d96fe824bddf)), closes [#4640](https://github.com/Sage/carbon/issues/4640) [#4611](https://github.com/Sage/carbon/issues/4611)
 
 ### [102.10.1](https://github.com/Sage/carbon/compare/v102.10.0...v102.10.1) (2022-01-14)
 
-
 ### Bug Fixes
 
-* **mint-theme:** modify primary colour to be more accessible ([30b1b7b](https://github.com/Sage/carbon/commit/30b1b7be18f85cd8e4891eb6cc811b9f45d3339d))
+- **mint-theme:** modify primary colour to be more accessible ([30b1b7b](https://github.com/Sage/carbon/commit/30b1b7be18f85cd8e4891eb6cc811b9f45d3339d))
 
 ## [102.10.0](https://github.com/Sage/carbon/compare/v102.9.2...v102.10.0) (2022-01-14)
 
-
 ### Features
 
-* **tooltip:** describe tooltip using design tokens ([50d140d](https://github.com/Sage/carbon/commit/50d140d5f856829901982aed4727048183b5d9eb))
+- **tooltip:** describe tooltip using design tokens ([50d140d](https://github.com/Sage/carbon/commit/50d140d5f856829901982aed4727048183b5d9eb))
 
 ### [102.9.2](https://github.com/Sage/carbon/compare/v102.9.1...v102.9.2) (2022-01-13)
 
-
 ### Bug Fixes
 
-* **advanced-color-picker:** add missing ARIA propTypes ([2977902](https://github.com/Sage/carbon/commit/29779023048186dee4fa0102fe58dc19f3740e4d))
-* **alert:** add missing ARIA propTypes ([cb1e5b8](https://github.com/Sage/carbon/commit/cb1e5b84aab009f8e4453088b2f1d9452d1b0576))
-* **confirm:** add missing ARIA propTypes ([c6cd900](https://github.com/Sage/carbon/commit/c6cd90094f01d95e827dc14468321802388ea973))
-* **dialog-fullscreen:** add missing ARIA attributes ([b9b0e7a](https://github.com/Sage/carbon/commit/b9b0e7a6d5ff53056f10bfe9ba5d49b93c18c3e3)), closes [#4537](https://github.com/Sage/carbon/issues/4537) [#4669](https://github.com/Sage/carbon/issues/4669)
-* **dialog:** add missing ARIA attributes ([f804fda](https://github.com/Sage/carbon/commit/f804fdac14599ef9865eecdbc1a3876842f8f915))
-* **sidebar:** add missing ARIA propTypes ([0cf3243](https://github.com/Sage/carbon/commit/0cf32430564573da48ccf954314c6ad9585f2a06))
+- **advanced-color-picker:** add missing ARIA propTypes ([2977902](https://github.com/Sage/carbon/commit/29779023048186dee4fa0102fe58dc19f3740e4d))
+- **alert:** add missing ARIA propTypes ([cb1e5b8](https://github.com/Sage/carbon/commit/cb1e5b84aab009f8e4453088b2f1d9452d1b0576))
+- **confirm:** add missing ARIA propTypes ([c6cd900](https://github.com/Sage/carbon/commit/c6cd90094f01d95e827dc14468321802388ea973))
+- **dialog-fullscreen:** add missing ARIA attributes ([b9b0e7a](https://github.com/Sage/carbon/commit/b9b0e7a6d5ff53056f10bfe9ba5d49b93c18c3e3)), closes [#4537](https://github.com/Sage/carbon/issues/4537) [#4669](https://github.com/Sage/carbon/issues/4669)
+- **dialog:** add missing ARIA attributes ([f804fda](https://github.com/Sage/carbon/commit/f804fdac14599ef9865eecdbc1a3876842f8f915))
+- **sidebar:** add missing ARIA propTypes ([0cf3243](https://github.com/Sage/carbon/commit/0cf32430564573da48ccf954314c6ad9585f2a06))
 
 ### [102.9.1](https://github.com/Sage/carbon/compare/v102.9.0...v102.9.1) (2022-01-13)
 
-
 ### Bug Fixes
 
-* **pager:** relax height restrictions to prevent overflow ([ff285af](https://github.com/Sage/carbon/commit/ff285af46a5a1711d087ac2ee7aa1ea0968c5067))
+- **pager:** relax height restrictions to prevent overflow ([ff285af](https://github.com/Sage/carbon/commit/ff285af46a5a1711d087ac2ee7aa1ea0968c5067))
 
 ## [102.9.0](https://github.com/Sage/carbon/compare/v102.8.1...v102.9.0) (2022-01-12)
 
-
 ### Features
 
-* **icon:** use design tokens to describe icon component ([e7356f0](https://github.com/Sage/carbon/commit/e7356f0fb22aa3c7ae09539eaa2ab7a429d93367))
+- **icon:** use design tokens to describe icon component ([e7356f0](https://github.com/Sage/carbon/commit/e7356f0fb22aa3c7ae09539eaa2ab7a429d93367))
 
 ### [102.8.1](https://github.com/Sage/carbon/compare/v102.8.0...v102.8.1) (2022-01-11)
 
-
 ### Bug Fixes
 
-* **date-range:** prevent both fields becoming populated when one value passed ([5143311](https://github.com/Sage/carbon/commit/51433119c0456cf42f98ad3fd1dfb9c2541394bf)), closes [#4615](https://github.com/Sage/carbon/issues/4615)
+- **date-range:** prevent both fields becoming populated when one value passed ([5143311](https://github.com/Sage/carbon/commit/51433119c0456cf42f98ad3fd1dfb9c2541394bf)), closes [#4615](https://github.com/Sage/carbon/issues/4615)
 
 ## [102.8.0](https://github.com/Sage/carbon/compare/v102.7.4...v102.8.0) (2022-01-11)
 
-
 ### Features
 
-* **checkbox:** describe checkbox using tokens, update of tests after changes ([d8fc6e6](https://github.com/Sage/carbon/commit/d8fc6e66b6ffa8615669452c2de9c826d21ee38f))
-
+- **checkbox:** describe checkbox using tokens, update of tests after changes ([d8fc6e6](https://github.com/Sage/carbon/commit/d8fc6e66b6ffa8615669452c2de9c826d21ee38f))
 
 ### Bug Fixes
 
-* **radio-button:** remove not used baseTheme ([c2aae7e](https://github.com/Sage/carbon/commit/c2aae7e3d65ac9829cf07b42f0703a34f5b2347f))
+- **radio-button:** remove not used baseTheme ([c2aae7e](https://github.com/Sage/carbon/commit/c2aae7e3d65ac9829cf07b42f0703a34f5b2347f))
 
 ### [102.7.4](https://github.com/Sage/carbon/compare/v102.7.3...v102.7.4) (2022-01-11)
 
-
 ### Bug Fixes
 
-* **split-button:** apply type of button to split button toggle ([c2bbd74](https://github.com/Sage/carbon/commit/c2bbd74cd8b6b8c352a90a3a2881285a4db3e060)), closes [#4651](https://github.com/Sage/carbon/issues/4651)
+- **split-button:** apply type of button to split button toggle ([c2bbd74](https://github.com/Sage/carbon/commit/c2bbd74cd8b6b8c352a90a3a2881285a4db3e060)), closes [#4651](https://github.com/Sage/carbon/issues/4651)
 
 ### [102.7.3](https://github.com/Sage/carbon/compare/v102.7.2...v102.7.3) (2022-01-07)
 
-
 ### Bug Fixes
 
-* **form:** fix sticky footer ([f5ec1c7](https://github.com/Sage/carbon/commit/f5ec1c71655ff4ecd8150f167130ebe38ae25efc))
+- **form:** fix sticky footer ([f5ec1c7](https://github.com/Sage/carbon/commit/f5ec1c71655ff4ecd8150f167130ebe38ae25efc))
 
 ### [102.7.2](https://github.com/Sage/carbon/compare/v102.7.1...v102.7.2) (2022-01-07)
 
-
 ### Bug Fixes
 
-* **message:** incorrect content width ([828df96](https://github.com/Sage/carbon/commit/828df96cd1feda923470ab3b58bdde45c2cd18ee))
+- **message:** incorrect content width ([828df96](https://github.com/Sage/carbon/commit/828df96cd1feda923470ab3b58bdde45c2cd18ee))
 
 ### [102.7.1](https://github.com/Sage/carbon/compare/v102.7.0...v102.7.1) (2022-01-06)
 
-
 ### Bug Fixes
 
-* **textarea:** pass value down to input ([423bc75](https://github.com/Sage/carbon/commit/423bc757076e760dd74c12023fd321a1f5a10cd6)), closes [#4645](https://github.com/Sage/carbon/issues/4645)
+- **textarea:** pass value down to input ([423bc75](https://github.com/Sage/carbon/commit/423bc757076e760dd74c12023fd321a1f5a10cd6)), closes [#4645](https://github.com/Sage/carbon/issues/4645)
 
 ## [102.7.0](https://github.com/Sage/carbon/compare/v102.6.1...v102.7.0) (2022-01-05)
 
-
 ### Features
 
-* **loader-bar:** describe loader-bar using design tokens, update of tests after changes ([73a5a25](https://github.com/Sage/carbon/commit/73a5a2507e4df65458ede88ed9bb752099b07130))
-* **loader-square:** describe loader-square using design tokens, update of tests after changes ([811484d](https://github.com/Sage/carbon/commit/811484d7acbb47e47d1c25b6a720140d18f61f79))
-* **loader, loader-bar:** add missing tokens in base-theme ([396d941](https://github.com/Sage/carbon/commit/396d94139d4f0f96acd692c6fb2769134391be73))
+- **loader-bar:** describe loader-bar using design tokens, update of tests after changes ([73a5a25](https://github.com/Sage/carbon/commit/73a5a2507e4df65458ede88ed9bb752099b07130))
+- **loader-square:** describe loader-square using design tokens, update of tests after changes ([811484d](https://github.com/Sage/carbon/commit/811484d7acbb47e47d1c25b6a720140d18f61f79))
+- **loader, loader-bar:** add missing tokens in base-theme ([396d941](https://github.com/Sage/carbon/commit/396d94139d4f0f96acd692c6fb2769134391be73))
 
 ### [102.6.1](https://github.com/Sage/carbon/compare/v102.6.0...v102.6.1) (2022-01-05)
 
-
 ### Bug Fixes
 
-* **page:** ensure that children are constrained inside of component ([598edfd](https://github.com/Sage/carbon/commit/598edfd5ae09c8818a27e8bff841d7e2e7adde93)), closes [#4616](https://github.com/Sage/carbon/issues/4616)
+- **page:** ensure that children are constrained inside of component ([598edfd](https://github.com/Sage/carbon/commit/598edfd5ae09c8818a27e8bff841d7e2e7adde93)), closes [#4616](https://github.com/Sage/carbon/issues/4616)
 
 ## [102.6.0](https://github.com/Sage/carbon/compare/v102.5.0...v102.6.0) (2022-01-05)
 
-
 ### Features
 
-* **inline-input:** remove row and column dependency ([b7d5227](https://github.com/Sage/carbon/commit/b7d52275933be4a66c30487e87874d697a607513))
+- **inline-input:** remove row and column dependency ([b7d5227](https://github.com/Sage/carbon/commit/b7d52275933be4a66c30487e87874d697a607513))
 
 ## [102.5.0](https://github.com/Sage/carbon/compare/v102.4.6...v102.5.0) (2022-01-05)
 
-
 ### Features
 
-* **button:** describe button using design tokens, update of tests after changes ([04f01cf](https://github.com/Sage/carbon/commit/04f01cf473de7de3a3c64614c8fc21a804e8e19f))
+- **button:** describe button using design tokens, update of tests after changes ([04f01cf](https://github.com/Sage/carbon/commit/04f01cf473de7de3a3c64614c8fc21a804e8e19f))
 
 ### [102.4.6](https://github.com/Sage/carbon/compare/v102.4.5...v102.4.6) (2022-01-04)
 
-
 ### Bug Fixes
 
-* **design-tokens:** add support for multiple instances of carbon provider ([923049b](https://github.com/Sage/carbon/commit/923049bb9db38fa81e2a9ec2b57f17211f5f82e0))
+- **design-tokens:** add support for multiple instances of carbon provider ([923049b](https://github.com/Sage/carbon/commit/923049bb9db38fa81e2a9ec2b57f17211f5f82e0))
 
 ### [102.4.5](https://github.com/Sage/carbon/compare/v102.4.4...v102.4.5) (2022-01-04)
 
-
 ### Bug Fixes
 
-* **button:** pass `aria-hidden=true` to button icon ([95146b5](https://github.com/Sage/carbon/commit/95146b53f8c723b13d351a6fc692f75c65c1e08d))
+- **button:** pass `aria-hidden=true` to button icon ([95146b5](https://github.com/Sage/carbon/commit/95146b53f8c723b13d351a6fc692f75c65c1e08d))
 
 ### [102.4.4](https://github.com/Sage/carbon/compare/v102.4.3...v102.4.4) (2021-12-23)
 
-
 ### Bug Fixes
 
-* **checkbox-group:** remove incorrect margin in form ([4a061e7](https://github.com/Sage/carbon/commit/4a061e70e9b0982e8d45af6790547b75d9440e9e)), closes [#4641](https://github.com/Sage/carbon/issues/4641)
+- **checkbox-group:** remove incorrect margin in form ([4a061e7](https://github.com/Sage/carbon/commit/4a061e70e9b0982e8d45af6790547b75d9440e9e)), closes [#4641](https://github.com/Sage/carbon/issues/4641)
 
 ### [102.4.3](https://github.com/Sage/carbon/compare/v102.4.2...v102.4.3) (2021-12-21)
 
-
 ### Bug Fixes
 
-* **flat-table-cell:** ensure that pl prop is correctly applied to a sub row ([28c7ffa](https://github.com/Sage/carbon/commit/28c7ffaf84da80587c36dc1284b4b710b9778d5f)), closes [#4348](https://github.com/Sage/carbon/issues/4348)
+- **flat-table-cell:** ensure that pl prop is correctly applied to a sub row ([28c7ffa](https://github.com/Sage/carbon/commit/28c7ffaf84da80587c36dc1284b4b710b9778d5f)), closes [#4348](https://github.com/Sage/carbon/issues/4348)
 
 ### [102.4.2](https://github.com/Sage/carbon/compare/v102.4.1...v102.4.2) (2021-12-21)
 
-
 ### Bug Fixes
 
-* **dismissible-box:** remove minWidth from component ([e5b78d6](https://github.com/Sage/carbon/commit/e5b78d68291c2ea345d8b2d435a52dcacb354742)), closes [#4627](https://github.com/Sage/carbon/issues/4627)
+- **dismissible-box:** remove minWidth from component ([e5b78d6](https://github.com/Sage/carbon/commit/e5b78d68291c2ea345d8b2d435a52dcacb354742)), closes [#4627](https://github.com/Sage/carbon/issues/4627)
 
 ### [102.4.1](https://github.com/Sage/carbon/compare/v102.4.0...v102.4.1) (2021-12-21)
 
-
 ### Bug Fixes
 
-* **alert:** fix incorrect prop type for title prop ([fb82edb](https://github.com/Sage/carbon/commit/fb82edba788e880bde42bd77c4b83fd61ecfcc20)), closes [#4600](https://github.com/Sage/carbon/issues/4600)
-* **dialog:** add missing prop types to ts definition file ([a4ba3ce](https://github.com/Sage/carbon/commit/a4ba3ce8b4a02c66a032fac8928397d77c63181b))
-* **modal:** add missing prop types to ts definition file ([fbe0b27](https://github.com/Sage/carbon/commit/fbe0b278524a7454ee5521222d04cdb3a6d8754d))
+- **alert:** fix incorrect prop type for title prop ([fb82edb](https://github.com/Sage/carbon/commit/fb82edba788e880bde42bd77c4b83fd61ecfcc20)), closes [#4600](https://github.com/Sage/carbon/issues/4600)
+- **dialog:** add missing prop types to ts definition file ([a4ba3ce](https://github.com/Sage/carbon/commit/a4ba3ce8b4a02c66a032fac8928397d77c63181b))
+- **modal:** add missing prop types to ts definition file ([fbe0b27](https://github.com/Sage/carbon/commit/fbe0b278524a7454ee5521222d04cdb3a6d8754d))
 
 ## [102.4.0](https://github.com/Sage/carbon/compare/v102.3.0...v102.4.0) (2021-12-14)
 
-
 ### Features
 
-* **message:** describe Message component using design tokens ([d3b7c0b](https://github.com/Sage/carbon/commit/d3b7c0b9d9e56b843fa7a17c578763e414819d09))
-* **message:** describe type-icon with design tokens, fix snapshots ([5da258a](https://github.com/Sage/carbon/commit/5da258a3fcff856bd4c7ab8396c8f7866cc4f7e2))
+- **message:** describe Message component using design tokens ([d3b7c0b](https://github.com/Sage/carbon/commit/d3b7c0b9d9e56b843fa7a17c578763e414819d09))
+- **message:** describe type-icon with design tokens, fix snapshots ([5da258a](https://github.com/Sage/carbon/commit/5da258a3fcff856bd4c7ab8396c8f7866cc4f7e2))
 
 ## [102.3.0](https://github.com/Sage/carbon/compare/v102.2.0...v102.3.0) (2021-12-14)
 
-
 ### Features
 
-* **link:** describe link component using design tokens ([545980b](https://github.com/Sage/carbon/commit/545980b3b2ae1dbc90ee94d1c66ce15538146841))
+- **link:** describe link component using design tokens ([545980b](https://github.com/Sage/carbon/commit/545980b3b2ae1dbc90ee94d1c66ce15538146841))
 
 ## [102.2.0](https://github.com/Sage/carbon/compare/v102.1.0...v102.2.0) (2021-12-13)
 
-
 ### Features
 
-* **radio-button:** describe RadioButton component using design tokens ([f235a2f](https://github.com/Sage/carbon/commit/f235a2f7712654bde2765a8655ecd4d81f574c83))
+- **radio-button:** describe RadioButton component using design tokens ([f235a2f](https://github.com/Sage/carbon/commit/f235a2f7712654bde2765a8655ecd4d81f574c83))
 
 ## [102.1.0](https://github.com/Sage/carbon/compare/v102.0.1...v102.1.0) (2021-12-13)
 
-
 ### Features
 
-* **label:** describe label using design tokens, remove theme in css files ([cc8ea45](https://github.com/Sage/carbon/commit/cc8ea454251824ab2b85c90f948072792a4a91f8))
+- **label:** describe label using design tokens, remove theme in css files ([cc8ea45](https://github.com/Sage/carbon/commit/cc8ea454251824ab2b85c90f948072792a4a91f8))
 
 ### [102.0.1](https://github.com/Sage/carbon/compare/v102.0.0...v102.0.1) (2021-12-07)
 
-
 ### Bug Fixes
 
-* **button-toggle:** add missing ARIA props ([912c59f](https://github.com/Sage/carbon/commit/912c59f667826fc0404bade4f71d8a8a8f9cf5c5))
-* **button-toggle:** add missing data props ([2d950a5](https://github.com/Sage/carbon/commit/2d950a5c89f1fd8f4fd2f10bb01307fa54e39a6c))
-* **button-toggle:** remove icon margin when content is not defined ([22985cd](https://github.com/Sage/carbon/commit/22985cda656eea520bee42059804c5d8c71375cf))
+- **button-toggle:** add missing ARIA props ([912c59f](https://github.com/Sage/carbon/commit/912c59f667826fc0404bade4f71d8a8a8f9cf5c5))
+- **button-toggle:** add missing data props ([2d950a5](https://github.com/Sage/carbon/commit/2d950a5c89f1fd8f4fd2f10bb01307fa54e39a6c))
+- **button-toggle:** remove icon margin when content is not defined ([22985cd](https://github.com/Sage/carbon/commit/22985cda656eea520bee42059804c5d8c71375cf))
 
 ## [102.0.0](https://github.com/Sage/carbon/compare/v101.4.5...v102.0.0) (2021-12-06)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **decimal:** Decimal has been refactored to be a functional component from a class based
-component. This means that you are no longer able to extend this component.
+- **decimal:** Decimal has been refactored to be a functional component from a class based
+  component. This means that you are no longer able to extend this component.
 
 fixes FE-3640
 
 ### Code Refactoring
 
-* **decimal:** convert class to functional component ([5eb2d32](https://github.com/Sage/carbon/commit/5eb2d32b31788fa3774d1c7ae5e4834b1bd39e0c))
+- **decimal:** convert class to functional component ([5eb2d32](https://github.com/Sage/carbon/commit/5eb2d32b31788fa3774d1c7ae5e4834b1bd39e0c))
 
 ### [101.4.5](https://github.com/Sage/carbon/compare/v101.4.4...v101.4.5) (2021-12-06)
 
-
 ### Bug Fixes
 
-* **character count:** allow screen reader to read character count ([6724f29](https://github.com/Sage/carbon/commit/6724f2932c8175d7b1b7cde850986b0050aae393))
+- **character count:** allow screen reader to read character count ([6724f29](https://github.com/Sage/carbon/commit/6724f2932c8175d7b1b7cde850986b0050aae393))
 
 ### [101.4.4](https://github.com/Sage/carbon/compare/v101.4.3...v101.4.4) (2021-12-06)
 
-
 ### Bug Fixes
 
-* **design-tokens:** provide tokens outside root ([73fbd06](https://github.com/Sage/carbon/commit/73fbd065f1fc762de19589c0548eeb9c2610fc9d))
+- **design-tokens:** provide tokens outside root ([73fbd06](https://github.com/Sage/carbon/commit/73fbd065f1fc762de19589c0548eeb9c2610fc9d))
 
 ### [101.4.3](https://github.com/Sage/carbon/compare/v101.4.2...v101.4.3) (2021-12-06)
 
-
 ### Bug Fixes
 
-* **radio-button, label:** when help prop is provided, pass input context values to children ([095a27b](https://github.com/Sage/carbon/commit/095a27b0f2b28c1900504f65e77a76c8f7736fac))
-* **validation-icon:** add conditional styling for displaying pointer cursor ([3366053](https://github.com/Sage/carbon/commit/3366053304bf56d29833bad0d9ddb124ff654bf0))
+- **radio-button, label:** when help prop is provided, pass input context values to children ([095a27b](https://github.com/Sage/carbon/commit/095a27b0f2b28c1900504f65e77a76c8f7736fac))
+- **validation-icon:** add conditional styling for displaying pointer cursor ([3366053](https://github.com/Sage/carbon/commit/3366053304bf56d29833bad0d9ddb124ff654bf0))
 
 ### [101.4.2](https://github.com/Sage/carbon/compare/v101.4.1...v101.4.2) (2021-12-03)
 
-
 ### Bug Fixes
 
-* **tile select:** apply opacity to prefixAdornment when component is disabled ([f08f183](https://github.com/Sage/carbon/commit/f08f1839d6a7a781c325c1e8b66d4c981d1b7947)), closes [#4606](https://github.com/Sage/carbon/issues/4606)
+- **tile select:** apply opacity to prefixAdornment when component is disabled ([f08f183](https://github.com/Sage/carbon/commit/f08f1839d6a7a781c325c1e8b66d4c981d1b7947)), closes [#4606](https://github.com/Sage/carbon/issues/4606)
 
 ### [101.4.1](https://github.com/Sage/carbon/compare/v101.4.0...v101.4.1) (2021-12-03)
 
-
 ### Bug Fixes
 
-* **date:** enforce ISO date in value prop ([643c263](https://github.com/Sage/carbon/commit/643c26320749bcf7de93277c0917044118582922)), closes [#3945](https://github.com/Sage/carbon/issues/3945) [#4453](https://github.com/Sage/carbon/issues/4453)
-* **date:** include moment locales ([a9016f2](https://github.com/Sage/carbon/commit/a9016f24baea94506e26ab33448192d4401ab0ac)), closes [#4479](https://github.com/Sage/carbon/issues/4479)
-* **date:** modify custom event in onBlur to return correct values ([e87836f](https://github.com/Sage/carbon/commit/e87836f7cede8c53434f48aca8d3aba3980b42bd))
+- **date:** enforce ISO date in value prop ([643c263](https://github.com/Sage/carbon/commit/643c26320749bcf7de93277c0917044118582922)), closes [#3945](https://github.com/Sage/carbon/issues/3945) [#4453](https://github.com/Sage/carbon/issues/4453)
+- **date:** include moment locales ([a9016f2](https://github.com/Sage/carbon/commit/a9016f24baea94506e26ab33448192d4401ab0ac)), closes [#4479](https://github.com/Sage/carbon/issues/4479)
+- **date:** modify custom event in onBlur to return correct values ([e87836f](https://github.com/Sage/carbon/commit/e87836f7cede8c53434f48aca8d3aba3980b42bd))
 
 ## [101.4.0](https://github.com/Sage/carbon/compare/v101.3.3...v101.4.0) (2021-12-01)
 
-
 ### Features
 
-* **link:** make skip link possible to be translated ([ce8bab7](https://github.com/Sage/carbon/commit/ce8bab70391dd6b00e2c1b2469c00c35d6f68279))
+- **link:** make skip link possible to be translated ([ce8bab7](https://github.com/Sage/carbon/commit/ce8bab70391dd6b00e2c1b2469c00c35d6f68279))
 
 ### [101.3.3](https://github.com/Sage/carbon/compare/v101.3.2...v101.3.3) (2021-12-01)
 
-
 ### Bug Fixes
 
-* **search:** fix incorrect tabindex behaviour ([18fe998](https://github.com/Sage/carbon/commit/18fe9985cf395fd269032af3e323c34011d364dd))
+- **search:** fix incorrect tabindex behaviour ([18fe998](https://github.com/Sage/carbon/commit/18fe9985cf395fd269032af3e323c34011d364dd))
 
 ### [101.3.2](https://github.com/Sage/carbon/compare/v101.3.1...v101.3.2) (2021-11-30)
 
-
 ### Bug Fixes
 
-* **inputs:** make validation messages readable by voiceover ([89312f1](https://github.com/Sage/carbon/commit/89312f18a984758888346f0c2a2c31967586c0f8))
+- **inputs:** make validation messages readable by voiceover ([89312f1](https://github.com/Sage/carbon/commit/89312f18a984758888346f0c2a2c31967586c0f8))
 
 ### [101.3.1](https://github.com/Sage/carbon/compare/v101.3.0...v101.3.1) (2021-11-26)
 
-
 ### Bug Fixes
 
-* **tab-header, tab-title:** refactor components to no longer render ul and li elements ([42be1eb](https://github.com/Sage/carbon/commit/42be1eb2fc122aad7b737de212a20e42867b28f3)), closes [#4517](https://github.com/Sage/carbon/issues/4517)
+- **tab-header, tab-title:** refactor components to no longer render ul and li elements ([42be1eb](https://github.com/Sage/carbon/commit/42be1eb2fc122aad7b737de212a20e42867b28f3)), closes [#4517](https://github.com/Sage/carbon/issues/4517)
 
 ## [101.3.0](https://github.com/Sage/carbon/compare/v101.2.0...v101.3.0) (2021-11-26)
 
-
 ### Features
 
-* **flat-table:** add overflow x prop and story ([faddf0f](https://github.com/Sage/carbon/commit/faddf0f582b6abe9881a0c1a70e2d01e0b0aafd6))
-
+- **flat-table:** add overflow x prop and story ([faddf0f](https://github.com/Sage/carbon/commit/faddf0f582b6abe9881a0c1a70e2d01e0b0aafd6))
 
 ### Bug Fixes
 
-* **flat-table:** make scrollable content accessible via keyboard ([ca44a6f](https://github.com/Sage/carbon/commit/ca44a6f13d9b6c3f0ceaeac6fef037e29faa563e)), closes [#4259](https://github.com/Sage/carbon/issues/4259)
+- **flat-table:** make scrollable content accessible via keyboard ([ca44a6f](https://github.com/Sage/carbon/commit/ca44a6f13d9b6c3f0ceaeac6fef037e29faa563e)), closes [#4259](https://github.com/Sage/carbon/issues/4259)
 
 ## [101.2.0](https://github.com/Sage/carbon/compare/v101.1.0...v101.2.0) (2021-11-25)
 
-
 ### Features
 
-* **icon-button:** add TooltipProvider and event handles to toggle Tooltip if child has one ([a242e97](https://github.com/Sage/carbon/commit/a242e976fd8c244fa1328f4b8ae44fa23ef16877)), closes [#4542](https://github.com/Sage/carbon/issues/4542)
-* **tooltip-provider:** add additional props to control tooltip behaviours of wrapped children ([90f0ec6](https://github.com/Sage/carbon/commit/90f0ec635cd619aa3d0c72028cf5dc1bb0eaa8a7))
-
+- **icon-button:** add TooltipProvider and event handles to toggle Tooltip if child has one ([a242e97](https://github.com/Sage/carbon/commit/a242e976fd8c244fa1328f4b8ae44fa23ef16877)), closes [#4542](https://github.com/Sage/carbon/issues/4542)
+- **tooltip-provider:** add additional props to control tooltip behaviours of wrapped children ([90f0ec6](https://github.com/Sage/carbon/commit/90f0ec635cd619aa3d0c72028cf5dc1bb0eaa8a7))
 
 ### Bug Fixes
 
-* **icon-button:** add missing aria-label to story ([6d5f1b5](https://github.com/Sage/carbon/commit/6d5f1b52b19177615ddaf266620264ffede4284c)), closes [#4552](https://github.com/Sage/carbon/issues/4552)
+- **icon-button:** add missing aria-label to story ([6d5f1b5](https://github.com/Sage/carbon/commit/6d5f1b52b19177615ddaf266620264ffede4284c)), closes [#4552](https://github.com/Sage/carbon/issues/4552)
 
 ## [101.1.0](https://github.com/Sage/carbon/compare/v101.0.4...v101.1.0) (2021-11-25)
 
-
 ### Features
 
-* **multi-select:** add keyboard accessibility ([7335a5e](https://github.com/Sage/carbon/commit/7335a5e1fb43007ea4649f7ae18909b50eaf8142))
+- **multi-select:** add keyboard accessibility ([7335a5e](https://github.com/Sage/carbon/commit/7335a5e1fb43007ea4649f7ae18909b50eaf8142))
 
 ### [101.0.4](https://github.com/Sage/carbon/compare/v101.0.3...v101.0.4) (2021-11-24)
 
-
 ### Bug Fixes
 
-* **text-editor:** replace regex used to format web links ([5d53668](https://github.com/Sage/carbon/commit/5d53668598fdfe394ba5b00a2352b6a5c11f8bfe))
+- **text-editor:** replace regex used to format web links ([5d53668](https://github.com/Sage/carbon/commit/5d53668598fdfe394ba5b00a2352b6a5c11f8bfe))
 
 ### [101.0.3](https://github.com/Sage/carbon/compare/v101.0.2...v101.0.3) (2021-11-24)
 
-
 ### Bug Fixes
 
-* **design-tokens:** fix providing transparency design tokens ([94b56d0](https://github.com/Sage/carbon/commit/94b56d03115485b1a8193cb37e46e25eb94f9600))
+- **design-tokens:** fix providing transparency design tokens ([94b56d0](https://github.com/Sage/carbon/commit/94b56d03115485b1a8193cb37e46e25eb94f9600))
 
 ### [101.0.2](https://github.com/Sage/carbon/compare/v101.0.1...v101.0.2) (2021-11-24)
 
-
 ### Bug Fixes
 
-* **textbox:** change fieldHelp sizing to match input width ([6c517c9](https://github.com/Sage/carbon/commit/6c517c9cd55d0f37071d615bb44ffbadbb5ce781)), closes [#4543](https://github.com/Sage/carbon/issues/4543)
+- **textbox:** change fieldHelp sizing to match input width ([6c517c9](https://github.com/Sage/carbon/commit/6c517c9cd55d0f37071d615bb44ffbadbb5ce781)), closes [#4543](https://github.com/Sage/carbon/issues/4543)
 
 ### [101.0.1](https://github.com/Sage/carbon/compare/v101.0.0...v101.0.1) (2021-11-23)
 
-
 ### Bug Fixes
 
-* **select:** render wrapped text correctly in SelectList ([0b18685](https://github.com/Sage/carbon/commit/0b1868577375ae4be2407f07da0dbe14fb6fbd65)), closes [#4489](https://github.com/Sage/carbon/issues/4489)
+- **select:** render wrapped text correctly in SelectList ([0b18685](https://github.com/Sage/carbon/commit/0b1868577375ae4be2407f07da0dbe14fb6fbd65)), closes [#4489](https://github.com/Sage/carbon/issues/4489)
 
 ## [101.0.0](https://github.com/Sage/carbon/compare/v100.1.1...v101.0.0) (2021-11-23)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **design-tokens:** CarbonScopedTokensProvider is a part of CarbonProvider
+- **design-tokens:** CarbonScopedTokensProvider is a part of CarbonProvider
 
 Design tokens in form of CSS variables will be provided without need of using additional elements.
 
 ### Bug Fixes
 
-* **design-tokens:** fix design tokens provider implementation ([a62f953](https://github.com/Sage/carbon/commit/a62f95333bea396654c55e932c26c21b6b372502))
+- **design-tokens:** fix design tokens provider implementation ([a62f953](https://github.com/Sage/carbon/commit/a62f95333bea396654c55e932c26c21b6b372502))
 
 ### [100.1.1](https://github.com/Sage/carbon/compare/v100.1.0...v100.1.1) (2021-11-19)
 
-
 ### Bug Fixes
 
-* **page:** export page correctly from pages interface ([e315b92](https://github.com/Sage/carbon/commit/e315b92e3bbd11a10aa55a5764b09f282505159a)), closes [#4562](https://github.com/Sage/carbon/issues/4562)
+- **page:** export page correctly from pages interface ([e315b92](https://github.com/Sage/carbon/commit/e315b92e3bbd11a10aa55a5764b09f282505159a)), closes [#4562](https://github.com/Sage/carbon/issues/4562)
 
 ## [100.1.0](https://github.com/Sage/carbon/compare/v100.0.0...v100.1.0) (2021-11-18)
 
-
 ### Features
 
-* **focus-trap:** add flag to trigger refocus of either last focused element first element ([5ae3922](https://github.com/Sage/carbon/commit/5ae39226b4102106f08e997129aa7cef49548ecd))
-
+- **focus-trap:** add flag to trigger refocus of either last focused element first element ([5ae3922](https://github.com/Sage/carbon/commit/5ae39226b4102106f08e997129aa7cef49548ecd))
 
 ### Bug Fixes
 
-* **modal, modal-manager:** modal and manager now set a refocus flag when stacked modals are closed ([5b9c5f7](https://github.com/Sage/carbon/commit/5b9c5f75465ccd0145322710ef112e213961083e)), closes [#4502](https://github.com/Sage/carbon/issues/4502)
+- **modal, modal-manager:** modal and manager now set a refocus flag when stacked modals are closed ([5b9c5f7](https://github.com/Sage/carbon/commit/5b9c5f75465ccd0145322710ef112e213961083e)), closes [#4502](https://github.com/Sage/carbon/issues/4502)
 
 ## [100.0.0](https://github.com/Sage/carbon/compare/v99.1.0...v100.0.0) (2021-11-18)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **date-range:** The component can no longer be extended as it is not a class anymore
+- **date-range:** The component can no longer be extended as it is not a class anymore
 
 ### Code Refactoring
 
-* **date-range:** convert component from class-based to functional ([ec69281](https://github.com/Sage/carbon/commit/ec692814f8783d183359500c659ab66767be9b44))
+- **date-range:** convert component from class-based to functional ([ec69281](https://github.com/Sage/carbon/commit/ec692814f8783d183359500c659ab66767be9b44))
 
 ## [99.1.0](https://github.com/Sage/carbon/compare/v99.0.1...v99.1.0) (2021-11-18)
 
-
 ### Features
 
-* **progress-tracker:** create new component ([49b8454](https://github.com/Sage/carbon/commit/49b84545ecb9b5dcd05d80f0f000b7764b389350))
+- **progress-tracker:** create new component ([49b8454](https://github.com/Sage/carbon/commit/49b84545ecb9b5dcd05d80f0f000b7764b389350))
 
 ### [99.0.1](https://github.com/Sage/carbon/compare/v99.0.0...v99.0.1) (2021-11-18)
 
-
 ### Bug Fixes
 
-* **loader-bar:** change width of loader ([a16a51e](https://github.com/Sage/carbon/commit/a16a51ef9c02d84c1153974e4ef4e37e618aedcf))
+- **loader-bar:** change width of loader ([a16a51e](https://github.com/Sage/carbon/commit/a16a51ef9c02d84c1153974e4ef4e37e618aedcf))
 
 ## [99.0.0](https://github.com/Sage/carbon/compare/v98.0.1...v99.0.0) (2021-11-15)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **detail:** Class methods will be removed
-and Detail will no longer be extendable.
+- **detail:** Class methods will be removed
+  and Detail will no longer be extendable.
 
 ### Code Refactoring
 
-* **detail:** refactor to a functional component ([788a6b9](https://github.com/Sage/carbon/commit/788a6b97df01f07228d3623f37a327f6ed476216))
+- **detail:** refactor to a functional component ([788a6b9](https://github.com/Sage/carbon/commit/788a6b97df01f07228d3623f37a327f6ed476216))
 
 ### [98.0.1](https://github.com/Sage/carbon/compare/v98.0.0...v98.0.1) (2021-11-12)
 
-
 ### Bug Fixes
 
-* **search:** correct tabbing order when searchButton true and no search value ([38e4bf0](https://github.com/Sage/carbon/commit/38e4bf0d8e9599d946b232c4d5ae370b33598e55)), closes [#4480](https://github.com/Sage/carbon/issues/4480)
+- **search:** correct tabbing order when searchButton true and no search value ([38e4bf0](https://github.com/Sage/carbon/commit/38e4bf0d8e9599d946b232c4d5ae370b33598e55)), closes [#4480](https://github.com/Sage/carbon/issues/4480)
 
 ## [98.0.0](https://github.com/Sage/carbon/compare/v97.0.0...v98.0.0) (2021-11-10)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **toast:** Toast is no longer a class component.
-That means that it is not possible to extend it and its methods are now private
+- **toast:** Toast is no longer a class component.
+  That means that it is not possible to extend it and its methods are now private
 
 ### Code Refactoring
 
-* **toast:** refactor from class based to a functional component ([cc8ee89](https://github.com/Sage/carbon/commit/cc8ee893f3606b7b36cda75fe047238852970075))
+- **toast:** refactor from class based to a functional component ([cc8ee89](https://github.com/Sage/carbon/commit/cc8ee893f3606b7b36cda75fe047238852970075))
 
 ## [97.0.0](https://github.com/Sage/carbon/compare/v96.1.0...v97.0.0) (2021-11-10)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **textarea:** Textarea is no longer a class component.
-That means that it is not possible to extend it and its methods are now private
+- **textarea:** Textarea is no longer a class component.
+  That means that it is not possible to extend it and its methods are now private
 
 ### Code Refactoring
 
-* **textarea:** refactor from class based to a functional component ([2b91f34](https://github.com/Sage/carbon/commit/2b91f34637a20de056ebd82417151556b240929e))
+- **textarea:** refactor from class based to a functional component ([2b91f34](https://github.com/Sage/carbon/commit/2b91f34637a20de056ebd82417151556b240929e))
 
 ## [96.1.0](https://github.com/Sage/carbon/compare/v96.0.0...v96.1.0) (2021-11-09)
 
-
 ### Features
 
-* **multi-action-button:** add support for tertiary buttonType ([ee12f79](https://github.com/Sage/carbon/commit/ee12f79ab2efedc085f7821c0107522b3e471b5f))
+- **multi-action-button:** add support for tertiary buttonType ([ee12f79](https://github.com/Sage/carbon/commit/ee12f79ab2efedc085f7821c0107522b3e471b5f))
 
 ## [96.0.0](https://github.com/Sage/carbon/compare/v95.1.3...v96.0.0) (2021-11-05)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **show-edit-pod:** ShowEditPod is no longer a class component.
-That means that it is not possible to extend it and its methods are now private
+- **show-edit-pod:** ShowEditPod is no longer a class component.
+  That means that it is not possible to extend it and its methods are now private
 
 ### Code Refactoring
 
-* **show-edit-pod:** refactor from class based to a functional component ([f8875d2](https://github.com/Sage/carbon/commit/f8875d29e70f4670dc38a526fec142a39726f1e2))
+- **show-edit-pod:** refactor from class based to a functional component ([f8875d2](https://github.com/Sage/carbon/commit/f8875d29e70f4670dc38a526fec142a39726f1e2))
 
 ### [95.1.3](https://github.com/Sage/carbon/compare/v95.1.2...v95.1.3) (2021-11-05)
 
-
 ### Bug Fixes
 
-* **filterable-select:** prevent re-renders from setting selectedValue to undefined ([cdf72fd](https://github.com/Sage/carbon/commit/cdf72fde8f24708163307188f945a95a7624d2b3))
-* **multi-select:** prevent re-renders from setting selectedValue to undefined ([70c7ecc](https://github.com/Sage/carbon/commit/70c7eccbf78d77859065e8621ef405d905ccf68e)), closes [#4482](https://github.com/Sage/carbon/issues/4482)
-* **simple-select:** prevent re-renders from setting selectedValue to undefined ([d5c0669](https://github.com/Sage/carbon/commit/d5c0669b369bf28fe836ddf0fee85dcfa05b3e4d))
+- **filterable-select:** prevent re-renders from setting selectedValue to undefined ([cdf72fd](https://github.com/Sage/carbon/commit/cdf72fde8f24708163307188f945a95a7624d2b3))
+- **multi-select:** prevent re-renders from setting selectedValue to undefined ([70c7ecc](https://github.com/Sage/carbon/commit/70c7eccbf78d77859065e8621ef405d905ccf68e)), closes [#4482](https://github.com/Sage/carbon/issues/4482)
+- **simple-select:** prevent re-renders from setting selectedValue to undefined ([d5c0669](https://github.com/Sage/carbon/commit/d5c0669b369bf28fe836ddf0fee85dcfa05b3e4d))
 
 ### [95.1.2](https://github.com/Sage/carbon/compare/v95.1.1...v95.1.2) (2021-11-05)
 
-
 ### Bug Fixes
 
-* **tabs:** enable validations when renderHiddenTabs set ([09874f5](https://github.com/Sage/carbon/commit/09874f566663ba296c0cf3300bb4ad69432e3f69)), closes [#4501](https://github.com/Sage/carbon/issues/4501)
+- **tabs:** enable validations when renderHiddenTabs set ([09874f5](https://github.com/Sage/carbon/commit/09874f566663ba296c0cf3300bb4ad69432e3f69)), closes [#4501](https://github.com/Sage/carbon/issues/4501)
 
 ### [95.1.1](https://github.com/Sage/carbon/compare/v95.1.0...v95.1.1) (2021-11-02)
 
-
 ### Bug Fixes
 
-* **tabs:** remove extra grey border on warning and info ([bb0ffed](https://github.com/Sage/carbon/commit/bb0ffed36fddea5390b58be46776dc411847a24d)), closes [#4254](https://github.com/Sage/carbon/issues/4254)
+- **tabs:** remove extra grey border on warning and info ([bb0ffed](https://github.com/Sage/carbon/commit/bb0ffed36fddea5390b58be46776dc411847a24d)), closes [#4254](https://github.com/Sage/carbon/issues/4254)
 
 ## [95.1.0](https://github.com/Sage/carbon/compare/v95.0.2...v95.1.0) (2021-10-28)
 
-
 ### Features
 
-* **button-toggle-group:** surface helpAriaLabel prop ([e92e6b8](https://github.com/Sage/carbon/commit/e92e6b8c5e71eb400eae5eb3dbc62cb1398cec9b))
-* **checkbox:** surface helpAriaLabel prop ([cb3695a](https://github.com/Sage/carbon/commit/cb3695a7d9bd0f7cf6642d473c6f73aecaa15c80))
-* **date:** surface helpAriaLabel prop ([f3d4923](https://github.com/Sage/carbon/commit/f3d492305a58a2133654384ac747c4d72481aeb9))
-* **decimal:** surface helpAriaLabel prop ([4dcb2f6](https://github.com/Sage/carbon/commit/4dcb2f61cb1b021487eabfdea63b12f89f62599b))
-* **grouped-character:** surface helpAriaLabel prop ([a4c543f](https://github.com/Sage/carbon/commit/a4c543f80051706f7bcad54fef5b9d16625f2622))
-* **heading:** surface helpAriaLabel prop ([fe3cb1e](https://github.com/Sage/carbon/commit/fe3cb1e86915cdcf235f8ddd1960a2dc6f45ce7d))
-* **help:** surface ariaLabel prop and set aria-hidden on Icon if no href passed ([e92dcc2](https://github.com/Sage/carbon/commit/e92dcc2ee67440b867f7f5f1ea88c48106f7ef6f)), closes [#4404](https://github.com/Sage/carbon/issues/4404)
-* **numeral-date:** surface helpAriaLabel prop and integrat TooltipProvider ([5cd4acb](https://github.com/Sage/carbon/commit/5cd4acbbddd0e57cba77830918612e435fa9c070))
-* **radio-button:** surface helpAriaLabel prop ([cda7876](https://github.com/Sage/carbon/commit/cda787633b169ec68d7a508f0e4f548ae323782c))
-* **switch:** surface helpAriaLabel prop ([066d7a1](https://github.com/Sage/carbon/commit/066d7a1ffcebfefcfe5ae268a84b0a86b1537986))
-* **textarea:** surface helpAriaLabel prop ([8fd953d](https://github.com/Sage/carbon/commit/8fd953d10120a3d3362bded3edb425043eec2753))
-* **textbox:** surface helpAriaLabel prop ([61778e5](https://github.com/Sage/carbon/commit/61778e54d7a1543b9510562d466e37b6a34aef8f))
-
+- **button-toggle-group:** surface helpAriaLabel prop ([e92e6b8](https://github.com/Sage/carbon/commit/e92e6b8c5e71eb400eae5eb3dbc62cb1398cec9b))
+- **checkbox:** surface helpAriaLabel prop ([cb3695a](https://github.com/Sage/carbon/commit/cb3695a7d9bd0f7cf6642d473c6f73aecaa15c80))
+- **date:** surface helpAriaLabel prop ([f3d4923](https://github.com/Sage/carbon/commit/f3d492305a58a2133654384ac747c4d72481aeb9))
+- **decimal:** surface helpAriaLabel prop ([4dcb2f6](https://github.com/Sage/carbon/commit/4dcb2f61cb1b021487eabfdea63b12f89f62599b))
+- **grouped-character:** surface helpAriaLabel prop ([a4c543f](https://github.com/Sage/carbon/commit/a4c543f80051706f7bcad54fef5b9d16625f2622))
+- **heading:** surface helpAriaLabel prop ([fe3cb1e](https://github.com/Sage/carbon/commit/fe3cb1e86915cdcf235f8ddd1960a2dc6f45ce7d))
+- **help:** surface ariaLabel prop and set aria-hidden on Icon if no href passed ([e92dcc2](https://github.com/Sage/carbon/commit/e92dcc2ee67440b867f7f5f1ea88c48106f7ef6f)), closes [#4404](https://github.com/Sage/carbon/issues/4404)
+- **numeral-date:** surface helpAriaLabel prop and integrat TooltipProvider ([5cd4acb](https://github.com/Sage/carbon/commit/5cd4acbbddd0e57cba77830918612e435fa9c070))
+- **radio-button:** surface helpAriaLabel prop ([cda7876](https://github.com/Sage/carbon/commit/cda787633b169ec68d7a508f0e4f548ae323782c))
+- **switch:** surface helpAriaLabel prop ([066d7a1](https://github.com/Sage/carbon/commit/066d7a1ffcebfefcfe5ae268a84b0a86b1537986))
+- **textarea:** surface helpAriaLabel prop ([8fd953d](https://github.com/Sage/carbon/commit/8fd953d10120a3d3362bded3edb425043eec2753))
+- **textbox:** surface helpAriaLabel prop ([61778e5](https://github.com/Sage/carbon/commit/61778e54d7a1543b9510562d466e37b6a34aef8f))
 
 ### Bug Fixes
 
-* **icon:** add support for keyboard focus, gold outline, role and ariaLabel when has tooltip ([9801bee](https://github.com/Sage/carbon/commit/9801bee6b8f5bb7764a78939c5f616877c0e9d4d)), closes [#4428](https://github.com/Sage/carbon/issues/4428)
+- **icon:** add support for keyboard focus, gold outline, role and ariaLabel when has tooltip ([9801bee](https://github.com/Sage/carbon/commit/9801bee6b8f5bb7764a78939c5f616877c0e9d4d)), closes [#4428](https://github.com/Sage/carbon/issues/4428)
 
 ### [95.0.2](https://github.com/Sage/carbon/compare/v95.0.1...v95.0.2) (2021-10-27)
 
-
 ### Bug Fixes
 
-* **focus-trap:** add null check to focus-trap ref ([7e4cf21](https://github.com/Sage/carbon/commit/7e4cf214000e784b84fb5fa7bd760d05c82c8b3b))
+- **focus-trap:** add null check to focus-trap ref ([7e4cf21](https://github.com/Sage/carbon/commit/7e4cf214000e784b84fb5fa7bd760d05c82c8b3b))
 
 ### [95.0.1](https://github.com/Sage/carbon/compare/v95.0.0...v95.0.1) (2021-10-27)
 
-
 ### Bug Fixes
 
-* **tabs:** memoize `tabRef` array so it regenerate when children change ([eef4267](https://github.com/Sage/carbon/commit/eef4267a3075c4aac1601bbb40c1ed69b3beadee)), closes [#4498](https://github.com/Sage/carbon/issues/4498)
-* **tabs:** set tab stop when no tab is selected to support keyboard navigation ([5b39c0c](https://github.com/Sage/carbon/commit/5b39c0c9471d49a18bcb9c3aa97ab0188d531479)), closes [#4478](https://github.com/Sage/carbon/issues/4478)
+- **tabs:** memoize `tabRef` array so it regenerate when children change ([eef4267](https://github.com/Sage/carbon/commit/eef4267a3075c4aac1601bbb40c1ed69b3beadee)), closes [#4498](https://github.com/Sage/carbon/issues/4498)
+- **tabs:** set tab stop when no tab is selected to support keyboard navigation ([5b39c0c](https://github.com/Sage/carbon/commit/5b39c0c9471d49a18bcb9c3aa97ab0188d531479)), closes [#4478](https://github.com/Sage/carbon/issues/4478)
 
 ## [95.0.0](https://github.com/Sage/carbon/compare/v94.8.0...v95.0.0) (2021-10-27)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **icon:** bgTheme and iconColor props have been removed
-from Icon. Please use bg and color props instead.
+- **icon:** bgTheme and iconColor props have been removed
+  from Icon. Please use bg and color props instead.
 
 ### Code Refactoring
 
-* **icon:** remove bgTheme and iconColor props ([c2e6863](https://github.com/Sage/carbon/commit/c2e686390020ef1d62dc1c690593e73082b8f479))
+- **icon:** remove bgTheme and iconColor props ([c2e6863](https://github.com/Sage/carbon/commit/c2e686390020ef1d62dc1c690593e73082b8f479))
 
 ## [94.8.0](https://github.com/Sage/carbon/compare/v94.7.1...v94.8.0) (2021-10-26)
 
-
 ### Features
 
-* **checkable-input:** surface ariaLabelledBy prop and prevent setting labeId when no label is set ([37a4632](https://github.com/Sage/carbon/commit/37a4632272860e84ac7dc24dd3cde6d67d911980))
-* **flat-table-checkbox:** surface ariaLabelledBy prop for accessibility when in a selectable table ([ab82739](https://github.com/Sage/carbon/commit/ab8273986a32c48d6f19d206fbe78a6f449b644d))
+- **checkable-input:** surface ariaLabelledBy prop and prevent setting labeId when no label is set ([37a4632](https://github.com/Sage/carbon/commit/37a4632272860e84ac7dc24dd3cde6d67d911980))
+- **flat-table-checkbox:** surface ariaLabelledBy prop for accessibility when in a selectable table ([ab82739](https://github.com/Sage/carbon/commit/ab8273986a32c48d6f19d206fbe78a6f449b644d))
 
 ### [94.7.1](https://github.com/Sage/carbon/compare/v94.7.0...v94.7.1) (2021-10-26)
 
-
 ### Bug Fixes
 
-* **design-tokens:** improve values of tokens using theme.space, add tokens containing opacity ([0a3289c](https://github.com/Sage/carbon/commit/0a3289c3aca47477acb1bab8b480e128f501f37a))
+- **design-tokens:** improve values of tokens using theme.space, add tokens containing opacity ([0a3289c](https://github.com/Sage/carbon/commit/0a3289c3aca47477acb1bab8b480e128f501f37a))
 
 ## [94.7.0](https://github.com/Sage/carbon/compare/v94.6.2...v94.7.0) (2021-10-22)
 
-
 ### Features
 
-* **popover-container:** surface aria label props for buttons and container ([1c0f9db](https://github.com/Sage/carbon/commit/1c0f9db41749159be2adeda4863c433517e04b38)), closes [#4436](https://github.com/Sage/carbon/issues/4436)
+- **popover-container:** surface aria label props for buttons and container ([1c0f9db](https://github.com/Sage/carbon/commit/1c0f9db41749159be2adeda4863c433517e04b38)), closes [#4436](https://github.com/Sage/carbon/issues/4436)
 
 ### [94.6.2](https://github.com/Sage/carbon/compare/v94.6.1...v94.6.2) (2021-10-22)
 
-
 ### Bug Fixes
 
-* **flat-table-row:** increase specificity of styles targeting chevron icon when row is expandable ([00e47dc](https://github.com/Sage/carbon/commit/00e47dc1f9f9090fdeb52f801258c8bd9fc7b38f)), closes [#4497](https://github.com/Sage/carbon/issues/4497)
+- **flat-table-row:** increase specificity of styles targeting chevron icon when row is expandable ([00e47dc](https://github.com/Sage/carbon/commit/00e47dc1f9f9090fdeb52f801258c8bd9fc7b38f)), closes [#4497](https://github.com/Sage/carbon/issues/4497)
 
 ### [94.6.1](https://github.com/Sage/carbon/compare/v94.6.0...v94.6.1) (2021-10-22)
 
-
 ### Bug Fixes
 
-* **accordion:** ensure iconAlign prop works when buttonHeading prop is true ([1bcbd18](https://github.com/Sage/carbon/commit/1bcbd187845644715669aaed9337f6d9970246dd))
+- **accordion:** ensure iconAlign prop works when buttonHeading prop is true ([1bcbd18](https://github.com/Sage/carbon/commit/1bcbd187845644715669aaed9337f6d9970246dd))
 
 ## [94.6.0](https://github.com/Sage/carbon/compare/v94.5.0...v94.6.0) (2021-10-21)
 
-
 ### Features
 
-* **duelling-picklist:** update picklist spacings ([b3389e3](https://github.com/Sage/carbon/commit/b3389e3d6bafca88346cb02a09c90106e3497602))
-
+- **duelling-picklist:** update picklist spacings ([b3389e3](https://github.com/Sage/carbon/commit/b3389e3d6bafca88346cb02a09c90106e3497602))
 
 ### Bug Fixes
 
-* **duelling-picklist:** correct padding on group ([f1e5958](https://github.com/Sage/carbon/commit/f1e5958b5c322e9458a058d3408c735cce8b6f52))
+- **duelling-picklist:** correct padding on group ([f1e5958](https://github.com/Sage/carbon/commit/f1e5958b5c322e9458a058d3408c735cce8b6f52))
 
 ## [94.5.0](https://github.com/Sage/carbon/compare/v94.4.1...v94.5.0) (2021-10-21)
 
-
 ### Features
 
-* **design-tokens:** added design tokens support ([269684e](https://github.com/Sage/carbon/commit/269684e7c4afd69a1030798b06bbb1f7b1b94190))
-
+- **design-tokens:** added design tokens support ([269684e](https://github.com/Sage/carbon/commit/269684e7c4afd69a1030798b06bbb1f7b1b94190))
 
 ### Bug Fixes
 
-* **desgin-tokens:** add possibility of switching off token provider in themeSelector ([9b7b24a](https://github.com/Sage/carbon/commit/9b7b24abe8f26eb1a86aeeacf7de371074857ed5))
-* **design-tokens:** fix stories for global and scoped providers ([bfa17da](https://github.com/Sage/carbon/commit/bfa17da007e04adc6d1249c0ea97de2ffc3944f4))
-* **design-tokens:** fix typo in parameters variable in theme selector ([41e1e0c](https://github.com/Sage/carbon/commit/41e1e0cee42042da934ca292eb243976e24afe18))
+- **desgin-tokens:** add possibility of switching off token provider in themeSelector ([9b7b24a](https://github.com/Sage/carbon/commit/9b7b24abe8f26eb1a86aeeacf7de371074857ed5))
+- **design-tokens:** fix stories for global and scoped providers ([bfa17da](https://github.com/Sage/carbon/commit/bfa17da007e04adc6d1249c0ea97de2ffc3944f4))
+- **design-tokens:** fix typo in parameters variable in theme selector ([41e1e0c](https://github.com/Sage/carbon/commit/41e1e0cee42042da934ca292eb243976e24afe18))
 
 ### [94.4.1](https://github.com/Sage/carbon/compare/v94.4.0...v94.4.1) (2021-10-20)
 
-
 ### Bug Fixes
 
-* **button:** ensure values passed in via `px` prop are applied ([208eb65](https://github.com/Sage/carbon/commit/208eb65d5cb7936bb9047d5ee5e6cfd70509c18d))
+- **button:** ensure values passed in via `px` prop are applied ([208eb65](https://github.com/Sage/carbon/commit/208eb65d5cb7936bb9047d5ee5e6cfd70509c18d))
 
 ## [94.4.0](https://github.com/Sage/carbon/compare/v94.3.0...v94.4.0) (2021-10-20)
 
-
 ### Features
 
-* **switches:** adjust switches to current designs ([6c64089](https://github.com/Sage/carbon/commit/6c64089059909bda228532ed5f3486f5177af86e))
+- **switches:** adjust switches to current designs ([6c64089](https://github.com/Sage/carbon/commit/6c64089059909bda228532ed5f3486f5177af86e))
 
 ## [94.3.0](https://github.com/Sage/carbon/compare/v94.2.0...v94.3.0) (2021-10-19)
 
-
 ### Features
 
-* **link:** spread any aria props onto the a or button element ([d8ce077](https://github.com/Sage/carbon/commit/d8ce07757d45046224405821cc01cc482ce48ac9)), closes [#4440](https://github.com/Sage/carbon/issues/4440)
+- **link:** spread any aria props onto the a or button element ([d8ce077](https://github.com/Sage/carbon/commit/d8ce07757d45046224405821cc01cc482ce48ac9)), closes [#4440](https://github.com/Sage/carbon/issues/4440)
 
 ## [94.2.0](https://github.com/Sage/carbon/compare/v94.1.3...v94.2.0) (2021-10-19)
 
-
 ### Features
 
-* **flat-table:** expose minHeight prop and move footer to be direct sibling of table ([7239a0d](https://github.com/Sage/carbon/commit/7239a0de3ea808ffc0e8d21e1c5a9ff4c7e8c1a9)), closes [#4273](https://github.com/Sage/carbon/issues/4273)
+- **flat-table:** expose minHeight prop and move footer to be direct sibling of table ([7239a0d](https://github.com/Sage/carbon/commit/7239a0de3ea808ffc0e8d21e1c5a9ff4c7e8c1a9)), closes [#4273](https://github.com/Sage/carbon/issues/4273)
 
 ### [94.1.3](https://github.com/Sage/carbon/compare/v94.1.2...v94.1.3) (2021-10-15)
 
-
 ### Bug Fixes
 
-* **date:** add onClick handling ([cdb8829](https://github.com/Sage/carbon/commit/cdb8829ea37e8d8482c4a8db511e909f0d01ce8c)), closes [#4421](https://github.com/Sage/carbon/issues/4421)
+- **date:** add onClick handling ([cdb8829](https://github.com/Sage/carbon/commit/cdb8829ea37e8d8482c4a8db511e909f0d01ce8c)), closes [#4421](https://github.com/Sage/carbon/issues/4421)
 
 ### [94.1.2](https://github.com/Sage/carbon/compare/v94.1.1...v94.1.2) (2021-10-14)
 
-
 ### Bug Fixes
 
-* **menu-fullscreen:** add listener to trigger focus trap on transitionend event ([c06216a](https://github.com/Sage/carbon/commit/c06216a488ee18d806469727555d8f426ca43d78)), closes [#4287](https://github.com/Sage/carbon/issues/4287)
+- **menu-fullscreen:** add listener to trigger focus trap on transitionend event ([c06216a](https://github.com/Sage/carbon/commit/c06216a488ee18d806469727555d8f426ca43d78)), closes [#4287](https://github.com/Sage/carbon/issues/4287)
 
 ### [94.1.1](https://github.com/Sage/carbon/compare/v94.1.0...v94.1.1) (2021-10-14)
 
-
 ### Bug Fixes
 
-* **button:** add default margin 0 ([3d9854c](https://github.com/Sage/carbon/commit/3d9854cdcf6fc22e1d83ff32ef29f7423a46a87a))
+- **button:** add default margin 0 ([3d9854c](https://github.com/Sage/carbon/commit/3d9854cdcf6fc22e1d83ff32ef29f7423a46a87a))
 
 ## [94.1.0](https://github.com/Sage/carbon/compare/v94.0.3...v94.1.0) (2021-10-14)
 
-
 ### Features
 
-* **dismissible-box:** add new component ([2b08253](https://github.com/Sage/carbon/commit/2b082539b5d7112122a2a42ee99c0c4b6d8d94b7))
+- **dismissible-box:** add new component ([2b08253](https://github.com/Sage/carbon/commit/2b082539b5d7112122a2a42ee99c0c4b6d8d94b7))
 
 ### [94.0.3](https://github.com/Sage/carbon/compare/v94.0.2...v94.0.3) (2021-10-14)
 
-
 ### Bug Fixes
 
-* **action-popover:** correct dom structure when rendering custom button ([3f47b85](https://github.com/Sage/carbon/commit/3f47b855e29a30f93ed82354b4d6e83d8fcfcff4)), closes [#4401](https://github.com/Sage/carbon/issues/4401)
+- **action-popover:** correct dom structure when rendering custom button ([3f47b85](https://github.com/Sage/carbon/commit/3f47b855e29a30f93ed82354b4d6e83d8fcfcff4)), closes [#4401](https://github.com/Sage/carbon/issues/4401)
 
 ### [94.0.2](https://github.com/Sage/carbon/compare/v94.0.1...v94.0.2) (2021-10-13)
 
-
 ### Bug Fixes
 
-* **radio-button:** make field help and tooltip content readable for screen readers ([a796cd8](https://github.com/Sage/carbon/commit/a796cd82d20f5aa86a3a042fec6a4799d8292540))
+- **radio-button:** make field help and tooltip content readable for screen readers ([a796cd8](https://github.com/Sage/carbon/commit/a796cd82d20f5aa86a3a042fec6a4799d8292540))
 
 ### [94.0.1](https://github.com/Sage/carbon/compare/v94.0.0...v94.0.1) (2021-10-13)
 
-
 ### Bug Fixes
 
-* **hidden-checkable-input:** make inputref prop optional in ts interface ([eeab991](https://github.com/Sage/carbon/commit/eeab991888fb02938662e1d5535c0debbc7454fd)), closes [#4450](https://github.com/Sage/carbon/issues/4450)
+- **hidden-checkable-input:** make inputref prop optional in ts interface ([eeab991](https://github.com/Sage/carbon/commit/eeab991888fb02938662e1d5535c0debbc7454fd)), closes [#4450](https://github.com/Sage/carbon/issues/4450)
 
 ## [94.0.0](https://github.com/Sage/carbon/compare/v93.0.4...v94.0.0) (2021-10-13)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **drag-and-drop:** drag-and-drop has been removed from Carbon.
-Please use the Draggable component instead
-* **configurable-items:** ConfigurableItems has been removed from Carbon
+- **drag-and-drop:** drag-and-drop has been removed from Carbon.
+  Please use the Draggable component instead
+- **configurable-items:** ConfigurableItems has been removed from Carbon
 
 ### Code Refactoring
 
-* **configurable-items:** deprecate configurable items and pattern ([c0c1ed5](https://github.com/Sage/carbon/commit/c0c1ed5de8d56752e5d2465d46983b74d4e126b0))
-* **drag-and-drop:** deprecate drag-and-drop ([ba6a8b8](https://github.com/Sage/carbon/commit/ba6a8b846e100df6d5dc47e6d024254a0cc24543))
+- **configurable-items:** deprecate configurable items and pattern ([c0c1ed5](https://github.com/Sage/carbon/commit/c0c1ed5de8d56752e5d2465d46983b74d4e126b0))
+- **drag-and-drop:** deprecate drag-and-drop ([ba6a8b8](https://github.com/Sage/carbon/commit/ba6a8b846e100df6d5dc47e6d024254a0cc24543))
 
 ### [93.0.4](https://github.com/Sage/carbon/compare/v93.0.3...v93.0.4) (2021-10-12)
 
-
 ### Bug Fixes
 
-* publish to npm ([feae4e3](https://github.com/Sage/carbon/commit/feae4e3e570dd6ae59a74ed9ef3bf6635877810c))
+- publish to npm ([feae4e3](https://github.com/Sage/carbon/commit/feae4e3e570dd6ae59a74ed9ef3bf6635877810c))
 
 ### [93.0.3](https://github.com/Sage/carbon/compare/v93.0.2...v93.0.3) (2021-10-11)
 
-
 ### Bug Fixes
 
-* **dialog:** correct title prop type ([0ce39e1](https://github.com/Sage/carbon/commit/0ce39e1735d7cf9968f930cafb2f84a2a5137fa6)), closes [#4449](https://github.com/Sage/carbon/issues/4449)
-* **dialog-full-screen:** correct title prop type ([50e1716](https://github.com/Sage/carbon/commit/50e17166d679523e9e5faf847c700f732c869a00))
-* **heading:** correct title and subheader prop types ([d6c9f8a](https://github.com/Sage/carbon/commit/d6c9f8af25c4d67bf8b6f02c46ec79fa5cd5a608))
-* **page:** correct title and children prop types ([6a511c1](https://github.com/Sage/carbon/commit/6a511c15f83c1b998d4a866d054bf4ea3e6ba006))
-* **pages:** correct children prop type ([15cadcc](https://github.com/Sage/carbon/commit/15cadcc20c0b9903b2ed02c92c8625ac0d4a4871))
-* **tabs:** correct children prop type ([9be9e66](https://github.com/Sage/carbon/commit/9be9e66f94bfbcab90c4cb677d00bd7757024e3b))
+- **dialog:** correct title prop type ([0ce39e1](https://github.com/Sage/carbon/commit/0ce39e1735d7cf9968f930cafb2f84a2a5137fa6)), closes [#4449](https://github.com/Sage/carbon/issues/4449)
+- **dialog-full-screen:** correct title prop type ([50e1716](https://github.com/Sage/carbon/commit/50e17166d679523e9e5faf847c700f732c869a00))
+- **heading:** correct title and subheader prop types ([d6c9f8a](https://github.com/Sage/carbon/commit/d6c9f8af25c4d67bf8b6f02c46ec79fa5cd5a608))
+- **page:** correct title and children prop types ([6a511c1](https://github.com/Sage/carbon/commit/6a511c15f83c1b998d4a866d054bf4ea3e6ba006))
+- **pages:** correct children prop type ([15cadcc](https://github.com/Sage/carbon/commit/15cadcc20c0b9903b2ed02c92c8625ac0d4a4871))
+- **tabs:** correct children prop type ([9be9e66](https://github.com/Sage/carbon/commit/9be9e66f94bfbcab90c4cb677d00bd7757024e3b))
 
 ### [93.0.2](https://github.com/Sage/carbon/compare/v93.0.1...v93.0.2) (2021-10-07)
 
-
 ### Bug Fixes
 
-* **duelling-picklist:** correct dom structure of picklist groups ([f73d26f](https://github.com/Sage/carbon/commit/f73d26fe4153a0acd8646be1e1b8bac4e57c10d5)), closes [#4340](https://github.com/Sage/carbon/issues/4340)
+- **duelling-picklist:** correct dom structure of picklist groups ([f73d26f](https://github.com/Sage/carbon/commit/f73d26fe4153a0acd8646be1e1b8bac4e57c10d5)), closes [#4340](https://github.com/Sage/carbon/issues/4340)
 
 ### [93.0.1](https://github.com/Sage/carbon/compare/v93.0.0...v93.0.1) (2021-10-07)
 
-
 ### Bug Fixes
 
-* **accordion:** fix group documentation example ([31b9e27](https://github.com/Sage/carbon/commit/31b9e27fbef95bb36a1729e62a556069d95c9973))
+- **accordion:** fix group documentation example ([31b9e27](https://github.com/Sage/carbon/commit/31b9e27fbef95bb36a1729e62a556069d95c9973))
 
 ## [93.0.0](https://github.com/Sage/carbon/compare/v92.0.0...v93.0.0) (2021-10-07)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **utils:** guid helper is now an internal util
-and should not be used outside of Carbon
-* **utils:** tags helper is now an internal util
-and should not be used outside of Carbon
-* **utils:** events helper is now an internal util
-and should not be used outside of Carbon
-* **utils:** filter-object-properties helper is now an internal util
-and should not be used outside of Carbon
-* **utils:** with-unique-id-props helper is now an internal util
-and should not be used outside of Carbon
-* **utils:** date helper is now an internal util
-and should not be used outside of Carbon
-* **utils:** extract-props helper is now an internal util
-and should not be used outside of Carbon
-* **utils:** immutable helper is now an internal util
-and should not be used outside of Carbon
-* **utils:** validations helper has been removed
-* **utils:** serialize helper is now an internal util
-and should not be used outside of Carbon
-* **utils:** dnd helpers are now internal utils
-and should not be used outside of Carbon
-* **utils:** text helper has been removed
-* **utils:** scrollable-parent helper has been changed
-to be draggable-context internal util and should not be used outside of Carbon
-* **utils:** to-array helper has been removed
-* **utils:** poller helper has been removed
-* **utils:** prop-types helper has been removed
-* **utils:** chainFunctions helper has been removed
-* **utils:** browser-type-check helper is now an internal util
-and should not be used outside of Carbon
-* **utils:** browser helper is now an internal util
-and should not be used outside of Carbon
-* **utils:** ether util is now an internal util
-and should not be used outside of Carbon
-* **utils:** base-registry util has been removed
-* **utils:** logger util is now an internal util
-and should not be used outside of Carbon
-* **utils:** service util has been removed
-* **utils:** should-component-update util has been removed
+- **utils:** guid helper is now an internal util
+  and should not be used outside of Carbon
+- **utils:** tags helper is now an internal util
+  and should not be used outside of Carbon
+- **utils:** events helper is now an internal util
+  and should not be used outside of Carbon
+- **utils:** filter-object-properties helper is now an internal util
+  and should not be used outside of Carbon
+- **utils:** with-unique-id-props helper is now an internal util
+  and should not be used outside of Carbon
+- **utils:** date helper is now an internal util
+  and should not be used outside of Carbon
+- **utils:** extract-props helper is now an internal util
+  and should not be used outside of Carbon
+- **utils:** immutable helper is now an internal util
+  and should not be used outside of Carbon
+- **utils:** validations helper has been removed
+- **utils:** serialize helper is now an internal util
+  and should not be used outside of Carbon
+- **utils:** dnd helpers are now internal utils
+  and should not be used outside of Carbon
+- **utils:** text helper has been removed
+- **utils:** scrollable-parent helper has been changed
+  to be draggable-context internal util and should not be used outside of Carbon
+- **utils:** to-array helper has been removed
+- **utils:** poller helper has been removed
+- **utils:** prop-types helper has been removed
+- **utils:** chainFunctions helper has been removed
+- **utils:** browser-type-check helper is now an internal util
+  and should not be used outside of Carbon
+- **utils:** browser helper is now an internal util
+  and should not be used outside of Carbon
+- **utils:** ether util is now an internal util
+  and should not be used outside of Carbon
+- **utils:** base-registry util has been removed
+- **utils:** logger util is now an internal util
+  and should not be used outside of Carbon
+- **utils:** service util has been removed
+- **utils:** should-component-update util has been removed
 
 ### Code Refactoring
 
-* **utils:** change scrollable-parent helper to be internal ([b4b22df](https://github.com/Sage/carbon/commit/b4b22df6426eb7eab62b3decea8fac83b7d25ba1))
-* **utils:** move browser helper to the internal folder ([68c49b4](https://github.com/Sage/carbon/commit/68c49b49c1c3e0095365cbd7b6002a5a25886d9d))
-* **utils:** move browser-type-check helper to the internal folder ([30ce4fe](https://github.com/Sage/carbon/commit/30ce4fead7f79cd315ea918b2e0efd009b68dd1e))
-* **utils:** move date helper to the internal folder ([53ed827](https://github.com/Sage/carbon/commit/53ed8272794df4adeabc851142530c4380c8f58f))
-* **utils:** move dnd helpers to drag-and-drop internal folder ([266d307](https://github.com/Sage/carbon/commit/266d3075e8d8fe44cabc3cb98067516db073baff))
-* **utils:** move ether utils to the internal folder ([6b0ed28](https://github.com/Sage/carbon/commit/6b0ed284e848d22156bf84ef33cd43e706b5b169))
-* **utils:** move events helper to the internal folder ([d58f85c](https://github.com/Sage/carbon/commit/d58f85c9fbec1d8a9b1ba492ed784262c690cce0))
-* **utils:** move extract-props helper to the internal folder ([f26b9a4](https://github.com/Sage/carbon/commit/f26b9a46f40695419894e819e9139233070b54ff))
-* **utils:** move filter-object-properties helper to the internal folder ([f892094](https://github.com/Sage/carbon/commit/f892094d2b50f758f6fb5088a8816ee9590d5258))
-* **utils:** move guid helper to the internal folder ([7ce9a97](https://github.com/Sage/carbon/commit/7ce9a97372f74a891847fd44c5c426d4c78da599))
-* **utils:** move immutable helper to the internal folder ([90b86e0](https://github.com/Sage/carbon/commit/90b86e0e5715e22fb1b0c68179d103c674413afd))
-* **utils:** move logger util to the internal folder ([52e83f2](https://github.com/Sage/carbon/commit/52e83f20e56c50c5b570a5374ffa71b0789e77d1))
-* **utils:** move serialize helper to table-ajax component internal folder ([8a2e417](https://github.com/Sage/carbon/commit/8a2e41740a92386afc7bdf9c79e83855a0fa5ac3))
-* **utils:** move tags helper to the internal folder ([d94195b](https://github.com/Sage/carbon/commit/d94195bb29b9465915e4ffb7efad753d49d9fab6))
-* **utils:** move with-unique-id-props helper to the internal folder ([b1e13d3](https://github.com/Sage/carbon/commit/b1e13d3d800e395950d88ff01d1818d753c09117))
-* **utils:** remove base-registry util ([aa77ebe](https://github.com/Sage/carbon/commit/aa77ebe06fa89e059c2788d6cf63a6b959d36d61))
-* **utils:** remove chainFunctions helper ([907021d](https://github.com/Sage/carbon/commit/907021dc72b0b62ca6093611b8c362b472af1ab4))
-* **utils:** remove poller helper ([757a68b](https://github.com/Sage/carbon/commit/757a68b39dd403db6090c1db56af512705ec465a))
-* **utils:** remove prop-types helper ([42bd890](https://github.com/Sage/carbon/commit/42bd89085676f2e4d68c987b4adf501dd11b86a6))
-* **utils:** remove service util ([d33590e](https://github.com/Sage/carbon/commit/d33590e6733b1ba0cc06a2db7f61ccb113486b55))
-* **utils:** remove should-component-update util ([1e68f98](https://github.com/Sage/carbon/commit/1e68f98dca6ef85fbf0be14cb657e05a27f71cbd))
-* **utils:** remove text helper ([e2cb375](https://github.com/Sage/carbon/commit/e2cb375cac335223cde3e3b37ece6ca4a3ca7a82))
-* **utils:** remove to-array helper ([e6d6099](https://github.com/Sage/carbon/commit/e6d609975945f23fbfd2afc5fea3e4dd82844a17))
-* **utils:** remove validations helper ([f03086a](https://github.com/Sage/carbon/commit/f03086aea20ad17f6964394f74fd2a3868203cd7))
+- **utils:** change scrollable-parent helper to be internal ([b4b22df](https://github.com/Sage/carbon/commit/b4b22df6426eb7eab62b3decea8fac83b7d25ba1))
+- **utils:** move browser helper to the internal folder ([68c49b4](https://github.com/Sage/carbon/commit/68c49b49c1c3e0095365cbd7b6002a5a25886d9d))
+- **utils:** move browser-type-check helper to the internal folder ([30ce4fe](https://github.com/Sage/carbon/commit/30ce4fead7f79cd315ea918b2e0efd009b68dd1e))
+- **utils:** move date helper to the internal folder ([53ed827](https://github.com/Sage/carbon/commit/53ed8272794df4adeabc851142530c4380c8f58f))
+- **utils:** move dnd helpers to drag-and-drop internal folder ([266d307](https://github.com/Sage/carbon/commit/266d3075e8d8fe44cabc3cb98067516db073baff))
+- **utils:** move ether utils to the internal folder ([6b0ed28](https://github.com/Sage/carbon/commit/6b0ed284e848d22156bf84ef33cd43e706b5b169))
+- **utils:** move events helper to the internal folder ([d58f85c](https://github.com/Sage/carbon/commit/d58f85c9fbec1d8a9b1ba492ed784262c690cce0))
+- **utils:** move extract-props helper to the internal folder ([f26b9a4](https://github.com/Sage/carbon/commit/f26b9a46f40695419894e819e9139233070b54ff))
+- **utils:** move filter-object-properties helper to the internal folder ([f892094](https://github.com/Sage/carbon/commit/f892094d2b50f758f6fb5088a8816ee9590d5258))
+- **utils:** move guid helper to the internal folder ([7ce9a97](https://github.com/Sage/carbon/commit/7ce9a97372f74a891847fd44c5c426d4c78da599))
+- **utils:** move immutable helper to the internal folder ([90b86e0](https://github.com/Sage/carbon/commit/90b86e0e5715e22fb1b0c68179d103c674413afd))
+- **utils:** move logger util to the internal folder ([52e83f2](https://github.com/Sage/carbon/commit/52e83f20e56c50c5b570a5374ffa71b0789e77d1))
+- **utils:** move serialize helper to table-ajax component internal folder ([8a2e417](https://github.com/Sage/carbon/commit/8a2e41740a92386afc7bdf9c79e83855a0fa5ac3))
+- **utils:** move tags helper to the internal folder ([d94195b](https://github.com/Sage/carbon/commit/d94195bb29b9465915e4ffb7efad753d49d9fab6))
+- **utils:** move with-unique-id-props helper to the internal folder ([b1e13d3](https://github.com/Sage/carbon/commit/b1e13d3d800e395950d88ff01d1818d753c09117))
+- **utils:** remove base-registry util ([aa77ebe](https://github.com/Sage/carbon/commit/aa77ebe06fa89e059c2788d6cf63a6b959d36d61))
+- **utils:** remove chainFunctions helper ([907021d](https://github.com/Sage/carbon/commit/907021dc72b0b62ca6093611b8c362b472af1ab4))
+- **utils:** remove poller helper ([757a68b](https://github.com/Sage/carbon/commit/757a68b39dd403db6090c1db56af512705ec465a))
+- **utils:** remove prop-types helper ([42bd890](https://github.com/Sage/carbon/commit/42bd89085676f2e4d68c987b4adf501dd11b86a6))
+- **utils:** remove service util ([d33590e](https://github.com/Sage/carbon/commit/d33590e6733b1ba0cc06a2db7f61ccb113486b55))
+- **utils:** remove should-component-update util ([1e68f98](https://github.com/Sage/carbon/commit/1e68f98dca6ef85fbf0be14cb657e05a27f71cbd))
+- **utils:** remove text helper ([e2cb375](https://github.com/Sage/carbon/commit/e2cb375cac335223cde3e3b37ece6ca4a3ca7a82))
+- **utils:** remove to-array helper ([e6d6099](https://github.com/Sage/carbon/commit/e6d609975945f23fbfd2afc5fea3e4dd82844a17))
+- **utils:** remove validations helper ([f03086a](https://github.com/Sage/carbon/commit/f03086aea20ad17f6964394f74fd2a3868203cd7))
 
 ## [92.0.0](https://github.com/Sage/carbon/compare/v91.2.1...v92.0.0) (2021-10-05)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **form:** Sticky footers on Form will no longer disappear on
-scrolling to the bottom of the form.
+- **form:** Sticky footers on Form will no longer disappear on
+  scrolling to the bottom of the form.
 
 The height prop on Form can be used to set the size of a Form
 with a sticky footer, particularly within a Dialog
 
 ### Features
 
-* **form:** add height prop ([3ca7369](https://github.com/Sage/carbon/commit/3ca736973cfb586a92401b25a9d34604879d293d))
-
+- **form:** add height prop ([3ca7369](https://github.com/Sage/carbon/commit/3ca736973cfb586a92401b25a9d34604879d293d))
 
 ### Bug Fixes
 
-* **form:** rewrite sticky footer ([e07b956](https://github.com/Sage/carbon/commit/e07b95682d4221e4121fe3fdaff6e6da34781d29))
+- **form:** rewrite sticky footer ([e07b956](https://github.com/Sage/carbon/commit/e07b95682d4221e4121fe3fdaff6e6da34781d29))
 
 ### [91.2.1](https://github.com/Sage/carbon/compare/v91.2.0...v91.2.1) (2021-10-04)
 
-
 ### Bug Fixes
 
-* **icon:** add missing sage_coin to type definition ([7e68f70](https://github.com/Sage/carbon/commit/7e68f70a711773de8fca2ad1dcfd21a05fda3102))
+- **icon:** add missing sage_coin to type definition ([7e68f70](https://github.com/Sage/carbon/commit/7e68f70a711773de8fca2ad1dcfd21a05fda3102))
 
 ## [91.2.0](https://github.com/Sage/carbon/compare/v91.1.1...v91.2.0) (2021-10-04)
 
-
 ### Features
 
-* **storybook:** add locale switcher ([38ed6f5](https://github.com/Sage/carbon/commit/38ed6f5db2e83aa4bfbf2933799e7f4dc4c31498))
+- **storybook:** add locale switcher ([38ed6f5](https://github.com/Sage/carbon/commit/38ed6f5db2e83aa4bfbf2933799e7f4dc4c31498))
 
 ### [91.1.1](https://github.com/Sage/carbon/compare/v91.1.0...v91.1.1) (2021-10-01)
 
-
 ### Bug Fixes
 
-* **pager:** resolve typing for pageSizeSelectionOptions to be an array of objects ([e92d9bb](https://github.com/Sage/carbon/commit/e92d9bb59b9bfcb7bb7fb644aff84ea76584ed4a))
+- **pager:** resolve typing for pageSizeSelectionOptions to be an array of objects ([e92d9bb](https://github.com/Sage/carbon/commit/e92d9bb59b9bfcb7bb7fb644aff84ea76584ed4a))
 
 ## [91.1.0](https://github.com/Sage/carbon/compare/v91.0.2...v91.1.0) (2021-10-01)
 
-
 ### Features
 
-* **simple-select:** add prop to specify the open direction of a select list ([cf2c928](https://github.com/Sage/carbon/commit/cf2c928cc123a5c8bb0ebae8fc62b274d56246b7))
+- **simple-select:** add prop to specify the open direction of a select list ([cf2c928](https://github.com/Sage/carbon/commit/cf2c928cc123a5c8bb0ebae8fc62b274d56246b7))
 
 ### [91.0.2](https://github.com/Sage/carbon/compare/v91.0.1...v91.0.2) (2021-09-28)
 
-
 ### Bug Fixes
 
-* **menu:** remove menubar and menuitem roles ([b2f6f0d](https://github.com/Sage/carbon/commit/b2f6f0dba1e089a2ccd9a0d1aa9daad941152410)), closes [#4394](https://github.com/Sage/carbon/issues/4394)
+- **menu:** remove menubar and menuitem roles ([b2f6f0d](https://github.com/Sage/carbon/commit/b2f6f0dba1e089a2ccd9a0d1aa9daad941152410)), closes [#4394](https://github.com/Sage/carbon/issues/4394)
 
 ### [91.0.1](https://github.com/Sage/carbon/compare/v91.0.0...v91.0.1) (2021-09-27)
 
-
 ### Bug Fixes
 
-* **i18n-provider:** fix type definition ([73b485f](https://github.com/Sage/carbon/commit/73b485f4d718d80387216cf94497fff4b7936a35))
+- **i18n-provider:** fix type definition ([73b485f](https://github.com/Sage/carbon/commit/73b485f4d718d80387216cf94497fff4b7936a35))
 
 ## [91.0.0](https://github.com/Sage/carbon/compare/v90.0.2...v91.0.0) (2021-09-24)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **split-button:** SplitButton is now a functional component and cannot be extended
+- **split-button:** SplitButton is now a functional component and cannot be extended
 
 ### Code Refactoring
 
-* **split-button:** rewrite class component to functional ([c459149](https://github.com/Sage/carbon/commit/c45914901baf38eeeaa72f801664fe95da45c75c))
+- **split-button:** rewrite class component to functional ([c459149](https://github.com/Sage/carbon/commit/c45914901baf38eeeaa72f801664fe95da45c75c))
 
 ### [90.0.2](https://github.com/Sage/carbon/compare/v90.0.1...v90.0.2) (2021-09-24)
 
-
 ### Bug Fixes
 
-* **simple-select:** change the test story format from mdx to js ([ef617d3](https://github.com/Sage/carbon/commit/ef617d366f41529b05d1766357fb8f222ebd4f4f))
+- **simple-select:** change the test story format from mdx to js ([ef617d3](https://github.com/Sage/carbon/commit/ef617d366f41529b05d1766357fb8f222ebd4f4f))
 
 ### [90.0.1](https://github.com/Sage/carbon/compare/v90.0.0...v90.0.1) (2021-09-24)
 
-
 ### Bug Fixes
 
-* **vertical-divider:** change tint type to number ([bbe5556](https://github.com/Sage/carbon/commit/bbe55562f0b664867934f56fb344d413c84a2621)), closes [#4422](https://github.com/Sage/carbon/issues/4422)
+- **vertical-divider:** change tint type to number ([bbe5556](https://github.com/Sage/carbon/commit/bbe55562f0b664867934f56fb344d413c84a2621)), closes [#4422](https://github.com/Sage/carbon/issues/4422)
 
 ## [90.0.0](https://github.com/Sage/carbon/compare/v89.3.0...v90.0.0) (2021-09-24)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **inputs:** Props not declared in propTypes (including className) are no longer
-being spread on the root element in following components:
-ButtonToggleGroup, Checkbox, Date, Decimal,
-GroupedCharacter, Number, RadioButton, Select, MultiSelect,
-FilterableSelect, Switch, Textarea, Textbox.
+- **inputs:** Props not declared in propTypes (including className) are no longer
+  being spread on the root element in following components:
+  ButtonToggleGroup, Checkbox, Date, Decimal,
+  GroupedCharacter, Number, RadioButton, Select, MultiSelect,
+  FilterableSelect, Switch, Textarea, Textbox.
 
 Furthermore in all these components apart from the ButtonToggleGroup
 all not declared props will be passed to the underlying HTML input
@@ -6383,467 +5575,413 @@ element
 
 ### Code Refactoring
 
-* **inputs:** change the way props are spread internally ([1cc93ec](https://github.com/Sage/carbon/commit/1cc93ec3e81acf5f8c44834d327587daaca46ae5))
+- **inputs:** change the way props are spread internally ([1cc93ec](https://github.com/Sage/carbon/commit/1cc93ec3e81acf5f8c44834d327587daaca46ae5))
 
 ## [89.3.0](https://github.com/Sage/carbon/compare/v89.2.0...v89.3.0) (2021-09-23)
 
-
 ### Features
 
-* **content:** change a string type of the title prop to a node type ([b096825](https://github.com/Sage/carbon/commit/b0968256b02e9cc588a0e0d32e627f0ea9b49b43))
+- **content:** change a string type of the title prop to a node type ([b096825](https://github.com/Sage/carbon/commit/b0968256b02e9cc588a0e0d32e627f0ea9b49b43))
 
 ## [89.2.0](https://github.com/Sage/carbon/compare/v89.1.0...v89.2.0) (2021-09-23)
 
-
 ### Features
 
-* **i18n:** add types for the base locale file ([47964d5](https://github.com/Sage/carbon/commit/47964d52ce00e0f525c9a0877e01d9c0f97b409d))
+- **i18n:** add types for the base locale file ([47964d5](https://github.com/Sage/carbon/commit/47964d52ce00e0f525c9a0877e01d9c0f97b409d))
 
 ## [89.1.0](https://github.com/Sage/carbon/compare/v89.0.0...v89.1.0) (2021-09-23)
 
-
 ### Features
 
-* **tile-select:** add support for rendering accordion footer ([0dd1f32](https://github.com/Sage/carbon/commit/0dd1f326d19ab3f213df3eaf15781aef88677924))
+- **tile-select:** add support for rendering accordion footer ([0dd1f32](https://github.com/Sage/carbon/commit/0dd1f326d19ab3f213df3eaf15781aef88677924))
 
 ## [89.0.0](https://github.com/Sage/carbon/compare/v88.0.0...v89.0.0) (2021-09-22)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **pod-manager:** deprecated pod-manager component has been removed
-* **pod:** Pod is now a functional component and cannot be extended
+- **pod-manager:** deprecated pod-manager component has been removed
+- **pod:** Pod is now a functional component and cannot be extended
 
 ### Code Refactoring
 
-* **pod:** rewrite class component to functional ([fc65a0f](https://github.com/Sage/carbon/commit/fc65a0f37c77d7815a1cb5ce95d0153240dc5785))
-* **pod-manager:** remove deprecated pod-manager component ([997d734](https://github.com/Sage/carbon/commit/997d7346aea263831bafcaae30136a2a7c5e5ef1))
+- **pod:** rewrite class component to functional ([fc65a0f](https://github.com/Sage/carbon/commit/fc65a0f37c77d7815a1cb5ce95d0153240dc5785))
+- **pod-manager:** remove deprecated pod-manager component ([997d734](https://github.com/Sage/carbon/commit/997d7346aea263831bafcaae30136a2a7c5e5ef1))
 
 ## [88.0.0](https://github.com/Sage/carbon/compare/v87.5.0...v88.0.0) (2021-09-22)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **profile:** Profile is now a functional component and cannot be extended
+- **profile:** Profile is now a functional component and cannot be extended
 
 ### Code Refactoring
 
-* **profile:** convert from class to functional component ([2a704f7](https://github.com/Sage/carbon/commit/2a704f715bd821b8daa9585237533d0d8e3293a4))
+- **profile:** convert from class to functional component ([2a704f7](https://github.com/Sage/carbon/commit/2a704f715bd821b8daa9585237533d0d8e3293a4))
 
 ## [87.5.0](https://github.com/Sage/carbon/compare/v87.4.0...v87.5.0) (2021-09-21)
 
-
 ### Features
 
-* **tile-select:** surface new additonalInformation prop ([fa21724](https://github.com/Sage/carbon/commit/fa217241427360d78d9248a434a16bdb09e7367f))
+- **tile-select:** surface new additonalInformation prop ([fa21724](https://github.com/Sage/carbon/commit/fa217241427360d78d9248a434a16bdb09e7367f))
 
 ## [87.4.0](https://github.com/Sage/carbon/compare/v87.3.0...v87.4.0) (2021-09-20)
 
-
 ### Features
 
-* **navigation-bar:** add sticky position ([1b298fe](https://github.com/Sage/carbon/commit/1b298fefe9dbcc696fa66a71c843a052a65cd258))
+- **navigation-bar:** add sticky position ([1b298fe](https://github.com/Sage/carbon/commit/1b298fefe9dbcc696fa66a71c843a052a65cd258))
 
 ## [87.3.0](https://github.com/Sage/carbon/compare/v87.2.0...v87.3.0) (2021-09-20)
 
-
 ### Features
 
-* **flat-table:** add drag and drop functionality to table rows ([20671e4](https://github.com/Sage/carbon/commit/20671e43a0a8c5861503f4cca3202aa9fd07af3c))
+- **flat-table:** add drag and drop functionality to table rows ([20671e4](https://github.com/Sage/carbon/commit/20671e43a0a8c5861503f4cca3202aa9fd07af3c))
 
 ## [87.2.0](https://github.com/Sage/carbon/compare/v87.1.0...v87.2.0) (2021-09-17)
 
-
 ### Features
 
-* **textbox:** add a character counter ([bffdf35](https://github.com/Sage/carbon/commit/bffdf3598a0ad86499fb3f6af8c7e1f2ba30c635))
+- **textbox:** add a character counter ([bffdf35](https://github.com/Sage/carbon/commit/bffdf3598a0ad86499fb3f6af8c7e1f2ba30c635))
 
 ## [87.1.0](https://github.com/Sage/carbon/compare/v87.0.1...v87.1.0) (2021-09-17)
 
-
 ### Features
 
-* **menu-item:** add callbacks for submenu toggle ([2507335](https://github.com/Sage/carbon/commit/2507335f816e5b9f63677abb8ae01907262fcb77)), closes [#4303](https://github.com/Sage/carbon/issues/4303)
+- **menu-item:** add callbacks for submenu toggle ([2507335](https://github.com/Sage/carbon/commit/2507335f816e5b9f63677abb8ae01907262fcb77)), closes [#4303](https://github.com/Sage/carbon/issues/4303)
 
 ### [87.0.1](https://github.com/Sage/carbon/compare/v87.0.0...v87.0.1) (2021-09-16)
 
-
 ### Bug Fixes
 
-* **textbox:** fix incorrect styling when required and in error state ([83794d8](https://github.com/Sage/carbon/commit/83794d8cd62175187ee0a9d86574ad8227fd7c90))
+- **textbox:** fix incorrect styling when required and in error state ([83794d8](https://github.com/Sage/carbon/commit/83794d8cd62175187ee0a9d86574ad8227fd7c90))
 
 ## [87.0.0](https://github.com/Sage/carbon/compare/v86.0.1...v87.0.0) (2021-09-15)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **form-summary:** `errors.messages.formSummary` key returns an array of strings instead of a string
+- **form-summary:** `errors.messages.formSummary` key returns an array of strings instead of a string
 
 ### Code Refactoring
 
-* **form-summary:** change the design of the validation message ([6dc74a9](https://github.com/Sage/carbon/commit/6dc74a9c4777e9131906fb5ba0b33e3e173dd07b))
+- **form-summary:** change the design of the validation message ([6dc74a9](https://github.com/Sage/carbon/commit/6dc74a9c4777e9131906fb5ba0b33e3e173dd07b))
 
 ### [86.0.1](https://github.com/Sage/carbon/compare/v86.0.0...v86.0.1) (2021-09-15)
 
-
 ### Bug Fixes
 
-* **flat-table-head:** ensure table head row children are an array before running find function ([e0b42e8](https://github.com/Sage/carbon/commit/e0b42e805dd92212351dc036645dbe56ab0f0550)), closes [#4378](https://github.com/Sage/carbon/issues/4378)
+- **flat-table-head:** ensure table head row children are an array before running find function ([e0b42e8](https://github.com/Sage/carbon/commit/e0b42e805dd92212351dc036645dbe56ab0f0550)), closes [#4378](https://github.com/Sage/carbon/issues/4378)
 
 ## [86.0.0](https://github.com/Sage/carbon/compare/v85.0.0...v86.0.0) (2021-09-14)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **pages:** Pages is no more class component
+- **pages:** Pages is no more class component
 
 ### Code Refactoring
 
-* **pages:** rewrite to be functional ([accc933](https://github.com/Sage/carbon/commit/accc9334e957df0f80198361c62ad4cc4f921af3))
+- **pages:** rewrite to be functional ([accc933](https://github.com/Sage/carbon/commit/accc9334e957df0f80198361c62ad4cc4f921af3))
 
 ## [85.0.0](https://github.com/Sage/carbon/compare/v84.5.0...v85.0.0) (2021-09-13)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **carousel:** Carousel is now a functional component and cannot be extended
+- **carousel:** Carousel is now a functional component and cannot be extended
 
 ### Code Refactoring
 
-* **carousel:** change class component to functional ([3536d54](https://github.com/Sage/carbon/commit/3536d543d752a6ca4b7bc62d4ffe4377696bf59f))
+- **carousel:** change class component to functional ([3536d54](https://github.com/Sage/carbon/commit/3536d543d752a6ca4b7bc62d4ffe4377696bf59f))
 
 ## [84.5.0](https://github.com/Sage/carbon/compare/v84.4.0...v84.5.0) (2021-09-13)
 
-
 ### Features
 
-* **loader-bar:** create loader-bar ([a5d5f7c](https://github.com/Sage/carbon/commit/a5d5f7c042814426a149e3787c81c9c82f2d4817))
+- **loader-bar:** create loader-bar ([a5d5f7c](https://github.com/Sage/carbon/commit/a5d5f7c042814426a149e3787c81c9c82f2d4817))
 
 ## [84.4.0](https://github.com/Sage/carbon/compare/v84.3.0...v84.4.0) (2021-09-09)
 
-
 ### Features
 
-* **link:** render an anchor element whenever a href prop is passed ([18e6471](https://github.com/Sage/carbon/commit/18e64719fd2f736e32c878b9b5611a630dac4fb6))
+- **link:** render an anchor element whenever a href prop is passed ([18e6471](https://github.com/Sage/carbon/commit/18e64719fd2f736e32c878b9b5611a630dac4fb6))
 
 ## [84.3.0](https://github.com/Sage/carbon/compare/v84.2.1...v84.3.0) (2021-09-09)
 
-
 ### Features
 
-* **inline-inputs:** add labelWidth and inputWidth props ([d7412b2](https://github.com/Sage/carbon/commit/d7412b253ea784d7fbb2cd8ff83a7eff041943e2))
-
+- **inline-inputs:** add labelWidth and inputWidth props ([d7412b2](https://github.com/Sage/carbon/commit/d7412b253ea784d7fbb2cd8ff83a7eff041943e2))
 
 ### Bug Fixes
 
-* **inline-inputs:** center label position when in form ([cafc9e4](https://github.com/Sage/carbon/commit/cafc9e45eae860935056b4b733e6d886e6b73c76))
+- **inline-inputs:** center label position when in form ([cafc9e4](https://github.com/Sage/carbon/commit/cafc9e45eae860935056b4b733e6d886e6b73c76))
 
 ### [84.2.1](https://github.com/Sage/carbon/compare/v84.2.0...v84.2.1) (2021-09-08)
 
-
 ### Bug Fixes
 
-* **pager:** update show select value when page size prop is changed ([41e4a5e](https://github.com/Sage/carbon/commit/41e4a5e5e6f8622d3ca09f5037907242c6d0bc50))
+- **pager:** update show select value when page size prop is changed ([41e4a5e](https://github.com/Sage/carbon/commit/41e4a5e5e6f8622d3ca09f5037907242c6d0bc50))
 
 ## [84.2.0](https://github.com/Sage/carbon/compare/v84.1.0...v84.2.0) (2021-09-07)
 
-
 ### Features
 
-* **button-bar:** create button-bar component ([cf7aa18](https://github.com/Sage/carbon/commit/cf7aa18fff616fe1a7adc77dfc8b6ad29f2e4de6))
+- **button-bar:** create button-bar component ([cf7aa18](https://github.com/Sage/carbon/commit/cf7aa18fff616fe1a7adc77dfc8b6ad29f2e4de6))
 
 ## [84.1.0](https://github.com/Sage/carbon/compare/v84.0.2...v84.1.0) (2021-09-03)
 
-
 ### Features
 
-* **tile-select:** add support for rendering prefixAdornment ([16afad0](https://github.com/Sage/carbon/commit/16afad0dca0f2dd7a1b914082ad80e42f3683082))
-
+- **tile-select:** add support for rendering prefixAdornment ([16afad0](https://github.com/Sage/carbon/commit/16afad0dca0f2dd7a1b914082ad80e42f3683082))
 
 ### Bug Fixes
 
-* **tile-select:** ensure title, subtitle and adornment wrap at smaller screen resolution ([c3af2cb](https://github.com/Sage/carbon/commit/c3af2cbdad4649b4a93171c1928af7b2e95e8f9d)), closes [#4219](https://github.com/Sage/carbon/issues/4219)
+- **tile-select:** ensure title, subtitle and adornment wrap at smaller screen resolution ([c3af2cb](https://github.com/Sage/carbon/commit/c3af2cbdad4649b4a93171c1928af7b2e95e8f9d)), closes [#4219](https://github.com/Sage/carbon/issues/4219)
 
 ### [84.0.2](https://github.com/Sage/carbon/compare/v84.0.1...v84.0.2) (2021-09-03)
 
-
 ### Bug Fixes
 
-* **sidebar:** add a type of children in interface, update the position and the size prop types ([56e6841](https://github.com/Sage/carbon/commit/56e6841828d013586f49d7f7022e496a68e58b14))
+- **sidebar:** add a type of children in interface, update the position and the size prop types ([56e6841](https://github.com/Sage/carbon/commit/56e6841828d013586f49d7f7022e496a68e58b14))
 
 ### [84.0.1](https://github.com/Sage/carbon/compare/v84.0.0...v84.0.1) (2021-09-02)
 
-
 ### Bug Fixes
 
-* **tile:** address spelling mistake with horizontal in the options for orientation prop ([e03b41a](https://github.com/Sage/carbon/commit/e03b41ad9a49592ce56515fbc32b1fe51938aa57))
+- **tile:** address spelling mistake with horizontal in the options for orientation prop ([e03b41a](https://github.com/Sage/carbon/commit/e03b41ad9a49592ce56515fbc32b1fe51938aa57))
 
 ## [84.0.0](https://github.com/Sage/carbon/compare/v83.2.0...v84.0.0) (2021-09-02)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **help:** aria-label and value are no longer rendered based on children
-There is a codemod available to assist with this upgrade:
-npx carbon-codemod add-prop src carbon-react/lib/components/help aria-label <value>
-See https://github.com/Sage/carbon-codemod for more information.
+- **help:** aria-label and value are no longer rendered based on children
+  There is a codemod available to assist with this upgrade:
+  npx carbon-codemod add-prop src carbon-react/lib/components/help aria-label <value>
+  See <https://github.com/Sage/carbon-codemod> for more information.
 
 ### Features
 
-* **help:** change the children proptype from string to node ([dad2b7f](https://github.com/Sage/carbon/commit/dad2b7f3b44fe3a1de4efe13d78ed774a4fd31fa))
-* **icon:** change the tooltip message proptype from string to node ([5b1a8e4](https://github.com/Sage/carbon/commit/5b1a8e42433dc1463fe84a59e0e5c8c8b3d7a6dd))
-
+- **help:** change the children proptype from string to node ([dad2b7f](https://github.com/Sage/carbon/commit/dad2b7f3b44fe3a1de4efe13d78ed774a4fd31fa))
+- **icon:** change the tooltip message proptype from string to node ([5b1a8e4](https://github.com/Sage/carbon/commit/5b1a8e42433dc1463fe84a59e0e5c8c8b3d7a6dd))
 
 ### Bug Fixes
 
-* **link:** import the proper link component and the styled link ([b03de73](https://github.com/Sage/carbon/commit/b03de735769f7b8bad8b12b99087ee1d3c2016be))
+- **link:** import the proper link component and the styled link ([b03de73](https://github.com/Sage/carbon/commit/b03de735769f7b8bad8b12b99087ee1d3c2016be))
 
 ## [83.2.0](https://github.com/Sage/carbon/compare/v83.1.0...v83.2.0) (2021-09-02)
 
-
 ### Features
 
-* **definition-list:** add support for rendering component as single column ([61e03d5](https://github.com/Sage/carbon/commit/61e03d5286cacfe58685336734e72b09b7df8529))
+- **definition-list:** add support for rendering component as single column ([61e03d5](https://github.com/Sage/carbon/commit/61e03d5286cacfe58685336734e72b09b7df8529))
 
 ## [83.1.0](https://github.com/Sage/carbon/compare/v83.0.3...v83.1.0) (2021-09-01)
 
-
 ### Features
 
-* **button:** make icon only buttons squares ([dad293b](https://github.com/Sage/carbon/commit/dad293bf731289ce9b0635ddc4e4959e7e5cf3f3))
+- **button:** make icon only buttons squares ([dad293b](https://github.com/Sage/carbon/commit/dad293bf731289ce9b0635ddc4e4959e7e5cf3f3))
 
 ### [83.0.3](https://github.com/Sage/carbon/compare/v83.0.2...v83.0.3) (2021-08-31)
 
-
 ### Bug Fixes
 
-* **toast:** stop blocking interactions with other elements ([84fd647](https://github.com/Sage/carbon/commit/84fd64756d245d06fa0b241bcafabfc85df0c223))
+- **toast:** stop blocking interactions with other elements ([84fd647](https://github.com/Sage/carbon/commit/84fd64756d245d06fa0b241bcafabfc85df0c223))
 
 ### [83.0.2](https://github.com/Sage/carbon/compare/v83.0.1...v83.0.2) (2021-08-30)
 
-
 ### Bug Fixes
 
-* **select:** stop form submit when enter key is pressed with open list ([4351789](https://github.com/Sage/carbon/commit/4351789c9db826af5c235069e845b0c99971fe3a))
+- **select:** stop form submit when enter key is pressed with open list ([4351789](https://github.com/Sage/carbon/commit/4351789c9db826af5c235069e845b0c99971fe3a))
 
 ### [83.0.1](https://github.com/Sage/carbon/compare/v83.0.0...v83.0.1) (2021-08-30)
 
-
 ### Bug Fixes
 
-* **pod:** add missing height prop type definition ([ec6d3ca](https://github.com/Sage/carbon/commit/ec6d3ca1128b79135d2f7fea70043a66ce86f402))
+- **pod:** add missing height prop type definition ([ec6d3ca](https://github.com/Sage/carbon/commit/ec6d3ca1128b79135d2f7fea70043a66ce86f402))
 
 ## [83.0.0](https://github.com/Sage/carbon/compare/v82.1.0...v83.0.0) (2021-08-30)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **pill:** all components that extend the pill component will need to be changed
+- **pill:** all components that extend the pill component will need to be changed
 
 ### Code Refactoring
 
-* **pill:** convert a class component to a function component ([e0302a4](https://github.com/Sage/carbon/commit/e0302a45da527d019b5836f6e78bb29fc04ee178))
+- **pill:** convert a class component to a function component ([e0302a4](https://github.com/Sage/carbon/commit/e0302a45da527d019b5836f6e78bb29fc04ee178))
 
 ## [82.1.0](https://github.com/Sage/carbon/compare/v82.0.1...v82.1.0) (2021-08-30)
 
-
 ### Features
 
-* **icon:** add arrow_left_right_small ([eb8f078](https://github.com/Sage/carbon/commit/eb8f078469945d95f229ab759648a99d765a2f10))
-* **icon:** add circle_with_dots ([c9047d1](https://github.com/Sage/carbon/commit/c9047d16a6848a54306e31c3229184a10c389600))
-* **icon:** add pause ([63c6eaf](https://github.com/Sage/carbon/commit/63c6eafbed10e9bb6d1d1c8e63bb036fccb8a059))
-* **icon:** add squares_nine ([0706c99](https://github.com/Sage/carbon/commit/0706c99abe3b4ea91ff8ad05c9d8bc205b68dfe6))
+- **icon:** add arrow_left_right_small ([eb8f078](https://github.com/Sage/carbon/commit/eb8f078469945d95f229ab759648a99d765a2f10))
+- **icon:** add circle_with_dots ([c9047d1](https://github.com/Sage/carbon/commit/c9047d16a6848a54306e31c3229184a10c389600))
+- **icon:** add pause ([63c6eaf](https://github.com/Sage/carbon/commit/63c6eafbed10e9bb6d1d1c8e63bb036fccb8a059))
+- **icon:** add squares_nine ([0706c99](https://github.com/Sage/carbon/commit/0706c99abe3b4ea91ff8ad05c9d8bc205b68dfe6))
 
 ### [82.0.1](https://github.com/Sage/carbon/compare/v82.0.0...v82.0.1) (2021-08-27)
 
-
 ### Bug Fixes
 
-* **filterable-select:** list not closed on click outside in Safari ([29b49df](https://github.com/Sage/carbon/commit/29b49df58606f56866b72c66a1699ba9d7b7e898))
+- **filterable-select:** list not closed on click outside in Safari ([29b49df](https://github.com/Sage/carbon/commit/29b49df58606f56866b72c66a1699ba9d7b7e898))
 
 ## [82.0.0](https://github.com/Sage/carbon/compare/v81.3.0...v82.0.0) (2021-08-24)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **link:** remove get icon, tabIndex and componentProps functions
+- **link:** remove get icon, tabIndex and componentProps functions
 
 ### Code Refactoring
 
-* **link:** convert a class component to a function component ([44c56e6](https://github.com/Sage/carbon/commit/44c56e6bb6f877c5b2e3ce9165f1fa3fc01a7a90))
+- **link:** convert a class component to a function component ([44c56e6](https://github.com/Sage/carbon/commit/44c56e6bb6f877c5b2e3ce9165f1fa3fc01a7a90))
 
 ## [81.3.0](https://github.com/Sage/carbon/compare/v81.2.2...v81.3.0) (2021-08-23)
 
-
 ### Features
 
-* **checkbox, checkbox-group:** add tooltipPosition prop to the interface ([b000e45](https://github.com/Sage/carbon/commit/b000e4553f9432b5e1db8cef9faf2655b5daf252))
-* **date:** add tooltipPosition prop to interface ([97c41c0](https://github.com/Sage/carbon/commit/97c41c0796159063e671707ecc40027ce9d1a181))
-* **date-range:** add tooltipPosition prop to interface ([68def53](https://github.com/Sage/carbon/commit/68def5369fd0d91d31bd05389be6d11aecbc38fc))
-* **decimal:** add tooltipPosition prop to interface ([3322ec3](https://github.com/Sage/carbon/commit/3322ec317a5a1fcc1676a50355eb5fd6183e99ae))
-* **filterable-select:** add tooltipPosition prop to interface ([327e96b](https://github.com/Sage/carbon/commit/327e96b7c641f10899ce2f0d20420a98e652a0e5))
-* **icon:** component consumes TooltipContext to allow overriding toolitip position ([a7e0841](https://github.com/Sage/carbon/commit/a7e084111a2bcbdf38ff2cb2577da276210e112d))
-* **multi-select:** add tooltipPosition prop to interface ([68f1d91](https://github.com/Sage/carbon/commit/68f1d9190d9b1fc9c52424db53a66c848705c2f3))
-* **numeral-date:** add tooltipPosition prop to interface ([bf5e35d](https://github.com/Sage/carbon/commit/bf5e35d65ad7ab9adbdc86dedf14f18ac503566f))
-* **radio-button, radio-button-group:** add tooltipPosition prop to interface ([7aa0ce1](https://github.com/Sage/carbon/commit/7aa0ce1f75974f6a3a4868b10c158a70b68fcb57))
-* **simple-select:** add tooltipPosition prop to interface ([a7f3e9a](https://github.com/Sage/carbon/commit/a7f3e9a212770b5115c8893ac7689f58b81f5168))
-* **switch:** add tooltipPosition prop to interface ([57e994e](https://github.com/Sage/carbon/commit/57e994ed4cbff10bd983362f7f9032b06d45f37f))
-* **textarea:** add tooltipPosition prop to interface ([016466d](https://github.com/Sage/carbon/commit/016466dc19ab5e5b122139836c1566a1a7754019))
-* **textbox:** integrate TooltipProvider and surface tooltipPosition prop ([c05dd40](https://github.com/Sage/carbon/commit/c05dd40c4bbde571e1ae32e496fac16f59d02441))
-* **tooltip-provider:** add context and provider component ([957f14a](https://github.com/Sage/carbon/commit/957f14af0c246b919d9791684a656eba7be53e73))
+- **checkbox, checkbox-group:** add tooltipPosition prop to the interface ([b000e45](https://github.com/Sage/carbon/commit/b000e4553f9432b5e1db8cef9faf2655b5daf252))
+- **date:** add tooltipPosition prop to interface ([97c41c0](https://github.com/Sage/carbon/commit/97c41c0796159063e671707ecc40027ce9d1a181))
+- **date-range:** add tooltipPosition prop to interface ([68def53](https://github.com/Sage/carbon/commit/68def5369fd0d91d31bd05389be6d11aecbc38fc))
+- **decimal:** add tooltipPosition prop to interface ([3322ec3](https://github.com/Sage/carbon/commit/3322ec317a5a1fcc1676a50355eb5fd6183e99ae))
+- **filterable-select:** add tooltipPosition prop to interface ([327e96b](https://github.com/Sage/carbon/commit/327e96b7c641f10899ce2f0d20420a98e652a0e5))
+- **icon:** component consumes TooltipContext to allow overriding toolitip position ([a7e0841](https://github.com/Sage/carbon/commit/a7e084111a2bcbdf38ff2cb2577da276210e112d))
+- **multi-select:** add tooltipPosition prop to interface ([68f1d91](https://github.com/Sage/carbon/commit/68f1d9190d9b1fc9c52424db53a66c848705c2f3))
+- **numeral-date:** add tooltipPosition prop to interface ([bf5e35d](https://github.com/Sage/carbon/commit/bf5e35d65ad7ab9adbdc86dedf14f18ac503566f))
+- **radio-button, radio-button-group:** add tooltipPosition prop to interface ([7aa0ce1](https://github.com/Sage/carbon/commit/7aa0ce1f75974f6a3a4868b10c158a70b68fcb57))
+- **simple-select:** add tooltipPosition prop to interface ([a7f3e9a](https://github.com/Sage/carbon/commit/a7f3e9a212770b5115c8893ac7689f58b81f5168))
+- **switch:** add tooltipPosition prop to interface ([57e994e](https://github.com/Sage/carbon/commit/57e994ed4cbff10bd983362f7f9032b06d45f37f))
+- **textarea:** add tooltipPosition prop to interface ([016466d](https://github.com/Sage/carbon/commit/016466dc19ab5e5b122139836c1566a1a7754019))
+- **textbox:** integrate TooltipProvider and surface tooltipPosition prop ([c05dd40](https://github.com/Sage/carbon/commit/c05dd40c4bbde571e1ae32e496fac16f59d02441))
+- **tooltip-provider:** add context and provider component ([957f14a](https://github.com/Sage/carbon/commit/957f14af0c246b919d9791684a656eba7be53e73))
 
 ### [81.2.2](https://github.com/Sage/carbon/compare/v81.2.1...v81.2.2) (2021-08-20)
 
-
 ### Bug Fixes
 
-* **select:** scroll option into view when using keyboard navigation ([d09ef73](https://github.com/Sage/carbon/commit/d09ef739f730039f6105273f75b16a40ad753f78)), closes [#4270](https://github.com/Sage/carbon/issues/4270)
+- **select:** scroll option into view when using keyboard navigation ([d09ef73](https://github.com/Sage/carbon/commit/d09ef739f730039f6105273f75b16a40ad753f78)), closes [#4270](https://github.com/Sage/carbon/issues/4270)
 
 ### [81.2.1](https://github.com/Sage/carbon/compare/v81.2.0...v81.2.1) (2021-08-19)
 
-
 ### Bug Fixes
 
-* **focus-trap:** add mutation observer ([562fd12](https://github.com/Sage/carbon/commit/562fd12379df01d52a32b24bc979fa03a919e190)), closes [#4255](https://github.com/Sage/carbon/issues/4255)
+- **focus-trap:** add mutation observer ([562fd12](https://github.com/Sage/carbon/commit/562fd12379df01d52a32b24bc979fa03a919e190)), closes [#4255](https://github.com/Sage/carbon/issues/4255)
 
 ## [81.2.0](https://github.com/Sage/carbon/compare/v81.1.1...v81.2.0) (2021-08-18)
 
-
 ### Features
 
-* **toolbar:** add support for overriding translations in TextEditor Toolbar ([483a43f](https://github.com/Sage/carbon/commit/483a43fd4b2a8515299560512fa3fc4d9552c9b1)), closes [#4121](https://github.com/Sage/carbon/issues/4121)
+- **toolbar:** add support for overriding translations in TextEditor Toolbar ([483a43f](https://github.com/Sage/carbon/commit/483a43fd4b2a8515299560512fa3fc4d9552c9b1)), closes [#4121](https://github.com/Sage/carbon/issues/4121)
 
 ### [81.1.1](https://github.com/Sage/carbon/compare/v81.1.0...v81.1.1) (2021-08-18)
 
-
 ### Bug Fixes
 
-* **date-picker:** month could not be changed in datepicker ([053bb88](https://github.com/Sage/carbon/commit/053bb88286d37a56c59e6640b3b2cfe74cc8540f))
+- **date-picker:** month could not be changed in datepicker ([053bb88](https://github.com/Sage/carbon/commit/053bb88286d37a56c59e6640b3b2cfe74cc8540f))
 
 ## [81.1.0](https://github.com/Sage/carbon/compare/v81.0.5...v81.1.0) (2021-08-17)
 
-
 ### Features
 
-* **sidebar:** implement ref forwarding ([da9fbd1](https://github.com/Sage/carbon/commit/da9fbd1129b3324b70147ac755da077ba2f05b46))
-
+- **sidebar:** implement ref forwarding ([da9fbd1](https://github.com/Sage/carbon/commit/da9fbd1129b3324b70147ac755da077ba2f05b46))
 
 ### Bug Fixes
 
-* **sidebar:** incorrect typescript class export ([9a1b9c8](https://github.com/Sage/carbon/commit/9a1b9c843725871f32897d59c8c4e649838a9ff8))
-* **sidebar:** sidebar context not exported in typescript ([1e026e4](https://github.com/Sage/carbon/commit/1e026e47c1d6f82dfe221e07e8c2ff4f3b5d3e50))
+- **sidebar:** incorrect typescript class export ([9a1b9c8](https://github.com/Sage/carbon/commit/9a1b9c843725871f32897d59c8c4e649838a9ff8))
+- **sidebar:** sidebar context not exported in typescript ([1e026e4](https://github.com/Sage/carbon/commit/1e026e47c1d6f82dfe221e07e8c2ff4f3b5d3e50))
 
 ### [81.0.5](https://github.com/Sage/carbon/compare/v81.0.4...v81.0.5) (2021-08-06)
 
-
 ### Bug Fixes
 
-* **link:** add additional ARIA if no children ([1d8a598](https://github.com/Sage/carbon/commit/1d8a5986b4f3a6d2175c9f0dddc3c2cafdd09072))
-* **menu:** add aria-role to fix accessibility violations ([8e562a0](https://github.com/Sage/carbon/commit/8e562a086223617764815aa2e454c9d0f12f3f5f))
-* **menu-full-screen:** add missing ARIA ([020b7d2](https://github.com/Sage/carbon/commit/020b7d291560938fdc878392b5ba1a24fe0ee6da))
-* **menu-item:** add ariaLabel to submenu ([e1c1765](https://github.com/Sage/carbon/commit/e1c1765af5293f86e1ed8422baed296942ce2f1e))
+- **link:** add additional ARIA if no children ([1d8a598](https://github.com/Sage/carbon/commit/1d8a5986b4f3a6d2175c9f0dddc3c2cafdd09072))
+- **menu:** add aria-role to fix accessibility violations ([8e562a0](https://github.com/Sage/carbon/commit/8e562a086223617764815aa2e454c9d0f12f3f5f))
+- **menu-full-screen:** add missing ARIA ([020b7d2](https://github.com/Sage/carbon/commit/020b7d291560938fdc878392b5ba1a24fe0ee6da))
+- **menu-item:** add ariaLabel to submenu ([e1c1765](https://github.com/Sage/carbon/commit/e1c1765af5293f86e1ed8422baed296942ce2f1e))
 
 ### [81.0.4](https://github.com/Sage/carbon/compare/v81.0.3...v81.0.4) (2021-08-05)
 
-
 ### Bug Fixes
 
-* **flat-table:** ensure correct z-index is applied to flat-table-header ([0aeb143](https://github.com/Sage/carbon/commit/0aeb1435935e06b59b1f9086945174e9673c8637)), closes [#4226](https://github.com/Sage/carbon/issues/4226)
-* **flat-table-header:** add padding-right specifically for Firefox ([d85e134](https://github.com/Sage/carbon/commit/d85e1342d3c26ed794f87fdb4541b783ef4c4986))
-* **flat-table-row:** apply border-left if preceding row has a row header ([04af1c5](https://github.com/Sage/carbon/commit/04af1c53c32d44f1bf0e95791b8b276926b47389))
+- **flat-table:** ensure correct z-index is applied to flat-table-header ([0aeb143](https://github.com/Sage/carbon/commit/0aeb1435935e06b59b1f9086945174e9673c8637)), closes [#4226](https://github.com/Sage/carbon/issues/4226)
+- **flat-table-header:** add padding-right specifically for Firefox ([d85e134](https://github.com/Sage/carbon/commit/d85e1342d3c26ed794f87fdb4541b783ef4c4986))
+- **flat-table-row:** apply border-left if preceding row has a row header ([04af1c5](https://github.com/Sage/carbon/commit/04af1c53c32d44f1bf0e95791b8b276926b47389))
 
 ### [81.0.3](https://github.com/Sage/carbon/compare/v81.0.2...v81.0.3) (2021-08-05)
 
-
 ### Bug Fixes
 
-* **flat-table-row:** remove hover state for rows within drawer sidebar and no onclick ([222f5fb](https://github.com/Sage/carbon/commit/222f5fb7c28c0ccf8de9cecf85c4dea4806119f8)), closes [#4276](https://github.com/Sage/carbon/issues/4276)
+- **flat-table-row:** remove hover state for rows within drawer sidebar and no onclick ([222f5fb](https://github.com/Sage/carbon/commit/222f5fb7c28c0ccf8de9cecf85c4dea4806119f8)), closes [#4276](https://github.com/Sage/carbon/issues/4276)
 
 ### [81.0.2](https://github.com/Sage/carbon/compare/v81.0.1...v81.0.2) (2021-08-05)
 
-
 ### Bug Fixes
 
-* **card:** incorrect props on a static card ([1c069b8](https://github.com/Sage/carbon/commit/1c069b860a1657872c1547847a3ba83df1e06434))
+- **card:** incorrect props on a static card ([1c069b8](https://github.com/Sage/carbon/commit/1c069b860a1657872c1547847a3ba83df1e06434))
 
 ### [81.0.1](https://github.com/Sage/carbon/compare/v81.0.0...v81.0.1) (2021-08-04)
 
-
 ### Bug Fixes
 
-* **search:** incorrect margin when used in Form ([f0a0241](https://github.com/Sage/carbon/commit/f0a0241f5d3b6a44bbfec3b5480e91a1fcf46a32))
+- **search:** incorrect margin when used in Form ([f0a0241](https://github.com/Sage/carbon/commit/f0a0241f5d3b6a44bbfec3b5480e91a1fcf46a32))
 
 ## [81.0.0](https://github.com/Sage/carbon/compare/v80.1.0...v81.0.0) (2021-08-04)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **pod:** description prop removed,
-functionality could be replicated by rendering a description as Pod child
-there is a codemod available to assist with this change:
-(https://github.com/Sage/carbon-codemod/tree/master/transforms/move-pod-description-to-content)
-* **pod:** collapse functionality removed,
-Accordion Component could be used to replicate it
-There is a codemod available to assist with this change:
-(https://github.com/Sage/carbon-codemod/tree/master/
-transforms/replace-collapsible-pod-with-accordion)
+- **pod:** description prop removed,
+  functionality could be replicated by rendering a description as Pod child
+  there is a codemod available to assist with this change:
+  (<https://github.com/Sage/carbon-codemod/tree/master/transforms/move-pod-description-to-content>)
+- **pod:** collapse functionality removed,
+  Accordion Component could be used to replicate it
+  There is a codemod available to assist with this change:
+  (<https://github.com/Sage/carbon-codemod/tree/master/>
+  transforms/replace-collapsible-pod-with-accordion)
 
 ### Code Refactoring
 
-* **pod:** remove collapse functionality ([4babacb](https://github.com/Sage/carbon/commit/4babacb441f1d131221749ba68c7b9384750af29))
-* **pod:** remove description prop ([46f2480](https://github.com/Sage/carbon/commit/46f248021e7b79bcfff6d397a6ecac22055cf06d))
+- **pod:** remove collapse functionality ([4babacb](https://github.com/Sage/carbon/commit/4babacb441f1d131221749ba68c7b9384750af29))
+- **pod:** remove description prop ([46f2480](https://github.com/Sage/carbon/commit/46f248021e7b79bcfff6d397a6ecac22055cf06d))
 
 ## [80.1.0](https://github.com/Sage/carbon/compare/v80.0.0...v80.1.0) (2021-08-02)
 
-
 ### Features
 
-* **pod:** added softDelete, onDelete and onUndo functionalities ([76b23ef](https://github.com/Sage/carbon/commit/76b23ef5964300876f85e00a71056bdd1987e57f))
-* **show-edit-pod:** added softDelete, onDelete and onUndo functionalities ([df467f9](https://github.com/Sage/carbon/commit/df467f93bb7c1775eb1ba8107ec5e6a986012eb4))
+- **pod:** added softDelete, onDelete and onUndo functionalities ([76b23ef](https://github.com/Sage/carbon/commit/76b23ef5964300876f85e00a71056bdd1987e57f))
+- **show-edit-pod:** added softDelete, onDelete and onUndo functionalities ([df467f9](https://github.com/Sage/carbon/commit/df467f93bb7c1775eb1ba8107ec5e6a986012eb4))
 
 ## [80.0.0](https://github.com/Sage/carbon/compare/v79.1.1...v80.0.0) (2021-07-30)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **i18n:** Translations are providing via a locale file (https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md).
-`validationMessage` method of validations helper has been removed.
-`formatDateToCurrentLocale`, `withinRange`, `weekdaysMinified`, `formatValue` and `isValidDate` methods of date helper have been removed.
+- **i18n:** Translations are providing via a locale file (<https://github.com/Sage/carbon/blob/master/rfcs/text/i18n.md>).
+  `validationMessage` method of validations helper has been removed.
+  `formatDateToCurrentLocale`, `withinRange`, `weekdaysMinified`, `formatValue` and `isValidDate` methods of date helper have been removed.
 
 ### Code Refactoring
 
-* **i18n:** remove i18n-js ([2307677](https://github.com/Sage/carbon/commit/2307677498808506e3a8852dbf2a482a443fb3b5))
+- **i18n:** remove i18n-js ([2307677](https://github.com/Sage/carbon/commit/2307677498808506e3a8852dbf2a482a443fb3b5))
 
 ### [79.1.1](https://github.com/Sage/carbon/compare/v79.1.0...v79.1.1) (2021-07-26)
 
-
 ### Bug Fixes
 
-* **tile-select:** disabled prop is not working correctly ([b74e3ca](https://github.com/Sage/carbon/commit/b74e3caf72853f05863b248db2bdd8203ce564cb))
+- **tile-select:** disabled prop is not working correctly ([b74e3ca](https://github.com/Sage/carbon/commit/b74e3caf72853f05863b248db2bdd8203ce564cb))
 
 ## [79.1.0](https://github.com/Sage/carbon/compare/v79.0.1...v79.1.0) (2021-07-26)
 
-
 ### Features
 
-* **multi-select:** add pill color override functionality ([93e5e3e](https://github.com/Sage/carbon/commit/93e5e3e95a3da680d472e80ca6d13382e18feb6d))
+- **multi-select:** add pill color override functionality ([93e5e3e](https://github.com/Sage/carbon/commit/93e5e3e95a3da680d472e80ca6d13382e18feb6d))
 
 ### [79.0.1](https://github.com/Sage/carbon/compare/v79.0.0...v79.0.1) (2021-07-23)
 
-
 ### Bug Fixes
 
-* **sidebar:** fix header not respecting container width ([de13810](https://github.com/Sage/carbon/commit/de13810885f244731dd4e9b32a22dd8ca6724ec2)), closes [#4240](https://github.com/Sage/carbon/issues/4240)
+- **sidebar:** fix header not respecting container width ([de13810](https://github.com/Sage/carbon/commit/de13810885f244731dd4e9b32a22dd8ca6724ec2)), closes [#4240](https://github.com/Sage/carbon/issues/4240)
 
 ## [79.0.0](https://github.com/Sage/carbon/compare/v78.0.0...v79.0.0) (2021-07-23)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **options-helper:** OptionsHelper has been removed. All references will stop work.
-Types are exported from their own files.
+- **options-helper:** OptionsHelper has been removed. All references will stop work.
+  Types are exported from their own files.
 
 All affected files are listed below:
+
 - checkbox
 - date
 - decimal
@@ -6904,2398 +6042,2113 @@ All affected files are listed below:
 
 ### Bug Fixes
 
-* remove jest-styled-components ([33582ca](https://github.com/Sage/carbon/commit/33582ca2042fcef23e74d71b31ab924d04ae5a62))
-
+- remove jest-styled-components ([33582ca](https://github.com/Sage/carbon/commit/33582ca2042fcef23e74d71b31ab924d04ae5a62))
 
 ### Code Refactoring
 
-* **options-helper:** remove util ([84ce69f](https://github.com/Sage/carbon/commit/84ce69f48d09df294086f1d4ec231e00dd1bba33))
+- **options-helper:** remove util ([84ce69f](https://github.com/Sage/carbon/commit/84ce69f48d09df294086f1d4ec231e00dd1bba33))
 
 ## [78.0.0](https://github.com/Sage/carbon/compare/v77.14.3...v78.0.0) (2021-07-22)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **simple-color-picker:** SimpleColorPicker has moved to src/components/simple-color-picker
-* **radio-button:** RadioButton has moved to src/components/radio-button
-* **decimal:** Decimal has new import path - carbon-react/lib/components/decimal
-There is a codemod available to assist with this upgrade:
-npx carbon-codemod move-experimental-components <target>
-See https://github.com/Sage/carbon-codemod for more information.
-* **form-field:** FormField has moved to src/__internal__/form-field
-* **input:** Input has moved to src/__internal__/input/
-* **validation-icon:** ValidationIcon has moved to src/__internal__/
-* **label:** Label is now an internal component
-* **date-range:** `DateRange` has been moved to src/components/date-range. There is a codemod
-available to assist with this upgrade
-(https://github.com/Sage/carbon-codemod/tree/master/transforms/move-experimental-components)
-* **date:** Date has been moved to src/components/date. There is a codemod available to assist
-with this upgrade
-(https://github.com/Sage/carbon-codemod/tree/master/transforms/move-experimental-components)
-* **switch:** Switch has moved to src/components/switch
-* **checkbox:** Checkbox and CheckboxGroup have moved
-to src/components/checkbox
-* **numeral-date:** NumeralDate has moved to src/components/numeral-date
-* **grouped-character:** GroupedCharacter has new import path -
-carbon-react/lib/components/grouped-character
-There is a codemod available to assist with this upgrade:
-npx carbon-codemod move-experimental-components <target>
-See https://github.com/Sage/carbon-codemod for more information.
-* **search:** Search has new import path - carbon-react/lib/components/search
-* **textarea:** Textarea has moved to src/components/textarea
-* **number:** Number has new import path - carbon-react/lib/components/number
-There is a codemod available to assist with this upgrade:
-npx carbon-codemod move-experimental-components <target>
-See https://github.com/Sage/carbon-codemod for more information.
-* **field-help:** FieldHelp has moved to the internal folder
-* **fieldset:** Fieldset has moved to src/components/fieldset
-* **textbox:** New component path src/components/textbox
-* **input-icon-toggle:** New component path src/__internal__/input-icon-toggle
+- **simple-color-picker:** SimpleColorPicker has moved to src/components/simple-color-picker
+- **radio-button:** RadioButton has moved to src/components/radio-button
+- **decimal:** Decimal has new import path - carbon-react/lib/components/decimal
+  There is a codemod available to assist with this upgrade:
+  npx carbon-codemod move-experimental-components <target>
+  See <https://github.com/Sage/carbon-codemod> for more information.
+- **form-field:** FormField has moved to src/**internal**/form-field
+- **input:** Input has moved to src/**internal**/input/
+- **validation-icon:** ValidationIcon has moved to src/**internal**/
+- **label:** Label is now an internal component
+- **date-range:** `DateRange` has been moved to src/components/date-range. There is a codemod
+  available to assist with this upgrade
+  (<https://github.com/Sage/carbon-codemod/tree/master/transforms/move-experimental-components>)
+- **date:** Date has been moved to src/components/date. There is a codemod available to assist
+  with this upgrade
+  (<https://github.com/Sage/carbon-codemod/tree/master/transforms/move-experimental-components>)
+- **switch:** Switch has moved to src/components/switch
+- **checkbox:** Checkbox and CheckboxGroup have moved
+  to src/components/checkbox
+- **numeral-date:** NumeralDate has moved to src/components/numeral-date
+- **grouped-character:** GroupedCharacter has new import path -
+  carbon-react/lib/components/grouped-character
+  There is a codemod available to assist with this upgrade:
+  npx carbon-codemod move-experimental-components <target>
+  See <https://github.com/Sage/carbon-codemod> for more information.
+- **search:** Search has new import path - carbon-react/lib/components/search
+- **textarea:** Textarea has moved to src/components/textarea
+- **number:** Number has new import path - carbon-react/lib/components/number
+  There is a codemod available to assist with this upgrade:
+  npx carbon-codemod move-experimental-components <target>
+  See <https://github.com/Sage/carbon-codemod> for more information.
+- **field-help:** FieldHelp has moved to the internal folder
+- **fieldset:** Fieldset has moved to src/components/fieldset
+- **textbox:** New component path src/components/textbox
+- **input-icon-toggle:** New component path src/**internal**/input-icon-toggle
 
 ### Features
 
-* **input-icon-toggle:** add onblur and onfocus handlers ([8dcbdcd](https://github.com/Sage/carbon/commit/8dcbdcd75e08c477a1daded69da87a76c3de71d4))
-* **validation-icon:** add onblur and onfocus handlers ([32c0c50](https://github.com/Sage/carbon/commit/32c0c50eda739322ec3f269e9ed211a274494eeb))
-
+- **input-icon-toggle:** add onblur and onfocus handlers ([8dcbdcd](https://github.com/Sage/carbon/commit/8dcbdcd75e08c477a1daded69da87a76c3de71d4))
+- **validation-icon:** add onblur and onfocus handlers ([32c0c50](https://github.com/Sage/carbon/commit/32c0c50eda739322ec3f269e9ed211a274494eeb))
 
 ### Bug Fixes
 
-* **switch:** fix console error in sizes story ([035ca1b](https://github.com/Sage/carbon/commit/035ca1be212bbe10a838132e827aeb2b3c996782))
-* **switch-slider:** pass correct props down to loader ([b2f8bce](https://github.com/Sage/carbon/commit/b2f8bcee846dec43c806139b44c42ad02dae2961))
-
+- **switch:** fix console error in sizes story ([035ca1b](https://github.com/Sage/carbon/commit/035ca1be212bbe10a838132e827aeb2b3c996782))
+- **switch-slider:** pass correct props down to loader ([b2f8bce](https://github.com/Sage/carbon/commit/b2f8bcee846dec43c806139b44c42ad02dae2961))
 
 ### Code Refactoring
 
-* **checkbox:** move from experimental to components ([03ca633](https://github.com/Sage/carbon/commit/03ca633dcc15639ac951d2e6d36bd37546691341))
-* **date:** move from experimental into main components directory ([cc87589](https://github.com/Sage/carbon/commit/cc87589fc5bd8db6c181fa23f753df830384d01c))
-* **date-range:** move component out of experimental into main components directory ([933761e](https://github.com/Sage/carbon/commit/933761efd1c156a49fb35d6e5e918ff63a46cf21))
-* **decimal:** move component from experimental ([ea1fbe9](https://github.com/Sage/carbon/commit/ea1fbe97f3e75ceab68ebbab94a1b1998095af39))
-* **field-help:** move to internal folder ([af60bf8](https://github.com/Sage/carbon/commit/af60bf8d5f0c12e5a48739c37bed6606203400e8))
-* **fieldset:** move fieldset from experimental to components ([72aa35c](https://github.com/Sage/carbon/commit/72aa35c06f59ff85a3a0a8f2145497c05f73445b))
-* **form-field:** move from experimental to internal ([2165bed](https://github.com/Sage/carbon/commit/2165bed7cdbca62bfe253b79ce440adcc4cc305a))
-* **grouped-character:** move component from experimental ([8d66245](https://github.com/Sage/carbon/commit/8d6624504d1aca19cca9b8ca48196dde7dff8438))
-* **input:** move from experimental to internal ([4b36d02](https://github.com/Sage/carbon/commit/4b36d02132f2c08ac0d225bdd6328d3ebe80a8cf))
-* **input-icon-toggle:** make experimental input-icon-toggle component internal ([dc64b1c](https://github.com/Sage/carbon/commit/dc64b1c4240f5a9b7afe949cdca2f29ddef27f28))
-* **label:** make experimental label component an internal one ([02b2dcd](https://github.com/Sage/carbon/commit/02b2dcd865903f521930c026ba7d860136e97619))
-* **number:** move component from experimental to components ([25e9405](https://github.com/Sage/carbon/commit/25e94056cfe3db259c8c14c3ab8f41ccda626439))
-* **numeral-date:** move out of external folder ([c35df12](https://github.com/Sage/carbon/commit/c35df12ae8d25db31fbb57123d50dce59f8aed29))
-* **radio-button:** move from experimental to components ([bc80509](https://github.com/Sage/carbon/commit/bc80509fdfb70ccda46bd8c0a32fcc1cd4878d3c))
-* **search:** make experimental search component a regular one ([6f66963](https://github.com/Sage/carbon/commit/6f66963da54dfc347ef5da891e2b672edc441d3f))
-* **simple-color-picker:** move from experimental to components ([40261dd](https://github.com/Sage/carbon/commit/40261dd5178691aa848e455ee4a3c6b6f5f52a24))
-* **switch:** move from experimental to components ([994e59c](https://github.com/Sage/carbon/commit/994e59c3d0874c041c43a0080e550884fb4eef4c))
-* **textarea:** move from experimental to components ([f09f77f](https://github.com/Sage/carbon/commit/f09f77fd8d62f21f64853cfaae1c8f47aec749fc))
-* **textbox:** make experimental textbox component a regular one ([7012713](https://github.com/Sage/carbon/commit/701271352c4205c7459fd0e6a7bec98ca759b450))
-* **validation-icon:** move to internal folder ([d4032c7](https://github.com/Sage/carbon/commit/d4032c7454845ded424219257c27c84001f6be92))
+- **checkbox:** move from experimental to components ([03ca633](https://github.com/Sage/carbon/commit/03ca633dcc15639ac951d2e6d36bd37546691341))
+- **date:** move from experimental into main components directory ([cc87589](https://github.com/Sage/carbon/commit/cc87589fc5bd8db6c181fa23f753df830384d01c))
+- **date-range:** move component out of experimental into main components directory ([933761e](https://github.com/Sage/carbon/commit/933761efd1c156a49fb35d6e5e918ff63a46cf21))
+- **decimal:** move component from experimental ([ea1fbe9](https://github.com/Sage/carbon/commit/ea1fbe97f3e75ceab68ebbab94a1b1998095af39))
+- **field-help:** move to internal folder ([af60bf8](https://github.com/Sage/carbon/commit/af60bf8d5f0c12e5a48739c37bed6606203400e8))
+- **fieldset:** move fieldset from experimental to components ([72aa35c](https://github.com/Sage/carbon/commit/72aa35c06f59ff85a3a0a8f2145497c05f73445b))
+- **form-field:** move from experimental to internal ([2165bed](https://github.com/Sage/carbon/commit/2165bed7cdbca62bfe253b79ce440adcc4cc305a))
+- **grouped-character:** move component from experimental ([8d66245](https://github.com/Sage/carbon/commit/8d6624504d1aca19cca9b8ca48196dde7dff8438))
+- **input:** move from experimental to internal ([4b36d02](https://github.com/Sage/carbon/commit/4b36d02132f2c08ac0d225bdd6328d3ebe80a8cf))
+- **input-icon-toggle:** make experimental input-icon-toggle component internal ([dc64b1c](https://github.com/Sage/carbon/commit/dc64b1c4240f5a9b7afe949cdca2f29ddef27f28))
+- **label:** make experimental label component an internal one ([02b2dcd](https://github.com/Sage/carbon/commit/02b2dcd865903f521930c026ba7d860136e97619))
+- **number:** move component from experimental to components ([25e9405](https://github.com/Sage/carbon/commit/25e94056cfe3db259c8c14c3ab8f41ccda626439))
+- **numeral-date:** move out of external folder ([c35df12](https://github.com/Sage/carbon/commit/c35df12ae8d25db31fbb57123d50dce59f8aed29))
+- **radio-button:** move from experimental to components ([bc80509](https://github.com/Sage/carbon/commit/bc80509fdfb70ccda46bd8c0a32fcc1cd4878d3c))
+- **search:** make experimental search component a regular one ([6f66963](https://github.com/Sage/carbon/commit/6f66963da54dfc347ef5da891e2b672edc441d3f))
+- **simple-color-picker:** move from experimental to components ([40261dd](https://github.com/Sage/carbon/commit/40261dd5178691aa848e455ee4a3c6b6f5f52a24))
+- **switch:** move from experimental to components ([994e59c](https://github.com/Sage/carbon/commit/994e59c3d0874c041c43a0080e550884fb4eef4c))
+- **textarea:** move from experimental to components ([f09f77f](https://github.com/Sage/carbon/commit/f09f77fd8d62f21f64853cfaae1c8f47aec749fc))
+- **textbox:** make experimental textbox component a regular one ([7012713](https://github.com/Sage/carbon/commit/701271352c4205c7459fd0e6a7bec98ca759b450))
+- **validation-icon:** move to internal folder ([d4032c7](https://github.com/Sage/carbon/commit/d4032c7454845ded424219257c27c84001f6be92))
 
 ### [77.14.3](https://github.com/Sage/carbon/compare/v77.14.2...v77.14.3) (2021-07-22)
 
-
 ### Bug Fixes
 
-* **dependency:** move cypress-real-events to dev dependency ([f93d2b2](https://github.com/Sage/carbon/commit/f93d2b20350608fa9cddfff3dc0422c4d1126c77))
+- **dependency:** move cypress-real-events to dev dependency ([f93d2b2](https://github.com/Sage/carbon/commit/f93d2b20350608fa9cddfff3dc0422c4d1126c77))
 
 ### [77.14.2](https://github.com/Sage/carbon/compare/v77.14.1...v77.14.2) (2021-07-22)
 
-
 ### Bug Fixes
 
-* **textbox:** added missing labeAlign propType definition ([8dff28b](https://github.com/Sage/carbon/commit/8dff28b51820f2e52452d9d8adf6bbf0210ea8b1))
+- **textbox:** added missing labeAlign propType definition ([8dff28b](https://github.com/Sage/carbon/commit/8dff28b51820f2e52452d9d8adf6bbf0210ea8b1))
 
 ### [77.14.1](https://github.com/Sage/carbon/compare/v77.14.0...v77.14.1) (2021-07-21)
 
-
 ### Bug Fixes
 
-* **checkable-input:** fix invalid aria formats ([4db6af4](https://github.com/Sage/carbon/commit/4db6af4a265e34821dae89eb56471408f9a4d9ea))
-* **flat-table:** add aria-label to various stories ([613786b](https://github.com/Sage/carbon/commit/613786b2945b4f4827a46c388cbf0ef781088236))
-* **icon-button:** ensure buttons have discernible text ([70ce422](https://github.com/Sage/carbon/commit/70ce4220e57b72da9b6f4fecf105c0ccfb5c9cc1))
+- **checkable-input:** fix invalid aria formats ([4db6af4](https://github.com/Sage/carbon/commit/4db6af4a265e34821dae89eb56471408f9a4d9ea))
+- **flat-table:** add aria-label to various stories ([613786b](https://github.com/Sage/carbon/commit/613786b2945b4f4827a46c388cbf0ef781088236))
+- **icon-button:** ensure buttons have discernible text ([70ce422](https://github.com/Sage/carbon/commit/70ce4220e57b72da9b6f4fecf105c0ccfb5c9cc1))
 
 ## [77.14.0](https://github.com/Sage/carbon/compare/v77.13.3...v77.14.0) (2021-07-21)
 
-
 ### Features
 
-* **menu-full-screen:** add new component to achieve fullscreen menu view ([55d42a2](https://github.com/Sage/carbon/commit/55d42a28ca1a21349b8ac5158624586d8e0f6bc5))
+- **menu-full-screen:** add new component to achieve fullscreen menu view ([55d42a2](https://github.com/Sage/carbon/commit/55d42a28ca1a21349b8ac5158624586d8e0f6bc5))
 
 ### [77.13.3](https://github.com/Sage/carbon/compare/v77.13.2...v77.13.3) (2021-07-20)
 
-
 ### Bug Fixes
 
-* **tabs:** remove default margins and paddings ([d301b3a](https://github.com/Sage/carbon/commit/d301b3a7e87d20c3f26a1dfe6fe0534e74afba7a))
+- **tabs:** remove default margins and paddings ([d301b3a](https://github.com/Sage/carbon/commit/d301b3a7e87d20c3f26a1dfe6fe0534e74afba7a))
 
 ### [77.13.2](https://github.com/Sage/carbon/compare/v77.13.1...v77.13.2) (2021-07-16)
 
-
 ### Bug Fixes
 
-* **search:** correct onClick prop ts type ([e5b3b7b](https://github.com/Sage/carbon/commit/e5b3b7b8c3124d2ba4da233378de53fb11cc4ae0)), closes [#4185](https://github.com/Sage/carbon/issues/4185)
+- **search:** correct onClick prop ts type ([e5b3b7b](https://github.com/Sage/carbon/commit/e5b3b7b8c3124d2ba4da233378de53fb11cc4ae0)), closes [#4185](https://github.com/Sage/carbon/issues/4185)
 
 ### [77.13.1](https://github.com/Sage/carbon/compare/v77.13.0...v77.13.1) (2021-07-16)
 
-
 ### Bug Fixes
 
-* **simple-color-picker:** set cursor to not-allowed when component is disabled ([790c8e2](https://github.com/Sage/carbon/commit/790c8e23b3f133377d0d6297eb4431b858348fc8))
+- **simple-color-picker:** set cursor to not-allowed when component is disabled ([790c8e2](https://github.com/Sage/carbon/commit/790c8e23b3f133377d0d6297eb4431b858348fc8))
 
 ## [77.13.0](https://github.com/Sage/carbon/compare/v77.12.2...v77.13.0) (2021-07-16)
 
-
 ### Features
 
-* **link-preview:** add new component to support displaying link previews ([4348aaf](https://github.com/Sage/carbon/commit/4348aaf65e095dce3d0393449d579286d9bab931))
-* **note:** add support for rendering link previews ([5519c30](https://github.com/Sage/carbon/commit/5519c3045cf3f81bc18f4e426e19c3d01a021201))
-* **text-editor:** add support for rendering editor link previews ([a436ea5](https://github.com/Sage/carbon/commit/a436ea5b2ee05e4d54afa2a930815aedf4673e84))
-
+- **link-preview:** add new component to support displaying link previews ([4348aaf](https://github.com/Sage/carbon/commit/4348aaf65e095dce3d0393449d579286d9bab931))
+- **note:** add support for rendering link previews ([5519c30](https://github.com/Sage/carbon/commit/5519c3045cf3f81bc18f4e426e19c3d01a021201))
+- **text-editor:** add support for rendering editor link previews ([a436ea5](https://github.com/Sage/carbon/commit/a436ea5b2ee05e4d54afa2a930815aedf4673e84))
 
 ### Bug Fixes
 
-* **toolbar:** add missing focus trigger when right key press and last button focused ([5d713fd](https://github.com/Sage/carbon/commit/5d713fda086d0e40d619e1a955f9849ddff7397a))
+- **toolbar:** add missing focus trigger when right key press and last button focused ([5d713fd](https://github.com/Sage/carbon/commit/5d713fda086d0e40d619e1a955f9849ddff7397a))
 
 ### [77.12.2](https://github.com/Sage/carbon/compare/v77.12.1...v77.12.2) (2021-07-15)
 
-
 ### Bug Fixes
 
-* **tile-select:** prevent focus outline when tile select is disabled ([e6c9a17](https://github.com/Sage/carbon/commit/e6c9a174401e6162d6d44273ca0e1af398e11256)), closes [#4227](https://github.com/Sage/carbon/issues/4227)
+- **tile-select:** prevent focus outline when tile select is disabled ([e6c9a17](https://github.com/Sage/carbon/commit/e6c9a174401e6162d6d44273ca0e1af398e11256)), closes [#4227](https://github.com/Sage/carbon/issues/4227)
 
 ### [77.12.1](https://github.com/Sage/carbon/compare/v77.12.0...v77.12.1) (2021-07-14)
 
-
 ### Bug Fixes
 
-* **sidebar:** support for Form with stickyFooter ([164aebb](https://github.com/Sage/carbon/commit/164aebbbe63d00bfffbd11d6e90a1e6f3692787c))
+- **sidebar:** support for Form with stickyFooter ([164aebb](https://github.com/Sage/carbon/commit/164aebbbe63d00bfffbd11d6e90a1e6f3692787c))
 
 ## [77.12.0](https://github.com/Sage/carbon/compare/v77.11.2...v77.12.0) (2021-07-14)
 
-
 ### Features
 
-* **filterable-select:** add onFilterChange prop ([9ecb067](https://github.com/Sage/carbon/commit/9ecb067c4ea1f37e6b44e8830b7c77ca6108d1e0))
-* **multi-select:** add onFilterChange prop ([8058dab](https://github.com/Sage/carbon/commit/8058dabe83609b437eccea2852a141d5e4618057))
-
+- **filterable-select:** add onFilterChange prop ([9ecb067](https://github.com/Sage/carbon/commit/9ecb067c4ea1f37e6b44e8830b7c77ca6108d1e0))
+- **multi-select:** add onFilterChange prop ([8058dab](https://github.com/Sage/carbon/commit/8058dabe83609b437eccea2852a141d5e4618057))
 
 ### Bug Fixes
 
-* **filterable-select:** text value cleared when option list changes ([8190fe0](https://github.com/Sage/carbon/commit/8190fe0eba28468d5eb8e55ec9634f1265a708f0))
-* **filterable-select:** text value cleared when select is closed ([0fe05fc](https://github.com/Sage/carbon/commit/0fe05fcfb6e43ce22682c9f91a93d480b7388849))
-* **multi-select:** text value cleared when select is closed ([d65759a](https://github.com/Sage/carbon/commit/d65759ae3929dd61a29e449dbab2ac2e9e1fe738))
+- **filterable-select:** text value cleared when option list changes ([8190fe0](https://github.com/Sage/carbon/commit/8190fe0eba28468d5eb8e55ec9634f1265a708f0))
+- **filterable-select:** text value cleared when select is closed ([0fe05fc](https://github.com/Sage/carbon/commit/0fe05fcfb6e43ce22682c9f91a93d480b7388849))
+- **multi-select:** text value cleared when select is closed ([d65759a](https://github.com/Sage/carbon/commit/d65759ae3929dd61a29e449dbab2ac2e9e1fe738))
 
 ### [77.11.2](https://github.com/Sage/carbon/compare/v77.11.1...v77.11.2) (2021-07-13)
 
-
 ### Bug Fixes
 
-* **flat-table-row:** reduce z-index value when onclick passed to row ([a7d1a10](https://github.com/Sage/carbon/commit/a7d1a105f2a254e83d0e8a3456292965d5cdcbfd))
+- **flat-table-row:** reduce z-index value when onclick passed to row ([a7d1a10](https://github.com/Sage/carbon/commit/a7d1a105f2a254e83d0e8a3456292965d5cdcbfd))
 
 ### [77.11.1](https://github.com/Sage/carbon/compare/v77.11.0...v77.11.1) (2021-07-13)
 
-
 ### Bug Fixes
 
-* **radio-button, checkable-input:** fix invalid values in ARIA attributes ([284b578](https://github.com/Sage/carbon/commit/284b578619907016791452bfee4850dfaa454fd1))
+- **radio-button, checkable-input:** fix invalid values in ARIA attributes ([284b578](https://github.com/Sage/carbon/commit/284b578619907016791452bfee4850dfaa454fd1))
 
 ## [77.11.0](https://github.com/Sage/carbon/compare/v77.10.1...v77.11.0) (2021-07-12)
 
-
 ### Features
 
-* **button:** add target and rel props ([e12e9da](https://github.com/Sage/carbon/commit/e12e9daa4a7b63941d577299324c71f64fd1788e)), closes [#4231](https://github.com/Sage/carbon/issues/4231)
+- **button:** add target and rel props ([e12e9da](https://github.com/Sage/carbon/commit/e12e9daa4a7b63941d577299324c71f64fd1788e)), closes [#4231](https://github.com/Sage/carbon/issues/4231)
 
 ### [77.10.1](https://github.com/Sage/carbon/compare/v77.10.0...v77.10.1) (2021-07-12)
 
-
 ### Bug Fixes
 
-* **input:** remove background on input when required ([f4d3642](https://github.com/Sage/carbon/commit/f4d36422c696c43f5aab1fa834dcbe9223c4014c))
+- **input:** remove background on input when required ([f4d3642](https://github.com/Sage/carbon/commit/f4d36422c696c43f5aab1fa834dcbe9223c4014c))
 
 ## [77.10.0](https://github.com/Sage/carbon/compare/v77.9.0...v77.10.0) (2021-07-12)
 
-
 ### Features
 
-* **carbon-provider:** add carbon-provider component (contains default theme and global style) ([04d3ec2](https://github.com/Sage/carbon/commit/04d3ec20038c3c53dd43550d6868efbcc8c5268f))
+- **carbon-provider:** add carbon-provider component (contains default theme and global style) ([04d3ec2](https://github.com/Sage/carbon/commit/04d3ec20038c3c53dd43550d6868efbcc8c5268f))
 
 ## [77.9.0](https://github.com/Sage/carbon/compare/v77.8.1...v77.9.0) (2021-07-09)
 
-
 ### Features
 
-* **typography:** add support for white-space styling and truncation ([bb9316f](https://github.com/Sage/carbon/commit/bb9316fec25010833e7eea9b45cbe1c675a25c04)), closes [#4122](https://github.com/Sage/carbon/issues/4122)
+- **typography:** add support for white-space styling and truncation ([bb9316f](https://github.com/Sage/carbon/commit/bb9316fec25010833e7eea9b45cbe1c675a25c04)), closes [#4122](https://github.com/Sage/carbon/issues/4122)
 
 ### [77.8.1](https://github.com/Sage/carbon/compare/v77.8.0...v77.8.1) (2021-07-09)
 
-
 ### Bug Fixes
 
-* **menu:** focus search using arrow keys ([d590812](https://github.com/Sage/carbon/commit/d590812972185e4302a7c0f6f4b3f04a4654251a))
+- **menu:** focus search using arrow keys ([d590812](https://github.com/Sage/carbon/commit/d590812972185e4302a7c0f6f4b3f04a4654251a))
 
 ## [77.8.0](https://github.com/Sage/carbon/compare/v77.7.4...v77.8.0) (2021-07-09)
 
-
 ### Features
 
-* **flat-table:** add new extra-large size ([49ffb8f](https://github.com/Sage/carbon/commit/49ffb8f68ad13a3a53ec826a3386efd40c83bf4a))
-* **icon:** add extraSmall option to bgSize prop ([c5d1ed5](https://github.com/Sage/carbon/commit/c5d1ed5ac6c0bd81e6c6d1a885039c109f242770))
+- **flat-table:** add new extra-large size ([49ffb8f](https://github.com/Sage/carbon/commit/49ffb8f68ad13a3a53ec826a3386efd40c83bf4a))
+- **icon:** add extraSmall option to bgSize prop ([c5d1ed5](https://github.com/Sage/carbon/commit/c5d1ed5ac6c0bd81e6c6d1a885039c109f242770))
 
 ### [77.7.4](https://github.com/Sage/carbon/compare/v77.7.3...v77.7.4) (2021-07-08)
 
-
 ### Bug Fixes
 
-* **button-toggle:** fix hover styling on disabled state ([9133223](https://github.com/Sage/carbon/commit/9133223df176e9c6ee1cd7f12e5003493a752664))
+- **button-toggle:** fix hover styling on disabled state ([9133223](https://github.com/Sage/carbon/commit/9133223df176e9c6ee1cd7f12e5003493a752664))
 
 ### [77.7.3](https://github.com/Sage/carbon/compare/v77.7.2...v77.7.3) (2021-07-08)
 
-
 ### Bug Fixes
 
-* **flat-table:** fix incorrect row outline in safari ([343a179](https://github.com/Sage/carbon/commit/343a1790e1ac616bcf0c2e0d09d3a0ef1964f40e))
+- **flat-table:** fix incorrect row outline in safari ([343a179](https://github.com/Sage/carbon/commit/343a1790e1ac616bcf0c2e0d09d3a0ef1964f40e))
 
 ### [77.7.2](https://github.com/Sage/carbon/compare/v77.7.1...v77.7.2) (2021-07-08)
 
-
 ### Bug Fixes
 
-* **numeral-date:** update size prop type to have correct oneOf syntax ([be912c4](https://github.com/Sage/carbon/commit/be912c409873d985755c86363b5d6f3daa86f45d))
+- **numeral-date:** update size prop type to have correct oneOf syntax ([be912c4](https://github.com/Sage/carbon/commit/be912c409873d985755c86363b5d6f3daa86f45d))
 
 ### [77.7.1](https://github.com/Sage/carbon/compare/v77.7.0...v77.7.1) (2021-07-08)
 
-
 ### Bug Fixes
 
-* **flat-table:** scrolling content in table header ([6de6e67](https://github.com/Sage/carbon/commit/6de6e67857a7c97d1da87b59efdff0d99353b850))
+- **flat-table:** scrolling content in table header ([6de6e67](https://github.com/Sage/carbon/commit/6de6e67857a7c97d1da87b59efdff0d99353b850))
 
 ## [77.7.0](https://github.com/Sage/carbon/compare/v77.6.4...v77.7.0) (2021-07-07)
 
-
 ### Features
 
-* **button-toggle:** enhance button toggle visuals ([98d32c6](https://github.com/Sage/carbon/commit/98d32c69ca79ff20e4933b8f4626a5616f62c2c5))
+- **button-toggle:** enhance button toggle visuals ([98d32c6](https://github.com/Sage/carbon/commit/98d32c69ca79ff20e4933b8f4626a5616f62c2c5))
 
 ### [77.6.4](https://github.com/Sage/carbon/compare/v77.6.3...v77.6.4) (2021-07-07)
 
-
 ### Bug Fixes
 
-* **note:** ensure date aligns when no edited status ([f3c6dbe](https://github.com/Sage/carbon/commit/f3c6dbef6aa5b1e09478610e28a8e96b4ed14683))
+- **note:** ensure date aligns when no edited status ([f3c6dbe](https://github.com/Sage/carbon/commit/f3c6dbef6aa5b1e09478610e28a8e96b4ed14683))
 
 ### [77.6.3](https://github.com/Sage/carbon/compare/v77.6.2...v77.6.3) (2021-07-07)
 
-
 ### Bug Fixes
 
-* **note:** removes required constraint from name prop type ([f1ec59c](https://github.com/Sage/carbon/commit/f1ec59c1c4a2b79d2c42266d61fbd15456cd7879))
+- **note:** removes required constraint from name prop type ([f1ec59c](https://github.com/Sage/carbon/commit/f1ec59c1c4a2b79d2c42266d61fbd15456cd7879))
 
 ### [77.6.2](https://github.com/Sage/carbon/compare/v77.6.1...v77.6.2) (2021-07-07)
 
-
 ### Bug Fixes
 
-* **flat-table-row:** add support for setting tabindex on subrows with onclick handler passed ([aebcfc6](https://github.com/Sage/carbon/commit/aebcfc643eeada4518999d5c2cae8835b76809f6)), closes [#4214](https://github.com/Sage/carbon/issues/4214)
+- **flat-table-row:** add support for setting tabindex on subrows with onclick handler passed ([aebcfc6](https://github.com/Sage/carbon/commit/aebcfc643eeada4518999d5c2cae8835b76809f6)), closes [#4214](https://github.com/Sage/carbon/issues/4214)
 
 ### [77.6.1](https://github.com/Sage/carbon/compare/v77.6.0...v77.6.1) (2021-07-06)
 
-
 ### Bug Fixes
 
-* **date:** provide proper focus outline color ([0591951](https://github.com/Sage/carbon/commit/0591951da80a4b797f91e18d6f49d09c9b1033df))
+- **date:** provide proper focus outline color ([0591951](https://github.com/Sage/carbon/commit/0591951da80a4b797f91e18d6f49d09c9b1033df))
 
 ## [77.6.0](https://github.com/Sage/carbon/compare/v77.5.0...v77.6.0) (2021-07-06)
 
-
 ### Features
 
-* **tabs:** add tabsHeaderWidth prop ([b76b8a7](https://github.com/Sage/carbon/commit/b76b8a746ec1c0233ce21c62f93ebb12676468a6)), closes [#4024](https://github.com/Sage/carbon/issues/4024)
+- **tabs:** add tabsHeaderWidth prop ([b76b8a7](https://github.com/Sage/carbon/commit/b76b8a746ec1c0233ce21c62f93ebb12676468a6)), closes [#4024](https://github.com/Sage/carbon/issues/4024)
 
 ## [77.5.0](https://github.com/Sage/carbon/compare/v77.4.0...v77.5.0) (2021-07-06)
 
-
 ### Features
 
-* **switch:** change hover behaviour ([fcf2f31](https://github.com/Sage/carbon/commit/fcf2f31f77c111a10f9de2805e5211dea0752e05))
+- **switch:** change hover behaviour ([fcf2f31](https://github.com/Sage/carbon/commit/fcf2f31f77c111a10f9de2805e5211dea0752e05))
 
 ## [77.4.0](https://github.com/Sage/carbon/compare/v77.3.5...v77.4.0) (2021-07-05)
 
-
 ### Features
 
-* **pod:** add height prop support ([2ed2535](https://github.com/Sage/carbon/commit/2ed25352d14f2d4cc4c972b6bde49ee19f2be007))
+- **pod:** add height prop support ([2ed2535](https://github.com/Sage/carbon/commit/2ed25352d14f2d4cc4c972b6bde49ee19f2be007))
 
 ### [77.3.5](https://github.com/Sage/carbon/compare/v77.3.4...v77.3.5) (2021-07-01)
 
-
 ### Bug Fixes
 
-* **fieldset:** fix incorrect html structure in internal fieldset ([7e23e48](https://github.com/Sage/carbon/commit/7e23e4814f83114995d30371c96640bce30667d2))
+- **fieldset:** fix incorrect html structure in internal fieldset ([7e23e48](https://github.com/Sage/carbon/commit/7e23e4814f83114995d30371c96640bce30667d2))
 
 ### [77.3.4](https://github.com/Sage/carbon/compare/v77.3.3...v77.3.4) (2021-06-30)
 
-
 ### Bug Fixes
 
-* **filterable-select:** remove call to set open state of select list on textbox blur ([ae1d406](https://github.com/Sage/carbon/commit/ae1d406c724ef2da9f46c4275997fb8981cb2839))
-* **multi-select:** remove call to set open state of select list on textbox blur ([07f6b46](https://github.com/Sage/carbon/commit/07f6b4632281a180c7441817f262ce56bac2b6e7))
-* **simple-select:** remove call to set open state of select list on textbox blur ([c814c78](https://github.com/Sage/carbon/commit/c814c7834f296798b76d37190b5918b7e728da8d))
-* **tab-title:** remove call to stoppropagation onclick of tab title ([7a19c7a](https://github.com/Sage/carbon/commit/7a19c7a81e899e934494ab424379bb3558cbd277))
+- **filterable-select:** remove call to set open state of select list on textbox blur ([ae1d406](https://github.com/Sage/carbon/commit/ae1d406c724ef2da9f46c4275997fb8981cb2839))
+- **multi-select:** remove call to set open state of select list on textbox blur ([07f6b46](https://github.com/Sage/carbon/commit/07f6b4632281a180c7441817f262ce56bac2b6e7))
+- **simple-select:** remove call to set open state of select list on textbox blur ([c814c78](https://github.com/Sage/carbon/commit/c814c7834f296798b76d37190b5918b7e728da8d))
+- **tab-title:** remove call to stoppropagation onclick of tab title ([7a19c7a](https://github.com/Sage/carbon/commit/7a19c7a81e899e934494ab424379bb3558cbd277))
 
 ### [77.3.3](https://github.com/Sage/carbon/compare/v77.3.2...v77.3.3) (2021-06-29)
 
-
 ### Bug Fixes
 
-* **button-toggle-group:** allow empty and false children ([5621624](https://github.com/Sage/carbon/commit/56216243f2bc30e583b24733bda3e821022e078a))
+- **button-toggle-group:** allow empty and false children ([5621624](https://github.com/Sage/carbon/commit/56216243f2bc30e583b24733bda3e821022e078a))
 
 ### [77.3.2](https://github.com/Sage/carbon/compare/v77.3.1...v77.3.2) (2021-06-29)
 
-
 ### Bug Fixes
 
-* **flat-table-row-header:** fix pl and px props not being applied ([58a8291](https://github.com/Sage/carbon/commit/58a82910f9fa5b3243baed2df39ca57c1c3c99c4))
+- **flat-table-row-header:** fix pl and px props not being applied ([58a8291](https://github.com/Sage/carbon/commit/58a82910f9fa5b3243baed2df39ca57c1c3c99c4))
 
 ### [77.3.1](https://github.com/Sage/carbon/compare/v77.3.0...v77.3.1) (2021-06-29)
 
-
 ### Bug Fixes
 
-* **flat-table:** incorrect bottom border color in transparent headers ([8ec5262](https://github.com/Sage/carbon/commit/8ec52626f1176e510101eebd8643d721a6de2d73))
+- **flat-table:** incorrect bottom border color in transparent headers ([8ec5262](https://github.com/Sage/carbon/commit/8ec52626f1176e510101eebd8643d721a6de2d73))
 
 ## [77.3.0](https://github.com/Sage/carbon/compare/v77.2.2...v77.3.0) (2021-06-29)
 
-
 ### Features
 
-* **action-popover:** add horizontalAlignment prop ([9b827d8](https://github.com/Sage/carbon/commit/9b827d85a03802a623b4afc63f9c8720314e7a01))
+- **action-popover:** add horizontalAlignment prop ([9b827d8](https://github.com/Sage/carbon/commit/9b827d85a03802a623b4afc63f9c8720314e7a01))
 
 ### [77.2.2](https://github.com/Sage/carbon/compare/v77.2.1...v77.2.2) (2021-06-24)
 
-
 ### Bug Fixes
 
-* **flat-table:** fix styled-system pl support ([c74748f](https://github.com/Sage/carbon/commit/c74748fa748d9d4aa8615f45c3909bc172dc743c)), closes [#4145](https://github.com/Sage/carbon/issues/4145)
+- **flat-table:** fix styled-system pl support ([c74748f](https://github.com/Sage/carbon/commit/c74748fa748d9d4aa8615f45c3909bc172dc743c)), closes [#4145](https://github.com/Sage/carbon/issues/4145)
 
 ### [77.2.1](https://github.com/Sage/carbon/compare/v77.2.0...v77.2.1) (2021-06-23)
 
-
 ### Bug Fixes
 
-* **menu-item:** stop hover css applying to span ([f336f4f](https://github.com/Sage/carbon/commit/f336f4fcb13e61453841214c829fa5c730b403f7)), closes [#4178](https://github.com/Sage/carbon/issues/4178)
+- **menu-item:** stop hover css applying to span ([f336f4f](https://github.com/Sage/carbon/commit/f336f4fcb13e61453841214c829fa5c730b403f7)), closes [#4178](https://github.com/Sage/carbon/issues/4178)
 
 ## [77.2.0](https://github.com/Sage/carbon/compare/v77.1.4...v77.2.0) (2021-06-22)
 
-
 ### Features
 
-* **flat-table:** add alternative header background color ([88271cd](https://github.com/Sage/carbon/commit/88271cdf32a2e9c6d1fb6ecb8abe4d7bdd04db04))
-* **flat-table:** add horizontal border color control ([a18d043](https://github.com/Sage/carbon/commit/a18d043e725e807a9668c4388e0dacd680490492))
-* **flat-table:** add horizontal border size control ([d131634](https://github.com/Sage/carbon/commit/d131634900b75196f6e9d16596badfbd25112abe))
-* **flat-table:** add row background color prop ([c275359](https://github.com/Sage/carbon/commit/c275359c9afbba720353dd74b4487e09168405f0))
-* **flat-table:** add toColor util to bgColor prop ([db9e495](https://github.com/Sage/carbon/commit/db9e4959d1045a4692c488be8fcedd518b010d23))
-* **flat-table:** add vertical border color control ([0a25e76](https://github.com/Sage/carbon/commit/0a25e765849b2d7ee9bcd004c6d927bb8ba34c7b))
-* **flat-table:** add vertical border size control ([d10a217](https://github.com/Sage/carbon/commit/d10a2171ca845e40d6682f6696d4c8abe18855c6))
-
+- **flat-table:** add alternative header background color ([88271cd](https://github.com/Sage/carbon/commit/88271cdf32a2e9c6d1fb6ecb8abe4d7bdd04db04))
+- **flat-table:** add horizontal border color control ([a18d043](https://github.com/Sage/carbon/commit/a18d043e725e807a9668c4388e0dacd680490492))
+- **flat-table:** add horizontal border size control ([d131634](https://github.com/Sage/carbon/commit/d131634900b75196f6e9d16596badfbd25112abe))
+- **flat-table:** add row background color prop ([c275359](https://github.com/Sage/carbon/commit/c275359c9afbba720353dd74b4487e09168405f0))
+- **flat-table:** add toColor util to bgColor prop ([db9e495](https://github.com/Sage/carbon/commit/db9e4959d1045a4692c488be8fcedd518b010d23))
+- **flat-table:** add vertical border color control ([0a25e76](https://github.com/Sage/carbon/commit/0a25e765849b2d7ee9bcd004c6d927bb8ba34c7b))
+- **flat-table:** add vertical border size control ([d10a217](https://github.com/Sage/carbon/commit/d10a2171ca845e40d6682f6696d4c8abe18855c6))
 
 ### Bug Fixes
 
-* **flat-table:** incorrect border color in multiline headers ([bf93744](https://github.com/Sage/carbon/commit/bf93744cc832caa3cec5deb4cc8c3fea3ae9d2ae))
+- **flat-table:** incorrect border color in multiline headers ([bf93744](https://github.com/Sage/carbon/commit/bf93744cc832caa3cec5deb4cc8c3fea3ae9d2ae))
 
 ### [77.1.4](https://github.com/Sage/carbon/compare/v77.1.3...v77.1.4) (2021-06-22)
 
-
 ### Bug Fixes
 
-* **search:** update onkeydown and onclick type definitions to not use synthetic event ([2082fac](https://github.com/Sage/carbon/commit/2082fac6b5360aad6d2a762dace113af59ffd2ee))
-* **simple-color-picker, simple-color:** update onkeydown and onmousedown to not use synthetic event ([e20752c](https://github.com/Sage/carbon/commit/e20752c46c31c6dc80707d380c4126fca7d0f967))
+- **search:** update onkeydown and onclick type definitions to not use synthetic event ([2082fac](https://github.com/Sage/carbon/commit/2082fac6b5360aad6d2a762dace113af59ffd2ee))
+- **simple-color-picker, simple-color:** update onkeydown and onmousedown to not use synthetic event ([e20752c](https://github.com/Sage/carbon/commit/e20752c46c31c6dc80707d380c4126fca7d0f967))
 
 ### [77.1.3](https://github.com/Sage/carbon/compare/v77.1.2...v77.1.3) (2021-06-21)
 
-
 ### Bug Fixes
 
-* **card:** extend styled system margin props in ts interface ([d44372a](https://github.com/Sage/carbon/commit/d44372aafdc410041ae27bcd84fa4996a0c3f064))
+- **card:** extend styled system margin props in ts interface ([d44372a](https://github.com/Sage/carbon/commit/d44372aafdc410041ae27bcd84fa4996a0c3f064))
 
 ### [77.1.2](https://github.com/Sage/carbon/compare/v77.1.1...v77.1.2) (2021-06-21)
 
-
 ### Bug Fixes
 
-* **loader:** destructure props and only spread rest props on root element ([aeb92f6](https://github.com/Sage/carbon/commit/aeb92f64f79a7d75e8779320ffb383b08f9ac2f9))
+- **loader:** destructure props and only spread rest props on root element ([aeb92f6](https://github.com/Sage/carbon/commit/aeb92f64f79a7d75e8779320ffb383b08f9ac2f9))
 
 ### [77.1.1](https://github.com/Sage/carbon/compare/v77.1.0...v77.1.1) (2021-06-21)
 
-
 ### Bug Fixes
 
-* **pod:** update incorrect type definition from padding to size ([52f2246](https://github.com/Sage/carbon/commit/52f2246a8ba5d99ce757647e0be3e9cf4bbbf013))
+- **pod:** update incorrect type definition from padding to size ([52f2246](https://github.com/Sage/carbon/commit/52f2246a8ba5d99ce757647e0be3e9cf4bbbf013))
 
 ## [77.1.0](https://github.com/Sage/carbon/compare/v77.0.1...v77.1.0) (2021-06-18)
 
-
 ### Features
 
-* **confirm:** more flexible button usage ([f76a088](https://github.com/Sage/carbon/commit/f76a088c126bafab4881a1f39346e685e1e95f21))
+- **confirm:** more flexible button usage ([f76a088](https://github.com/Sage/carbon/commit/f76a088c126bafab4881a1f39346e685e1e95f21))
 
 ### [77.0.1](https://github.com/Sage/carbon/compare/v77.0.0...v77.0.1) (2021-06-17)
 
-
 ### Bug Fixes
 
-* **select-list:** add data role to internal loader component ([c9bc71a](https://github.com/Sage/carbon/commit/c9bc71af3cbd8f86d30df0857f341a61f4acf9d8))
+- **select-list:** add data role to internal loader component ([c9bc71a](https://github.com/Sage/carbon/commit/c9bc71af3cbd8f86d30df0857f341a61f4acf9d8))
 
 ## [77.0.0](https://github.com/Sage/carbon/compare/v76.5.6...v77.0.0) (2021-06-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **decimal:** The decimal component no longer uses `i18n-js` for decimal formatting,
-you should use the `locale` prop instead.
-* **decimal:** `formatDecimal` no longer supports the `round` option first introduced in v73.0.0
+- **decimal:** The decimal component no longer uses `i18n-js` for decimal formatting,
+  you should use the `locale` prop instead.
+- **decimal:** `formatDecimal` no longer supports the `round` option first introduced in v73.0.0
 
 closes FE-3500
 closes FE-4148
 
 ### Features
 
-* **decimal:** add locale support ([7cec047](https://github.com/Sage/carbon/commit/7cec0471db24e5b0d3c6150be6ea71038e14ecae)), closes [#3559](https://github.com/Sage/carbon/issues/3559)
+- **decimal:** add locale support ([7cec047](https://github.com/Sage/carbon/commit/7cec0471db24e5b0d3c6150be6ea71038e14ecae)), closes [#3559](https://github.com/Sage/carbon/issues/3559)
 
 ### [76.5.6](https://github.com/Sage/carbon/compare/v76.5.5...v76.5.6) (2021-06-14)
 
-
 ### Bug Fixes
 
-* **accordion:** fix unit test coverage ([00e8e26](https://github.com/Sage/carbon/commit/00e8e26a29f18d2b5048cb7d943ba578e9b5e8dc))
-* **accordion:** resize accordion when children resize ([f27ebc7](https://github.com/Sage/carbon/commit/f27ebc76f9f525ac6ba596f7abe9ccd048fba7fa))
+- **accordion:** fix unit test coverage ([00e8e26](https://github.com/Sage/carbon/commit/00e8e26a29f18d2b5048cb7d943ba578e9b5e8dc))
+- **accordion:** resize accordion when children resize ([f27ebc7](https://github.com/Sage/carbon/commit/f27ebc76f9f525ac6ba596f7abe9ccd048fba7fa))
 
 ### [76.5.5](https://github.com/Sage/carbon/compare/v76.5.4...v76.5.5) (2021-06-14)
 
-
 ### Bug Fixes
 
-* **search:** remove the onClick prop from the input ([b767581](https://github.com/Sage/carbon/commit/b7675817c320770c8dc2785770106cf0bebfcf7a))
+- **search:** remove the onClick prop from the input ([b767581](https://github.com/Sage/carbon/commit/b7675817c320770c8dc2785770106cf0bebfcf7a))
 
 ### [76.5.4](https://github.com/Sage/carbon/compare/v76.5.3...v76.5.4) (2021-06-11)
 
-
 ### Bug Fixes
 
-* **icon:** implement color values from theme correctly ([9a60fb9](https://github.com/Sage/carbon/commit/9a60fb9f8f80f028872cfef9fbca86c87f29f5b8))
+- **icon:** implement color values from theme correctly ([9a60fb9](https://github.com/Sage/carbon/commit/9a60fb9f8f80f028872cfef9fbca86c87f29f5b8))
 
 ### [76.5.3](https://github.com/Sage/carbon/compare/v76.5.2...v76.5.3) (2021-06-11)
 
-
 ### Bug Fixes
 
-* **radio-button:** allow ref forwarding to allow access to the underlying input ([e241985](https://github.com/Sage/carbon/commit/e2419850832c7be7337e5156c5716cbfe199c199))
+- **radio-button:** allow ref forwarding to allow access to the underlying input ([e241985](https://github.com/Sage/carbon/commit/e2419850832c7be7337e5156c5716cbfe199c199))
 
 ### [76.5.2](https://github.com/Sage/carbon/compare/v76.5.1...v76.5.2) (2021-06-10)
 
-
 ### Bug Fixes
 
-* **note:** add decorator to content to ensure correct html applied ([8a31825](https://github.com/Sage/carbon/commit/8a31825b2e85229a111699cc8964235a874bc995)), closes [#4137](https://github.com/Sage/carbon/issues/4137)
+- **note:** add decorator to content to ensure correct html applied ([8a31825](https://github.com/Sage/carbon/commit/8a31825b2e85229a111699cc8964235a874bc995)), closes [#4137](https://github.com/Sage/carbon/issues/4137)
 
 ### [76.5.1](https://github.com/Sage/carbon/compare/v76.5.0...v76.5.1) (2021-06-09)
 
-
 ### Bug Fixes
 
-* **button:** update forwardref prop type to allow function or object ([158b413](https://github.com/Sage/carbon/commit/158b413ee20fe57972a9d3e2d5392126cc65e5de))
-* **row:** add support for none gutter value ([fc4df58](https://github.com/Sage/carbon/commit/fc4df58cac73cceef54fafb59afaed5e577ea026))
+- **button:** update forwardref prop type to allow function or object ([158b413](https://github.com/Sage/carbon/commit/158b413ee20fe57972a9d3e2d5392126cc65e5de))
+- **row:** add support for none gutter value ([fc4df58](https://github.com/Sage/carbon/commit/fc4df58cac73cceef54fafb59afaed5e577ea026))
 
 ## [76.5.0](https://github.com/Sage/carbon/compare/v76.4.0...v76.5.0) (2021-06-09)
 
-
 ### Features
 
-* **numeral-date:** add size prop ([582c512](https://github.com/Sage/carbon/commit/582c51284f23563b4007fec65e3722f5406c156e))
+- **numeral-date:** add size prop ([582c512](https://github.com/Sage/carbon/commit/582c51284f23563b4007fec65e3722f5406c156e))
 
 ## [76.4.0](https://github.com/Sage/carbon/compare/v76.3.2...v76.4.0) (2021-06-08)
 
-
 ### Features
 
-* **anchor-navigation:** add stickynavigation prop structure warning ([0e3b4be](https://github.com/Sage/carbon/commit/0e3b4be459a8b8e2b7219305e685fdd101c15383))
+- **anchor-navigation:** add stickynavigation prop structure warning ([0e3b4be](https://github.com/Sage/carbon/commit/0e3b4be459a8b8e2b7219305e685fdd101c15383))
 
 ### [76.3.2](https://github.com/Sage/carbon/compare/v76.3.1...v76.3.2) (2021-06-08)
 
-
 ### Bug Fixes
 
-* **icon:** hover only for interactive icons ([a9cd54f](https://github.com/Sage/carbon/commit/a9cd54fe57bc975e01d28960f7e4f82c7b73ea75))
+- **icon:** hover only for interactive icons ([a9cd54f](https://github.com/Sage/carbon/commit/a9cd54fe57bc975e01d28960f7e4f82c7b73ea75))
 
 ### [76.3.1](https://github.com/Sage/carbon/compare/v76.3.0...v76.3.1) (2021-06-08)
 
-
 ### Bug Fixes
 
-* **step-sequence-item:** update theme colours for completed steps ([a05449f](https://github.com/Sage/carbon/commit/a05449f072b35a38847e0a2eced4a38da98eab52)), closes [#4117](https://github.com/Sage/carbon/issues/4117)
+- **step-sequence-item:** update theme colours for completed steps ([a05449f](https://github.com/Sage/carbon/commit/a05449f072b35a38847e0a2eced4a38da98eab52)), closes [#4117](https://github.com/Sage/carbon/issues/4117)
 
 ## [76.3.0](https://github.com/Sage/carbon/compare/v76.2.0...v76.3.0) (2021-06-08)
 
-
 ### Features
 
-* **button-toggle-group:** restrict children to button-toggle only ([c1a51b0](https://github.com/Sage/carbon/commit/c1a51b0aeab65baae0edce89286c25ea6e7ec466))
+- **button-toggle-group:** restrict children to button-toggle only ([c1a51b0](https://github.com/Sage/carbon/commit/c1a51b0aeab65baae0edce89286c25ea6e7ec466))
 
 ## [76.2.0](https://github.com/Sage/carbon/compare/v76.1.5...v76.2.0) (2021-06-07)
 
-
 ### Features
 
-* **icon:** 4 new icons, undo, sage coin and currency envelopes ([a29083b](https://github.com/Sage/carbon/commit/a29083b378e0ce80ac2e75d108c10881a298c6ea))
+- **icon:** 4 new icons, undo, sage coin and currency envelopes ([a29083b](https://github.com/Sage/carbon/commit/a29083b378e0ce80ac2e75d108c10881a298c6ea))
 
 ### [76.1.5](https://github.com/Sage/carbon/compare/v76.1.4...v76.1.5) (2021-06-07)
 
-
 ### Bug Fixes
 
-* **definition-list:** fix conditional rendering logic ([20aa302](https://github.com/Sage/carbon/commit/20aa3024a506b6c64d56f9e08a8fb906e8a804ab)), closes [#4013](https://github.com/Sage/carbon/issues/4013)
+- **definition-list:** fix conditional rendering logic ([20aa302](https://github.com/Sage/carbon/commit/20aa3024a506b6c64d56f9e08a8fb906e8a804ab)), closes [#4013](https://github.com/Sage/carbon/issues/4013)
 
 ### [76.1.4](https://github.com/Sage/carbon/compare/v76.1.3...v76.1.4) (2021-06-04)
 
-
 ### Bug Fixes
 
-* **accordion:** fix incorrect content height ([3a2b425](https://github.com/Sage/carbon/commit/3a2b425d67af59cea45de7f8037de5549b655d50))
+- **accordion:** fix incorrect content height ([3a2b425](https://github.com/Sage/carbon/commit/3a2b425d67af59cea45de7f8037de5549b655d50))
 
 ### [76.1.3](https://github.com/Sage/carbon/compare/v76.1.2...v76.1.3) (2021-06-02)
 
-
 ### Bug Fixes
 
-* **link:** change wrapper from div to span ([0aa3a99](https://github.com/Sage/carbon/commit/0aa3a99c89c92260c433d576364552380a40aee5))
+- **link:** change wrapper from div to span ([0aa3a99](https://github.com/Sage/carbon/commit/0aa3a99c89c92260c433d576364552380a40aee5))
 
 ### [76.1.2](https://github.com/Sage/carbon/compare/v76.1.1...v76.1.2) (2021-06-01)
 
-
 ### Bug Fixes
 
-* **tooltip:** fix arrow misalignment in left positioned tooltip ([b317b02](https://github.com/Sage/carbon/commit/b317b029bdcf2c15d263c9cd53f45c2119baac12))
+- **tooltip:** fix arrow misalignment in left positioned tooltip ([b317b02](https://github.com/Sage/carbon/commit/b317b029bdcf2c15d263c9cd53f45c2119baac12))
 
 ### [76.1.1](https://github.com/Sage/carbon/compare/v76.1.0...v76.1.1) (2021-06-01)
 
-
 ### Bug Fixes
 
-* incorrect typescript onFocus and onBlur definitions ([4008096](https://github.com/Sage/carbon/commit/40080961bff7627d440b9af02b10bafb3e1eba02))
+- incorrect typescript onFocus and onBlur definitions ([4008096](https://github.com/Sage/carbon/commit/40080961bff7627d440b9af02b10bafb3e1eba02))
 
 ## [76.1.0](https://github.com/Sage/carbon/compare/v76.0.1...v76.1.0) (2021-06-01)
 
-
 ### Features
 
-* **flat-table-checkbox:** surface onclick prop and remove internal onclick from  composed checkbox ([8408258](https://github.com/Sage/carbon/commit/84082583f4fbcb6297784a7b751c29e57a1ab72d))
+- **flat-table-checkbox:** surface onclick prop and remove internal onclick from composed checkbox ([8408258](https://github.com/Sage/carbon/commit/84082583f4fbcb6297784a7b751c29e57a1ab72d))
 
 ### [76.0.1](https://github.com/Sage/carbon/compare/v76.0.0...v76.0.1) (2021-05-31)
 
-
 ### Bug Fixes
 
-* **step-sequence:** fix incorrect item alignment ([0b9ad66](https://github.com/Sage/carbon/commit/0b9ad661a76ac0c2fea1ca8f4e1435f17bfb87a0))
+- **step-sequence:** fix incorrect item alignment ([0b9ad66](https://github.com/Sage/carbon/commit/0b9ad661a76ac0c2fea1ca8f4e1435f17bfb87a0))
 
 ## [76.0.0](https://github.com/Sage/carbon/compare/v75.2.6...v76.0.0) (2021-05-28)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **checkbox:** stop padding support for the checkbox component
-* **navigation-bar:** Navigation Bar no longer extends Box
-Fixes FE-3560
-* **textbox:** Textbox no longer supports styled-system padding props
-* **multi-action-button:** Removed several `get` functions as part of the refactor which could have been
-accessed in a consuming application
-* **flat-table:** FlatTable uses margin. FlatTableCell FlatTableHeader FlatTableRowHeader use padding
-* **tile:** `pixelWidth` prop has been removed
-* **show-edit-pod:** `padding` prop on ShowEditPod component has been renamed to `size`.
-To help with migration use `rename-prop` codemod:
-https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop
-* **pod:** `padding` prop on Pod component has been renamed to `size`.
-To help with migration use `rename-prop` codemod:
-https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop
-* **form-summary:** FormSummary has been moved to __internal__ folder, to fix issues you will
-have to update your imports
-* **scrollable-block:** ScrollableBlock no longer extends Box
-* **menu-item:** MenuItem no longer extends Box
-* **menu:** Menu component no longer extends Box
-* **hr:** Use margin only. Padding has been removed.
-* **tile-footer:** `margin` props no longer supported in `TileFooter`
+- **checkbox:** stop padding support for the checkbox component
+- **navigation-bar:** Navigation Bar no longer extends Box
+  Fixes FE-3560
+- **textbox:** Textbox no longer supports styled-system padding props
+- **multi-action-button:** Removed several `get` functions as part of the refactor which could have been
+  accessed in a consuming application
+- **flat-table:** FlatTable uses margin. FlatTableCell FlatTableHeader FlatTableRowHeader use padding
+- **tile:** `pixelWidth` prop has been removed
+- **show-edit-pod:** `padding` prop on ShowEditPod component has been renamed to `size`.
+  To help with migration use `rename-prop` codemod:
+  <https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop>
+- **pod:** `padding` prop on Pod component has been renamed to `size`.
+  To help with migration use `rename-prop` codemod:
+  <https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop>
+- **form-summary:** FormSummary has been moved to **internal** folder, to fix issues you will
+  have to update your imports
+- **scrollable-block:** ScrollableBlock no longer extends Box
+- **menu-item:** MenuItem no longer extends Box
+- **menu:** Menu component no longer extends Box
+- **hr:** Use margin only. Padding has been removed.
+- **tile-footer:** `margin` props no longer supported in `TileFooter`
 
 ### Features
 
-* **form:** add padding and margin with styled-system ([c3e0837](https://github.com/Sage/carbon/commit/c3e0837a4b1a0eba8651491670ebea554b87bd37))
-* **multi-action-button:** surface styled system margin props ([869f714](https://github.com/Sage/carbon/commit/869f714f3ae6dcde99446a017855a6a1ef05a214))
-* **pod:** add styled-system margin prop support ([9b4dc77](https://github.com/Sage/carbon/commit/9b4dc77227ae6e4dd2daf4c00ca3e40014a206ca))
-* **show-edit-pod:** add styled-system margin prop support ([3e0c531](https://github.com/Sage/carbon/commit/3e0c531cc9bb57baa8f8046721a607dc6de7d56c))
-* **textbox:** update styled-system props ([1dee3e8](https://github.com/Sage/carbon/commit/1dee3e8a203ffbd40c27984ec049257dcf6329b3))
-* **tile:** add support for styled system width ([3d09671](https://github.com/Sage/carbon/commit/3d09671bf130b1dffc97c83e09dbd57c7054b41a))
-
+- **form:** add padding and margin with styled-system ([c3e0837](https://github.com/Sage/carbon/commit/c3e0837a4b1a0eba8651491670ebea554b87bd37))
+- **multi-action-button:** surface styled system margin props ([869f714](https://github.com/Sage/carbon/commit/869f714f3ae6dcde99446a017855a6a1ef05a214))
+- **pod:** add styled-system margin prop support ([9b4dc77](https://github.com/Sage/carbon/commit/9b4dc77227ae6e4dd2daf4c00ca3e40014a206ca))
+- **show-edit-pod:** add styled-system margin prop support ([3e0c531](https://github.com/Sage/carbon/commit/3e0c531cc9bb57baa8f8046721a607dc6de7d56c))
+- **textbox:** update styled-system props ([1dee3e8](https://github.com/Sage/carbon/commit/1dee3e8a203ffbd40c27984ec049257dcf6329b3))
+- **tile:** add support for styled system width ([3d09671](https://github.com/Sage/carbon/commit/3d09671bf130b1dffc97c83e09dbd57c7054b41a))
 
 ### Bug Fixes
 
-* **navigation-bar:** allow padding props to override media query styles ([29ba9f3](https://github.com/Sage/carbon/commit/29ba9f3264d9140e4c4fc6d60f90976b7111f575))
-
+- **navigation-bar:** allow padding props to override media query styles ([29ba9f3](https://github.com/Sage/carbon/commit/29ba9f3264d9140e4c4fc6d60f90976b7111f575))
 
 ### Miscellaneous Chores
 
-* **form-summary:** move files to __internal__ folder ([960f2c6](https://github.com/Sage/carbon/commit/960f2c62afb7ca3a806dca24cdade1799dae6b58))
-
+- **form-summary:** move files to **internal** folder ([960f2c6](https://github.com/Sage/carbon/commit/960f2c62afb7ca3a806dca24cdade1799dae6b58))
 
 ### Code Refactoring
 
-* **checkbox:** update styled system implementation ([59fbf2b](https://github.com/Sage/carbon/commit/59fbf2bf50d97711138563d4cbc84cd43a6f957d))
-* **flat-table:** update styled system implementation ([140a287](https://github.com/Sage/carbon/commit/140a2874dee6bb05c2e21ff0c6e91c6bdf6729ff))
-* **hr:** update styled system implementation ([9549bc3](https://github.com/Sage/carbon/commit/9549bc32a8cfa9da0155c7f2d3eabbce6b667355))
-* **menu:** replace box extension with flexbox and layout props ([f6294fd](https://github.com/Sage/carbon/commit/f6294fdf534999cf99734dc1d806c710a5edefb8))
-* **menu-item:** replace box extension with flexbox and layout props ([c61d4a0](https://github.com/Sage/carbon/commit/c61d4a0fc4d6ed719f6149428b98c127c84fee50))
-* **multi-action-button:** convert to functional component ([177d66e](https://github.com/Sage/carbon/commit/177d66ea1bb860a02a23f53c9d5fdc03a1511012))
-* **navigation-bar:** replace box extension with flexbox and padding props ([94327c5](https://github.com/Sage/carbon/commit/94327c5952b5325c945a9411ac9ee0ea8b41b51b))
-* **scrollable-block:** replace box extension with composition ([5f07251](https://github.com/Sage/carbon/commit/5f072516a1914f1ee990dab11893f5f9d6680672))
-* **tile-footer:** remove support for styled system margin props ([025697a](https://github.com/Sage/carbon/commit/025697a7398b03f5c8e385816f8c8ebb2186adfb))
+- **checkbox:** update styled system implementation ([59fbf2b](https://github.com/Sage/carbon/commit/59fbf2bf50d97711138563d4cbc84cd43a6f957d))
+- **flat-table:** update styled system implementation ([140a287](https://github.com/Sage/carbon/commit/140a2874dee6bb05c2e21ff0c6e91c6bdf6729ff))
+- **hr:** update styled system implementation ([9549bc3](https://github.com/Sage/carbon/commit/9549bc32a8cfa9da0155c7f2d3eabbce6b667355))
+- **menu:** replace box extension with flexbox and layout props ([f6294fd](https://github.com/Sage/carbon/commit/f6294fdf534999cf99734dc1d806c710a5edefb8))
+- **menu-item:** replace box extension with flexbox and layout props ([c61d4a0](https://github.com/Sage/carbon/commit/c61d4a0fc4d6ed719f6149428b98c127c84fee50))
+- **multi-action-button:** convert to functional component ([177d66e](https://github.com/Sage/carbon/commit/177d66ea1bb860a02a23f53c9d5fdc03a1511012))
+- **navigation-bar:** replace box extension with flexbox and padding props ([94327c5](https://github.com/Sage/carbon/commit/94327c5952b5325c945a9411ac9ee0ea8b41b51b))
+- **scrollable-block:** replace box extension with composition ([5f07251](https://github.com/Sage/carbon/commit/5f072516a1914f1ee990dab11893f5f9d6680672))
+- **tile-footer:** remove support for styled system margin props ([025697a](https://github.com/Sage/carbon/commit/025697a7398b03f5c8e385816f8c8ebb2186adfb))
 
 ### [75.2.6](https://github.com/Sage/carbon/compare/v75.2.5...v75.2.6) (2021-05-28)
 
-
 ### Bug Fixes
 
-* **tile-select:** incorrect ts type definitions ([c40625c](https://github.com/Sage/carbon/commit/c40625c03ca49e20fd368e258e90ffab99bbcf8a))
+- **tile-select:** incorrect ts type definitions ([c40625c](https://github.com/Sage/carbon/commit/c40625c03ca49e20fd368e258e90ffab99bbcf8a))
 
 ### [75.2.5](https://github.com/Sage/carbon/compare/v75.2.4...v75.2.5) (2021-05-28)
 
-
 ### Bug Fixes
 
-* **simple-color-picker:** add guard to prevent calling onBlur when undefined ([58d954f](https://github.com/Sage/carbon/commit/58d954f8890a38991716f95b0b938f583db48129)), closes [#4062](https://github.com/Sage/carbon/issues/4062)
+- **simple-color-picker:** add guard to prevent calling onBlur when undefined ([58d954f](https://github.com/Sage/carbon/commit/58d954f8890a38991716f95b0b938f583db48129)), closes [#4062](https://github.com/Sage/carbon/issues/4062)
 
 ### [75.2.4](https://github.com/Sage/carbon/compare/v75.2.3...v75.2.4) (2021-05-28)
 
-
 ### Bug Fixes
 
-* **decimal:** fix not working inputs in stories ([dde6934](https://github.com/Sage/carbon/commit/dde6934f713a29836e7563aee0ec06341e0c64f8))
+- **decimal:** fix not working inputs in stories ([dde6934](https://github.com/Sage/carbon/commit/dde6934f713a29836e7563aee0ec06341e0c64f8))
 
 ### [75.2.3](https://github.com/Sage/carbon/compare/v75.2.2...v75.2.3) (2021-05-27)
 
-
 ### Bug Fixes
 
-* **tab:** make customLayout prop optional in TS definition ([a97721b](https://github.com/Sage/carbon/commit/a97721bf84b2dcd97c465661a18f41e89c8bccc1)), closes [#4025](https://github.com/Sage/carbon/issues/4025)
-* **tabs:** add missing colon to tab-title styles ([9541462](https://github.com/Sage/carbon/commit/9541462b2c90c62e75851fcf52a3cac3a46cd0f1)), closes [#4048](https://github.com/Sage/carbon/issues/4048)
+- **tab:** make customLayout prop optional in TS definition ([a97721b](https://github.com/Sage/carbon/commit/a97721bf84b2dcd97c465661a18f41e89c8bccc1)), closes [#4025](https://github.com/Sage/carbon/issues/4025)
+- **tabs:** add missing colon to tab-title styles ([9541462](https://github.com/Sage/carbon/commit/9541462b2c90c62e75851fcf52a3cac3a46cd0f1)), closes [#4048](https://github.com/Sage/carbon/issues/4048)
 
 ### [75.2.2](https://github.com/Sage/carbon/compare/v75.2.1...v75.2.2) (2021-05-27)
 
-
 ### Bug Fixes
 
-* **search:** update vertical alignment of the close input icon ([e53cd6b](https://github.com/Sage/carbon/commit/e53cd6b5616363ebeb0d1c5b5939c2b999c32c9e))
+- **search:** update vertical alignment of the close input icon ([e53cd6b](https://github.com/Sage/carbon/commit/e53cd6b5616363ebeb0d1c5b5939c2b999c32c9e))
 
 ### [75.2.1](https://github.com/Sage/carbon/compare/v75.2.0...v75.2.1) (2021-05-27)
 
-
 ### Bug Fixes
 
-* **date-range:** fix incorrect date picker positioning ([6fb85c6](https://github.com/Sage/carbon/commit/6fb85c6b0a565b58223698535092422ec7dcde21))
+- **date-range:** fix incorrect date picker positioning ([6fb85c6](https://github.com/Sage/carbon/commit/6fb85c6b0a565b58223698535092422ec7dcde21))
 
 ## [75.2.0](https://github.com/Sage/carbon/compare/v75.1.0...v75.2.0) (2021-05-27)
 
-
 ### Features
 
-* **portrait:** adds prop to specify fallback icon ([3b78281](https://github.com/Sage/carbon/commit/3b782818bc9db6de3813bb4ef4345e48ac96f42d))
+- **portrait:** adds prop to specify fallback icon ([3b78281](https://github.com/Sage/carbon/commit/3b782818bc9db6de3813bb4ef4345e48ac96f42d))
 
 ## [75.1.0](https://github.com/Sage/carbon/compare/v75.0.1...v75.1.0) (2021-05-27)
 
-
 ### Features
 
-* **duelling-picklist:** add context to support focusing elements after an item or group moves ([984d42b](https://github.com/Sage/carbon/commit/984d42b087bd4f04f8652b625a08067f28ffc117))
-
+- **duelling-picklist:** add context to support focusing elements after an item or group moves ([984d42b](https://github.com/Sage/carbon/commit/984d42b087bd4f04f8652b625a08067f28ffc117))
 
 ### Bug Fixes
 
-* **duelling-picklist:** add error if children do not have 2 picklist ([1ccb1ab](https://github.com/Sage/carbon/commit/1ccb1abb1793ef58472e5f95a657c5802ac62b4b))
+- **duelling-picklist:** add error if children do not have 2 picklist ([1ccb1ab](https://github.com/Sage/carbon/commit/1ccb1abb1793ef58472e5f95a657c5802ac62b4b))
 
 ### [75.0.1](https://github.com/Sage/carbon/compare/v75.0.0...v75.0.1) (2021-05-27)
 
-
 ### Bug Fixes
 
-* **date-range:** fix react-testing-library errors ([1102017](https://github.com/Sage/carbon/commit/11020174cdbc341219d55486458335908f60ea4c))
+- **date-range:** fix react-testing-library errors ([1102017](https://github.com/Sage/carbon/commit/11020174cdbc341219d55486458335908f60ea4c))
 
 ## [75.0.0](https://github.com/Sage/carbon/compare/v74.5.1...v75.0.0) (2021-05-27)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **tabs:** Internal support for updating window location has been removed from the `Tabs`
-component, the `setLocation` prop has also been removed as it serves no purpose beyond serving as a
-guard for this functionality. Consumers who wish to have this functionality should utilise the
-`onTabChange` and `selectedTabId` props with whatever `history` implementation they want to.
+- **tabs:** Internal support for updating window location has been removed from the `Tabs`
+  component, the `setLocation` prop has also been removed as it serves no purpose beyond serving as a
+  guard for this functionality. Consumers who wish to have this functionality should utilise the
+  `onTabChange` and `selectedTabId` props with whatever `history` implementation they want to.
 
 ### Features
 
-* **tabs:** remove internal support for history and url manipulation ([bd76906](https://github.com/Sage/carbon/commit/bd7690686d17911a8417f927f9797ed4a5231d50)), closes [#3520](https://github.com/Sage/carbon/issues/3520)
+- **tabs:** remove internal support for history and url manipulation ([bd76906](https://github.com/Sage/carbon/commit/bd7690686d17911a8417f927f9797ed4a5231d50)), closes [#3520](https://github.com/Sage/carbon/issues/3520)
 
 ### [74.5.1](https://github.com/Sage/carbon/compare/v74.5.0...v74.5.1) (2021-05-21)
 
-
 ### Bug Fixes
 
-* **sidebar:** make close button css more specific ([bb7adaf](https://github.com/Sage/carbon/commit/bb7adaf721a4b457328ae6757962fe9ed5766b64)), closes [#3943](https://github.com/Sage/carbon/issues/3943)
+- **sidebar:** make close button css more specific ([bb7adaf](https://github.com/Sage/carbon/commit/bb7adaf721a4b457328ae6757962fe9ed5766b64)), closes [#3943](https://github.com/Sage/carbon/issues/3943)
 
 ## [74.5.0](https://github.com/Sage/carbon/compare/v74.4.0...v74.5.0) (2021-05-21)
 
-
 ### Features
 
-* **drawer:** add sticky footer option ([42de058](https://github.com/Sage/carbon/commit/42de058c7438c090b2af3f900aba5a6efdb95fe5))
-* **drawer:** add sticky header option ([6ffd744](https://github.com/Sage/carbon/commit/6ffd7449ace605b20233f3c8c246f4a777414904))
-* **sticky-footer:** add new internal sticky footer component ([b3383a7](https://github.com/Sage/carbon/commit/b3383a706f44b7e253149a9613e94aef95f52943))
+- **drawer:** add sticky footer option ([42de058](https://github.com/Sage/carbon/commit/42de058c7438c090b2af3f900aba5a6efdb95fe5))
+- **drawer:** add sticky header option ([6ffd744](https://github.com/Sage/carbon/commit/6ffd7449ace605b20233f3c8c246f4a777414904))
+- **sticky-footer:** add new internal sticky footer component ([b3383a7](https://github.com/Sage/carbon/commit/b3383a706f44b7e253149a9613e94aef95f52943))
 
 ## [74.4.0](https://github.com/Sage/carbon/compare/v74.3.1...v74.4.0) (2021-05-21)
 
-
 ### Features
 
-* **grouped-character:** add styled-system margin support ([04c5055](https://github.com/Sage/carbon/commit/04c50556bf03120e284459ae11a808a37442627f))
+- **grouped-character:** add styled-system margin support ([04c5055](https://github.com/Sage/carbon/commit/04c50556bf03120e284459ae11a808a37442627f))
 
 ### [74.3.1](https://github.com/Sage/carbon/compare/v74.3.0...v74.3.1) (2021-05-19)
 
-
 ### Bug Fixes
 
-* **checkable-inputs:** fix name prop forwarding ([0c98eab](https://github.com/Sage/carbon/commit/0c98eab2091bd656b5a393cbf1b3694c3a7dd503))
+- **checkable-inputs:** fix name prop forwarding ([0c98eab](https://github.com/Sage/carbon/commit/0c98eab2091bd656b5a393cbf1b3694c3a7dd503))
 
 ## [74.3.0](https://github.com/Sage/carbon/compare/v74.2.0...v74.3.0) (2021-05-19)
 
-
 ### Features
 
-* **accordion-group:** allow empty children ([d925be9](https://github.com/Sage/carbon/commit/d925be9d1080e03b17174361e661fe06cabda0d6))
-* **draggable-container:** allow empty children ([6803776](https://github.com/Sage/carbon/commit/6803776c38f4aef73bf6f05c786327cae0647f4a))
-* **grid:** allow empty children ([c0ad597](https://github.com/Sage/carbon/commit/c0ad5978fd0efc55064b27667c97446ff5e43782))
-* **simple-color-picker:** allow empty children ([58da22c](https://github.com/Sage/carbon/commit/58da22c4d64975e89e5b8eac80eb4b55513ae277))
+- **accordion-group:** allow empty children ([d925be9](https://github.com/Sage/carbon/commit/d925be9d1080e03b17174361e661fe06cabda0d6))
+- **draggable-container:** allow empty children ([6803776](https://github.com/Sage/carbon/commit/6803776c38f4aef73bf6f05c786327cae0647f4a))
+- **grid:** allow empty children ([c0ad597](https://github.com/Sage/carbon/commit/c0ad5978fd0efc55064b27667c97446ff5e43782))
+- **simple-color-picker:** allow empty children ([58da22c](https://github.com/Sage/carbon/commit/58da22c4d64975e89e5b8eac80eb4b55513ae277))
 
 ## [74.2.0](https://github.com/Sage/carbon/compare/v74.1.2...v74.2.0) (2021-05-19)
 
-
 ### Features
 
-* **decimal:** add styled-system margin props ([77dcd95](https://github.com/Sage/carbon/commit/77dcd95b7877b558d63fc5811a547c57fa01d3be))
+- **decimal:** add styled-system margin props ([77dcd95](https://github.com/Sage/carbon/commit/77dcd95b7877b558d63fc5811a547c57fa01d3be))
 
 ### [74.1.2](https://github.com/Sage/carbon/compare/v74.1.1...v74.1.2) (2021-05-18)
 
-
 ### Bug Fixes
 
-* **pill:** fix text wrap if there are multiple words ([a9333ff](https://github.com/Sage/carbon/commit/a9333fffb7040a84ccabec6e524c1845085561ed))
+- **pill:** fix text wrap if there are multiple words ([a9333ff](https://github.com/Sage/carbon/commit/a9333fffb7040a84ccabec6e524c1845085561ed))
 
 ### [74.1.1](https://github.com/Sage/carbon/compare/v74.1.0...v74.1.1) (2021-05-14)
 
-
 ### Bug Fixes
 
-* **date-range:** fix incorrect gaps between date fields ([70507ba](https://github.com/Sage/carbon/commit/70507ba053215e541f32ed9918709ab63643e110))
+- **date-range:** fix incorrect gaps between date fields ([70507ba](https://github.com/Sage/carbon/commit/70507ba053215e541f32ed9918709ab63643e110))
 
 ## [74.1.0](https://github.com/Sage/carbon/compare/v74.0.0...v74.1.0) (2021-05-14)
 
-
 ### Features
 
-* **icon:** 7 new icons, carets directions and larger size ([beb20ec](https://github.com/Sage/carbon/commit/beb20ec3a1cc8b464c6624a3fb0502a38485e6ad))
+- **icon:** 7 new icons, carets directions and larger size ([beb20ec](https://github.com/Sage/carbon/commit/beb20ec3a1cc8b464c6624a3fb0502a38485e6ad))
 
 ## [74.0.0](https://github.com/Sage/carbon/compare/v73.6.1...v74.0.0) (2021-05-14)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **button:** Fixes FE-2759
-* **action-popover:** Fixes FE-2757
-* **anchor-navigation:** Fixes FE-2758
-* **accordion:** Fixes FE-2756
-* **textbox:** Fixes FE-2755
-* **radio-button-group:** Fixes FE-2754
-* **label:** Fixes FE-2753
-* **input:** Fixes FE-2752
-* **fieldset:** Fixes FE-2750
-* **form-field:** Fixes FE-2751
+- **button:** Fixes FE-2759
+- **action-popover:** Fixes FE-2757
+- **anchor-navigation:** Fixes FE-2758
+- **accordion:** Fixes FE-2756
+- **textbox:** Fixes FE-2755
+- **radio-button-group:** Fixes FE-2754
+- **label:** Fixes FE-2753
+- **input:** Fixes FE-2752
+- **fieldset:** Fixes FE-2750
+- **form-field:** Fixes FE-2751
 
 ### Code Refactoring
 
-* **accordion:** remove style override props ([cd59de6](https://github.com/Sage/carbon/commit/cd59de6c2a01752470f07d0b67700878eef62159))
-* **action-popover:** remove style override props ([b373382](https://github.com/Sage/carbon/commit/b37338274758ea00cbbc6f48c3bf7af8069ac03e))
-* **anchor-navigation:** remove style override props ([1d4aeb2](https://github.com/Sage/carbon/commit/1d4aeb2e49ebf828e5b4ae7d5bfce4a48e5deb22))
-* **button:** remove style override props ([b7cb8e2](https://github.com/Sage/carbon/commit/b7cb8e26af944cb979b7b9c3e2211be084beec5c))
-* **fieldset:** remove style override props ([cedd350](https://github.com/Sage/carbon/commit/cedd35047f55b558c5149990a4433696677e1e27))
-* **form-field:** remove style override props ([3bcc36e](https://github.com/Sage/carbon/commit/3bcc36e80239e040fc1dd5822eea9fe02c2b2c40))
-* **input:** remove style override props ([00c222b](https://github.com/Sage/carbon/commit/00c222bb00c603f5d2b77b44efb9871c5eda164c))
-* **label:** remove style override props ([6397187](https://github.com/Sage/carbon/commit/6397187f9ac2f1882e19ae3316fbac2eda636d8f))
-* **radio-button-group:** remove style override props ([5ba73b6](https://github.com/Sage/carbon/commit/5ba73b6d48bee44fc6bd8e25735d0632eb37ab41))
-* **textbox:** remove style override props ([38c827b](https://github.com/Sage/carbon/commit/38c827bfdd347c7979dc12642c639469df27c9c0))
+- **accordion:** remove style override props ([cd59de6](https://github.com/Sage/carbon/commit/cd59de6c2a01752470f07d0b67700878eef62159))
+- **action-popover:** remove style override props ([b373382](https://github.com/Sage/carbon/commit/b37338274758ea00cbbc6f48c3bf7af8069ac03e))
+- **anchor-navigation:** remove style override props ([1d4aeb2](https://github.com/Sage/carbon/commit/1d4aeb2e49ebf828e5b4ae7d5bfce4a48e5deb22))
+- **button:** remove style override props ([b7cb8e2](https://github.com/Sage/carbon/commit/b7cb8e26af944cb979b7b9c3e2211be084beec5c))
+- **fieldset:** remove style override props ([cedd350](https://github.com/Sage/carbon/commit/cedd35047f55b558c5149990a4433696677e1e27))
+- **form-field:** remove style override props ([3bcc36e](https://github.com/Sage/carbon/commit/3bcc36e80239e040fc1dd5822eea9fe02c2b2c40))
+- **input:** remove style override props ([00c222b](https://github.com/Sage/carbon/commit/00c222bb00c603f5d2b77b44efb9871c5eda164c))
+- **label:** remove style override props ([6397187](https://github.com/Sage/carbon/commit/6397187f9ac2f1882e19ae3316fbac2eda636d8f))
+- **radio-button-group:** remove style override props ([5ba73b6](https://github.com/Sage/carbon/commit/5ba73b6d48bee44fc6bd8e25735d0632eb37ab41))
+- **textbox:** remove style override props ([38c827b](https://github.com/Sage/carbon/commit/38c827bfdd347c7979dc12642c639469df27c9c0))
 
 ### [73.6.1](https://github.com/Sage/carbon/compare/v73.6.0...v73.6.1) (2021-05-13)
 
-
 ### Bug Fixes
 
-* **portrait:** fix portrait tooltip error ([3631635](https://github.com/Sage/carbon/commit/3631635463e7e2000c90294ed27a4ca4aed38bc0))
+- **portrait:** fix portrait tooltip error ([3631635](https://github.com/Sage/carbon/commit/3631635463e7e2000c90294ed27a4ca4aed38bc0))
 
 ## [73.6.0](https://github.com/Sage/carbon/compare/v73.5.0...v73.6.0) (2021-05-13)
 
-
 ### Features
 
-* **menu-item:** add max width prop for truncation ([d9e58da](https://github.com/Sage/carbon/commit/d9e58da0cf0f3877d62d248c532592b28a62c3ff))
+- **menu-item:** add max width prop for truncation ([d9e58da](https://github.com/Sage/carbon/commit/d9e58da0cf0f3877d62d248c532592b28a62c3ff))
 
 ## [73.5.0](https://github.com/Sage/carbon/compare/v73.4.0...v73.5.0) (2021-05-13)
 
-
 ### Features
 
-* **textarea:** add styled-system margin prop support ([d5825a5](https://github.com/Sage/carbon/commit/d5825a5cecbd1edcecc152a4d8a9f645c506eeaf))
+- **textarea:** add styled-system margin prop support ([d5825a5](https://github.com/Sage/carbon/commit/d5825a5cecbd1edcecc152a4d8a9f645c506eeaf))
 
 ## [73.4.0](https://github.com/Sage/carbon/compare/v73.3.0...v73.4.0) (2021-05-13)
 
-
 ### Features
 
-* **date:** add styled-system margin support ([9ab0c56](https://github.com/Sage/carbon/commit/9ab0c569e0f838362546be8880e7373dd1a4fa3e))
+- **date:** add styled-system margin support ([9ab0c56](https://github.com/Sage/carbon/commit/9ab0c569e0f838362546be8880e7373dd1a4fa3e))
 
 ## [73.3.0](https://github.com/Sage/carbon/compare/v73.2.0...v73.3.0) (2021-05-13)
 
-
 ### Features
 
-* **dialog,dialog-full-screen:** add help prop ([79b5d41](https://github.com/Sage/carbon/commit/79b5d412ebf6d5bd59cb42a9a02c2367abd44aca))
-
+- **dialog,dialog-full-screen:** add help prop ([79b5d41](https://github.com/Sage/carbon/commit/79b5d412ebf6d5bd59cb42a9a02c2367abd44aca))
 
 ### Bug Fixes
 
-* **dialog:** title wrapping ([e259aed](https://github.com/Sage/carbon/commit/e259aedf4ce8716a41c04c8ecfabfa23929f507c))
+- **dialog:** title wrapping ([e259aed](https://github.com/Sage/carbon/commit/e259aedf4ce8716a41c04c8ecfabfa23929f507c))
 
 ## [73.2.0](https://github.com/Sage/carbon/compare/v73.1.0...v73.2.0) (2021-05-12)
 
-
 ### Features
 
-* **button-toggle-group:** add styled-system props ([510a643](https://github.com/Sage/carbon/commit/510a64392403d0e4fa6706465478bcd3bbde21ac))
+- **button-toggle-group:** add styled-system props ([510a643](https://github.com/Sage/carbon/commit/510a64392403d0e4fa6706465478bcd3bbde21ac))
 
 ## [73.1.0](https://github.com/Sage/carbon/compare/v73.0.0...v73.1.0) (2021-05-12)
 
-
 ### Features
 
-* **simple-color-picker:** add styled system margin ([27862c5](https://github.com/Sage/carbon/commit/27862c50d55135c2dd824ce73d27b4fa83752611))
+- **simple-color-picker:** add styled system margin ([27862c5](https://github.com/Sage/carbon/commit/27862c50d55135c2dd824ce73d27b4fa83752611))
 
 ## [73.0.0](https://github.com/Sage/carbon/compare/v72.0.0...v73.0.0) (2021-05-11)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **decimal:** Precision prop can no longer be changed on the fly. Your app will need to refresh in order for the user to see the new precision value.
+- **decimal:** Precision prop can no longer be changed on the fly. Your app will need to refresh in order for the user to see the new precision value.
 
 ### Code Refactoring
 
-* **decimal:** allow the user to input any value ([1a2307a](https://github.com/Sage/carbon/commit/1a2307a0046384fe79566338341a10f723e403cc))
+- **decimal:** allow the user to input any value ([1a2307a](https://github.com/Sage/carbon/commit/1a2307a0046384fe79566338341a10f723e403cc))
 
 ## [72.0.0](https://github.com/Sage/carbon/compare/v71.4.2...v72.0.0) (2021-05-11)
 
-
 ### ⚠ BREAKING CHANGES
 
-* all TypeScript projects have to add @types/styled-system
-and @types/styled-components as dev dependencies
+- all TypeScript projects have to add @types/styled-system
+  and @types/styled-components as dev dependencies
 
 ### Features
 
-* **validation-icon:** add ts type definitions ([15a9f81](https://github.com/Sage/carbon/commit/15a9f81a18b90581b9fa8a7f025db5dd44a652a1))
-* add global style type definition file ([169a3f5](https://github.com/Sage/carbon/commit/169a3f5f414425c5c2aebad1eca7fbb96f0f9f60))
-* add type definitions to mockmatchmedia util ([205a000](https://github.com/Sage/carbon/commit/205a0004de8ec1481f3fd44f8c00d1f3f373d834))
-* **action-toolbar:** add ts type definitions ([0050574](https://github.com/Sage/carbon/commit/0050574c374dfef0072407b9a0cbac031729d55e))
-* **alert:** add ts type definitions ([c35be8e](https://github.com/Sage/carbon/commit/c35be8e1f27f3fed095f8cff948330e2d69e2bed))
-* **app-wrapper:** add ts type definitions ([dbbcc30](https://github.com/Sage/carbon/commit/dbbcc30dbe8ccc4eb0d5f80d1b906caa50f59b50)), closes [#3696](https://github.com/Sage/carbon/issues/3696)
-* **button-toggle:** add ts type definitions ([f289949](https://github.com/Sage/carbon/commit/f2899498c17c274626bb4855e888615994a904cc))
-* **button-toggle-group:** add ts type definitions ([1ca5da7](https://github.com/Sage/carbon/commit/1ca5da7e10ef7fb216fb403fef15d06ede5588f5))
-* **card:** add ts type definitions ([fc6129b](https://github.com/Sage/carbon/commit/fc6129bdf671cb339522a948e282ee022da2e1fb))
-* **carousel:** add ts type definitions ([7c5490a](https://github.com/Sage/carbon/commit/7c5490a9d8a51966fda8fd83fe6f26122f51c640))
-* **checkable-input:** add type definitions ([16421e3](https://github.com/Sage/carbon/commit/16421e3e527a12c9700870a21efcc329573b18d9))
-* **configurable-items:** add ts type definitions ([890aaa5](https://github.com/Sage/carbon/commit/890aaa55b7de487c86f1febb63c89dc663eaa340))
-* **detail:** add ts type definitions ([ffc91d6](https://github.com/Sage/carbon/commit/ffc91d69da23cf57343025bb8d8e7f459ef1b09b))
-* **dialog:** add ts type definitions ([e8b7192](https://github.com/Sage/carbon/commit/e8b7192188c91dc6fdd09bafb50408562dea0b7c))
-* **dialog-full-screen:** add ts type definitions ([37ffe53](https://github.com/Sage/carbon/commit/37ffe53b2129d930f37a6a3fef87ee6c50dac56a)), closes [#3697](https://github.com/Sage/carbon/issues/3697)
-* **duelling-picklist:** add picklist-group ts type definitions ([a08ca70](https://github.com/Sage/carbon/commit/a08ca704254a4547d5ae86dd8972d88af5df073f))
-* **form-field:** add type definitions ([f6ba4f9](https://github.com/Sage/carbon/commit/f6ba4f97e876aa8678d358c9d8f56b76da35c910))
-* **heading:** add ts type definitions ([9598cc3](https://github.com/Sage/carbon/commit/9598cc3409bbd844c11514408d28d4fe1e64ea1e)), closes [#3699](https://github.com/Sage/carbon/issues/3699)
-* **icon-button:** add ts type definitions ([1c18a99](https://github.com/Sage/carbon/commit/1c18a99760804b4d33c35fb5090a08c18f4a2d0c))
-* **inline-inpouts:** add ts type definitions ([bbd8fef](https://github.com/Sage/carbon/commit/bbd8fefa3941dd9565b515f1a0faabfce46de615))
-* **loader:** add ts type definitions ([c5e0ada](https://github.com/Sage/carbon/commit/c5e0ada95883a97f4dfe0270a028c0a68d7fc8b6)), closes [#3700](https://github.com/Sage/carbon/issues/3700)
-* **menu:** add scrollableblock type definitions ([348f91e](https://github.com/Sage/carbon/commit/348f91ee27752666368216479d877dd842556344))
-* **message:** add ts type definitions ([12cdd01](https://github.com/Sage/carbon/commit/12cdd01b863cc6130855caec460f4805181bf723)), closes [#3701](https://github.com/Sage/carbon/issues/3701)
-* **modal:** add ts type definitions ([108bec4](https://github.com/Sage/carbon/commit/108bec46f7f5161b3e9accb676af5487a1131d6d))
-* **mount-in-app:** add ts type definitions ([2b4aacd](https://github.com/Sage/carbon/commit/2b4aacd57e6e77308f7b9bd0e913055c46754304))
-* **multi-action-button:** add ts type definitions ([2598a7f](https://github.com/Sage/carbon/commit/2598a7f9d741edd9607390209540fc893a837fea))
-* **pages:** add ts type definitions ([2a3f736](https://github.com/Sage/carbon/commit/2a3f736567ea3c0c40599f773e8d9b7c20c60904))
-* **portal:** add ts type definitions ([c769de8](https://github.com/Sage/carbon/commit/c769de817a848d6d5f2166c349df45e4f32b71be))
-* **preview:** add ts type definitions ([b653c65](https://github.com/Sage/carbon/commit/b653c653517f5bea94052481bafcd08be132d72b))
-* **profile:** add ts type definitions ([74baa19](https://github.com/Sage/carbon/commit/74baa190894172a36c2a5b020475000872f1377d))
-* **settings-row:** add ts type definitions ([85822c9](https://github.com/Sage/carbon/commit/85822c9321d18dc777c78731f0be1ce6bfd15ffd))
-* **show-edit-pod:** add ts type definitions ([7bd13b2](https://github.com/Sage/carbon/commit/7bd13b2b7871bbf1f6133c725368e1483a6ef642))
-* **sidebar:** add ts type definitions ([cc69fc1](https://github.com/Sage/carbon/commit/cc69fc14fc0f8ffd4f4dc0b1df1beb7952ce3688)), closes [#3702](https://github.com/Sage/carbon/issues/3702)
-* **simple-select:** add select-textbox type definitions ([a100cc9](https://github.com/Sage/carbon/commit/a100cc9c36cc6da32348d5cc891d3924861fda36))
-* **split-button:** add ts type definitions ([0598f16](https://github.com/Sage/carbon/commit/0598f16f541452afa70c7de459ab22cc410a740c))
-* **step-sequence:** add ts type definitions ([29c40b2](https://github.com/Sage/carbon/commit/29c40b230235fa720188871bbe697fd9bf943400))
-* add ts type definitions to theme config files ([b62b21a](https://github.com/Sage/carbon/commit/b62b21af624919aa0cd2b0d327b7f3d6bf9fff21)), closes [#3705](https://github.com/Sage/carbon/issues/3705)
-
+- **validation-icon:** add ts type definitions ([15a9f81](https://github.com/Sage/carbon/commit/15a9f81a18b90581b9fa8a7f025db5dd44a652a1))
+- add global style type definition file ([169a3f5](https://github.com/Sage/carbon/commit/169a3f5f414425c5c2aebad1eca7fbb96f0f9f60))
+- add type definitions to mockmatchmedia util ([205a000](https://github.com/Sage/carbon/commit/205a0004de8ec1481f3fd44f8c00d1f3f373d834))
+- **action-toolbar:** add ts type definitions ([0050574](https://github.com/Sage/carbon/commit/0050574c374dfef0072407b9a0cbac031729d55e))
+- **alert:** add ts type definitions ([c35be8e](https://github.com/Sage/carbon/commit/c35be8e1f27f3fed095f8cff948330e2d69e2bed))
+- **app-wrapper:** add ts type definitions ([dbbcc30](https://github.com/Sage/carbon/commit/dbbcc30dbe8ccc4eb0d5f80d1b906caa50f59b50)), closes [#3696](https://github.com/Sage/carbon/issues/3696)
+- **button-toggle:** add ts type definitions ([f289949](https://github.com/Sage/carbon/commit/f2899498c17c274626bb4855e888615994a904cc))
+- **button-toggle-group:** add ts type definitions ([1ca5da7](https://github.com/Sage/carbon/commit/1ca5da7e10ef7fb216fb403fef15d06ede5588f5))
+- **card:** add ts type definitions ([fc6129b](https://github.com/Sage/carbon/commit/fc6129bdf671cb339522a948e282ee022da2e1fb))
+- **carousel:** add ts type definitions ([7c5490a](https://github.com/Sage/carbon/commit/7c5490a9d8a51966fda8fd83fe6f26122f51c640))
+- **checkable-input:** add type definitions ([16421e3](https://github.com/Sage/carbon/commit/16421e3e527a12c9700870a21efcc329573b18d9))
+- **configurable-items:** add ts type definitions ([890aaa5](https://github.com/Sage/carbon/commit/890aaa55b7de487c86f1febb63c89dc663eaa340))
+- **detail:** add ts type definitions ([ffc91d6](https://github.com/Sage/carbon/commit/ffc91d69da23cf57343025bb8d8e7f459ef1b09b))
+- **dialog:** add ts type definitions ([e8b7192](https://github.com/Sage/carbon/commit/e8b7192188c91dc6fdd09bafb50408562dea0b7c))
+- **dialog-full-screen:** add ts type definitions ([37ffe53](https://github.com/Sage/carbon/commit/37ffe53b2129d930f37a6a3fef87ee6c50dac56a)), closes [#3697](https://github.com/Sage/carbon/issues/3697)
+- **duelling-picklist:** add picklist-group ts type definitions ([a08ca70](https://github.com/Sage/carbon/commit/a08ca704254a4547d5ae86dd8972d88af5df073f))
+- **form-field:** add type definitions ([f6ba4f9](https://github.com/Sage/carbon/commit/f6ba4f97e876aa8678d358c9d8f56b76da35c910))
+- **heading:** add ts type definitions ([9598cc3](https://github.com/Sage/carbon/commit/9598cc3409bbd844c11514408d28d4fe1e64ea1e)), closes [#3699](https://github.com/Sage/carbon/issues/3699)
+- **icon-button:** add ts type definitions ([1c18a99](https://github.com/Sage/carbon/commit/1c18a99760804b4d33c35fb5090a08c18f4a2d0c))
+- **inline-inpouts:** add ts type definitions ([bbd8fef](https://github.com/Sage/carbon/commit/bbd8fefa3941dd9565b515f1a0faabfce46de615))
+- **loader:** add ts type definitions ([c5e0ada](https://github.com/Sage/carbon/commit/c5e0ada95883a97f4dfe0270a028c0a68d7fc8b6)), closes [#3700](https://github.com/Sage/carbon/issues/3700)
+- **menu:** add scrollableblock type definitions ([348f91e](https://github.com/Sage/carbon/commit/348f91ee27752666368216479d877dd842556344))
+- **message:** add ts type definitions ([12cdd01](https://github.com/Sage/carbon/commit/12cdd01b863cc6130855caec460f4805181bf723)), closes [#3701](https://github.com/Sage/carbon/issues/3701)
+- **modal:** add ts type definitions ([108bec4](https://github.com/Sage/carbon/commit/108bec46f7f5161b3e9accb676af5487a1131d6d))
+- **mount-in-app:** add ts type definitions ([2b4aacd](https://github.com/Sage/carbon/commit/2b4aacd57e6e77308f7b9bd0e913055c46754304))
+- **multi-action-button:** add ts type definitions ([2598a7f](https://github.com/Sage/carbon/commit/2598a7f9d741edd9607390209540fc893a837fea))
+- **pages:** add ts type definitions ([2a3f736](https://github.com/Sage/carbon/commit/2a3f736567ea3c0c40599f773e8d9b7c20c60904))
+- **portal:** add ts type definitions ([c769de8](https://github.com/Sage/carbon/commit/c769de817a848d6d5f2166c349df45e4f32b71be))
+- **preview:** add ts type definitions ([b653c65](https://github.com/Sage/carbon/commit/b653c653517f5bea94052481bafcd08be132d72b))
+- **profile:** add ts type definitions ([74baa19](https://github.com/Sage/carbon/commit/74baa190894172a36c2a5b020475000872f1377d))
+- **settings-row:** add ts type definitions ([85822c9](https://github.com/Sage/carbon/commit/85822c9321d18dc777c78731f0be1ce6bfd15ffd))
+- **show-edit-pod:** add ts type definitions ([7bd13b2](https://github.com/Sage/carbon/commit/7bd13b2b7871bbf1f6133c725368e1483a6ef642))
+- **sidebar:** add ts type definitions ([cc69fc1](https://github.com/Sage/carbon/commit/cc69fc14fc0f8ffd4f4dc0b1df1beb7952ce3688)), closes [#3702](https://github.com/Sage/carbon/issues/3702)
+- **simple-select:** add select-textbox type definitions ([a100cc9](https://github.com/Sage/carbon/commit/a100cc9c36cc6da32348d5cc891d3924861fda36))
+- **split-button:** add ts type definitions ([0598f16](https://github.com/Sage/carbon/commit/0598f16f541452afa70c7de459ab22cc410a740c))
+- **step-sequence:** add ts type definitions ([29c40b2](https://github.com/Sage/carbon/commit/29c40b230235fa720188871bbe697fd9bf943400))
+- add ts type definitions to theme config files ([b62b21a](https://github.com/Sage/carbon/commit/b62b21af624919aa0cd2b0d327b7f3d6bf9fff21)), closes [#3705](https://github.com/Sage/carbon/issues/3705)
 
 ### Bug Fixes
 
-* **accordion:** incorrect ts type definitions ([fec618f](https://github.com/Sage/carbon/commit/fec618fc854d71e09c8fc907023fae7bbbf2f795))
-* **action-popover:** incorrect ts type definitions ([7f520c2](https://github.com/Sage/carbon/commit/7f520c287bf01ca835a35563c17ed33f77e1cf5b))
-* **advanced-color-picker:** incorrect ts type definitions ([4fbe849](https://github.com/Sage/carbon/commit/4fbe8492893f481f3b8f923ff0ef7535262a313c))
-* **anchor-navigation:** incorrect ts type definitions ([fc68fdd](https://github.com/Sage/carbon/commit/fc68fdd619c9a7bdd767dcad485d8b15ad30eae0))
-* **badge:** incorrect ts type definitions ([b3cdc6e](https://github.com/Sage/carbon/commit/b3cdc6e46eb12b1258f6737b1a3e686f5cd4292f))
-* **batch-selection:** ts type definitions not properly exported ([7b59608](https://github.com/Sage/carbon/commit/7b59608f4858048d01c07b4b65ca87b07e73a36a))
-* **box:** ts type definitions not properly exported ([b0dc5e6](https://github.com/Sage/carbon/commit/b0dc5e61b3482f3fd3c0d7e4d9ba26c3a58f05dd)), closes [#3733](https://github.com/Sage/carbon/issues/3733)
-* **button:** incorrect ts margin type definitions ([1fa2e36](https://github.com/Sage/carbon/commit/1fa2e36952ccce4b53baebad73f9fe3ee21c520a)), closes [#3727](https://github.com/Sage/carbon/issues/3727)
-* **checkbox-group:** incorrect children type in typescript ([cc480c5](https://github.com/Sage/carbon/commit/cc480c509b6daf95522ea5855502df0c54dca8cc))
-* **confirm:** type definitions not exported ([befd66e](https://github.com/Sage/carbon/commit/befd66e8f817d4a29a991aecadffac7a8d007e2b)), closes [#3710](https://github.com/Sage/carbon/issues/3710) [#3809](https://github.com/Sage/carbon/issues/3809)
-* **draggable:** incorrect ts type definitions ([e855976](https://github.com/Sage/carbon/commit/e85597664ac2ab74a22214f3d9ee58c3967da363))
-* **drawer:** incorrect ts type definitions ([6e4ab56](https://github.com/Sage/carbon/commit/6e4ab56ced4e24f955a48b5c81f8c34b1f95aa6a)), closes [#3694](https://github.com/Sage/carbon/issues/3694)
-* **flat-table:** missing ts type definitions ([088183e](https://github.com/Sage/carbon/commit/088183e3020514a76148ae3f3d213d08ffba4038))
-* **form:** type definitions not properly exported ([01c07ed](https://github.com/Sage/carbon/commit/01c07ed8aea5d51fd1577c3a466d551ace99c6ef)), closes [#3690](https://github.com/Sage/carbon/issues/3690)
-* **hr:** type definitions not properly exported ([9dce2b9](https://github.com/Sage/carbon/commit/9dce2b941c249794a7c560dab8aa881caabd0204)), closes [#3691](https://github.com/Sage/carbon/issues/3691)
-* **link:** internallink export missing in type definitions ([37002c1](https://github.com/Sage/carbon/commit/37002c1574f84f5cc4346f53e370c8561cfa3f55))
-* **number:** incorrect import of textbox type definitions ([984f9db](https://github.com/Sage/carbon/commit/984f9db4558d10f1ee6ab5272e11480f0fa28749))
-* **pill:** ts type definitions not properly exported ([379efd3](https://github.com/Sage/carbon/commit/379efd366d31d0b629456dc4e69f32e1671978d1)), closes [#3708](https://github.com/Sage/carbon/issues/3708)
-* **popover-container:** type definitions not properly exported ([c127258](https://github.com/Sage/carbon/commit/c12725811dcebf92a89531ead0eede14f060f7c9)), closes [#3707](https://github.com/Sage/carbon/issues/3707)
-* **radio-button:** type definitions not properly exported ([3873c81](https://github.com/Sage/carbon/commit/3873c81822a72b9d6a2d01f199e12adcac6826cc))
-* **simple-select:** optionrow and optiongroupheader type definitions not exported ([8143417](https://github.com/Sage/carbon/commit/8143417a391c1383e99e5d86829d764031adb507))
-* **tabs:** ts props other than children should be optional ([df5a6b8](https://github.com/Sage/carbon/commit/df5a6b86ac195ff755797a88a7b55e71f983bbcf)), closes [#3568](https://github.com/Sage/carbon/issues/3568)
-* **tile-select:** ts type prop should not be required ([3e7343b](https://github.com/Sage/carbon/commit/3e7343b6c1c646f72d843f41dd886c6f6dcf5a3d))
-* **toast:** type definitions not properly exported ([a9b3dfe](https://github.com/Sage/carbon/commit/a9b3dfee3fe874e405bc63f2437d0f6e292ea77b)), closes [#3712](https://github.com/Sage/carbon/issues/3712)
-* **typography:** incorrect prop name in type definitions ([afcebf4](https://github.com/Sage/carbon/commit/afcebf420cce2da574ad0c7450a69b60a127bec0))
-* incorrect typescript exports ([cd60012](https://github.com/Sage/carbon/commit/cd600127eefe5a1aab205664193eafb21da0ebd3))
-
+- **accordion:** incorrect ts type definitions ([fec618f](https://github.com/Sage/carbon/commit/fec618fc854d71e09c8fc907023fae7bbbf2f795))
+- **action-popover:** incorrect ts type definitions ([7f520c2](https://github.com/Sage/carbon/commit/7f520c287bf01ca835a35563c17ed33f77e1cf5b))
+- **advanced-color-picker:** incorrect ts type definitions ([4fbe849](https://github.com/Sage/carbon/commit/4fbe8492893f481f3b8f923ff0ef7535262a313c))
+- **anchor-navigation:** incorrect ts type definitions ([fc68fdd](https://github.com/Sage/carbon/commit/fc68fdd619c9a7bdd767dcad485d8b15ad30eae0))
+- **badge:** incorrect ts type definitions ([b3cdc6e](https://github.com/Sage/carbon/commit/b3cdc6e46eb12b1258f6737b1a3e686f5cd4292f))
+- **batch-selection:** ts type definitions not properly exported ([7b59608](https://github.com/Sage/carbon/commit/7b59608f4858048d01c07b4b65ca87b07e73a36a))
+- **box:** ts type definitions not properly exported ([b0dc5e6](https://github.com/Sage/carbon/commit/b0dc5e61b3482f3fd3c0d7e4d9ba26c3a58f05dd)), closes [#3733](https://github.com/Sage/carbon/issues/3733)
+- **button:** incorrect ts margin type definitions ([1fa2e36](https://github.com/Sage/carbon/commit/1fa2e36952ccce4b53baebad73f9fe3ee21c520a)), closes [#3727](https://github.com/Sage/carbon/issues/3727)
+- **checkbox-group:** incorrect children type in typescript ([cc480c5](https://github.com/Sage/carbon/commit/cc480c509b6daf95522ea5855502df0c54dca8cc))
+- **confirm:** type definitions not exported ([befd66e](https://github.com/Sage/carbon/commit/befd66e8f817d4a29a991aecadffac7a8d007e2b)), closes [#3710](https://github.com/Sage/carbon/issues/3710) [#3809](https://github.com/Sage/carbon/issues/3809)
+- **draggable:** incorrect ts type definitions ([e855976](https://github.com/Sage/carbon/commit/e85597664ac2ab74a22214f3d9ee58c3967da363))
+- **drawer:** incorrect ts type definitions ([6e4ab56](https://github.com/Sage/carbon/commit/6e4ab56ced4e24f955a48b5c81f8c34b1f95aa6a)), closes [#3694](https://github.com/Sage/carbon/issues/3694)
+- **flat-table:** missing ts type definitions ([088183e](https://github.com/Sage/carbon/commit/088183e3020514a76148ae3f3d213d08ffba4038))
+- **form:** type definitions not properly exported ([01c07ed](https://github.com/Sage/carbon/commit/01c07ed8aea5d51fd1577c3a466d551ace99c6ef)), closes [#3690](https://github.com/Sage/carbon/issues/3690)
+- **hr:** type definitions not properly exported ([9dce2b9](https://github.com/Sage/carbon/commit/9dce2b941c249794a7c560dab8aa881caabd0204)), closes [#3691](https://github.com/Sage/carbon/issues/3691)
+- **link:** internallink export missing in type definitions ([37002c1](https://github.com/Sage/carbon/commit/37002c1574f84f5cc4346f53e370c8561cfa3f55))
+- **number:** incorrect import of textbox type definitions ([984f9db](https://github.com/Sage/carbon/commit/984f9db4558d10f1ee6ab5272e11480f0fa28749))
+- **pill:** ts type definitions not properly exported ([379efd3](https://github.com/Sage/carbon/commit/379efd366d31d0b629456dc4e69f32e1671978d1)), closes [#3708](https://github.com/Sage/carbon/issues/3708)
+- **popover-container:** type definitions not properly exported ([c127258](https://github.com/Sage/carbon/commit/c12725811dcebf92a89531ead0eede14f060f7c9)), closes [#3707](https://github.com/Sage/carbon/issues/3707)
+- **radio-button:** type definitions not properly exported ([3873c81](https://github.com/Sage/carbon/commit/3873c81822a72b9d6a2d01f199e12adcac6826cc))
+- **simple-select:** optionrow and optiongroupheader type definitions not exported ([8143417](https://github.com/Sage/carbon/commit/8143417a391c1383e99e5d86829d764031adb507))
+- **tabs:** ts props other than children should be optional ([df5a6b8](https://github.com/Sage/carbon/commit/df5a6b86ac195ff755797a88a7b55e71f983bbcf)), closes [#3568](https://github.com/Sage/carbon/issues/3568)
+- **tile-select:** ts type prop should not be required ([3e7343b](https://github.com/Sage/carbon/commit/3e7343b6c1c646f72d843f41dd886c6f6dcf5a3d))
+- **toast:** type definitions not properly exported ([a9b3dfe](https://github.com/Sage/carbon/commit/a9b3dfee3fe874e405bc63f2437d0f6e292ea77b)), closes [#3712](https://github.com/Sage/carbon/issues/3712)
+- **typography:** incorrect prop name in type definitions ([afcebf4](https://github.com/Sage/carbon/commit/afcebf420cce2da574ad0c7450a69b60a127bec0))
+- incorrect typescript exports ([cd60012](https://github.com/Sage/carbon/commit/cd600127eefe5a1aab205664193eafb21da0ebd3))
 
 ### Miscellaneous Chores
 
-* add styled-system and styled-components types dependencies ([fc8e62d](https://github.com/Sage/carbon/commit/fc8e62d3857723cf5985319b23c245c21598751b))
+- add styled-system and styled-components types dependencies ([fc8e62d](https://github.com/Sage/carbon/commit/fc8e62d3857723cf5985319b23c245c21598751b))
 
 ### [71.4.2](https://github.com/Sage/carbon/compare/v71.4.1...v71.4.2) (2021-05-10)
 
-
 ### Bug Fixes
 
-* **dialog-full-screen:** fix content ref forwarding ([7d0cdc0](https://github.com/Sage/carbon/commit/7d0cdc0295f6a6f01c14d7c47af3db1061fc41e1))
+- **dialog-full-screen:** fix content ref forwarding ([7d0cdc0](https://github.com/Sage/carbon/commit/7d0cdc0295f6a6f01c14d7c47af3db1061fc41e1))
 
 ### [71.4.1](https://github.com/Sage/carbon/compare/v71.4.0...v71.4.1) (2021-05-07)
 
-
 ### Bug Fixes
 
-* **flat-table:** allow multiple header rows to be sticky ([e70dfa9](https://github.com/Sage/carbon/commit/e70dfa98deeb283cf0410d0b3fa9a27547384ede)), closes [#3728](https://github.com/Sage/carbon/issues/3728)
-* **flat-table:** allow row headers to be sticky within flat-table-head ([84dfa9b](https://github.com/Sage/carbon/commit/84dfa9b03e6545ca82161dfafc5cb5a437dd0e13))
+- **flat-table:** allow multiple header rows to be sticky ([e70dfa9](https://github.com/Sage/carbon/commit/e70dfa98deeb283cf0410d0b3fa9a27547384ede)), closes [#3728](https://github.com/Sage/carbon/issues/3728)
+- **flat-table:** allow row headers to be sticky within flat-table-head ([84dfa9b](https://github.com/Sage/carbon/commit/84dfa9b03e6545ca82161dfafc5cb5a437dd0e13))
 
 ## [71.4.0](https://github.com/Sage/carbon/compare/v71.3.0...v71.4.0) (2021-05-07)
 
-
 ### Features
 
-* **switch:** add styled system margin ([ca01fee](https://github.com/Sage/carbon/commit/ca01fee166410f63d5e576fd2202f4c4f108c4d5))
+- **switch:** add styled system margin ([ca01fee](https://github.com/Sage/carbon/commit/ca01fee166410f63d5e576fd2202f4c4f108c4d5))
 
 ## [71.3.0](https://github.com/Sage/carbon/compare/v71.2.1...v71.3.0) (2021-05-06)
 
-
 ### Features
 
-* **draggable:** add styled-system props support ([9a2ca2b](https://github.com/Sage/carbon/commit/9a2ca2baa006935e1c67b450a01dd7e5a064bd3c))
+- **draggable:** add styled-system props support ([9a2ca2b](https://github.com/Sage/carbon/commit/9a2ca2baa006935e1c67b450a01dd7e5a064bd3c))
 
 ### [71.2.1](https://github.com/Sage/carbon/compare/v71.2.0...v71.2.1) (2021-05-06)
 
-
 ### Bug Fixes
 
-* **search:** fix outline appearing onClick around the X icon ([6f8fb38](https://github.com/Sage/carbon/commit/6f8fb38cc50091ab482e10e1ad63c9d822ddb905)), closes [#3857](https://github.com/Sage/carbon/issues/3857)
+- **search:** fix outline appearing onClick around the X icon ([6f8fb38](https://github.com/Sage/carbon/commit/6f8fb38cc50091ab482e10e1ad63c9d822ddb905)), closes [#3857](https://github.com/Sage/carbon/issues/3857)
 
 ## [71.2.0](https://github.com/Sage/carbon/compare/v71.1.0...v71.2.0) (2021-05-06)
 
-
 ### Features
 
-* **image:** create new component to support rendering images ([c77e4b1](https://github.com/Sage/carbon/commit/c77e4b18d17fcfff03257c4179d0ffc60eaca425))
+- **image:** create new component to support rendering images ([c77e4b1](https://github.com/Sage/carbon/commit/c77e4b18d17fcfff03257c4179d0ffc60eaca425))
 
 ## [71.1.0](https://github.com/Sage/carbon/compare/v71.0.0...v71.1.0) (2021-05-04)
 
-
 ### Features
 
-* **detail:** add styled-system margin support ([5ccbf34](https://github.com/Sage/carbon/commit/5ccbf349855a065ea3ce845a457e3540a6651a14))
+- **detail:** add styled-system margin support ([5ccbf34](https://github.com/Sage/carbon/commit/5ccbf349855a065ea3ce845a457e3540a6651a14))
 
 ## [71.0.0](https://github.com/Sage/carbon/compare/v70.9.0...v71.0.0) (2021-05-04)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **menu-item:** Removed keyboardOverride prop from MenuItem
+- **menu-item:** Removed keyboardOverride prop from MenuItem
 
 ### Code Refactoring
 
-* **menu-item:** remove keyboard override option ([6531b2f](https://github.com/Sage/carbon/commit/6531b2fcf8bc57ea87679af6f652c0e6d860c51d))
+- **menu-item:** remove keyboard override option ([6531b2f](https://github.com/Sage/carbon/commit/6531b2fcf8bc57ea87679af6f652c0e6d860c51d))
 
 ## [70.9.0](https://github.com/Sage/carbon/compare/v70.8.0...v70.9.0) (2021-04-30)
 
-
 ### Features
 
-* **content:** add margin props ([d95b9c5](https://github.com/Sage/carbon/commit/d95b9c52f1357d16d294b6d8ef269b0e257cc8c3))
+- **content:** add margin props ([d95b9c5](https://github.com/Sage/carbon/commit/d95b9c52f1357d16d294b6d8ef269b0e257cc8c3))
 
 ## [70.8.0](https://github.com/Sage/carbon/compare/v70.7.0...v70.8.0) (2021-04-30)
 
-
 ### Features
 
-* **heading:** add styled-system margin support ([86b54e1](https://github.com/Sage/carbon/commit/86b54e17054e5769444199f4b3b255704699deca))
+- **heading:** add styled-system margin support ([86b54e1](https://github.com/Sage/carbon/commit/86b54e17054e5769444199f4b3b255704699deca))
 
 ## [70.7.0](https://github.com/Sage/carbon/compare/v70.6.0...v70.7.0) (2021-04-29)
 
-
 ### Features
 
-* **accordion-group:** add styled-system margin support ([782d2d6](https://github.com/Sage/carbon/commit/782d2d6e6bf93d6d68ee93e04de2644b32c67718))
+- **accordion-group:** add styled-system margin support ([782d2d6](https://github.com/Sage/carbon/commit/782d2d6e6bf93d6d68ee93e04de2644b32c67718))
 
 ## [70.6.0](https://github.com/Sage/carbon/compare/v70.5.1...v70.6.0) (2021-04-29)
 
-
 ### Features
 
-* **dialog-full-screen:** add auto focus functionality ([0c36bbb](https://github.com/Sage/carbon/commit/0c36bbb20a178ed11107e79dfe895e4a8123d788))
+- **dialog-full-screen:** add auto focus functionality ([0c36bbb](https://github.com/Sage/carbon/commit/0c36bbb20a178ed11107e79dfe895e4a8123d788))
 
 ### [70.5.1](https://github.com/Sage/carbon/compare/v70.5.0...v70.5.1) (2021-04-29)
 
-
 ### Bug Fixes
 
-* **filterable-select:** call onChange when value is deleted or not matched ([6c18561](https://github.com/Sage/carbon/commit/6c18561d8e4881fc4c54c8445e81588a3696c1d0))
+- **filterable-select:** call onChange when value is deleted or not matched ([6c18561](https://github.com/Sage/carbon/commit/6c18561d8e4881fc4c54c8445e81588a3696c1d0))
 
 ## [70.5.0](https://github.com/Sage/carbon/compare/v70.4.1...v70.5.0) (2021-04-29)
 
-
 ### Features
 
-* **help:** add support for styled-system margin interface ([025d8b1](https://github.com/Sage/carbon/commit/025d8b14bd75422485d2bb1748ac2eca765d87cd))
-* **icon:** add support for styled-system margin interface ([31e4089](https://github.com/Sage/carbon/commit/31e40892b681dd6e5f752eb13df97cd593223947))
-* **validation-icon:** add support for styled-system margin interface ([f3cf951](https://github.com/Sage/carbon/commit/f3cf951d15a18264b7196f3ff97dc843746405e9))
+- **help:** add support for styled-system margin interface ([025d8b1](https://github.com/Sage/carbon/commit/025d8b14bd75422485d2bb1748ac2eca765d87cd))
+- **icon:** add support for styled-system margin interface ([31e4089](https://github.com/Sage/carbon/commit/31e40892b681dd6e5f752eb13df97cd593223947))
+- **validation-icon:** add support for styled-system margin interface ([f3cf951](https://github.com/Sage/carbon/commit/f3cf951d15a18264b7196f3ff97dc843746405e9))
 
 ### [70.4.1](https://github.com/Sage/carbon/compare/v70.4.0...v70.4.1) (2021-04-29)
 
-
 ### Bug Fixes
 
-* **select:** fix not resizing list during window resize ([f173917](https://github.com/Sage/carbon/commit/f173917b6cdf3a8ca6c88f716a8d5d515bddea1f))
+- **select:** fix not resizing list during window resize ([f173917](https://github.com/Sage/carbon/commit/f173917b6cdf3a8ca6c88f716a8d5d515bddea1f))
 
 ## [70.4.0](https://github.com/Sage/carbon/compare/v70.3.0...v70.4.0) (2021-04-28)
 
-
 ### Features
 
-* **action-popover:** add styled-system margin support ([5816ef7](https://github.com/Sage/carbon/commit/5816ef7594bafd6a712971548a4dd6c9d601b939))
+- **action-popover:** add styled-system margin support ([5816ef7](https://github.com/Sage/carbon/commit/5816ef7594bafd6a712971548a4dd6c9d601b939))
 
 ## [70.3.0](https://github.com/Sage/carbon/compare/v70.2.0...v70.3.0) (2021-04-28)
 
-
 ### Features
 
-* add tooltip and onClick to Portrait component - FE-3502 ([73a0075](https://github.com/Sage/carbon/commit/73a0075c59bd7692739491f6029a10c387fdd44b)), closes [#3554](https://github.com/Sage/carbon/issues/3554)
+- add tooltip and onClick to Portrait component - FE-3502 ([73a0075](https://github.com/Sage/carbon/commit/73a0075c59bd7692739491f6029a10c387fdd44b)), closes [#3554](https://github.com/Sage/carbon/issues/3554)
 
 ## [70.2.0](https://github.com/Sage/carbon/compare/v70.1.1...v70.2.0) (2021-04-28)
 
-
 ### Features
 
-* **card:** add styled-system margin support ([e902aa2](https://github.com/Sage/carbon/commit/e902aa239ed4e2aa6941d185cb9d591e1abe8074))
+- **card:** add styled-system margin support ([e902aa2](https://github.com/Sage/carbon/commit/e902aa239ed4e2aa6941d185cb9d591e1abe8074))
 
 ### [70.1.1](https://github.com/Sage/carbon/compare/v70.1.0...v70.1.1) (2021-04-28)
 
-
 ### Bug Fixes
 
-* **definition-list:** fix dl focused elements outline cut by "overflow: hidden" ([f7ca1d3](https://github.com/Sage/carbon/commit/f7ca1d3e3ef4f202a9598e44431a7c6f763f1684))
+- **definition-list:** fix dl focused elements outline cut by "overflow: hidden" ([f7ca1d3](https://github.com/Sage/carbon/commit/f7ca1d3e3ef4f202a9598e44431a7c6f763f1684))
 
 ## [70.1.0](https://github.com/Sage/carbon/compare/v70.0.1...v70.1.0) (2021-04-28)
 
-
 ### Features
 
-* **duelling-picklist:** add support for styled-system margin interface ([8a373be](https://github.com/Sage/carbon/commit/8a373be175c0f45cd868694afe79e01c302a7ed7))
+- **duelling-picklist:** add support for styled-system margin interface ([8a373be](https://github.com/Sage/carbon/commit/8a373be175c0f45cd868694afe79e01c302a7ed7))
 
 ### [70.0.1](https://github.com/Sage/carbon/compare/v70.0.0...v70.0.1) (2021-04-27)
 
-
 ### Bug Fixes
 
-* **flat-table-row-header:** add zIndex to styles ([2026816](https://github.com/Sage/carbon/commit/20268167cb7c6df456ee5efda62a7f16d297a10b)), closes [#3909](https://github.com/Sage/carbon/issues/3909)
+- **flat-table-row-header:** add zIndex to styles ([2026816](https://github.com/Sage/carbon/commit/20268167cb7c6df456ee5efda62a7f16d297a10b)), closes [#3909](https://github.com/Sage/carbon/issues/3909)
 
 ## [70.0.0](https://github.com/Sage/carbon/compare/v69.1.1...v70.0.0) (2021-04-26)
 
-
 ### ⚠ BREAKING CHANGES
 
-* DialogFullScreen, Dialog, Alert and Confirm components
-no longer support enabling background UI interactions or disabling focus trap
-Dialog, Alert and Confirm height prop behaviour has changed
+- DialogFullScreen, Dialog, Alert and Confirm components
+  no longer support enabling background UI interactions or disabling focus trap
+  Dialog, Alert and Confirm height prop behaviour has changed
 
 ### Code Refactoring
 
-* refactor modal based components ([59c65da](https://github.com/Sage/carbon/commit/59c65da42ac78f6b20c38364390f45b63de9310d))
+- refactor modal based components ([59c65da](https://github.com/Sage/carbon/commit/59c65da42ac78f6b20c38364390f45b63de9310d))
 
 ### [69.1.1](https://github.com/Sage/carbon/compare/v69.1.0...v69.1.1) (2021-04-26)
 
-
 ### Bug Fixes
 
-* **select-list:** fix bottom of focus border is cut off by the select-list ([b944350](https://github.com/Sage/carbon/commit/b944350ce2af7d2a1c5494d84bb2bccf631abf17))
+- **select-list:** fix bottom of focus border is cut off by the select-list ([b944350](https://github.com/Sage/carbon/commit/b944350ce2af7d2a1c5494d84bb2bccf631abf17))
 
 ## [69.1.0](https://github.com/Sage/carbon/compare/v69.0.0...v69.1.0) (2021-04-23)
 
-
 ### Features
 
-* **tile-select:** add new footer prop ([baa4442](https://github.com/Sage/carbon/commit/baa4442ffef9a50e39b9f686909aa94c04fb9128))
-* **tile-select:** expand prop types for title, subtitle and description to node ([7563e4e](https://github.com/Sage/carbon/commit/7563e4ebc797cb0301307a3bee372f60d51e0ed9))
+- **tile-select:** add new footer prop ([baa4442](https://github.com/Sage/carbon/commit/baa4442ffef9a50e39b9f686909aa94c04fb9128))
+- **tile-select:** expand prop types for title, subtitle and description to node ([7563e4e](https://github.com/Sage/carbon/commit/7563e4ebc797cb0301307a3bee372f60d51e0ed9))
 
 ## [69.0.0](https://github.com/Sage/carbon/compare/v68.25.3...v69.0.0) (2021-04-22)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **babel:** polyfills for IE11 will no longer be included in our build.
-We polyfill the latest 2 versions of Chrome, Firefox, Edge and Safari
+- **babel:** polyfills for IE11 will no longer be included in our build.
+  We polyfill the latest 2 versions of Chrome, Firefox, Edge and Safari
 
 ### Miscellaneous Chores
 
-* **babel:** update config ([5cac737](https://github.com/Sage/carbon/commit/5cac737abbf0549374b78043964b1173424bf6a3))
+- **babel:** update config ([5cac737](https://github.com/Sage/carbon/commit/5cac737abbf0549374b78043964b1173424bf6a3))
 
 ### [68.25.3](https://github.com/Sage/carbon/compare/v68.25.2...v68.25.3) (2021-04-22)
 
-
 ### Bug Fixes
 
-* **flat-table-row:** add support for controlling expanded rows externally ([721f975](https://github.com/Sage/carbon/commit/721f9751f6687bcdd04dd66160e9d157eb649e45)), closes [#3875](https://github.com/Sage/carbon/issues/3875)
+- **flat-table-row:** add support for controlling expanded rows externally ([721f975](https://github.com/Sage/carbon/commit/721f9751f6687bcdd04dd66160e9d157eb649e45)), closes [#3875](https://github.com/Sage/carbon/issues/3875)
 
 ### [68.25.2](https://github.com/Sage/carbon/compare/v68.25.1...v68.25.2) (2021-04-20)
 
-
 ### Bug Fixes
 
-* **flat-table:** ensure all th elements are sticky when sticky head prop is set ([82dd6c9](https://github.com/Sage/carbon/commit/82dd6c985ea73016ca52a500faa0b46690aad63a)), closes [#3876](https://github.com/Sage/carbon/issues/3876)
+- **flat-table:** ensure all th elements are sticky when sticky head prop is set ([82dd6c9](https://github.com/Sage/carbon/commit/82dd6c985ea73016ca52a500faa0b46690aad63a)), closes [#3876](https://github.com/Sage/carbon/issues/3876)
 
 ### [68.25.1](https://github.com/Sage/carbon/compare/v68.25.0...v68.25.1) (2021-04-19)
 
-
 ### Bug Fixes
 
-* **flat-table:** fix an alignment gap between the colapse icon and the text ([c8d90e5](https://github.com/Sage/carbon/commit/c8d90e56804b4e55870f0721b2013e5e5f48438f))
+- **flat-table:** fix an alignment gap between the colapse icon and the text ([c8d90e5](https://github.com/Sage/carbon/commit/c8d90e56804b4e55870f0721b2013e5e5f48438f))
 
 ## [68.25.0](https://github.com/Sage/carbon/compare/v68.24.0...v68.25.0) (2021-04-16)
 
-
 ### Features
 
-* **grid-container:** use prop-types from styled-system ([ca91366](https://github.com/Sage/carbon/commit/ca913661ebacc3cd1f87e258ab984b1ca13ef109))
+- **grid-container:** use prop-types from styled-system ([ca91366](https://github.com/Sage/carbon/commit/ca913661ebacc3cd1f87e258ab984b1ca13ef109))
 
 ## [68.24.0](https://github.com/Sage/carbon/compare/v68.23.0...v68.24.0) (2021-04-16)
 
-
 ### Features
 
-* **portrait:** add styled-system margin ([e3de07d](https://github.com/Sage/carbon/commit/e3de07d33031d890e37cf01062c79b233ca0631d))
+- **portrait:** add styled-system margin ([e3de07d](https://github.com/Sage/carbon/commit/e3de07d33031d890e37cf01062c79b233ca0631d))
 
 ## [68.23.0](https://github.com/Sage/carbon/compare/v68.22.1...v68.23.0) (2021-04-16)
 
-
 ### Features
 
-* **preview:** add styled system margin props to Preview ([83e0ba3](https://github.com/Sage/carbon/commit/83e0ba3f39e01df1f689493885dd5635554c9560))
+- **preview:** add styled system margin props to Preview ([83e0ba3](https://github.com/Sage/carbon/commit/83e0ba3f39e01df1f689493885dd5635554c9560))
 
 ### [68.22.1](https://github.com/Sage/carbon/compare/v68.22.0...v68.22.1) (2021-04-15)
 
-
 ### Reverts
 
-* "docs: add info about chromatic for major branch" ([de23064](https://github.com/Sage/carbon/commit/de23064b09cd2b762ddf6346be3fa220f16ab72c))
+- "docs: add info about chromatic for major branch" ([de23064](https://github.com/Sage/carbon/commit/de23064b09cd2b762ddf6346be3fa220f16ab72c))
 
 ## [68.22.0](https://github.com/Sage/carbon/compare/v68.21.0...v68.22.0) (2021-04-15)
 
-
 ### Features
 
-* **step-sequence:** add styled system margin props to StepSequence ([8415302](https://github.com/Sage/carbon/commit/84153020d27f9ae28c1dba4f0a49ce5015696c9a))
+- **step-sequence:** add styled system margin props to StepSequence ([8415302](https://github.com/Sage/carbon/commit/84153020d27f9ae28c1dba4f0a49ce5015696c9a))
 
 ## [68.21.0](https://github.com/Sage/carbon/compare/v68.20.1...v68.21.0) (2021-04-15)
 
-
 ### Features
 
-* **settings-row:** add support for styled system margin props ([88276d6](https://github.com/Sage/carbon/commit/88276d607ae108ac64d86dc1fb27585d56203593))
+- **settings-row:** add support for styled system margin props ([88276d6](https://github.com/Sage/carbon/commit/88276d607ae108ac64d86dc1fb27585d56203593))
 
 ### [68.20.1](https://github.com/Sage/carbon/compare/v68.20.0...v68.20.1) (2021-04-15)
 
-
 ### Bug Fixes
 
-* **day-picker:** fix bottom of focus border is cut off by the date picker ([700822a](https://github.com/Sage/carbon/commit/700822a498325551e1d3dbc9c0b770625b485212))
+- **day-picker:** fix bottom of focus border is cut off by the date picker ([700822a](https://github.com/Sage/carbon/commit/700822a498325551e1d3dbc9c0b770625b485212))
 
 ## [68.20.0](https://github.com/Sage/carbon/compare/v68.19.0...v68.20.0) (2021-04-14)
 
-
 ### Features
 
-* **popover-container:** surface styled system padding props ([a99d967](https://github.com/Sage/carbon/commit/a99d9679e2a13f789976f3c7bcd02bd411301ca5))
+- **popover-container:** surface styled system padding props ([a99d967](https://github.com/Sage/carbon/commit/a99d9679e2a13f789976f3c7bcd02bd411301ca5))
 
 ## [68.19.0](https://github.com/Sage/carbon/compare/v68.18.0...v68.19.0) (2021-04-14)
 
-
 ### Features
 
-* **tile-select, tile-select-group:** surface styled system margin props ([0326f1a](https://github.com/Sage/carbon/commit/0326f1a8c7617206d3524f2ef80d093677802529))
+- **tile-select, tile-select-group:** surface styled system margin props ([0326f1a](https://github.com/Sage/carbon/commit/0326f1a8c7617206d3524f2ef80d093677802529))
 
 ## [68.18.0](https://github.com/Sage/carbon/compare/v68.17.0...v68.18.0) (2021-04-14)
 
-
 ### Features
 
-* **message:** add styled-system margin props ([26e793e](https://github.com/Sage/carbon/commit/26e793e3eefe092f2cf539f5597355e7a716cc8c))
+- **message:** add styled-system margin props ([26e793e](https://github.com/Sage/carbon/commit/26e793e3eefe092f2cf539f5597355e7a716cc8c))
 
 ## [68.17.0](https://github.com/Sage/carbon/compare/v68.16.0...v68.17.0) (2021-04-13)
 
-
 ### Features
 
-* **flat-table-cell, flat-table-row-header:** add width prop to table cell and new truncate styling ([86b42b8](https://github.com/Sage/carbon/commit/86b42b8166c68cb1d8818c02b31e3b79f2e4ca52))
-
+- **flat-table-cell, flat-table-row-header:** add width prop to table cell and new truncate styling ([86b42b8](https://github.com/Sage/carbon/commit/86b42b8166c68cb1d8818c02b31e3b79f2e4ca52))
 
 ### Bug Fixes
 
-* **flat-table-cell, flat-table-header:** raise specificity of spacing styles ([8bd10ce](https://github.com/Sage/carbon/commit/8bd10cea837de190791aee32ea4e9be433008f4a)), closes [#3846](https://github.com/Sage/carbon/issues/3846)
+- **flat-table-cell, flat-table-header:** raise specificity of spacing styles ([8bd10ce](https://github.com/Sage/carbon/commit/8bd10cea837de190791aee32ea4e9be433008f4a)), closes [#3846](https://github.com/Sage/carbon/issues/3846)
 
 ## [68.16.0](https://github.com/Sage/carbon/compare/v68.15.0...v68.16.0) (2021-04-13)
 
-
 ### Features
 
-* **split-button:** surface styled system margin props ([5495b2d](https://github.com/Sage/carbon/commit/5495b2df06322c2c4fc366278cc1e8fcccd32f36))
-
+- **split-button:** surface styled system margin props ([5495b2d](https://github.com/Sage/carbon/commit/5495b2df06322c2c4fc366278cc1e8fcccd32f36))
 
 ### Bug Fixes
 
-* **split-button:** prevent padding props being spread into main button ([7bd7ade](https://github.com/Sage/carbon/commit/7bd7ade4943238e24e323ad4c664a0f4a57c9e83))
+- **split-button:** prevent padding props being spread into main button ([7bd7ade](https://github.com/Sage/carbon/commit/7bd7ade4943238e24e323ad4c664a0f4a57c9e83))
 
 ## [68.15.0](https://github.com/Sage/carbon/compare/v68.14.0...v68.15.0) (2021-04-12)
 
-
 ### Features
 
-* **textbox:** change labelHelp type to ReactNode ([fbd15e6](https://github.com/Sage/carbon/commit/fbd15e62ad242d96787729224aae6fbde22c098d)), closes [#3434](https://github.com/Sage/carbon/issues/3434)
+- **textbox:** change labelHelp type to ReactNode ([fbd15e6](https://github.com/Sage/carbon/commit/fbd15e62ad242d96787729224aae6fbde22c098d)), closes [#3434](https://github.com/Sage/carbon/issues/3434)
 
 ## [68.14.0](https://github.com/Sage/carbon/compare/v68.13.0...v68.14.0) (2021-04-12)
 
-
 ### Features
 
-* **profile:** add styled-system margin props ([a891678](https://github.com/Sage/carbon/commit/a89167874bac998162406be61035a2f4775b6121))
+- **profile:** add styled-system margin props ([a891678](https://github.com/Sage/carbon/commit/a89167874bac998162406be61035a2f4775b6121))
 
 ## [68.13.0](https://github.com/Sage/carbon/compare/v68.12.0...v68.13.0) (2021-04-12)
 
-
 ### Features
 
-* **note:** add styled-system margin props ([dca47cd](https://github.com/Sage/carbon/commit/dca47cd45aed8e75bb0ebd253ae218f6b68b0e35))
+- **note:** add styled-system margin props ([dca47cd](https://github.com/Sage/carbon/commit/dca47cd45aed8e75bb0ebd253ae218f6b68b0e35))
 
 ## [68.12.0](https://github.com/Sage/carbon/compare/v68.11.0...v68.12.0) (2021-04-12)
 
-
 ### Features
 
-* **text-editor:** surface styled system margin props ([9825c61](https://github.com/Sage/carbon/commit/9825c617e53284001113a1db9fbad4e855b59438))
+- **text-editor:** surface styled system margin props ([9825c61](https://github.com/Sage/carbon/commit/9825c617e53284001113a1db9fbad4e855b59438))
 
 ## [68.11.0](https://github.com/Sage/carbon/compare/v68.10.0...v68.11.0) (2021-04-09)
 
-
 ### Features
 
-* **tabs, tab:** surface styled system margin interface in tabs and padding interface in tab ([5e125af](https://github.com/Sage/carbon/commit/5e125af229a54e826076e6928e5e59a0058d5ecb))
+- **tabs, tab:** surface styled system margin interface in tabs and padding interface in tab ([5e125af](https://github.com/Sage/carbon/commit/5e125af229a54e826076e6928e5e59a0058d5ecb))
 
 ## [68.10.0](https://github.com/Sage/carbon/compare/v68.9.2...v68.10.0) (2021-04-09)
 
-
 ### Features
 
-* **loader:** add styled-system ([28f4656](https://github.com/Sage/carbon/commit/28f4656c4017bbd9e2977ea83b7683446e365117))
+- **loader:** add styled-system ([28f4656](https://github.com/Sage/carbon/commit/28f4656c4017bbd9e2977ea83b7683446e365117))
 
 ### [68.9.2](https://github.com/Sage/carbon/compare/v68.9.1...v68.9.2) (2021-04-08)
 
-
 ### Bug Fixes
 
-* **flat-table:** fix gap between table content and sticky footer ([c547f4e](https://github.com/Sage/carbon/commit/c547f4efdd035bb2dd0013b94c21bb38df8237c7)), closes [#3850](https://github.com/Sage/carbon/issues/3850)
+- **flat-table:** fix gap between table content and sticky footer ([c547f4e](https://github.com/Sage/carbon/commit/c547f4efdd035bb2dd0013b94c21bb38df8237c7)), closes [#3850](https://github.com/Sage/carbon/issues/3850)
 
 ### [68.9.1](https://github.com/Sage/carbon/compare/v68.9.0...v68.9.1) (2021-04-08)
 
-
 ### Bug Fixes
 
-* **filterable-select:** check event has a data element attribute before checking the value ([39db098](https://github.com/Sage/carbon/commit/39db09875b242632a1624e8540706988eac4bce0)), closes [#3754](https://github.com/Sage/carbon/issues/3754)
+- **filterable-select:** check event has a data element attribute before checking the value ([39db098](https://github.com/Sage/carbon/commit/39db09875b242632a1624e8540706988eac4bce0)), closes [#3754](https://github.com/Sage/carbon/issues/3754)
 
 ## [68.9.0](https://github.com/Sage/carbon/compare/v68.8.3...v68.9.0) (2021-04-06)
 
-
 ### Features
 
-* **icon-button:** add styled-system ([45d4a72](https://github.com/Sage/carbon/commit/45d4a72589877f6d4d5edb00808a923f1c6799b9))
+- **icon-button:** add styled-system ([45d4a72](https://github.com/Sage/carbon/commit/45d4a72589877f6d4d5edb00808a923f1c6799b9))
 
 ### [68.8.3](https://github.com/Sage/carbon/compare/v68.8.2...v68.8.3) (2021-04-01)
 
-
 ### Bug Fixes
 
-* **simple-select:** remove with: auto for transparent ([045ae94](https://github.com/Sage/carbon/commit/045ae942a5f68a861b702af9aa18a6ec20d0596a))
-* **simple-select:** update icon position ([4636ba2](https://github.com/Sage/carbon/commit/4636ba24047070976f125677c4c921114f1ded7b))
+- **simple-select:** remove with: auto for transparent ([045ae94](https://github.com/Sage/carbon/commit/045ae942a5f68a861b702af9aa18a6ec20d0596a))
+- **simple-select:** update icon position ([4636ba2](https://github.com/Sage/carbon/commit/4636ba24047070976f125677c4c921114f1ded7b))
 
 ### [68.8.2](https://github.com/Sage/carbon/compare/v68.8.1...v68.8.2) (2021-04-01)
 
-
 ### Bug Fixes
 
-* **search:** stop event propagation for characters and numbers ([6754cdf](https://github.com/Sage/carbon/commit/6754cdfc1817c9223ad2952923939e74bbef374e)), closes [#3830](https://github.com/Sage/carbon/issues/3830)
+- **search:** stop event propagation for characters and numbers ([6754cdf](https://github.com/Sage/carbon/commit/6754cdfc1817c9223ad2952923939e74bbef374e)), closes [#3830](https://github.com/Sage/carbon/issues/3830)
 
 ### [68.8.1](https://github.com/Sage/carbon/compare/v68.8.0...v68.8.1) (2021-04-01)
 
-
 ### Bug Fixes
 
-* **flat-table-row:** add border left to the th element directly after a row header ([fa4e02a](https://github.com/Sage/carbon/commit/fa4e02a81acaa875fe7bb40042edfecf14404462)), closes [#3564](https://github.com/Sage/carbon/issues/3564)
-* **flat-table-row:** ensure any cells preceding row headers are also positioned sticky ([b27ff64](https://github.com/Sage/carbon/commit/b27ff64d428390853d3f0a04d9f2283e831a49bd)), closes [#3721](https://github.com/Sage/carbon/issues/3721)
+- **flat-table-row:** add border left to the th element directly after a row header ([fa4e02a](https://github.com/Sage/carbon/commit/fa4e02a81acaa875fe7bb40042edfecf14404462)), closes [#3564](https://github.com/Sage/carbon/issues/3564)
+- **flat-table-row:** ensure any cells preceding row headers are also positioned sticky ([b27ff64](https://github.com/Sage/carbon/commit/b27ff64d428390853d3f0a04d9f2283e831a49bd)), closes [#3721](https://github.com/Sage/carbon/issues/3721)
 
 ## [68.8.0](https://github.com/Sage/carbon/compare/v68.7.0...v68.8.0) (2021-04-01)
 
-
 ### Features
 
-* **validation-icon:** surface ml and mr props to adjust icon spacing ([334ba8f](https://github.com/Sage/carbon/commit/334ba8fb0850eb7d35701af41a27f1268fba5fc8))
+- **validation-icon:** surface ml and mr props to adjust icon spacing ([334ba8f](https://github.com/Sage/carbon/commit/334ba8fb0850eb7d35701af41a27f1268fba5fc8))
 
 ## [68.7.0](https://github.com/Sage/carbon/compare/v68.6.1...v68.7.0) (2021-03-31)
 
-
 ### Features
 
-* **drawer:** allows to use custom height ([5e9bfa5](https://github.com/Sage/carbon/commit/5e9bfa512bbba01b00bc17ab12134b5089021f47))
+- **drawer:** allows to use custom height ([5e9bfa5](https://github.com/Sage/carbon/commit/5e9bfa512bbba01b00bc17ab12134b5089021f47))
 
 ### [68.6.1](https://github.com/Sage/carbon/compare/v68.6.0...v68.6.1) (2021-03-31)
 
-
 ### Bug Fixes
 
-* **pager:** update pager after enter key is pressed ([f254d5d](https://github.com/Sage/carbon/commit/f254d5d4387dd2037abe16ec9f77948d35074749))
+- **pager:** update pager after enter key is pressed ([f254d5d](https://github.com/Sage/carbon/commit/f254d5d4387dd2037abe16ec9f77948d35074749))
 
 ## [68.6.0](https://github.com/Sage/carbon/compare/v68.5.2...v68.6.0) (2021-03-30)
 
-
 ### Features
 
-* **duelling-picklist:** add grouping option ([73f1a67](https://github.com/Sage/carbon/commit/73f1a67a1fe498985be7008d1001acc8d2db2371))
-* **picklist-item:** add locked option ([114c86e](https://github.com/Sage/carbon/commit/114c86e955dcdf0f2996695fb7e7fd536cf611cd))
+- **duelling-picklist:** add grouping option ([73f1a67](https://github.com/Sage/carbon/commit/73f1a67a1fe498985be7008d1001acc8d2db2371))
+- **picklist-item:** add locked option ([114c86e](https://github.com/Sage/carbon/commit/114c86e955dcdf0f2996695fb7e7fd536cf611cd))
 
 ### [68.5.2](https://github.com/Sage/carbon/compare/v68.5.1...v68.5.2) (2021-03-26)
 
-
 ### Bug Fixes
 
-* **tab-title:** fix styling issues with border and selected state ([69512c0](https://github.com/Sage/carbon/commit/69512c068676ee24ee5e1220ee9a3d7d1f30a8d1)), closes [#3773](https://github.com/Sage/carbon/issues/3773)
-* **tabs-header:** allow tabs to be scrollable when position is left and they overflow parent ([ffa4ebf](https://github.com/Sage/carbon/commit/ffa4ebf0674bfc3b791c6ad5527ac8acba94e568)), closes [#3352](https://github.com/Sage/carbon/issues/3352)
+- **tab-title:** fix styling issues with border and selected state ([69512c0](https://github.com/Sage/carbon/commit/69512c068676ee24ee5e1220ee9a3d7d1f30a8d1)), closes [#3773](https://github.com/Sage/carbon/issues/3773)
+- **tabs-header:** allow tabs to be scrollable when position is left and they overflow parent ([ffa4ebf](https://github.com/Sage/carbon/commit/ffa4ebf0674bfc3b791c6ad5527ac8acba94e568)), closes [#3352](https://github.com/Sage/carbon/issues/3352)
 
 ### [68.5.1](https://github.com/Sage/carbon/compare/v68.5.0...v68.5.1) (2021-03-25)
 
-
 ### Bug Fixes
 
-* **flat-table-row:** allow null children ([9d14614](https://github.com/Sage/carbon/commit/9d14614d69267f4f902a984abc982cd79d99e992)), closes [#3790](https://github.com/Sage/carbon/issues/3790)
+- **flat-table-row:** allow null children ([9d14614](https://github.com/Sage/carbon/commit/9d14614d69267f4f902a984abc982cd79d99e992)), closes [#3790](https://github.com/Sage/carbon/issues/3790)
 
 ## [68.5.0](https://github.com/Sage/carbon/compare/v68.4.1...v68.5.0) (2021-03-24)
 
-
 ### Features
 
-* **date-picker:** auto position pop up ([809f314](https://github.com/Sage/carbon/commit/809f314713a9378badfd48c2a2b21965d76def4a))
+- **date-picker:** auto position pop up ([809f314](https://github.com/Sage/carbon/commit/809f314713a9378badfd48c2a2b21965d76def4a))
 
 ### [68.4.1](https://github.com/Sage/carbon/compare/v68.4.0...v68.4.1) (2021-03-22)
 
-
 ### Bug Fixes
 
-* **card:** render component with string as the children ([43dc93d](https://github.com/Sage/carbon/commit/43dc93da6184fdce26965ac733b7cd87efb9c2a9)), closes [#2617](https://github.com/Sage/carbon/issues/2617)
+- **card:** render component with string as the children ([43dc93d](https://github.com/Sage/carbon/commit/43dc93da6184fdce26965ac733b7cd87efb9c2a9)), closes [#2617](https://github.com/Sage/carbon/issues/2617)
 
 ## [68.4.0](https://github.com/Sage/carbon/compare/v68.3.3...v68.4.0) (2021-03-17)
 
-
 ### Features
 
-* **link:** add rel prop ([b502bec](https://github.com/Sage/carbon/commit/b502bec098757f04d35b52400a0dc9ea479b8594))
+- **link:** add rel prop ([b502bec](https://github.com/Sage/carbon/commit/b502bec098757f04d35b52400a0dc9ea479b8594))
 
 ### [68.3.3](https://github.com/Sage/carbon/compare/v68.3.2...v68.3.3) (2021-03-16)
 
-
 ### Bug Fixes
 
-* **pod:** fix footer text colour when pod is hovered ([d6dbe7b](https://github.com/Sage/carbon/commit/d6dbe7b88b55b05def91a1935e883768423359bc)), closes [#3584](https://github.com/Sage/carbon/issues/3584)
+- **pod:** fix footer text colour when pod is hovered ([d6dbe7b](https://github.com/Sage/carbon/commit/d6dbe7b88b55b05def91a1935e883768423359bc)), closes [#3584](https://github.com/Sage/carbon/issues/3584)
 
 ### [68.3.2](https://github.com/Sage/carbon/compare/v68.3.1...v68.3.2) (2021-03-16)
 
-
 ### Bug Fixes
 
-* **radio-button-group, checkbox-group:** disable group behaviour when validation is not on label ([463b116](https://github.com/Sage/carbon/commit/463b116a11cf35a2cf901fd9fc3abed5fc03555e))
+- **radio-button-group, checkbox-group:** disable group behaviour when validation is not on label ([463b116](https://github.com/Sage/carbon/commit/463b116a11cf35a2cf901fd9fc3abed5fc03555e))
 
 ### [68.3.1](https://github.com/Sage/carbon/compare/v68.3.0...v68.3.1) (2021-03-15)
 
-
 ### Bug Fixes
 
-* **menu:** fix search styles ([ce4405e](https://github.com/Sage/carbon/commit/ce4405ea5d8abbff2d032d756f0fdbb35b2835de)), closes [#3591](https://github.com/Sage/carbon/issues/3591)
-* **menu:** fix search styles ([0efe3dd](https://github.com/Sage/carbon/commit/0efe3dd07e82a9002c57985886a8e887e008b56d)), closes [#3591](https://github.com/Sage/carbon/issues/3591)
+- **menu:** fix search styles ([ce4405e](https://github.com/Sage/carbon/commit/ce4405ea5d8abbff2d032d756f0fdbb35b2835de)), closes [#3591](https://github.com/Sage/carbon/issues/3591)
+- **menu:** fix search styles ([0efe3dd](https://github.com/Sage/carbon/commit/0efe3dd07e82a9002c57985886a8e887e008b56d)), closes [#3591](https://github.com/Sage/carbon/issues/3591)
 
 ## [68.3.0](https://github.com/Sage/carbon/compare/v68.2.0...v68.3.0) (2021-03-12)
 
-
 ### Features
 
-* **link:** add isSkipLink prop ([cfefb6f](https://github.com/Sage/carbon/commit/cfefb6fd584e9aefb1abc4cdf4de84ed867bbe8a))
+- **link:** add isSkipLink prop ([cfefb6f](https://github.com/Sage/carbon/commit/cfefb6fd584e9aefb1abc4cdf4de84ed867bbe8a))
 
 ## [68.2.0](https://github.com/Sage/carbon/compare/v68.1.1...v68.2.0) (2021-03-12)
 
-
 ### Features
 
-* **button-toggle-group:** add support for overriding tooltip flip behaviour ([79d5f23](https://github.com/Sage/carbon/commit/79d5f239069fa771543802deb5a9a1b2f58ab6be))
-* **fieldset:** add tooltip flip override to validation icon rendered on labels ([2abfbd4](https://github.com/Sage/carbon/commit/2abfbd44528274f8363f1ee1c684f40fc76947e3))
-* **help:** add support for tooltip flip placement overrides ([2c01499](https://github.com/Sage/carbon/commit/2c014998f6166556d5e937ee8d5c3c4a37ae5267))
-* **icon:** add support for tooltip flip placement overrides ([47dc424](https://github.com/Sage/carbon/commit/47dc4244acdae1b53ca4ad4857803d51ab831bd9))
-* **label:** add tooltip flip override to validation icon when rendered ([2b88b25](https://github.com/Sage/carbon/commit/2b88b25242f5862584ff03b6aaa832537b8267ec))
-* **simple-color-picker:** add tooltip flip overrides to validation icon ([224d99d](https://github.com/Sage/carbon/commit/224d99d8747c03a5e558118a11a07771fb4e9257))
-* **switch:** add tooltip flip override to validation icon rendered on input ([ba6b73a](https://github.com/Sage/carbon/commit/ba6b73a074648f0558536962352b629b7727e2d8))
-* **tooltip:** add support for overriding default flip placements ([73a35d6](https://github.com/Sage/carbon/commit/73a35d61a360d8680e7703472cf5abe6f194acfd))
-* **validation-icon:** add support for tooltip flip placement overrides ([0471c5b](https://github.com/Sage/carbon/commit/0471c5b612a37f42045e6f7237559ee81b28f5ae))
+- **button-toggle-group:** add support for overriding tooltip flip behaviour ([79d5f23](https://github.com/Sage/carbon/commit/79d5f239069fa771543802deb5a9a1b2f58ab6be))
+- **fieldset:** add tooltip flip override to validation icon rendered on labels ([2abfbd4](https://github.com/Sage/carbon/commit/2abfbd44528274f8363f1ee1c684f40fc76947e3))
+- **help:** add support for tooltip flip placement overrides ([2c01499](https://github.com/Sage/carbon/commit/2c014998f6166556d5e937ee8d5c3c4a37ae5267))
+- **icon:** add support for tooltip flip placement overrides ([47dc424](https://github.com/Sage/carbon/commit/47dc4244acdae1b53ca4ad4857803d51ab831bd9))
+- **label:** add tooltip flip override to validation icon when rendered ([2b88b25](https://github.com/Sage/carbon/commit/2b88b25242f5862584ff03b6aaa832537b8267ec))
+- **simple-color-picker:** add tooltip flip overrides to validation icon ([224d99d](https://github.com/Sage/carbon/commit/224d99d8747c03a5e558118a11a07771fb4e9257))
+- **switch:** add tooltip flip override to validation icon rendered on input ([ba6b73a](https://github.com/Sage/carbon/commit/ba6b73a074648f0558536962352b629b7727e2d8))
+- **tooltip:** add support for overriding default flip placements ([73a35d6](https://github.com/Sage/carbon/commit/73a35d61a360d8680e7703472cf5abe6f194acfd))
+- **validation-icon:** add support for tooltip flip placement overrides ([0471c5b](https://github.com/Sage/carbon/commit/0471c5b612a37f42045e6f7237559ee81b28f5ae))
 
 ### [68.1.1](https://github.com/Sage/carbon/compare/v68.1.0...v68.1.1) (2021-03-11)
 
-
 ### Bug Fixes
 
-* **select:** fix incorrect textbox behaviour on safari ([6077c18](https://github.com/Sage/carbon/commit/6077c186ede063693ea44fd04a33c3684a906d42))
+- **select:** fix incorrect textbox behaviour on safari ([6077c18](https://github.com/Sage/carbon/commit/6077c186ede063693ea44fd04a33c3684a906d42))
 
 ## [68.1.0](https://github.com/Sage/carbon/compare/v68.0.2...v68.1.0) (2021-03-11)
 
-
 ### Features
 
-* **action-popover-item:** support for download button ([0dcdb65](https://github.com/Sage/carbon/commit/0dcdb654473e007d8a89787d99b9034f358c3350))
+- **action-popover-item:** support for download button ([0dcdb65](https://github.com/Sage/carbon/commit/0dcdb654473e007d8a89787d99b9034f358c3350))
 
 ### [68.0.2](https://github.com/Sage/carbon/compare/v68.0.1...v68.0.2) (2021-03-11)
 
-
 ### Bug Fixes
 
-* **button:** add border radius to button styles ([3142e17](https://github.com/Sage/carbon/commit/3142e170fb9182c67d3749b1b36d667a49fab30a)), closes [#3630](https://github.com/Sage/carbon/issues/3630)
+- **button:** add border radius to button styles ([3142e17](https://github.com/Sage/carbon/commit/3142e170fb9182c67d3749b1b36d667a49fab30a)), closes [#3630](https://github.com/Sage/carbon/issues/3630)
 
 ### [68.0.1](https://github.com/Sage/carbon/compare/v68.0.0...v68.0.1) (2021-03-09)
 
-
 ### Bug Fixes
 
-* **select:** fix onblur fired on option mousedown event ([664350e](https://github.com/Sage/carbon/commit/664350e2825a96e250c3261620634abbc429dd6a))
+- **select:** fix onblur fired on option mousedown event ([664350e](https://github.com/Sage/carbon/commit/664350e2825a96e250c3261620634abbc429dd6a))
 
 ## [68.0.0](https://github.com/Sage/carbon/compare/v67.0.0...v68.0.0) (2021-03-09)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **icon:** Icon component fontSize prop `medium` value equivalent is now named `large`.
-To update your code use `replace-prop-value` codemod:
-https://github.com/Sage/carbon-codemod/tree/master/transforms/replace-prop-value
+- **icon:** Icon component fontSize prop `medium` value equivalent is now named `large`.
+  To update your code use `replace-prop-value` codemod:
+  <https://github.com/Sage/carbon-codemod/tree/master/transforms/replace-prop-value>
 
 ### Features
 
-* **icon:** add additional fontSize and bgSize prop values ([3b58601](https://github.com/Sage/carbon/commit/3b586014ba86cdcb4797655e1d42ceea27fd6e3d))
+- **icon:** add additional fontSize and bgSize prop values ([3b58601](https://github.com/Sage/carbon/commit/3b586014ba86cdcb4797655e1d42ceea27fd6e3d))
 
 ## [67.0.0](https://github.com/Sage/carbon/compare/v66.19.2...v67.0.0) (2021-03-08)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **sidebar:** SidebarHeader is now internal component, use header prop
+- **sidebar:** SidebarHeader is now internal component, use header prop
 
 ### Features
 
-* **sidebar:** add styled system to sidebar ([48a38d4](https://github.com/Sage/carbon/commit/48a38d4e67cd73e1324c29eddfe3865ec8dc58f8)), closes [#3221](https://github.com/Sage/carbon/issues/3221)
+- **sidebar:** add styled system to sidebar ([48a38d4](https://github.com/Sage/carbon/commit/48a38d4e67cd73e1324c29eddfe3865ec8dc58f8)), closes [#3221](https://github.com/Sage/carbon/issues/3221)
 
 ### [66.19.2](https://github.com/Sage/carbon/compare/v66.19.1...v66.19.2) (2021-03-05)
 
-
 ### Bug Fixes
 
-* **focus-trap:** update trap to use ref from content container ([e59b5f4](https://github.com/Sage/carbon/commit/e59b5f4dcf14ed41227e9b1ee91f04e30687c1b4)), closes [#3770](https://github.com/Sage/carbon/issues/3770)
+- **focus-trap:** update trap to use ref from content container ([e59b5f4](https://github.com/Sage/carbon/commit/e59b5f4dcf14ed41227e9b1ee91f04e30687c1b4)), closes [#3770](https://github.com/Sage/carbon/issues/3770)
 
 ### [66.19.1](https://github.com/Sage/carbon/compare/v66.19.0...v66.19.1) (2021-03-04)
 
-
 ### Bug Fixes
 
-* fix dropdown alignment in split and multi action buttons ([a6caf26](https://github.com/Sage/carbon/commit/a6caf26be1d19104c7ba3e76cdcb0c8568e5d19f))
+- fix dropdown alignment in split and multi action buttons ([a6caf26](https://github.com/Sage/carbon/commit/a6caf26be1d19104c7ba3e76cdcb0c8568e5d19f))
 
 ## [66.19.0](https://github.com/Sage/carbon/compare/v66.18.1...v66.19.0) (2021-03-04)
 
-
 ### Features
 
-* **select:** add multi column functionality ([736a109](https://github.com/Sage/carbon/commit/736a109ee2546f1d6f6e502aecb432aa0968e3b3))
+- **select:** add multi column functionality ([736a109](https://github.com/Sage/carbon/commit/736a109ee2546f1d6f6e502aecb432aa0968e3b3))
 
 ### [66.18.1](https://github.com/Sage/carbon/compare/v66.18.0...v66.18.1) (2021-03-02)
 
-
 ### Bug Fixes
 
-* **tabs:** fix border gap ([7546b26](https://github.com/Sage/carbon/commit/7546b261d29ddbba3632a049252f9b80bf0ffb03))
-* **tabs:** fix incorrect large tab alignment ([bcc3101](https://github.com/Sage/carbon/commit/bcc3101be6bfad9c979871fc59738c9e9e6f25be))
+- **tabs:** fix border gap ([7546b26](https://github.com/Sage/carbon/commit/7546b261d29ddbba3632a049252f9b80bf0ffb03))
+- **tabs:** fix incorrect large tab alignment ([bcc3101](https://github.com/Sage/carbon/commit/bcc3101be6bfad9c979871fc59738c9e9e6f25be))
 
 ## [66.18.0](https://github.com/Sage/carbon/compare/v66.17.0...v66.18.0) (2021-02-26)
 
-
 ### Features
 
-* **storybook:** update storybook to v6 ([4912c66](https://github.com/Sage/carbon/commit/4912c66a1daf40ff601045ebc006c150f7526d2a))
+- **storybook:** update storybook to v6 ([4912c66](https://github.com/Sage/carbon/commit/4912c66a1daf40ff601045ebc006c150f7526d2a))
 
 ## [66.17.0](https://github.com/Sage/carbon/compare/v66.16.0...v66.17.0) (2021-02-26)
 
-
 ### Features
 
-* **toast:** center toast by default ([d78128f](https://github.com/Sage/carbon/commit/d78128fa703df2cead27a32cfe0590327508c26e))
+- **toast:** center toast by default ([d78128f](https://github.com/Sage/carbon/commit/d78128fa703df2cead27a32cfe0590327508c26e))
 
 ## [66.16.0](https://github.com/Sage/carbon/compare/v66.15.0...v66.16.0) (2021-02-26)
 
-
 ### Features
 
-* **styled-system:** add width util ([90dea96](https://github.com/Sage/carbon/commit/90dea96465be44dc026c1250f98e306bb7bd07ca))
+- **styled-system:** add width util ([90dea96](https://github.com/Sage/carbon/commit/90dea96465be44dc026c1250f98e306bb7bd07ca))
 
 ## [66.15.0](https://github.com/Sage/carbon/compare/v66.14.0...v66.15.0) (2021-02-25)
 
-
 ### Features
 
-* **confim:** add new props ([504b60f](https://github.com/Sage/carbon/commit/504b60f162156f5e3434331a75b08fa2ea7bbfe8))
+- **confim:** add new props ([504b60f](https://github.com/Sage/carbon/commit/504b60f162156f5e3434331a75b08fa2ea7bbfe8))
 
 ## [66.14.0](https://github.com/Sage/carbon/compare/v66.13.3...v66.14.0) (2021-02-25)
 
-
 ### Features
 
-* **card:** add styled-system padding props ([6cc3cd6](https://github.com/Sage/carbon/commit/6cc3cd69d619f9531a6421a82dd5ff4c59b2bc8a)), closes [#3519](https://github.com/Sage/carbon/issues/3519)
+- **card:** add styled-system padding props ([6cc3cd6](https://github.com/Sage/carbon/commit/6cc3cd69d619f9531a6421a82dd5ff4c59b2bc8a)), closes [#3519](https://github.com/Sage/carbon/issues/3519)
 
 ### [66.13.3](https://github.com/Sage/carbon/compare/v66.13.2...v66.13.3) (2021-02-25)
 
-
 ### Bug Fixes
 
-* **heading:** remove as prop from heading title wrapper ([a1a6a90](https://github.com/Sage/carbon/commit/a1a6a90a37a735cdbd91d53c4a8a32e27f554425))
+- **heading:** remove as prop from heading title wrapper ([a1a6a90](https://github.com/Sage/carbon/commit/a1a6a90a37a735cdbd91d53c4a8a32e27f554425))
 
 ### [66.13.2](https://github.com/Sage/carbon/compare/v66.13.1...v66.13.2) (2021-02-25)
 
-
 ### Bug Fixes
 
-* **dl:** support for conditional rendering ([00c7101](https://github.com/Sage/carbon/commit/00c7101ecf29423b591e1fd4eaedf169f7f545a1))
+- **dl:** support for conditional rendering ([00c7101](https://github.com/Sage/carbon/commit/00c7101ecf29423b591e1fd4eaedf169f7f545a1))
 
 ### [66.13.1](https://github.com/Sage/carbon/compare/v66.13.0...v66.13.1) (2021-02-24)
 
-
 ### Bug Fixes
 
-* **numeral-date:** prevent error being thrown when default date format is used ([3f9c535](https://github.com/Sage/carbon/commit/3f9c535210d194d39e41fcb96b17399e34b49e82)), closes [#3264](https://github.com/Sage/carbon/issues/3264)
+- **numeral-date:** prevent error being thrown when default date format is used ([3f9c535](https://github.com/Sage/carbon/commit/3f9c535210d194d39e41fcb96b17399e34b49e82)), closes [#3264](https://github.com/Sage/carbon/issues/3264)
 
 ## [66.13.0](https://github.com/Sage/carbon/compare/v66.12.4...v66.13.0) (2021-02-24)
 
-
 ### Features
 
-* **tile-select:** add props to  override action button and render sibling adornment ([8f84c27](https://github.com/Sage/carbon/commit/8f84c27306f674b1f13e602d5e9a95700ca32f2d))
+- **tile-select:** add props to override action button and render sibling adornment ([8f84c27](https://github.com/Sage/carbon/commit/8f84c27306f674b1f13e602d5e9a95700ca32f2d))
 
 ### [66.12.4](https://github.com/Sage/carbon/compare/v66.12.3...v66.12.4) (2021-02-24)
 
-
 ### Bug Fixes
 
-* **text-editor:** update import path ([d851b72](https://github.com/Sage/carbon/commit/d851b7228828df9330e387710fbbd0ceaf950c57))
+- **text-editor:** update import path ([d851b72](https://github.com/Sage/carbon/commit/d851b7228828df9330e387710fbbd0ceaf950c57))
 
 ### [66.12.3](https://github.com/Sage/carbon/compare/v66.12.2...v66.12.3) (2021-02-23)
 
-
 ### Bug Fixes
 
-* **date-input:** incorrect year in datepicker when date is not valid ([608164e](https://github.com/Sage/carbon/commit/608164e27c92fc2577da530073ec6910bc3c9f21))
+- **date-input:** incorrect year in datepicker when date is not valid ([608164e](https://github.com/Sage/carbon/commit/608164e27c92fc2577da530073ec6910bc3c9f21))
 
 ### [66.12.2](https://github.com/Sage/carbon/compare/v66.12.1...v66.12.2) (2021-02-23)
 
-
 ### Bug Fixes
 
-* **dialog:** correct calculation to apply fixed bottom ([e1e5fd5](https://github.com/Sage/carbon/commit/e1e5fd536ff229461ff9b716c7c17ba46db009ab)), closes [#3257](https://github.com/Sage/carbon/issues/3257)
+- **dialog:** correct calculation to apply fixed bottom ([e1e5fd5](https://github.com/Sage/carbon/commit/e1e5fd536ff229461ff9b716c7c17ba46db009ab)), closes [#3257](https://github.com/Sage/carbon/issues/3257)
 
 ### [66.12.1](https://github.com/Sage/carbon/compare/v66.12.0...v66.12.1) (2021-02-22)
 
-
 ### Bug Fixes
 
-* **select:** incorrect typescript children types ([b436fea](https://github.com/Sage/carbon/commit/b436feadad57d92a5b6ae640b88ae33dc9ba9f99))
+- **select:** incorrect typescript children types ([b436fea](https://github.com/Sage/carbon/commit/b436feadad57d92a5b6ae640b88ae33dc9ba9f99))
 
 ## [66.12.0](https://github.com/Sage/carbon/compare/v66.11.1...v66.12.0) (2021-02-22)
 
-
 ### Features
 
-* **radio-button:** allow use of all styled system margin props ([4698606](https://github.com/Sage/carbon/commit/46986061d1bddef119d95c2d60eb83e0d9f1e1d5))
+- **radio-button:** allow use of all styled system margin props ([4698606](https://github.com/Sage/carbon/commit/46986061d1bddef119d95c2d60eb83e0d9f1e1d5))
 
 ### [66.11.1](https://github.com/Sage/carbon/compare/v66.11.0...v66.11.1) (2021-02-21)
 
-
 ### Bug Fixes
 
-* **date-range:** allow empty values for start and end dates ([01eb5bc](https://github.com/Sage/carbon/commit/01eb5bc1cb58fb4a084fc2b9e85009960621d20c)), closes [#3501](https://github.com/Sage/carbon/issues/3501)
+- **date-range:** allow empty values for start and end dates ([01eb5bc](https://github.com/Sage/carbon/commit/01eb5bc1cb58fb4a084fc2b9e85009960621d20c)), closes [#3501](https://github.com/Sage/carbon/issues/3501)
 
 ## [66.11.0](https://github.com/Sage/carbon/compare/v66.10.2...v66.11.0) (2021-02-19)
 
-
 ### Features
 
-* **flat-table:** add expandable rows option ([9701362](https://github.com/Sage/carbon/commit/9701362ba12e1a4e26881981848d1cb500473c92))
+- **flat-table:** add expandable rows option ([9701362](https://github.com/Sage/carbon/commit/9701362ba12e1a4e26881981848d1cb500473c92))
 
 ### [66.10.2](https://github.com/Sage/carbon/compare/v66.10.1...v66.10.2) (2021-02-19)
 
-
 ### Bug Fixes
 
-* **date:** set format based on translation ([024f338](https://github.com/Sage/carbon/commit/024f338ce7c1df99589ab9154c8aaf8c0071fdb0))
+- **date:** set format based on translation ([024f338](https://github.com/Sage/carbon/commit/024f338ce7c1df99589ab9154c8aaf8c0071fdb0))
 
 ### [66.10.1](https://github.com/Sage/carbon/compare/v66.10.0...v66.10.1) (2021-02-19)
 
-
 ### Bug Fixes
 
-* **focus-trap:** handle radio button focus ([ce3cc9b](https://github.com/Sage/carbon/commit/ce3cc9bfd0f456a663380af5f6cdcd035cb4e930)), closes [#3623](https://github.com/Sage/carbon/issues/3623)
+- **focus-trap:** handle radio button focus ([ce3cc9b](https://github.com/Sage/carbon/commit/ce3cc9bfd0f456a663380af5f6cdcd035cb4e930)), closes [#3623](https://github.com/Sage/carbon/issues/3623)
 
 ## [66.10.0](https://github.com/Sage/carbon/compare/v66.9.0...v66.10.0) (2021-02-19)
 
-
 ### Features
 
-* **tab:** allows Tab to be a link ([96e1597](https://github.com/Sage/carbon/commit/96e1597faeb3912f811729ae972b0d50eb6a4e6d))
+- **tab:** allows Tab to be a link ([96e1597](https://github.com/Sage/carbon/commit/96e1597faeb3912f811729ae972b0d50eb6a4e6d))
 
 ## [66.9.0](https://github.com/Sage/carbon/compare/v66.8.0...v66.9.0) (2021-02-18)
 
-
 ### Features
 
-* **select:** add popperjs positioning mechanism ([9bd1a74](https://github.com/Sage/carbon/commit/9bd1a74962903c0b3c8f9c2455227701e210afec))
-
+- **select:** add popperjs positioning mechanism ([9bd1a74](https://github.com/Sage/carbon/commit/9bd1a74962903c0b3c8f9c2455227701e210afec))
 
 ### Bug Fixes
 
-* **multi-select:** fix closing multi-select when deleting pills ([80c95de](https://github.com/Sage/carbon/commit/80c95defa941128402a159c97cb19e8bf5d9f53a))
+- **multi-select:** fix closing multi-select when deleting pills ([80c95de](https://github.com/Sage/carbon/commit/80c95defa941128402a159c97cb19e8bf5d9f53a))
 
 ## [66.8.0](https://github.com/Sage/carbon/compare/v66.7.0...v66.8.0) (2021-02-18)
 
-
 ### Features
 
-* **text-editor:** add rows prop to support custom min  height ([966d405](https://github.com/Sage/carbon/commit/966d405be3e4b9aff3b28d01633a2108b7996c63)), closes [#3632](https://github.com/Sage/carbon/issues/3632)
+- **text-editor:** add rows prop to support custom min height ([966d405](https://github.com/Sage/carbon/commit/966d405be3e4b9aff3b28d01633a2108b7996c63)), closes [#3632](https://github.com/Sage/carbon/issues/3632)
 
 ## [66.7.0](https://github.com/Sage/carbon/compare/v66.6.1...v66.7.0) (2021-02-18)
 
-
 ### Features
 
-* **help:** add support for tooltip background and font color overrides ([c169979](https://github.com/Sage/carbon/commit/c16997917ce6184ec67d31eb0510bf90e723a0a2))
-* **icon:** add support for tooltip background and font color overrides ([d4f5db9](https://github.com/Sage/carbon/commit/d4f5db934c27ea44b688f35a169ddb79c461e9be))
-* **tooltip:** add support for background and font color overrides ([f607f77](https://github.com/Sage/carbon/commit/f607f77c973c71c79198b20d3609c68782f5da24))
-
+- **help:** add support for tooltip background and font color overrides ([c169979](https://github.com/Sage/carbon/commit/c16997917ce6184ec67d31eb0510bf90e723a0a2))
+- **icon:** add support for tooltip background and font color overrides ([d4f5db9](https://github.com/Sage/carbon/commit/d4f5db934c27ea44b688f35a169ddb79c461e9be))
+- **tooltip:** add support for background and font color overrides ([f607f77](https://github.com/Sage/carbon/commit/f607f77c973c71c79198b20d3609c68782f5da24))
 
 ### Bug Fixes
 
-* **tooltip:** ensure long text strings wrap instead of overflow ([de44e2b](https://github.com/Sage/carbon/commit/de44e2b34bc3ce8f347b71fe552edc1ed2f9d981))
+- **tooltip:** ensure long text strings wrap instead of overflow ([de44e2b](https://github.com/Sage/carbon/commit/de44e2b34bc3ce8f347b71fe552edc1ed2f9d981))
 
 ### [66.6.1](https://github.com/Sage/carbon/compare/v66.6.0...v66.6.1) (2021-02-17)
 
-
 ### Bug Fixes
 
-* **date:** change onBlur event parameters ([16d186d](https://github.com/Sage/carbon/commit/16d186d09794863c7d042fa8b3c7ae20262b0bf7)), closes [#3132](https://github.com/Sage/carbon/issues/3132)
+- **date:** change onBlur event parameters ([16d186d](https://github.com/Sage/carbon/commit/16d186d09794863c7d042fa8b3c7ae20262b0bf7)), closes [#3132](https://github.com/Sage/carbon/issues/3132)
 
 ## [66.6.0](https://github.com/Sage/carbon/compare/v66.5.0...v66.6.0) (2021-02-17)
 
-
 ### Features
 
-* **heading:** add pills container ([4464a20](https://github.com/Sage/carbon/commit/4464a202253641623966bbe15bcc11f573a85d6c))
+- **heading:** add pills container ([4464a20](https://github.com/Sage/carbon/commit/4464a202253641623966bbe15bcc11f573a85d6c))
 
 ## [66.5.0](https://github.com/Sage/carbon/compare/v66.4.1...v66.5.0) (2021-02-17)
 
-
 ### Features
 
-* **button:** icon only button ([cd03584](https://github.com/Sage/carbon/commit/cd035845a772b7fb6331809c845f5b1facb56337)), closes [#3236](https://github.com/Sage/carbon/issues/3236)
+- **button:** icon only button ([cd03584](https://github.com/Sage/carbon/commit/cd035845a772b7fb6331809c845f5b1facb56337)), closes [#3236](https://github.com/Sage/carbon/issues/3236)
 
 ### [66.4.1](https://github.com/Sage/carbon/compare/v66.4.0...v66.4.1) (2021-02-17)
 
-
 ### Bug Fixes
 
-* **flat-table-row:** remove border bottom colour overrides ([9e0b424](https://github.com/Sage/carbon/commit/9e0b424657f20e1948a0598896beaf07fd055aa7)), closes [#3522](https://github.com/Sage/carbon/issues/3522)
+- **flat-table-row:** remove border bottom colour overrides ([9e0b424](https://github.com/Sage/carbon/commit/9e0b424657f20e1948a0598896beaf07fd055aa7)), closes [#3522](https://github.com/Sage/carbon/issues/3522)
 
 ## [66.4.0](https://github.com/Sage/carbon/compare/v66.3.0...v66.4.0) (2021-02-16)
 
-
 ### Features
 
-* **pager:** add props to conditional render elements and smart render buttons ([90be09b](https://github.com/Sage/carbon/commit/90be09b3c6a77a81748f737ea8529cf64a908137)), closes [#3425](https://github.com/Sage/carbon/issues/3425)
+- **pager:** add props to conditional render elements and smart render buttons ([90be09b](https://github.com/Sage/carbon/commit/90be09b3c6a77a81748f737ea8529cf64a908137)), closes [#3425](https://github.com/Sage/carbon/issues/3425)
 
 ## [66.3.0](https://github.com/Sage/carbon/compare/v66.2.3...v66.3.0) (2021-02-16)
 
-
 ### Features
 
-* **select:** add cypress test ([556dd08](https://github.com/Sage/carbon/commit/556dd088dc060f3b51b4e95f47b15fff67d70842))
-
+- **select:** add cypress test ([556dd08](https://github.com/Sage/carbon/commit/556dd088dc060f3b51b4e95f47b15fff67d70842))
 
 ### Bug Fixes
 
-* **filterable-select:** display value cleared on click when in a modal ([a45932f](https://github.com/Sage/carbon/commit/a45932f3883694146e62e97ea020541c71163827))
-* **filterable-select:** predefined text value not displayed when options loaded asynchronously ([8a14890](https://github.com/Sage/carbon/commit/8a1489096e4eb938c048c37225c7396c3568c6fd)), closes [#3431](https://github.com/Sage/carbon/issues/3431)
-* **filterable-select:** value not cleared when filter does not match any option ([b6599d3](https://github.com/Sage/carbon/commit/b6599d35383b90676572cbcd9ee125ca1fe0e8dd))
-* **filterable-select:** value not cleared when filter is deleted ([af4495d](https://github.com/Sage/carbon/commit/af4495dc5b53f4665cff9807f4cab87c0a475eda))
-* **select:** display value cleared on click when in a modal ([c40f7d8](https://github.com/Sage/carbon/commit/c40f7d8eb641899e797e98dca1da505a5b597016)), closes [#3557](https://github.com/Sage/carbon/issues/3557)
+- **filterable-select:** display value cleared on click when in a modal ([a45932f](https://github.com/Sage/carbon/commit/a45932f3883694146e62e97ea020541c71163827))
+- **filterable-select:** predefined text value not displayed when options loaded asynchronously ([8a14890](https://github.com/Sage/carbon/commit/8a1489096e4eb938c048c37225c7396c3568c6fd)), closes [#3431](https://github.com/Sage/carbon/issues/3431)
+- **filterable-select:** value not cleared when filter does not match any option ([b6599d3](https://github.com/Sage/carbon/commit/b6599d35383b90676572cbcd9ee125ca1fe0e8dd))
+- **filterable-select:** value not cleared when filter is deleted ([af4495d](https://github.com/Sage/carbon/commit/af4495dc5b53f4665cff9807f4cab87c0a475eda))
+- **select:** display value cleared on click when in a modal ([c40f7d8](https://github.com/Sage/carbon/commit/c40f7d8eb641899e797e98dca1da505a5b597016)), closes [#3557](https://github.com/Sage/carbon/issues/3557)
 
 ### [66.2.3](https://github.com/Sage/carbon/compare/v66.2.2...v66.2.3) (2021-02-15)
 
-
 ### Bug Fixes
 
-* **switch:** make value prop optional ([48c8962](https://github.com/Sage/carbon/commit/48c8962355288f6883d8f55226a35c3a9dee7818)), closes [#3265](https://github.com/Sage/carbon/issues/3265)
+- **switch:** make value prop optional ([48c8962](https://github.com/Sage/carbon/commit/48c8962355288f6883d8f55226a35c3a9dee7818)), closes [#3265](https://github.com/Sage/carbon/issues/3265)
 
 ### [66.2.2](https://github.com/Sage/carbon/compare/v66.2.1...v66.2.2) (2021-02-12)
 
-
 ### Bug Fixes
 
-* **tile:** add box sizing to container to ensure it respects  parent width ([6abeccb](https://github.com/Sage/carbon/commit/6abeccbeea02bd777237449fd2ecb43efb48c7f9)), closes [#3458](https://github.com/Sage/carbon/issues/3458)
+- **tile:** add box sizing to container to ensure it respects parent width ([6abeccb](https://github.com/Sage/carbon/commit/6abeccbeea02bd777237449fd2ecb43efb48c7f9)), closes [#3458](https://github.com/Sage/carbon/issues/3458)
 
 ### [66.2.1](https://github.com/Sage/carbon/compare/v66.2.0...v66.2.1) (2021-02-12)
 
-
 ### Bug Fixes
 
-* **content:** add support for passing data tags to root of component ([64c4543](https://github.com/Sage/carbon/commit/64c454343f869e1c637e6c39941154846abcf7d7)), closes [#3661](https://github.com/Sage/carbon/issues/3661)
+- **content:** add support for passing data tags to root of component ([64c4543](https://github.com/Sage/carbon/commit/64c454343f869e1c637e6c39941154846abcf7d7)), closes [#3661](https://github.com/Sage/carbon/issues/3661)
 
 ## [66.2.0](https://github.com/Sage/carbon/compare/v66.1.0...v66.2.0) (2021-02-12)
 
-
 ### Features
 
-* **multi-select:** add isLoading prop ([1924d68](https://github.com/Sage/carbon/commit/1924d68993d96fdc3ee3b85278150457b04f726e))
+- **multi-select:** add isLoading prop ([1924d68](https://github.com/Sage/carbon/commit/1924d68993d96fdc3ee3b85278150457b04f726e))
 
 ## [66.1.0](https://github.com/Sage/carbon/compare/v66.0.3...v66.1.0) (2021-02-12)
 
-
 ### Features
 
-* **pager:** add alternate variant styling ([d750304](https://github.com/Sage/carbon/commit/d750304f5b983c5dbc608c10b878289147307078))
+- **pager:** add alternate variant styling ([d750304](https://github.com/Sage/carbon/commit/d750304f5b983c5dbc608c10b878289147307078))
 
 ### [66.0.3](https://github.com/Sage/carbon/compare/v66.0.2...v66.0.3) (2021-02-11)
 
-
 ### Bug Fixes
 
-* **toast:** add z-index to toast portal ([2f8215c](https://github.com/Sage/carbon/commit/2f8215c5c5ba00fafbf1a6dc45511ad4425dbab0)), closes [#3640](https://github.com/Sage/carbon/issues/3640) [#3627](https://github.com/Sage/carbon/issues/3627)
+- **toast:** add z-index to toast portal ([2f8215c](https://github.com/Sage/carbon/commit/2f8215c5c5ba00fafbf1a6dc45511ad4425dbab0)), closes [#3640](https://github.com/Sage/carbon/issues/3640) [#3627](https://github.com/Sage/carbon/issues/3627)
 
 ### [66.0.2](https://github.com/Sage/carbon/compare/v66.0.1...v66.0.2) (2021-02-11)
 
-
 ### Bug Fixes
 
-* **grid-container:** children proptype definition ([5342d4e](https://github.com/Sage/carbon/commit/5342d4e737e6dbfb3c774b54096887fad678d1cd)), closes [#3272](https://github.com/Sage/carbon/issues/3272)
+- **grid-container:** children proptype definition ([5342d4e](https://github.com/Sage/carbon/commit/5342d4e737e6dbfb3c774b54096887fad678d1cd)), closes [#3272](https://github.com/Sage/carbon/issues/3272)
 
 ### [66.0.1](https://github.com/Sage/carbon/compare/v66.0.0...v66.0.1) (2021-02-10)
 
-
 ### Bug Fixes
 
-* exclude specified knobs for DateInput ([6dbc378](https://github.com/Sage/carbon/commit/6dbc378511cb147f7332dcd33d13ec4826273122))
+- exclude specified knobs for DateInput ([6dbc378](https://github.com/Sage/carbon/commit/6dbc378511cb147f7332dcd33d13ec4826273122))
 
 ## [66.0.0](https://github.com/Sage/carbon/compare/v65.2.0...v66.0.0) (2021-02-09)
 
-
 ### ⚠ BREAKING CHANGES
 
-* The global css has been removed you should
-change `import "carbon-react/lib/utils/css";` to be `import GlobalStyle
-from 'carbon-react/lib/style/global-style';` and render `<GlobalStyle
-/>` as part of your root component.
+- The global css has been removed you should
+  change `import "carbon-react/lib/utils/css";` to be `import GlobalStyle from 'carbon-react/lib/style/global-style';` and render `<GlobalStyle />` as part of your root component.
 
 ### Miscellaneous Chores
 
-* remove global scss ([1a28578](https://github.com/Sage/carbon/commit/1a285788da2a1465d43a41160be7e5ebff201639))
+- remove global scss ([1a28578](https://github.com/Sage/carbon/commit/1a285788da2a1465d43a41160be7e5ebff201639))
 
 ## [65.2.0](https://github.com/Sage/carbon/compare/v65.1.0...v65.2.0) (2021-02-09)
 
-
 ### Features
 
-* **pill:** add styled system props to Pill - FE-3563 ([796da16](https://github.com/Sage/carbon/commit/796da165b3640daa2b01647f75d4e7866e083b5c))
+- **pill:** add styled system props to Pill - FE-3563 ([796da16](https://github.com/Sage/carbon/commit/796da165b3640daa2b01647f75d4e7866e083b5c))
 
 ## [65.1.0](https://github.com/Sage/carbon/compare/v65.0.0...v65.1.0) (2021-02-09)
 
-
 ### Features
 
-* **icon:** 6 new icons, chevrons, expand and square dot, new glyphs for euro, pound and services ([837eb74](https://github.com/Sage/carbon/commit/837eb742bcdebdf0b1774cc732a30ac6a97d8124))
+- **icon:** 6 new icons, chevrons, expand and square dot, new glyphs for euro, pound and services ([837eb74](https://github.com/Sage/carbon/commit/837eb742bcdebdf0b1774cc732a30ac6a97d8124))
 
 ## [65.0.0](https://github.com/Sage/carbon/compare/v64.0.0...v65.0.0) (2021-02-08)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **select:** Setting padding is no longer possible through styled-system props.
-Please use only margin styled system props
+- **select:** Setting padding is no longer possible through styled-system props.
+  Please use only margin styled system props
 
 ### Features
 
-* **filterable-select:** add margin styled-system props ([865b38f](https://github.com/Sage/carbon/commit/865b38fb708b00087276cb7ddf9b874ea6dc9dde))
-* **multi-select:** add margin styled-system props ([0d9812e](https://github.com/Sage/carbon/commit/0d9812ee03fc5f3680694f726644e96f0c2b641a))
-* **select:** add margin styled system props ([44ede21](https://github.com/Sage/carbon/commit/44ede2126a4e538227e1db7afc3890756e1726b3))
-
+- **filterable-select:** add margin styled-system props ([865b38f](https://github.com/Sage/carbon/commit/865b38fb708b00087276cb7ddf9b874ea6dc9dde))
+- **multi-select:** add margin styled-system props ([0d9812e](https://github.com/Sage/carbon/commit/0d9812ee03fc5f3680694f726644e96f0c2b641a))
+- **select:** add margin styled system props ([44ede21](https://github.com/Sage/carbon/commit/44ede2126a4e538227e1db7afc3890756e1726b3))
 
 ### Bug Fixes
 
-* **search:** change placeholder color ([0165eeb](https://github.com/Sage/carbon/commit/0165eebac22dfbbb599dda683ef44e6129a6c2cf))
-* **select:** change placeholder color ([e27136d](https://github.com/Sage/carbon/commit/e27136d0f165417029efcf19298d026731ac7bd9))
+- **search:** change placeholder color ([0165eeb](https://github.com/Sage/carbon/commit/0165eebac22dfbbb599dda683ef44e6129a6c2cf))
+- **select:** change placeholder color ([e27136d](https://github.com/Sage/carbon/commit/e27136d0f165417029efcf19298d026731ac7bd9))
 
 ## [64.0.0](https://github.com/Sage/carbon/compare/v63.4.1...v64.0.0) (2021-02-05)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **menu-item:** remove routerLink and to props from MenuItem.
-See the documentation at https://carbon.sage.com/?path=/docs/documentation-usage-with-routing--page
-for how to implement this functionality
-* **link:** remove routerLink and to props from Link.
-See the documentation at https://carbon.sage.com/?path=/docs/documentation-usage-with-routing--page
-for how to implement this functionality.
-Also the onClick prop will no longer render the link as a button element
-* **button:** remove renderRouterLink, href and to props from Button.
-See the documentation at https://carbon.sage.com/?path=/docs/documentation-usage-with-routing--page
-for how to implement this functionality
+- **menu-item:** remove routerLink and to props from MenuItem.
+  See the documentation at <https://carbon.sage.com/?path=/docs/documentation-usage-with-routing--page>
+  for how to implement this functionality
+- **link:** remove routerLink and to props from Link.
+  See the documentation at <https://carbon.sage.com/?path=/docs/documentation-usage-with-routing--page>
+  for how to implement this functionality.
+  Also the onClick prop will no longer render the link as a button element
+- **button:** remove renderRouterLink, href and to props from Button.
+  See the documentation at <https://carbon.sage.com/?path=/docs/documentation-usage-with-routing--page>
+  for how to implement this functionality
 
 ### Code Refactoring
 
-* **button:** remove router link props ([b37d3fd](https://github.com/Sage/carbon/commit/b37d3fd200a194e0b7ceca37d594983e37f7d3fb))
-* **link:** remove router link props ([50931cf](https://github.com/Sage/carbon/commit/50931cf270ce34e4ef58d34d6ddd2b0df087aea9))
-* **menu-item:** remove router link props ([4198eff](https://github.com/Sage/carbon/commit/4198eff14f595fe63732f0691103df6ae3bc2e57))
+- **button:** remove router link props ([b37d3fd](https://github.com/Sage/carbon/commit/b37d3fd200a194e0b7ceca37d594983e37f7d3fb))
+- **link:** remove router link props ([50931cf](https://github.com/Sage/carbon/commit/50931cf270ce34e4ef58d34d6ddd2b0df087aea9))
+- **menu-item:** remove router link props ([4198eff](https://github.com/Sage/carbon/commit/4198eff14f595fe63732f0691103df6ae3bc2e57))
 
 ### [63.4.1](https://github.com/Sage/carbon/compare/v63.4.0...v63.4.1) (2021-02-05)
 
-
 ### Bug Fixes
 
-* **fieldset:** support spacing between fieldset in form ([33d4126](https://github.com/Sage/carbon/commit/33d41264fd1ccec69e7d93d2ad4a593945b67305))
+- **fieldset:** support spacing between fieldset in form ([33d4126](https://github.com/Sage/carbon/commit/33d41264fd1ccec69e7d93d2ad4a593945b67305))
 
 ## [63.4.0](https://github.com/Sage/carbon/compare/v63.3.1...v63.4.0) (2021-02-04)
 
-
 ### Features
 
-* **box:** add overflowwrap prop to support breaking content that overflows ([915bf5e](https://github.com/Sage/carbon/commit/915bf5ec00aefb5bbf684a1ef043dd3201b0933f))
+- **box:** add overflowwrap prop to support breaking content that overflows ([915bf5e](https://github.com/Sage/carbon/commit/915bf5ec00aefb5bbf684a1ef043dd3201b0933f))
 
 ### [63.3.1](https://github.com/Sage/carbon/compare/v63.3.0...v63.3.1) (2021-02-03)
 
-
 ### Bug Fixes
 
-* **menu, search:** update zIndex ([e136f60](https://github.com/Sage/carbon/commit/e136f60dfe8da0579045c600c256f652fd29dcac))
+- **menu, search:** update zIndex ([e136f60](https://github.com/Sage/carbon/commit/e136f60dfe8da0579045c600c256f652fd29dcac))
 
 ## [63.3.0](https://github.com/Sage/carbon/compare/v63.2.0...v63.3.0) (2021-02-02)
 
-
 ### Features
 
-* **button:** add noWrap prop ([ab675ad](https://github.com/Sage/carbon/commit/ab675ad812f7139b8c205d607ff7ecdca067237e)), closes [#3503](https://github.com/Sage/carbon/issues/3503)
+- **button:** add noWrap prop ([ab675ad](https://github.com/Sage/carbon/commit/ab675ad812f7139b8c205d607ff7ecdca067237e)), closes [#3503](https://github.com/Sage/carbon/issues/3503)
 
 ## [63.2.0](https://github.com/Sage/carbon/compare/v63.1.0...v63.2.0) (2021-02-02)
 
-
 ### Features
 
-* **filterable-select:** add open on focus functionality ([a249a23](https://github.com/Sage/carbon/commit/a249a23eb799c8503d6b66fd98dfa6ce6e92d592))
+- **filterable-select:** add open on focus functionality ([a249a23](https://github.com/Sage/carbon/commit/a249a23eb799c8503d6b66fd98dfa6ce6e92d592))
 
 ## [63.1.0](https://github.com/Sage/carbon/compare/v63.0.2...v63.1.0) (2021-02-01)
 
-
 ### Features
 
-* **toast:** allow custom max width for the toast ([f582d3a](https://github.com/Sage/carbon/commit/f582d3ab4f103c748c847bbd07fe808ec0bf7d6c))
+- **toast:** allow custom max width for the toast ([f582d3a](https://github.com/Sage/carbon/commit/f582d3ab4f103c748c847bbd07fe808ec0bf7d6c))
 
 ### [63.0.2](https://github.com/Sage/carbon/compare/v63.0.1...v63.0.2) (2021-02-01)
 
-
 ### Bug Fixes
 
-* **message:** add aria label for close button ([7f0fa70](https://github.com/Sage/carbon/commit/7f0fa705f0c9bd1818ead98727e7dde003770e73)), closes [#3406](https://github.com/Sage/carbon/issues/3406)
+- **message:** add aria label for close button ([7f0fa70](https://github.com/Sage/carbon/commit/7f0fa705f0c9bd1818ead98727e7dde003770e73)), closes [#3406](https://github.com/Sage/carbon/issues/3406)
 
 ### [63.0.1](https://github.com/Sage/carbon/compare/v63.0.0...v63.0.1) (2021-02-01)
 
-
 ### Bug Fixes
 
-* **dialog:** fix sticky footer transition ([f6d1360](https://github.com/Sage/carbon/commit/f6d13605de157f1f6a76cda6d193b72bb192c490)), closes [#3563](https://github.com/Sage/carbon/issues/3563)
+- **dialog:** fix sticky footer transition ([f6d1360](https://github.com/Sage/carbon/commit/f6d13605de157f1f6a76cda6d193b72bb192c490)), closes [#3563](https://github.com/Sage/carbon/issues/3563)
 
 ## [63.0.0](https://github.com/Sage/carbon/compare/v62.0.1...v63.0.0) (2021-02-01)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **focus-trap:** the focus trap util function has been removed
+- **focus-trap:** the focus trap util function has been removed
 
 ### Bug Fixes
 
-* **focus-trap:** add focus trap component and remove util function ([cde1081](https://github.com/Sage/carbon/commit/cde1081c14c38eb782ea68437f90b385bdaea914))
+- **focus-trap:** add focus trap component and remove util function ([cde1081](https://github.com/Sage/carbon/commit/cde1081c14c38eb782ea68437f90b385bdaea914))
 
 ### [62.0.1](https://github.com/Sage/carbon/compare/v62.0.0...v62.0.1) (2021-02-01)
 
-
 ### Bug Fixes
 
-* **pager:** fix incorrect behaviour when page count is zero ([1ecff03](https://github.com/Sage/carbon/commit/1ecff0388a7d33f79e2c01f6884b2b0eedf8854f))
+- **pager:** fix incorrect behaviour when page count is zero ([1ecff03](https://github.com/Sage/carbon/commit/1ecff0388a7d33f79e2c01f6884b2b0eedf8854f))
 
 ## [62.0.0](https://github.com/Sage/carbon/compare/v61.1.0...v62.0.0) (2021-01-28)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **tooltip:** The `TooltipDecorator` has been removed, and the interface for `Tooltip` has been
-updated
+- **tooltip:** The `TooltipDecorator` has been removed, and the interface for `Tooltip` has been
+  updated
 
 ### Features
 
-* **tooltip:** add tippyjs wrapper and remove decorator ([8114ae2](https://github.com/Sage/carbon/commit/8114ae2390d41b173c02fed7f2eaeb5ce3c05705))
+- **tooltip:** add tippyjs wrapper and remove decorator ([8114ae2](https://github.com/Sage/carbon/commit/8114ae2390d41b173c02fed7f2eaeb5ce3c05705))
 
 ## [61.1.0](https://github.com/Sage/carbon/compare/v61.0.1...v61.1.0) (2021-01-27)
 
-
 ### Features
 
-* **filterable-select:** implement object id property comparison ([a2bd662](https://github.com/Sage/carbon/commit/a2bd662ec3e7e8394569eec2d3f51ba28e5f7994))
-* **multi-select:** implement object id property comparison ([e68aa57](https://github.com/Sage/carbon/commit/e68aa57abbe2fd26de83f1c6c7e2092bbcf04b77))
-* **select:** implement object id property comparison ([32026b3](https://github.com/Sage/carbon/commit/32026b3a61a776ad2e76f8b941f7faeafccd01e9))
+- **filterable-select:** implement object id property comparison ([a2bd662](https://github.com/Sage/carbon/commit/a2bd662ec3e7e8394569eec2d3f51ba28e5f7994))
+- **multi-select:** implement object id property comparison ([e68aa57](https://github.com/Sage/carbon/commit/e68aa57abbe2fd26de83f1c6c7e2092bbcf04b77))
+- **select:** implement object id property comparison ([32026b3](https://github.com/Sage/carbon/commit/32026b3a61a776ad2e76f8b941f7faeafccd01e9))
 
 ### [61.0.1](https://github.com/Sage/carbon/compare/v61.0.0...v61.0.1) (2021-01-26)
 
-
 ### Bug Fixes
 
-* **sidebar:** disable scroll on document if sidebar is open ([738304a](https://github.com/Sage/carbon/commit/738304ac4452a274d8b57d126b20d7d4a206a2ec)), closes [#3541](https://github.com/Sage/carbon/issues/3541)
+- **sidebar:** disable scroll on document if sidebar is open ([738304a](https://github.com/Sage/carbon/commit/738304ac4452a274d8b57d126b20d7d4a206a2ec)), closes [#3541](https://github.com/Sage/carbon/issues/3541)
 
 ## [61.0.0](https://github.com/Sage/carbon/compare/v60.1.0...v61.0.0) (2021-01-26)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **button:** The margin left 16px styling applied to the sibling buttons has been removed. An
-add-prop codemod has been created to help facilitate the adding of the margin left spacing prop and
-the value to the buttons in your project.
+- **button:** The margin left 16px styling applied to the sibling buttons has been removed. An
+  add-prop codemod has been created to help facilitate the adding of the margin left spacing prop and
+  the value to the buttons in your project.
 
 ### Miscellaneous Chores
 
-* **button:** remove sibling styling for button ([164fab8](https://github.com/Sage/carbon/commit/164fab85185ae5567939d0e5b4360be2837adc01)), closes [#3392](https://github.com/Sage/carbon/issues/3392)
+- **button:** remove sibling styling for button ([164fab8](https://github.com/Sage/carbon/commit/164fab85185ae5567939d0e5b4360be2837adc01)), closes [#3392](https://github.com/Sage/carbon/issues/3392)
 
 ## [60.1.0](https://github.com/Sage/carbon/compare/v60.0.0...v60.1.0) (2021-01-26)
 
-
 ### Features
 
-* **multi-action-button:** render content in portal ([66d452c](https://github.com/Sage/carbon/commit/66d452c89daaa417ccfdff549ad98f78e35ab965))
-* **split-button:** render content in portal ([fee50f5](https://github.com/Sage/carbon/commit/fee50f5f922f0a84276d8a88ecc1c62a83611c25))
-* add new internal popover component ([de2962b](https://github.com/Sage/carbon/commit/de2962b7acd8237b8365c6404343291a5aae7376))
+- **multi-action-button:** render content in portal ([66d452c](https://github.com/Sage/carbon/commit/66d452c89daaa417ccfdff549ad98f78e35ab965))
+- **split-button:** render content in portal ([fee50f5](https://github.com/Sage/carbon/commit/fee50f5f922f0a84276d8a88ecc1c62a83611c25))
+- add new internal popover component ([de2962b](https://github.com/Sage/carbon/commit/de2962b7acd8237b8365c6404343291a5aae7376))
 
 ## [60.0.0](https://github.com/Sage/carbon/compare/v59.1.0...v60.0.0) (2021-01-26)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **content:** prop `as` has been replaced with `variant` as `as` prop is reserved for Styled Components.
-To update your code you can use the following codemod
-https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop
+- **content:** prop `as` has been replaced with `variant` as `as` prop is reserved for Styled Components.
+  To update your code you can use the following codemod
+  <https://github.com/Sage/carbon-codemod/tree/master/transforms/rename-prop>
 
 ### Code Refactoring
 
-* **content:** update to be functional ([93c4e86](https://github.com/Sage/carbon/commit/93c4e8645867e529941b62ba5a0b16d24601f867))
+- **content:** update to be functional ([93c4e86](https://github.com/Sage/carbon/commit/93c4e8645867e529941b62ba5a0b16d24601f867))
 
 ## [59.1.0](https://github.com/Sage/carbon/compare/v59.0.2...v59.1.0) (2021-01-25)
 
-
 ### Features
 
-* **action-popover:** render content in portal ([9c12819](https://github.com/Sage/carbon/commit/9c1281907bc06e24ae5a6a88bac2b08b493e6d51))
-* add new internal popover component ([5df1eb6](https://github.com/Sage/carbon/commit/5df1eb6e951a8972caf2aea43a2429e1fbdd8582))
+- **action-popover:** render content in portal ([9c12819](https://github.com/Sage/carbon/commit/9c1281907bc06e24ae5a6a88bac2b08b493e6d51))
+- add new internal popover component ([5df1eb6](https://github.com/Sage/carbon/commit/5df1eb6e951a8972caf2aea43a2429e1fbdd8582))
 
 ### [59.0.2](https://github.com/Sage/carbon/compare/v59.0.1...v59.0.2) (2021-01-22)
 
-
 ### Bug Fixes
 
-* **date:** fix date crashing when allowEmptyValue is set ([f6fb41c](https://github.com/Sage/carbon/commit/f6fb41c24aebe78950c987274b78a8f04a6ee448))
+- **date:** fix date crashing when allowEmptyValue is set ([f6fb41c](https://github.com/Sage/carbon/commit/f6fb41c24aebe78950c987274b78a8f04a6ee448))
 
 ### [59.0.1](https://github.com/Sage/carbon/compare/v59.0.0...v59.0.1) (2021-01-21)
 
-
 ### Bug Fixes
 
-* **focus-trap:** filter disabled inputs in query selector ([d616577](https://github.com/Sage/carbon/commit/d6165777ed5ff55e72d6f981d3f623a351eb6b05))
+- **focus-trap:** filter disabled inputs in query selector ([d616577](https://github.com/Sage/carbon/commit/d6165777ed5ff55e72d6f981d3f623a351eb6b05))
 
 ## [59.0.0](https://github.com/Sage/carbon/compare/v58.1.0...v59.0.0) (2021-01-19)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **text-editor:** remove cancel and save buttons from the toolbar,
-use toolbarElements prop to render custom elements such as these buttons
+- **text-editor:** remove cancel and save buttons from the toolbar,
+  use toolbarElements prop to render custom elements such as these buttons
 
 ### Code Refactoring
 
-* **text-editor:** allow user to render toolbar action controls ([d27b878](https://github.com/Sage/carbon/commit/d27b878d70d8526ef3d21d8c8577175da40d3589)), closes [#3444](https://github.com/Sage/carbon/issues/3444)
+- **text-editor:** allow user to render toolbar action controls ([d27b878](https://github.com/Sage/carbon/commit/d27b878d70d8526ef3d21d8c8577175da40d3589)), closes [#3444](https://github.com/Sage/carbon/issues/3444)
 
 ## [58.1.0](https://github.com/Sage/carbon/compare/v58.0.0...v58.1.0) (2021-01-18)
 
-
 ### Features
 
-* add new `pod-manager` component ([8c418cd](https://github.com/Sage/carbon/commit/8c418cd3a7eb6df8af3db20867a71b9eccbfb1c6)), closes [#3046](https://github.com/Sage/carbon/issues/3046)
+- add new `pod-manager` component ([8c418cd](https://github.com/Sage/carbon/commit/8c418cd3a7eb6df8af3db20867a71b9eccbfb1c6)), closes [#3046](https://github.com/Sage/carbon/issues/3046)
 
 ## [58.0.0](https://github.com/Sage/carbon/compare/v57.0.0...v58.0.0) (2021-01-12)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **menulist:** deprecated menu-list and menu-list-item components
+- **menulist:** deprecated menu-list and menu-list-item components
 
 ### Miscellaneous Chores
 
-* **menulist:** remove component ([f6d2a4b](https://github.com/Sage/carbon/commit/f6d2a4b6a5966e985525a57f6481f554f2a0b8dd))
+- **menulist:** remove component ([f6d2a4b](https://github.com/Sage/carbon/commit/f6d2a4b6a5966e985525a57f6481f554f2a0b8dd))
 
 ## [57.0.0](https://github.com/Sage/carbon/compare/v56.1.0...v57.0.0) (2021-01-12)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **checkbox:** group-checkbox prop label is renamed to legend
+- **checkbox:** group-checkbox prop label is renamed to legend
 
 There is a codemod available to assist with this upgrade
 `npx carbon-codemod rename-prop <target> carbon-react/lib/components/checkbox-group label legend`
-See https://github.com/Sage/carbon-codemod for more information.
+See <https://github.com/Sage/carbon-codemod> for more information.
 
 ### Code Refactoring
 
-* **checkbox:** modify checkbox-group to use fieldset ([a3da4cc](https://github.com/Sage/carbon/commit/a3da4cc53f00f2e76d2857bbf0ea6a394741be93))
+- **checkbox:** modify checkbox-group to use fieldset ([a3da4cc](https://github.com/Sage/carbon/commit/a3da4cc53f00f2e76d2857bbf0ea6a394741be93))
 
 ## [56.1.0](https://github.com/Sage/carbon/compare/v56.0.1...v56.1.0) (2021-01-11)
 
-
 ### Features
 
-* **search:** added keyboard navigation to clear text button ([069dbab](https://github.com/Sage/carbon/commit/069dbabd11378fdad3e214acae5da9d56ca70b70)), closes [#3485](https://github.com/Sage/carbon/issues/3485)
+- **search:** added keyboard navigation to clear text button ([069dbab](https://github.com/Sage/carbon/commit/069dbabd11378fdad3e214acae5da9d56ca70b70)), closes [#3485](https://github.com/Sage/carbon/issues/3485)
 
 ### [56.0.1](https://github.com/Sage/carbon/compare/v56.0.0...v56.0.1) (2021-01-11)
 
-
 ### Bug Fixes
 
-* **dialog:** dialog centering with dynamic content ([2f15659](https://github.com/Sage/carbon/commit/2f156596b89422246c019a2a49721b5bcb4401d3)), closes [#3470](https://github.com/Sage/carbon/issues/3470)
+- **dialog:** dialog centering with dynamic content ([2f15659](https://github.com/Sage/carbon/commit/2f156596b89422246c019a2a49721b5bcb4401d3)), closes [#3470](https://github.com/Sage/carbon/issues/3470)
 
 ## [56.0.0](https://github.com/Sage/carbon/compare/v55.0.0...v56.0.0) (2021-01-08)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **flat-table:** default paddings of flat table cell removed,
-cell should match row height or expand the row,
-cell paddings should depend on FlatTable size prop
+- **flat-table:** default paddings of flat table cell removed,
+  cell should match row height or expand the row,
+  cell paddings should depend on FlatTable size prop
 
 ### Features
 
-* **flat-table:** add aria-describedby prop ([ab52374](https://github.com/Sage/carbon/commit/ab52374ed0d2bda268e91bf627b5a86ef073d30b))
-* **flat-table:** add caption prop ([617f8a9](https://github.com/Sage/carbon/commit/617f8a9e79d26921254b885e35ef85a6312a68ae))
-* **flat-table:** add size prop to control cell size ([af095f9](https://github.com/Sage/carbon/commit/af095f9c2c9ae03ec70c0700dd21fdf10d2797e6))
-* **flat-table:** add zebra stripes functionality ([f8c32db](https://github.com/Sage/carbon/commit/f8c32dbb82cf6c665c63468e49480b39d51cfa05))
-
+- **flat-table:** add aria-describedby prop ([ab52374](https://github.com/Sage/carbon/commit/ab52374ed0d2bda268e91bf627b5a86ef073d30b))
+- **flat-table:** add caption prop ([617f8a9](https://github.com/Sage/carbon/commit/617f8a9e79d26921254b885e35ef85a6312a68ae))
+- **flat-table:** add size prop to control cell size ([af095f9](https://github.com/Sage/carbon/commit/af095f9c2c9ae03ec70c0700dd21fdf10d2797e6))
+- **flat-table:** add zebra stripes functionality ([f8c32db](https://github.com/Sage/carbon/commit/f8c32dbb82cf6c665c63468e49480b39d51cfa05))
 
 ### Bug Fixes
 
-* **flat-table:** row header not highlighted ([efc3654](https://github.com/Sage/carbon/commit/efc3654fb51e18ebede9a982a6ba1e5dc0adf300))
-
+- **flat-table:** row header not highlighted ([efc3654](https://github.com/Sage/carbon/commit/efc3654fb51e18ebede9a982a6ba1e5dc0adf300))
 
 ### Code Refactoring
 
-* **flat-table:** remove flat table cell default paddings ([ef4fa5b](https://github.com/Sage/carbon/commit/ef4fa5b9dddbb7b5cf01563fd7b89f862767bd0d))
+- **flat-table:** remove flat table cell default paddings ([ef4fa5b](https://github.com/Sage/carbon/commit/ef4fa5b9dddbb7b5cf01563fd7b89f862767bd0d))
 
 ## [55.0.0](https://github.com/Sage/carbon/compare/v54.6.2...v55.0.0) (2021-01-07)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **inputicon:** removed InputIcon decorator
+- **inputicon:** removed InputIcon decorator
 
 ### Code Refactoring
 
-* **inputicon:** remove whole decorator ([ebe9dc2](https://github.com/Sage/carbon/commit/ebe9dc20c77e88f49cc1bcee8c9eb80149cf3979))
+- **inputicon:** remove whole decorator ([ebe9dc2](https://github.com/Sage/carbon/commit/ebe9dc20c77e88f49cc1bcee8c9eb80149cf3979))
 
 ### [54.6.2](https://github.com/Sage/carbon/compare/v54.6.1...v54.6.2) (2021-01-07)
 
-
 ### Bug Fixes
 
-* **menuitem:** check for null chldren ([58bf841](https://github.com/Sage/carbon/commit/58bf841be15af1045950483f0ba5a48688d3f0da)), closes [#3540](https://github.com/Sage/carbon/issues/3540)
+- **menuitem:** check for null chldren ([58bf841](https://github.com/Sage/carbon/commit/58bf841be15af1045950483f0ba5a48688d3f0da)), closes [#3540](https://github.com/Sage/carbon/issues/3540)
 
 ### [54.6.1](https://github.com/Sage/carbon/compare/v54.6.0...v54.6.1) (2021-01-06)
 
-
 ### Bug Fixes
 
-* **tabs:** prevent padding override for large tabs with siblings ([3387ca0](https://github.com/Sage/carbon/commit/3387ca08d0861553e3ef8e8bc4f85f72a5c4d543))
+- **tabs:** prevent padding override for large tabs with siblings ([3387ca0](https://github.com/Sage/carbon/commit/3387ca08d0861553e3ef8e8bc4f85f72a5c4d543))
 
 ## [54.6.0](https://github.com/Sage/carbon/compare/v54.5.0...v54.6.0) (2021-01-04)
 
-
 ### Features
 
-* **menu:** add scrollable block component ([4814977](https://github.com/Sage/carbon/commit/4814977945c7f4ae06556feca7b4ab3df31da8cb))
+- **menu:** add scrollable block component ([4814977](https://github.com/Sage/carbon/commit/4814977945c7f4ae06556feca7b4ab3df31da8cb))
 
 ## [54.5.0](https://github.com/Sage/carbon/compare/v54.4.0...v54.5.0) (2020-12-30)
 
-
 ### Features
 
-* **numeral-date:** add date parts internal validation ([b10a5f8](https://github.com/Sage/carbon/commit/b10a5f8508b2966e0f123b246ec189b6960f2910))
+- **numeral-date:** add date parts internal validation ([b10a5f8](https://github.com/Sage/carbon/commit/b10a5f8508b2966e0f123b246ec189b6960f2910))
 
 ## [54.4.0](https://github.com/Sage/carbon/compare/v54.3.7...v54.4.0) (2020-12-24)
 
-
 ### Features
 
-* **menu:** allow icon only, keyboard override and accessiblity props ([6f33d2a](https://github.com/Sage/carbon/commit/6f33d2ac4d353f41d3d0f318471d4b0331c80392)), closes [#3505](https://github.com/Sage/carbon/issues/3505) [#3292](https://github.com/Sage/carbon/issues/3292)
+- **menu:** allow icon only, keyboard override and accessiblity props ([6f33d2a](https://github.com/Sage/carbon/commit/6f33d2ac4d353f41d3d0f318471d4b0331c80392)), closes [#3505](https://github.com/Sage/carbon/issues/3505) [#3292](https://github.com/Sage/carbon/issues/3292)
 
 ### [54.3.7](https://github.com/Sage/carbon/compare/v54.3.6...v54.3.7) (2020-12-22)
 
-
 ### Bug Fixes
 
-* **carousel:** fix not unique slide selector id ([e2ddd4d](https://github.com/Sage/carbon/commit/e2ddd4d5e08cfe9569ce3e84a7396597fb3d0eb4))
+- **carousel:** fix not unique slide selector id ([e2ddd4d](https://github.com/Sage/carbon/commit/e2ddd4d5e08cfe9569ce3e84a7396597fb3d0eb4))
 
 ### [54.3.6](https://github.com/Sage/carbon/compare/v54.3.5...v54.3.6) (2020-12-22)
 
-
 ### Bug Fixes
 
-* **sidebar:** fix sidebar crashing while closing with enableBackgroundUI ([f5d7c47](https://github.com/Sage/carbon/commit/f5d7c4788047198b3e5fa705e21067e2c07c97ab))
+- **sidebar:** fix sidebar crashing while closing with enableBackgroundUI ([f5d7c47](https://github.com/Sage/carbon/commit/f5d7c4788047198b3e5fa705e21067e2c07c97ab))
 
 ### [54.3.5](https://github.com/Sage/carbon/compare/v54.3.4...v54.3.5) (2020-12-22)
 
-
 ### Bug Fixes
 
-* **split-button:** fix accessibility issues ([670ab7c](https://github.com/Sage/carbon/commit/670ab7cd249b3a3be4f7eb92a175a7bc3ee2533a))
+- **split-button:** fix accessibility issues ([670ab7c](https://github.com/Sage/carbon/commit/670ab7cd249b3a3be4f7eb92a175a7bc3ee2533a))
 
 ### [54.3.4](https://github.com/Sage/carbon/compare/v54.3.3...v54.3.4) (2020-12-18)
 
-
 ### Bug Fixes
 
-* **menu:** allow null children ([237b62e](https://github.com/Sage/carbon/commit/237b62e30680e724ce59b1376ebf1e22df340bdb)), closes [#3497](https://github.com/Sage/carbon/issues/3497)
+- **menu:** allow null children ([237b62e](https://github.com/Sage/carbon/commit/237b62e30680e724ce59b1376ebf1e22df340bdb)), closes [#3497](https://github.com/Sage/carbon/issues/3497)
 
 ### [54.3.3](https://github.com/Sage/carbon/compare/v54.3.2...v54.3.3) (2020-12-18)
 
-
 ### Bug Fixes
 
-* **submenu:** stop submenu width from flexing with parent ([95066a3](https://github.com/Sage/carbon/commit/95066a33b41afaa6ce9df66db9033fd1ee71bf70))
+- **submenu:** stop submenu width from flexing with parent ([95066a3](https://github.com/Sage/carbon/commit/95066a33b41afaa6ce9df66db9033fd1ee71bf70))
 
 ### [54.3.2](https://github.com/Sage/carbon/compare/v54.3.1...v54.3.2) (2020-12-18)
 
-
 ### Bug Fixes
 
-* **navbar:** remove old styling to allow full width ([03542c0](https://github.com/Sage/carbon/commit/03542c0911b94e2020fad37743b0981e70f30a91))
+- **navbar:** remove old styling to allow full width ([03542c0](https://github.com/Sage/carbon/commit/03542c0911b94e2020fad37743b0981e70f30a91))
 
 ### [54.3.1](https://github.com/Sage/carbon/compare/v54.3.0...v54.3.1) (2020-12-18)
 
-
 ### Bug Fixes
 
-* **action-popover:** close action popover when submenu item is clicked ([993a07c](https://github.com/Sage/carbon/commit/993a07c5c01f99f4871b1b3df0159a4cfb37ffcc))
-* **action-popover:** incorrect event capturing on outside click ([fedd9c1](https://github.com/Sage/carbon/commit/fedd9c1ed7f747d20727352f5c4492795e66d587))
+- **action-popover:** close action popover when submenu item is clicked ([993a07c](https://github.com/Sage/carbon/commit/993a07c5c01f99f4871b1b3df0159a4cfb37ffcc))
+- **action-popover:** incorrect event capturing on outside click ([fedd9c1](https://github.com/Sage/carbon/commit/fedd9c1ed7f747d20727352f5c4492795e66d587))
 
 ## [54.3.0](https://github.com/Sage/carbon/compare/v54.2.0...v54.3.0) (2020-12-17)
 
-
 ### Features
 
-* **box:** extend box to support scrollbar style ([1f7f691](https://github.com/Sage/carbon/commit/1f7f6912c17abf9aa843b44e57787cf639e55b9f))
+- **box:** extend box to support scrollbar style ([1f7f691](https://github.com/Sage/carbon/commit/1f7f6912c17abf9aa843b44e57787cf639e55b9f))
 
 ## [54.2.0](https://github.com/Sage/carbon/compare/v54.1.2...v54.2.0) (2020-12-17)
 
-
 ### Features
 
-* **search:** add styling for dark theme ([56b3779](https://github.com/Sage/carbon/commit/56b37793627cd0d7b4731fa7bc11c2fddaea367f))
+- **search:** add styling for dark theme ([56b3779](https://github.com/Sage/carbon/commit/56b37793627cd0d7b4731fa7bc11c2fddaea367f))
 
 ### [54.1.2](https://github.com/Sage/carbon/compare/v54.1.1...v54.1.2) (2020-12-17)
 
-
 ### Bug Fixes
 
-* **tooltip:** change tooltip text-align to be always left ([8b37b7e](https://github.com/Sage/carbon/commit/8b37b7e1966d153845d7dedff798e921756bd419))
+- **tooltip:** change tooltip text-align to be always left ([8b37b7e](https://github.com/Sage/carbon/commit/8b37b7e1966d153845d7dedff798e921756bd419))
 
 ### [54.1.1](https://github.com/Sage/carbon/compare/v54.1.0...v54.1.1) (2020-12-16)
 
-
 ### Bug Fixes
 
-* fix withuniqueid hoc id assignment mechanism ([4d0e161](https://github.com/Sage/carbon/commit/4d0e161cd292f560501f0b2dabcbc12b57141e4f))
+- fix withuniqueid hoc id assignment mechanism ([4d0e161](https://github.com/Sage/carbon/commit/4d0e161cd292f560501f0b2dabcbc12b57141e4f))
 
 ## [54.1.0](https://github.com/Sage/carbon/compare/v54.0.1...v54.1.0) (2020-12-16)
 
-
 ### Features
 
-* **filterable-select:** clear filter on close ([f2e9bc3](https://github.com/Sage/carbon/commit/f2e9bc352ac6c2b948f3670c6090ef8437d70065))
+- **filterable-select:** clear filter on close ([f2e9bc3](https://github.com/Sage/carbon/commit/f2e9bc352ac6c2b948f3670c6090ef8437d70065))
 
 ### [54.0.1](https://github.com/Sage/carbon/compare/v54.0.0...v54.0.1) (2020-12-10)
 
-
 ### Bug Fixes
 
-* **alert:** fix styling bug with close icon ([13cfc33](https://github.com/Sage/carbon/commit/13cfc336852d43be858548fdfeca5f66a5111213))
+- **alert:** fix styling bug with close icon ([13cfc33](https://github.com/Sage/carbon/commit/13cfc336852d43be858548fdfeca5f66a5111213))
 
 ## [54.0.0](https://github.com/Sage/carbon/compare/v53.1.1...v54.0.0) (2020-12-09)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **fieldset:** Fieldset component no longer supports classic theme
-* **select:** Experimental Select component has been removed, please use our new Select component  `import { Select, Option } from "carbon-react/lib/components/select"`
-* **select-async:** SelectAsync component has been removed, please use our new Select component  `import { Select, Option } from "carbon-react/lib/components/select"`
-Also check an example of how to provide data fetching functionality
-https://carbon.sage.com/?path=/docs/select--with-is-loading-prop
-* **date:** Date component no longer supports classic theme
-* **textbox:** Textbox no longer supports classic theme
-* **textarea:** Textarea input no longer supports classic theme
-* **grouped-character:** GroupedCharacter no longer supports classic theme
-* **decimal:** Experimental Decimal component no longer supports classic theme
-* **date-range:** DateRange component no longer supports classic theme
-* **simple-color-picker:** SimpleColorPicker component no longer supports classic theme
-* **number:** Number input no longer supports classic theme
+- **fieldset:** Fieldset component no longer supports classic theme
+- **select:** Experimental Select component has been removed, please use our new Select component `import { Select, Option } from "carbon-react/lib/components/select"`
+- **select-async:** SelectAsync component has been removed, please use our new Select component `import { Select, Option } from "carbon-react/lib/components/select"`
+  Also check an example of how to provide data fetching functionality
+  <https://carbon.sage.com/?path=/docs/select--with-is-loading-prop>
+- **date:** Date component no longer supports classic theme
+- **textbox:** Textbox no longer supports classic theme
+- **textarea:** Textarea input no longer supports classic theme
+- **grouped-character:** GroupedCharacter no longer supports classic theme
+- **decimal:** Experimental Decimal component no longer supports classic theme
+- **date-range:** DateRange component no longer supports classic theme
+- **simple-color-picker:** SimpleColorPicker component no longer supports classic theme
+- **number:** Number input no longer supports classic theme
 
 ### Miscellaneous Chores
 
-* **date:** remove classic theme support ([e856b97](https://github.com/Sage/carbon/commit/e856b97a842133afe21fe708e1920e2b5f2270a5))
-* **date-range:** remove classic theme support ([9283b56](https://github.com/Sage/carbon/commit/9283b5681c2435980b5a5c4bdb462fcbe6e68c1f))
-* **decimal:** remove classic theme support ([7eff047](https://github.com/Sage/carbon/commit/7eff0470110f18586f542ceb5dd42cb961e8c768))
-* **fieldset:** remove classic theme support ([7f30056](https://github.com/Sage/carbon/commit/7f300561658c088e538fc04b697f082b73cd8123))
-* **grouped-character:** remove classic theme support ([ef51f0f](https://github.com/Sage/carbon/commit/ef51f0f8b26cd7c0b831cb55928cb45a56ea7c3b))
-* **number:** remove classic theme support ([5866222](https://github.com/Sage/carbon/commit/58662226e83b50dd931518885d841f20d7bce006))
-* **select:** remove experimental select component ([95961f4](https://github.com/Sage/carbon/commit/95961f47926c4a5653075b781d92dd95f456de27))
-* **select-async:** remove select-async component ([dcaf64c](https://github.com/Sage/carbon/commit/dcaf64c8e00b79d3cfaaab5d89331b51ee09a1c8))
-* **simple-color-picker:** remove classic theme support ([66aa3cb](https://github.com/Sage/carbon/commit/66aa3cb16590e560df734758acab1827e3c99d2f))
-* **textarea:** remove classic theme support ([3cfbbdd](https://github.com/Sage/carbon/commit/3cfbbdde02d0dd96f4a8c99467f7450d657f82ea))
-* **textbox:** remove classic theme support ([c1081fb](https://github.com/Sage/carbon/commit/c1081fb680234d7c14735986403eb141b362e642))
+- **date:** remove classic theme support ([e856b97](https://github.com/Sage/carbon/commit/e856b97a842133afe21fe708e1920e2b5f2270a5))
+- **date-range:** remove classic theme support ([9283b56](https://github.com/Sage/carbon/commit/9283b5681c2435980b5a5c4bdb462fcbe6e68c1f))
+- **decimal:** remove classic theme support ([7eff047](https://github.com/Sage/carbon/commit/7eff0470110f18586f542ceb5dd42cb961e8c768))
+- **fieldset:** remove classic theme support ([7f30056](https://github.com/Sage/carbon/commit/7f300561658c088e538fc04b697f082b73cd8123))
+- **grouped-character:** remove classic theme support ([ef51f0f](https://github.com/Sage/carbon/commit/ef51f0f8b26cd7c0b831cb55928cb45a56ea7c3b))
+- **number:** remove classic theme support ([5866222](https://github.com/Sage/carbon/commit/58662226e83b50dd931518885d841f20d7bce006))
+- **select:** remove experimental select component ([95961f4](https://github.com/Sage/carbon/commit/95961f47926c4a5653075b781d92dd95f456de27))
+- **select-async:** remove select-async component ([dcaf64c](https://github.com/Sage/carbon/commit/dcaf64c8e00b79d3cfaaab5d89331b51ee09a1c8))
+- **simple-color-picker:** remove classic theme support ([66aa3cb](https://github.com/Sage/carbon/commit/66aa3cb16590e560df734758acab1827e3c99d2f))
+- **textarea:** remove classic theme support ([3cfbbdd](https://github.com/Sage/carbon/commit/3cfbbdde02d0dd96f4a8c99467f7450d657f82ea))
+- **textbox:** remove classic theme support ([c1081fb](https://github.com/Sage/carbon/commit/c1081fb680234d7c14735986403eb141b362e642))
 
 ### [53.1.1](https://github.com/Sage/carbon/compare/v53.1.0...v53.1.1) (2020-12-09)
 
-
 ### Bug Fixes
 
-* **dialog:** fix styling for pill close icon ([ac11a2d](https://github.com/Sage/carbon/commit/ac11a2df9a6f1b6bec31535b0fc27539da5353d2))
+- **dialog:** fix styling for pill close icon ([ac11a2d](https://github.com/Sage/carbon/commit/ac11a2df9a6f1b6bec31535b0fc27539da5353d2))
 
 ## [53.1.0](https://github.com/Sage/carbon/compare/v53.0.0...v53.1.0) (2020-12-09)
 
-
 ### Features
 
-* **filterable-select:** add infinite scroll callback ([5cd8ef2](https://github.com/Sage/carbon/commit/5cd8ef2e869d69dc89c6883ddfc7d152ec0cd0f3))
-* **select:** add infinite scroll callback ([2836fed](https://github.com/Sage/carbon/commit/2836fedc106e47c39edf82eee640d7d709e2d357))
-* **select:** add list height transition animation ([3fb5fb2](https://github.com/Sage/carbon/commit/3fb5fb25ac6a76fedac1ea8758fed1af1190dea3))
+- **filterable-select:** add infinite scroll callback ([5cd8ef2](https://github.com/Sage/carbon/commit/5cd8ef2e869d69dc89c6883ddfc7d152ec0cd0f3))
+- **select:** add infinite scroll callback ([2836fed](https://github.com/Sage/carbon/commit/2836fedc106e47c39edf82eee640d7d709e2d357))
+- **select:** add list height transition animation ([3fb5fb2](https://github.com/Sage/carbon/commit/3fb5fb25ac6a76fedac1ea8758fed1af1190dea3))
 
 ## [53.0.0](https://github.com/Sage/carbon/compare/v52.0.0...v53.0.0) (2020-12-08)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **action-popover:** Classic theme styling has been removed
-* **action-toolbar:** Classic theme is no longer supported
-* **dialog-full-screen/full-screen-heading:** removal of classic theme from dialog full screen component.
+- **action-popover:** Classic theme styling has been removed
+- **action-toolbar:** Classic theme is no longer supported
+- **dialog-full-screen/full-screen-heading:** removal of classic theme from dialog full screen component.
 
 fixes FE-3633 and FE-3361
-* **dismiss-button:** dismiss-button component is being removed as it is no longer used internally.
-* **action-popover:** Classic theme styling has been removed
-* **action-toolbar:** Classic theme is no longer supported
-* **dialog-full-screen/full-screen-heading:** removal of classic theme from dialog full screen component.
+
+- **dismiss-button:** dismiss-button component is being removed as it is no longer used internally.
+- **action-popover:** Classic theme styling has been removed
+- **action-toolbar:** Classic theme is no longer supported
+- **dialog-full-screen/full-screen-heading:** removal of classic theme from dialog full screen component.
 
 fixes FE-3633 and FE-3361
-* **dismiss-button:** dismiss-button component is being removed as it is no longer used internally.
-* **action-popover:** Classic theme styling has been removed
-* **dialog-full-screen/full-screen-heading:** removal of classic theme from dialog full screen component.
+
+- **dismiss-button:** dismiss-button component is being removed as it is no longer used internally.
+- **action-popover:** Classic theme styling has been removed
+- **dialog-full-screen/full-screen-heading:** removal of classic theme from dialog full screen component.
 
 fixes FE-3633 and FE-3361
-* **action-toolbar:** Classic theme is no longer supported
-* **dismiss-button:** dismiss-button component is being removed as it is no longer used internally.
+
+- **action-toolbar:** Classic theme is no longer supported
+- **dismiss-button:** dismiss-button component is being removed as it is no longer used internally.
 
 ### Miscellaneous Chores
 
-* **action-popover:** remove support for classic theme ([a80eaea](https://github.com/Sage/carbon/commit/a80eaea2902190e0573f0a0d9ae68a6f27fa847f))
-* **action-popover:** remove support for classic theme ([8a60053](https://github.com/Sage/carbon/commit/8a600535bcc4c0f63e5367058340acd15bd0caa4))
-* **action-popover:** remove support for classic theme ([d0bbc44](https://github.com/Sage/carbon/commit/d0bbc44aab016924e14bc3c067cf932bf27d7f97))
-* **action-toolbar:** remove classic theme support ([a4e69c8](https://github.com/Sage/carbon/commit/a4e69c8b91cc51e37d7f4c3d07cf037b9e44ebe0))
-* **action-toolbar:** remove classic theme support ([5221a63](https://github.com/Sage/carbon/commit/5221a63bf4728ae927db72cecde0578bcbb26b9c))
-* **action-toolbar:** remove classic theme support ([96f3e2c](https://github.com/Sage/carbon/commit/96f3e2c459c0d861caa54825f596dac239d0e292))
-* **dialog-full-screen/full-screen-heading:** remove classic theme ([a073d1f](https://github.com/Sage/carbon/commit/a073d1f4c87c821bf978c6b86d9f7c4fbd812b6f))
-* **dialog-full-screen/full-screen-heading:** remove classic theme ([5679196](https://github.com/Sage/carbon/commit/5679196e9e42e41f18b90667f0527d039f06f537))
-* **dialog-full-screen/full-screen-heading:** remove classic theme ([b7e2ad7](https://github.com/Sage/carbon/commit/b7e2ad7b6b23b6590b62cc00973df4e38d6c9934))
-* **dismiss-button:** remove dismiss-button component ([61ea851](https://github.com/Sage/carbon/commit/61ea851e99ebdd533a51b6de07555b0083d252a2)), closes [#2647](https://github.com/Sage/carbon/issues/2647)
-* **dismiss-button:** remove dismiss-button component ([b1d7302](https://github.com/Sage/carbon/commit/b1d73022078e41929bde3cf048a47e98e6111eda)), closes [#2647](https://github.com/Sage/carbon/issues/2647)
-* **dismiss-button:** remove dismiss-button component ([d948ed5](https://github.com/Sage/carbon/commit/d948ed5a084e8871a00ef8fdc5e3017dc15eb311)), closes [#2647](https://github.com/Sage/carbon/issues/2647)
+- **action-popover:** remove support for classic theme ([a80eaea](https://github.com/Sage/carbon/commit/a80eaea2902190e0573f0a0d9ae68a6f27fa847f))
+- **action-popover:** remove support for classic theme ([8a60053](https://github.com/Sage/carbon/commit/8a600535bcc4c0f63e5367058340acd15bd0caa4))
+- **action-popover:** remove support for classic theme ([d0bbc44](https://github.com/Sage/carbon/commit/d0bbc44aab016924e14bc3c067cf932bf27d7f97))
+- **action-toolbar:** remove classic theme support ([a4e69c8](https://github.com/Sage/carbon/commit/a4e69c8b91cc51e37d7f4c3d07cf037b9e44ebe0))
+- **action-toolbar:** remove classic theme support ([5221a63](https://github.com/Sage/carbon/commit/5221a63bf4728ae927db72cecde0578bcbb26b9c))
+- **action-toolbar:** remove classic theme support ([96f3e2c](https://github.com/Sage/carbon/commit/96f3e2c459c0d861caa54825f596dac239d0e292))
+- **dialog-full-screen/full-screen-heading:** remove classic theme ([a073d1f](https://github.com/Sage/carbon/commit/a073d1f4c87c821bf978c6b86d9f7c4fbd812b6f))
+- **dialog-full-screen/full-screen-heading:** remove classic theme ([5679196](https://github.com/Sage/carbon/commit/5679196e9e42e41f18b90667f0527d039f06f537))
+- **dialog-full-screen/full-screen-heading:** remove classic theme ([b7e2ad7](https://github.com/Sage/carbon/commit/b7e2ad7b6b23b6590b62cc00973df4e38d6c9934))
+- **dismiss-button:** remove dismiss-button component ([61ea851](https://github.com/Sage/carbon/commit/61ea851e99ebdd533a51b6de07555b0083d252a2)), closes [#2647](https://github.com/Sage/carbon/issues/2647)
+- **dismiss-button:** remove dismiss-button component ([b1d7302](https://github.com/Sage/carbon/commit/b1d73022078e41929bde3cf048a47e98e6111eda)), closes [#2647](https://github.com/Sage/carbon/issues/2647)
+- **dismiss-button:** remove dismiss-button component ([d948ed5](https://github.com/Sage/carbon/commit/d948ed5a084e8871a00ef8fdc5e3017dc15eb311)), closes [#2647](https://github.com/Sage/carbon/issues/2647)
 
 ## [52.0.0](https://github.com/Sage/carbon/compare/v51.0.0...v52.0.0) (2020-12-08)
 
-
 ### ⚠ BREAKING CHANGES
 
-* Components that render a button now default to `type=button` instead of `type=submit`. The `Button` component has not changed and you can still override the button type using the `type` prop.
+- Components that render a button now default to `type=button` instead of `type=submit`. The `Button` component has not changed and you can still override the button type using the `type` prop.
 
 ### Bug Fixes
 
-* prevent accidental form submission ([6286f5c](https://github.com/Sage/carbon/commit/6286f5cbc3fcc7a7671ba51a4f6e5900749adbd0)), closes [#3405](https://github.com/Sage/carbon/issues/3405)
+- prevent accidental form submission ([6286f5c](https://github.com/Sage/carbon/commit/6286f5cbc3fcc7a7671ba51a4f6e5900749adbd0)), closes [#3405](https://github.com/Sage/carbon/issues/3405)
 
 ## [51.0.0](https://github.com/Sage/carbon/compare/v50.3.1...v51.0.0) (2020-12-07)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **sort:** `asc` and `desc` are no more supported, there are new ones
-`ascending` and `descending`
+- **sort:** `asc` and `desc` are no more supported, there are new ones
+  `ascending` and `descending`
 
 You will need replace
 `<Sort sortType="asc" />`
@@ -9303,335 +8156,312 @@ with
 `<Sort sortType="ascending" />`
 
 Or you can use our codemod for replacing prop values
-https://github.com/Sage/carbon-codemod/tree/master/transforms/replace-prop-value
+<https://github.com/Sage/carbon-codemod/tree/master/transforms/replace-prop-value>
 
 ### Features
 
-* **sort:** add accessibility for screen readers ([10d0140](https://github.com/Sage/carbon/commit/10d01406496e55dcd0668ef48ff0c4c7626f936a))
+- **sort:** add accessibility for screen readers ([10d0140](https://github.com/Sage/carbon/commit/10d01406496e55dcd0668ef48ff0c4c7626f936a))
 
 ### [50.3.1](https://github.com/Sage/carbon/compare/v50.3.0...v50.3.1) (2020-12-02)
 
-
 ### Bug Fixes
 
-* **action-popover:** incorrect submenu proptype ([08f4117](https://github.com/Sage/carbon/commit/08f4117c92502f5a73b698f0e78ed10bd26f36fa))
+- **action-popover:** incorrect submenu proptype ([08f4117](https://github.com/Sage/carbon/commit/08f4117c92502f5a73b698f0e78ed10bd26f36fa))
 
 ## [50.3.0](https://github.com/Sage/carbon/compare/v50.2.0...v50.3.0) (2020-11-26)
 
-
 ### Features
 
-* **tile:** add new `TileFooter` component ([9897490](https://github.com/Sage/carbon/commit/9897490648fd2d16355ed070fce37003ba184b72))
+- **tile:** add new `TileFooter` component ([9897490](https://github.com/Sage/carbon/commit/9897490648fd2d16355ed070fce37003ba184b72))
 
 ## [50.2.0](https://github.com/Sage/carbon/compare/v50.1.0...v50.2.0) (2020-11-26)
 
-
 ### Features
 
-* **filterable-select:** add loader for async ([2953ae0](https://github.com/Sage/carbon/commit/2953ae0aba29525f10f48556b79d1eaa141b9d9f))
-* **select:** add loader for async ([889a9a6](https://github.com/Sage/carbon/commit/889a9a6a69db9431682f2dd5aa6dbce9b218a03b))
-
+- **filterable-select:** add loader for async ([2953ae0](https://github.com/Sage/carbon/commit/2953ae0aba29525f10f48556b79d1eaa141b9d9f))
+- **select:** add loader for async ([889a9a6](https://github.com/Sage/carbon/commit/889a9a6a69db9431682f2dd5aa6dbce9b218a03b))
 
 ### Bug Fixes
 
-* **filterable-select:** when readonly pressing a key opens the list ([38fd162](https://github.com/Sage/carbon/commit/38fd162304bc418f0d2e944b7dc91a5dd18071df))
-* **multi-select:** when readonly pressing a key opens the list ([1f2e9c3](https://github.com/Sage/carbon/commit/1f2e9c32eb10657710efe0c03eeb7ede511fbedd))
-* **select:** proptype warning when option has object in value ([2001474](https://github.com/Sage/carbon/commit/20014742bc57b15d76767663aa69d419c6bb9087)), closes [#3327](https://github.com/Sage/carbon/issues/3327)
-* **select:** typescript definitions not exported ([53e7a33](https://github.com/Sage/carbon/commit/53e7a3376d7329166530b7522c1f3ca88d7352e0))
-* **select:** when readonly pressing a key opens the list ([9c5862f](https://github.com/Sage/carbon/commit/9c5862f001bd5bd810a19a548da8a8faa917e12a))
+- **filterable-select:** when readonly pressing a key opens the list ([38fd162](https://github.com/Sage/carbon/commit/38fd162304bc418f0d2e944b7dc91a5dd18071df))
+- **multi-select:** when readonly pressing a key opens the list ([1f2e9c3](https://github.com/Sage/carbon/commit/1f2e9c32eb10657710efe0c03eeb7ede511fbedd))
+- **select:** proptype warning when option has object in value ([2001474](https://github.com/Sage/carbon/commit/20014742bc57b15d76767663aa69d419c6bb9087)), closes [#3327](https://github.com/Sage/carbon/issues/3327)
+- **select:** typescript definitions not exported ([53e7a33](https://github.com/Sage/carbon/commit/53e7a3376d7329166530b7522c1f3ca88d7352e0))
+- **select:** when readonly pressing a key opens the list ([9c5862f](https://github.com/Sage/carbon/commit/9c5862f001bd5bd810a19a548da8a8faa917e12a))
 
 ## [50.1.0](https://github.com/Sage/carbon/compare/v50.0.0...v50.1.0) (2020-11-25)
 
-
 ### Features
 
-* **textbox:** add space props ([334852f](https://github.com/Sage/carbon/commit/334852ff5a667d37e15762b599c4bf91e65b85a4))
+- **textbox:** add space props ([334852f](https://github.com/Sage/carbon/commit/334852ff5a667d37e15762b599c4bf91e65b85a4))
 
 ## [50.0.0](https://github.com/Sage/carbon/compare/v49.4.0...v50.0.0) (2020-11-25)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **row:** Row and Column components no loger support classic theme, also `.carbon-row` and `.carbon-column` classNames no longer exist, adjust your code accordingly before updating if your code relies on these classes.
-* **table-ajax:** classic theme support has been removed
-* **settings-row:** SettingsRow no longer support classic theme
-* **table:** classic theme support has been removed
-* **message:** Message component no logger support classic theme. Also `<Message as="info" roundedCorners border={false}>My Message</Message>` has been
-removed in favour of `<Message variant="info">My Message</Message>`.
+- **row:** Row and Column components no loger support classic theme, also `.carbon-row` and `.carbon-column` classNames no longer exist, adjust your code accordingly before updating if your code relies on these classes.
+- **table-ajax:** classic theme support has been removed
+- **settings-row:** SettingsRow no longer support classic theme
+- **table:** classic theme support has been removed
+- **message:** Message component no logger support classic theme. Also `<Message as="info" roundedCorners border={false}>My Message</Message>` has been
+  removed in favour of `<Message variant="info">My Message</Message>`.
 
 There is a codemod available to assist with this upgrade `npx carbon-codemod message-remove-classic-theme <target>`.
 
-See https://github.com/Sage/carbon-codemod for more information
-* **flash:** Flash component has been removed please use Toast component instead.
-To help with migration please use our codemod `npx carbon-codemod replace-flash-with-toast <target>`
-* **draggable-context:** draggable context components no longer supports classic theme
+See <https://github.com/Sage/carbon-codemod> for more information
+
+- **flash:** Flash component has been removed please use Toast component instead.
+  To help with migration please use our codemod `npx carbon-codemod replace-flash-with-toast <target>`
+- **draggable-context:** draggable context components no longer supports classic theme
 
 ### Features
 
-* **toast:** add timeout functionality ([8ea5018](https://github.com/Sage/carbon/commit/8ea5018e15b8a6b9c17365d74eaa742630e75326))
-
+- **toast:** add timeout functionality ([8ea5018](https://github.com/Sage/carbon/commit/8ea5018e15b8a6b9c17365d74eaa742630e75326))
 
 ### Bug Fixes
 
-* **message:** change incorrect type of title prop ([cbccfb6](https://github.com/Sage/carbon/commit/cbccfb60a776b4d157ab471a59cac05433b461f0))
-* **toast:** correct toast propTypes descriptions ([9f07af1](https://github.com/Sage/carbon/commit/9f07af141ac03fcd11b7f9eedc1a2b58d275068f))
-
+- **message:** change incorrect type of title prop ([cbccfb6](https://github.com/Sage/carbon/commit/cbccfb60a776b4d157ab471a59cac05433b461f0))
+- **toast:** correct toast propTypes descriptions ([9f07af1](https://github.com/Sage/carbon/commit/9f07af141ac03fcd11b7f9eedc1a2b58d275068f))
 
 ### Miscellaneous Chores
 
-* **draggable-context:** remove classic theme support ([de92007](https://github.com/Sage/carbon/commit/de92007b514754b21e151255258b5fd4c656ed4b))
-* **flash:** remove flash component ([658af77](https://github.com/Sage/carbon/commit/658af778d78e03123734a81aadfaf348134f7a35))
-* **message:** remove classic theme support ([9d355b2](https://github.com/Sage/carbon/commit/9d355b26ba3762feec82e23a8266a1f8f202ea7d))
-* **row:** remove classic theme support ([280a8b5](https://github.com/Sage/carbon/commit/280a8b5b5be63a0fa9c2957147733c2f908db172))
-* **settings-row:** remove classic theme support ([d8bd20d](https://github.com/Sage/carbon/commit/d8bd20dd456542e6939a60cfb6c9ec65602a635e))
-* **table:** remove classic theme support ([bdd3e07](https://github.com/Sage/carbon/commit/bdd3e07b0f3b7445f1fa7f75f1467c4d86a0e480))
-* **table-ajax:** remove classic theme support ([df425a9](https://github.com/Sage/carbon/commit/df425a907f850646556f6ff2c482a03e771c39b9))
+- **draggable-context:** remove classic theme support ([de92007](https://github.com/Sage/carbon/commit/de92007b514754b21e151255258b5fd4c656ed4b))
+- **flash:** remove flash component ([658af77](https://github.com/Sage/carbon/commit/658af778d78e03123734a81aadfaf348134f7a35))
+- **message:** remove classic theme support ([9d355b2](https://github.com/Sage/carbon/commit/9d355b26ba3762feec82e23a8266a1f8f202ea7d))
+- **row:** remove classic theme support ([280a8b5](https://github.com/Sage/carbon/commit/280a8b5b5be63a0fa9c2957147733c2f908db172))
+- **settings-row:** remove classic theme support ([d8bd20d](https://github.com/Sage/carbon/commit/d8bd20dd456542e6939a60cfb6c9ec65602a635e))
+- **table:** remove classic theme support ([bdd3e07](https://github.com/Sage/carbon/commit/bdd3e07b0f3b7445f1fa7f75f1467c4d86a0e480))
+- **table-ajax:** remove classic theme support ([df425a9](https://github.com/Sage/carbon/commit/df425a907f850646556f6ff2c482a03e771c39b9))
 
 ## [49.4.0](https://github.com/Sage/carbon/compare/v49.3.0...v49.4.0) (2020-11-20)
 
-
 ### Features
 
-* **menu-item:** add prop to hide dropdown arrow for items with submenu ([ef9bc4d](https://github.com/Sage/carbon/commit/ef9bc4d5c449fcdeeb7abbc9616c3b9a1006141a))
+- **menu-item:** add prop to hide dropdown arrow for items with submenu ([ef9bc4d](https://github.com/Sage/carbon/commit/ef9bc4d5c449fcdeeb7abbc9616c3b9a1006141a))
 
 ## [49.3.0](https://github.com/Sage/carbon/compare/v49.2.0...v49.3.0) (2020-11-19)
 
-
 ### Features
 
-* **action-popover:** add support to place menu above button ([929a438](https://github.com/Sage/carbon/commit/929a438f314de6bd43ba1899495e8cc10d3f7871))
+- **action-popover:** add support to place menu above button ([929a438](https://github.com/Sage/carbon/commit/929a438f314de6bd43ba1899495e8cc10d3f7871))
 
 ## [49.2.0](https://github.com/Sage/carbon/compare/v49.1.0...v49.2.0) (2020-11-18)
 
-
 ### Features
 
-* **select:** add option group headers ([83aa90a](https://github.com/Sage/carbon/commit/83aa90a740e20cc9eae30fadfd84dcb62c38e123))
+- **select:** add option group headers ([83aa90a](https://github.com/Sage/carbon/commit/83aa90a740e20cc9eae30fadfd84dcb62c38e123))
 
 ## [49.1.0](https://github.com/Sage/carbon/compare/v49.0.2...v49.1.0) (2020-11-18)
 
-
 ### Features
 
-* **definition-list:** add support for spacing props ([744812b](https://github.com/Sage/carbon/commit/744812b7f28e056055618858e66a9d3f533fa7ce)), closes [#3387](https://github.com/Sage/carbon/issues/3387)
+- **definition-list:** add support for spacing props ([744812b](https://github.com/Sage/carbon/commit/744812b7f28e056055618858e66a9d3f533fa7ce)), closes [#3387](https://github.com/Sage/carbon/issues/3387)
 
 ### [49.0.2](https://github.com/Sage/carbon/compare/v49.0.1...v49.0.2) (2020-11-17)
 
-
 ### Bug Fixes
 
-* **textarea:** align label with input text ([ca0c871](https://github.com/Sage/carbon/commit/ca0c8719cb7065da4396f5a8c4f6b11494d6a5dd)), closes [#3224](https://github.com/Sage/carbon/issues/3224)
+- **textarea:** align label with input text ([ca0c871](https://github.com/Sage/carbon/commit/ca0c8719cb7065da4396f5a8c4f6b11494d6a5dd)), closes [#3224](https://github.com/Sage/carbon/issues/3224)
 
 ### [49.0.1](https://github.com/Sage/carbon/compare/v49.0.0...v49.0.1) (2020-11-17)
 
-
 ### Bug Fixes
 
-* **accordion:** update headings grid to allow subtitle to span columns ([3b2fa89](https://github.com/Sage/carbon/commit/3b2fa89b78b09fce540e6708649e36a8dc8a5e62))
+- **accordion:** update headings grid to allow subtitle to span columns ([3b2fa89](https://github.com/Sage/carbon/commit/3b2fa89b78b09fce540e6708649e36a8dc8a5e62))
 
 ## [49.0.0](https://github.com/Sage/carbon/compare/v48.7.1...v49.0.0) (2020-11-17)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **pages:** Removal of classic theme from the Pages component. Component no longer supports
-classic theme.
+- **pages:** Removal of classic theme from the Pages component. Component no longer supports
+  classic theme.
 
 fixes FE-3117
-* **mount-in-app:** Removal of classic theme from the mount in app component. Component no longer
-supports classic theme.
+
+- **mount-in-app:** Removal of classic theme from the mount in app component. Component no longer
+  supports classic theme.
 
 fixes FE-3116
-* **menu-list:** Classic theme has been removed from the MenuList component. This component no
-longer supports the classic theme.
+
+- **menu-list:** Classic theme has been removed from the MenuList component. This component no
+  longer supports the classic theme.
 
 fixes FE-3114
-* **link:** Classic styling has been removed from the link the component. The link component no
-longer supports the classic theme.
+
+- **link:** Classic styling has been removed from the link the component. The link component no
+  longer supports the classic theme.
 
 fixes FE-3113
-* **menu-list:** Classic theme has been removed from the MenuList component. This component no
-longer supports the classic theme.
+
+- **menu-list:** Classic theme has been removed from the MenuList component. This component no
+  longer supports the classic theme.
 
 fixes FE-3114
-* **link:** Classic styling has been removed from the link the component. The link component no
-longer supports the classic theme.
+
+- **link:** Classic styling has been removed from the link the component. The link component no
+  longer supports the classic theme.
 
 fixes FE-3113
 
 ### Miscellaneous Chores
 
-* **link:** remove classic theme ([4a030e3](https://github.com/Sage/carbon/commit/4a030e37adeb945d367bc48c4d6667a2a3c552b7))
-* **link:** remove classic theme ([0ebf9cc](https://github.com/Sage/carbon/commit/0ebf9cc970eda74b66166972ea01c231da04bf5b))
-* **menu-list:** remove classic theme ([51167c6](https://github.com/Sage/carbon/commit/51167c669fd7b4fc01ca7a0163938a070034fc0e))
-* **menu-list:** remove classic theme ([85786d8](https://github.com/Sage/carbon/commit/85786d89554d76beda8f06ea8c0eed421e6f5f0b))
-* **mount-in-app:** remove classic theme ([9446069](https://github.com/Sage/carbon/commit/94460691c6f8bb3b16fafe6e240270a44ea404c6))
-* **pages:** remove classic theme ([610841f](https://github.com/Sage/carbon/commit/610841f8ae006e2b862bbb4c43a887c552cdbbd8))
+- **link:** remove classic theme ([4a030e3](https://github.com/Sage/carbon/commit/4a030e37adeb945d367bc48c4d6667a2a3c552b7))
+- **link:** remove classic theme ([0ebf9cc](https://github.com/Sage/carbon/commit/0ebf9cc970eda74b66166972ea01c231da04bf5b))
+- **menu-list:** remove classic theme ([51167c6](https://github.com/Sage/carbon/commit/51167c669fd7b4fc01ca7a0163938a070034fc0e))
+- **menu-list:** remove classic theme ([85786d8](https://github.com/Sage/carbon/commit/85786d89554d76beda8f06ea8c0eed421e6f5f0b))
+- **mount-in-app:** remove classic theme ([9446069](https://github.com/Sage/carbon/commit/94460691c6f8bb3b16fafe6e240270a44ea404c6))
+- **pages:** remove classic theme ([610841f](https://github.com/Sage/carbon/commit/610841f8ae006e2b862bbb4c43a887c552cdbbd8))
 
 ### [48.7.1](https://github.com/Sage/carbon/compare/v48.7.0...v48.7.1) (2020-11-13)
 
-
 ### Bug Fixes
 
-* **flat-table:** fix incorrect type definitions ([d8a8597](https://github.com/Sage/carbon/commit/d8a8597accdd91f2e33052fc04c4255997214fc6))
+- **flat-table:** fix incorrect type definitions ([d8a8597](https://github.com/Sage/carbon/commit/d8a8597accdd91f2e33052fc04c4255997214fc6))
 
 ## [48.7.0](https://github.com/Sage/carbon/compare/v48.6.3...v48.7.0) (2020-11-12)
 
-
 ### Features
 
-* **flat-table:** add support for rendering table footer ([aa5ef93](https://github.com/Sage/carbon/commit/aa5ef93785e7fec2beb877742a4ec8c48d1c35a0))
+- **flat-table:** add support for rendering table footer ([aa5ef93](https://github.com/Sage/carbon/commit/aa5ef93785e7fec2beb877742a4ec8c48d1c35a0))
 
 ### [48.6.3](https://github.com/Sage/carbon/compare/v48.6.2...v48.6.3) (2020-11-12)
 
-
 ### Bug Fixes
 
-* **radio-button:** align legend with first radio-button ([c08ae52](https://github.com/Sage/carbon/commit/c08ae5252f55956bb2d1a0fb8d9af26e84b67d39)), closes [#3269](https://github.com/Sage/carbon/issues/3269)
+- **radio-button:** align legend with first radio-button ([c08ae52](https://github.com/Sage/carbon/commit/c08ae5252f55956bb2d1a0fb8d9af26e84b67d39)), closes [#3269](https://github.com/Sage/carbon/issues/3269)
 
 ### [48.6.2](https://github.com/Sage/carbon/compare/v48.6.1...v48.6.2) (2020-11-11)
 
-
 ### Bug Fixes
 
-* **menu-divider:** add default cursor to passive submenu elements ([c449531](https://github.com/Sage/carbon/commit/c4495315a7fe909d43360d9ca0439c613fb1a670))
+- **menu-divider:** add default cursor to passive submenu elements ([c449531](https://github.com/Sage/carbon/commit/c4495315a7fe909d43360d9ca0439c613fb1a670))
 
 ### [48.6.1](https://github.com/Sage/carbon/compare/v48.6.0...v48.6.1) (2020-11-09)
 
-
 ### Bug Fixes
 
-* **menu-item:** add height when onclick passed and button renders ([cec05f3](https://github.com/Sage/carbon/commit/cec05f3580a5f5bf9fceb9953349d8a08a72f0f9)), closes [#3308](https://github.com/Sage/carbon/issues/3308)
+- **menu-item:** add height when onclick passed and button renders ([cec05f3](https://github.com/Sage/carbon/commit/cec05f3580a5f5bf9fceb9953349d8a08a72f0f9)), closes [#3308](https://github.com/Sage/carbon/issues/3308)
 
 ## [48.6.0](https://github.com/Sage/carbon/compare/v48.5.0...v48.6.0) (2020-11-06)
 
-
 ### Features
 
-* **menu-item:** add support for alternate background color variant ([bd14b40](https://github.com/Sage/carbon/commit/bd14b4015eba45a64e2e946ca5facf2ec184ec94))
+- **menu-item:** add support for alternate background color variant ([bd14b40](https://github.com/Sage/carbon/commit/bd14b4015eba45a64e2e946ca5facf2ec184ec94))
 
 ## [48.5.0](https://github.com/Sage/carbon/compare/v48.4.0...v48.5.0) (2020-11-06)
 
-
 ### Features
 
-* **dialog-full-screen:** add prop `disableContentPadding` ([95d2717](https://github.com/Sage/carbon/commit/95d2717da44720d620eec149b7d646f5799bc092))
+- **dialog-full-screen:** add prop `disableContentPadding` ([95d2717](https://github.com/Sage/carbon/commit/95d2717da44720d620eec149b7d646f5799bc092))
 
 ## [48.4.0](https://github.com/Sage/carbon/compare/v48.3.1...v48.4.0) (2020-11-06)
 
-
 ### Features
 
-* **navigation-bar:** add support for custom spacing props ([242d26e](https://github.com/Sage/carbon/commit/242d26e7261135bfc7cf8ac7dd4cde7e2ee46a56))
-
+- **navigation-bar:** add support for custom spacing props ([242d26e](https://github.com/Sage/carbon/commit/242d26e7261135bfc7cf8ac7dd4cde7e2ee46a56))
 
 ### Bug Fixes
 
-* **radio-button:** warning when react node passed in label prop ([edbfb8f](https://github.com/Sage/carbon/commit/edbfb8fa023b5a2dcd16eb92037a72bfa61bb758))
+- **radio-button:** warning when react node passed in label prop ([edbfb8f](https://github.com/Sage/carbon/commit/edbfb8fa023b5a2dcd16eb92037a72bfa61bb758))
 
 ### [48.3.1](https://github.com/Sage/carbon/compare/v48.3.0...v48.3.1) (2020-11-02)
 
-
 ### Bug Fixes
 
-* **search:** fix story ([4ff48d9](https://github.com/Sage/carbon/commit/4ff48d917321ed122f303df350b3f43dd95036a8))
-* **search:** fix styling ([60a1deb](https://github.com/Sage/carbon/commit/60a1deb0e782797243d2a63f154b06fb421c5bc9))
-* **search:** search icon show in wrong time ([436a4f4](https://github.com/Sage/carbon/commit/436a4f475f34f53f8f4086301c56ed91cea0c0aa))
-* **search:** work in controlled mode ([56f897f](https://github.com/Sage/carbon/commit/56f897f8a62743aa3b03420f55de1cca5926f9c1))
+- **search:** fix story ([4ff48d9](https://github.com/Sage/carbon/commit/4ff48d917321ed122f303df350b3f43dd95036a8))
+- **search:** fix styling ([60a1deb](https://github.com/Sage/carbon/commit/60a1deb0e782797243d2a63f154b06fb421c5bc9))
+- **search:** search icon show in wrong time ([436a4f4](https://github.com/Sage/carbon/commit/436a4f475f34f53f8f4086301c56ed91cea0c0aa))
+- **search:** work in controlled mode ([56f897f](https://github.com/Sage/carbon/commit/56f897f8a62743aa3b03420f55de1cca5926f9c1))
 
 ## [48.3.0](https://github.com/Sage/carbon/compare/v48.2.0...v48.3.0) (2020-11-02)
 
-
 ### Features
 
-* **icon:** add custom color support ([7b69b04](https://github.com/Sage/carbon/commit/7b69b042e8998b185b1c4767e6f80ba84bca7a44))
-* **pill:** add custom color support ([c542205](https://github.com/Sage/carbon/commit/c5422051419050a6e5c4dd5293fea784f078e293))
+- **icon:** add custom color support ([7b69b04](https://github.com/Sage/carbon/commit/7b69b042e8998b185b1c4767e6f80ba84bca7a44))
+- **pill:** add custom color support ([c542205](https://github.com/Sage/carbon/commit/c5422051419050a6e5c4dd5293fea784f078e293))
 
 ## [48.2.0](https://github.com/Sage/carbon/compare/v48.1.0...v48.2.0) (2020-11-02)
 
-
 ### Features
 
-* **accordion:** add tertiary button heading styling option ([254f1de](https://github.com/Sage/carbon/commit/254f1de4bcd737c4c0eb3c812309ca89c070f972))
+- **accordion:** add tertiary button heading styling option ([254f1de](https://github.com/Sage/carbon/commit/254f1de4bcd737c4c0eb3c812309ca89c070f972))
 
 ## [48.1.0](https://github.com/Sage/carbon/compare/v48.0.0...v48.1.0) (2020-10-30)
 
-
 ### Features
 
-* **date:** add option to disable portal in component ([ec01acf](https://github.com/Sage/carbon/commit/ec01acf6a2f7bddf51b4a24918faa77eba57acbe))
-* **select:** add option to disable portal in component ([b0013bf](https://github.com/Sage/carbon/commit/b0013bfaa79dc7afb8faf18dea7d553a9a1c0b47))
-
+- **date:** add option to disable portal in component ([ec01acf](https://github.com/Sage/carbon/commit/ec01acf6a2f7bddf51b4a24918faa77eba57acbe))
+- **select:** add option to disable portal in component ([b0013bf](https://github.com/Sage/carbon/commit/b0013bfaa79dc7afb8faf18dea7d553a9a1c0b47))
 
 ### Bug Fixes
 
-* **date:** fix failing snapshots ([1bd4c06](https://github.com/Sage/carbon/commit/1bd4c0670f36f6848c3c6e7bf6387eb2eff431a1))
-* **select:** fix select list positioning mechanism ([ee4686c](https://github.com/Sage/carbon/commit/ee4686cd1ac2e361ef3377d7e4bc956a8da0e232))
+- **date:** fix failing snapshots ([1bd4c06](https://github.com/Sage/carbon/commit/1bd4c0670f36f6848c3c6e7bf6387eb2eff431a1))
+- **select:** fix select list positioning mechanism ([ee4686c](https://github.com/Sage/carbon/commit/ee4686cd1ac2e361ef3377d7e4bc956a8da0e232))
 
 ## [48.0.0](https://github.com/Sage/carbon/compare/v47.1.2...v48.0.0) (2020-10-30)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **accordion:** prop `customPadding` no longer exists, after adding `styled-system` you can add any padding you need to Accordion
-To fix issues you will have to replace
+- **accordion:** prop `customPadding` no longer exists, after adding `styled-system` you can add any padding you need to Accordion
+  To fix issues you will have to replace
+
 ```
 <Accordion customPadding="50" />
 ```
+
 with
+
 ```
 <Accordion py="50px" />
 ```
-to see more information about `styled-system` go visit https://styled-system.com/api
+
+to see more information about `styled-system` go visit <https://styled-system.com/api>
 
 feat(accordion): add prop headerSpacing
 
 headerSpacing prop allow you to use styled-system spacing API for Accordion Title
 
 feat(accordion): add new prop `disableContentPadding`
-* **tile:** - Tile will no longer support for padding prop  like `S, M, L, XL`
-- Tile will now support styled-system values for the padding and margin. You can see more here https://styled-system.com/api
+
+- **tile:** - Tile will no longer support for padding prop like `S, M, L, XL`
+
+* Tile will now support styled-system values for the padding and margin. You can see more here <https://styled-system.com/api>
 
 ### Features
 
-* **accordion:** add styled-system ([ca27839](https://github.com/Sage/carbon/commit/ca27839f09f27c112eb54cfd0dfb201610800f9a))
-* **tile:** add styled-system ([e2de6fa](https://github.com/Sage/carbon/commit/e2de6fa0886bfa1da52ae2043de49ac3ed725da1))
+- **accordion:** add styled-system ([ca27839](https://github.com/Sage/carbon/commit/ca27839f09f27c112eb54cfd0dfb201610800f9a))
+- **tile:** add styled-system ([e2de6fa](https://github.com/Sage/carbon/commit/e2de6fa0886bfa1da52ae2043de49ac3ed725da1))
 
 ### [47.1.2](https://github.com/Sage/carbon/compare/v47.1.1...v47.1.2) (2020-10-30)
 
-
 ### Bug Fixes
 
-* **theme:** update base/none theme primary color ([173d35f](https://github.com/Sage/carbon/commit/173d35f898097d456ef9ab18aa84c451096f4ada))
+- **theme:** update base/none theme primary color ([173d35f](https://github.com/Sage/carbon/commit/173d35f898097d456ef9ab18aa84c451096f4ada))
 
 ### [47.1.1](https://github.com/Sage/carbon/compare/v47.1.0...v47.1.1) (2020-10-29)
 
-
 ### Bug Fixes
 
-* **date:** datepicker incorrect weekday short names ([9947e44](https://github.com/Sage/carbon/commit/9947e44e522b0d9b58a5fbd89fcbfb0d57a3d91c))
-* **date:** datepicker weekdays not translated ([0377971](https://github.com/Sage/carbon/commit/037797189f74524dc26da8108d1dede3929ef531)), closes [#3120](https://github.com/Sage/carbon/issues/3120)
+- **date:** datepicker incorrect weekday short names ([9947e44](https://github.com/Sage/carbon/commit/9947e44e522b0d9b58a5fbd89fcbfb0d57a3d91c))
+- **date:** datepicker weekdays not translated ([0377971](https://github.com/Sage/carbon/commit/037797189f74524dc26da8108d1dede3929ef531)), closes [#3120](https://github.com/Sage/carbon/issues/3120)
 
 ## [47.1.0](https://github.com/Sage/carbon/compare/v47.0.0...v47.1.0) (2020-10-28)
 
-
 ### Features
 
-* **filterable-select:** add list action button ([c2ef17a](https://github.com/Sage/carbon/commit/c2ef17a05861660f2f49b02081cd97db866ddc2d))
-
+- **filterable-select:** add list action button ([c2ef17a](https://github.com/Sage/carbon/commit/c2ef17a05861660f2f49b02081cd97db866ddc2d))
 
 ### Bug Fixes
 
-* **button:** change forwardref proptype ([9e2599d](https://github.com/Sage/carbon/commit/9e2599d00ea19c3a48692006b8b43601386e4b40))
+- **button:** change forwardref proptype ([9e2599d](https://github.com/Sage/carbon/commit/9e2599d00ea19c3a48692006b8b43601386e4b40))
 
 ## [47.0.0](https://github.com/Sage/carbon/compare/v46.0.0...v47.0.0) (2020-10-27)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **color:** The `atOpacity` function has been removed from the
-theme palette. To use this utility you should import it directly
-`import atOpacity from “carbon-react/lib/style/utils/at-opacity`.
+- **color:** The `atOpacity` function has been removed from the
+  theme palette. To use this utility you should import it directly
+  `import atOpacity from “carbon-react/lib/style/utils/at-opacity`.
 
 BREKAING CHANGE: The file “carbon-react/lib/style/index” has been
 removed.
@@ -9640,551 +8470,494 @@ If you want to use `blackAtOpacity` you can use
 `theme.palette.blackOpacity` or you can use `atOpacity` directly.
 Please note that `blackAtOpacity` previously returned a white opacity
 you can use `theme.palette.whiteOpacity` to keep this behaviour.
-If you want to use `generatePalette` you can import it directly `import
-generatePalette from “carbon-react/lib/style/palette`.
+If you want to use `generatePalette` you can import it directly `import generatePalette from “carbon-react/lib/style/palette`.
 
 ### Features
 
-* **color:** add palette support to color props ([68a32d6](https://github.com/Sage/carbon/commit/68a32d63ac3dba4847becc39327cf9a4c5600f29))
-* **typography:** create typography component ([45c981d](https://github.com/Sage/carbon/commit/45c981d67f8d598a7166f4aa91443b2e64bcd4f5))
-
+- **color:** add palette support to color props ([68a32d6](https://github.com/Sage/carbon/commit/68a32d63ac3dba4847becc39327cf9a4c5600f29))
+- **typography:** create typography component ([45c981d](https://github.com/Sage/carbon/commit/45c981d67f8d598a7166f4aa91443b2e64bcd4f5))
 
 ### Bug Fixes
 
-* **color:** add missing backgroundColor definitions ([2cd3afb](https://github.com/Sage/carbon/commit/2cd3afb90c85f2d3265952ae95c1d3803bbcc05c))
+- **color:** add missing backgroundColor definitions ([2cd3afb](https://github.com/Sage/carbon/commit/2cd3afb90c85f2d3265952ae95c1d3803bbcc05c))
 
 ## [46.0.0](https://github.com/Sage/carbon/compare/v45.3.0...v46.0.0) (2020-10-27)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **grid-container:** change styled system spacing props from margin to padding
+- **grid-container:** change styled system spacing props from margin to padding
 
 There is a codemod available to assist with this upgrade
 `npx carbon-codemod rename-prop <target> carbon-react/lib/components/grid m p`
-See https://github.com/Sage/carbon-codemod for more information.
+See <https://github.com/Sage/carbon-codemod> for more information.
 
 ### Bug Fixes
 
-* **grid-container:** margins are not counted in scrollHeight ([81c2e5b](https://github.com/Sage/carbon/commit/81c2e5b7227c54ca63c93a8d89647f6a526c67fa))
+- **grid-container:** margins are not counted in scrollHeight ([81c2e5b](https://github.com/Sage/carbon/commit/81c2e5b7227c54ca63c93a8d89647f6a526c67fa))
 
 ## [45.3.0](https://github.com/Sage/carbon/compare/v45.2.1...v45.3.0) (2020-10-27)
 
-
 ### Features
 
-* **box:** add new box component ([9d0df49](https://github.com/Sage/carbon/commit/9d0df497857d42a0f1d6c35c3ae2fbea1e9b1dae))
+- **box:** add new box component ([9d0df49](https://github.com/Sage/carbon/commit/9d0df497857d42a0f1d6c35c3ae2fbea1e9b1dae))
 
 ### [45.2.1](https://github.com/Sage/carbon/compare/v45.2.0...v45.2.1) (2020-10-26)
 
-
 ### Bug Fixes
 
-* **inputs:** show input icon if info validation is empty string ([cdca91a](https://github.com/Sage/carbon/commit/cdca91aff59ed8e5266ddf8772362ac7a4683a26)), closes [#3137](https://github.com/Sage/carbon/issues/3137)
+- **inputs:** show input icon if info validation is empty string ([cdca91a](https://github.com/Sage/carbon/commit/cdca91aff59ed8e5266ddf8772362ac7a4683a26)), closes [#3137](https://github.com/Sage/carbon/issues/3137)
 
 ## [45.2.0](https://github.com/Sage/carbon/compare/v45.1.0...v45.2.0) (2020-10-26)
 
-
 ### Features
 
-* **text-editor:** add support for validation icon and error styles ([9c6f114](https://github.com/Sage/carbon/commit/9c6f114faf2afb2ccc9fe4720efa23642739097c))
+- **text-editor:** add support for validation icon and error styles ([9c6f114](https://github.com/Sage/carbon/commit/9c6f114faf2afb2ccc9fe4720efa23642739097c))
 
 ## [45.1.0](https://github.com/Sage/carbon/compare/v45.0.1...v45.1.0) (2020-10-22)
 
-
 ### Features
 
-* **dialogfullscreen:** ability to add content to header ([d972587](https://github.com/Sage/carbon/commit/d972587330eed73deabcfb9eeac87a382d1572d1))
+- **dialogfullscreen:** ability to add content to header ([d972587](https://github.com/Sage/carbon/commit/d972587330eed73deabcfb9eeac87a382d1572d1))
 
 ### [45.0.1](https://github.com/Sage/carbon/compare/v45.0.0...v45.0.1) (2020-10-22)
 
-
 ### Bug Fixes
 
-* **radiobutton:** check for onchange passed in ([b5dacc6](https://github.com/Sage/carbon/commit/b5dacc6242ed66c50a0f1f245f28531ecbe509a1)), closes [#3263](https://github.com/Sage/carbon/issues/3263)
+- **radiobutton:** check for onchange passed in ([b5dacc6](https://github.com/Sage/carbon/commit/b5dacc6242ed66c50a0f1f245f28531ecbe509a1)), closes [#3263](https://github.com/Sage/carbon/issues/3263)
 
 ## [45.0.0](https://github.com/Sage/carbon/compare/v44.1.0...v45.0.0) (2020-10-22)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **help:** classic styling has been removed from the component
+- **help:** classic styling has been removed from the component
 
 fixes FE-3110
-* **heading:** removal of the classic styling from the heading component.
+
+- **heading:** removal of the classic styling from the heading component.
 
 fixes FE-3109
-* **confirm:** confirm component no longer supports classic styling
+
+- **confirm:** confirm component no longer supports classic styling
 
 fixes FE-3104
 
 ### Miscellaneous Chores
 
-* **confirm:** remove classic styling ([151cdfb](https://github.com/Sage/carbon/commit/151cdfbd80f84d86520bc0cc6eef9eb1504858fb))
-* **heading:** remove classic theme ([649c264](https://github.com/Sage/carbon/commit/649c26456e3a73a669cc3c7a70449736c5b3f99d))
-* **help:** remove classic theme ([a6b32c3](https://github.com/Sage/carbon/commit/a6b32c3bfaa34aa102bc1fcbf6d7ec7ba36edac7))
+- **confirm:** remove classic styling ([151cdfb](https://github.com/Sage/carbon/commit/151cdfbd80f84d86520bc0cc6eef9eb1504858fb))
+- **heading:** remove classic theme ([649c264](https://github.com/Sage/carbon/commit/649c26456e3a73a669cc3c7a70449736c5b3f99d))
+- **help:** remove classic theme ([a6b32c3](https://github.com/Sage/carbon/commit/a6b32c3bfaa34aa102bc1fcbf6d7ec7ba36edac7))
 
 ## [44.1.0](https://github.com/Sage/carbon/compare/v44.0.0...v44.1.0) (2020-10-21)
 
-
 ### Features
 
-* **text-editor:** allow to focus editor when label is clicked ([3beaf2a](https://github.com/Sage/carbon/commit/3beaf2af6a1472e662f6c2b241f1870f3b0bdb08))
+- **text-editor:** allow to focus editor when label is clicked ([3beaf2a](https://github.com/Sage/carbon/commit/3beaf2af6a1472e662f6c2b241f1870f3b0bdb08))
 
 ## [44.0.0](https://github.com/Sage/carbon/compare/v43.0.0...v44.0.0) (2020-10-20)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **tabs:** `setTarget` callback is no longer available, `onTabChange` should be used instead
+- **tabs:** `setTarget` callback is no longer available, `onTabChange` should be used instead
 
 ### Bug Fixes
 
-* **tabs:** tabs position left in sidebar and remove set target callback ([a3afc81](https://github.com/Sage/carbon/commit/a3afc813db8657925c343f62523d2a47c1000872)), closes [#3214](https://github.com/Sage/carbon/issues/3214)
+- **tabs:** tabs position left in sidebar and remove set target callback ([a3afc81](https://github.com/Sage/carbon/commit/a3afc813db8657925c343f62523d2a47c1000872)), closes [#3214](https://github.com/Sage/carbon/issues/3214)
 
 ## [43.0.0](https://github.com/Sage/carbon/compare/v42.6.0...v43.0.0) (2020-10-20)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **button-toggle:** button-toggle component no longer supports classic theme
-* **step-sequence:** step-sequence and step-sequence-item components no longer supports classic theme
-* **tooltip:** tooltip component no longer supports classic theme
-* **icon:** Icon component no longer supports classic theme
-* **show-edit-pod:** ShowEditPod component no longer supports classic theme, also `as` and `podType` props have been removed in favour of `variant` prop
+- **button-toggle:** button-toggle component no longer supports classic theme
+- **step-sequence:** step-sequence and step-sequence-item components no longer supports classic theme
+- **tooltip:** tooltip component no longer supports classic theme
+- **icon:** Icon component no longer supports classic theme
+- **show-edit-pod:** ShowEditPod component no longer supports classic theme, also `as` and `podType` props have been removed in favour of `variant` prop
 
 There is a codemod available to assist with this upgrade
- `npx carbon-codemod rename-prop <target> carbon-react/lib/components/show-edit-pod as variant`
- or
-  `npx carbon-codemod rename-prop <target> carbon-react/lib/components/show-edit-pod podType variant`
+`npx carbon-codemod rename-prop <target> carbon-react/lib/components/show-edit-pod as variant`
+or
+`npx carbon-codemod rename-prop <target> carbon-react/lib/components/show-edit-pod podType variant`
 
-See https://github.com/Sage/carbon-codemod for more information.
-* **pod:** Pod component no longer supports classic theme, also `as` and `podType` props have been removed in favour of `variant` prop
+See <https://github.com/Sage/carbon-codemod> for more information.
+
+- **pod:** Pod component no longer supports classic theme, also `as` and `podType` props have been removed in favour of `variant` prop
 
 There is a codemod available to assist with this upgrade
- `npx carbon-codemod rename-prop <target> carbon-react/lib/components/pod as variant`
- or
-  `npx carbon-codemod rename-prop <target> carbon-react/lib/components/pod podType variant`
+`npx carbon-codemod rename-prop <target> carbon-react/lib/components/pod as variant`
+or
+`npx carbon-codemod rename-prop <target> carbon-react/lib/components/pod podType variant`
 
-See https://github.com/Sage/carbon-codemod for more information.
-* **radio-button:** radio button component no longer supports classic theme
-* **pill:** The classic theme has been removed from `Pill`. To
-upgrade please use a DLS theme.
-* **pill:** The `as` prop is no longer supported in `Pill`. It has
-no effect when using a DLS theme. In future this will change the root
-element so any existing usages should be removed.
+See <https://github.com/Sage/carbon-codemod> for more information.
+
+- **radio-button:** radio button component no longer supports classic theme
+- **pill:** The classic theme has been removed from `Pill`. To
+  upgrade please use a DLS theme.
+- **pill:** The `as` prop is no longer supported in `Pill`. It has
+  no effect when using a DLS theme. In future this will change the root
+  element so any existing usages should be removed.
 
 Fixes FE-3089
 
 ### Miscellaneous Chores
 
-* **button-toggle:** remove classic theme support ([75a2238](https://github.com/Sage/carbon/commit/75a22383ed4988c09f92bb89ac665c9d68ea55d1))
-* **icon:** remove classic theme support ([2661503](https://github.com/Sage/carbon/commit/266150312e2079d5c584058ba3e24ea9d423c07a))
-* **pill:** remove classic theme ([d765b95](https://github.com/Sage/carbon/commit/d765b954a9eff00ce1cac2e0ab5fd97a8ce56465))
-* **pod:** remove classic theme support ([154e75f](https://github.com/Sage/carbon/commit/154e75f4243cae1e222a8218a71d9dad431099b8))
-* **radio-button:** remove classic theme support ([a8a5e94](https://github.com/Sage/carbon/commit/a8a5e9449da671009b4df7948a74098ac882fdc6))
-* **show-edit-pod:** remove classic theme support ([4517785](https://github.com/Sage/carbon/commit/451778533049c5218ed2f4c698f76f1a9153327d))
-* **step-sequence:** remove classic theme support ([45eb633](https://github.com/Sage/carbon/commit/45eb633a07df1f8c85a3628b98123fb91f95de1c))
-* **tooltip:** remove classic theme support ([d9f98d2](https://github.com/Sage/carbon/commit/d9f98d2b5f3c7cd616ac4261a2333376e453345f))
+- **button-toggle:** remove classic theme support ([75a2238](https://github.com/Sage/carbon/commit/75a22383ed4988c09f92bb89ac665c9d68ea55d1))
+- **icon:** remove classic theme support ([2661503](https://github.com/Sage/carbon/commit/266150312e2079d5c584058ba3e24ea9d423c07a))
+- **pill:** remove classic theme ([d765b95](https://github.com/Sage/carbon/commit/d765b954a9eff00ce1cac2e0ab5fd97a8ce56465))
+- **pod:** remove classic theme support ([154e75f](https://github.com/Sage/carbon/commit/154e75f4243cae1e222a8218a71d9dad431099b8))
+- **radio-button:** remove classic theme support ([a8a5e94](https://github.com/Sage/carbon/commit/a8a5e9449da671009b4df7948a74098ac882fdc6))
+- **show-edit-pod:** remove classic theme support ([4517785](https://github.com/Sage/carbon/commit/451778533049c5218ed2f4c698f76f1a9153327d))
+- **step-sequence:** remove classic theme support ([45eb633](https://github.com/Sage/carbon/commit/45eb633a07df1f8c85a3628b98123fb91f95de1c))
+- **tooltip:** remove classic theme support ([d9f98d2](https://github.com/Sage/carbon/commit/d9f98d2b5f3c7cd616ac4261a2333376e453345f))
 
 ## [42.6.0](https://github.com/Sage/carbon/compare/v42.5.2...v42.6.0) (2020-10-16)
 
-
 ### Features
 
-* **accordion:** add support to rendering validation icon beside heading ([4e0c130](https://github.com/Sage/carbon/commit/4e0c1301573a3f6e648b41b5507eeeaa022f1acc))
+- **accordion:** add support to rendering validation icon beside heading ([4e0c130](https://github.com/Sage/carbon/commit/4e0c1301573a3f6e648b41b5507eeeaa022f1acc))
 
 ### [42.5.2](https://github.com/Sage/carbon/compare/v42.5.1...v42.5.2) (2020-10-16)
 
-
 ### Bug Fixes
 
-* **label:** remove margin from label when input in form ([9f27214](https://github.com/Sage/carbon/commit/9f27214bd1f5c9ec31ef2a8ee77946c294ddc28c))
+- **label:** remove margin from label when input in form ([9f27214](https://github.com/Sage/carbon/commit/9f27214bd1f5c9ec31ef2a8ee77946c294ddc28c))
 
 ### [42.5.1](https://github.com/Sage/carbon/compare/v42.5.0...v42.5.1) (2020-10-15)
 
-
 ### Bug Fixes
 
-* **filterable-select:** visible value cannot be cleared ([2b89fed](https://github.com/Sage/carbon/commit/2b89fed087ccbc6f2d0509608fde5a8f89f9ad66))
-* **simple-select:** visible value cannot be cleared ([fbaa76f](https://github.com/Sage/carbon/commit/fbaa76f93f4632f60ee58a4597b4236e9032e497))
+- **filterable-select:** visible value cannot be cleared ([2b89fed](https://github.com/Sage/carbon/commit/2b89fed087ccbc6f2d0509608fde5a8f89f9ad66))
+- **simple-select:** visible value cannot be cleared ([fbaa76f](https://github.com/Sage/carbon/commit/fbaa76f93f4632f60ee58a4597b4236e9032e497))
 
 ## [42.5.0](https://github.com/Sage/carbon/compare/v42.4.0...v42.5.0) (2020-10-14)
 
-
 ### Features
 
-* add asterisk to required fields ([157e02e](https://github.com/Sage/carbon/commit/157e02e02d4881a677f48c4988ccaa044988cbab))
+- add asterisk to required fields ([157e02e](https://github.com/Sage/carbon/commit/157e02e02d4881a677f48c4988ccaa044988cbab))
 
 ## [42.4.0](https://github.com/Sage/carbon/compare/v42.3.3...v42.4.0) (2020-10-14)
 
-
 ### Features
 
-* **flat-table:** add possibility to set column width and cell paddings ([fcae564](https://github.com/Sage/carbon/commit/fcae564a1c499a2bf4becd9d384a975a6f51f712))
-
+- **flat-table:** add possibility to set column width and cell paddings ([fcae564](https://github.com/Sage/carbon/commit/fcae564a1c499a2bf4becd9d384a975a6f51f712))
 
 ### Bug Fixes
 
-* **flat-table:** update incorrect typescript prop definitions ([0749454](https://github.com/Sage/carbon/commit/0749454c43ae2cac845f8da48d7c7d961f4d65e0))
+- **flat-table:** update incorrect typescript prop definitions ([0749454](https://github.com/Sage/carbon/commit/0749454c43ae2cac845f8da48d7c7d961f4d65e0))
 
 ### [42.3.3](https://github.com/Sage/carbon/compare/v42.3.2...v42.3.3) (2020-10-13)
 
-
 ### Bug Fixes
 
-* **validation:** renders tooltip in 'top' position when validation ([01884a7](https://github.com/Sage/carbon/commit/01884a77c858291f00afed2a016503ac45543c47)), closes [#3191](https://github.com/Sage/carbon/issues/3191)
+- **validation:** renders tooltip in 'top' position when validation ([01884a7](https://github.com/Sage/carbon/commit/01884a77c858291f00afed2a016503ac45543c47)), closes [#3191](https://github.com/Sage/carbon/issues/3191)
 
 ### [42.3.2](https://github.com/Sage/carbon/compare/v42.3.1...v42.3.2) (2020-10-09)
 
-
 ### Bug Fixes
 
-* **select:** stop passing onblur to style wrapper ([da246cf](https://github.com/Sage/carbon/commit/da246cf88f7a3d49d06e52f61f1091e8f37dbe23))
+- **select:** stop passing onblur to style wrapper ([da246cf](https://github.com/Sage/carbon/commit/da246cf88f7a3d49d06e52f61f1091e8f37dbe23))
 
 ### [42.3.1](https://github.com/Sage/carbon/compare/v42.3.0...v42.3.1) (2020-10-07)
 
-
 ### Bug Fixes
 
-* **search:** address alignment styling bug with search button ([5aa9307](https://github.com/Sage/carbon/commit/5aa93070356299974a1e8fd7feebafdc97145395))
+- **search:** address alignment styling bug with search button ([5aa9307](https://github.com/Sage/carbon/commit/5aa93070356299974a1e8fd7feebafdc97145395))
 
 ## [42.3.0](https://github.com/Sage/carbon/compare/v42.2.0...v42.3.0) (2020-10-02)
 
-
 ### Features
 
-* **button:** add spacing props ([abf89e3](https://github.com/Sage/carbon/commit/abf89e33593814381cf00c0f48416e3c1c95e601))
-* **select:** add spacing props ([b3684de](https://github.com/Sage/carbon/commit/b3684de16e00c0fe3d0426e13d336ec783b211d4))
+- **button:** add spacing props ([abf89e3](https://github.com/Sage/carbon/commit/abf89e33593814381cf00c0f48416e3c1c95e601))
+- **select:** add spacing props ([b3684de](https://github.com/Sage/carbon/commit/b3684de16e00c0fe3d0426e13d336ec783b211d4))
 
 ## [42.2.0](https://github.com/Sage/carbon/compare/v42.1.0...v42.2.0) (2020-10-02)
 
-
 ### Features
 
-* **dialog full screen:** added reference to scrollable content ([00183f9](https://github.com/Sage/carbon/commit/00183f9035484f54afa3b7f6790796f22b2ecc7d)), closes [#3116](https://github.com/Sage/carbon/issues/3116)
+- **dialog full screen:** added reference to scrollable content ([00183f9](https://github.com/Sage/carbon/commit/00183f9035484f54afa3b7f6790796f22b2ecc7d)), closes [#3116](https://github.com/Sage/carbon/issues/3116)
 
 ## [42.1.0](https://github.com/Sage/carbon/compare/v42.0.0...v42.1.0) (2020-10-02)
 
-
 ### Features
 
-* **accordion:** calculate content height on window resize ([2e8dd71](https://github.com/Sage/carbon/commit/2e8dd71be47933f9bad9fc0497247890d26c59f3))
-
+- **accordion:** calculate content height on window resize ([2e8dd71](https://github.com/Sage/carbon/commit/2e8dd71be47933f9bad9fc0497247890d26c59f3))
 
 ### Bug Fixes
 
-* **definition-list:** display as grid to enable content wrapping ([3af247a](https://github.com/Sage/carbon/commit/3af247a548a87bcab495372c2197de9764b46d24))
+- **definition-list:** display as grid to enable content wrapping ([3af247a](https://github.com/Sage/carbon/commit/3af247a548a87bcab495372c2197de9764b46d24))
 
 ## [42.0.0](https://github.com/Sage/carbon/compare/v41.2.0...v42.0.0) (2020-09-30)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **switch:** switch component no longer supports classic theme
-* **checkbox:** checkbox component no longer supports classic theme
-* **sidebar:** The classic theme has been removed from sidebar. To
-upgrade please use a DLS theme.
+- **switch:** switch component no longer supports classic theme
+- **checkbox:** checkbox component no longer supports classic theme
+- **sidebar:** The classic theme has been removed from sidebar. To
+  upgrade please use a DLS theme.
 
 Fixes FE-3088
-* **carousel:** The classic theme has been removed from carousel. To upgrade
-please use a DLS theme.
-* **carousel:** The `transition` prop has been removed from carousel. This was used in the classic theme.
+
+- **carousel:** The classic theme has been removed from carousel. To upgrade
+  please use a DLS theme.
+- **carousel:** The `transition` prop has been removed from carousel. This was used in the classic theme.
 
 fixes FE-2908
 
 ### Miscellaneous Chores
 
-* **carousel:** remove classic theme ([6c44050](https://github.com/Sage/carbon/commit/6c44050afc227a6659f9abd71cf8b9df8c17af1b))
-* **checkbox:** remove classic theme support ([99ad721](https://github.com/Sage/carbon/commit/99ad7217638e8d0f56bf2c26836c4c2185ac0360))
-* **sidebar:** remove classic theme ([d3c1175](https://github.com/Sage/carbon/commit/d3c117557f4ed284f8764fafe67bf6e97667fe6b))
-* **switch:** remove classic theme support ([53a22c0](https://github.com/Sage/carbon/commit/53a22c02d45bb330771541b46b796f9fb5b5a617))
+- **carousel:** remove classic theme ([6c44050](https://github.com/Sage/carbon/commit/6c44050afc227a6659f9abd71cf8b9df8c17af1b))
+- **checkbox:** remove classic theme support ([99ad721](https://github.com/Sage/carbon/commit/99ad7217638e8d0f56bf2c26836c4c2185ac0360))
+- **sidebar:** remove classic theme ([d3c1175](https://github.com/Sage/carbon/commit/d3c117557f4ed284f8764fafe67bf6e97667fe6b))
+- **switch:** remove classic theme support ([53a22c0](https://github.com/Sage/carbon/commit/53a22c02d45bb330771541b46b796f9fb5b5a617))
 
 ## [41.2.0](https://github.com/Sage/carbon/compare/v41.1.1...v41.2.0) (2020-09-29)
 
-
 ### Features
 
-* **vertical-divider:** add new component ([3b2eb23](https://github.com/Sage/carbon/commit/3b2eb2384ef8e924f5cda90e36b5abafe05ebbcb))
+- **vertical-divider:** add new component ([3b2eb23](https://github.com/Sage/carbon/commit/3b2eb2384ef8e924f5cda90e36b5abafe05ebbcb))
 
 ### [41.1.1](https://github.com/Sage/carbon/compare/v41.1.0...v41.1.1) (2020-09-21)
 
-
 ### Bug Fixes
 
-* **help:** navigate to URL when href is set ([c7a3a7d](https://github.com/Sage/carbon/commit/c7a3a7d4c44fad74d1b109a08b277e19b11c22e9)), closes [#3009](https://github.com/Sage/carbon/issues/3009)
+- **help:** navigate to URL when href is set ([c7a3a7d](https://github.com/Sage/carbon/commit/c7a3a7d4c44fad74d1b109a08b277e19b11c22e9)), closes [#3009](https://github.com/Sage/carbon/issues/3009)
 
 ## [41.1.0](https://github.com/Sage/carbon/compare/v41.0.0...v41.1.0) (2020-09-21)
 
-
 ### Features
 
-* **hr:** add styled-system spacing props ([4058325](https://github.com/Sage/carbon/commit/40583259b5f96b4aaba72cda28a3816d8e06c2d2))
+- **hr:** add styled-system spacing props ([4058325](https://github.com/Sage/carbon/commit/40583259b5f96b4aaba72cda28a3816d8e06c2d2))
 
 ## [41.0.0](https://github.com/Sage/carbon/compare/v40.6.0...v41.0.0) (2020-09-21)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **grid:** gridColumnStart and gridColumnEnd props in GridItem
-and GridItem responsiveSettings replaced with gridColumn styled-system compatible prop,
-gridRowStart and gridRowEnd props in GridItem and GridItem responsiveSettings
-replaced with gridRow styled-system compatible prop
+- **grid:** gridColumnStart and gridColumnEnd props in GridItem
+  and GridItem responsiveSettings replaced with gridColumn styled-system compatible prop,
+  gridRowStart and gridRowEnd props in GridItem and GridItem responsiveSettings
+  replaced with gridRow styled-system compatible prop
 
 ### Features
 
-* **grid:** add styled-system cusom padding and margin props ([1144f9a](https://github.com/Sage/carbon/commit/1144f9a49e78446bf9f09de77f9fcf1d5d1603dc))
+- **grid:** add styled-system cusom padding and margin props ([1144f9a](https://github.com/Sage/carbon/commit/1144f9a49e78446bf9f09de77f9fcf1d5d1603dc))
 
 ## [40.6.0](https://github.com/Sage/carbon/compare/v40.5.0...v40.6.0) (2020-09-18)
 
-
 ### Features
 
-* **confirm:** add props (destructive and iconType) ([92fa833](https://github.com/Sage/carbon/commit/92fa8335b8ae263a29e5bc6d1740153de0012f9f))
+- **confirm:** add props (destructive and iconType) ([92fa833](https://github.com/Sage/carbon/commit/92fa8335b8ae263a29e5bc6d1740153de0012f9f))
 
 ## [40.5.0](https://github.com/Sage/carbon/compare/v40.4.1...v40.5.0) (2020-09-17)
 
-
 ### Features
 
-* add adaptive props to input components ([7ed9b9c](https://github.com/Sage/carbon/commit/7ed9b9c21f0345cb2e12378d321a832b4c8cc9c6))
+- add adaptive props to input components ([7ed9b9c](https://github.com/Sage/carbon/commit/7ed9b9c21f0345cb2e12378d321a832b4c8cc9c6))
 
 ### [40.4.1](https://github.com/Sage/carbon/compare/v40.4.0...v40.4.1) (2020-09-15)
 
-
 ### Bug Fixes
 
-* **button-toggle:** no focus outline when button is clicked ([af821eb](https://github.com/Sage/carbon/commit/af821ebf72b6e7529b6a343ff64cbefb8a168ece))
+- **button-toggle:** no focus outline when button is clicked ([af821eb](https://github.com/Sage/carbon/commit/af821ebf72b6e7529b6a343ff64cbefb8a168ece))
 
 ## [40.4.0](https://github.com/Sage/carbon/compare/v40.3.1...v40.4.0) (2020-09-15)
 
-
 ### Features
 
-* **validations:** display validations when field is readOnly ([12a7047](https://github.com/Sage/carbon/commit/12a70475e29e6fcb4f6b8db191c711520737d21e)), closes [#3097](https://github.com/Sage/carbon/issues/3097)
+- **validations:** display validations when field is readOnly ([12a7047](https://github.com/Sage/carbon/commit/12a70475e29e6fcb4f6b8db191c711520737d21e)), closes [#3097](https://github.com/Sage/carbon/issues/3097)
 
 ### [40.3.1](https://github.com/Sage/carbon/compare/v40.3.0...v40.3.1) (2020-09-14)
 
-
 ### Bug Fixes
 
-* **note:** update invariant to check inline control constructor ([8d504f0](https://github.com/Sage/carbon/commit/8d504f0a25ffc4a8d26466a26507342cad32b411)), closes [#3208](https://github.com/Sage/carbon/issues/3208)
+- **note:** update invariant to check inline control constructor ([8d504f0](https://github.com/Sage/carbon/commit/8d504f0a25ffc4a8d26466a26507342cad32b411)), closes [#3208](https://github.com/Sage/carbon/issues/3208)
 
 ## [40.3.0](https://github.com/Sage/carbon/compare/v40.2.0...v40.3.0) (2020-09-11)
 
-
 ### Features
 
-* **icon:** add spacing props support ([193545b](https://github.com/Sage/carbon/commit/193545b2139bb1ccea06cfa101b74e64e614ff86))
-* **pill:** add spacing props support ([e4b7ede](https://github.com/Sage/carbon/commit/e4b7ede8088d0c8d1c8edb63d1e819586abe941a))
-
+- **icon:** add spacing props support ([193545b](https://github.com/Sage/carbon/commit/193545b2139bb1ccea06cfa101b74e64e614ff86))
+- **pill:** add spacing props support ([e4b7ede](https://github.com/Sage/carbon/commit/e4b7ede8088d0c8d1c8edb63d1e819586abe941a))
 
 ### Bug Fixes
 
-* **pill:** fix incorrect margin top applied to pill ([5be5816](https://github.com/Sage/carbon/commit/5be5816414a7f7d831ce366507a71dd7080ef468))
+- **pill:** fix incorrect margin top applied to pill ([5be5816](https://github.com/Sage/carbon/commit/5be5816414a7f7d831ce366507a71dd7080ef468))
 
 ## [40.2.0](https://github.com/Sage/carbon/compare/v40.1.0...v40.2.0) (2020-09-10)
 
-
 ### Features
 
-* **definition list:** create definition list component ([6af9b9b](https://github.com/Sage/carbon/commit/6af9b9b02095b79da5967c7dd31beb5b2d0b76c8))
+- **definition list:** create definition list component ([6af9b9b](https://github.com/Sage/carbon/commit/6af9b9b02095b79da5967c7dd31beb5b2d0b76c8))
 
 ## [40.1.0](https://github.com/Sage/carbon/compare/v40.0.0...v40.1.0) (2020-09-10)
 
-
 ### Features
 
-* **textbox:** add prefix prop to display emphasized prefix ([bbbfdbb](https://github.com/Sage/carbon/commit/bbbfdbb44b3f6fc97af709cd733f9cd10f4cea66))
-
+- **textbox:** add prefix prop to display emphasized prefix ([bbbfdbb](https://github.com/Sage/carbon/commit/bbbfdbb44b3f6fc97af709cd733f9cd10f4cea66))
 
 ### Bug Fixes
 
-* **input:** remove user agent input padding ([89d811e](https://github.com/Sage/carbon/commit/89d811ec48d21c0ca521acf9df279eb21f456915))
+- **input:** remove user agent input padding ([89d811e](https://github.com/Sage/carbon/commit/89d811ec48d21c0ca521acf9df279eb21f456915))
 
 ## [40.0.0](https://github.com/Sage/carbon/compare/v39.3.0...v40.0.0) (2020-09-08)
 
-
 ### ⚠ BREAKING CHANGES
 
-* default spacings for input components have changed
+- default spacings for input components have changed
 
 ### Features
 
-* **button:** add margin props ([722b3d6](https://github.com/Sage/carbon/commit/722b3d6c08bc43b354442fbdc67bf9369fe27286))
-* **form:** implement vertical spacing option ([87a53a8](https://github.com/Sage/carbon/commit/87a53a890eca60bf414a638f751d1ea7442c4933))
-* **form-field:** implement horizontal label spacing option ([ffee308](https://github.com/Sage/carbon/commit/ffee308a979cf39f8af94fd46b47b6411c5d12d2))
-* **switch:** add new props for switch alignment ([7b50282](https://github.com/Sage/carbon/commit/7b50282376cbed334365cc2ccdcafcf4ccd1b0b7))
-* add margin left prop to checkable inputs ([70167ef](https://github.com/Sage/carbon/commit/70167efa00c05c26488437f045ae565edff49053))
-
+- **button:** add margin props ([722b3d6](https://github.com/Sage/carbon/commit/722b3d6c08bc43b354442fbdc67bf9369fe27286))
+- **form:** implement vertical spacing option ([87a53a8](https://github.com/Sage/carbon/commit/87a53a890eca60bf414a638f751d1ea7442c4933))
+- **form-field:** implement horizontal label spacing option ([ffee308](https://github.com/Sage/carbon/commit/ffee308a979cf39f8af94fd46b47b6411c5d12d2))
+- **switch:** add new props for switch alignment ([7b50282](https://github.com/Sage/carbon/commit/7b50282376cbed334365cc2ccdcafcf4ccd1b0b7))
+- add margin left prop to checkable inputs ([70167ef](https://github.com/Sage/carbon/commit/70167efa00c05c26488437f045ae565edff49053))
 
 ### Miscellaneous Chores
 
-* add breaking change message ([670851a](https://github.com/Sage/carbon/commit/670851a100f2166924eb6142ef30d8e65869e4f4))
+- add breaking change message ([670851a](https://github.com/Sage/carbon/commit/670851a100f2166924eb6142ef30d8e65869e4f4))
 
 ## [39.3.0](https://github.com/Sage/carbon/compare/v39.2.1...v39.3.0) (2020-09-07)
 
-
 ### Features
 
-* **drawer, tabs:** add support for custom target overrides via context ([7fe79d3](https://github.com/Sage/carbon/commit/7fe79d3d9ae9039a2ed34d1cb075df2bcc455d7d))
+- **drawer, tabs:** add support for custom target overrides via context ([7fe79d3](https://github.com/Sage/carbon/commit/7fe79d3d9ae9039a2ed34d1cb075df2bcc455d7d))
 
 ### [39.2.1](https://github.com/Sage/carbon/compare/v39.2.0...v39.2.1) (2020-09-04)
 
-
 ### Bug Fixes
 
-* **button:** update onClick typescript definition ([bdd2dca](https://github.com/Sage/carbon/commit/bdd2dcaf9c9699173b8a19bdbca2c1ea7307364f))
-* **numeral-date:** update onClick and onBlur typescript definition ([de25f13](https://github.com/Sage/carbon/commit/de25f1318b09a10a0bb7671b7a4463cf62073a23))
+- **button:** update onClick typescript definition ([bdd2dca](https://github.com/Sage/carbon/commit/bdd2dcaf9c9699173b8a19bdbca2c1ea7307364f))
+- **numeral-date:** update onClick and onBlur typescript definition ([de25f13](https://github.com/Sage/carbon/commit/de25f1318b09a10a0bb7671b7a4463cf62073a23))
 
 ## [39.2.0](https://github.com/Sage/carbon/compare/v39.1.0...v39.2.0) (2020-09-04)
 
-
 ### Features
 
-* **checkbox:** add spacing props ([e2a7c39](https://github.com/Sage/carbon/commit/e2a7c391c8c4c49c5b30818bdd25cffec5101c39))
+- **checkbox:** add spacing props ([e2a7c39](https://github.com/Sage/carbon/commit/e2a7c391c8c4c49c5b30818bdd25cffec5101c39))
 
 ## [39.1.0](https://github.com/Sage/carbon/compare/v39.0.0...v39.1.0) (2020-09-03)
 
-
 ### Features
 
-* **menu:** add keyboard navigation ([8fa77e1](https://github.com/Sage/carbon/commit/8fa77e11b3c9b04158fc4c99d901c9d693ce8597))
+- **menu:** add keyboard navigation ([8fa77e1](https://github.com/Sage/carbon/commit/8fa77e11b3c9b04158fc4c99d901c9d693ce8597))
 
 ## [39.0.0](https://github.com/Sage/carbon/compare/v38.2.0...v39.0.0) (2020-09-01)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **toast:** toast will be dismissed when esc key
-is pressed, regardless of the focus on the close button
-* **modal:** when multiple modals are being open,
-esc key will close only the topmost one
-* **icon-button:** esc key will no longer trigger onAction prop
+- **toast:** toast will be dismissed when esc key
+  is pressed, regardless of the focus on the close button
+- **modal:** when multiple modals are being open,
+  esc key will close only the topmost one
+- **icon-button:** esc key will no longer trigger onAction prop
 
 ### Features
 
-* **toast:** dismiss toast on esc without focussing on the component ([ace80dd](https://github.com/Sage/carbon/commit/ace80dd0f9fd6a234413821b99a33e48dbc6d41f))
-
+- **toast:** dismiss toast on esc without focussing on the component ([ace80dd](https://github.com/Sage/carbon/commit/ace80dd0f9fd6a234413821b99a33e48dbc6d41f))
 
 ### Bug Fixes
 
-* **icon-button:** 'esc' key triggers onAction closing a modal ([0fd16ba](https://github.com/Sage/carbon/commit/0fd16ba1f901d5f80d3de19ef967c316981c3f92))
-* **modal:** esc key closes all nested modals ([47c4c26](https://github.com/Sage/carbon/commit/47c4c26bf6ab1a1be7b31db2020065b4a6803ca7))
+- **icon-button:** 'esc' key triggers onAction closing a modal ([0fd16ba](https://github.com/Sage/carbon/commit/0fd16ba1f901d5f80d3de19ef967c316981c3f92))
+- **modal:** esc key closes all nested modals ([47c4c26](https://github.com/Sage/carbon/commit/47c4c26bf6ab1a1be7b31db2020065b4a6803ca7))
 
 ## [38.2.0](https://github.com/Sage/carbon/compare/v38.1.4...v38.2.0) (2020-08-28)
 
-
 ### Features
 
-* **tabs, tab:** add extendedline, borders, size, siblings, customlayout ([dbf7ce2](https://github.com/Sage/carbon/commit/dbf7ce2358b9e6cb5930b5ff8d62adf791cfeb39))
-
+- **tabs, tab:** add extendedline, borders, size, siblings, customlayout ([dbf7ce2](https://github.com/Sage/carbon/commit/dbf7ce2358b9e6cb5930b5ff8d62adf791cfeb39))
 
 ### Bug Fixes
 
-* **tabs:** add support for component being controlled via ontabchange ([f70f4bb](https://github.com/Sage/carbon/commit/f70f4bb9639f231f581133f97c6e45bc92d40eac)), closes [#3170](https://github.com/Sage/carbon/issues/3170)
+- **tabs:** add support for component being controlled via ontabchange ([f70f4bb](https://github.com/Sage/carbon/commit/f70f4bb9639f231f581133f97c6e45bc92d40eac)), closes [#3170](https://github.com/Sage/carbon/issues/3170)
 
 ### [38.1.4](https://github.com/Sage/carbon/compare/v38.1.3...v38.1.4) (2020-08-27)
 
-
 ### Bug Fixes
 
-* **batch-selection:** fix incorrect colorTheme proptypes ([1c20a37](https://github.com/Sage/carbon/commit/1c20a37e52a2c973f8fadbc0d524d5ea77666624))
-* **storybook:** fix various story related errors ([07c96f4](https://github.com/Sage/carbon/commit/07c96f451832e90c90ffc7cfe9ecc130d48bee99))
+- **batch-selection:** fix incorrect colorTheme proptypes ([1c20a37](https://github.com/Sage/carbon/commit/1c20a37e52a2c973f8fadbc0d524d5ea77666624))
+- **storybook:** fix various story related errors ([07c96f4](https://github.com/Sage/carbon/commit/07c96f451832e90c90ffc7cfe9ecc130d48bee99))
 
 ### [38.1.3](https://github.com/Sage/carbon/compare/v38.1.2...v38.1.3) (2020-08-26)
 
-
 ### Bug Fixes
 
-* **switch:** fix switch validation icon overlapping the label ([ce6575f](https://github.com/Sage/carbon/commit/ce6575f6939762b5f9ef8e3f9a0a2aa67b81cad7))
+- **switch:** fix switch validation icon overlapping the label ([ce6575f](https://github.com/Sage/carbon/commit/ce6575f6939762b5f9ef8e3f9a0a2aa67b81cad7))
 
 ### [38.1.2](https://github.com/Sage/carbon/compare/v38.1.1...v38.1.2) (2020-08-26)
 
-
 ### Bug Fixes
 
-* **confirm:** fix incorrect button order ([9ac9aea](https://github.com/Sage/carbon/commit/9ac9aea87e7d996cd2a1522abc73776e316e11bd))
+- **confirm:** fix incorrect button order ([9ac9aea](https://github.com/Sage/carbon/commit/9ac9aea87e7d996cd2a1522abc73776e316e11bd))
 
 ### [38.1.1](https://github.com/Sage/carbon/compare/v38.1.0...v38.1.1) (2020-08-23)
 
-
 ### Bug Fixes
 
-* **portrait:** remove incorrect size propType values ([8bcc171](https://github.com/Sage/carbon/commit/8bcc17101edaff59abe4c47c2f5aeb28a0029bb4))
+- **portrait:** remove incorrect size propType values ([8bcc171](https://github.com/Sage/carbon/commit/8bcc17101edaff59abe4c47c2f5aeb28a0029bb4))
 
 ## [38.1.0](https://github.com/Sage/carbon/compare/v38.0.2...v38.1.0) (2020-08-21)
 
-
 ### Features
 
-* **navigation-bar:** add a loading state ([c5b5355](https://github.com/Sage/carbon/commit/c5b5355d01ca8b0d2c8f809ebfdd09f16b21ea35))
+- **navigation-bar:** add a loading state ([c5b5355](https://github.com/Sage/carbon/commit/c5b5355d01ca8b0d2c8f809ebfdd09f16b21ea35))
 
 ### [38.0.2](https://github.com/Sage/carbon/compare/v38.0.1...v38.0.2) (2020-08-21)
 
-
 ### Bug Fixes
 
-* **pager:** fix incorrect prop types passed to page size select ([61bab41](https://github.com/Sage/carbon/commit/61bab41a5c91250d6500194ef7b6727e041da347)), closes [#3152](https://github.com/Sage/carbon/issues/3152)
+- **pager:** fix incorrect prop types passed to page size select ([61bab41](https://github.com/Sage/carbon/commit/61bab41a5c91250d6500194ef7b6727e041da347)), closes [#3152](https://github.com/Sage/carbon/issues/3152)
 
 ### [38.0.1](https://github.com/Sage/carbon/compare/v38.0.0...v38.0.1) (2020-08-13)
 
-
 ### Bug Fixes
 
-* **note:** remove min width to allow note to size dynamically ([8b0bef3](https://github.com/Sage/carbon/commit/8b0bef33c4e3b60cfd6774971f63055265450093))
+- **note:** remove min width to allow note to size dynamically ([8b0bef3](https://github.com/Sage/carbon/commit/8b0bef33c4e3b60cfd6774971f63055265450093))
 
 ## [38.0.0](https://github.com/Sage/carbon/compare/v37.3.0...v38.0.0) (2020-08-12)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **numeral-date:** NumeralDate onChange prop method arguments have been changed. Event.target.value will now have the same structure as the value passed as a prop to the component.
+- **numeral-date:** NumeralDate onChange prop method arguments have been changed. Event.target.value will now have the same structure as the value passed as a prop to the component.
 
 ### Features
 
-* **numeral-date:** add controlled uncontrolled mode switch warning ([e795696](https://github.com/Sage/carbon/commit/e795696e96dfdb272890cc5c8976d59adbd5dc6b))
-* **numeral-date:** add label support to numeral date component ([c51ddd9](https://github.com/Sage/carbon/commit/c51ddd9cb9e9ed949179f56d28d9264aaaba9e05))
-* **numeral-date:** restrict available date formats ([500a0f2](https://github.com/Sage/carbon/commit/500a0f23e72d502fae98d05429376faebf94ab4f))
-
+- **numeral-date:** add controlled uncontrolled mode switch warning ([e795696](https://github.com/Sage/carbon/commit/e795696e96dfdb272890cc5c8976d59adbd5dc6b))
+- **numeral-date:** add label support to numeral date component ([c51ddd9](https://github.com/Sage/carbon/commit/c51ddd9cb9e9ed949179f56d28d9264aaaba9e05))
+- **numeral-date:** restrict available date formats ([500a0f2](https://github.com/Sage/carbon/commit/500a0f23e72d502fae98d05429376faebf94ab4f))
 
 ### Bug Fixes
 
-* **numeral-date:** fix incorrect onchange prop method arguments ([3828664](https://github.com/Sage/carbon/commit/3828664d752c861eb76d97ad9ca463b847cd5965))
+- **numeral-date:** fix incorrect onchange prop method arguments ([3828664](https://github.com/Sage/carbon/commit/3828664d752c861eb76d97ad9ca463b847cd5965))
 
 ## [37.3.0](https://github.com/Sage/carbon/compare/v37.2.0...v37.3.0) (2020-08-07)
 
-
 ### Features
 
-* **icon:** added 2 new icons, flag and hide ([fb18f43](https://github.com/Sage/carbon/commit/fb18f43c991806ae46ebf03d7cc153b2007465f3))
+- **icon:** added 2 new icons, flag and hide ([fb18f43](https://github.com/Sage/carbon/commit/fb18f43c991806ae46ebf03d7cc153b2007465f3))
 
 ## [37.2.0](https://github.com/Sage/carbon/compare/v37.1.0...v37.2.0) (2020-08-06)
 
-
 ### Features
 
-* **validations:** show tooltip when input is hovered or focused ([c8d9360](https://github.com/Sage/carbon/commit/c8d9360fdd8145796e973ed035d69aae1815c2e1))
-
+- **validations:** show tooltip when input is hovered or focused ([c8d9360](https://github.com/Sage/carbon/commit/c8d9360fdd8145796e973ed035d69aae1815c2e1))
 
 ### Bug Fixes
 
-* **label:** render icons outside of label element ([e1fc428](https://github.com/Sage/carbon/commit/e1fc4281119ab53557d00f961bf290a8e891143e))
+- **label:** render icons outside of label element ([e1fc428](https://github.com/Sage/carbon/commit/e1fc4281119ab53557d00f961bf290a8e891143e))
 
 ## [37.1.0](https://github.com/Sage/carbon/compare/v37.0.0...v37.1.0) (2020-08-05)
 
-
 ### Features
 
-* add new MultiSelect component ([fe43a50](https://github.com/Sage/carbon/commit/fe43a50e99107b5e6b551cfc32d07d7f93b2bd94))
+- add new MultiSelect component ([fe43a50](https://github.com/Sage/carbon/commit/fe43a50e99107b5e6b551cfc32d07d7f93b2bd94))
 
 ## [37.0.0](https://github.com/Sage/carbon/compare/v36.0.0...v37.0.0) (2020-08-03)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **note:** The following props are now required for the Note component.
-- noteContent
+- **note:** The following props are now required for the Note component.
+
+* noteContent
+
 - name
 - createdDate
 - status.text if status is provided
@@ -10193,269 +8966,252 @@ esc key will close only the topmost one
 
 ### Bug Fixes
 
-* **note:** add default theme ([915dbcf](https://github.com/Sage/carbon/commit/915dbcf183b32aa2c155409f0770818c46d7fea2))
-* **note:** enforce required props ([4e8f09a](https://github.com/Sage/carbon/commit/4e8f09abb2490cb3114e70e0720db9b7baabf2c2))
+- **note:** add default theme ([915dbcf](https://github.com/Sage/carbon/commit/915dbcf183b32aa2c155409f0770818c46d7fea2))
+- **note:** enforce required props ([4e8f09a](https://github.com/Sage/carbon/commit/4e8f09abb2490cb3114e70e0720db9b7baabf2c2))
 
 ## [36.0.0](https://github.com/Sage/carbon/compare/v35.4.0...v36.0.0) (2020-07-29)
 
-
 ### ⚠ BREAKING CHANGES
 
-* The with-validation higher order component and custom validators have been removed.
-To update please check our validations guide in docs/validations
-* The deprecated form component has been
-removed. To upgrade please use the new form component.
-* The experimental form component has been
-removed. To upgrade please use the new form component.
-* The deprecated input-label decorator has been removed
-* The deprecated input-validation decorator has been removed
-* The deprecated input decorator has been removed
-* The deprecated input-decorator-bridge has been removed.
-* The deprecated dropdown component has been removed. To upgrade please use the select component.
-* The deprecated spinner component has been
-removed. To upgrade please use the loader component.
-* The deprecated animated-menu-button component has been removed.
-* Deprecated Textbox has been removed. To upgrade please use the experimental Textbox component.
-* The deprecated Filter component has been removed
-* **show-edit-pod:** afterFormValidation, beforeFormValidation and validateOnMount props on ShowEditPod has been removed, onSave callback has been added which is triggered by clicking on save button
-* The deprecated create component has been removed.
-To upgrade please use the Button component. [There is codemod to help with this upgrade.](
-https://github.com/Sage/carbon-codemod/tree/master/transforms/deprecate-create)
+- The with-validation higher order component and custom validators have been removed.
+  To update please check our validations guide in docs/validations
+- The deprecated form component has been
+  removed. To upgrade please use the new form component.
+- The experimental form component has been
+  removed. To upgrade please use the new form component.
+- The deprecated input-label decorator has been removed
+- The deprecated input-validation decorator has been removed
+- The deprecated input decorator has been removed
+- The deprecated input-decorator-bridge has been removed.
+- The deprecated dropdown component has been removed. To upgrade please use the select component.
+- The deprecated spinner component has been
+  removed. To upgrade please use the loader component.
+- The deprecated animated-menu-button component has been removed.
+- Deprecated Textbox has been removed. To upgrade please use the experimental Textbox component.
+- The deprecated Filter component has been removed
+- **show-edit-pod:** afterFormValidation, beforeFormValidation and validateOnMount props on ShowEditPod has been removed, onSave callback has been added which is triggered by clicking on save button
+- The deprecated create component has been removed.
+  To upgrade please use the Button component. [There is codemod to help with this upgrade.](https://github.com/Sage/carbon-codemod/tree/master/transforms/deprecate-create)
 
 Fixes FE-1921, fixes FE-2875
-* The deprecated dropdown-filter component has been removed.
-* The deprecated dropdown-filter-ajax component has been removed.
+
+- The deprecated dropdown-filter component has been removed.
+- The deprecated dropdown-filter-ajax component has been removed.
 
 Fixes FE-1921
-* The deprecated date component has been removed. To
-upgrade please use the experimental date component.
+
+- The deprecated date component has been removed. To
+  upgrade please use the experimental date component.
 
 Fixes FE-1921
-* The deprecated date-range component has been removed. To
-upgrade please use the experimental date-range component.
+
+- The deprecated date-range component has been removed. To
+  upgrade please use the experimental date-range component.
 
 Fixes FE-1921
-* The deprecated fieldset component has been removed. To
-upgrade please use the experimental fieldset component.
+
+- The deprecated fieldset component has been removed. To
+  upgrade please use the experimental fieldset component.
 
 Fixes FE-1921
-* The deprecated radio-button component has been removed.
-To upgrade please use the experimental radio-button component.
+
+- The deprecated radio-button component has been removed.
+  To upgrade please use the experimental radio-button component.
 
 Fixes FE-1921
-* The deprecated simple-color-picker component has been
-removed. To upgrade please use the experimental simple-color-picker component.
+
+- The deprecated simple-color-picker component has been
+  removed. To upgrade please use the experimental simple-color-picker component.
 
 Fixes FE-1921
 
 ### Miscellaneous Chores
 
-* remove custom validators and with-validation hoc ([ee37d49](https://github.com/Sage/carbon/commit/ee37d4955b4ab757b7220eeb9a911a8ca7cc00a9))
-* remove deprecated animated-menu-button component ([8332008](https://github.com/Sage/carbon/commit/8332008a811d02487c7c41ba548d009cecb7de3e))
-* remove deprecated create component ([6801af4](https://github.com/Sage/carbon/commit/6801af4655647e4b90860b4fea68de842aae2508))
-* remove deprecated date component ([e32dbbf](https://github.com/Sage/carbon/commit/e32dbbf21b7e47480aa9d1ed1b2d2d82e14540af))
-* remove deprecated date-range component ([f7e3d20](https://github.com/Sage/carbon/commit/f7e3d20bda2eb7064811e1c60a098f170384b5b7))
-* remove deprecated dropdown component ([b0ba9be](https://github.com/Sage/carbon/commit/b0ba9be1d8fe66758a1bb652b06240efe75bb9b7))
-* remove deprecated dropdown-filter component ([a7d0a5c](https://github.com/Sage/carbon/commit/a7d0a5ceb9d11396d7aa3169647468c7db512e44)), closes [#2913](https://github.com/Sage/carbon/issues/2913)
-* remove deprecated dropdown-filter-ajax component ([a97082b](https://github.com/Sage/carbon/commit/a97082b1683ee43578fc6eef650c413bf7f42e8e))
-* remove deprecated fieldset component ([b43c9f5](https://github.com/Sage/carbon/commit/b43c9f5fc9c1292a76e9e503068eca1ae60ad69b))
-* remove deprecated filter component ([ced84b7](https://github.com/Sage/carbon/commit/ced84b759826993c63de1a3aa36aa5db0d5ff18c))
-* remove deprecated form component ([9b2f62f](https://github.com/Sage/carbon/commit/9b2f62fb377ddbceb54d6666deeb229e5129d824))
-* remove deprecated input decorator ([e5f5c9e](https://github.com/Sage/carbon/commit/e5f5c9e780183c7e3a7b700aa575676c53e9f94b))
-* remove deprecated input-decorator-bridge ([fc9e19b](https://github.com/Sage/carbon/commit/fc9e19bb08228d361c52c252b1e151f45793e700))
-* remove deprecated input-label decorator ([8bc6963](https://github.com/Sage/carbon/commit/8bc69631c69c190e112f4b63a5c78289b9058088))
-* remove deprecated input-validation decorator ([a63b192](https://github.com/Sage/carbon/commit/a63b19273436931c772b719a259a3ef30aad62b2))
-* remove deprecated radio-button component ([1b380cd](https://github.com/Sage/carbon/commit/1b380cd496cff2f17a5437144e6505209c928966))
-* remove deprecated simple-color-picker component ([f0360f9](https://github.com/Sage/carbon/commit/f0360f937b2247fa14f0f910fb37ce155220c707))
-* remove deprecated spinner component ([4806a2a](https://github.com/Sage/carbon/commit/4806a2a8194907a8cd416a0eb1ab1af5df5ec89a))
-* remove deprecated textbox ([d438355](https://github.com/Sage/carbon/commit/d43835524046e4ac37d1ba2c5e3a207499fb0594))
-* remove experimental form component ([d1b7f4f](https://github.com/Sage/carbon/commit/d1b7f4f80eb1326e6d716e6509e53905a1fa26c9))
-* **show-edit-pod:** replace deprecated Form component ([9cb9faa](https://github.com/Sage/carbon/commit/9cb9faa001689d857b30ed1d397f0a6db8354221))
+- remove custom validators and with-validation hoc ([ee37d49](https://github.com/Sage/carbon/commit/ee37d4955b4ab757b7220eeb9a911a8ca7cc00a9))
+- remove deprecated animated-menu-button component ([8332008](https://github.com/Sage/carbon/commit/8332008a811d02487c7c41ba548d009cecb7de3e))
+- remove deprecated create component ([6801af4](https://github.com/Sage/carbon/commit/6801af4655647e4b90860b4fea68de842aae2508))
+- remove deprecated date component ([e32dbbf](https://github.com/Sage/carbon/commit/e32dbbf21b7e47480aa9d1ed1b2d2d82e14540af))
+- remove deprecated date-range component ([f7e3d20](https://github.com/Sage/carbon/commit/f7e3d20bda2eb7064811e1c60a098f170384b5b7))
+- remove deprecated dropdown component ([b0ba9be](https://github.com/Sage/carbon/commit/b0ba9be1d8fe66758a1bb652b06240efe75bb9b7))
+- remove deprecated dropdown-filter component ([a7d0a5c](https://github.com/Sage/carbon/commit/a7d0a5ceb9d11396d7aa3169647468c7db512e44)), closes [#2913](https://github.com/Sage/carbon/issues/2913)
+- remove deprecated dropdown-filter-ajax component ([a97082b](https://github.com/Sage/carbon/commit/a97082b1683ee43578fc6eef650c413bf7f42e8e))
+- remove deprecated fieldset component ([b43c9f5](https://github.com/Sage/carbon/commit/b43c9f5fc9c1292a76e9e503068eca1ae60ad69b))
+- remove deprecated filter component ([ced84b7](https://github.com/Sage/carbon/commit/ced84b759826993c63de1a3aa36aa5db0d5ff18c))
+- remove deprecated form component ([9b2f62f](https://github.com/Sage/carbon/commit/9b2f62fb377ddbceb54d6666deeb229e5129d824))
+- remove deprecated input decorator ([e5f5c9e](https://github.com/Sage/carbon/commit/e5f5c9e780183c7e3a7b700aa575676c53e9f94b))
+- remove deprecated input-decorator-bridge ([fc9e19b](https://github.com/Sage/carbon/commit/fc9e19bb08228d361c52c252b1e151f45793e700))
+- remove deprecated input-label decorator ([8bc6963](https://github.com/Sage/carbon/commit/8bc69631c69c190e112f4b63a5c78289b9058088))
+- remove deprecated input-validation decorator ([a63b192](https://github.com/Sage/carbon/commit/a63b19273436931c772b719a259a3ef30aad62b2))
+- remove deprecated radio-button component ([1b380cd](https://github.com/Sage/carbon/commit/1b380cd496cff2f17a5437144e6505209c928966))
+- remove deprecated simple-color-picker component ([f0360f9](https://github.com/Sage/carbon/commit/f0360f937b2247fa14f0f910fb37ce155220c707))
+- remove deprecated spinner component ([4806a2a](https://github.com/Sage/carbon/commit/4806a2a8194907a8cd416a0eb1ab1af5df5ec89a))
+- remove deprecated textbox ([d438355](https://github.com/Sage/carbon/commit/d43835524046e4ac37d1ba2c5e3a207499fb0594))
+- remove experimental form component ([d1b7f4f](https://github.com/Sage/carbon/commit/d1b7f4f80eb1326e6d716e6509e53905a1fa26c9))
+- **show-edit-pod:** replace deprecated Form component ([9cb9faa](https://github.com/Sage/carbon/commit/9cb9faa001689d857b30ed1d397f0a6db8354221))
 
 ## [35.4.0](https://github.com/Sage/carbon/compare/v35.3.0...v35.4.0) (2020-07-29)
 
-
 ### Features
 
-* **tabs, tab:** make components functional use new context api and ([e0bb281](https://github.com/Sage/carbon/commit/e0bb281c6f3f7b19bf1093dd0afec45d8b563a19))
+- **tabs, tab:** make components functional use new context api and ([e0bb281](https://github.com/Sage/carbon/commit/e0bb281c6f3f7b19bf1093dd0afec45d8b563a19))
 
 ## [35.3.0](https://github.com/Sage/carbon/compare/v35.2.0...v35.3.0) (2020-07-29)
 
-
 ### Features
 
-* **hr:** add new hr component ([f57fc38](https://github.com/Sage/carbon/commit/f57fc38e6a5f181c9fa8be7a1202f70467a2d5fa))
+- **hr:** add new hr component ([f57fc38](https://github.com/Sage/carbon/commit/f57fc38e6a5f181c9fa8be7a1202f70467a2d5fa))
 
 ## [35.2.0](https://github.com/Sage/carbon/compare/v35.1.1...v35.2.0) (2020-07-23)
 
-
 ### Features
 
-* **accordion:** enable custom padding ([cd67639](https://github.com/Sage/carbon/commit/cd6763964b88de4194537d58ea853d228c31c5a2))
-* **accordion:** enable custom width ([61651e8](https://github.com/Sage/carbon/commit/61651e8bf6c7707e6ccf2d570ae9db1cbbb47b61))
-* **accordion:** implement full border ([ef02757](https://github.com/Sage/carbon/commit/ef02757634f713f7e9c749a9827900ce93f980c2))
-* **accordion:** implement large and small size ([00374c3](https://github.com/Sage/carbon/commit/00374c3506749947965b534c0a53848cf52a1814))
-* **accordion:** implement white and transparent scheme ([f6490d0](https://github.com/Sage/carbon/commit/f6490d0cb9220873db2ba90cd5fc8bba03349863))
+- **accordion:** enable custom padding ([cd67639](https://github.com/Sage/carbon/commit/cd6763964b88de4194537d58ea853d228c31c5a2))
+- **accordion:** enable custom width ([61651e8](https://github.com/Sage/carbon/commit/61651e8bf6c7707e6ccf2d570ae9db1cbbb47b61))
+- **accordion:** implement full border ([ef02757](https://github.com/Sage/carbon/commit/ef02757634f713f7e9c749a9827900ce93f980c2))
+- **accordion:** implement large and small size ([00374c3](https://github.com/Sage/carbon/commit/00374c3506749947965b534c0a53848cf52a1814))
+- **accordion:** implement white and transparent scheme ([f6490d0](https://github.com/Sage/carbon/commit/f6490d0cb9220873db2ba90cd5fc8bba03349863))
 
 ### [35.1.1](https://github.com/Sage/carbon/compare/v35.1.0...v35.1.1) (2020-07-17)
 
-
 ### Bug Fixes
 
-* **dialog:** auto focus dialog when opened ([4322681](https://github.com/Sage/carbon/commit/432268110a1feea23d60e7b77f6e493c5b3cfd87)), closes [#2960](https://github.com/Sage/carbon/issues/2960)
+- **dialog:** auto focus dialog when opened ([4322681](https://github.com/Sage/carbon/commit/432268110a1feea23d60e7b77f6e493c5b3cfd87)), closes [#2960](https://github.com/Sage/carbon/issues/2960)
 
 ## [35.1.0](https://github.com/Sage/carbon/compare/v35.0.0...v35.1.0) (2020-07-17)
 
-
 ### Features
 
-* **note:** create component and tooltip status ([834fe52](https://github.com/Sage/carbon/commit/834fe529fb42a501a9ec2627b4f2204a3e8ff6b7))
+- **note:** create component and tooltip status ([834fe52](https://github.com/Sage/carbon/commit/834fe529fb42a501a9ec2627b4f2204a3e8ff6b7))
 
 ## [35.0.0](https://github.com/Sage/carbon/compare/v34.0.2...v35.0.0) (2020-07-17)
 
-
 ### ⚠ BREAKING CHANGES
 
-* The deprecated rainbow component has been removed. There is no suitable replacement within carbon so please find an alternative library for your use case.
+- The deprecated rainbow component has been removed. There is no suitable replacement within carbon so please find an alternative library for your use case.
 
 ### Miscellaneous Chores
 
-* remove deprecated rainbow component ([f0b97ef](https://github.com/Sage/carbon/commit/f0b97efa565fbda0f9d8baf7c806f27b649e0012)), closes [#3008](https://github.com/Sage/carbon/issues/3008)
+- remove deprecated rainbow component ([f0b97ef](https://github.com/Sage/carbon/commit/f0b97efa565fbda0f9d8baf7c806f27b649e0012)), closes [#3008](https://github.com/Sage/carbon/issues/3008)
 
 ### [34.0.2](https://github.com/Sage/carbon/compare/v34.0.1...v34.0.2) (2020-07-16)
 
-
 ### Bug Fixes
 
-* **text-editor:** update styling for lists ([a2fe8eb](https://github.com/Sage/carbon/commit/a2fe8ebbf37419d2f9f87bb7ad5b0d980dbb8b87))
+- **text-editor:** update styling for lists ([a2fe8eb](https://github.com/Sage/carbon/commit/a2fe8ebbf37419d2f9f87bb7ad5b0d980dbb8b87))
 
 ### [34.0.1](https://github.com/Sage/carbon/compare/v34.0.0...v34.0.1) (2020-07-16)
 
-
 ### Bug Fixes
 
-* **tooltip:** ensure toolip repositions when off screen ([25b1c4a](https://github.com/Sage/carbon/commit/25b1c4af989621f2b20901956fd942df61bed083))
+- **tooltip:** ensure toolip repositions when off screen ([25b1c4a](https://github.com/Sage/carbon/commit/25b1c4af989621f2b20901956fd942df61bed083))
 
 ## [34.0.0](https://github.com/Sage/carbon/compare/v33.3.0...v34.0.0) (2020-07-16)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **menu:** `Menu` scheme colors `primary` and `secondary` no
-longer exists.
-To upgrade replace
-`<Menu menuType="primary" />` with `<Menu />`
-or
-`<Menu menuType="secondary" />` with `<Menu menuType="dark" />`
-* **menu:** The `Menu` prop `divide` no longer exists.
-To upgrade replace `<MenuItem divide />` with
-`<MenuDivider /><MenuItem />`
+- **menu:** `Menu` scheme colors `primary` and `secondary` no
+  longer exists.
+  To upgrade replace
+  `<Menu menuType="primary" />` with `<Menu />`
+  or
+  `<Menu menuType="secondary" />` with `<Menu menuType="dark" />`
+- **menu:** The `Menu` prop `divide` no longer exists.
+  To upgrade replace `<MenuItem divide />` with
+  `<MenuDivider /><MenuItem />`
 
 Fixes FE-2315
 
 ### Features
 
-* **menu:** update visual appearance to match design system ([3b30e4e](https://github.com/Sage/carbon/commit/3b30e4e79d264fb83d8c86dfc87ff89149eadbc1))
+- **menu:** update visual appearance to match design system ([3b30e4e](https://github.com/Sage/carbon/commit/3b30e4e79d264fb83d8c86dfc87ff89149eadbc1))
 
 ## [33.3.0](https://github.com/Sage/carbon/compare/v33.2.0...v33.3.0) (2020-07-15)
 
-
 ### Features
 
-* add new FilterableSelect Component ([ae2833b](https://github.com/Sage/carbon/commit/ae2833b595d0fba22b9094aa8f151915ccfb2f2a))
-* add new SimpleSelect Component ([d6c6ec3](https://github.com/Sage/carbon/commit/d6c6ec33bd9ab4a6a75b3402a4eac582f5555c84))
-
+- add new FilterableSelect Component ([ae2833b](https://github.com/Sage/carbon/commit/ae2833b595d0fba22b9094aa8f151915ccfb2f2a))
+- add new SimpleSelect Component ([d6c6ec3](https://github.com/Sage/carbon/commit/d6c6ec33bd9ab4a6a75b3402a4eac582f5555c84))
 
 ### Bug Fixes
 
-* **input-icon-toggle:** add missing onMouseDown prop ([b0ab93a](https://github.com/Sage/carbon/commit/b0ab93a84ebd4b7ec4660b726f72a0067c02f561))
+- **input-icon-toggle:** add missing onMouseDown prop ([b0ab93a](https://github.com/Sage/carbon/commit/b0ab93a84ebd4b7ec4660b726f72a0067c02f561))
 
 ## [33.2.0](https://github.com/Sage/carbon/compare/v33.1.0...v33.2.0) (2020-07-13)
 
-
 ### Features
 
-* **text-editor:** add new text editor component ([3717bb9](https://github.com/Sage/carbon/commit/3717bb9fd9b37ee5c9266aeacac7b02f2140e713))
+- **text-editor:** add new text editor component ([3717bb9](https://github.com/Sage/carbon/commit/3717bb9fd9b37ee5c9266aeacac7b02f2140e713))
 
 ## [33.1.0](https://github.com/Sage/carbon/compare/v33.0.1...v33.1.0) (2020-07-13)
 
-
 ### Features
 
-* **table-ajax:** replace deprecated spinner with loader component ([855bc25](https://github.com/Sage/carbon/commit/855bc2576bc2c2d4bbeef0483bb9a7344da102ad))
+- **table-ajax:** replace deprecated spinner with loader component ([855bc25](https://github.com/Sage/carbon/commit/855bc2576bc2c2d4bbeef0483bb9a7344da102ad))
 
 ### [33.0.1](https://github.com/Sage/carbon/compare/v33.0.0...v33.0.1) (2020-07-09)
 
-
 ### Bug Fixes
 
-* **menu-item:** `routerLink` prop is not provided when there is no submenu ([92b601e](https://github.com/Sage/carbon/commit/92b601e62a3b7081faba94d976794f43f2ce58cb)), closes [#3056](https://github.com/Sage/carbon/issues/3056)
+- **menu-item:** `routerLink` prop is not provided when there is no submenu ([92b601e](https://github.com/Sage/carbon/commit/92b601e62a3b7081faba94d976794f43f2ce58cb)), closes [#3056](https://github.com/Sage/carbon/issues/3056)
 
 ## [33.0.0](https://github.com/Sage/carbon/compare/v32.0.3...v33.0.0) (2020-07-08)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **navigation-bar:** `as` prop is no more supported as the prop is reserved for Styled-Components.
-there is new prop called `navigationType`.
-Also `primary` and `secondary` has been replaced with `light` and `dark`.
-After update you will need to replace
-`<NavigationBar as="primary" />` with `<NavigationBar />`
-or
-`NavigationBar as="secondary" />` with `<NavigationBar navigationType="dark" />`
+- **navigation-bar:** `as` prop is no more supported as the prop is reserved for Styled-Components.
+  there is new prop called `navigationType`.
+  Also `primary` and `secondary` has been replaced with `light` and `dark`.
+  After update you will need to replace
+  `<NavigationBar as="primary" />` with `<NavigationBar />`
+  or
+  `NavigationBar as="secondary" />` with `<NavigationBar navigationType="dark" />`
 
 ### Features
 
-* **navigation-bar:** update component ([7815170](https://github.com/Sage/carbon/commit/7815170858f05a90b8747f8f616e9f7909f96386))
+- **navigation-bar:** update component ([7815170](https://github.com/Sage/carbon/commit/7815170858f05a90b8747f8f616e9f7909f96386))
 
 ### [32.0.3](https://github.com/Sage/carbon/compare/v32.0.2...v32.0.3) (2020-07-08)
 
-
 ### Bug Fixes
 
-* **switch:** fix misaligned validation icon on large switch ([afc2f68](https://github.com/Sage/carbon/commit/afc2f68b5a6de1a9001ca18daf4b30bf94db89dc))
+- **switch:** fix misaligned validation icon on large switch ([afc2f68](https://github.com/Sage/carbon/commit/afc2f68b5a6de1a9001ca18daf4b30bf94db89dc))
 
 ### [32.0.2](https://github.com/Sage/carbon/compare/v32.0.1...v32.0.2) (2020-07-02)
 
-
 ### Bug Fixes
 
-* **filter:** add deprecation warning ([373a9b4](https://github.com/Sage/carbon/commit/373a9b416277aea11ee36c40db48cd5c070a7baa))
+- **filter:** add deprecation warning ([373a9b4](https://github.com/Sage/carbon/commit/373a9b416277aea11ee36c40db48cd5c070a7baa))
 
 ### [32.0.1](https://github.com/Sage/carbon/compare/v32.0.0...v32.0.1) (2020-06-30)
 
-
 ### Bug Fixes
 
-* **anchor-navigation:** fix anchor navigation item prop type definitions ([0605c7a](https://github.com/Sage/carbon/commit/0605c7a25523ebff2748bda96a7452b309caa6ad))
+- **anchor-navigation:** fix anchor navigation item prop type definitions ([0605c7a](https://github.com/Sage/carbon/commit/0605c7a25523ebff2748bda96a7452b309caa6ad))
 
 ## [32.0.0](https://github.com/Sage/carbon/compare/v31.1.1...v32.0.0) (2020-06-29)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **menu:** prop `as` has been replaced with `menuType`. Keyword `as` is reserved for
-Styled-Components.
-To update your components you will need to replace
-`<Menu as="primary" />` with `<Menu menuType="primary" />`
+- **menu:** prop `as` has been replaced with `menuType`. Keyword `as` is reserved for
+  Styled-Components.
+  To update your components you will need to replace
+  `<Menu as="primary" />` with `<Menu menuType="primary" />`
 
 ### Code Refactoring
 
-* **menu:** refactor component ([ea2e727](https://github.com/Sage/carbon/commit/ea2e7272faadfeea4b2a08caf3367db1e6e7f137))
+- **menu:** refactor component ([ea2e727](https://github.com/Sage/carbon/commit/ea2e7272faadfeea4b2a08caf3367db1e6e7f137))
 
 ### [31.1.1](https://github.com/Sage/carbon/compare/v31.1.0...v31.1.1) (2020-06-26)
 
-
 ### Bug Fixes
 
-* increase width on validation labels ([a10e90e](https://github.com/Sage/carbon/commit/a10e90eafe336c35b6b8d878caf38efbefa41026))
+- increase width on validation labels ([a10e90e](https://github.com/Sage/carbon/commit/a10e90eafe336c35b6b8d878caf38efbefa41026))
 
 ## [31.1.0](https://github.com/Sage/carbon/compare/v31.0.0...v31.1.0) (2020-06-25)
 
-
 ### Features
 
-* **button:** add full-width buttons ([82e96b4](https://github.com/Sage/carbon/commit/82e96b4e24601bd7232759f08caa50d28db01934))
+- **button:** add full-width buttons ([82e96b4](https://github.com/Sage/carbon/commit/82e96b4e24601bd7232759f08caa50d28db01934))
 
 ## [31.0.0](https://github.com/Sage/carbon/compare/v30.1.0...v31.0.0) (2020-06-23)
 
@@ -10463,1112 +9219,976 @@ These breaking changes were reverted, there are no breaking changes in this rele
 
 ## [30.1.0](https://github.com/Sage/carbon/compare/v30.0.0...v30.1.0) (2020-06-15)
 
-
 ### Features
 
-* **icon:** added 15 new icons ([922d68d](https://github.com/Sage/carbon/commit/922d68dd784b7d3e147f1cbc773fa9727ff6d836))
+- **icon:** added 15 new icons ([922d68d](https://github.com/Sage/carbon/commit/922d68dd784b7d3e147f1cbc773fa9727ff6d836))
 
 ## [30.0.0](https://github.com/Sage/carbon/compare/v29.0.0...v30.0.0) (2020-06-12)
 
-
 ### ⚠ BREAKING CHANGES
 
-* The deprecated grouped-character component has been
-removed. To upgrade please use the experimental grouped-character
-component.
+- The deprecated grouped-character component has been
+  removed. To upgrade please use the experimental grouped-character
+  component.
 
 ### Miscellaneous Chores
 
-* remove deprecated grouped-character component ([44d26b2](https://github.com/Sage/carbon/commit/44d26b20ebe68776434d37dad2f6481ab45c0a0a))
+- remove deprecated grouped-character component ([44d26b2](https://github.com/Sage/carbon/commit/44d26b20ebe68776434d37dad2f6481ab45c0a0a))
 
 ## [29.0.0](https://github.com/Sage/carbon/compare/v28.0.0...v29.0.0) (2020-06-12)
 
-
 ### ⚠ BREAKING CHANGES
 
-* The deprecated textarea component has been removed. To
-upgrade please use the experimental textarea component.
+- The deprecated textarea component has been removed. To
+  upgrade please use the experimental textarea component.
 
 Fixes FE-1921
 
 ### Miscellaneous Chores
 
-* remove deprecated textarea component ([052ce56](https://github.com/Sage/carbon/commit/052ce5623674994a0bf6d6757db124db30e74e9f))
+- remove deprecated textarea component ([052ce56](https://github.com/Sage/carbon/commit/052ce5623674994a0bf6d6757db124db30e74e9f))
 
 ## [28.0.0](https://github.com/Sage/carbon/compare/v27.0.0...v28.0.0) (2020-06-11)
 
-
 ### ⚠ BREAKING CHANGES
 
-* The deprecated number component has been removed. To
-upgrade please use the experimental number component.
+- The deprecated number component has been removed. To
+  upgrade please use the experimental number component.
 
 Fixes FE-1921
 
 ### Miscellaneous Chores
 
-* remove deprecated number component ([badcaf1](https://github.com/Sage/carbon/commit/badcaf1763b69d1ad912114b19ce7a739ee682fb))
+- remove deprecated number component ([badcaf1](https://github.com/Sage/carbon/commit/badcaf1763b69d1ad912114b19ce7a739ee682fb))
 
 ## [27.0.0](https://github.com/Sage/carbon/compare/v26.0.0...v27.0.0) (2020-06-11)
 
-
 ### ⚠ BREAKING CHANGES
 
-* The deprecated decimal component has been removed. To
-upgrade please use the experimental decimal component.
+- The deprecated decimal component has been removed. To
+  upgrade please use the experimental decimal component.
 
 ### Miscellaneous Chores
 
-* remove deprecated decimal component ([78eb3ce](https://github.com/Sage/carbon/commit/78eb3ce723d2f78d24d2de97d0d6f67fb00702be))
+- remove deprecated decimal component ([78eb3ce](https://github.com/Sage/carbon/commit/78eb3ce723d2f78d24d2de97d0d6f67fb00702be))
 
 ## [26.0.0](https://github.com/Sage/carbon/compare/v25.0.0...v26.0.0) (2020-06-11)
 
-
 ### ⚠ BREAKING CHANGES
 
-* The deprecated checkbox component has been removed. To
-upgrade please use the experimental checkbox.
-* The classic theme is no longer supported. To upgrade
-please use a DLS theme.
+- The deprecated checkbox component has been removed. To
+  upgrade please use the experimental checkbox.
+- The classic theme is no longer supported. To upgrade
+  please use a DLS theme.
 
 ### Miscellaneous Chores
 
-* remove classic theme from configurable-items ([74e1434](https://github.com/Sage/carbon/commit/74e1434fd587d00c6208e54f5d67bfc95eaa62d9))
-* remove deprecated checkbox component ([1f30e6d](https://github.com/Sage/carbon/commit/1f30e6dde3108a0c53f4e9df1b15b83c517c1c68))
+- remove classic theme from configurable-items ([74e1434](https://github.com/Sage/carbon/commit/74e1434fd587d00c6208e54f5d67bfc95eaa62d9))
+- remove deprecated checkbox component ([1f30e6d](https://github.com/Sage/carbon/commit/1f30e6dde3108a0c53f4e9df1b15b83c517c1c68))
 
 ## [25.0.0](https://github.com/Sage/carbon/compare/v24.0.1...v25.0.0) (2020-06-10)
 
-
 ### ⚠ BREAKING CHANGES
 
-* The deprecated switch component has been removed. To
-upgrade please use the experimental switch component.
+- The deprecated switch component has been removed. To
+  upgrade please use the experimental switch component.
 
 Fixes FE-1921
 
 ### Miscellaneous Chores
 
-* remove deprecated switch component ([fe7ddc2](https://github.com/Sage/carbon/commit/fe7ddc2548964f5aa3c9538d1ab762db80844810))
+- remove deprecated switch component ([fe7ddc2](https://github.com/Sage/carbon/commit/fe7ddc2548964f5aa3c9538d1ab762db80844810))
 
 ### [24.0.1](https://github.com/Sage/carbon/compare/v24.0.0...v24.0.1) (2020-06-10)
 
-
 ### Bug Fixes
 
-* **button-toggle:** onBlur not being passed on button toggle input ([1287a19](https://github.com/Sage/carbon/commit/1287a19631298f928ed91025dec2601f0a376b7a))
+- **button-toggle:** onBlur not being passed on button toggle input ([1287a19](https://github.com/Sage/carbon/commit/1287a19631298f928ed91025dec2601f0a376b7a))
 
 ## [24.0.0](https://github.com/Sage/carbon/compare/v23.2.1...v24.0.0) (2020-06-09)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **validations:** validator functions applied to inputs no longer work, validations have to be handled externally by the consumer of the library
-* **validations:** remove support for `validations`, `warnings`, `info`, `hasError`, `hasWarning`, `hasInfo`, `tooltipMessage`, `inputIcon`, `forceUpdateTriggerToggle`, `addInputToFormState`, `unblockValidation`, `useValidationIcon` from all inputs and input groups
-to display validation visuals use new `error`, `warning` and `info` props - check components props descriptions for more details
-* **validations:** remove support for `startMessage` and `endMessage` from `DateRange`
-to display validation visuals use new `startError`, `endError`, `startWarning`, `endWarning`, `startInfo` and `endInfo` props - check `DateRange` props description for more details
-* **validations:** rename `labelInline` to `legendInline` on `RadioButtonGroup`
+- **validations:** validator functions applied to inputs no longer work, validations have to be handled externally by the consumer of the library
+- **validations:** remove support for `validations`, `warnings`, `info`, `hasError`, `hasWarning`, `hasInfo`, `tooltipMessage`, `inputIcon`, `forceUpdateTriggerToggle`, `addInputToFormState`, `unblockValidation`, `useValidationIcon` from all inputs and input groups
+  to display validation visuals use new `error`, `warning` and `info` props - check components props descriptions for more details
+- **validations:** remove support for `startMessage` and `endMessage` from `DateRange`
+  to display validation visuals use new `startError`, `endError`, `startWarning`, `endWarning`, `startInfo` and `endInfo` props - check `DateRange` props description for more details
+- **validations:** rename `labelInline` to `legendInline` on `RadioButtonGroup`
 
 ### Features
 
-* **validations:** implement new input validations interface ([0015029](https://github.com/Sage/carbon/commit/0015029c46d75f68d60884019d59e5d01afd2ce4))
+- **validations:** implement new input validations interface ([0015029](https://github.com/Sage/carbon/commit/0015029c46d75f68d60884019d59e5d01afd2ce4))
 
 ### [23.2.1](https://github.com/Sage/carbon/compare/v23.2.0...v23.2.1) (2020-06-05)
 
-
 ### Bug Fixes
 
-* **drawer:** drawer update ([2835f99](https://github.com/Sage/carbon/commit/2835f99569615ce3164ff6e5691d31393f27a131)), closes [#2918](https://github.com/Sage/carbon/issues/2918)
+- **drawer:** drawer update ([2835f99](https://github.com/Sage/carbon/commit/2835f99569615ce3164ff6e5691d31393f27a131)), closes [#2918](https://github.com/Sage/carbon/issues/2918)
 
 ## [23.2.0](https://github.com/Sage/carbon/compare/v23.1.0...v23.2.0) (2020-06-04)
 
-
 ### Features
 
-* **grid-item:** add align and justify props ([e8ed5ef](https://github.com/Sage/carbon/commit/e8ed5efd9f93205c054c679bdac2db4e29735272))
+- **grid-item:** add align and justify props ([e8ed5ef](https://github.com/Sage/carbon/commit/e8ed5efd9f93205c054c679bdac2db4e29735272))
 
 ## [23.1.0](https://github.com/Sage/carbon/compare/v23.0.0...v23.1.0) (2020-06-03)
 
-
 ### Features
 
-* **tile-select:** create tile-select component ([ec7273f](https://github.com/Sage/carbon/commit/ec7273fb53593d76a07ddb8bd83db815a6cf787a))
+- **tile-select:** create tile-select component ([ec7273f](https://github.com/Sage/carbon/commit/ec7273fb53593d76a07ddb8bd83db815a6cf787a))
 
 ## [23.0.0](https://github.com/Sage/carbon/compare/v22.2.0...v23.0.0) (2020-06-02)
 
-
 ### ⚠ BREAKING CHANGES
 
-* removes classic theme support from profile
-* **profile:** removes classic theme support from profile
+- removes classic theme support from profile
+- **profile:** removes classic theme support from profile
 
 ### Bug Fixes
 
-* **profile:** profile story not loading in storybook ([2599f42](https://github.com/Sage/carbon/commit/2599f428121e321da79db031e314e7bd3a1c2368))
+- **profile:** profile story not loading in storybook ([2599f42](https://github.com/Sage/carbon/commit/2599f428121e321da79db031e314e7bd3a1c2368))
 
-
-* Merge pull request #2966 from Sage/FE-2822-profile-storybook-error ([619da30](https://github.com/Sage/carbon/commit/619da3029b5bd5e4a39c45586e8d92002330abbb)), closes [#2966](https://github.com/Sage/carbon/issues/2966)
+- Merge pull request #2966 from Sage/FE-2822-profile-storybook-error ([619da30](https://github.com/Sage/carbon/commit/619da3029b5bd5e4a39c45586e8d92002330abbb)), closes [#2966](https://github.com/Sage/carbon/issues/2966)
 
 ## [22.2.0](https://github.com/Sage/carbon/compare/v22.1.1...v22.2.0) (2020-06-01)
 
-
 ### Features
 
-* **drawer, flat-table, flat-table-row:** add sidebar context ([4351fae](https://github.com/Sage/carbon/commit/4351fae87dce5648542b027e2d6f18a14970a9f9))
+- **drawer, flat-table, flat-table-row:** add sidebar context ([4351fae](https://github.com/Sage/carbon/commit/4351fae87dce5648542b027e2d6f18a14970a9f9))
 
 ### [22.1.1](https://github.com/Sage/carbon/compare/v22.1.0...v22.1.1) (2020-05-29)
 
-
 ### Bug Fixes
 
-* **drawer:** update overflow behaviour ([5883c89](https://github.com/Sage/carbon/commit/5883c89ff50282e706e02c98b69db3a5a275b8c7))
+- **drawer:** update overflow behaviour ([5883c89](https://github.com/Sage/carbon/commit/5883c89ff50282e706e02c98b69db3a5a275b8c7))
 
 ## [22.1.0](https://github.com/Sage/carbon/compare/v22.0.3...v22.1.0) (2020-05-29)
 
-
 ### Features
 
-* **toast:** multiple toasts can now stack ([f508f0f](https://github.com/Sage/carbon/commit/f508f0f9a3ed861a7514da9c5dde74662f733339)), closes [#2737](https://github.com/Sage/carbon/issues/2737)
-
+- **toast:** multiple toasts can now stack ([f508f0f](https://github.com/Sage/carbon/commit/f508f0f9a3ed861a7514da9c5dde74662f733339)), closes [#2737](https://github.com/Sage/carbon/issues/2737)
 
 ### Bug Fixes
 
-* **portal:** compatibility with styled components lib ([3688c34](https://github.com/Sage/carbon/commit/3688c348be18f24a0ad238b7209f41637b3fc7de))
+- **portal:** compatibility with styled components lib ([3688c34](https://github.com/Sage/carbon/commit/3688c348be18f24a0ad238b7209f41637b3fc7de))
 
 ### [22.0.3](https://github.com/Sage/carbon/compare/v22.0.2...v22.0.3) (2020-05-28)
 
-
 ### Bug Fixes
 
-* **link:** add target prop ([87bc937](https://github.com/Sage/carbon/commit/87bc937e5c0163d52a75694a37f167dbab5ae131)), closes [#2921](https://github.com/Sage/carbon/issues/2921)
+- **link:** add target prop ([87bc937](https://github.com/Sage/carbon/commit/87bc937e5c0163d52a75694a37f167dbab5ae131)), closes [#2921](https://github.com/Sage/carbon/issues/2921)
 
 ### [22.0.2](https://github.com/Sage/carbon/compare/v22.0.1...v22.0.2) (2020-05-28)
 
-
 ### Bug Fixes
 
-* **checkbox:** update typescript definitions ([578de51](https://github.com/Sage/carbon/commit/578de51964caf864bf7f22224ff2388ca07fb48b)), closes [#2813](https://github.com/Sage/carbon/issues/2813)
+- **checkbox:** update typescript definitions ([578de51](https://github.com/Sage/carbon/commit/578de51964caf864bf7f22224ff2388ca07fb48b)), closes [#2813](https://github.com/Sage/carbon/issues/2813)
 
 ### [22.0.1](https://github.com/Sage/carbon/compare/v22.0.0...v22.0.1) (2020-05-27)
 
-
 ### Bug Fixes
 
-* **inline-input:** update story and knobs ([9a7daff](https://github.com/Sage/carbon/commit/9a7daffa3871a4885f73c9c0c869185989ae9d04))
+- **inline-input:** update story and knobs ([9a7daff](https://github.com/Sage/carbon/commit/9a7daffa3871a4885f73c9c0c869185989ae9d04))
 
 ## [22.0.0](https://github.com/Sage/carbon/compare/v21.1.2...v22.0.0) (2020-05-26)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **portrait:** removes classic theme support from portrait
+- **portrait:** removes classic theme support from portrait
 
 ### Bug Fixes
 
-* **portrait:** portrait story not loading in storybook ([667a89a](https://github.com/Sage/carbon/commit/667a89a5d67a2138a8ee748a288af913cf2a111e))
+- **portrait:** portrait story not loading in storybook ([667a89a](https://github.com/Sage/carbon/commit/667a89a5d67a2138a8ee748a288af913cf2a111e))
 
 ### [21.1.2](https://github.com/Sage/carbon/compare/v21.1.1...v21.1.2) (2020-05-22)
 
-
 ### Bug Fixes
 
-* **date:** allow to programatically set date as empty string ([7d9e596](https://github.com/Sage/carbon/commit/7d9e596d50971a8d36000726aa4eac31691b5cde))
+- **date:** allow to programatically set date as empty string ([7d9e596](https://github.com/Sage/carbon/commit/7d9e596d50971a8d36000726aa4eac31691b5cde))
 
 ### [21.1.1](https://github.com/Sage/carbon/compare/v21.1.0...v21.1.1) (2020-05-22)
 
-
 ### Bug Fixes
 
-* **button:** add missing type declarations ([36aeedc](https://github.com/Sage/carbon/commit/36aeedcaff749244712b71f9ca8736b6c288e3b4))
-* **content:** add typescript declarations ([de8c335](https://github.com/Sage/carbon/commit/de8c335f8c6ef96f3e69ebb37b7e605eeec73c6d))
+- **button:** add missing type declarations ([36aeedc](https://github.com/Sage/carbon/commit/36aeedcaff749244712b71f9ca8736b6c288e3b4))
+- **content:** add typescript declarations ([de8c335](https://github.com/Sage/carbon/commit/de8c335f8c6ef96f3e69ebb37b7e605eeec73c6d))
 
 ## [21.1.0](https://github.com/Sage/carbon/compare/v21.0.1...v21.1.0) (2020-05-22)
 
-
 ### Features
 
-* **flat-table-checkbox:** add new component used when rows selectable ([ca387f1](https://github.com/Sage/carbon/commit/ca387f16d5a78650f8dd870ddc9830e4c038e95e))
-* **flat-table-row:** add new prop to apply highlighted styling ([28ecefa](https://github.com/Sage/carbon/commit/28ecefa203843df00d8cacaa0a5384085a31d0a9))
-* **flat-table-row:** add new prop to apply styling when row is selected ([19c60ff](https://github.com/Sage/carbon/commit/19c60ffe4d942cdae1918b2948cc678bb949d7b6))
+- **flat-table-checkbox:** add new component used when rows selectable ([ca387f1](https://github.com/Sage/carbon/commit/ca387f16d5a78650f8dd870ddc9830e4c038e95e))
+- **flat-table-row:** add new prop to apply highlighted styling ([28ecefa](https://github.com/Sage/carbon/commit/28ecefa203843df00d8cacaa0a5384085a31d0a9))
+- **flat-table-row:** add new prop to apply styling when row is selected ([19c60ff](https://github.com/Sage/carbon/commit/19c60ffe4d942cdae1918b2948cc678bb949d7b6))
 
 ### [21.0.1](https://github.com/Sage/carbon/compare/v21.0.0...v21.0.1) (2020-05-22)
 
-
 ### Bug Fixes
 
-* **inline-input:** implement aria-labelledby ([59aae72](https://github.com/Sage/carbon/commit/59aae7268c926f4f1935deb280fa9ea830af66e7))
+- **inline-input:** implement aria-labelledby ([59aae72](https://github.com/Sage/carbon/commit/59aae7268c926f4f1935deb280fa9ea830af66e7))
 
 ## [21.0.0](https://github.com/Sage/carbon/compare/v20.2.0...v21.0.0) (2020-05-22)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **action-popover:** In order for the styling to work as before you should pass this component into the `renderButton` prop to guarantee the same look as previously
-* **button:** The `styleOverride` prop has been removed
+- **action-popover:** In order for the styling to work as before you should pass this component into the `renderButton` prop to guarantee the same look as previously
+- **button:** The `styleOverride` prop has been removed
 
 ### Features
 
-* **action-popover:** add a menu button wrapper component ([0cecc47](https://github.com/Sage/carbon/commit/0cecc4748a7967eae04002e5185f41e898ab95af))
-
+- **action-popover:** add a menu button wrapper component ([0cecc47](https://github.com/Sage/carbon/commit/0cecc4748a7967eae04002e5185f41e898ab95af))
 
 ### Code Refactoring
 
-* **button:** remove style override prop from component ([39df8bc](https://github.com/Sage/carbon/commit/39df8bc0218bb6b9a3e2a2ed858b5475fd09fa4f))
+- **button:** remove style override prop from component ([39df8bc](https://github.com/Sage/carbon/commit/39df8bc0218bb6b9a3e2a2ed858b5475fd09fa4f))
 
 ## [20.2.0](https://github.com/Sage/carbon/compare/v20.1.3...v20.2.0) (2020-05-21)
 
-
 ### Features
 
-* **accordion:** allow passing data-role prop to the root element ([5b08c5d](https://github.com/Sage/carbon/commit/5b08c5d7da72c2715936de5d3c63cb38ad1d7772))
+- **accordion:** allow passing data-role prop to the root element ([5b08c5d](https://github.com/Sage/carbon/commit/5b08c5d7da72c2715936de5d3c63cb38ad1d7772))
 
 ### [20.1.3](https://github.com/Sage/carbon/compare/v20.1.2...v20.1.3) (2020-05-18)
 
-
 ### Bug Fixes
 
-* **search:** fix height, width and background style bugs ([86147a6](https://github.com/Sage/carbon/commit/86147a6d44ef0c07256a6b3a347e1e8be869da21))
+- **search:** fix height, width and background style bugs ([86147a6](https://github.com/Sage/carbon/commit/86147a6d44ef0c07256a6b3a347e1e8be869da21))
 
 ### [20.1.2](https://github.com/Sage/carbon/compare/v20.1.1...v20.1.2) (2020-05-14)
 
-
 ### Bug Fixes
 
-* **link:** update routerLink prop to allow Router Link as prop ([8e66353](https://github.com/Sage/carbon/commit/8e663534e8a227ed29c74755c92cc7da7e4199e2)), closes [#2924](https://github.com/Sage/carbon/issues/2924)
-* **menu:** add routerLink prop as no longer provided by link component ([44035b4](https://github.com/Sage/carbon/commit/44035b48075a1a0a255db118961d66da74090393))
+- **link:** update routerLink prop to allow Router Link as prop ([8e66353](https://github.com/Sage/carbon/commit/8e663534e8a227ed29c74755c92cc7da7e4199e2)), closes [#2924](https://github.com/Sage/carbon/issues/2924)
+- **menu:** add routerLink prop as no longer provided by link component ([44035b4](https://github.com/Sage/carbon/commit/44035b48075a1a0a255db118961d66da74090393))
 
 ### [20.1.1](https://github.com/Sage/carbon/compare/v20.1.0...v20.1.1) (2020-05-11)
 
-
 ### Bug Fixes
 
-* **drawer:** add unit test ([65c4b44](https://github.com/Sage/carbon/commit/65c4b4492db92a86600c506819a1f636a8906fc5))
-* **drawer:** improve stories ([885c933](https://github.com/Sage/carbon/commit/885c933ae70cd52c9d22deedd80fb46de137e965))
-* **drawer:** make content overflow ([6c3414b](https://github.com/Sage/carbon/commit/6c3414b536d192f1b556bdb8f77a51d6e8e4c9de))
-* **drawer:** story update ([b1c2bb8](https://github.com/Sage/carbon/commit/b1c2bb85c8048ef603858c6e67d4e0813ed95342))
-* **drawer:** update data attribute and spec ([3b1ca57](https://github.com/Sage/carbon/commit/3b1ca57d897ca707238e04b8ee85f99f04c47134))
-* **drawer:** update snapshot ([a5746e0](https://github.com/Sage/carbon/commit/a5746e05c543ae4207235e868a9c339d8cb4a076))
-* **drawer:** update style ([eae6c55](https://github.com/Sage/carbon/commit/eae6c558c113db31b4de0cc14ff7280aa66492b2))
+- **drawer:** add unit test ([65c4b44](https://github.com/Sage/carbon/commit/65c4b4492db92a86600c506819a1f636a8906fc5))
+- **drawer:** improve stories ([885c933](https://github.com/Sage/carbon/commit/885c933ae70cd52c9d22deedd80fb46de137e965))
+- **drawer:** make content overflow ([6c3414b](https://github.com/Sage/carbon/commit/6c3414b536d192f1b556bdb8f77a51d6e8e4c9de))
+- **drawer:** story update ([b1c2bb8](https://github.com/Sage/carbon/commit/b1c2bb85c8048ef603858c6e67d4e0813ed95342))
+- **drawer:** update data attribute and spec ([3b1ca57](https://github.com/Sage/carbon/commit/3b1ca57d897ca707238e04b8ee85f99f04c47134))
+- **drawer:** update snapshot ([a5746e0](https://github.com/Sage/carbon/commit/a5746e05c543ae4207235e868a9c339d8cb4a076))
+- **drawer:** update style ([eae6c55](https://github.com/Sage/carbon/commit/eae6c558c113db31b4de0cc14ff7280aa66492b2))
 
 ## [20.1.0](https://github.com/Sage/carbon/compare/v20.0.1...v20.1.0) (2020-05-11)
 
-
 ### Features
 
-* **flat-table:** add colspan and rowspan props ([c968e01](https://github.com/Sage/carbon/commit/c968e01eace657a4571d95d5e633eda7dde1cfa0))
+- **flat-table:** add colspan and rowspan props ([c968e01](https://github.com/Sage/carbon/commit/c968e01eace657a4571d95d5e633eda7dde1cfa0))
 
 ### [20.0.1](https://github.com/Sage/carbon/compare/v20.0.0...v20.0.1) (2020-05-07)
 
-
 ### Bug Fixes
 
-* **inline-input:** fix responsive width ([f8b9df8](https://github.com/Sage/carbon/commit/f8b9df8a328a3e9b6b7859a5459a6e661f8b8b1d)), closes [#2748](https://github.com/Sage/carbon/issues/2748)
+- **inline-input:** fix responsive width ([f8b9df8](https://github.com/Sage/carbon/commit/f8b9df8a328a3e9b6b7859a5459a6e661f8b8b1d)), closes [#2748](https://github.com/Sage/carbon/issues/2748)
 
 ## [20.0.0](https://github.com/Sage/carbon/compare/v19.0.1...v20.0.0) (2020-05-06)
 
-
 ### ⚠ BREAKING CHANGES
 
-* styled-components is now a peer dependency.
+- styled-components is now a peer dependency.
 
 To upgrade you should install styled-components@^4.4.1 in your project.
 
 ### Miscellaneous Chores
 
-* make styled-component a peer dependency ([50a75a3](https://github.com/Sage/carbon/commit/50a75a3f7287a94e0e16a970a613136ffa527aa2))
+- make styled-component a peer dependency ([50a75a3](https://github.com/Sage/carbon/commit/50a75a3f7287a94e0e16a970a613136ffa527aa2))
 
 ### [19.0.1](https://github.com/Sage/carbon/compare/v19.0.0...v19.0.1) (2020-05-06)
 
-
 ### Bug Fixes
 
-* **colors:** make used colors in Carbon DLS compliant ([d04e114](https://github.com/Sage/carbon/commit/d04e114e887a8dad65fe8544d65d4dfa37c24248))
-* **popover-container:** fix displaying under other components ([3db3fed](https://github.com/Sage/carbon/commit/3db3fed6214762350a42e292a1ddc6098b16c54f))
+- **colors:** make used colors in Carbon DLS compliant ([d04e114](https://github.com/Sage/carbon/commit/d04e114e887a8dad65fe8544d65d4dfa37c24248))
+- **popover-container:** fix displaying under other components ([3db3fed](https://github.com/Sage/carbon/commit/3db3fed6214762350a42e292a1ddc6098b16c54f))
 
 ## [19.0.0](https://github.com/Sage/carbon/compare/v18.1.1...v19.0.0) (2020-05-05)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **pager:** Pager interface changed to controlled. Implementation now offers callback functions onNext, onPrevious, onFirst, onLast, onPagination.
+- **pager:** Pager interface changed to controlled. Implementation now offers callback functions onNext, onPrevious, onFirst, onLast, onPagination.
 
 ### Bug Fixes
 
-* **pager:** new pager component ([4d7311c](https://github.com/Sage/carbon/commit/4d7311c22fe10691e02cf967515b81459c85838d))
-* **table:** updated default value of page size for pagination ([40579fe](https://github.com/Sage/carbon/commit/40579fed0c0c74d8d53848dc770bf9e50f6d202d))
+- **pager:** new pager component ([4d7311c](https://github.com/Sage/carbon/commit/4d7311c22fe10691e02cf967515b81459c85838d))
+- **table:** updated default value of page size for pagination ([40579fe](https://github.com/Sage/carbon/commit/40579fed0c0c74d8d53848dc770bf9e50f6d202d))
 
 ### [18.1.1](https://github.com/Sage/carbon/compare/v18.1.0...v18.1.1) (2020-05-04)
 
-
 ### Bug Fixes
 
-* **checkbox:** css styling fix for label ([062b9cc](https://github.com/Sage/carbon/commit/062b9cc83d9b904b29b22dbbcd9fe537fb8066d8))
-* **switch:** css styling fix for label ([16b88e9](https://github.com/Sage/carbon/commit/16b88e9521ed807dee02d34528296e6fd4850de2))
+- **checkbox:** css styling fix for label ([062b9cc](https://github.com/Sage/carbon/commit/062b9cc83d9b904b29b22dbbcd9fe537fb8066d8))
+- **switch:** css styling fix for label ([16b88e9](https://github.com/Sage/carbon/commit/16b88e9521ed807dee02d34528296e6fd4850de2))
 
 ## [18.1.0](https://github.com/Sage/carbon/compare/v18.0.0...v18.1.0) (2020-05-04)
 
-
 ### Features
 
-* **button:** add dashed button ([4fb2e30](https://github.com/Sage/carbon/commit/4fb2e307e52d7db6777ddff43aaaa96497c54b85))
+- **button:** add dashed button ([4fb2e30](https://github.com/Sage/carbon/commit/4fb2e307e52d7db6777ddff43aaaa96497c54b85))
 
 ## [18.0.0](https://github.com/Sage/carbon/compare/v17.5.1...v18.0.0) (2020-04-30)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **popover-container:** `iconType` prop is no longer supported
-To upgrade you should use `renderOpenComponent` prop to customise the
-open button.
+- **popover-container:** `iconType` prop is no longer supported
+  To upgrade you should use `renderOpenComponent` prop to customise the
+  open button.
 
 ### Features
 
-* **popover-container:** add render props and support controlled usage ([b53a77c](https://github.com/Sage/carbon/commit/b53a77cbd00b68dcaa686c15886ee90b4fffce71))
+- **popover-container:** add render props and support controlled usage ([b53a77c](https://github.com/Sage/carbon/commit/b53a77cbd00b68dcaa686c15886ee90b4fffce71))
 
 ### [17.5.1](https://github.com/Sage/carbon/compare/v17.5.0...v17.5.1) (2020-04-30)
 
-
 ### Bug Fixes
 
-* **popover-container:** revert previous release due to breaking change ([c33cef2](https://github.com/Sage/carbon/commit/c33cef2a57bb8027cabd2b8d45306143a112eaf1))
+- **popover-container:** revert previous release due to breaking change ([c33cef2](https://github.com/Sage/carbon/commit/c33cef2a57bb8027cabd2b8d45306143a112eaf1))
 
 ## [17.5.0](https://github.com/Sage/carbon/compare/v17.4.3...v17.5.0) (2020-04-30)
 
-
 ### Features
 
-* **popover-container:** add render props and support controlled usage ([6e1671f](https://github.com/Sage/carbon/commit/6e1671ff57816aa438ef9f9d4787583693c4467a))
+- **popover-container:** add render props and support controlled usage ([6e1671f](https://github.com/Sage/carbon/commit/6e1671ff57816aa438ef9f9d4787583693c4467a))
 
 ### [17.4.3](https://github.com/Sage/carbon/compare/v17.4.2...v17.4.3) (2020-04-30)
 
-
 ### Bug Fixes
 
-* **card-footer:** update the footer non interactive text colour to black ([57488a7](https://github.com/Sage/carbon/commit/57488a7d245a1a81ba1e7fb550c029e7816b363b)), closes [#2900](https://github.com/Sage/carbon/issues/2900)
+- **card-footer:** update the footer non interactive text colour to black ([57488a7](https://github.com/Sage/carbon/commit/57488a7d245a1a81ba1e7fb550c029e7816b363b)), closes [#2900](https://github.com/Sage/carbon/issues/2900)
 
 ### [17.4.2](https://github.com/Sage/carbon/compare/v17.4.1...v17.4.2) (2020-04-29)
 
-
 ### Bug Fixes
 
-* **anchor-navigation:** incorrect scroll animation in firefox ([96396f5](https://github.com/Sage/carbon/commit/96396f5ce48b7f0f5835c5250bc21f861a1f63c6))
+- **anchor-navigation:** incorrect scroll animation in firefox ([96396f5](https://github.com/Sage/carbon/commit/96396f5ce48b7f0f5835c5250bc21f861a1f63c6))
 
 ### [17.4.1](https://github.com/Sage/carbon/compare/v17.4.0...v17.4.1) (2020-04-29)
 
-
 ### Bug Fixes
 
-* **input:** update autofill style ([a4c6cae](https://github.com/Sage/carbon/commit/a4c6caea4330620e9086e3555c07dcbd8d365072))
+- **input:** update autofill style ([a4c6cae](https://github.com/Sage/carbon/commit/a4c6caea4330620e9086e3555c07dcbd8d365072))
 
 ## [17.4.0](https://github.com/Sage/carbon/compare/v17.3.2...v17.4.0) (2020-04-28)
 
-
 ### Features
 
-* **drawer:** create drawer component ([cee6f98](https://github.com/Sage/carbon/commit/cee6f98c4bfa5a513b4709f1b502c27ca0944e01))
+- **drawer:** create drawer component ([cee6f98](https://github.com/Sage/carbon/commit/cee6f98c4bfa5a513b4709f1b502c27ca0944e01))
 
 ### [17.3.2](https://github.com/Sage/carbon/compare/v17.3.1...v17.3.2) (2020-04-28)
 
-
 ### Bug Fixes
 
-* **accordion:** add content resize animation ([10d59ef](https://github.com/Sage/carbon/commit/10d59ef36236eb2334587da143ad19f1c2e41181))
-* **accordion:** lack of accordion resize when content size changes ([1f7267f](https://github.com/Sage/carbon/commit/1f7267f3c036331d32dafef35adf7decc5a4def6))
+- **accordion:** add content resize animation ([10d59ef](https://github.com/Sage/carbon/commit/10d59ef36236eb2334587da143ad19f1c2e41181))
+- **accordion:** lack of accordion resize when content size changes ([1f7267f](https://github.com/Sage/carbon/commit/1f7267f3c036331d32dafef35adf7decc5a4def6))
 
 ### [17.3.1](https://github.com/Sage/carbon/compare/v17.3.0...v17.3.1) (2020-04-28)
 
-
 ### Bug Fixes
 
-* **date:** allow to open date picker by clicking on calendar icon ([1fc5251](https://github.com/Sage/carbon/commit/1fc52515fa932106a3d9614658350460f0528d3e))
+- **date:** allow to open date picker by clicking on calendar icon ([1fc5251](https://github.com/Sage/carbon/commit/1fc52515fa932106a3d9614658350460f0528d3e))
 
 ## [17.3.0](https://github.com/Sage/carbon/compare/v17.2.3...v17.3.0) (2020-04-27)
 
-
 ### Features
 
-* **flat-table:** add new component sort and table themes ([4e14426](https://github.com/Sage/carbon/commit/4e14426e2c42f6904c54b2c0038c6cad7115d1cd))
+- **flat-table:** add new component sort and table themes ([4e14426](https://github.com/Sage/carbon/commit/4e14426e2c42f6904c54b2c0038c6cad7115d1cd))
 
 ### [17.2.3](https://github.com/Sage/carbon/compare/v17.2.2...v17.2.3) (2020-04-22)
 
-
 ### Bug Fixes
 
-* update version for cucumber preprocessor ([f8b0b21](https://github.com/Sage/carbon/commit/f8b0b217ab8aa15d2e1ed9068c7eeb25be1ac19e))
+- update version for cucumber preprocessor ([f8b0b21](https://github.com/Sage/carbon/commit/f8b0b217ab8aa15d2e1ed9068c7eeb25be1ac19e))
 
 ### [17.2.2](https://github.com/Sage/carbon/compare/v17.2.1...v17.2.2) (2020-04-21)
 
-
 ### Bug Fixes
 
-* **row:** allow number prop type for columns, columnSpan, columnOffset ([f9657f7](https://github.com/Sage/carbon/commit/f9657f7384308ae31c235ba08f60bf8c5dee09ab))
+- **row:** allow number prop type for columns, columnSpan, columnOffset ([f9657f7](https://github.com/Sage/carbon/commit/f9657f7384308ae31c235ba08f60bf8c5dee09ab))
 
 ### [17.2.1](https://github.com/Sage/carbon/compare/v17.2.0...v17.2.1) (2020-04-21)
 
-
 ### Bug Fixes
 
-* **flat-table:** update hover color for flat table row and cell ([ba68e91](https://github.com/Sage/carbon/commit/ba68e91d9d2c5b4aea3f36188e492f4c04b9b6a0))
+- **flat-table:** update hover color for flat table row and cell ([ba68e91](https://github.com/Sage/carbon/commit/ba68e91d9d2c5b4aea3f36188e492f4c04b9b6a0))
 
 ## [17.2.0](https://github.com/Sage/carbon/compare/v17.1.2...v17.2.0) (2020-04-21)
 
-
 ### Features
 
-* **form:** create new form component ([eaa6f16](https://github.com/Sage/carbon/commit/eaa6f16238c68d800c05626c56423e69cf2f60bf))
+- **form:** create new form component ([eaa6f16](https://github.com/Sage/carbon/commit/eaa6f16238c68d800c05626c56423e69cf2f60bf))
 
 ### [17.1.2](https://github.com/Sage/carbon/compare/v17.1.1...v17.1.2) (2020-04-20)
 
-
 ### Bug Fixes
 
-* **tabs:** padding and outline styling to match dls ([a5f03c4](https://github.com/Sage/carbon/commit/a5f03c401b071b8dd270d1dcea3533694ecf0049))
+- **tabs:** padding and outline styling to match dls ([a5f03c4](https://github.com/Sage/carbon/commit/a5f03c401b071b8dd270d1dcea3533694ecf0049))
 
 ### [17.1.1](https://github.com/Sage/carbon/compare/v17.1.0...v17.1.1) (2020-04-20)
 
-
 ### Bug Fixes
 
-* **action-popover:** remove display style attr and add width to menu btn ([cca36fe](https://github.com/Sage/carbon/commit/cca36feb0009540f361de8502f3b9f5fb32dc5f4))
+- **action-popover:** remove display style attr and add width to menu btn ([cca36fe](https://github.com/Sage/carbon/commit/cca36feb0009540f361de8502f3b9f5fb32dc5f4))
 
 ## [17.1.0](https://github.com/Sage/carbon/compare/v17.0.0...v17.1.0) (2020-04-17)
 
-
 ### Features
 
-* **numeral date:** create numeral date component ([12f12d3](https://github.com/Sage/carbon/commit/12f12d3a0ee81d6744e28d91a6d99c9c7a061d6e))
+- **numeral date:** create numeral date component ([12f12d3](https://github.com/Sage/carbon/commit/12f12d3a0ee81d6744e28d91a6d99c9c7a061d6e))
 
 ## [17.0.0](https://github.com/Sage/carbon/compare/v16.8.2...v17.0.0) (2020-04-17)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **deps-dev:** react-router is no longer a dependency and the `router.js` util,
-including the startRouter function has been removed from the code base as it
-relied on react-router v3. Consuming projects are now required to install their
-own routing solution, in order for the `Button` and `Link` components to work as
-previously when passing in a `to` prop, a routing link component must also be
-passed in via renderProps
+- **deps-dev:** react-router is no longer a dependency and the `router.js` util,
+  including the startRouter function has been removed from the code base as it
+  relied on react-router v3. Consuming projects are now required to install their
+  own routing solution, in order for the `Button` and `Link` components to work as
+  previously when passing in a `to` prop, a routing link component must also be
+  passed in via renderProps
 
 ### Miscellaneous Chores
 
-* **deps-dev:** move react router to dev dep and delete router util ([a7fc8a9](https://github.com/Sage/carbon/commit/a7fc8a9b864ea86309555d09a50b3725543cecb5))
+- **deps-dev:** move react router to dev dep and delete router util ([a7fc8a9](https://github.com/Sage/carbon/commit/a7fc8a9b864ea86309555d09a50b3725543cecb5))
 
 ### [16.8.2](https://github.com/Sage/carbon/compare/v16.8.1...v16.8.2) (2020-04-10)
 
-
 ### Bug Fixes
 
-* **action-popover:** add top position when menu right aligned in safari ([f9f8774](https://github.com/Sage/carbon/commit/f9f8774276c101647b29c991ed389eafd68e88d9))
+- **action-popover:** add top position when menu right aligned in safari ([f9f8774](https://github.com/Sage/carbon/commit/f9f8774276c101647b29c991ed389eafd68e88d9))
 
 ### [16.8.1](https://github.com/Sage/carbon/compare/v16.8.0...v16.8.1) (2020-04-07)
 
-
 ### Bug Fixes
 
-* **select:** allow passing custom validation icon type prop to component ([a333235](https://github.com/Sage/carbon/commit/a3332359a5bc3e75ab427de52bfc41ec9f267c63))
+- **select:** allow passing custom validation icon type prop to component ([a333235](https://github.com/Sage/carbon/commit/a3332359a5bc3e75ab427de52bfc41ec9f267c63))
 
 ## [16.8.0](https://github.com/Sage/carbon/compare/v16.7.0...v16.8.0) (2020-04-06)
 
-
 ### Features
 
-* **action-popover:** add support for custom menu button override ([df3477b](https://github.com/Sage/carbon/commit/df3477b523e5c81e442b916e1bb768984a8dcd83))
-
+- **action-popover:** add support for custom menu button override ([df3477b](https://github.com/Sage/carbon/commit/df3477b523e5c81e442b916e1bb768984a8dcd83))
 
 ### Bug Fixes
 
-* **popover-menu:** add guard against null item refs ([1b316e8](https://github.com/Sage/carbon/commit/1b316e806ea9acd2480ec85d2b5bdfb04333f233))
+- **popover-menu:** add guard against null item refs ([1b316e8](https://github.com/Sage/carbon/commit/1b316e806ea9acd2480ec85d2b5bdfb04333f233))
 
 ## [16.7.0](https://github.com/Sage/carbon/compare/v16.6.0...v16.7.0) (2020-04-02)
 
-
 ### Features
 
-* **radio-button-group:** add style override ([919d372](https://github.com/Sage/carbon/commit/919d372f6933c8d1b1a7de6dcce93f1b2993cf17))
+- **radio-button-group:** add style override ([919d372](https://github.com/Sage/carbon/commit/919d372f6933c8d1b1a7de6dcce93f1b2993cf17))
 
 ## [16.6.0](https://github.com/Sage/carbon/compare/v16.5.2...v16.6.0) (2020-04-02)
 
-
 ### Features
 
-* **select:** value added to customFilter option ([0048bc2](https://github.com/Sage/carbon/commit/0048bc2e04c024b2833e8fa41649d27900e4bd33)), closes [#2697](https://github.com/Sage/carbon/issues/2697)
+- **select:** value added to customFilter option ([0048bc2](https://github.com/Sage/carbon/commit/0048bc2e04c024b2833e8fa41649d27900e4bd33)), closes [#2697](https://github.com/Sage/carbon/issues/2697)
 
 ### [16.5.2](https://github.com/Sage/carbon/compare/v16.5.1...v16.5.2) (2020-04-01)
 
-
 ### Bug Fixes
 
-* **search:** close icon persists when the field is empty ([de5d217](https://github.com/Sage/carbon/commit/de5d217d70ef6b23dd0ccc8f1db78b16d7cecbe8))
+- **search:** close icon persists when the field is empty ([de5d217](https://github.com/Sage/carbon/commit/de5d217d70ef6b23dd0ccc8f1db78b16d7cecbe8))
 
 ### [16.5.1](https://github.com/Sage/carbon/compare/v16.5.0...v16.5.1) (2020-04-01)
 
-
 ### Bug Fixes
 
-* **date:** allow passing custom validation icon type prop to component ([16f4c50](https://github.com/Sage/carbon/commit/16f4c50b5d37c34b52e1f4b8999db720f4c58792))
+- **date:** allow passing custom validation icon type prop to component ([16f4c50](https://github.com/Sage/carbon/commit/16f4c50b5d37c34b52e1f4b8999db720f4c58792))
 
 ## [16.5.0](https://github.com/Sage/carbon/compare/v16.4.1...v16.5.0) (2020-03-31)
 
-
 ### Features
 
-* **advanced-colour-picker:** create advanced color picker component ([af13999](https://github.com/Sage/carbon/commit/af13999aeaee358c7dcec5805f18a53241872189))
-
+- **advanced-colour-picker:** create advanced color picker component ([af13999](https://github.com/Sage/carbon/commit/af13999aeaee358c7dcec5805f18a53241872189))
 
 ### Bug Fixes
 
-* **modal:** return event for onclose callback ([714be37](https://github.com/Sage/carbon/commit/714be3798a187bd882649a413d7166842e7b8e98))
-* **simple-color-picker:** use SVG for transparent color preview ([8941e03](https://github.com/Sage/carbon/commit/8941e03731fdab316abee8ce8603195499f4b78f))
+- **modal:** return event for onclose callback ([714be37](https://github.com/Sage/carbon/commit/714be3798a187bd882649a413d7166842e7b8e98))
+- **simple-color-picker:** use SVG for transparent color preview ([8941e03](https://github.com/Sage/carbon/commit/8941e03731fdab316abee8ce8603195499f4b78f))
 
 ### [16.4.1](https://github.com/Sage/carbon/compare/v16.4.0...v16.4.1) (2020-03-31)
 
-
 ### Bug Fixes
 
-* **input:** add null check to input focus handler ([13095a9](https://github.com/Sage/carbon/commit/13095a90f4347ddf29e8b0f55aed18cf906070bf))
+- **input:** add null check to input focus handler ([13095a9](https://github.com/Sage/carbon/commit/13095a90f4347ddf29e8b0f55aed18cf906070bf))
 
 ## [16.4.0](https://github.com/Sage/carbon/compare/v16.3.0...v16.4.0) (2020-03-31)
 
-
 ### Features
 
-* **action-popover:** support for aligning menu to right of button ([ed42599](https://github.com/Sage/carbon/commit/ed42599a40ce971d253a990e0b63762c807137c5))
+- **action-popover:** support for aligning menu to right of button ([ed42599](https://github.com/Sage/carbon/commit/ed42599a40ce971d253a990e0b63762c807137c5))
 
 ## [16.3.0](https://github.com/Sage/carbon/compare/v16.2.1...v16.3.0) (2020-03-30)
 
-
 ### Features
 
-* **button:** add support for style override object ([894ac96](https://github.com/Sage/carbon/commit/894ac96af3148127f9b458a92ad163c82a34f057))
+- **button:** add support for style override object ([894ac96](https://github.com/Sage/carbon/commit/894ac96af3148127f9b458a92ad163c82a34f057))
 
 ### [16.2.1](https://github.com/Sage/carbon/compare/v16.2.0...v16.2.1) (2020-03-27)
 
-
 ### Bug Fixes
 
-* **icon-button:** hover background over focus outline ([4968edf](https://github.com/Sage/carbon/commit/4968edfef33a3b6b67675f5641d2bc115b4f89b0))
+- **icon-button:** hover background over focus outline ([4968edf](https://github.com/Sage/carbon/commit/4968edfef33a3b6b67675f5641d2bc115b4f89b0))
 
 ## [16.2.0](https://github.com/Sage/carbon/compare/v16.1.0...v16.2.0) (2020-03-27)
 
-
 ### Features
 
-* **fieldset:** add address fieldset ([192deef](https://github.com/Sage/carbon/commit/192deef13f7b67d1e52a901afd2d9b8c1039efab))
+- **fieldset:** add address fieldset ([192deef](https://github.com/Sage/carbon/commit/192deef13f7b67d1e52a901afd2d9b8c1039efab))
 
 ## [16.1.0](https://github.com/Sage/carbon/compare/v16.0.0...v16.1.0) (2020-03-27)
 
-
 ### Features
 
-* **button:** add destructive secondary buttons ([5e2346b](https://github.com/Sage/carbon/commit/5e2346b4b5c20aacc2e4d6aeb4a58390d1a38233))
-* **button:** add destructive tertiary buttons ([3544a56](https://github.com/Sage/carbon/commit/3544a56d135b84fea94be5973ed0dbc10cfc2e09))
+- **button:** add destructive secondary buttons ([5e2346b](https://github.com/Sage/carbon/commit/5e2346b4b5c20aacc2e4d6aeb4a58390d1a38233))
+- **button:** add destructive tertiary buttons ([3544a56](https://github.com/Sage/carbon/commit/3544a56d135b84fea94be5973ed0dbc10cfc2e09))
 
 ## [16.0.0](https://github.com/Sage/carbon/compare/v15.0.0...v16.0.0) (2020-03-26)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **button:** `<Button buttonType="destructive"/>` has been
-removed in favour of `<Button buttonType="primary" destructive />`.
+- **button:** `<Button buttonType="destructive"/>` has been
+  removed in favour of `<Button buttonType="primary" destructive />`.
 
-There is a codemod available to assist with this upgrade `npx
-carbon-codemod button-destructive <target>`.
+There is a codemod available to assist with this upgrade `npx carbon-codemod button-destructive <target>`.
 
-See https://github.com/Sage/carbon-codemod for more information.
+See <https://github.com/Sage/carbon-codemod> for more information.
 
 ### Miscellaneous Chores
 
-* **button:** remove destructive button type ([c1ee90b](https://github.com/Sage/carbon/commit/c1ee90b747f906ac1d9dc06538c02b39ceb3dbe4))
+- **button:** remove destructive button type ([c1ee90b](https://github.com/Sage/carbon/commit/c1ee90b747f906ac1d9dc06538c02b39ceb3dbe4))
 
 ## [15.0.0](https://github.com/Sage/carbon/compare/v14.11.0...v15.0.0) (2020-03-26)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **multi-action-button:** The Classic theme is no longer supported. To upgrade
-please use the Mint or Aegean theme.
-* **split-button:** The Classic theme is no longer supported. To upgrade
-please use the Mint or Aegean theme.
-* **button:** The Classic theme is no longer supported. To upgrade
-please use the Mint or Aegean theme.
+- **multi-action-button:** The Classic theme is no longer supported. To upgrade
+  please use the Mint or Aegean theme.
+- **split-button:** The Classic theme is no longer supported. To upgrade
+  please use the Mint or Aegean theme.
+- **button:** The Classic theme is no longer supported. To upgrade
+  please use the Mint or Aegean theme.
 
 Fixes FE-2629
 
 ### Miscellaneous Chores
 
-* **button:** drop classic support ([68ddad5](https://github.com/Sage/carbon/commit/68ddad51e887d20dd7f4c9e43728666730ed28e4))
-* **multi-action-button:** drop classic support ([383a8bc](https://github.com/Sage/carbon/commit/383a8bc54beed64ffe7fc97ed60e304e18d44b14))
-* **split-button:** drop classic support ([808d4bb](https://github.com/Sage/carbon/commit/808d4bbcc0216f39e360d73e3a73cc92e42ae72c))
+- **button:** drop classic support ([68ddad5](https://github.com/Sage/carbon/commit/68ddad51e887d20dd7f4c9e43728666730ed28e4))
+- **multi-action-button:** drop classic support ([383a8bc](https://github.com/Sage/carbon/commit/383a8bc54beed64ffe7fc97ed60e304e18d44b14))
+- **split-button:** drop classic support ([808d4bb](https://github.com/Sage/carbon/commit/808d4bbcc0216f39e360d73e3a73cc92e42ae72c))
 
 ## [14.11.0](https://github.com/Sage/carbon/compare/v14.10.0...v14.11.0) (2020-03-25)
 
-
 ### Features
 
-* **select:** add transparent variant ([b60facb](https://github.com/Sage/carbon/commit/b60facb0fc667701940f83c452ce36aa9fb836d4))
-* **simple-color-picker:** adds transparent color ([76c37c1](https://github.com/Sage/carbon/commit/76c37c107a22de56357333cebb3b9dd2a109b657))
-* **textbox:** add style override functionality ([6f6fbee](https://github.com/Sage/carbon/commit/6f6fbeed36801255e8339904a17e4487b318ec84))
+- **select:** add transparent variant ([b60facb](https://github.com/Sage/carbon/commit/b60facb0fc667701940f83c452ce36aa9fb836d4))
+- **simple-color-picker:** adds transparent color ([76c37c1](https://github.com/Sage/carbon/commit/76c37c107a22de56357333cebb3b9dd2a109b657))
+- **textbox:** add style override functionality ([6f6fbee](https://github.com/Sage/carbon/commit/6f6fbeed36801255e8339904a17e4487b318ec84))
 
 ## [14.10.0](https://github.com/Sage/carbon/compare/v14.9.0...v14.10.0) (2020-03-25)
 
-
 ### Features
 
-* **textbox:** add style override functionality ([b57b459](https://github.com/Sage/carbon/commit/b57b459c4f5e511dd9dc0eb40586755608568b47))
+- **textbox:** add style override functionality ([b57b459](https://github.com/Sage/carbon/commit/b57b459c4f5e511dd9dc0eb40586755608568b47))
 
 ## [14.9.0](https://github.com/Sage/carbon/compare/v14.8.1...v14.9.0) (2020-03-25)
 
-
 ### Features
 
-* **select:** add transparent variant ([2ffe8b9](https://github.com/Sage/carbon/commit/2ffe8b9271a27eed1bc95cf12aa5e554b1b6dd54))
+- **select:** add transparent variant ([2ffe8b9](https://github.com/Sage/carbon/commit/2ffe8b9271a27eed1bc95cf12aa5e554b1b6dd54))
 
 ### [14.8.1](https://github.com/Sage/carbon/compare/v14.8.0...v14.8.1) (2020-03-24)
 
-
 ### Bug Fixes
 
-* **select:** resolved error when only one option child is set ([6cb9a06](https://github.com/Sage/carbon/commit/6cb9a06b9f83d1c245dd3218b83504be1159e65e)), closes [#2567](https://github.com/Sage/carbon/issues/2567)
+- **select:** resolved error when only one option child is set ([6cb9a06](https://github.com/Sage/carbon/commit/6cb9a06b9f83d1c245dd3218b83504be1159e65e)), closes [#2567](https://github.com/Sage/carbon/issues/2567)
 
 ## [14.8.0](https://github.com/Sage/carbon/compare/v14.7.0...v14.8.0) (2020-03-24)
 
-
 ### Features
 
-* **badge:** add new component ([e1a9697](https://github.com/Sage/carbon/commit/e1a9697a0247bd8caa5c5012bf4db46229a75f66))
-* **badge:** add new component ([3b0effe](https://github.com/Sage/carbon/commit/3b0effe30d32f2a069857396e993b33eadfc3fef))
-* **badge:** add new component ([3caf804](https://github.com/Sage/carbon/commit/3caf8042c942e62e7afa2021f8ffe56d01300940))
-* **badge:** add new component ([a9bd1cc](https://github.com/Sage/carbon/commit/a9bd1cc0a99a29bf05efa653ad13b6eec4cac6d9))
-* **badge:** add new component ([4a35eaf](https://github.com/Sage/carbon/commit/4a35eafdaf222e61290e9995490938a7929e275c))
-* **badge:** add new component ([e3f3fbf](https://github.com/Sage/carbon/commit/e3f3fbf6fd8088ae0a2655676200d239a58f9373))
-* **badge:** add new component ([7c0275d](https://github.com/Sage/carbon/commit/7c0275def723964f08ce46246651361ccc17972f))
-* **badge:** add new component ([9b23f32](https://github.com/Sage/carbon/commit/9b23f32c06c566d0a4190827dd84d0a9f8cbf8a3))
-* **badge:** add new component ([c2961ed](https://github.com/Sage/carbon/commit/c2961ed440d6a2f9bf2b832a942497f70df9a2b9))
+- **badge:** add new component ([e1a9697](https://github.com/Sage/carbon/commit/e1a9697a0247bd8caa5c5012bf4db46229a75f66))
+- **badge:** add new component ([3b0effe](https://github.com/Sage/carbon/commit/3b0effe30d32f2a069857396e993b33eadfc3fef))
+- **badge:** add new component ([3caf804](https://github.com/Sage/carbon/commit/3caf8042c942e62e7afa2021f8ffe56d01300940))
+- **badge:** add new component ([a9bd1cc](https://github.com/Sage/carbon/commit/a9bd1cc0a99a29bf05efa653ad13b6eec4cac6d9))
+- **badge:** add new component ([4a35eaf](https://github.com/Sage/carbon/commit/4a35eafdaf222e61290e9995490938a7929e275c))
+- **badge:** add new component ([e3f3fbf](https://github.com/Sage/carbon/commit/e3f3fbf6fd8088ae0a2655676200d239a58f9373))
+- **badge:** add new component ([7c0275d](https://github.com/Sage/carbon/commit/7c0275def723964f08ce46246651361ccc17972f))
+- **badge:** add new component ([9b23f32](https://github.com/Sage/carbon/commit/9b23f32c06c566d0a4190827dd84d0a9f8cbf8a3))
+- **badge:** add new component ([c2961ed](https://github.com/Sage/carbon/commit/c2961ed440d6a2f9bf2b832a942497f70df9a2b9))
 
 ## [14.7.0](https://github.com/Sage/carbon/compare/v14.6.0...v14.7.0) (2020-03-24)
 
-
 ### Features
 
-* **duelling-picklist:** create duelling-picklist component ([e122180](https://github.com/Sage/carbon/commit/e12218007d3f933fba760a18476ffab37a31f927))
+- **duelling-picklist:** create duelling-picklist component ([e122180](https://github.com/Sage/carbon/commit/e12218007d3f933fba760a18476ffab37a31f927))
 
 ## [14.6.0](https://github.com/Sage/carbon/compare/v14.5.1...v14.6.0) (2020-03-24)
 
-
 ### Features
 
-* **action-popover:** add submenu support ([07ea29a](https://github.com/Sage/carbon/commit/07ea29ab24eecd3e7c6bd0792b49db0e2d7b1acf))
+- **action-popover:** add submenu support ([07ea29a](https://github.com/Sage/carbon/commit/07ea29ab24eecd3e7c6bd0792b49db0e2d7b1acf))
 
 ### [14.5.1](https://github.com/Sage/carbon/compare/v14.5.0...v14.5.1) (2020-03-23)
 
-
 ### Bug Fixes
 
-* **pill:** close button styling ([e054884](https://github.com/Sage/carbon/commit/e054884dd0af65d65041901fce03fd8dcbfbe679))
+- **pill:** close button styling ([e054884](https://github.com/Sage/carbon/commit/e054884dd0af65d65041901fce03fd8dcbfbe679))
 
 ## [14.5.0](https://github.com/Sage/carbon/compare/v14.4.0...v14.5.0) (2020-03-20)
 
-
 ### Features
 
-* **icon:** add icons ([513966b](https://github.com/Sage/carbon/commit/513966bf9536dd52693d58f43317e7b20c39c110))
+- **icon:** add icons ([513966b](https://github.com/Sage/carbon/commit/513966bf9536dd52693d58f43317e7b20c39c110))
 
 ## [14.4.0](https://github.com/Sage/carbon/compare/v14.3.0...v14.4.0) (2020-03-20)
 
-
 ### Features
 
-* add new BatchSelection component ([6a61955](https://github.com/Sage/carbon/commit/6a61955d7c5a669438814079e56f0966e22d6eac))
+- add new BatchSelection component ([6a61955](https://github.com/Sage/carbon/commit/6a61955d7c5a669438814079e56f0966e22d6eac))
 
 ## [14.3.0](https://github.com/Sage/carbon/compare/v14.2.2...v14.3.0) (2020-03-18)
 
-
 ### Features
 
-* **grid:** add responsive grid component ([62e76c5](https://github.com/Sage/carbon/commit/62e76c5c2c35fc28761d2b963cd30b2144e3e755))
+- **grid:** add responsive grid component ([62e76c5](https://github.com/Sage/carbon/commit/62e76c5c2c35fc28761d2b963cd30b2144e3e755))
 
 ### [14.2.2](https://github.com/Sage/carbon/compare/v14.2.1...v14.2.2) (2020-03-18)
 
-
 ### Bug Fixes
 
-* **icon-button:** remove firefox focus-inner border ([c6b0601](https://github.com/Sage/carbon/commit/c6b0601b0b70c7df1bd70a1f05811312b71dea66))
+- **icon-button:** remove firefox focus-inner border ([c6b0601](https://github.com/Sage/carbon/commit/c6b0601b0b70c7df1bd70a1f05811312b71dea66))
 
 ### [14.2.1](https://github.com/Sage/carbon/compare/v14.2.0...v14.2.1) (2020-03-17)
 
-
 ### Bug Fixes
 
-* **fonts:** add support for consumer adding font ([fedf494](https://github.com/Sage/carbon/commit/fedf4944063f784d823694b774e005ee55fa2c2a))
+- **fonts:** add support for consumer adding font ([fedf494](https://github.com/Sage/carbon/commit/fedf4944063f784d823694b774e005ee55fa2c2a))
 
 ## [14.2.0](https://github.com/Sage/carbon/compare/v14.1.2...v14.2.0) (2020-03-17)
 
-
 ### Features
 
-* **switch:** add i18n support ([cbf5fda](https://github.com/Sage/carbon/commit/cbf5fdac1527e0ca6d6e6b2a16af3f8eb608cfaa)), closes [#2722](https://github.com/Sage/carbon/issues/2722)
+- **switch:** add i18n support ([cbf5fda](https://github.com/Sage/carbon/commit/cbf5fdac1527e0ca6d6e6b2a16af3f8eb608cfaa)), closes [#2722](https://github.com/Sage/carbon/issues/2722)
 
 ### [14.1.2](https://github.com/Sage/carbon/compare/v14.1.1...v14.1.2) (2020-03-17)
 
-
 ### Bug Fixes
 
-* **alert:** use icon-button component for close ([f24352c](https://github.com/Sage/carbon/commit/f24352cf57e8c6189d4eba552421694864cc1d8e))
+- **alert:** use icon-button component for close ([f24352c](https://github.com/Sage/carbon/commit/f24352cf57e8c6189d4eba552421694864cc1d8e))
 
 ### [14.1.1](https://github.com/Sage/carbon/compare/v14.1.0...v14.1.1) (2020-03-16)
 
-
 ### Bug Fixes
 
-* **sidebar:** close button styling ([58c1674](https://github.com/Sage/carbon/commit/58c16748814873f5923cdd093e839fd91aeacced))
-* **sidebar:** fixed close icon alignment in classic story ([61aaf5d](https://github.com/Sage/carbon/commit/61aaf5d8787f850695cdabdff702ab289b5afd48))
+- **sidebar:** close button styling ([58c1674](https://github.com/Sage/carbon/commit/58c16748814873f5923cdd093e839fd91aeacced))
+- **sidebar:** fixed close icon alignment in classic story ([61aaf5d](https://github.com/Sage/carbon/commit/61aaf5d8787f850695cdabdff702ab289b5afd48))
 
 ## [14.1.0](https://github.com/Sage/carbon/compare/v14.0.2...v14.1.0) (2020-03-13)
 
-
 ### Features
 
-* **simple-color-picker:** keyboard accessbility, up and down navigation ([351db41](https://github.com/Sage/carbon/commit/351db41f22611c937f7530ffd992be95829a22d3))
+- **simple-color-picker:** keyboard accessbility, up and down navigation ([351db41](https://github.com/Sage/carbon/commit/351db41f22611c937f7530ffd992be95829a22d3))
 
 ### [14.0.2](https://github.com/Sage/carbon/compare/v14.0.1...v14.0.2) (2020-03-13)
 
-
 ### Bug Fixes
 
-* **multi-action-button:** change button text misalignment ([6013c0c](https://github.com/Sage/carbon/commit/6013c0cbd2b336d223c0e47d61a80982b4581802))
+- **multi-action-button:** change button text misalignment ([6013c0c](https://github.com/Sage/carbon/commit/6013c0cbd2b336d223c0e47d61a80982b4581802))
 
 ### [14.0.1](https://github.com/Sage/carbon/compare/v14.0.0...v14.0.1) (2020-03-12)
 
-
 ### Bug Fixes
 
-* **toast:** close button styling ([a55eaa1](https://github.com/Sage/carbon/commit/a55eaa192415689247b537d8281dc78aa4fa3ac9))
+- **toast:** close button styling ([a55eaa1](https://github.com/Sage/carbon/commit/a55eaa192415689247b537d8281dc78aa4fa3ac9))
 
 ## [14.0.0](https://github.com/Sage/carbon/compare/v13.12.0...v14.0.0) (2020-03-11)
 
-
 ### ⚠ BREAKING CHANGES
 
-* The Lato font import has been removed from carbon
-consuming applications are now responsible for including them, how to do so has been documented in README.md
+- The Lato font import has been removed from carbon
+  consuming applications are now responsible for including them, how to do so has been documented in README.md
 
 ### Miscellaneous Chores
 
-* remove cdn font import and add local font for storybook ([1ea3565](https://github.com/Sage/carbon/commit/1ea3565bed715ba6f9801bf92973adda0d987f56))
+- remove cdn font import and add local font for storybook ([1ea3565](https://github.com/Sage/carbon/commit/1ea3565bed715ba6f9801bf92973adda0d987f56))
 
 ## [13.12.0](https://github.com/Sage/carbon/compare/v13.11.0...v13.12.0) (2020-03-11)
 
-
 ### Features
 
-* **button:** add destructive prop ([cef3676](https://github.com/Sage/carbon/commit/cef3676d754722ba171eaa1dc1f79e447b61b6d2))
+- **button:** add destructive prop ([cef3676](https://github.com/Sage/carbon/commit/cef3676d754722ba171eaa1dc1f79e447b61b6d2))
 
 ## [13.11.0](https://github.com/Sage/carbon/compare/v13.10.0...v13.11.0) (2020-03-11)
 
-
 ### Features
 
-* **popover-container:** add new component ([871b56d](https://github.com/Sage/carbon/commit/871b56d1c82890d39ae1c489316d1304708d41b4))
+- **popover-container:** add new component ([871b56d](https://github.com/Sage/carbon/commit/871b56d1c82890d39ae1c489316d1304708d41b4))
 
 ## [13.10.0](https://github.com/Sage/carbon/compare/v13.9.1...v13.10.0) (2020-03-11)
 
-
 ### Features
 
-* **anchor-navigation:** create anchor-navigation component ([12d0d88](https://github.com/Sage/carbon/commit/12d0d8873d5243c132a04a85fc0c9ed2f9962326))
+- **anchor-navigation:** create anchor-navigation component ([12d0d88](https://github.com/Sage/carbon/commit/12d0d8873d5243c132a04a85fc0c9ed2f9962326))
 
 ### [13.9.1](https://github.com/Sage/carbon/compare/v13.9.0...v13.9.1) (2020-03-10)
 
-
 ### Bug Fixes
 
-* **dialog-full-screen:** close button styling ([13e31ef](https://github.com/Sage/carbon/commit/13e31ef4861645a5865cc757749152498b90c260))
+- **dialog-full-screen:** close button styling ([13e31ef](https://github.com/Sage/carbon/commit/13e31ef4861645a5865cc757749152498b90c260))
 
 ## [13.9.0](https://github.com/Sage/carbon/compare/v13.8.0...v13.9.0) (2020-03-09)
 
-
 ### Features
 
-* **radio-button:** add support for inline radio buttons/legend ([6af3ff6](https://github.com/Sage/carbon/commit/6af3ff609a5b646492e21abd22c4ff8c22478010))
+- **radio-button:** add support for inline radio buttons/legend ([6af3ff6](https://github.com/Sage/carbon/commit/6af3ff609a5b646492e21abd22c4ff8c22478010))
 
 ## [13.8.0](https://github.com/Sage/carbon/compare/v13.7.1...v13.8.0) (2020-03-09)
 
-
 ### Features
 
-* **draggable:** add new component ([c3acd71](https://github.com/Sage/carbon/commit/c3acd71d44ad5de09e4599e4ab0f935d0270907c))
-* **draggable:** add propTypes support ([ce961c4](https://github.com/Sage/carbon/commit/ce961c42cd95bbcc74cffd3c063c88afd81479ad))
-* **draggable:** back item to original position ([089fe50](https://github.com/Sage/carbon/commit/089fe50db10d282524516a75f167aae6db734bf6))
-* **draggable:** callback run on correct drop ([4dc0818](https://github.com/Sage/carbon/commit/4dc0818c2effdf9569134c595399eee546bbc6a7))
-* **draggable:** fix lint ([69ae840](https://github.com/Sage/carbon/commit/69ae840294901c8c8d7133fb7fe6633b07c74176))
-* **draggable:** make props to be optional ([1cd9f64](https://github.com/Sage/carbon/commit/1cd9f648f089fb592420ae3d08bc8d30dd0d3077))
-* **draggable:** rename property ([5469027](https://github.com/Sage/carbon/commit/5469027f4b119009313c8474f404bf62f0857ec6))
+- **draggable:** add new component ([c3acd71](https://github.com/Sage/carbon/commit/c3acd71d44ad5de09e4599e4ab0f935d0270907c))
+- **draggable:** add propTypes support ([ce961c4](https://github.com/Sage/carbon/commit/ce961c42cd95bbcc74cffd3c063c88afd81479ad))
+- **draggable:** back item to original position ([089fe50](https://github.com/Sage/carbon/commit/089fe50db10d282524516a75f167aae6db734bf6))
+- **draggable:** callback run on correct drop ([4dc0818](https://github.com/Sage/carbon/commit/4dc0818c2effdf9569134c595399eee546bbc6a7))
+- **draggable:** fix lint ([69ae840](https://github.com/Sage/carbon/commit/69ae840294901c8c8d7133fb7fe6633b07c74176))
+- **draggable:** make props to be optional ([1cd9f64](https://github.com/Sage/carbon/commit/1cd9f648f089fb592420ae3d08bc8d30dd0d3077))
+- **draggable:** rename property ([5469027](https://github.com/Sage/carbon/commit/5469027f4b119009313c8474f404bf62f0857ec6))
 
 ### [13.7.1](https://github.com/Sage/carbon/compare/v13.7.0...v13.7.1) (2020-03-09)
 
-
 ### Bug Fixes
 
-* **dialog:** close button styling ([f156763](https://github.com/Sage/carbon/commit/f156763575f462d2b7908daf2060e274c8f636d9))
+- **dialog:** close button styling ([f156763](https://github.com/Sage/carbon/commit/f156763575f462d2b7908daf2060e274c8f636d9))
 
 ## [13.7.0](https://github.com/Sage/carbon/compare/v13.6.2...v13.7.0) (2020-03-05)
 
-
 ### Features
 
-* **flat-table:** add clickable row functionality ([0e11e22](https://github.com/Sage/carbon/commit/0e11e2211c81c831ce52be1c7920b1aa1234d1f8))
+- **flat-table:** add clickable row functionality ([0e11e22](https://github.com/Sage/carbon/commit/0e11e2211c81c831ce52be1c7920b1aa1234d1f8))
 
 ### [13.6.2](https://github.com/Sage/carbon/compare/v13.6.1...v13.6.2) (2020-03-03)
 
-
 ### Bug Fixes
 
-* **storybook:** enable theme selector on Windows ([ecfbb17](https://github.com/Sage/carbon/commit/ecfbb17229b1a8aa4753e1f8c187a9dde3c93d1a))
+- **storybook:** enable theme selector on Windows ([ecfbb17](https://github.com/Sage/carbon/commit/ecfbb17229b1a8aa4753e1f8c187a9dde3c93d1a))
 
 ### [13.6.1](https://github.com/Sage/carbon/compare/v13.6.0...v13.6.1) (2020-03-02)
 
-
 ### Bug Fixes
 
-* **checkbox:** fix incorrect key assignment in checkbox story ([e5566cf](https://github.com/Sage/carbon/commit/e5566cfc509589cf46c30f56909daefbce8f2515))
-* **checkbox:** restore proper checkbox behaviour in validations story ([b49f633](https://github.com/Sage/carbon/commit/b49f633b9e30bb8a947b4010538ebbb4136b86ee))
+- **checkbox:** fix incorrect key assignment in checkbox story ([e5566cf](https://github.com/Sage/carbon/commit/e5566cfc509589cf46c30f56909daefbce8f2515))
+- **checkbox:** restore proper checkbox behaviour in validations story ([b49f633](https://github.com/Sage/carbon/commit/b49f633b9e30bb8a947b4010538ebbb4136b86ee))
 
 ## [13.6.0](https://github.com/Sage/carbon/compare/v13.5.1...v13.6.0) (2020-02-27)
 
-
 ### Features
 
-* **textbox based components:** update readonly styling ([a1c7499](https://github.com/Sage/carbon/commit/a1c74993862c0f724504e6f87f7b4085dc9077ea))
+- **textbox based components:** update readonly styling ([a1c7499](https://github.com/Sage/carbon/commit/a1c74993862c0f724504e6f87f7b4085dc9077ea))
 
 ### [13.5.1](https://github.com/Sage/carbon/compare/v13.5.0...v13.5.1) (2020-02-27)
 
-
 ### Performance Improvements
 
-* **storybook:** solve action event serialization performance issues ([f9de61a](https://github.com/Sage/carbon/commit/f9de61aa5cc5741b84f018a241c438e4820885cb))
+- **storybook:** solve action event serialization performance issues ([f9de61a](https://github.com/Sage/carbon/commit/f9de61aa5cc5741b84f018a241c438e4820885cb))
 
 ## [13.5.0](https://github.com/Sage/carbon/compare/v13.4.0...v13.5.0) (2020-02-26)
 
-
 ### Features
 
-* **accordion:** create accordion component ([e494ceb](https://github.com/Sage/carbon/commit/e494cebd27314031d71b8803d6b99f81d2567501))
+- **accordion:** create accordion component ([e494ceb](https://github.com/Sage/carbon/commit/e494cebd27314031d71b8803d6b99f81d2567501))
 
 ## [13.4.0](https://github.com/Sage/carbon/compare/v13.3.2...v13.4.0) (2020-02-24)
 
-
 ### Features
 
-* **icon-button:** new component to be used in place of close icon ([53b2404](https://github.com/Sage/carbon/commit/53b2404b1bde6510958751dfefe9e69fa3971197))
+- **icon-button:** new component to be used in place of close icon ([53b2404](https://github.com/Sage/carbon/commit/53b2404b1bde6510958751dfefe9e69fa3971197))
 
 ### [13.3.2](https://github.com/Sage/carbon/compare/v13.3.1...v13.3.2) (2020-02-24)
 
-
 ### Bug Fixes
 
-* **menu-item:** fixed style regression ([187b4df](https://github.com/Sage/carbon/commit/187b4df3e780423e9741dbb241ce6e630c84d10e))
+- **menu-item:** fixed style regression ([187b4df](https://github.com/Sage/carbon/commit/187b4df3e780423e9741dbb241ce6e630c84d10e))
 
 ### [13.3.1](https://github.com/Sage/carbon/compare/v13.3.0...v13.3.1) (2020-02-21)
 
-
 ### Bug Fixes
 
-* **pager:** add singular/plural default translations for records ([ffaf35c](https://github.com/Sage/carbon/commit/ffaf35c1ebe630582b94626fea3cb7d6111723d5))
-* **pager:** remove whitespace from translation template ([4e4c746](https://github.com/Sage/carbon/commit/4e4c7464f9258a656e0f55a6d05dbe3706a842b3))
-* **pager:** use page size value for translation of page size ([c608a5b](https://github.com/Sage/carbon/commit/c608a5be451e4fa617c05d43657c333bdc807708))
+- **pager:** add singular/plural default translations for records ([ffaf35c](https://github.com/Sage/carbon/commit/ffaf35c1ebe630582b94626fea3cb7d6111723d5))
+- **pager:** remove whitespace from translation template ([4e4c746](https://github.com/Sage/carbon/commit/4e4c7464f9258a656e0f55a6d05dbe3706a842b3))
+- **pager:** use page size value for translation of page size ([c608a5b](https://github.com/Sage/carbon/commit/c608a5be451e4fa617c05d43657c333bdc807708))
 
 ## [13.3.0](https://github.com/Sage/carbon/compare/v13.2.2...v13.3.0) (2020-02-20)
 
-
 ### Features
 
-* **search:** create search component ([2394a97](https://github.com/Sage/carbon/commit/2394a973fccbfb28ede86d84d6e1533ed42a5dfa))
+- **search:** create search component ([2394a97](https://github.com/Sage/carbon/commit/2394a973fccbfb28ede86d84d6e1533ed42a5dfa))
 
 ### [13.2.2](https://github.com/Sage/carbon/compare/v13.2.1...v13.2.2) (2020-02-20)
 
-
 ### Bug Fixes
 
-* **card:** add data role prop for automation ([0ba28d5](https://github.com/Sage/carbon/commit/0ba28d501235a27628e597caa129ef12d9f06b8c))
+- **card:** add data role prop for automation ([0ba28d5](https://github.com/Sage/carbon/commit/0ba28d501235a27628e597caa129ef12d9f06b8c))
 
 ### [13.2.1](https://github.com/Sage/carbon/compare/v13.2.0...v13.2.1) (2020-02-19)
 
-
 ### Bug Fixes
 
-* **form:** re-apply submit focus on invalid form submission ([66c5f08](https://github.com/Sage/carbon/commit/66c5f08348400d9fa5fd3a6a04dd13c2960210ba))
+- **form:** re-apply submit focus on invalid form submission ([66c5f08](https://github.com/Sage/carbon/commit/66c5f08348400d9fa5fd3a6a04dd13c2960210ba))
 
 ## [13.2.0](https://github.com/Sage/carbon/compare/v13.1.0...v13.2.0) (2020-02-17)
 
-
 ### Features
 
-* add new Flat Table component ([f335bb1](https://github.com/Sage/carbon/commit/f335bb1c50995822020ea4775da5b97ebc935bfc))
+- add new Flat Table component ([f335bb1](https://github.com/Sage/carbon/commit/f335bb1c50995822020ea4775da5b97ebc935bfc))
 
 ## [13.1.0](https://github.com/Sage/carbon/compare/v13.0.2...v13.1.0) (2020-02-14)
 
-
 ### Features
 
-* **pager:** added translation support for "Show" ([183d7bd](https://github.com/Sage/carbon/commit/183d7bd139e760178f7a07f679af2c444079762c))
+- **pager:** added translation support for "Show" ([183d7bd](https://github.com/Sage/carbon/commit/183d7bd139e760178f7a07f679af2c444079762c))
 
 ### [13.0.2](https://github.com/Sage/carbon/compare/v13.0.1...v13.0.2) (2020-02-14)
 
-
 ### Bug Fixes
 
-* updated browserslist depedency of babel/preset-env ([ccd5fb7](https://github.com/Sage/carbon/commit/ccd5fb71657783f10f4b187b3281d93f56b9478c))
+- updated browserslist depedency of babel/preset-env ([ccd5fb7](https://github.com/Sage/carbon/commit/ccd5fb71657783f10f4b187b3281d93f56b9478c))
 
 ### [13.0.1](https://github.com/Sage/carbon/compare/v13.0.0...v13.0.1) (2020-02-12)
 
-
 ### Bug Fixes
 
-* **help:** allow to set different icon on help component ([487be1b](https://github.com/Sage/carbon/commit/487be1bed194f0810442ed42328474d487c2143b))
+- **help:** allow to set different icon on help component ([487be1b](https://github.com/Sage/carbon/commit/487be1bed194f0810442ed42328474d487c2143b))
 
 ## [13.0.0](https://github.com/Sage/carbon/compare/v12.4.1...v13.0.0) (2020-02-12)
 
-
 ### ⚠ BREAKING CHANGES
 
-* **modal:** The autoFocus prop on Dialog is no longer supported. To
-migrate you should manually focus an element within the Dialog using
-`ref.focus()` or use `autoFocus` on an Input.
+- **modal:** The autoFocus prop on Dialog is no longer supported. To
+  migrate you should manually focus an element within the Dialog using
+  `ref.focus()` or use `autoFocus` on an Input.
 
 ### Features
 
-* **modal:** add focus trap to Dialog and Sidebar ([8230399](https://github.com/Sage/carbon/commit/82303998b99714991a3164a7a51f7c7203b0d975))
+- **modal:** add focus trap to Dialog and Sidebar ([8230399](https://github.com/Sage/carbon/commit/82303998b99714991a3164a7a51f7c7203b0d975))
 
 ### [12.4.2](https://github.com/Sage/carbon/compare/v12.4.1...v12.4.2) (2020-03-27)
 
-
 ### Bug Fixes
 
-* **input:** add null check to input focus handler ([13095a9](https://github.com/Sage/carbon/commit/13095a90f4347ddf29e8b0f55aed18cf906070bf))
+- **input:** add null check to input focus handler ([13095a9](https://github.com/Sage/carbon/commit/13095a90f4347ddf29e8b0f55aed18cf906070bf))
 
 ### [12.4.1](https://github.com/Sage/carbon/compare/v12.4.0...v12.4.1) (2020-02-11)
 
-
 ### Bug Fixes
 
-* **card:** update card to render div instead of button ([88dfa52](https://github.com/Sage/carbon/commit/88dfa523d7141b506d3e3a146b0f60bccfc09382))
+- **card:** update card to render div instead of button ([88dfa52](https://github.com/Sage/carbon/commit/88dfa523d7141b506d3e3a146b0f60bccfc09382))
 
 ## [12.4.0](https://github.com/Sage/carbon/compare/v12.3.0...v12.4.0) (2020-02-07)
 
-
 ### Features
 
-* **form:** add data-element attribute ([d872ebd](https://github.com/Sage/carbon/commit/d872ebd4455748847011598cecb6a6fc0eb103d0))
+- **form:** add data-element attribute ([d872ebd](https://github.com/Sage/carbon/commit/d872ebd4455748847011598cecb6a6fc0eb103d0))
 
 ## [12.3.0](https://github.com/Sage/carbon/compare/v12.2.1...v12.3.0) (2020-02-07)
 
-
 ### Features
 
-* **icon:** add icons ([0d8a4fc](https://github.com/Sage/carbon/commit/0d8a4fc147d5cf8995f5985a76f85c2370199f9b))
+- **icon:** add icons ([0d8a4fc](https://github.com/Sage/carbon/commit/0d8a4fc147d5cf8995f5985a76f85c2370199f9b))
 
 ### [12.2.1](https://github.com/Sage/carbon/compare/v12.2.0...v12.2.1) (2020-02-04)
 
-
 ### Bug Fixes
 
-* **checkbox:** restore checkmark visibility on uncontrolled component ([b38e98e](https://github.com/Sage/carbon/commit/b38e98e867d5be9486a4c5f7b7623991b3c54829))
+- **checkbox:** restore checkmark visibility on uncontrolled component ([b38e98e](https://github.com/Sage/carbon/commit/b38e98e867d5be9486a4c5f7b7623991b3c54829))
 
 ## [12.2.0](https://github.com/Sage/carbon/compare/v12.1.2...v12.2.0) (2020-02-03)
 
-
 ### Features
 
-* **textbox:** add click handler to textbox icon ([8600dbe](https://github.com/Sage/carbon/commit/8600dbec47f3cff086a08f09606181902d23a623))
+- **textbox:** add click handler to textbox icon ([8600dbe](https://github.com/Sage/carbon/commit/8600dbec47f3cff086a08f09606181902d23a623))
 
 ### [12.1.2](https://github.com/Sage/carbon/compare/v12.1.1...v12.1.2) (2020-01-28)
 
-
 ### Bug Fixes
 
-* errors displayed when default theme prop is set ([35b26de](https://github.com/Sage/carbon/commit/35b26deab26b49ad553f3cfaa2d632e7e454d1f1))
-* resolve linting issues ([63ceef5](https://github.com/Sage/carbon/commit/63ceef58c6d85d2be4d2bf58f6ca2abe88a08851))
+- errors displayed when default theme prop is set ([35b26de](https://github.com/Sage/carbon/commit/35b26deab26b49ad553f3cfaa2d632e7e454d1f1))
+- resolve linting issues ([63ceef5](https://github.com/Sage/carbon/commit/63ceef58c6d85d2be4d2bf58f6ca2abe88a08851))
 
 ### [12.1.1](https://github.com/Sage/carbon/compare/v12.1.0...v12.1.1) (2020-01-27)
 
-
 ### Bug Fixes
 
-* **checkable-input:** associate label with input ([49d5d4b](https://github.com/Sage/carbon/commit/49d5d4b0a21dd9ebf469c82971741efeb978b48d))
+- **checkable-input:** associate label with input ([49d5d4b](https://github.com/Sage/carbon/commit/49d5d4b0a21dd9ebf469c82971741efeb978b48d))
 
 ## [12.1.0](https://github.com/Sage/carbon/compare/v12.0.3...v12.1.0) (2020-01-23)
 
-
 ### Features
 
-* **inline-inputs:** add gutter support ([0237ded](https://github.com/Sage/carbon/commit/0237ded89d0396699d07393f797eb03fa259afac))
+- **inline-inputs:** add gutter support ([0237ded](https://github.com/Sage/carbon/commit/0237ded89d0396699d07393f797eb03fa259afac))
 
 ### [12.0.3](https://github.com/Sage/carbon/compare/v12.0.2...v12.0.3) (2020-01-22)
 
-
 ### Bug Fixes
 
-* **date:** support for runtime value update ([8b92bff](https://github.com/Sage/carbon/commit/8b92bff610f3ce8fb30999a1b299db18bc1edcf8)), closes [#2604](https://github.com/Sage/carbon/issues/2604)
+- **date:** support for runtime value update ([8b92bff](https://github.com/Sage/carbon/commit/8b92bff610f3ce8fb30999a1b299db18bc1edcf8)), closes [#2604](https://github.com/Sage/carbon/issues/2604)
 
 ### [12.0.2](https://github.com/Sage/carbon/compare/v12.0.1...v12.0.2) (2020-01-15)
 
-
 ### Bug Fixes
 
-* **card:** export footer ([10993d6](https://github.com/Sage/carbon/commit/10993d6d21fe79200456f822d4f4037c4130a355)), closes [#2596](https://github.com/Sage/carbon/issues/2596)
+- **card:** export footer ([10993d6](https://github.com/Sage/carbon/commit/10993d6d21fe79200456f822d4f4037c4130a355)), closes [#2596](https://github.com/Sage/carbon/issues/2596)
 
 ### [12.0.1](https://github.com/Sage/carbon/compare/v12.0.0...v12.0.1) (2020-01-14)
 
-
 ### Bug Fixes
 
-* **pager:** add I18n translation to First option ([236c0e0](https://github.com/Sage/carbon/commit/236c0e0acc7a8cb2ca702f17b6182f26904a009e)), closes [#2584](https://github.com/Sage/carbon/issues/2584)
+- **pager:** add I18n translation to First option ([236c0e0](https://github.com/Sage/carbon/commit/236c0e0acc7a8cb2ca702f17b6182f26904a009e)), closes [#2584](https://github.com/Sage/carbon/issues/2584)
 
 ## [12.0.0](https://github.com/Sage/carbon/compare/v11.0.1...v12.0.0) (2020-01-13)
 
-
 ### ⚠ BREAKING CHANGES
 
-* This removes renogen in favour of semantic-release
-* This is a major version bump and includes upgrades to
-webpack dependencies
-* some tests will now fail when targeting `<a />`
-elements so this is breaking
-* carbon-factory updated to v10 to support linting of
-hooks and replace 'stage 0' flag in precompile script
-* an invariant was added to require the initial value or
-defaultValue passed to the Date component to be iso format (YYYY-MM-DD)
+- This removes renogen in favour of semantic-release
+- This is a major version bump and includes upgrades to
+  webpack dependencies
+- some tests will now fail when targeting `<a />`
+  elements so this is breaking
+- carbon-factory updated to v10 to support linting of
+  hooks and replace 'stage 0' flag in precompile script
+- an invariant was added to require the initial value or
+  defaultValue passed to the Date component to be iso format (YYYY-MM-DD)
 
 ### Features
 
-* Add toggle open close to date ([0f6f409](https://github.com/Sage/carbon/commit/0f6f4098957c67a8ce81bbf5c0359a507bcf3c01))
-* adds support for src prop in Profile ([98b15ce](https://github.com/Sage/carbon/commit/98b15ce55bf748bc40c2a2efc8f8f3cfacdabdd5))
-
+- Add toggle open close to date ([0f6f409](https://github.com/Sage/carbon/commit/0f6f4098957c67a8ce81bbf5c0359a507bcf3c01))
+- adds support for src prop in Profile ([98b15ce](https://github.com/Sage/carbon/commit/98b15ce55bf748bc40c2a2efc8f8f3cfacdabdd5))
 
 ### Bug Fixes
 
-* adds invariant for init value to be iso format ([605f560](https://github.com/Sage/carbon/commit/605f560081572107e1d400bb1dd5d1cca90968aa))
-* correct typos ([75f494a](https://github.com/Sage/carbon/commit/75f494ab1aef9f770123067ef860618f231a37e1))
-* FE-2475 header alignment change when zoomed ([9ce577f](https://github.com/Sage/carbon/commit/9ce577f4bfe53617890405590c3dca3b6648d1e7))
-* fixes [#2500](https://github.com/Sage/carbon/issues/2500) renders a button as link when onClick passed ([517f847](https://github.com/Sage/carbon/commit/517f8470b07a329ad23243b01e32f386ee829c23))
-* implements styling in Heading/ Pages for when link is button ([1e18459](https://github.com/Sage/carbon/commit/1e18459e081c21cfb96fe6b400e99bc88efed062))
-* incorrect cursor on focused link component ([5865795](https://github.com/Sage/carbon/commit/58657955f55749623cfe05f20d73ad727353c197))
-* incorrect onBlur behaviour on checkable input ([6f37b2f](https://github.com/Sage/carbon/commit/6f37b2f99dfd2e40b70fd42fc879b656cf637fd1))
-* no theme not passed correctly to themesMap ([dbe8d44](https://github.com/Sage/carbon/commit/dbe8d440e1faf85ca129a24e10256ed0fc1a7146))
-* remove console log ([850f525](https://github.com/Sage/carbon/commit/850f5254979db087a2cffc4df854bd870175db8f))
-* reposition dialog close icon to align with header ([0210bef](https://github.com/Sage/carbon/commit/0210bef63acac93a35d8acd9a36b6041dd4cc0b3))
-* typos ([705adbd](https://github.com/Sage/carbon/commit/705adbd158e6283930d358ac6e949978fb81acb4))
-* update carbon-factory ([4edc009](https://github.com/Sage/carbon/commit/4edc009809eb832154deb1d140537544d037d649))
-* **date-component:** allow null value when renderd with allowEmptyValue ([a185f86](https://github.com/Sage/carbon/commit/a185f862538fc8b0812822cb7abfed59f3884e20))
-
+- adds invariant for init value to be iso format ([605f560](https://github.com/Sage/carbon/commit/605f560081572107e1d400bb1dd5d1cca90968aa))
+- correct typos ([75f494a](https://github.com/Sage/carbon/commit/75f494ab1aef9f770123067ef860618f231a37e1))
+- FE-2475 header alignment change when zoomed ([9ce577f](https://github.com/Sage/carbon/commit/9ce577f4bfe53617890405590c3dca3b6648d1e7))
+- fixes [#2500](https://github.com/Sage/carbon/issues/2500) renders a button as link when onClick passed ([517f847](https://github.com/Sage/carbon/commit/517f8470b07a329ad23243b01e32f386ee829c23))
+- implements styling in Heading/ Pages for when link is button ([1e18459](https://github.com/Sage/carbon/commit/1e18459e081c21cfb96fe6b400e99bc88efed062))
+- incorrect cursor on focused link component ([5865795](https://github.com/Sage/carbon/commit/58657955f55749623cfe05f20d73ad727353c197))
+- incorrect onBlur behaviour on checkable input ([6f37b2f](https://github.com/Sage/carbon/commit/6f37b2f99dfd2e40b70fd42fc879b656cf637fd1))
+- no theme not passed correctly to themesMap ([dbe8d44](https://github.com/Sage/carbon/commit/dbe8d440e1faf85ca129a24e10256ed0fc1a7146))
+- remove console log ([850f525](https://github.com/Sage/carbon/commit/850f5254979db087a2cffc4df854bd870175db8f))
+- reposition dialog close icon to align with header ([0210bef](https://github.com/Sage/carbon/commit/0210bef63acac93a35d8acd9a36b6041dd4cc0b3))
+- typos ([705adbd](https://github.com/Sage/carbon/commit/705adbd158e6283930d358ac6e949978fb81acb4))
+- update carbon-factory ([4edc009](https://github.com/Sage/carbon/commit/4edc009809eb832154deb1d140537544d037d649))
+- **date-component:** allow null value when renderd with allowEmptyValue ([a185f86](https://github.com/Sage/carbon/commit/a185f862538fc8b0812822cb7abfed59f3884e20))
 
 ### Miscellaneous Chores
 
-* updates carbon-factory dependency ([c0d6ee5](https://github.com/Sage/carbon/commit/c0d6ee5f9fae2379e925e286f22bfc14c1abadca))
-* upgrade carbon-factory to v11.0.0 ([7b8f10f](https://github.com/Sage/carbon/commit/7b8f10f8b67b1a8d07cbd112b80a238370af1e05))
-
+- updates carbon-factory dependency ([c0d6ee5](https://github.com/Sage/carbon/commit/c0d6ee5f9fae2379e925e286f22bfc14c1abadca))
+- upgrade carbon-factory to v11.0.0 ([7b8f10f](https://github.com/Sage/carbon/commit/7b8f10f8b67b1a8d07cbd112b80a238370af1e05))
 
 ### Continuous Integration
 
-* remove renogen ([41a346c](https://github.com/Sage/carbon/commit/41a346caec676fe62a887d798e34a32b350b6f49))
+- remove renogen ([41a346c](https://github.com/Sage/carbon/commit/41a346caec676fe62a887d798e34a32b350b6f49))

--- a/src/components/breadcrumbs/breadcrumbs.stories.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.stories.tsx
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof Breadcrumbs>;
 
 export const Default: Story = () => {
   return (
-    <Breadcrumbs>
+    <Breadcrumbs aria-label="Default breadcrumbs">
       <Crumb href="#">Breadcrumb 1</Crumb>
       <Crumb href="#">Breadcrumb 2</Crumb>
       <Crumb href="#">Breadcrumb 3</Crumb>
@@ -37,7 +37,10 @@ Default.storyName = "Default";
 export const OnDarkBackground: Story = () => {
   return (
     <Box p={2} bg="#000">
-      <Breadcrumbs isDarkBackground>
+      <Breadcrumbs
+        isDarkBackground
+        aria-label="Breadcrumbs on a dark background"
+      >
         <Crumb href="#">Breadcrumb 1</Crumb>
         <Crumb href="#">Breadcrumb 2</Crumb>
         <Crumb href="#">Breadcrumb 3</Crumb>

--- a/src/components/card/card.stories.tsx
+++ b/src/components/card/card.stories.tsx
@@ -63,7 +63,7 @@ export const DefaultStory: Story = {
             <Typography fontSize="16px" m={0} fontWeight="500">
               Body text
             </Typography>
-            <Heading title="More text" divider={false} />
+            <Heading title="More text" headingType="h2" divider={false} />
             <Typography>Even more text</Typography>
           </CardColumn>
         </CardRow>
@@ -103,7 +103,7 @@ export const SmallSpacing: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>
@@ -142,7 +142,7 @@ export const LargeSpacing: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>
@@ -181,7 +181,7 @@ export const WithWidthProvided: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>
@@ -220,7 +220,7 @@ export const WithCustomHeight: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>
@@ -259,7 +259,7 @@ export const WithExtraRoundness: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>
@@ -352,7 +352,7 @@ export const WithCustomBoxShadow: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>
@@ -390,7 +390,7 @@ export const DifferentCardRowPadding: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>
@@ -399,7 +399,7 @@ export const DifferentCardRowPadding: Story = () => {
           <Typography fontSize="16px" m={0} fontWeight="500">
             Body text
           </Typography>
-          <Heading title="More text" divider={false} />
+          <Heading title="More text" headingType="h2" divider={false} />
           <Typography>Even more text</Typography>
         </CardColumn>
       </CardRow>

--- a/src/components/definition-list/definition-list.stories.tsx
+++ b/src/components/definition-list/definition-list.stories.tsx
@@ -104,7 +104,7 @@ AsASingleColumn.storyName = "As a single column";
 export const MultipleSingleColumnsWithSegments: Story = () => (
   <Box width="65%" px={2} pt={4} pb={3}>
     <Box width="90%">
-      <Typography color="rgba(0,0,0,0.55)" variant="segment-subheader-alt">
+      <Typography color="rgba(0,0,0,0.55)" variant="h4">
         Segment Header
       </Typography>
       <Hr ml={0} mt={2} />

--- a/src/components/drawer/drawer.stories.tsx
+++ b/src/components/drawer/drawer.stories.tsx
@@ -629,6 +629,7 @@ export const CustomSidebar: Story = (args: DrawerProps) => {
                 ]}
               />
             }
+            title="Custom Sidebar - FlatTable component as sidebar content"
           >
             <FlatTableHead>
               <FlatTableRow>
@@ -669,7 +670,7 @@ export const CustomContent: Story = (args: DrawerProps) => (
       }
       {...args}
     >
-      <FlatTable>
+      <FlatTable title="Table for Custom Content - FlatTable component as drawer content">
         <FlatTableHead>
           <FlatTableRow>
             <FlatTableHeader>Client</FlatTableHeader>

--- a/src/components/flat-table/flat-table.component.tsx
+++ b/src/components/flat-table/flat-table.component.tsx
@@ -51,6 +51,8 @@ export interface FlatTableProps
   overflowX?: string;
   /** Width of the table. Any valid CSS string */
   width?: string;
+  /** The title to describe the table when one or more tables are used on a single page */
+  title?: string;
 }
 
 const FOCUSABLE_ROW_AND_CELL_QUERY =
@@ -73,6 +75,7 @@ export const FlatTable = ({
   minHeight,
   overflowX,
   width,
+  title,
   ...rest
 }: FlatTableProps) => {
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -254,6 +257,7 @@ export const FlatTable = ({
       isFocused={focused}
       {...rest}
       data-component="flat-table-wrapper"
+      title={title}
     >
       <StyledTableContainer
         ref={container}

--- a/src/components/flat-table/flat-table.stories.tsx
+++ b/src/components/flat-table/flat-table.stories.tsx
@@ -52,7 +52,7 @@ type Story = StoryObj<typeof FlatTable>;
 export const DefaultStory: Story = {
   name: "Default",
   render: (args) => (
-    <FlatTable {...args}>
+    <FlatTable {...args} title="Table for Default Story">
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader>
@@ -125,7 +125,7 @@ export const DefaultStory: Story = {
 
 export const WithRowHeader: Story = () => {
   return (
-    <FlatTable width="380px" overflowX="auto">
+    <FlatTable width="380px" overflowX="auto" title="Table for Row Header">
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader>ID Number</FlatTableHeader>
@@ -173,7 +173,11 @@ WithRowHeader.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithMultipleRowHeaders: Story = () => {
   return (
-    <FlatTable width="680px" overflowX="auto">
+    <FlatTable
+      width="680px"
+      overflowX="auto"
+      title="Table for Multiple Row Headers"
+    >
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader>Sticky Column</FlatTableHeader>
@@ -299,6 +303,7 @@ export const HorizontalScrolling: Story = () => {
       width="380px"
       overflowX="auto"
       aria-label="Horizontal scroll table"
+      title="Table for Horizontal Scroll Table"
     >
       <FlatTableHead>
         <FlatTableRow>
@@ -342,7 +347,7 @@ HorizontalScrolling.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithCustomCellPaddings: Story = () => {
   return (
-    <FlatTable>
+    <FlatTable title="Table for Custom Cell Paddings">
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader px={1} py={2}>
@@ -376,7 +381,7 @@ WithCustomCellPaddings.storyName = "With Custom Cell Paddings";
 
 export const WithCustomColumnWidth: Story = () => {
   return (
-    <FlatTable>
+    <FlatTable title="Table for Custom Column Width">
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader width={80}>Name</FlatTableHeader>
@@ -415,7 +420,7 @@ WithCustomColumnWidth.storyName = "With Custom Column Width";
 
 export const WithCustomRowBackgroundColor: Story = () => {
   return (
-    <FlatTable>
+    <FlatTable title="Table for Custom Row Backgroun Colour">
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableRowHeader>No.</FlatTableRowHeader>
@@ -467,7 +472,7 @@ WithCustomRowBackgroundColor.storyName = "With Custom Row Background Color";
 
 export const WithCustomHorizontalBorderSize: Story = () => {
   return (
-    <FlatTable>
+    <FlatTable title="Table for Custom Horizontal Border Size">
       <FlatTableHead>
         <FlatTableRow horizontalBorderSize="large">
           <FlatTableHeader>Name</FlatTableHeader>
@@ -503,7 +508,7 @@ WithCustomHorizontalBorderSize.storyName = "With Custom Horizontal Border Size";
 
 export const WithCustomHorizontalBorderColor: Story = () => {
   return (
-    <FlatTable>
+    <FlatTable title="Table for Custom Horizontal Border Colour">
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader>Name</FlatTableHeader>
@@ -546,7 +551,10 @@ WithCustomHorizontalBorderColor.storyName =
 
 export const WithCustomBottomBorderRadius: Story = () => {
   return (
-    <FlatTable bottomBorderRadius="borderRadius000">
+    <FlatTable
+      bottomBorderRadius="borderRadius000"
+      title="Table for Custom Bottom Border Radius"
+    >
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader>Name</FlatTableHeader>
@@ -588,7 +596,7 @@ WithCustomBottomBorderRadius.storyName = "With Custom Bottom Border Radius";
 
 export const WithCustomVerticalBorders: Story = () => {
   return (
-    <FlatTable>
+    <FlatTable title="Table for Custom Vertical Borders">
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader verticalBorder="small" verticalBorderColor="#335CDC">
@@ -679,7 +687,7 @@ WithCustomVerticalBorders.storyName = "With Custom Vertical Borders";
 
 export const WithAlternativeHeaderBackground: Story = () => {
   return (
-    <FlatTable>
+    <FlatTable title="Table for Alternative Header Background">
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader rowspan="2">Name</FlatTableHeader>
@@ -730,7 +738,7 @@ WithAlternativeHeaderBackground.storyName =
 
 export const WithTruncatedCellContent: Story = () => {
   return (
-    <FlatTable>
+    <FlatTable title="Table for Truncated Cell Content">
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader>Name</FlatTableHeader>
@@ -761,7 +769,7 @@ WithTruncatedCellContent.storyName = "With Truncated Cell Content";
 export const WithStickyHead: Story = () => {
   return (
     <Box height="150px">
-      <FlatTable hasStickyHead>
+      <FlatTable hasStickyHead title="Table for Sticky Header">
         <FlatTableHead>
           <FlatTableRow>
             <FlatTableHeader>Name</FlatTableHeader>
@@ -811,7 +819,13 @@ WithStickyHead.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithStickyHeadRowSpanAndColspan: Story = () => {
   return (
-    <FlatTable hasStickyHead height="380px" width="310px" overflowX="auto">
+    <FlatTable
+      hasStickyHead
+      height="380px"
+      width="310px"
+      overflowX="auto"
+      title="Table for Sticky Header with Row and Column spans"
+    >
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader rowspan={2}>Name</FlatTableHeader>
@@ -1047,6 +1061,7 @@ export const WithStickyFooter: Story = () => {
   return (
     <Box height={220} marginBottom={16}>
       <FlatTable
+        title="Table for Sticky Footer"
         hasStickyHead
         hasStickyFooter
         footer={
@@ -1114,6 +1129,7 @@ export const WithStickyFooterInsideOfLargerDiv: Story = () => {
   return (
     <Box height="220px" marginBottom="16px">
       <FlatTable
+        title="Table for Sticky Footer inside large Div"
         hasStickyHead
         hasStickyFooter
         footer={
@@ -1181,6 +1197,7 @@ export const WithHasMaxHeight: Story = () => {
   return (
     <Box height="180px" marginBottom="16px">
       <FlatTable
+        title="Table for Max Height"
         hasMaxHeight
         footer={
           <Pager
@@ -1223,7 +1240,7 @@ export const WithoutVerticalBorders: Story = {
 
 export const WithClickableRows: Story = () => {
   return (
-    <FlatTable>
+    <FlatTable title="Table for Clickable Rows">
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader>Name</FlatTableHeader>
@@ -1266,7 +1283,7 @@ WithClickableRows.parameters = { chromatic: { disableSnapshot: true } };
 
 export const Zebra: Story = () => {
   return (
-    <FlatTable isZebra>
+    <FlatTable isZebra title="Table for Zebra">
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader>Name</FlatTableHeader>
@@ -1404,7 +1421,7 @@ export const WithSortingHeaders: Story = {
     };
 
     return (
-      <FlatTable {...args}>
+      <FlatTable {...args} title="Table for sorting headers">
         <FlatTableHead>
           <FlatTableRow>
             {headData.map(({ name, isActive }) => {
@@ -1533,7 +1550,10 @@ export const WithSortingHeadersAndCustomAccessibleName: Story = {
     };
 
     return (
-      <FlatTable {...args}>
+      <FlatTable
+        {...args}
+        title="Table for sorting headers with custom accessible name"
+      >
         <FlatTableHead>
           <FlatTableRow>
             {headData.map(({ name, isActive }) => {
@@ -1567,7 +1587,7 @@ export const WithSortingHeadersAndCustomAccessibleName: Story = {
 
 export const WithColspan: Story = () => {
   return (
-    <FlatTable>
+    <FlatTable title="Table for Col Span">
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader>Name</FlatTableHeader>
@@ -1590,7 +1610,7 @@ WithColspan.storyName = "With colspan";
 
 export const WithRowspan: Story = () => {
   return (
-    <FlatTable>
+    <FlatTable title="Table for Row Span">
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader>Parent Name</FlatTableHeader>
@@ -1663,7 +1683,7 @@ export const WithSelectableRows: Story = () => {
           <Icon type="pdf" />
         </IconButton>
       </BatchSelection>
-      <FlatTable>
+      <FlatTable title="Table for Selectable Rows">
         <FlatTableHead>
           <FlatTableRow>
             <FlatTableCheckbox
@@ -1750,7 +1770,7 @@ export const WithHighlightableRows: Story = () => {
   };
 
   return (
-    <FlatTable>
+    <FlatTable title="Table for highlightable rows">
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader>Name</FlatTableHeader>
@@ -1857,7 +1877,7 @@ export const WithSelectableAndHighlightableRows: Story = () => {
           <Icon type="pdf" />
         </IconButton>
       </BatchSelection>
-      <FlatTable>
+      <FlatTable title="Table for selectable and highlightable rows">
         <FlatTableHead>
           <FlatTableRow>
             <FlatTableCheckbox
@@ -2081,6 +2101,7 @@ export const Paginated: Story = () => {
 
   return (
     <FlatTable
+      title="Table for pagination"
       footer={
         <Pager
           totalRecords={rows.length}
@@ -2470,6 +2491,7 @@ export const PaginatedWithStickyHeader: Story = () => {
   return (
     <Box height="200px">
       <FlatTable
+        title="Table for pagination with sticky header and footer"
         hasStickyHead
         hasStickyFooter
         footer={
@@ -2555,7 +2577,7 @@ export const WhenAChildOfSidebar: Story = () => {
         </IconButton>
       </BatchSelection>
       <DrawerSidebarContext.Provider value={{ isInSidebar: true }}>
-        <FlatTable>
+        <FlatTable title="Table for child of sidebar">
           <FlatTableHead>
             <FlatTableRow>
               <FlatTableCheckbox
@@ -2653,7 +2675,11 @@ export const Sizes: Story = () => {
     <Box>
       {sizes.map((size) => (
         <Box mb={3} key={size}>
-          <FlatTable size={size} aria-label={`flat-table-${size}`}>
+          <FlatTable
+            size={size}
+            aria-label={`flat-table-${size}`}
+            title={`Table for ${size} Size`}
+          >
             <FlatTableHead>
               <FlatTableRow>
                 <FlatTableHeader>Name</FlatTableHeader>
@@ -2716,7 +2742,7 @@ export const WithDraggableRows: Story = () => {
     },
   ];
   return (
-    <FlatTable>
+    <FlatTable title="Table for draggable rows">
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader />
@@ -2745,7 +2771,11 @@ export const WrappingRowHeaders: Story = () => {
   FlatTableRowHeaderWrapper.displayName = FlatTableRowHeader.displayName;
 
   return (
-    <FlatTable width="310px" overflowX="auto">
+    <FlatTable
+      width="310px"
+      overflowX="auto"
+      title="Table for wrapping row headers"
+    >
       <FlatTableHead>
         <FlatTableRow>
           <FlatTableHeader>Name</FlatTableHeader>

--- a/src/components/flat-table/flat-table.test.tsx
+++ b/src/components/flat-table/flat-table.test.tsx
@@ -1441,3 +1441,25 @@ test("should not throw an error when FlatTableHead rows have only one child", ()
     );
   }).not.toThrow();
 });
+
+test("should set the title correctly", () => {
+  render(
+    <FlatTable title="this is a title">
+      <FlatTableHead>
+        <FlatTableRow>
+          <FlatTableHeader>heading one</FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+      <FlatTableBody>
+        <FlatTableRow>
+          <FlatTableCell>child one</FlatTableCell>
+        </FlatTableRow>
+      </FlatTableBody>
+    </FlatTable>,
+  );
+
+  expect(screen.getByTestId("flat-table-wrapper")).toHaveAttribute(
+    "title",
+    "this is a title",
+  );
+});

--- a/src/components/global-header/global-header.stories.tsx
+++ b/src/components/global-header/global-header.stories.tsx
@@ -39,14 +39,25 @@ export default meta;
 type Story = StoryObj<typeof GlobalHeader>;
 
 export const Default: Story = () => {
-  return <GlobalHeader>Example content</GlobalHeader>;
+  return (
+    <GlobalHeader aria-label="Default global header component">
+      Example content
+    </GlobalHeader>
+  );
 };
 Default.storyName = "Default";
 
 export const WithLogo: Story = () => {
   const Logo = () => <img height={28} src={carbonLogo} alt="Carbon logo" />;
 
-  return <GlobalHeader logo={<Logo />}>Example content</GlobalHeader>;
+  return (
+    <GlobalHeader
+      logo={<Logo />}
+      aria-label="Global header component with logo"
+    >
+      Example content
+    </GlobalHeader>
+  );
 };
 WithLogo.storyName = "With Logo";
 
@@ -54,7 +65,10 @@ export const BasicMenu: Story = () => {
   const Logo = () => <img height={28} src={carbonLogo} alt="Carbon logo" />;
 
   return (
-    <GlobalHeader logo={<Logo />}>
+    <GlobalHeader
+      logo={<Logo />}
+      aria-label="Global header component with basic menu"
+    >
       <Menu menuType="black" flex="1">
         <MenuItem flex="1" submenu="Product Switcher">
           <MenuItem>Product A</MenuItem>
@@ -111,7 +125,10 @@ export const ResponsiveMenu: Story = () => {
   const Logo = () => <img height={28} src={carbonLogo} alt="Carbon logo" />;
 
   return (
-    <GlobalHeader logo={<Logo />}>
+    <GlobalHeader
+      logo={<Logo />}
+      aria-label="Global header component with responsive menu"
+    >
       <Menu menuType="black" flex="1">
         {fullscreenViewBreakPoint ? (
           <>
@@ -144,8 +161,11 @@ export const GlobalLocalNavBarLayout: Story = () => {
 
   return (
     <>
-      <GlobalHeader logo={<Logo />}>
-        <Menu menuType="black" flex="1">
+      <GlobalHeader
+        logo={<Logo />}
+        aria-label="Global header component with local nav bar"
+      >
+        <Menu menuType="black" flex="1" aria-label="Menu bar">
           <MenuItem flex="1" submenu="Product Switcher">
             <MenuItem href="#">Product A</MenuItem>
           </MenuItem>
@@ -159,7 +179,12 @@ export const GlobalLocalNavBarLayout: Story = () => {
           </MenuItem>
         </Menu>
       </GlobalHeader>
-      <NavigationBar position="fixed" orientation="top" offset="40px">
+      <NavigationBar
+        position="fixed"
+        orientation="top"
+        offset="40px"
+        aria-label="Local nav bar"
+      >
         <Menu flex="1">
           <MenuItem href="#" flex="1">
             Menu Item One

--- a/src/components/icon/icon.stories.tsx
+++ b/src/components/icon/icon.stories.tsx
@@ -41,6 +41,7 @@ export const WithTooltip: Story = () => {
         type="add"
         tooltipMessage="Hey I'm a default tooltip!"
         ariaLabel="Icon with tooltip"
+        role="img"
       />
       <Icon
         mr={8}
@@ -51,6 +52,7 @@ export const WithTooltip: Story = () => {
           </>
         }
         ariaLabel="Icon with tooltip"
+        role="img"
       />
       <Icon
         mr={8}
@@ -58,6 +60,7 @@ export const WithTooltip: Story = () => {
         tooltipMessage="Hey I'm a tooltip with a different position!"
         tooltipPosition="bottom"
         ariaLabel="Icon with tooltip"
+        role="img"
       />
       <Icon
         mr={8}
@@ -66,12 +69,14 @@ export const WithTooltip: Story = () => {
         tooltipBgColor="lightblue"
         tooltipFontColor="black"
         ariaLabel="Icon with tooltip"
+        role="img"
       />
       <Icon
         type="add"
         tooltipMessage="Hey I'm a tooltip with flip behaviour overrides!"
         tooltipFlipOverrides={["right", "left"]}
         ariaLabel="Icon with tooltip"
+        role="img"
       />
     </Box>
   );

--- a/src/components/link/link.stories.tsx
+++ b/src/components/link/link.stories.tsx
@@ -82,7 +82,7 @@ export const WithIsSkipLink: Story = () => {
         <MenuItem href="#">Menu Item 5</MenuItem>
       </Menu>
       <Box py={2} id="main-content">
-        <Typography mb={1} variant="h1">
+        <Typography mb={1} variant="h2">
           {" "}
           This is header of main content container{" "}
         </Typography>

--- a/src/components/pages/pages.stories.tsx
+++ b/src/components/pages/pages.stories.tsx
@@ -50,7 +50,12 @@ export const Default: Story = () => {
   return (
     <>
       <Button onClick={handleOpen}>Open Preview</Button>
-      <DialogFullScreen pagesStyling open={isOpen} onCancel={handleCancel}>
+      <DialogFullScreen
+        pagesStyling
+        open={isOpen}
+        onCancel={handleCancel}
+        aria-label="Full-screen dialog"
+      >
         <Pages pageIndex={pageIndex}>
           <Page title={<Heading title="My First Page" />}>
             <Button onClick={handleOnClick} disabled={isDisabled}>

--- a/src/components/pod/pod.stories.tsx
+++ b/src/components/pod/pod.stories.tsx
@@ -311,7 +311,7 @@ export const AddressExample: Story = () => {
   return (
     <Pod internalEditButton variant="tertiary">
       <Box>
-        <Typography variant="h5" fontWeight="500">
+        <Typography variant="h4" fontWeight="500">
           Unit 1
         </Typography>
         <Typography m={0}>South Nelson Industrial Estate</Typography>

--- a/src/components/popover-container/popover-container.mdx
+++ b/src/components/popover-container/popover-container.mdx
@@ -57,11 +57,11 @@ Use the `renderOpenComponent` and `renderCloseComponent` to render your own open
 
 These props use a render prop pattern - https://reactjs.org/docs/render-props.html
 
-##### Props passed through renderOpenComponent:
+#### Props passed through renderOpenComponent:
 
 <ArgTypes of={RenderOpenStories} />
 
-##### Props passed through renderCloseComponent:
+#### Props passed through renderCloseComponent:
 
 <ArgTypes of={RenderCloseStories} />
 

--- a/src/components/step-flow/step-flow.stories.tsx
+++ b/src/components/step-flow/step-flow.stories.tsx
@@ -51,7 +51,14 @@ export default meta;
 type Story = StoryObj<typeof StepFlow>;
 
 export const DefaultStory: Story = () => {
-  return <StepFlow title="Step title" currentStep={1} totalSteps={6} />;
+  return (
+    <StepFlow
+      title="Step title"
+      titleVariant="h2"
+      currentStep={1}
+      totalSteps={6}
+    />
+  );
 };
 DefaultStory.storyName = "Default";
 
@@ -63,7 +70,14 @@ export const TitleNodeStory: Story = () => {
     </Box>
   );
 
-  return <StepFlow title={titleNode} currentStep={1} totalSteps={6} />;
+  return (
+    <StepFlow
+      title={titleNode}
+      titleVariant="h2"
+      currentStep={1}
+      totalSteps={6}
+    />
+  );
 };
 TitleNodeStory.storyName = "Title Node";
 
@@ -71,6 +85,7 @@ export const TitleNodeStoryWithScreenReaderOnlyTitle: Story = () => {
   const titleNode = (
     <Box display="flex" alignItems="center">
       <StepFlowTitle
+        titleVariant="h2"
         titleString="Step title"
         screenReaderOnlyTitle="Step Title with a pointer image"
       />
@@ -93,6 +108,7 @@ export const CategoryStory: Story = () => {
       title="Step title"
       currentStep={1}
       totalSteps={6}
+      titleVariant="h2"
     />
   );
 };
@@ -106,6 +122,7 @@ export const ShowProgressIndicatorStory: Story = () => {
       currentStep={1}
       totalSteps={6}
       showProgressIndicator
+      titleVariant="h2"
     />
   );
 };
@@ -119,6 +136,7 @@ export const CurrentStepStory: Story = () => {
       currentStep={5}
       totalSteps={6}
       showProgressIndicator
+      titleVariant="h2"
     />
   );
 };
@@ -132,6 +150,7 @@ export const TotalStepsStory: Story = () => {
       currentStep={5}
       totalSteps={8}
       showProgressIndicator
+      titleVariant="h2"
     />
   );
 };
@@ -149,6 +168,7 @@ export const ShowCloseIconStory: Story = () => {
       totalSteps={6}
       showCloseIcon
       onDismiss={() => ""}
+      titleVariant="h2"
     />
   );
 };
@@ -191,6 +211,7 @@ export const ExampleImplementation: Story = () => {
             showCloseIcon
             onDismiss={() => setIsOpen(false)}
             mb="20px"
+            titleVariant="h2"
           />
         }
       >
@@ -265,6 +286,7 @@ export const ExampleImplementationWithTitleNode: Story = () => {
             showCloseIcon
             onDismiss={() => setIsOpen(false)}
             mb="20px"
+            titleVariant="h2"
           />
         }
       >

--- a/src/components/vertical-menu/vertical-menu.stories.tsx
+++ b/src/components/vertical-menu/vertical-menu.stories.tsx
@@ -63,7 +63,7 @@ const Link = ({ to, children, className }: LinkProps) => {
 
 export const Default: Story = () => (
   <Box height="100vh">
-    <VerticalMenu>
+    <VerticalMenu aria-label="Default vertical menu">
       <VerticalMenuItem
         iconType="analysis"
         adornment={(isOpen) =>
@@ -145,7 +145,11 @@ export const Default: Story = () => (
 Default.storyName = "Default";
 
 export const CustomWidthAndHeight: Story = () => (
-  <VerticalMenu width="500px" height="100vh">
+  <VerticalMenu
+    width="500px"
+    height="100vh"
+    aria-label="Vertical menu with custom width and height"
+  >
     <VerticalMenuItem
       iconType="analysis"
       adornment={
@@ -163,7 +167,7 @@ export const CustomWidthAndHeight: Story = () => (
 CustomWidthAndHeight.storyName = "Custom Width and Height";
 
 export const Adornment: Story = () => (
-  <VerticalMenu>
+  <VerticalMenu aria-label="Vertical menu with adornment">
     <VerticalMenuItem
       iconType="analysis"
       adornment={(isOpen) =>
@@ -191,7 +195,7 @@ export const Adornment: Story = () => (
 Adornment.storyName = "Adornment";
 
 export const Active: Story = () => (
-  <VerticalMenu>
+  <VerticalMenu aria-label="Active vertical menu">
     <VerticalMenuItem
       iconType="analysis"
       active={(isOpen) => !isOpen}
@@ -205,21 +209,21 @@ export const Active: Story = () => (
 Active.storyName = "Active";
 
 export const CustomItemPadding: Story = () => (
-  <VerticalMenu>
+  <VerticalMenu aria-label="Vertical menu with custom item padding">
     <VerticalMenuItem iconType="analysis" title="Item 1" padding="0 0 0 80px" />
   </VerticalMenu>
 );
 CustomItemPadding.storyName = "Custom Item Padding";
 
 export const CustomItemHeight: Story = () => (
-  <VerticalMenu>
+  <VerticalMenu aria-label="Vertical menu with custom item height">
     <VerticalMenuItem height="100px" iconType="analysis" title="Item 1" />
   </VerticalMenu>
 );
 CustomItemHeight.storyName = "Custom Item Height";
 
 export const CustomComponent: Story = () => (
-  <VerticalMenu>
+  <VerticalMenu aria-label="Custom vertical menu component">
     <VerticalMenuItem
       iconType="analysis"
       title="Item 1"
@@ -309,6 +313,10 @@ export const FullScreen: Story = () => {
     );
   }
 
-  return <VerticalMenu>{menuItems}</VerticalMenu>;
+  return (
+    <VerticalMenu aria-label="Full-screen vertical menu">
+      {menuItems}
+    </VerticalMenu>
+  );
 };
 FullScreen.storyName = "Full Screen";


### PR DESCRIPTION
### Proposed behaviour

The documentation offered by the storybook should be as accessible as possible. This PR aims to implement that by addressing a handful of issues:

- Changes the default secondary colour of the manager to the DS' Sage Green
- Fix the role assigned to the welcome page's headings
- Remove the duplicated `header` elements
- Add ARIA labels
- Add image alt text
- Replace blank table headings

### Current behaviour

A wide range of stories feature AXE failings, which results in a poor documentation experience for users who e.g. rely on assistive technologies.

### Checklist

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

The following issues are embedded within Storybook and can't be directly addressed:
- The Create a new story button throws a "Buttons must have discernible text" warning (only in localhost, live build is fine);
- The "Zooming and scaling" failure is due to Storybook's meta tag configuration which we can't override (so I've raised an issue with them to fix it)
- The accessibility control panel causes 4 landmark violations

### Testing instructions

Install Axe DevTools if not already installed. Open the documentation and then open the browser's inspector and switch to the DevTools tab. Run a full-page scan.
