### PR TITLE
chore: replace `toBeFocused` with testing library matcher `toHaveFocus`

### DIFF
--- a/src/__internal__/focus-trap/focus-trap.test.tsx
+++ b/src/__internal__/focus-trap/focus-trap.test.tsx
@@ -1324,10 +1324,10 @@ describe("when focus is lost to the document body and `topModalContext` has a va
     render(<ComponentWithTopModalContext trapIsTopModal />);
 
     await user.click(screen.getByText("I am some irrelevant text"));
-    expect(document.body).toBeFocused();
+    expect(document.body).toHaveFocus();
 
     await user.tab();
-    expect(screen.getByRole("button", { name: "One" })).toBeFocused();
+    expect(screen.getByRole("button", { name: "One" })).toHaveFocus();
   });
 
   it("should not do anything when the user tabs and the focus trap is not in the top modal", async () => {
@@ -1335,10 +1335,10 @@ describe("when focus is lost to the document body and `topModalContext` has a va
     render(<ComponentWithTopModalContext trapIsTopModal={false} />);
 
     await user.click(screen.getByText("I am some irrelevant text"));
-    expect(document.body).toBeFocused();
+    expect(document.body).toHaveFocus();
 
     await user.tab();
-    expect(screen.getByText("Outside button")).toBeFocused();
+    expect(screen.getByText("Outside button")).toHaveFocus();
   });
 });
 

--- a/src/__internal__/utils/helpers/events/events.test.ts
+++ b/src/__internal__/utils/helpers/events/events.test.ts
@@ -1,14 +1,14 @@
 import Events from "./events";
 
 describe("isEventType", () => {
-  test("Returns true when the event type and passed type match", () => {
+  it("returns true when the event type and passed type match", () => {
     const event = { type: "click" } as Event;
     const result = Events.isEventType(event, "click");
 
     expect(result).toBeTruthy();
   });
 
-  test("Returns false when the event type and passed type do not match", () => {
+  it("returns false when the event type and passed type do not match", () => {
     const event = { type: "click" } as Event;
     const result = Events.isEventType(event, "keyUp");
 
@@ -18,7 +18,7 @@ describe("isEventType", () => {
 
 describe("isKeyboardEvent", () => {
   test.each(["keyup", "keydown", "keypress"])(
-    "Returns true when the event type is a keyboard event type (%s)",
+    "returns true when the event type is a keyboard event type (%s)",
     (type) => {
       const event = { type } as Event;
       const result = Events.isKeyboardEvent(event);
@@ -27,7 +27,7 @@ describe("isKeyboardEvent", () => {
     }
   );
 
-  test("Returns false when the event type is not a keyboard event type", () => {
+  it("returns false when the event type is not a keyboard event type", () => {
     const event = { type: "click" } as Event;
     const result = Events.isKeyboardEvent(event);
 
@@ -36,28 +36,28 @@ describe("isKeyboardEvent", () => {
 });
 
 describe("isEnterOrSpaceKey", () => {
-  test("Returns true when the event type is a keyup event, and the key is the Enter key", () => {
+  it("returns true when the event type is a keyup event, and the key is the Enter key", () => {
     const event = { type: "keyup", key: "Enter" } as KeyboardEvent;
     const result = Events.isEnterOrSpaceKey(event);
 
     expect(result).toBeTruthy();
   });
 
-  test("Returns true when the event type is a keyup event, and the key is the Space key", () => {
+  it("returns true when the event type is a keyup event, and the key is the Space key", () => {
     const event = { type: "keyup", key: " " } as KeyboardEvent;
     const result = Events.isEnterOrSpaceKey(event);
 
     expect(result).toBeTruthy();
   });
 
-  test("Returns false when the event type is a keyup event, but the key is not the Enter key or the Space key", () => {
+  it("returns false when the event type is a keyup event, but the key is not the Enter key or the Space key", () => {
     const event = { type: "keyup", key: "Backspace" } as KeyboardEvent;
     const result = Events.isEnterOrSpaceKey(event);
 
     expect(result).toBeFalsy();
   });
 
-  test("Returns false when the event type is not a keyup event", () => {
+  it("returns false when the event type is not a keyup event", () => {
     const event = { type: "keydown" } as KeyboardEvent;
     const result = Events.isEnterOrSpaceKey(event);
 
@@ -67,7 +67,7 @@ describe("isEnterOrSpaceKey", () => {
 
 describe("isNumberKey", () => {
   test.each(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"])(
-    "Returns true when the event type is a number key event (%s)",
+    "returns true when the event type is a number key event (%s)",
     (key) => {
       const event = { key } as KeyboardEvent;
       const result = Events.isNumberKey(event);
@@ -76,7 +76,7 @@ describe("isNumberKey", () => {
     }
   );
 
-  test("Returns false when the event type is not a number key event", () => {
+  it("returns false when the event type is not a number key event", () => {
     const event = { key: "a" } as KeyboardEvent;
     const result = Events.isNumberKey(event);
 
@@ -85,14 +85,14 @@ describe("isNumberKey", () => {
 });
 
 describe("isLeftKey", () => {
-  test("Returns false when the event type is not a left key event", () => {
+  it("returns false when the event type is not a left key event", () => {
     const event = { key: "Backspace" } as KeyboardEvent;
     const result = Events.isLeftKey(event);
 
     expect(result).toBeFalsy();
   });
 
-  test("Returns true when the event type is a left key event", () => {
+  it("returns true when the event type is a left key event", () => {
     const event = { key: "ArrowLeft" } as KeyboardEvent;
     const result = Events.isLeftKey(event);
 
@@ -101,14 +101,14 @@ describe("isLeftKey", () => {
 });
 
 describe("isUpKey", () => {
-  test("Returns true when the event type is an up key event", () => {
+  it("returns true when the event type is an up key event", () => {
     const event = { key: "ArrowUp" } as KeyboardEvent;
     const result = Events.isUpKey(event);
 
     expect(result).toBeTruthy();
   });
 
-  test("Returns false when the event type is not an up key event", () => {
+  it("returns false when the event type is not an up key event", () => {
     const event = { key: "Backspace" } as KeyboardEvent;
     const result = Events.isUpKey(event);
 
@@ -117,14 +117,14 @@ describe("isUpKey", () => {
 });
 
 describe("isRightKey", () => {
-  test("Returns true when the event type is a right key event", () => {
+  it("returns true when the event type is a right key event", () => {
     const event = { key: "ArrowRight" } as KeyboardEvent;
     const result = Events.isRightKey(event);
 
     expect(result).toBeTruthy();
   });
 
-  test("Returns false when the event type is not a right key event", () => {
+  it("returns false when the event type is not a right key event", () => {
     const event = { key: "Backspace" } as KeyboardEvent;
     const result = Events.isRightKey(event);
 
@@ -133,14 +133,14 @@ describe("isRightKey", () => {
 });
 
 describe("isDownKey", () => {
-  test("Returns true when the event type is a down key event", () => {
+  it("returns true when the event type is a down key event", () => {
     const event = { key: "ArrowDown" } as KeyboardEvent;
     const result = Events.isDownKey(event);
 
     expect(result).toBeTruthy();
   });
 
-  test("Returns false when the event type is not a down key event", () => {
+  it("returns false when the event type is not a down key event", () => {
     const event = { key: "Backspace" } as KeyboardEvent;
     const result = Events.isDownKey(event);
 
@@ -149,14 +149,14 @@ describe("isDownKey", () => {
 });
 
 describe("isEscKey", () => {
-  test("Returns true when the event type is an Escape key event", () => {
+  it("returns true when the event type is an Escape key event", () => {
     const event = { key: "Escape" } as KeyboardEvent;
     const result = Events.isEscKey(event);
 
     expect(result).toBeTruthy();
   });
 
-  test("Returns false when the event type is not an Escape key event", () => {
+  it("returns false when the event type is not an Escape key event", () => {
     const event = { key: "Backspace" } as KeyboardEvent;
     const result = Events.isEscKey(event);
 
@@ -165,14 +165,14 @@ describe("isEscKey", () => {
 });
 
 describe("isEnterKey", () => {
-  test("Returns true when the event type is an Enter key event", () => {
+  it("returns true when the event type is an Enter key event", () => {
     const event = { key: "Enter" } as KeyboardEvent;
     const result = Events.isEnterKey(event);
 
     expect(result).toBeTruthy();
   });
 
-  test("Returns false when the event type is not an Enter key event", () => {
+  it("returns false when the event type is not an Enter key event", () => {
     const event = { key: "Backspace" } as KeyboardEvent;
     const result = Events.isEnterKey(event);
 
@@ -181,14 +181,14 @@ describe("isEnterKey", () => {
 });
 
 describe("isTabKey", () => {
-  test("Returns true when the event type is a Tab key event", () => {
+  it("returns true when the event type is a Tab key event", () => {
     const event = { key: "Tab" } as KeyboardEvent;
     const result = Events.isTabKey(event);
 
     expect(result).toBeTruthy();
   });
 
-  test("Returns false when the event type is not a Tab key event", () => {
+  it("returns false when the event type is not a Tab key event", () => {
     const event = { key: "Backspace" } as KeyboardEvent;
     const result = Events.isTabKey(event);
 
@@ -197,14 +197,14 @@ describe("isTabKey", () => {
 });
 
 describe("isShiftKey", () => {
-  test("Returns true when the event type is a Shift key event", () => {
+  it("returns true when the event type is a Shift key event", () => {
     const event = { shiftKey: true } as KeyboardEvent;
     const result = Events.isShiftKey(event);
 
     expect(result).toBeTruthy();
   });
 
-  test("Returns false when the event type is not a Shift key event", () => {
+  it("returns false when the event type is not a Shift key event", () => {
     const event = { key: "Tab" } as KeyboardEvent;
     const result = Events.isShiftKey(event);
 
@@ -213,14 +213,14 @@ describe("isShiftKey", () => {
 });
 
 describe("isSpaceKey", () => {
-  test("Returns true when the event type is a Space key event", () => {
+  it("returns true when the event type is a Space key event", () => {
     const event = { key: " " } as KeyboardEvent;
     const result = Events.isSpaceKey(event);
 
     expect(result).toBeTruthy();
   });
 
-  test("Returns false when the event type is not a Space key event", () => {
+  it("returns false when the event type is not a Space key event", () => {
     const event = { key: "Tab" } as KeyboardEvent;
     const result = Events.isSpaceKey(event);
 
@@ -229,14 +229,14 @@ describe("isSpaceKey", () => {
 });
 
 describe("isHomeKey", () => {
-  test("Returns true when the event type is a Home key event", () => {
+  it("returns true when the event type is a Home key event", () => {
     const event = { key: "Home" } as KeyboardEvent;
     const result = Events.isHomeKey(event);
 
     expect(result).toBeTruthy();
   });
 
-  test("Returns false when the event type is not a Home key event", () => {
+  it("returns false when the event type is not a Home key event", () => {
     const event = { key: "End" } as KeyboardEvent;
     const result = Events.isHomeKey(event);
 
@@ -245,14 +245,14 @@ describe("isHomeKey", () => {
 });
 
 describe("isEndKey", () => {
-  test("Returns true when the event type is an End key event", () => {
+  it("returns true when the event type is an End key event", () => {
     const event = { key: "End" } as KeyboardEvent;
     const result = Events.isEndKey(event);
 
     expect(result).toBeTruthy();
   });
 
-  test("Returns false when the event type is not an End key event", () => {
+  it("returns false when the event type is not an End key event", () => {
     const event = { key: "Home" } as KeyboardEvent;
     const result = Events.isEndKey(event);
 
@@ -261,28 +261,28 @@ describe("isEndKey", () => {
 });
 
 describe("composedPath", () => {
-  test("Returns an empty array if there is no target", () => {
+  it("returns an empty array if there is no target", () => {
     const event = new CustomEvent("click");
     const result = Events.composedPath(event);
 
     expect(result).toEqual([]);
   });
 
-  test("Returns an empty array if target is null", () => {
+  it("returns an empty array if target is null", () => {
     const event = { target: null } as CustomEvent;
     const result = Events.composedPath(event);
 
     expect(result).toEqual([]);
   });
 
-  test("Returns an empty array if there is no parent element", () => {
+  it("returns an empty array if there is no parent element", () => {
     const event = { target: document as EventTarget } as CustomEvent;
     const result = Events.composedPath(event);
 
     expect(result).toEqual([]);
   });
 
-  test("Returns the path from event.composedPath() if it is available", () => {
+  it("returns the path from event.composedPath() if it is available", () => {
     const path = Symbol("path");
     const composedPath = jest.fn();
     composedPath.mockReturnValue(path);
@@ -294,7 +294,7 @@ describe("composedPath", () => {
     expect(result).toBe(path);
   });
 
-  test("Builds path from DOM elements if event.composedPath is unavailable", () => {
+  it("builds path from DOM elements if event.composedPath is unavailable", () => {
     const div = document.createElement("div");
     const ul = document.createElement("ul");
     const li = document.createElement("li");
@@ -311,7 +311,7 @@ describe("composedPath", () => {
 
   /* TODO: FE-6826 Investigate if `composedPath` is still required post removal of Enzyme.  */
 
-  test("Builds the path if it is not available on the element from a ReactWrapper", () => {
+  it("builds the path if it is not available on the element from a ReactWrapper", () => {
     const div = document.createElement("div");
     const ul = document.createElement("ul");
     const li = document.createElement("li");

--- a/src/components/action-popover/action-popover.test.tsx
+++ b/src/components/action-popover/action-popover.test.tsx
@@ -267,7 +267,7 @@ test("clicking a menu item focuses the menu button", async () => {
   await user.click(screen.getByRole("button"));
   await user.click(screen.getByText("Print Invoice"));
 
-  expect(screen.getByRole("button")).toBeFocused();
+  expect(screen.getByRole("button")).toHaveFocus();
 });
 
 test("pressing enter on a menu item focuses the menu button", async () => {
@@ -284,7 +284,7 @@ test("pressing enter on a menu item focuses the menu button", async () => {
   screen.getByRole("button", { name: "Print Invoice" }).focus();
   await user.keyboard("{Enter}");
 
-  expect(screen.getByRole("button")).toBeFocused();
+  expect(screen.getByRole("button")).toHaveFocus();
 });
 
 test("clicking a disabled menu item does not call its onClick handler", async () => {
@@ -382,7 +382,7 @@ test("clicking a disabled menu item does not focus the menu button", async () =>
   await user.click(screen.getByRole("button"));
   await user.click(screen.getByText("Print Invoice"));
 
-  expect(screen.getByRole("button", { name: "actions" })).not.toBeFocused();
+  expect(screen.getByRole("button", { name: "actions" })).not.toHaveFocus();
 });
 
 test("pressing enter on a disabled menu item does not focus the menu button", async () => {
@@ -401,7 +401,7 @@ test("pressing enter on a disabled menu item does not focus the menu button", as
   screen.getByRole("button", { name: "Print Invoice" }).focus();
   await user.keyboard("{Enter}");
 
-  expect(screen.getByRole("button", { name: "actions" })).not.toBeFocused();
+  expect(screen.getByRole("button", { name: "actions" })).not.toHaveFocus();
 });
 
 test("clicking the menu button calls the onOpen prop", async () => {
@@ -452,7 +452,7 @@ test("clicking the menu button focuses the first focusable element", async () =>
   await user.click(screen.getByRole("button"));
   jest.runOnlyPendingTimers();
 
-  expect(screen.getByRole("button", { name: "example item" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item" })).toHaveFocus();
 });
 
 test("clicking the menu button with the menu open closes the menu and calls the onClose function", async () => {
@@ -551,7 +551,7 @@ test.each(["ArrowDown", "Space", "Enter"] as const)(
 
     expect(
       screen.getByRole("button", { name: "example item 1" })
-    ).toBeFocused();
+    ).toHaveFocus();
   }
 );
 
@@ -569,7 +569,7 @@ test("pressing ArrowUp key when focused on the menu button selects the last focu
   await user.keyboard("{ArrowUp}");
   jest.runOnlyPendingTimers();
 
-  expect(screen.getByRole("button", { name: "example item 2" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 2" })).toHaveFocus();
 });
 
 test.each([
@@ -595,7 +595,7 @@ test.each([
 
     expect(
       screen.getByRole("button", { name: "example item 1" })
-    ).toBeFocused();
+    ).toHaveFocus();
 
     await user.keyboard(keycode);
     jest.runOnlyPendingTimers();
@@ -619,7 +619,7 @@ test("pressing Escape when focused on a menu item focuses the MenuButton and clo
   await user.keyboard("{ArrowDown}");
   await user.keyboard("{Escape}");
 
-  expect(screen.getByRole("button", { name: "actions" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "actions" })).toHaveFocus();
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
 });
 
@@ -636,19 +636,19 @@ test("pressing the Down Arrow key when the menu is open focuses the next item an
 
   await user.click(screen.getByRole("button"));
   jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 1" })).toHaveFocus();
 
   await user.keyboard("{ArrowDown}");
   jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 2" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 2" })).toHaveFocus();
 
   await user.keyboard("{ArrowDown}");
   jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 3" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 3" })).toHaveFocus();
 
   await user.keyboard("{ArrowDown}");
   jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 1" })).toHaveFocus();
 });
 
 test("pressing the Up Arrow key when the menu is open focuses the previous item and wraps around when on the first item", async () => {
@@ -664,19 +664,19 @@ test("pressing the Up Arrow key when the menu is open focuses the previous item 
 
   await user.click(screen.getByRole("button"));
   jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 1" })).toHaveFocus();
 
   await user.keyboard("{ArrowUp}");
   jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 3" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 3" })).toHaveFocus();
 
   await user.keyboard("{ArrowUp}");
   jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 2" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 2" })).toHaveFocus();
 
   await user.keyboard("{ArrowUp}");
   jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 1" })).toHaveFocus();
 });
 
 test("pressing the Home key when the menu is open focuses the first item, no matter which item is currently focused", async () => {
@@ -693,34 +693,34 @@ test("pressing the Home key when the menu is open focuses the first item, no mat
 
   await user.click(screen.getByRole("button"));
   jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 1" })).toHaveFocus();
 
   await user.keyboard("{ArrowDown}");
   jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 2" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 2" })).toHaveFocus();
   await user.keyboard("{Home}");
   jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
-
-  await user.keyboard("{ArrowDown}");
-  jest.runOnlyPendingTimers();
-  await user.keyboard("{ArrowDown}");
-  jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 3" })).toBeFocused();
-  await user.keyboard("{Home}");
-  jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 1" })).toHaveFocus();
 
   await user.keyboard("{ArrowDown}");
   jest.runOnlyPendingTimers();
   await user.keyboard("{ArrowDown}");
   jest.runOnlyPendingTimers();
-  await user.keyboard("{ArrowDown}");
-  jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 4" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 3" })).toHaveFocus();
   await user.keyboard("{Home}");
   jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 1" })).toHaveFocus();
+
+  await user.keyboard("{ArrowDown}");
+  jest.runOnlyPendingTimers();
+  await user.keyboard("{ArrowDown}");
+  jest.runOnlyPendingTimers();
+  await user.keyboard("{ArrowDown}");
+  jest.runOnlyPendingTimers();
+  expect(screen.getByRole("button", { name: "example item 4" })).toHaveFocus();
+  await user.keyboard("{Home}");
+  jest.runOnlyPendingTimers();
+  expect(screen.getByRole("button", { name: "example item 1" })).toHaveFocus();
 });
 
 test("pressing the End key when the menu is open focuses the last item, no matter which item is currently focused", async () => {
@@ -738,21 +738,21 @@ test("pressing the End key when the menu is open focuses the last item, no matte
   await user.click(screen.getByRole("button"));
   jest.runOnlyPendingTimers();
 
-  expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 1" })).toHaveFocus();
 
   await user.keyboard("{End}");
   jest.runOnlyPendingTimers();
 
-  expect(screen.getByRole("button", { name: "example item 4" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 4" })).toHaveFocus();
 
   await user.keyboard("{ArrowUp}");
   jest.runOnlyPendingTimers();
 
-  expect(screen.getByRole("button", { name: "example item 3" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 3" })).toHaveFocus();
   await user.keyboard("{End}");
   jest.runOnlyPendingTimers();
 
-  expect(screen.getByRole("button", { name: "example item 4" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 4" })).toHaveFocus();
 
   await user.keyboard("{ArrowUp}");
   jest.runOnlyPendingTimers();
@@ -760,11 +760,11 @@ test("pressing the End key when the menu is open focuses the last item, no matte
   await user.keyboard("{ArrowUp}");
   jest.runOnlyPendingTimers();
 
-  expect(screen.getByRole("button", { name: "example item 2" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 2" })).toHaveFocus();
   await user.keyboard("{End}");
   jest.runOnlyPendingTimers();
 
-  expect(screen.getByRole("button", { name: "example item 4" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 4" })).toHaveFocus();
 });
 
 test("pressing Space when the menu is open does nothing", async () => {
@@ -782,13 +782,13 @@ test("pressing Space when the menu is open does nothing", async () => {
   jest.runOnlyPendingTimers();
 
   expect(screen.getByRole("list")).toBeVisible();
-  expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 1" })).toHaveFocus();
 
   await user.keyboard(" ");
   jest.runOnlyPendingTimers();
 
   expect(screen.getByRole("list")).toBeVisible();
-  expect(screen.getByRole("button", { name: "example item 1" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "example item 1" })).toHaveFocus();
 });
 
 test("pressing an alphabet character when the menu is open selects the next selectable item in the list starting with the letter that was pressed", async () => {
@@ -811,25 +811,25 @@ test("pressing an alphabet character when the menu is open selects the next sele
   await user.keyboard("p");
   jest.runOnlyPendingTimers();
 
-  expect(screen.getByRole("button", { name: "Print Invoice" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "Print Invoice" })).toHaveFocus();
 
   // moves to next element starting with D - noting that it skips the disabled "Disabled" item
   await user.keyboard("d");
   jest.runOnlyPendingTimers();
 
-  expect(screen.getByRole("button", { name: "Download CSV" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "Download CSV" })).toHaveFocus();
 
   // moves to next element starting with D, it loops to the start
   await user.keyboard("d");
   jest.runOnlyPendingTimers();
 
-  expect(screen.getByRole("button", { name: "Download PDF" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "Download PDF" })).toHaveFocus();
 
   // does nothing when there are no matches
   await user.keyboard("z");
   jest.runOnlyPendingTimers();
 
-  expect(screen.getByRole("button", { name: "Download PDF" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "Download PDF" })).toHaveFocus();
 });
 
 test("pressing a non-printable character key when the menu is open does nothing", async () => {
@@ -847,13 +847,13 @@ test("pressing a non-printable character key when the menu is open does nothing"
   jest.runOnlyPendingTimers();
 
   expect(screen.getByRole("list")).toBeVisible();
-  expect(screen.getByRole("button", { name: "first item" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "first item" })).toHaveFocus();
 
   await user.keyboard("{F1}");
   jest.runOnlyPendingTimers();
 
   expect(screen.getByRole("list")).toBeVisible();
-  expect(screen.getByRole("button", { name: "first item" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "first item" })).toHaveFocus();
 });
 
 test("an error is thrown, with appropriate error message, if invalid children are used", () => {
@@ -1116,7 +1116,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
 
     const firstItem = screen.getByRole("button", { name: "submenu item 1" });
     expect(firstItem).toBeVisible();
-    expect(firstItem).toBeFocused();
+    expect(firstItem).toHaveFocus();
   });
 
   it("closes the submenu and returns focus to the parent item when the right arrow key is pressed", async () => {
@@ -1157,7 +1157,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     expect(
       screen.queryByRole("button", { name: "submenu item 1" })
     ).not.toBeInTheDocument();
-    expect(parentItem).toBeFocused();
+    expect(parentItem).toHaveFocus();
   });
 
   it("leaves the submenu open, and keeps focus where it is, when an alphabetical key is pressed", async () => {
@@ -1199,7 +1199,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     ).toBeVisible();
     expect(
       screen.getByRole("button", { name: "submenu item 1" })
-    ).toBeFocused();
+    ).toHaveFocus();
   });
 
   it("opens the submenu and focuses the first item when the enter key is pressed", async () => {
@@ -1231,7 +1231,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
 
     const firstItem = screen.getByRole("button", { name: "submenu item 1" });
     expect(firstItem).toBeVisible();
-    expect(firstItem).toBeFocused();
+    expect(firstItem).toHaveFocus();
   });
 
   it("closes the entire parent menu and focuses the main menu button when a submenu item is clicked", async () => {
@@ -1262,7 +1262,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     await user.click(screen.getByRole("button", { name: "submenu item 1" }));
 
     expect(screen.queryByRole("list")).not.toBeInTheDocument();
-    expect(screen.getByRole("button")).toBeFocused();
+    expect(screen.getByRole("button")).toHaveFocus();
   });
 
   it("closes the entire parent menu and focuses the main menu button when the escape key is pressed", async () => {
@@ -1295,13 +1295,13 @@ describe("when an item has a submenu with default (left) alignment", () => {
 
     expect(
       screen.getByRole("button", { name: "submenu item 1" })
-    ).toBeFocused();
+    ).toHaveFocus();
 
     await user.keyboard("{Escape}");
     jest.runOnlyPendingTimers();
 
     expect(screen.queryByRole("list")).not.toBeInTheDocument();
-    expect(screen.getByRole("button")).toBeFocused();
+    expect(screen.getByRole("button")).toHaveFocus();
   });
 
   it("does not open the submenu on mouseenter when the item is disabled", async () => {
@@ -1437,7 +1437,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     ).toBeVisible();
     expect(
       screen.getByRole("button", { name: "submenu item 1" })
-    ).toBeFocused();
+    ).toHaveFocus();
   });
 });
 
@@ -1522,7 +1522,7 @@ describe("when there isn't enough space on the screen to render a submenu on the
 
     const firstItem = screen.getByRole("button", { name: "submenu item 1" });
     expect(firstItem).toBeVisible();
-    expect(firstItem).toBeFocused();
+    expect(firstItem).toHaveFocus();
   });
 
   it("closes the submenu and returns focus to parent item when the submenu is open and the left arrow key is pressed", async () => {
@@ -1563,7 +1563,7 @@ describe("when there isn't enough space on the screen to render a submenu on the
     expect(
       screen.queryByRole("button", { name: "submenu item 1" })
     ).not.toBeInTheDocument();
-    expect(parentItem).toBeFocused();
+    expect(parentItem).toHaveFocus();
   });
 });
 
@@ -1631,7 +1631,7 @@ describe("when the submenuPosition prop is set to 'right'", () => {
 
     const firstItem = screen.getByRole("button", { name: "submenu item 1" });
     expect(firstItem).toBeVisible();
-    expect(firstItem).toBeFocused();
+    expect(firstItem).toHaveFocus();
   });
 
   it("closes the submenu and returns focus to parent item when the submenu is open and the left arrow key is pressed", async () => {
@@ -1672,7 +1672,7 @@ describe("when the submenuPosition prop is set to 'right'", () => {
     expect(
       screen.queryByRole("button", { name: "submenu item 1" })
     ).not.toBeInTheDocument();
-    expect(parentItem).toBeFocused();
+    expect(parentItem).toHaveFocus();
   });
 });
 
@@ -1757,7 +1757,7 @@ describe("when the submenuPosition prop is set to 'right' and there isn't enough
 
     const firstItem = screen.getByRole("button", { name: "submenu item 1" });
     expect(firstItem).toBeVisible();
-    expect(firstItem).toBeFocused();
+    expect(firstItem).toHaveFocus();
   });
 
   it("closes the submenu and returns focus to parent item when the submenu is open and the right arrow key is pressed", async () => {
@@ -1798,7 +1798,7 @@ describe("when the submenuPosition prop is set to 'right' and there isn't enough
     expect(
       screen.queryByRole("button", { name: "submenu item 1" })
     ).not.toBeInTheDocument();
-    expect(parentItem).toBeFocused();
+    expect(parentItem).toHaveFocus();
   });
 });
 
@@ -1933,13 +1933,13 @@ describe("When ActionPopoverMenu contains multiple disabled items", () => {
 
     expect(
       screen.getByRole("button", { name: "example item 1" })
-    ).toBeFocused();
+    ).toHaveFocus();
     await user.keyboard("{ArrowDown}");
     jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 4" })
-    ).toBeFocused();
+    ).toHaveFocus();
   });
 
   it("should focus the previous focusable item when up arrow is pressed", async () => {
@@ -1961,19 +1961,19 @@ describe("When ActionPopoverMenu contains multiple disabled items", () => {
 
     expect(
       screen.getByRole("button", { name: "example item 1" })
-    ).toBeFocused();
+    ).toHaveFocus();
     await user.keyboard("{ArrowDown}");
     jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 4" })
-    ).toBeFocused();
+    ).toHaveFocus();
     await user.keyboard("{ArrowUp}");
     jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 1" })
-    ).toBeFocused();
+    ).toHaveFocus();
   });
 
   it("should focus the first focusable item when Home is pressed", async () => {
@@ -1995,25 +1995,25 @@ describe("When ActionPopoverMenu contains multiple disabled items", () => {
 
     expect(
       screen.getByRole("button", { name: "example item 2" })
-    ).toBeFocused();
+    ).toHaveFocus();
     await user.keyboard("{ArrowDown}");
     jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 4" })
-    ).toBeFocused();
+    ).toHaveFocus();
     await user.keyboard("{ArrowDown}");
     jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 5" })
-    ).toBeFocused();
+    ).toHaveFocus();
     await user.keyboard("{Home}");
     jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 2" })
-    ).toBeFocused();
+    ).toHaveFocus();
   });
 
   it("should focus the last focusable item when End is pressed", async () => {
@@ -2035,13 +2035,13 @@ describe("When ActionPopoverMenu contains multiple disabled items", () => {
 
     expect(
       screen.getByRole("button", { name: "example item 2" })
-    ).toBeFocused();
+    ).toHaveFocus();
     await user.keyboard("{End}");
     jest.runOnlyPendingTimers();
 
     expect(
       screen.getByRole("button", { name: "example item 5" })
-    ).toBeFocused();
+    ).toHaveFocus();
   });
 });
 

--- a/src/components/advanced-color-picker/advanced-color-picker.test.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.test.tsx
@@ -271,7 +271,7 @@ test("tabbing from the close button should focus the selected color input", asyn
 
   screen.getByRole("button", { name: "Close" }).focus();
   await user.keyboard("{Tab}");
-  expect(screen.getByRole("radio", { name: "orchid" })).toBeFocused();
+  expect(screen.getByRole("radio", { name: "orchid" })).toHaveFocus();
 });
 
 test("tabbing from a color input should focus the close button", async () => {
@@ -281,11 +281,11 @@ test("tabbing from a color input should focus the close button", async () => {
   await user.click(screen.getByRole("button", { name: "Change colour" }));
 
   await waitFor(() => {
-    expect(screen.getByRole("radio", { name: "orchid" })).toBeFocused();
+    expect(screen.getByRole("radio", { name: "orchid" })).toHaveFocus();
   });
 
   await user.keyboard("{Tab}");
-  expect(screen.getByRole("button", { name: "Close" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "Close" })).toHaveFocus();
 });
 
 test("shift-tabbing from the close button should focus the selected color input", async () => {
@@ -296,7 +296,7 @@ test("shift-tabbing from the close button should focus the selected color input"
 
   screen.getByRole("button", { name: "Close" }).focus();
   await user.keyboard("{Shift>}{Tab}");
-  expect(screen.getByRole("radio", { name: "orchid" })).toBeFocused();
+  expect(screen.getByRole("radio", { name: "orchid" })).toHaveFocus();
 });
 
 test("shift-tabbing from a color input should focus the close button", async () => {
@@ -306,11 +306,11 @@ test("shift-tabbing from a color input should focus the close button", async () 
   await user.click(screen.getByRole("button", { name: "Change colour" }));
 
   await waitFor(() => {
-    expect(screen.getByRole("radio", { name: "orchid" })).toBeFocused();
+    expect(screen.getByRole("radio", { name: "orchid" })).toHaveFocus();
   });
 
   await user.keyboard("{Shift>}{Tab}");
-  expect(screen.getByRole("button", { name: "Close" })).toBeFocused();
+  expect(screen.getByRole("button", { name: "Close" })).toHaveFocus();
 });
 
 test("when a color input is clicked, it triggers the onChange callback", async () => {
@@ -340,7 +340,7 @@ test("when the user closes the component, it does trigger the onBlur callback", 
   expect(onBlur).not.toHaveBeenCalled();
   await user.click(screen.getByRole("radio", { name: "white" }));
 
-  expect(await screen.findByRole("radio", { name: "white" })).toBeFocused();
+  expect(await screen.findByRole("radio", { name: "white" })).toHaveFocus();
 
   await user.click(screen.getByRole("button", { name: "Close" }));
   jest.runAllTimers();
@@ -360,7 +360,7 @@ test("when another color input is clicked, it does not trigger the onBlur callba
   expect(onBlur).not.toHaveBeenCalled();
   await user.click(screen.getByRole("radio", { name: "white" }));
 
-  expect(await screen.findByRole("radio", { name: "white" })).toBeFocused();
+  expect(await screen.findByRole("radio", { name: "white" })).toHaveFocus();
 
   await user.click(screen.getByRole("radio", { name: "pink" }));
   jest.runAllTimers();

--- a/src/components/anchor-navigation/anchor-navigation.test.tsx
+++ b/src/components/anchor-navigation/anchor-navigation.test.tsx
@@ -115,7 +115,7 @@ test("when navigation item is clicked, the item is selected and the section cont
     "var(--colorsActionMajor500)",
     { modifier: "& a" }
   );
-  expect(screen.getByTestId("section-2")).toBeFocused();
+  expect(screen.getByTestId("section-2")).toHaveFocus();
 });
 
 test("when Enter is pressed on a navigation item, the item is selected and the section container is focused", async () => {
@@ -141,7 +141,7 @@ test("when Enter is pressed on a navigation item, the item is selected and the s
     "var(--colorsActionMajor500)",
     { modifier: "& a" }
   );
-  expect(screen.getByTestId("section-2")).toBeFocused();
+  expect(screen.getByTestId("section-2")).toHaveFocus();
 });
 
 test("does not alter the tabindex of the container if it was already focusable", async () => {

--- a/src/components/heading/heading.test.tsx
+++ b/src/components/heading/heading.test.tsx
@@ -148,7 +148,7 @@ test("focuses the back link on mousedown", () => {
   const backLink = screen.getByRole("link", { name: "Back" });
   fireEvent.mouseDown(backLink);
 
-  expect(backLink).toBeFocused();
+  expect(backLink).toHaveFocus();
 });
 
 test("renders a back button, when the `backLink` prop is a function", () => {
@@ -165,7 +165,7 @@ test("focuses the back button on mousedown", async () => {
   const backLink = screen.getByRole("button", { name: "Back" });
   await user.click(backLink);
 
-  expect(backLink).toBeFocused();
+  expect(backLink).toHaveFocus();
 });
 
 test("renders a divider when the `divider` prop is true", () => {

--- a/src/components/menu/menu-full-screen/menu-full-screen.test.tsx
+++ b/src/components/menu/menu-full-screen/menu-full-screen.test.tsx
@@ -399,7 +399,7 @@ test("should focus the root container, when menu is opened", () => {
     </CarbonProvider>
   );
 
-  expect(screen.getByRole("dialog")).toBeFocused();
+  expect(screen.getByRole("dialog")).toHaveFocus();
 });
 
 test("should not render a divider when menu contains a falsy values", () => {

--- a/src/components/menu/menu.test.tsx
+++ b/src/components/menu/menu.test.tsx
@@ -32,7 +32,7 @@ test("should focus the last item when 'End' key is pressed by user", async () =>
   const lastMenuItem = screen.getByRole("link", { name: "test four" });
   await user.keyboard("{End}");
 
-  expect(lastMenuItem).toBeFocused();
+  expect(lastMenuItem).toHaveFocus();
 });
 
 test("should focus the first item when 'Home' key is pressed by user", async () => {
@@ -50,7 +50,7 @@ test("should focus the first item when 'Home' key is pressed by user", async () 
   const firstMenuItem = screen.getByRole("link", { name: "test one" });
   await user.keyboard("{Home}");
 
-  expect(firstMenuItem).toBeFocused();
+  expect(firstMenuItem).toHaveFocus();
 });
 
 test("should focus the next item in sequence, and remove focus from menu on last item, when 'Tab' key is pressed by user", async () => {
@@ -67,13 +67,13 @@ test("should focus the next item in sequence, and remove focus from menu on last
   items[0].focus();
   await user.tab();
 
-  expect(items[1]).toBeFocused();
+  expect(items[1]).toHaveFocus();
   await user.tab();
-  expect(items[2]).toBeFocused();
+  expect(items[2]).toHaveFocus();
   await user.tab();
-  expect(items[3]).toBeFocused();
+  expect(items[3]).toHaveFocus();
   await user.tab();
-  expect(document.body).toBeFocused();
+  expect(document.body).toHaveFocus();
 });
 
 test("should focus the previous item in sequence, and remove focus from menu on first item, when 'Shift+Tab' key is pressed by user", async () => {
@@ -90,13 +90,13 @@ test("should focus the previous item in sequence, and remove focus from menu on 
   items[3].focus();
   await user.tab({ shift: true });
 
-  expect(items[2]).toBeFocused();
+  expect(items[2]).toHaveFocus();
   await user.tab({ shift: true });
-  expect(items[1]).toBeFocused();
+  expect(items[1]).toHaveFocus();
   await user.tab({ shift: true });
-  expect(items[0]).toBeFocused();
+  expect(items[0]).toHaveFocus();
   await user.tab({ shift: true });
-  expect(document.body).toBeFocused();
+  expect(document.body).toHaveFocus();
 });
 
 test("should not focus the next item in sequence when 'arrowright' key is pressed by user", async () => {
@@ -113,11 +113,11 @@ test("should not focus the next item in sequence when 'arrowright' key is presse
   items[0].focus();
   await user.keyboard("{arrowright}");
 
-  expect(items[0]).toBeFocused();
+  expect(items[0]).toHaveFocus();
   await user.keyboard("{arrowright}");
-  expect(items[0]).toBeFocused();
+  expect(items[0]).toHaveFocus();
   await user.keyboard("{arrowright}");
-  expect(items[0]).toBeFocused();
+  expect(items[0]).toHaveFocus();
 });
 
 test("should not focus the previous item in sequence when 'arrowleft' key is pressed by user", async () => {
@@ -134,11 +134,11 @@ test("should not focus the previous item in sequence when 'arrowleft' key is pre
   items[3].focus();
   await user.keyboard("{arrowleft}");
 
-  expect(items[3]).toBeFocused();
+  expect(items[3]).toHaveFocus();
   await user.keyboard("{arrowleft}");
-  expect(items[3]).toBeFocused();
+  expect(items[3]).toHaveFocus();
   await user.keyboard("{arrowleft}");
-  expect(items[3]).toBeFocused();
+  expect(items[3]).toHaveFocus();
 });
 
 test("should not throw an error when conditionally rendered `children` are passed", () => {

--- a/src/components/select/__internal__/select-list/select-list.test.tsx
+++ b/src/components/select/__internal__/select-list/select-list.test.tsx
@@ -878,7 +878,7 @@ describe("closing behaviour", () => {
     screen.getByRole("option", { name: /blue/i }).focus();
     await user.tab();
 
-    expect(screen.getByRole("button", { name: /Click me/i })).toBeFocused();
+    expect(screen.getByRole("button", { name: /Click me/i })).toHaveFocus();
     expect(screen.getByRole("listbox")).toBeVisible();
   });
 });

--- a/src/components/simple-color-picker/simple-color-picker.test.tsx
+++ b/src/components/simple-color-picker/simple-color-picker.test.tsx
@@ -124,7 +124,7 @@ test("pressing the left arrow key when focused on the first color changes select
       target: expect.objectContaining({ value: "#582C83" }),
     })
   );
-  expect(screen.getAllByRole("radio")[2]).toBeFocused();
+  expect(screen.getAllByRole("radio")[2]).toHaveFocus();
 });
 
 test("pressing the right arrow key changes selection to the next color", async () => {
@@ -151,7 +151,7 @@ test("pressing the right arrow key changes selection to the next color", async (
       target: expect.objectContaining({ value: "#582C83" }),
     })
   );
-  expect(screen.getAllByRole("radio")[2]).toBeFocused();
+  expect(screen.getAllByRole("radio")[2]).toHaveFocus();
 });
 
 test("pressing the right arrow key when focused on the last color changes selection to the first color", async () => {
@@ -178,7 +178,7 @@ test("pressing the right arrow key when focused on the last color changes select
       target: expect.objectContaining({ value: "#00A376" }),
     })
   );
-  expect(screen.getAllByRole("radio")[0]).toBeFocused();
+  expect(screen.getAllByRole("radio")[0]).toHaveFocus();
 });
 
 test("when the input has multiple rows, pressing the up arrow key changes selection to the color immediately above", async () => {
@@ -207,7 +207,7 @@ test("when the input has multiple rows, pressing the up arrow key changes select
       target: expect.objectContaining({ value: "#00A376" }),
     })
   );
-  expect(screen.getAllByRole("radio")[0]).toBeFocused();
+  expect(screen.getAllByRole("radio")[0]).toHaveFocus();
 });
 
 test("when focus is already on the top row, pressing the up arrow key does not change selection", async () => {
@@ -231,7 +231,7 @@ test("when focus is already on the top row, pressing the up arrow key does not c
   await user.keyboard("{ArrowUp}");
 
   expect(onChange).not.toHaveBeenCalled();
-  expect(screen.getAllByRole("radio")[1]).toBeFocused();
+  expect(screen.getAllByRole("radio")[1]).toHaveFocus();
 });
 
 test("when the input has multiple rows, pressing the down arrow key changes selection to the color immediately below", async () => {
@@ -260,7 +260,7 @@ test("when the input has multiple rows, pressing the down arrow key changes sele
       target: expect.objectContaining({ value: "#582C83" }),
     })
   );
-  expect(screen.getAllByRole("radio")[2]).toBeFocused();
+  expect(screen.getAllByRole("radio")[2]).toHaveFocus();
 });
 
 test("when focus is already on the bottom row, pressing the down arrow key does not change selection", async () => {
@@ -285,7 +285,7 @@ test("when focus is already on the bottom row, pressing the down arrow key does 
   await user.keyboard("{ArrowDown}");
 
   expect(onChange).not.toHaveBeenCalled();
-  expect(screen.getAllByRole("radio")[3]).toBeFocused();
+  expect(screen.getAllByRole("radio")[3]).toHaveFocus();
 });
 
 test("focus is not changed if a non-arrow key is pressed", async () => {
@@ -307,7 +307,7 @@ test("focus is not changed if a non-arrow key is pressed", async () => {
   await user.keyboard("{Control}");
 
   expect(onChange).not.toHaveBeenCalled();
-  expect(screen.getAllByRole("radio")[0]).toBeFocused();
+  expect(screen.getAllByRole("radio")[0]).toHaveFocus();
 });
 
 test("the `onBlur` callback prop should not be called if focus moves from one color input to another", async () => {


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Replaces usage of `toBeFocused` with testing library matcher `toHaveFocus`
### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
`toBeFocused` is still used in some refactored unit test files

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Unit tests added or updated if required


#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
