### PR TITLE
fix(tabs): support for post-rebrand validation pattern

### DIFF
--- a/src/components/tabs/__internal__/tab-title/tab-title.style.ts
+++ b/src/components/tabs/__internal__/tab-title/tab-title.style.ts
@@ -23,6 +23,7 @@ interface StyledTitleContentProps
   hasCustomLayout?: boolean;
   hasHref?: boolean;
   hasSiblings?: boolean;
+  validationRedesignOptIn?: boolean;
 }
 
 const oldFocusStyling = `
@@ -31,7 +32,7 @@ const oldFocusStyling = `
 
 const StyledTitleContent = styled.span<StyledTitleContentProps>`
   outline: none;
-  display: inline-block;
+  display: inline-flex;
   line-height: 20px;
   margin: 0;
   position: relative;
@@ -51,6 +52,7 @@ const StyledTitleContent = styled.span<StyledTitleContentProps>`
     hasHref,
     alternateStyling,
     align,
+    validationRedesignOptIn,
   }) => css`
     text-align: ${align};
 
@@ -63,6 +65,12 @@ const StyledTitleContent = styled.span<StyledTitleContentProps>`
       border-bottom-left-radius: var(--borderRadius100);
       border-bottom-right-radius: var(--borderRadius000);
       border-top-right-radius: var(--borderRadius000);
+    `}
+
+    ${position === "left" &&
+    validationRedesignOptIn &&
+    css`
+      justify-content: space-between;
     `}
 
     ${position === "top" &&
@@ -149,7 +157,7 @@ const StyledTitleContent = styled.span<StyledTitleContentProps>`
     css`
       outline: 1px solid;
       outline-offset: -1px;
-      z-index: 2;
+      z-index: ${validationRedesignOptIn ? 1 : 2};
 
       ${info &&
       !warning &&
@@ -210,7 +218,7 @@ const StyledTitleContent = styled.span<StyledTitleContentProps>`
     css`
       outline: 2px solid var(--colorsSemanticNegative500);
       outline-offset: -2px;
-      z-index: 2;
+      z-index: ${validationRedesignOptIn ? 1 : 2};
 
       ${position === "top" &&
       css`
@@ -289,7 +297,9 @@ const StyledTitleContent = styled.span<StyledTitleContentProps>`
   `}
 `;
 
-const tabTitleStyles = css<TabTitleProps>`
+const tabTitleStyles = css<
+  TabTitleProps & { validationRedesignOptIn?: boolean }
+>`
   background-color: transparent;
   display: inline-block;
   border-top-left-radius: var(--borderRadius100);
@@ -328,6 +338,7 @@ const tabTitleStyles = css<TabTitleProps>`
     warning,
     info,
     isInSidebar,
+    validationRedesignOptIn,
   }) => css`
     height: ${size === "large" ? "var(--sizing600)" : "var(--sizing500)"};
 
@@ -360,9 +371,17 @@ const tabTitleStyles = css<TabTitleProps>`
     ${!isTabSelected &&
     css`
       color: var(--colorsActionMinorYin090);
+      ${validationRedesignOptIn &&
+      css`
+        background: transparent;
+      `}
 
       &:hover {
         background: var(--colorsActionMinor100);
+        ${validationRedesignOptIn &&
+        css`
+          background: var(--colorsUtilityMajor100);
+        `}
         color: var(--colorsActionMinorYin090);
         outline: none;
       }
@@ -415,7 +434,9 @@ const tabTitleStyles = css<TabTitleProps>`
       ${!isInSidebar &&
       !error &&
       css`
-        border-right: ${alternateStyling ? "1px" : "2px"} solid
+        --border-right-value: ${validationRedesignOptIn ? "0px" : "2px"}
+          border-right:
+          ${alternateStyling ? "1px" : "var(--border-right-value)"} solid
           var(--colorsActionMinor100);
       `}
 
@@ -443,6 +464,11 @@ const tabTitleStyles = css<TabTitleProps>`
         border-right: none;
       `}
 
+      ${!isTabSelected &&
+      css`
+        border-right-color: var(--colorsActionMinor100);
+      `}
+
       ${isTabSelected &&
       css`
         ${alternateStyling &&
@@ -456,7 +482,9 @@ const tabTitleStyles = css<TabTitleProps>`
           padding-bottom: 0px;
 
           ${StyledTitleContent} {
-            ${!(error || warning || info) && "margin-right: 2px;"}
+            ${!(error || warning || info) &&
+            !validationRedesignOptIn &&
+            "margin-right: 2px;"}
             border-right: none;
           }
         `}
@@ -510,6 +538,7 @@ interface StyledLayoutWrapperProps
   extends Pick<TabTitleProps, "titlePosition" | "position"> {
   hasCustomLayout?: boolean;
   hasCustomSibling?: boolean;
+  validationRedesignOptIn?: boolean;
 }
 
 const StyledLayoutWrapper = styled.div<StyledLayoutWrapperProps>`
@@ -518,6 +547,7 @@ const StyledLayoutWrapper = styled.div<StyledLayoutWrapperProps>`
     titlePosition = "before",
     hasCustomSibling,
     position,
+    validationRedesignOptIn,
   }) => css`
     ${hasCustomLayout &&
     css`
@@ -547,29 +577,61 @@ const StyledLayoutWrapper = styled.div<StyledLayoutWrapperProps>`
         z-index: 10;
 
         ${StyledIcon} {
-          height: 16px;
+          height: ${validationRedesignOptIn ? "0px" : "16px"};
           left: -2px;
-          top: ${position === "left" ? "1px" : "3px"};
         }
       }
     `}
   `}
 `;
 
-type StyledSelectedIndicatorProps = Pick<TabTitleProps, "position">;
+const StyledVerticalIndicator = styled.div`
+  position: absolute;
+  top: 0px;
+  bottom: 0px;
+  right: 0px;
+  box-shadow: inset calc(-1 * var(--sizing050)) 0px 0px 0px
+    var(--colorsActionMinor100);
+  width: 2px;
+  z-index: 1;
+`;
+
+type StyledSelectedIndicatorProps = Pick<
+  TabTitleProps,
+  "position" | "error" | "warning"
+> & {
+  validationRedesignOptIn?: boolean;
+};
 
 const StyledSelectedIndicator = styled.div<StyledSelectedIndicatorProps>`
   position: absolute;
   z-index: 1;
+  ${(validationRedesignOptIn) => css`
+    ${validationRedesignOptIn &&
+    css`
+      z-index: 2;
+    `}
+  `}
 
-  ${({ position = "top" }) => css`
+  ${({ position = "top", warning, error }) => css`
+    --selected-indicator-color: var(--colorsActionMajor500);
+
+    ${warning &&
+    css`
+      --selected-indicator-color: var(--colorsSemanticCaution500);
+    `}
+
+    ${error &&
+    css`
+      --selected-indicator-color: var(--colorsSemanticNegative500);
+    `}
     ${position === "top" &&
     css`
       bottom: 0px;
       left: 0px;
       right: 0px;
       box-shadow: inset 0px calc(-1 * var(--sizing050)) 0px
-        var(--colorsActionMajor500);
+        var(--selected-indicator-color);
       height: var(--sizing050);
     `}
 
@@ -579,7 +641,7 @@ const StyledSelectedIndicator = styled.div<StyledSelectedIndicatorProps>`
       bottom: 0px;
       right: 0px;
       box-shadow: inset calc(-1 * var(--sizing050)) 0px 0px 0px
-        var(--colorsActionMajor500);
+        var(--selected-indicator-color);
       width: var(--sizing050);
     `}
   `}
@@ -591,4 +653,5 @@ export {
   StyledTitleContent,
   StyledLayoutWrapper,
   StyledSelectedIndicator,
+  StyledVerticalIndicator,
 };

--- a/src/components/tabs/__internal__/tabs-header/tabs-header.component.tsx
+++ b/src/components/tabs/__internal__/tabs-header/tabs-header.component.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useContext } from "react";
 import {
   StyledTabsHeaderWrapper,
   StyledTabsHeaderList,
@@ -8,6 +8,7 @@ import {
   StyledVerticalTabsWrapper,
 } from "./tabs-header.style";
 import useThrottle from "../../../../hooks/__internal__/useThrottle";
+import NewValidationContext from "../../../carbon-provider/__internal__/new-validation.context";
 
 /*  In the original prototype the tabs have shadows that fade out as you scroll horizontally.
  *  This value is the closest replication to the way that the shadow disappears.
@@ -43,6 +44,8 @@ const TabsHeader = ({
 }: TabHeaderProps) => {
   const [leftScrollOpacity, setLeftScrollOpacity] = useState(0);
   const [rightScrollOpacity, setRightScrollOpacity] = useState(1);
+
+  const { validationRedesignOptIn } = useContext(NewValidationContext);
 
   const ref = useRef<HTMLDivElement>(null);
 
@@ -83,7 +86,9 @@ const TabsHeader = ({
       >
         {position === "top" ? (
           <StyledTabsWrapper>
-            <StyledTabsBottomBorderWrapper>
+            <StyledTabsBottomBorderWrapper
+              validationRedesignOptIn={validationRedesignOptIn}
+            >
               <StyledTabsBottomBorder />
             </StyledTabsBottomBorderWrapper>
             {children}

--- a/src/components/tabs/__internal__/tabs-header/tabs-header.style.ts
+++ b/src/components/tabs/__internal__/tabs-header/tabs-header.style.ts
@@ -165,11 +165,16 @@ const StyledVerticalTabsWrapper = styled.div<StyledVerticalTabsWrapperProps>`
   flex-direction: column;
 `;
 
-const StyledTabsBottomBorderWrapper = styled.div`
+const StyledTabsBottomBorderWrapper = styled.div<{
+  validationRedesignOptIn?: boolean;
+}>`
   position: absolute;
   width: 100%;
   height: auto;
-  bottom: 0;
+  bottom: 0px;
+  ${({ validationRedesignOptIn }) => css`
+    z-index: ${validationRedesignOptIn ? 2 : ""};
+  `}
 `;
 
 const StyledTabsBottomBorder = styled.div`

--- a/src/components/tabs/tabs.mdx
+++ b/src/components/tabs/tabs.mdx
@@ -241,6 +241,15 @@ const App = () => {
 };
 ```
 
+### New Validation
+
+The following examples use the new validation pattern that is available by setting the `validationRedesignOptIn` flag on the `CarbonProvider` to true.
+
+<Canvas
+  of={TabsStories.WithNewValidationRedesign}
+  name="tabs positioned top"
+/>
+
 ## Props
 
 ### Tabs

--- a/src/components/tabs/tabs.stories.tsx
+++ b/src/components/tabs/tabs.stories.tsx
@@ -9,6 +9,7 @@ import Pill from "../pill";
 import Icon from "../icon";
 import Box from "../box";
 import { Tabs, Tab } from ".";
+import CarbonProvider from "../carbon-provider/carbon-provider.component";
 
 const styledSystemProps = generateStyledSystemProps({
   margin: true,
@@ -889,6 +890,213 @@ export const WithValidationsPositionedTop: Story = () => {
 };
 WithValidationsPositionedTop.storyName = "With Validations Positioned Top";
 
+export const WithNewValidationRedesign: Story = () => {
+  const [errors, setErrors] = useState({
+    one: true,
+    two: false,
+    three: false,
+  });
+  const [warnings, setWarnings] = useState({
+    one: true,
+    two: true,
+    three: false,
+  });
+  const [infos, setInfos] = useState({ one: true, two: true, three: true });
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      <Box p="4px">
+        <Tabs align="left" position="top">
+          <Tab
+            errorMessage="this is an error message"
+            warningMessage="this is a warning message"
+            infoMessage="info"
+            tabId="tab-1"
+            title="Tab 1"
+            key="tab-1"
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.one}
+              onChange={() => setErrors({ ...errors, one: !errors.one })}
+              checked={errors.one}
+            />
+            <Checkbox
+              label="Add warning"
+              warning={warnings.one}
+              onChange={() => setWarnings({ ...warnings, one: !warnings.one })}
+              checked={warnings.one}
+            />
+            <Checkbox
+              label="Add info"
+              info={infos.one}
+              onChange={() => setInfos({ ...infos, one: !infos.one })}
+              checked={infos.one}
+            />
+          </Tab>
+          <Tab
+            errorMessage="this is an error message"
+            warningMessage="this is a warning message"
+            infoMessage="info"
+            tabId="tab-2"
+            title="Tab 2"
+            key="tab-2"
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.two}
+              onChange={() => setErrors({ ...errors, two: !errors.two })}
+            />
+            <Checkbox
+              label="Add warning"
+              warning={warnings.two}
+              onChange={() => setWarnings({ ...warnings, two: !warnings.two })}
+              checked={warnings.two}
+            />
+            <Checkbox
+              label="Add info"
+              info={infos.two}
+              onChange={() => setInfos({ ...infos, two: !infos.two })}
+              checked={infos.two}
+            />
+          </Tab>
+          <Tab
+            errorMessage="this is an error message"
+            warningMessage="this is a warning message"
+            infoMessage="info"
+            tabId="tab-3"
+            title="Tab 3"
+            key="tab-3"
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.three}
+              onChange={() => setErrors({ ...errors, three: !errors.three })}
+            />
+            <Checkbox
+              label="Add warning"
+              warning={warnings.three}
+              onChange={() =>
+                setWarnings({ ...warnings, three: !warnings.three })
+              }
+            />
+            <Checkbox
+              label="Add info"
+              info={infos.three}
+              onChange={() => setInfos({ ...infos, three: !infos.three })}
+              checked={infos.three}
+            />
+          </Tab>
+        </Tabs>
+      </Box>
+    </CarbonProvider>
+  );
+};
+WithNewValidationRedesign.storyName = "With New Validation Positioned Top";
+
+export const WithNewValidationsSizedLargePositionedTop: Story = () => {
+  const [errors, setErrors] = useState({
+    one: true,
+    two: false,
+    three: false,
+  });
+  const [warnings, setWarnings] = useState({
+    one: true,
+    two: true,
+    three: false,
+  });
+  const [infos, setInfos] = useState({ one: true, two: true, three: true });
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      <Box p="4px">
+        <Tabs size="large" align="left" position="top">
+          <Tab
+            errorMessage="error"
+            warningMessage="warning"
+            infoMessage="info"
+            tabId="tab-1"
+            title="Tab 1"
+            key="tab-1"
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.one}
+              onChange={() => setErrors({ ...errors, one: !errors.one })}
+              checked={errors.one}
+            />
+            <Checkbox
+              label="Add warning"
+              warning={warnings.one}
+              onChange={() => setWarnings({ ...warnings, one: !warnings.one })}
+              checked={warnings.one}
+            />
+            <Checkbox
+              label="Add info"
+              info={infos.one}
+              onChange={() => setInfos({ ...infos, one: !infos.one })}
+              checked={infos.one}
+            />
+          </Tab>
+          <Tab
+            errorMessage="error"
+            warningMessage="warning"
+            infoMessage="info"
+            tabId="tab-2"
+            title="Tab 2"
+            key="tab-2"
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.two}
+              onChange={() => setErrors({ ...errors, two: !errors.two })}
+            />
+            <Checkbox
+              label="Add warning"
+              warning={warnings.two}
+              onChange={() => setWarnings({ ...warnings, two: !warnings.two })}
+              checked={warnings.two}
+            />
+            <Checkbox
+              label="Add info"
+              info={infos.two}
+              onChange={() => setInfos({ ...infos, two: !infos.two })}
+              checked={infos.two}
+            />
+          </Tab>
+          <Tab
+            errorMessage="error"
+            warningMessage="warning"
+            infoMessage="info"
+            tabId="tab-3"
+            title="Tab 3"
+            key="tab-3"
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.three}
+              onChange={() => setErrors({ ...errors, three: !errors.three })}
+            />
+            <Checkbox
+              label="Add warning"
+              warning={warnings.three}
+              onChange={() =>
+                setWarnings({ ...warnings, three: !warnings.three })
+              }
+            />
+            <Checkbox
+              label="Add info"
+              info={infos.three}
+              onChange={() => setInfos({ ...infos, three: !infos.three })}
+              checked={infos.three}
+            />
+          </Tab>
+        </Tabs>
+      </Box>
+    </CarbonProvider>
+  );
+};
+WithNewValidationsSizedLargePositionedTop.storyName =
+  "With New Validations Sized Large Positioned Top";
+
 export const WithValidationsSizedLargePositionedTop: Story = () => {
   const [errors, setErrors] = useState({
     one: true,
@@ -1092,6 +1300,110 @@ export const WithValidationsPositionedLeft: Story = () => {
 };
 WithValidationsPositionedLeft.storyName = "With Validations Positioned Left";
 
+export const WithValidationsPositionedLeftRedesign: Story = () => {
+  const [errors, setErrors] = useState({
+    one: true,
+    two: false,
+    three: false,
+  });
+  const [warnings, setWarnings] = useState({
+    one: true,
+    two: true,
+    three: false,
+  });
+  const [infos, setInfos] = useState({ one: true, two: true, three: true });
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      <Box p="4px">
+        <Tabs align="left" position="left">
+          <Tab
+            errorMessage="this is an error message"
+            warningMessage="this is a warning message"
+            infoMessage="info"
+            tabId="tab-1"
+            title="Tab 1"
+            key="tab-1"
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.one}
+              onChange={() => setErrors({ ...errors, one: !errors.one })}
+              checked={errors.one}
+            />
+            <Checkbox
+              label="Add warning"
+              warning={warnings.one}
+              onChange={() => setWarnings({ ...warnings, one: !warnings.one })}
+              checked={warnings.one}
+            />
+            <Checkbox
+              label="Add info"
+              info={infos.one}
+              onChange={() => setInfos({ ...infos, one: !infos.one })}
+              checked={infos.one}
+            />
+          </Tab>
+          <Tab
+            errorMessage="this is an error message"
+            warningMessage="this is a warning message"
+            infoMessage="info"
+            tabId="tab-2"
+            title="Tab 2"
+            key="tab-2"
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.two}
+              onChange={() => setErrors({ ...errors, two: !errors.two })}
+            />
+            <Checkbox
+              label="Add warning"
+              warning={warnings.two}
+              onChange={() => setWarnings({ ...warnings, two: !warnings.two })}
+              checked={warnings.two}
+            />
+            <Checkbox
+              label="Add info"
+              info={infos.two}
+              onChange={() => setInfos({ ...infos, two: !infos.two })}
+              checked={infos.two}
+            />
+          </Tab>
+          <Tab
+            errorMessage="this is an error message"
+            warningMessage="this is a warning message"
+            infoMessage="info"
+            tabId="tab-3"
+            title="Tab 3"
+            key="tab-3"
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.three}
+              onChange={() => setErrors({ ...errors, three: !errors.three })}
+            />
+            <Checkbox
+              label="Add warning"
+              warning={warnings.three}
+              onChange={() =>
+                setWarnings({ ...warnings, three: !warnings.three })
+              }
+            />
+            <Checkbox
+              label="Add info"
+              info={infos.three}
+              onChange={() => setInfos({ ...infos, three: !infos.three })}
+              checked={infos.three}
+            />
+          </Tab>
+        </Tabs>
+      </Box>
+    </CarbonProvider>
+  );
+};
+WithValidationsPositionedLeftRedesign.storyName =
+  "With New Validation Positioned Left";
+
 export const WithValidationsSizedLargePositionedLeft: Story = () => {
   const [errors, setErrors] = useState({
     one: true,
@@ -1194,6 +1506,110 @@ export const WithValidationsSizedLargePositionedLeft: Story = () => {
 WithValidationsSizedLargePositionedLeft.storyName =
   "With Validations Sized Large Positioned Left";
 
+export const WithNewValidationsSizedLargePositionedLeft: Story = () => {
+  const [errors, setErrors] = useState({
+    one: true,
+    two: false,
+    three: false,
+  });
+  const [warnings, setWarnings] = useState({
+    one: true,
+    two: true,
+    three: false,
+  });
+  const [infos, setInfos] = useState({ one: true, two: true, three: true });
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      <Box p="4px">
+        <Tabs size="large" align="left" position="left">
+          <Tab
+            errorMessage="error"
+            warningMessage="warning"
+            infoMessage="info"
+            tabId="tab-1"
+            title="Tab 1"
+            key="tab-1"
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.one}
+              onChange={() => setErrors({ ...errors, one: !errors.one })}
+              checked={errors.one}
+            />
+            <Checkbox
+              label="Add warning"
+              warning={warnings.one}
+              onChange={() => setWarnings({ ...warnings, one: !warnings.one })}
+              checked={warnings.one}
+            />
+            <Checkbox
+              label="Add info"
+              info={infos.one}
+              onChange={() => setInfos({ ...infos, one: !infos.one })}
+              checked={infos.one}
+            />
+          </Tab>
+          <Tab
+            errorMessage="error"
+            warningMessage="warning"
+            infoMessage="info"
+            tabId="tab-2"
+            title="Tab 2"
+            key="tab-2"
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.two}
+              onChange={() => setErrors({ ...errors, two: !errors.two })}
+            />
+            <Checkbox
+              label="Add warning"
+              warning={warnings.two}
+              onChange={() => setWarnings({ ...warnings, two: !warnings.two })}
+              checked={warnings.two}
+            />
+            <Checkbox
+              label="Add info"
+              info={infos.two}
+              onChange={() => setInfos({ ...infos, two: !infos.two })}
+              checked={infos.two}
+            />
+          </Tab>
+          <Tab
+            errorMessage="error"
+            warningMessage="warning"
+            infoMessage="info"
+            tabId="tab-3"
+            title="Tab 3"
+            key="tab-3"
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.three}
+              onChange={() => setErrors({ ...errors, three: !errors.three })}
+            />
+            <Checkbox
+              label="Add warning"
+              warning={warnings.three}
+              onChange={() =>
+                setWarnings({ ...warnings, three: !warnings.three })
+              }
+            />
+            <Checkbox
+              label="Add info"
+              info={infos.three}
+              onChange={() => setInfos({ ...infos, three: !infos.three })}
+              checked={infos.three}
+            />
+          </Tab>
+        </Tabs>
+      </Box>
+    </CarbonProvider>
+  );
+};
+WithNewValidationsSizedLargePositionedLeft.storyName =
+  "With New Validations Sized Large Positioned Left";
+
 export const WithAdditionalTitleSiblings: Story = () => {
   const [errors, setErrors] = useState({
     one: true,
@@ -1266,6 +1682,82 @@ export const WithAdditionalTitleSiblings: Story = () => {
   );
 };
 WithAdditionalTitleSiblings.storyName = "With Additional Title Siblings";
+
+export const WithAdditionalTitleSiblingsRedesign: Story = () => {
+  const [errors, setErrors] = useState({
+    one: true,
+    two: false,
+    three: false,
+  });
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      <Box p="4px">
+        <Tabs align="left" position="top">
+          <Tab
+            errorMessage="this is an error message"
+            warningMessage="this is a warning message"
+            infoMessage="info"
+            tabId="tab-1"
+            title="Tab 1"
+            key="tab-1"
+            siblings={[
+              <Pill size="S" pillRole="status" fill key="pill">
+                12
+              </Pill>,
+              <Icon type="home" key="icon" />,
+            ]}
+            titlePosition="before"
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.one}
+              onChange={() => setErrors({ ...errors, one: !errors.one })}
+              checked={errors.one}
+            />
+          </Tab>
+          <Tab
+            errorMessage="this is an error message"
+            warningMessage="this is a warning message"
+            infoMessage="info"
+            tabId="tab-2"
+            title="Tab 2"
+            key="tab-2"
+            titlePosition="after"
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.two}
+              onChange={() => setErrors({ ...errors, two: !errors.two })}
+            />
+          </Tab>
+          <Tab
+            errorMessage="this is an error message"
+            warningMessage="this is a warning message"
+            infoMessage="info"
+            tabId="tab-3"
+            title="Tab 3"
+            key="tab-3"
+            siblings={[
+              <Pill size="S" pillRole="status" fill key="pill">
+                12
+              </Pill>,
+              <Icon type="home" key="icon" />,
+            ]}
+            titlePosition="after"
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.three}
+              onChange={() => setErrors({ ...errors, three: !errors.three })}
+            />
+          </Tab>
+        </Tabs>
+      </Box>
+    </CarbonProvider>
+  );
+};
+WithAdditionalTitleSiblingsRedesign.storyName =
+  "With New Validation Additional Title Siblings";
 
 export const WithAdditionalTitleSiblingsSizeLarge: Story = () => {
   const [errors, setErrors] = useState({
@@ -1445,6 +1937,113 @@ export const WithCustomLayout: Story = () => {
   );
 };
 WithCustomLayout.storyName = "With Custom Layout";
+
+export const WithCustomLayoutRedesign: Story = () => {
+  const [errors, setErrors] = useState({
+    one: false,
+    two: false,
+    three: false,
+  });
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      <Box p="4px">
+        <Tabs size="default" align="left" position="left">
+          <Tab
+            errorMessage="this is an error message"
+            warningMessage="this is a warning message"
+            infoMessage="info"
+            tabId="tab-1"
+            title="Tab 1"
+            key="tab-1"
+            customLayout={
+              <Box
+                width="calc(100% - 30px)"
+                display="flex"
+                flexDirection="column"
+                padding="4px 4px 22px 14px"
+              >
+                <Box display="flex" justifyContent="flex-end">
+                  <Icon type="settings" color="primary" />
+                  <Icon type="home" />
+                </Box>
+                <Box display="flex" justifyContent="flex-start">
+                  Tab 1
+                </Box>
+              </Box>
+            }
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.one}
+              onChange={() => setErrors({ ...errors, one: !errors.one })}
+            />
+          </Tab>
+          <Tab
+            errorMessage="this is an error message"
+            warningMessage="this is a warning message"
+            infoMessage="info"
+            tabId="tab-2"
+            title="Tab 2"
+            key="tab-2"
+            customLayout={
+              <Box
+                width="calc(100% - 30px)"
+                display="flex"
+                flexDirection="column"
+                padding="4px 4px 22px 14px"
+              >
+                <Box display="flex" justifyContent="flex-end">
+                  <Icon type="settings" color="primary" />
+                  <Icon type="home" />
+                </Box>
+                <Box display="flex" justifyContent="flex-start">
+                  Tab 2
+                </Box>
+              </Box>
+            }
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.two}
+              onChange={() => setErrors({ ...errors, two: !errors.two })}
+            />
+          </Tab>
+          <Tab
+            errorMessage="this is an error message"
+            warningMessage="this is a warning message"
+            infoMessage="info"
+            tabId="tab-3"
+            title="Tab 3"
+            key="tab-3"
+            customLayout={
+              <Box
+                width="calc(100% - 30px)"
+                display="flex"
+                flexDirection="column"
+                padding="4px 4px 22px 14px"
+              >
+                <Box display="flex" justifyContent="flex-end">
+                  <Icon type="settings" color="primary" />
+                  <Icon type="home" />
+                </Box>
+                <Box display="flex" justifyContent="flex-start">
+                  Tab 3
+                </Box>
+              </Box>
+            }
+          >
+            <Checkbox
+              label="Add error"
+              error={errors.three}
+              onChange={() => setErrors({ ...errors, three: !errors.three })}
+            />
+          </Tab>
+        </Tabs>
+      </Box>
+    </CarbonProvider>
+  );
+};
+WithCustomLayoutRedesign.storyName = "With New Validation Custom Layout";
 
 export const WithAlternateStyling: Story = () => {
   const [errors, setErrors] = useState({

--- a/src/components/tabs/tabs.test.tsx
+++ b/src/components/tabs/tabs.test.tsx
@@ -8,6 +8,7 @@ import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-
 import Drawer from "../drawer";
 import Textbox from "../textbox";
 import NumeralDate from "../numeral-date";
+import CarbonProvider from "../carbon-provider/carbon-provider.component";
 
 testStyledSystemMargin(
   (props) => (
@@ -863,6 +864,90 @@ test("when errors and warnings are both present in a tab, only the error icon is
       "icon-info",
     ),
   ).not.toBeInTheDocument();
+});
+
+test("error and warning icons are displayed correctly when the new validation flag is present and the tabs have position top", async () => {
+  const user = userEvent.setup();
+  render(
+    <CarbonProvider validationRedesignOptIn>
+      <Tabs selectedTabId="tab-1">
+        <Tab tabId="tab-1" title="Tab 1" errorMessage="error">
+          Content for tab 1
+          <Textbox error onChange={() => {}} />
+        </Tab>
+        <Tab tabId="tab-2" title="Tab 2" warningMessage="warning">
+          Content for tab 2
+          <Textbox warning onChange={() => {}} />
+        </Tab>
+      </Tabs>
+    </CarbonProvider>,
+  );
+
+  expect(
+    within(screen.getByRole("tab", { name: "Tab 1" })).getByTestId(
+      "icon-error",
+    ),
+  ).toBeInTheDocument();
+
+  expect(
+    within(screen.getByRole("tab", { name: "Tab 2" })).getByTestId(
+      "icon-warning",
+    ),
+  ).toBeInTheDocument();
+
+  await user.click(screen.getByRole("tab", { name: "Tab 1" }));
+
+  expect(screen.getByTestId("tab-selected-indicator")).toHaveStyle({
+    "--selected-indicator-color": "var(--colorsSemanticNegative500)",
+  });
+
+  await user.click(screen.getByRole("tab", { name: "Tab 2" }));
+
+  expect(screen.getByTestId("tab-selected-indicator")).toHaveStyle({
+    "--selected-indicator-color": "var(--colorsSemanticCaution500)",
+  });
+});
+
+test("error and warning icons are displayed correctly when the new validation flag is present and the tabs have position left", async () => {
+  const user = userEvent.setup();
+  render(
+    <CarbonProvider validationRedesignOptIn>
+      <Tabs selectedTabId="tab-1" position="left">
+        <Tab tabId="tab-1" title="Tab 1" errorMessage="error">
+          Content for tab 1
+          <Textbox error onChange={() => {}} />
+        </Tab>
+        <Tab tabId="tab-2" title="Tab 2" warningMessage="warning">
+          Content for tab 2
+          <Textbox warning onChange={() => {}} />
+        </Tab>
+      </Tabs>
+    </CarbonProvider>,
+  );
+
+  expect(
+    within(screen.getByRole("tab", { name: "Tab 1" })).getByTestId(
+      "icon-error",
+    ),
+  ).toBeInTheDocument();
+
+  expect(
+    within(screen.getByRole("tab", { name: "Tab 2" })).getByTestId(
+      "icon-warning",
+    ),
+  ).toBeInTheDocument();
+
+  await user.click(screen.getByRole("tab", { name: "Tab 1" }));
+
+  expect(screen.getByTestId("tab-selected-indicator")).toHaveStyle({
+    "--selected-indicator-color": "var(--colorsSemanticNegative500)",
+  });
+
+  await user.click(screen.getByRole("tab", { name: "Tab 2" }));
+
+  expect(screen.getByTestId("tab-selected-indicator")).toHaveStyle({
+    "--selected-indicator-color": "var(--colorsSemanticCaution500)",
+  });
 });
 
 test("when errors, warnings and infos are all present in a tab, only the error icon is displayed in the corresponding tab title", () => {


### PR DESCRIPTION
### Proposed behaviour
The necessary changes have been added to the `TabTitle` and `TabsHeader` components to solve the discrepancies with DS. The tooltip is no longer visible and the attributes `aria-invalid` and `aria-errormessage` are used in order to ensure the screen reader announces that the Tab has invalid content.

Position top:

https://github.com/user-attachments/assets/7ee293d6-1a08-4e08-b650-f2fe44ad2cd6

Position left:

https://github.com/user-attachments/assets/f6bcf213-3dd1-47c2-b6a8-e49fc5da5398

Additional siblings:

https://github.com/user-attachments/assets/3ef67b44-d631-499e-84b6-53900c9e7db2

Custom layout:

https://github.com/user-attachments/assets/f4488570-1970-4696-8386-3ab1096b89cb

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

The current behaviour which is not aligned can be seen below:
Position top:

https://github.com/user-attachments/assets/5edadc7a-d00a-4532-a34f-34a113e4e440

Position left:

https://github.com/user-attachments/assets/afafe510-c33d-4755-88a5-618fe6abadb4

Additional siblings:

https://github.com/user-attachments/assets/b7eef7d2-651f-4e35-9ba1-6c01d74d3965

Custom layout:

https://github.com/user-attachments/assets/8b9542a3-fd93-4628-9442-e4b45b002851



<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
