### PR TITLE
feat(multi-select): add onListScrollBottom 

### DIFF
--- a/src/components/select/multi-select/components.test-pw.tsx
+++ b/src/components/select/multi-select/components.test-pw.tsx
@@ -194,6 +194,85 @@ export const MultiSelectLazyLoadTwiceComponent = (
   );
 };
 
+export const MultiSelectWithInfiniteScrollComponent = (
+  props: Partial<MultiSelectProps>,
+) => {
+  const preventLoading = useRef(false);
+  const preventLazyLoading = useRef(false);
+  const lazyLoadingCounter = useRef(0);
+  const [value, setValue] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const asyncList = [
+    <Option text="Amber" value="amber" key="Amber" />,
+    <Option text="Black" value="black" key="Black" />,
+    <Option text="Blue" value="blue" key="Blue" />,
+    <Option text="Brown" value="brown" key="Brown" />,
+    <Option text="Green" value="green" key="Green" />,
+  ];
+  const getLazyLoaded = () => {
+    const counter = lazyLoadingCounter.current;
+    return [
+      <Option
+        text={`Lazy Loaded A${counter}`}
+        value={`lazyA${counter}`}
+        key={`lazyA${counter}`}
+      />,
+      <Option
+        text={`Lazy Loaded B${counter}`}
+        value={`lazyB${counter}`}
+        key={`lazyB${counter}`}
+      />,
+      <Option
+        text={`Lazy Loaded C${counter}`}
+        value={`lazyC${counter}`}
+        key={`lazyC${counter}`}
+      />,
+    ];
+  };
+  const [optionList, setOptionList] = useState<React.ReactElement[]>([]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value as unknown as string[]);
+  }
+
+  function loadList() {
+    if (preventLoading.current) {
+      return;
+    }
+    preventLoading.current = true;
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+      setOptionList(asyncList);
+    }, 2000);
+  }
+  function onLazyLoading() {
+    if (preventLazyLoading.current) {
+      return;
+    }
+    preventLazyLoading.current = true;
+    setIsLoading(true);
+    setTimeout(() => {
+      preventLazyLoading.current = false;
+      lazyLoadingCounter.current += 1;
+      setIsLoading(false);
+      setOptionList((prevList) => [...prevList, ...getLazyLoaded()]);
+    }, 2000);
+  }
+  return (
+    <MultiSelect
+      label="color"
+      value={value}
+      onChange={onChangeHandler}
+      onOpen={() => loadList()}
+      isLoading={isLoading}
+      onListScrollBottom={onLazyLoading}
+      {...props}
+    >
+      {optionList}
+    </MultiSelect>
+  );
+};
+
 export const MultiSelectObjectAsValueComponent = (
   props: Partial<MultiSelectProps>,
 ) => {

--- a/src/components/select/multi-select/multi-select-test.stories.tsx
+++ b/src/components/select/multi-select/multi-select-test.stories.tsx
@@ -21,6 +21,7 @@ export default {
         "onChange",
         "onChangeDeferred",
         "onFilterChange",
+        "onListScrollBottom",
         "onOpen",
         "onBlur",
         "onClick",
@@ -297,6 +298,85 @@ export const MultiSelectLazyLoadTwiceComponent = (
         {optionList}
       </MultiSelect>
     </div>
+  );
+};
+
+export const MultiSelectWithInfiniteScrollComponent = (
+  props: Partial<MultiSelectProps>,
+) => {
+  const preventLoading = useRef(false);
+  const preventLazyLoading = useRef(false);
+  const lazyLoadingCounter = useRef(0);
+  const [value, setValue] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const asyncList = [
+    <Option text="Amber" value="amber" key="Amber" />,
+    <Option text="Black" value="black" key="Black" />,
+    <Option text="Blue" value="blue" key="Blue" />,
+    <Option text="Brown" value="brown" key="Brown" />,
+    <Option text="Green" value="green" key="Green" />,
+  ];
+  const getLazyLoaded = () => {
+    const counter = lazyLoadingCounter.current;
+    return [
+      <Option
+        text={`Lazy Loaded A${counter}`}
+        value={`lazyA${counter}`}
+        key={`lazyA${counter}`}
+      />,
+      <Option
+        text={`Lazy Loaded B${counter}`}
+        value={`lazyB${counter}`}
+        key={`lazyB${counter}`}
+      />,
+      <Option
+        text={`Lazy Loaded C${counter}`}
+        value={`lazyC${counter}`}
+        key={`lazyC${counter}`}
+      />,
+    ];
+  };
+  const [optionList, setOptionList] = useState<React.ReactElement[]>([]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value as unknown as string[]);
+  }
+
+  function loadList() {
+    if (preventLoading.current) {
+      return;
+    }
+    preventLoading.current = true;
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+      setOptionList(asyncList);
+    }, 2000);
+  }
+  function onLazyLoading() {
+    if (preventLazyLoading.current) {
+      return;
+    }
+    preventLazyLoading.current = true;
+    setIsLoading(true);
+    setTimeout(() => {
+      preventLazyLoading.current = false;
+      lazyLoadingCounter.current += 1;
+      setIsLoading(false);
+      setOptionList((prevList) => [...prevList, ...getLazyLoaded()]);
+    }, 2000);
+  }
+  return (
+    <MultiSelect
+      label="color"
+      value={value}
+      onChange={onChangeHandler}
+      onOpen={() => loadList()}
+      isLoading={isLoading}
+      onListScrollBottom={onLazyLoading}
+      {...props}
+    >
+      {optionList}
+    </MultiSelect>
   );
 };
 

--- a/src/components/select/multi-select/multi-select.component.tsx
+++ b/src/components/select/multi-select/multi-select.component.tsx
@@ -65,6 +65,8 @@ export interface MultiSelectProps
   onFilterChange?: (filterText: string) => void;
   /** A custom callback for when the dropdown menu opens */
   onOpen?: () => void;
+  /** A callback that is triggered when a user scrolls to the bottom of the list */
+  onListScrollBottom?: () => void;
   /** If true the Component opens on focus */
   openOnFocus?: boolean;
   /** SelectList table header, should consist of multiple th elements.
@@ -124,6 +126,7 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
       noResultsMessage,
       placeholder,
       isLoading,
+      onListScrollBottom,
       tableHeader,
       multiColumn,
       tooltipPosition,
@@ -693,6 +696,7 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
         highlightedValue={highlightedValue}
         noResultsMessage={noResultsMessage}
         isLoading={isLoading}
+        onListScrollBottom={onListScrollBottom}
         tableHeader={tableHeader}
         multiColumn={multiColumn}
         listPlacement={listWidth !== undefined ? placement : listPlacement}

--- a/src/components/select/multi-select/multi-select.mdx
+++ b/src/components/select/multi-select/multi-select.mdx
@@ -110,6 +110,13 @@ See [Colors](../?path=/docs/documentation-colors--docs) for more information on 
 
 <Canvas of={MultiSelectStories.WithCustomColoredPills} />
 
+### Infinite scroll example
+
+The `isLoading` prop in combination with the `onListScrollBottom` prop can be used to implement infinite scroll.
+This prop will be called every time a user scrolls to the bottom of the list.
+
+<Canvas of={MultiSelectStories.WithInfiniteScroll} />
+
 ### With custom maxWidth
 
 In this example the `maxWidth` prop is 50%.

--- a/src/components/select/multi-select/multi-select.stories.tsx
+++ b/src/components/select/multi-select/multi-select.stories.tsx
@@ -433,6 +433,96 @@ export const WithCustomColoredPills: Story = () => {
 };
 WithCustomColoredPills.storyName = "With Custom Colored Pills";
 
+export const WithInfiniteScroll: Story = () => {
+  const preventLoading = useRef(false);
+  const preventLazyLoading = useRef(false);
+  const lazyLoadingCounter = useRef(0);
+
+  const [value, setValue] = useState<string[]>([]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value as unknown as string[]);
+  }
+  const [isLoading, setIsLoading] = useState(true);
+  const asyncList = [
+    <Option text="Amber" value="amber" key="Amber" />,
+    <Option text="Black" value="black" key="Black" />,
+    <Option text="Blue" value="blue" key="Blue" />,
+    <Option text="Brown" value="brown" key="Brown" />,
+    <Option text="Green" value="green" key="Green" />,
+  ];
+  const getLazyLoaded = () => {
+    const counter = lazyLoadingCounter.current;
+    return [
+      <Option
+        text={`Lazy Loaded A${counter}`}
+        value={`lazyA${counter}`}
+        key={`lazyA${counter}`}
+      />,
+      <Option
+        text={`Lazy Loaded B${counter}`}
+        value={`lazyB${counter}`}
+        key={`lazyB${counter}`}
+      />,
+      <Option
+        text={`Lazy Loaded C${counter}`}
+        value={`lazyC${counter}`}
+        key={`lazyC${counter}`}
+      />,
+    ];
+  };
+  const [optionList, setOptionList] = useState<React.ReactElement[]>([]);
+  function loadList() {
+    if (preventLoading.current) {
+      return;
+    }
+    preventLoading.current = true;
+    setIsLoading(true);
+    setTimeout(() => {
+      setOptionList(asyncList);
+      setIsLoading(false);
+    }, 2000);
+  }
+  function onLazyLoading() {
+    if (preventLazyLoading.current) {
+      return;
+    }
+    preventLazyLoading.current = true;
+    setIsLoading(true);
+    setTimeout(() => {
+      preventLazyLoading.current = false;
+      lazyLoadingCounter.current += 1;
+      setOptionList((prevList) => [...prevList, ...getLazyLoaded()]);
+      setIsLoading(false);
+    }, 2000);
+  }
+  function clearData() {
+    setOptionList([]);
+    setValue([]);
+    preventLoading.current = false;
+  }
+  return (
+    <Box height={300}>
+      <Button onClick={clearData} mb={2}>
+        reset
+      </Button>
+      <MultiSelect
+        name="infiniteScroll"
+        id="infiniteScroll"
+        label="color"
+        value={value}
+        onChange={onChangeHandler}
+        onOpen={() => loadList()}
+        isLoading={isLoading}
+        onListScrollBottom={onLazyLoading}
+      >
+        {optionList}
+      </MultiSelect>
+    </Box>
+  );
+};
+WithInfiniteScroll.storyName = "With infinite scroll";
+WithInfiniteScroll.parameters = { chromatic: { disableSnapshot: true } };
+
 export const WithCustomMaxWidth: Story = () => {
   return (
     <Box height={250}>

--- a/src/components/select/multi-select/multi-select.test.tsx
+++ b/src/components/select/multi-select/multi-select.test.tsx
@@ -1127,6 +1127,25 @@ test("marks input as required when required prop is true", () => {
   expect(screen.getByRole("combobox")).toBeRequired();
 });
 
+test("should not be call `onListScrollBottom` callback when an option is clicked", async () => {
+  const onListScrollBottomFn = jest.fn();
+  const user = userEvent.setup();
+  render(
+    <MultiSelect
+      onListScrollBottom={onListScrollBottomFn}
+      openOnFocus
+      label="filterable-select"
+      onChange={() => {}}
+    >
+      <Option value="opt1" text="green" />
+    </MultiSelect>,
+  );
+  screen.getByRole("combobox").focus();
+  await user.click(await screen.findByRole("option", { name: "green" }));
+
+  expect(onListScrollBottomFn).not.toHaveBeenCalled();
+});
+
 test("does not call onOpen, when openOnFocus is true and the input is refocused while the dropdown list is already open", async () => {
   const onOpen = jest.fn();
   render(


### PR DESCRIPTION
fix #6752

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

 adds the `onListScrollBottom` callback to `MultiSelect`, to be called when a user scrolls to the bottom of the select list

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently,  there is no `onListScrollBottom` callback on `MultiSelect`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
