### PR TITLE
fix(dialog, dialog-full-screen, sidebar): make overflowing content tabbale

### DIFF
--- a/playwright/components/dialog-full-screen/index.ts
+++ b/playwright/components/dialog-full-screen/index.ts
@@ -1,0 +1,8 @@
+import type { Page } from "@playwright/test";
+import DIALOG_FULL_SCREEN_CONTENT from "./locators";
+
+const dialogFullScreenContent = (page: Page) => {
+  return page.locator(DIALOG_FULL_SCREEN_CONTENT);
+};
+
+export default dialogFullScreenContent;

--- a/playwright/components/dialog-full-screen/locators.ts
+++ b/playwright/components/dialog-full-screen/locators.ts
@@ -1,0 +1,3 @@
+const DIALOG_FULL_SCREEN_CONTENT = '[data-role="dialog-full-screen-content"]';
+
+export default DIALOG_FULL_SCREEN_CONTENT;

--- a/playwright/components/dialog/index.ts
+++ b/playwright/components/dialog/index.ts
@@ -5,6 +5,7 @@ import {
   DIALOG_SUBTITLE,
   OPEN_PREVIEW,
   DIALOG_ARIALABEL,
+  DIALOG_CONTENT,
 } from "./locators";
 
 // component preview locators
@@ -24,10 +25,15 @@ const dialogAriaLabel = (page: Page) => {
   return page.locator(DIALOG_ARIALABEL);
 };
 
+const dialogContent = (page: Page) => {
+  return page.locator(DIALOG_CONTENT);
+};
+
 export {
   alertDialogPreview,
   dialogTitle,
   dialogSubtitle,
   openPreviewButton,
   dialogAriaLabel,
+  dialogContent,
 };

--- a/playwright/components/dialog/locators.ts
+++ b/playwright/components/dialog/locators.ts
@@ -5,3 +5,4 @@ export const DIALOG_TITLE = '[data-element="title"]';
 export const DIALOG_SUBTITLE = '[data-element="subtitle"]';
 export const OPEN_PREVIEW = '[data-component="button"]';
 export const DIALOG_ARIALABEL = "[aria-label]";
+export const DIALOG_CONTENT = '[data-role="dialog-content"]';

--- a/playwright/components/sidebar/index.ts
+++ b/playwright/components/sidebar/index.ts
@@ -1,7 +1,13 @@
 import { Page } from "@playwright/test";
-import { SIDEBAR_PREVIEW, SIDEBAR_COMPONENT } from "./locators";
+import {
+  SIDEBAR_PREVIEW,
+  SIDEBAR_COMPONENT,
+  SIDEBAR_CONTENT,
+} from "./locators";
 
 // component preview locators
 export const sidebarPreview = (page: Page) => page.locator(SIDEBAR_PREVIEW);
 
 export const sidebarComponent = (page: Page) => page.locator(SIDEBAR_COMPONENT);
+
+export const sidebarContent = (page: Page) => page.locator(SIDEBAR_CONTENT);

--- a/playwright/components/sidebar/locators.ts
+++ b/playwright/components/sidebar/locators.ts
@@ -1,3 +1,4 @@
 // component preview locators
 export const SIDEBAR_PREVIEW = '[data-element="sidebar"]';
 export const SIDEBAR_COMPONENT = '[data-component="sidebar"]';
+export const SIDEBAR_CONTENT = '[data-role="sidebar-content"]';

--- a/src/__internal__/focus-trap/focus-trap-utils.ts
+++ b/src/__internal__/focus-trap/focus-trap-utils.ts
@@ -5,6 +5,9 @@ type CustomRefObject<T> = {
 const defaultFocusableSelectors =
   'button:not([disabled]), [href], input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]';
 
+const defaultScrollableSelectors =
+  'div[data-role="sidebar-content"], div[data-role="dialog-content"], div[data-role="dialog-full-screen-content"]';
+
 const INTERVAL = 10;
 const MAX_TIME = 100;
 
@@ -243,6 +246,7 @@ const trapFunction = (
 
 export {
   defaultFocusableSelectors,
+  defaultScrollableSelectors,
   getNextElement,
   setElementFocus,
   onTabGuardFocus,

--- a/src/__internal__/focus-trap/focus-trap-utils.ts
+++ b/src/__internal__/focus-trap/focus-trap-utils.ts
@@ -6,7 +6,7 @@ const defaultFocusableSelectors =
   'button:not([disabled]), [href], input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]';
 
 const defaultScrollableSelectors =
-  'div[data-role="sidebar-content"], div[data-role="dialog-content"], div[data-role="dialog-full-screen-content"]';
+  'div[data-component="sidebar-content"], div[data-component="dialog-content"], div[data-component="dialog-full-screen-content"]';
 
 const INTERVAL = 10;
 const MAX_TIME = 100;

--- a/src/__internal__/focus-trap/focus-trap.component.tsx
+++ b/src/__internal__/focus-trap/focus-trap.component.tsx
@@ -9,6 +9,7 @@ import React, {
 
 import {
   defaultFocusableSelectors,
+  defaultScrollableSelectors,
   setElementFocus,
   onTabGuardFocus,
   trapFunction,
@@ -145,11 +146,29 @@ const FocusTrap = ({
       trapWrappers.forEach((ref) => {
         // istanbul ignore else
         if (ref.current) {
-          elements.push(
-            ...Array.from(ref.current.querySelectorAll(selector)).filter(
-              (el) => Number((el as HTMLElement).tabIndex) !== -1,
-            ),
+          const focusableElements = Array.from(
+            ref.current.querySelectorAll(selector),
+          ).filter((el) => Number((el as HTMLElement).tabIndex) !== -1);
+
+          elements.push(...focusableElements);
+
+          const scrollableElements = Array.from(
+            ref.current.querySelectorAll(defaultScrollableSelectors),
+          ).filter(
+            (el) =>
+              el.scrollHeight > el.clientHeight &&
+              (window.getComputedStyle(el).overflowY === "scroll" ||
+                window.getComputedStyle(el).overflowY === "auto"),
           );
+
+          scrollableElements.forEach((el) => {
+            const focusableElementsInContainer = el.querySelectorAll(
+              defaultFocusableSelectors,
+            );
+            if (focusableElementsInContainer.length === 0) {
+              el.setAttribute("tabindex", "0");
+            }
+          });
         }
       });
       return elements as HTMLElement[];

--- a/src/__internal__/focus-trap/focus-trap.component.tsx
+++ b/src/__internal__/focus-trap/focus-trap.component.tsx
@@ -152,23 +152,24 @@ const FocusTrap = ({
 
           elements.push(...focusableElements);
 
-          const scrollableElements = Array.from(
-            ref.current.querySelectorAll(defaultScrollableSelectors),
-          ).filter(
-            (el) =>
-              el.scrollHeight > el.clientHeight &&
-              (window.getComputedStyle(el).overflowY === "scroll" ||
-                window.getComputedStyle(el).overflowY === "auto"),
+          const scrollableElement = ref.current.querySelector(
+            defaultScrollableSelectors,
           );
 
-          scrollableElements.forEach((el) => {
-            const focusableElementsInContainer = el.querySelectorAll(
-              defaultFocusableSelectors,
-            );
-            if (focusableElementsInContainer.length === 0) {
-              el.setAttribute("tabindex", "0");
-            }
-          });
+          if (!scrollableElement) {
+            return;
+          }
+
+          if (
+            scrollableElement.scrollHeight > scrollableElement.clientHeight &&
+            (window.getComputedStyle(scrollableElement).overflowY ===
+              "scroll" ||
+              window.getComputedStyle(scrollableElement).overflowY ===
+                "auto") &&
+            !focusableElements.some((el) => scrollableElement.contains(el))
+          ) {
+            scrollableElement.setAttribute("tabindex", "0");
+          }
         }
       });
       return elements as HTMLElement[];

--- a/src/components/dialog-full-screen/content.style.ts
+++ b/src/components/dialog-full-screen/content.style.ts
@@ -1,9 +1,11 @@
 import styled, { css } from "styled-components";
 import { StyledForm, StyledFormContent } from "../form/form.style";
+import addFocusStyling from "../../style/utils/add-focus-styling";
 
 type StyledContentProps = {
   hasHeader: boolean;
   disableContentPadding?: boolean;
+  hasTitle?: boolean;
 };
 
 function computePadding() {
@@ -27,7 +29,13 @@ const StyledContent = styled.div<StyledContentProps>`
   overflow-y: auto;
 
   flex: 1;
-  width: 100%;
+
+  &:focus-visible {
+    margin: var(--spacing075);
+    ${({ hasTitle }) =>
+      !hasTitle && "border-top-left-radius: var(--borderRadius200)"};
+    ${addFocusStyling()}
+  }
 
   ${({ disableContentPadding }) =>
     disableContentPadding ? "padding: 0" : computePadding()}

--- a/src/components/dialog-full-screen/dialog-full-screen-test.stories.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen-test.stories.tsx
@@ -9,6 +9,7 @@ import Icon from "../icon";
 import Textbox from "../textbox";
 import Box from "../box";
 import { StepFlow } from "../step-flow";
+import Typography from "../typography";
 
 export default {
   title: "Dialog Full Screen/Test",
@@ -245,4 +246,18 @@ export const WithWrappedStickyForm: StoryType = {
     subtitle: "Subtitle",
   },
   parameters: { chromatic: { disableSnapshot: true } },
+};
+
+export const WithOverflowingContent: StoryType = () => (
+  <DialogFullScreen title="With Overflowing Content" open onCancel={() => {}}>
+    {Array.from({ length: 30 }, (_, i) => (
+      <Typography key={i}>This is line {i + 1}</Typography>
+    ))}
+  </DialogFullScreen>
+);
+
+WithOverflowingContent.parameters = {
+  chromatic: {
+    disableSnapshot: true,
+  },
 };

--- a/src/components/dialog-full-screen/dialog-full-screen.component.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.component.tsx
@@ -189,6 +189,7 @@ export const DialogFullScreen = ({
             hasHeader={title !== undefined}
             data-element="content"
             data-role="dialog-full-screen-content"
+            data-component="dialog-full-screen-content"
             ref={contentRef}
             hasTitle={!!title}
             disableContentPadding={disableContentPadding}

--- a/src/components/dialog-full-screen/dialog-full-screen.component.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.component.tsx
@@ -190,6 +190,7 @@ export const DialogFullScreen = ({
             data-element="content"
             data-role="dialog-full-screen-content"
             ref={contentRef}
+            hasTitle={!!title}
             disableContentPadding={disableContentPadding}
           >
             {children}

--- a/src/components/dialog-full-screen/dialog-full-screen.pw.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.pw.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { expect, test } from "@playwright/experimental-ct-react17";
 import type { Page } from "@playwright/test";
+import DialogFullScreen from ".";
 import {
   DialogFullScreenComponent,
   NestedDialog,
@@ -25,12 +26,14 @@ import {
   tooltipPreview,
   getComponent,
 } from "../../../playwright/components/index";
+import dialogFullScreenContent from "../../../playwright/components/dialog-full-screen";
 import {
   continuePressingTAB,
   continuePressingSHIFTTAB,
   checkAccessibility,
   waitForAnimationEnd,
   waitForElementFocus,
+  getStyle,
 } from "../../../playwright/support/helper";
 import { CHARACTERS } from "../../../playwright/support/constants";
 
@@ -564,6 +567,63 @@ test.describe("render DialogFullScreen component and check properties", () => {
 
     await expect(secondInputElement).not.toBeFocused();
     await expect(openToastElement).toBeFocused();
+  });
+});
+
+test.describe("when dialog full screen content is scrollable and has no interactive elements", () => {
+  test("should have the expected styling when the dialog full screen content is focused", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <DialogFullScreen open>
+        {Array.from({ length: 30 }, (_, i) => (
+          <p key={i}>Line {i + 1}</p>
+        ))}
+      </DialogFullScreen>,
+    );
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    await expect(dialogFullScreenContent(page)).toBeFocused();
+    await expect(dialogFullScreenContent(page)).toHaveCSS(
+      "box-shadow",
+      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+    );
+    await expect(dialogFullScreenContent(page)).toHaveCSS(
+      "outline",
+      "rgba(0, 0, 0, 0) solid 3px",
+    );
+  });
+
+  test("should have the expected styling when the dialog full screen content is focused and no title is passed", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <DialogFullScreen open>
+        {Array.from({ length: 30 }, (_, i) => (
+          <p key={i}>Line {i + 1}</p>
+        ))}
+      </DialogFullScreen>,
+    );
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    await expect(dialogFullScreenContent(page)).toBeFocused();
+    await expect(dialogFullScreenContent(page)).toHaveCSS(
+      "box-shadow",
+      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+    );
+    await expect(dialogFullScreenContent(page)).toHaveCSS(
+      "outline",
+      "rgba(0, 0, 0, 0) solid 3px",
+    );
+
+    const borderTopLeftRadius = await getStyle(
+      dialogFullScreenContent(page),
+      "border-top-left-radius",
+      "focus-visible",
+    );
+    await expect(borderTopLeftRadius).toBe("16px");
   });
 });
 

--- a/src/components/dialog-full-screen/dialog-full-screen.test.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.test.tsx
@@ -13,6 +13,7 @@ import StyledIconButton from "../icon-button/icon-button.style";
 import { StyledHeader, StyledHeading } from "../heading/heading.style";
 import Form from "../form";
 import CarbonProvider from "../carbon-provider";
+import Button from "../button";
 
 const ControlledDialog = ({
   onCancel,
@@ -112,6 +113,38 @@ test("when the focusFirstElement prop is passed, the corresponding element shoul
 
   await waitFor(() => {
     expect(screen.getByLabelText("should be focused")).toHaveFocus();
+  });
+});
+
+test("should add dialog full screen content to the tabbing order when scrollable with no other interactive elements", async () => {
+  render(<DialogFullScreen open>test</DialogFullScreen>);
+
+  const container = screen.getByTestId("dialog-full-screen-content");
+  jest.spyOn(container, "clientHeight", "get").mockImplementation(() => 10000);
+  jest.spyOn(container, "scrollHeight", "get").mockImplementation(() => 15000);
+
+  jest.runAllTimers();
+
+  await waitFor(() => {
+    expect(container).toHaveAttribute("tabindex", "0");
+  });
+});
+
+test("should not add dialog full screen content to the tabbing order when scrollable with other interactive elements", async () => {
+  render(
+    <DialogFullScreen open>
+      <Button>Test</Button>test
+    </DialogFullScreen>,
+  );
+
+  const container = screen.getByTestId("dialog-full-screen-content");
+  jest.spyOn(container, "clientHeight", "get").mockImplementation(() => 1000);
+  jest.spyOn(container, "scrollHeight", "get").mockImplementation(() => 1500);
+
+  jest.runAllTimers();
+
+  await waitFor(() => {
+    expect(container).not.toHaveAttribute("tabindex");
   });
 });
 

--- a/src/components/dialog/dialog-test.stories.tsx
+++ b/src/components/dialog/dialog-test.stories.tsx
@@ -494,3 +494,17 @@ export const WithButton = {
     );
   },
 };
+
+export const WithOverflowingContent: StoryType = () => (
+  <Dialog title="With Overflowing Content" open onCancel={() => {}}>
+    {Array.from({ length: 30 }, (_, i) => (
+      <Typography key={i}>This is line {i + 1}</Typography>
+    ))}
+  </Dialog>
+);
+
+WithOverflowingContent.parameters = {
+  chromatic: {
+    disableSnapshot: true,
+  },
+};

--- a/src/components/dialog/dialog.component.tsx
+++ b/src/components/dialog/dialog.component.tsx
@@ -239,6 +239,7 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
               {closeIcon}
               <StyledDialogContent
                 {...contentPadding}
+                hasTitle={!!title}
                 data-role="dialog-content"
                 tabIndex={-1}
               >

--- a/src/components/dialog/dialog.component.tsx
+++ b/src/components/dialog/dialog.component.tsx
@@ -241,6 +241,7 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
                 {...contentPadding}
                 hasTitle={!!title}
                 data-role="dialog-content"
+                data-component="dialog-content"
                 tabIndex={-1}
               >
                 {children}

--- a/src/components/dialog/dialog.pw.tsx
+++ b/src/components/dialog/dialog.pw.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { expect, test } from "@playwright/experimental-ct-react17";
 
+import Dialog from ".";
 import {
   DialogComponent,
   DialogWithFirstFocusableElement,
@@ -21,6 +22,7 @@ import {
   Responsive,
   UsingHandle,
 } from "./components.test-pw";
+import { dialogContent } from "../../../playwright/components/dialog";
 import { toastComponent } from "../../../playwright/components/toast";
 import {
   checkAccessibility,
@@ -584,6 +586,63 @@ test("Dialog should have rounded corners", async ({ mount, page }) => {
   await mount(<DialogComponent />);
 
   await expect(page.getByRole("dialog")).toHaveCSS("border-radius", "16px");
+});
+
+test.describe("when dialog content is scrollable and has no interactive elements", () => {
+  test("should have the expected styling when the dialog content is focused and a title is passed", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <Dialog title="Hello World" open>
+        {Array.from({ length: 30 }, (_, i) => (
+          <p key={i}>Line {i + 1}</p>
+        ))}
+      </Dialog>,
+    );
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    await expect(dialogContent(page)).toBeFocused();
+    await expect(dialogContent(page)).toHaveCSS(
+      "box-shadow",
+      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+    );
+    await expect(dialogContent(page)).toHaveCSS(
+      "outline",
+      "rgba(0, 0, 0, 0) solid 3px",
+    );
+  });
+
+  test("should have the expected styling when the dialog content is focused and no title is passed", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <Dialog open>
+        {Array.from({ length: 30 }, (_, i) => (
+          <p key={i}>Line {i + 1}</p>
+        ))}
+      </Dialog>,
+    );
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    await expect(dialogContent(page)).toBeFocused();
+    await expect(dialogContent(page)).toHaveCSS(
+      "box-shadow",
+      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+    );
+    await expect(dialogContent(page)).toHaveCSS(
+      "outline",
+      "rgba(0, 0, 0, 0) solid 3px",
+    );
+
+    const borderTopLeftRadius = await getStyle(
+      dialogContent(page),
+      "border-top-left-radius",
+      "focus-visible",
+    );
+    await expect(borderTopLeftRadius).toBe("16px");
+  });
 });
 
 // TODO: Skipped due to flaky focus behaviour. To review in FE-6428

--- a/src/components/dialog/dialog.style.ts
+++ b/src/components/dialog/dialog.style.ts
@@ -13,6 +13,7 @@ import {
   StyledForm,
   StyledFormFooter,
 } from "../form/form.style";
+import addFocusStyling from "../../style/utils/add-focus-styling";
 
 const dialogSizes = {
   auto: "fit-content",
@@ -120,12 +121,23 @@ const StyledDialogTitle = styled.div<StyledDialogTitleProps>`
   }
 `;
 
-const StyledDialogContent = styled.div<ContentPaddingInterface>`
+interface styledDialogContentProps extends ContentPaddingInterface {
+  hasTitle?: boolean;
+}
+
+const StyledDialogContent = styled.div<styledDialogContentProps>`
   box-sizing: border-box;
   display: block;
   overflow-y: auto;
   width: 100%;
   flex-grow: 1;
+
+  &:focus-visible {
+    border-bottom-left-radius: var(--borderRadius200);
+    ${({ hasTitle }) =>
+      !hasTitle && "border-top-left-radius: var(--borderRadius200)"};
+    ${addFocusStyling()}
+  }
 
   padding: 24px 32px 30px;
   ${paddingFn}

--- a/src/components/dialog/dialog.test.tsx
+++ b/src/components/dialog/dialog.test.tsx
@@ -9,6 +9,7 @@ import userEvent from "@testing-library/user-event";
 
 import CarbonProvider from "../carbon-provider";
 import Dialog, { DialogHandle, DialogProps } from ".";
+import Button from "../button";
 
 beforeEach(() => jest.useFakeTimers());
 afterEach(() => {
@@ -256,6 +257,34 @@ test("first focusable element is not focused when disableAutoFocus prop is passe
 
   const button = screen.getByRole("button", { name: /Focus me/i });
   expect(button).not.toHaveFocus();
+});
+
+test("should add dialog content to the tabbing order when scrollable with no other interactive elements", () => {
+  render(<Dialog open>test</Dialog>);
+
+  const container = screen.getByTestId("dialog-content");
+  jest.spyOn(container, "clientHeight", "get").mockImplementation(() => 1000);
+  jest.spyOn(container, "scrollHeight", "get").mockImplementation(() => 1500);
+
+  jest.runAllTimers();
+
+  expect(container).toHaveAttribute("tabindex", "0");
+});
+
+test("should not add dialog content to the tabbing order when scrollable with other interactive elements", () => {
+  render(
+    <Dialog open>
+      <Button>Test</Button>test
+    </Dialog>,
+  );
+
+  const container = screen.getByTestId("dialog-content");
+  jest.spyOn(container, "clientHeight", "get").mockImplementation(() => 1000);
+  jest.spyOn(container, "scrollHeight", "get").mockImplementation(() => 1500);
+
+  jest.runAllTimers();
+
+  expect(container).toHaveAttribute("tabindex", "-1");
 });
 
 test("height prop controls the dialog's height", () => {

--- a/src/components/sidebar/sidebar-test.stories.tsx
+++ b/src/components/sidebar/sidebar-test.stories.tsx
@@ -175,3 +175,24 @@ export const WithForm: StoryObj<typeof Sidebar> = {
     </Sidebar>
   ),
 };
+
+export const WithOverflowingContent: StoryObj<typeof Sidebar> = {
+  render: (args) => (
+    <Sidebar
+      {...args}
+      header={<Typography variant="h3">With overflowing content</Typography>}
+      open
+      onCancel={() => {}}
+    >
+      {Array.from({ length: 30 }, (_, i) => (
+        <Typography key={i}>This is line {i + 1}</Typography>
+      ))}
+    </Sidebar>
+  ),
+};
+
+WithOverflowingContent.parameters = {
+  chromatic: {
+    disableSnapshot: true,
+  },
+};

--- a/src/components/sidebar/sidebar.component.tsx
+++ b/src/components/sidebar/sidebar.component.tsx
@@ -176,6 +176,7 @@ export const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
         <StyledSidebarContent
           data-element="sidebar-content"
           data-role="sidebar-content"
+          data-component="sidebar-content"
           {...filterStyledSystemPaddingProps(rest)}
         >
           <SidebarContext.Provider value={{ isInSidebar: true }}>

--- a/src/components/sidebar/sidebar.pw.tsx
+++ b/src/components/sidebar/sidebar.pw.tsx
@@ -10,6 +10,7 @@ import { CLOSE_ICON_BUTTON } from "../../../playwright/components/locators";
 import {
   sidebarComponent,
   sidebarPreview,
+  sidebarContent,
 } from "../../../playwright/components/sidebar";
 import { CHARACTERS } from "../../../playwright/support/constants";
 import {
@@ -30,7 +31,7 @@ import {
   SidebarComponentWithOnCancel,
   TopModalOverride,
 } from "./components.test-pw";
-import { SidebarProps } from "./sidebar.component";
+import { Sidebar, SidebarProps } from "./sidebar.component";
 import { SIDEBAR_SIZES, SIDEBAR_SIZES_CSS } from "./sidebar.config";
 
 test.describe("Prop tests for Sidebar component", () => {
@@ -386,6 +387,30 @@ test.describe("Prop tests for Sidebar component", () => {
 
     await expect(DialogCloseIconButton).toBeFocused();
   });
+});
+
+test("should style focused scrollable sidebar content with no interactive elements correctly", async ({
+  mount,
+  page,
+}) => {
+  await mount(
+    <Sidebar open>
+      {Array.from({ length: 30 }, (_, i) => (
+        <p key={i}>Line {i + 1}</p>
+      ))}
+    </Sidebar>,
+  );
+  await page.keyboard.press("Tab");
+  await page.keyboard.press("Tab");
+  await expect(sidebarContent(page)).toBeFocused();
+  await expect(sidebarContent(page)).toHaveCSS(
+    "box-shadow",
+    "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+  );
+  await expect(sidebarContent(page)).toHaveCSS(
+    "outline",
+    "rgba(0, 0, 0, 0) solid 3px",
+  );
 });
 
 test.describe("Accessibility tests for Sidebar component", () => {

--- a/src/components/sidebar/sidebar.style.ts
+++ b/src/components/sidebar/sidebar.style.ts
@@ -8,6 +8,7 @@ import StyledIconButton from "../icon-button/icon-button.style";
 
 import { SIDEBAR_SIZES_CSS } from "./sidebar.config";
 import { StyledForm, StyledFormContent } from "../form/form.style";
+import addFocusStyling from "../../style/utils/add-focus-styling";
 
 type StyledSidebarProps = Pick<
   SidebarProps,
@@ -61,6 +62,11 @@ const StyledSidebarContent = styled.div<PaddingProps>`
   display: block;
   overflow-y: auto;
   flex-grow: 1;
+
+  &:focus-visible {
+    margin: var(--spacing075);
+    ${addFocusStyling()}
+  }
 
   padding: var(--spacing300) var(--spacing400) var(--spacing400);
   ${paddingFn}

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -14,6 +14,7 @@ import {
 import CarbonProvider from "../carbon-provider";
 
 import Sidebar, { SidebarProps } from ".";
+import Button from "../button";
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -242,6 +243,38 @@ test("focus is not trapped within sidebar when enableBackgroundUI is true", asyn
   await user.tab();
 
   expect(firstButton).not.toHaveFocus();
+});
+
+test("should add sidebar content to the tabbing order when scrollable with no other interactive elements", async () => {
+  render(<Sidebar open>test</Sidebar>);
+
+  const container = screen.getByTestId("sidebar-content");
+  jest.spyOn(container, "clientHeight", "get").mockImplementation(() => 1000);
+  jest.spyOn(container, "scrollHeight", "get").mockImplementation(() => 1500);
+
+  jest.runAllTimers();
+
+  await waitFor(() => {
+    expect(container).toHaveAttribute("tabindex", "0");
+  });
+});
+
+test("should not add sidebar content to the tabbing order when scrollable with other interactive elements", async () => {
+  render(
+    <Sidebar open>
+      <Button>Test</Button>test
+    </Sidebar>,
+  );
+
+  const container = screen.getByTestId("sidebar-content");
+  jest.spyOn(container, "clientHeight", "get").mockImplementation(() => 1000);
+  jest.spyOn(container, "scrollHeight", "get").mockImplementation(() => 1500);
+
+  jest.runAllTimers();
+
+  await waitFor(() => {
+    expect(container).not.toHaveAttribute("tabindex");
+  });
 });
 
 test("can refocus sidebar container using a forwarded ref", async () => {


### PR DESCRIPTION
fix #6999 

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

When any of the components' content containers overflow and contain no interactive elements, the container will be added to the tabbing order and can be focused via keyboard navigation to ensure their contents are accessible.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, some overflowing content is inaccessible due to being in an overflowing container with no interactive elements.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
