### PR TITLE
feat(tabs): align tabs with (frozen) design system

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,4 +1,5 @@
 import { Config } from "jest";
+
 import coverageThresholds from "./coverage-thresholds.json";
 
 const isCI = process.env.CI === "true";

--- a/playwright/components/tabs/index.ts
+++ b/playwright/components/tabs/index.ts
@@ -1,6 +1,10 @@
 import { Page } from "@playwright/test";
 
 // component preview locators
+export const tabWrapper = (page: Page) => {
+  return page.locator(`[data-role="tab-header-wrapper"]`);
+};
+
 export const tabList = (page: Page) => {
   return page.locator(`[role="tablist"]`);
 };
@@ -15,4 +19,14 @@ export const tabContentById = (page: Page, id: number) => {
 
 export const tabTitleById = (page: Page, id: number) => {
   return page.locator(`#tab-${id}-tab`);
+};
+
+export const navButtonWrapperById = (page: Page, direction: string) => {
+  return page.locator(
+    `[data-role="tab-navigation-button-wrapper-${direction}"]`,
+  );
+};
+
+export const navButtonById = (page: Page, direction: string) => {
+  return page.locator(`[data-role="tab-navigation-button-${direction}"]`);
 };

--- a/src/components/tabs/__internal__/tab-title/tab-title.component.tsx
+++ b/src/components/tabs/__internal__/tab-title/tab-title.component.tsx
@@ -116,8 +116,6 @@ const TabTitle = React.forwardRef(
     const handleKeyDown = (
       ev: React.KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>,
     ) => {
-      ev.stopPropagation();
-
       if (href && Events.isEnterOrSpaceKey(ev)) {
         return window.open(href, "_blank");
       }

--- a/src/components/tabs/__internal__/tab-title/tab-title.style.ts
+++ b/src/components/tabs/__internal__/tab-title/tab-title.style.ts
@@ -2,8 +2,8 @@ import styled, { css } from "styled-components";
 
 import StyledIcon from "../../../icon/icon.style";
 import StyledValidationIcon from "../../../../__internal__/validations/validation-icon.style";
+
 import { TabTitleProps } from ".";
-import addFocusStyling from "../../../../style/utils/add-focus-styling";
 
 interface StyledTitleContentProps
   extends Pick<
@@ -26,13 +26,10 @@ interface StyledTitleContentProps
   validationRedesignOptIn?: boolean;
 }
 
-const oldFocusStyling = `
-  outline: solid 3px var(--colorsSemanticFocus500);
-`;
-
 const StyledTitleContent = styled.span<StyledTitleContentProps>`
   outline: none;
-  display: inline-flex;
+  display: flex;
+  align-items: flex-start;
   line-height: 20px;
   margin: 0;
   position: relative;
@@ -151,7 +148,7 @@ const StyledTitleContent = styled.span<StyledTitleContentProps>`
       padding: 10px 16px;
 
       ${borders && `padding-bottom: 9px;`}
-    `} 
+    `}
 
     ${(warning || info) &&
     css`
@@ -180,7 +177,7 @@ const StyledTitleContent = styled.span<StyledTitleContentProps>`
         border-right-color: transparent;
         padding-right: ${size === "large" ? "26px" : "18px"};
       `}
-      
+
       &:hover {
         outline: 1px solid;
         outline-offset: -1px;
@@ -230,7 +227,7 @@ const StyledTitleContent = styled.span<StyledTitleContentProps>`
         border-right-color: transparent;
         padding-right: ${size === "large" ? "26px" : "18px"};
       `}
-    
+
       &:hover {
         outline: 2px solid var(--colorsSemanticNegative500);
         outline-offset: -2px;
@@ -342,187 +339,257 @@ const tabTitleStyles = css<
   }) => css`
     height: ${size === "large" ? "var(--sizing600)" : "var(--sizing500)"};
 
-    ${position === "top" &&
-    css`
-      ${borders &&
-      !(noRightBorder || noLeftBorder) &&
+    ${
+      position === "top" &&
       css`
-        &:nth-of-type(n + 1):not(:first-of-type) {
-          margin-left: -1px;
+        ${borders &&
+        !(noRightBorder || noLeftBorder) &&
+        css`
+          &:nth-of-type(n + 1):not(:first-of-type) {
+            margin-left: -1px;
+          }
+          &:first-child {
+            margin-left: 0;
+          }
+        `}
+      `
+    }
+    ${
+      position === "left" &&
+      css`
+        ${borders &&
+        css`
+          &:nth-of-type(n + 1):not(:first-of-type) {
+            margin-top: -1px;
+          }
+          &:first-child {
+            margin-top: 0;
+          }
+        `}
+      `
+    }
+
+    ${
+      !isTabSelected &&
+      css`
+        color: var(--colorsActionMinorYin090);
+        ${validationRedesignOptIn &&
+        css`
+          background: transparent;
+        `}
+
+        &:hover {
+          background: var(--colorsActionMinor100);
+          ${validationRedesignOptIn &&
+          css`
+            background: var(--colorsUtilityMajor100);
+          `}
+          color: var(--colorsActionMinorYin090);
+          outline: none;
         }
-        &:first-child {
-          margin-left: 0;
+        &:focus {
+          color: var(--colorsActionMinorYin090);
+          outline: none;
         }
-      `}
+      `
+    }
+
+    ${
+      isTabSelected &&
+      css`
+        color: var(--colorsActionMajorYin090);
+        background-color: var(--colorsActionMajorYang100);
+
+        ${(error || warning || info) &&
+        css`
+          padding-bottom: 0px;
+        `}
+
+        &:hover {
+          background-color: var(--colorsActionMajorYang100);
+          border-bottom-color: ${alternateStyling
+            ? "var(--colorsActionMinor100)"
+            : "var(--colorsActionMajor500)"};
+          color: var(--colorsActionMajorYin090);
+          cursor: default;
+        }
+      `
+    }
+
+    ${({ theme }) =>
+      `
+      &:focus {
+        outline: 4px solid ${!theme.focusRedesignOptOut ? "black" : /* istanbul ignore next */ "var(--colorsSemanticFocus500)"};
+        top: -2px;
+        z-index: 6;
+
+        > span[data-role="tab-title-content"] {
+          outline:none;
+        }
+
+        ${
+          position === "top"
+            ? css`
+                border-top-left-radius: var(--borderRadius100);
+                border-top-right-radius: var(--borderRadius100);
+              `
+            : css`
+                border-top-left-radius: var(--borderRadius100);
+                border-bottom-left-radius: var(--borderRadius100);
+              `
+        }
+
+        ${
+          !theme.focusRedesignOptOut
+            ? `::before {
+          content: "";
+          position: absolute;
+          top: 0;
+          left 0;
+          bottom: 0;
+          right: ${position === "top" ? "0" : "-1px"};
+          outline: 3px solid var(--colorsSemanticFocus500);
+          ${
+            position === "top"
+              ? css`
+                  border-top-left-radius: var(--borderRadius100);
+                  border-top-right-radius: var(--borderRadius100);
+                `
+              : css`
+                  border-top-left-radius: var(--borderRadius100);
+                  border-bottom-left-radius: var(--borderRadius100);
+                `
+          }
+          outline-offset: -2px;
+         z-index: 5;
+        }
+
+        > [data-element="tab-selected-indicator"] {
+         z-index: 4;
+         ${
+           position === "top"
+             ? css`
+                 bottom: 2px;
+                 left: 2px;
+                 right: 1px;
+               `
+             : css`
+                 bottom: 2px;
+                 right: 1px;
+               `
+         }
+        }`
+            : /* istanbul ignore next */ ""
+        }
+      }
     `}
-    ${position === "left" &&
-    css`
-      ${borders &&
+
+    ${
+      position === "left" &&
       css`
-        &:nth-of-type(n + 1):not(:first-of-type) {
-          margin-top: -1px;
-        }
+        background-color: transparent;
+        border-bottom: 0px;
+
+        ${!isInSidebar &&
+        !error &&
+        css`
+          --border-right-value: ${validationRedesignOptIn ? "0px" : "2px"}
+            border-right:
+            ${alternateStyling ? "1px" : "var(--border-right-value)"} solid
+            var(--colorsActionMinor100);
+        `}
+
+        ${!borders &&
+        css`
+          ${StyledTitleContent} {
+            border-bottom: none;
+          }
+        `}
+
+      display: flex;
+        height: auto;
+        margin-left: 0px;
+
         &:first-child {
           margin-top: 0;
         }
-      `}
-    `}
 
-    ${!isTabSelected &&
-    css`
-      color: var(--colorsActionMinorYin090);
-      ${validationRedesignOptIn &&
-      css`
-        background: transparent;
-      `}
-
-      &:hover {
-        background: var(--colorsActionMinor100);
-        ${validationRedesignOptIn &&
-        css`
-          background: var(--colorsUtilityMajor100);
-        `}
-        color: var(--colorsActionMinorYin090);
-        outline: none;
-      }
-      &:focus {
-        color: var(--colorsActionMinorYin090);
-        outline: none;
-      }
-    `}
-
-    ${isTabSelected &&
-    css`
-      color: var(--colorsActionMajorYin090);
-      background-color: var(--colorsActionMajorYang100);
-
-      ${(error || warning || info) &&
-      css`
-        padding-bottom: 0px;
-      `}
-
-      &:hover {
-        background-color: var(--colorsActionMajorYang100);
-        border-bottom-color: ${alternateStyling
-          ? "var(--colorsActionMinor100)"
-          : "var(--colorsActionMajor500)"};
-        color: var(--colorsActionMajorYin090);
-        cursor: default;
-      }
-    `}
-
-    &:focus {
-      ${({ theme }) =>
-        `${
-          !theme.focusRedesignOptOut
-            ? addFocusStyling()
-            : /* istanbul ignore next */ oldFocusStyling
-        }`}
-      z-index: 3;
-
-      ${isInSidebar &&
-      css`
-        outline-offset: -3px;
-      `}
-    }
-
-    ${position === "left" &&
-    css`
-      background-color: transparent;
-      border-bottom: 0px;
-
-      ${!isInSidebar &&
-      !error &&
-      css`
-        --border-right-value: ${validationRedesignOptIn ? "0px" : "2px"}
-          border-right:
-          ${alternateStyling ? "1px" : "var(--border-right-value)"} solid
-          var(--colorsActionMinor100);
-      `}
-
-      ${!borders &&
-      css`
-        ${StyledTitleContent} {
-          border-bottom: none;
+        &:hover {
+          ${alternateStyling &&
+          "border-right-color: var(--colorsActionMinor100)"}
         }
-      `}
 
-      display: flex;
-      height: auto;
-      margin-left: 0px;
+        ${(warning || info) &&
+        css`
+          border-right: none;
+        `}
 
-      &:first-child {
-        margin-top: 0;
-      }
-
-      &:hover {
-        ${alternateStyling && "border-right-color: var(--colorsActionMinor100)"}
-      }
-
-      ${(warning || info) &&
-      css`
-        border-right: none;
-      `}
-
-      ${!isTabSelected &&
-      css`
-        border-right-color: var(--colorsActionMinor100);
-      `}
-
-      ${isTabSelected &&
-      css`
-        ${alternateStyling &&
+        ${!isTabSelected &&
         css`
           border-right-color: var(--colorsActionMinor100);
         `}
 
-        ${!alternateStyling &&
+      ${isTabSelected &&
         css`
-          border-right: none;
-          padding-bottom: 0px;
+          ${alternateStyling &&
+          css`
+            border-right-color: var(--colorsActionMinor100);
+          `}
 
-          ${StyledTitleContent} {
-            ${!(error || warning || info) &&
-            !validationRedesignOptIn &&
-            "margin-right: 2px;"}
+          ${!alternateStyling &&
+          css`
             border-right: none;
-          }
-        `}
-  
+            padding-bottom: 0px;
+
+            ${StyledTitleContent} {
+              ${!(error || warning || info) &&
+              !validationRedesignOptIn &&
+              "margin-right: 2px;"}
+              border-right: none;
+            }
+          `}
+
         background-color: var(--colorsActionMajorYang100);
 
-        &:hover {
-          ${alternateStyling &&
-          "border-right-color: var(--colorsActionMinor100);"}
-          background-color: var(--colorsActionMajorYang100);
-          ${(error || warning || info) &&
-          "border-right-color: var(--colorsSemanticNegative500);"}
-        }
+          &:hover {
+            ${alternateStyling &&
+            "border-right-color: var(--colorsActionMinor100);"}
+            background-color: var(--colorsActionMajorYang100);
+            ${(error || warning || info) &&
+            "border-right-color: var(--colorsSemanticNegative500);"}
+          }
 
-        &:focus {
-          ${(error || warning || info) &&
-          "border-right-color: var(--colorsSemanticNegative500);"}
-        }
-      `}
-    `}
+          &:focus {
+            ${(error || warning || info) &&
+            "border-right-color: var(--colorsSemanticNegative500);"}
+          }
+        `}
+      `
+    }
 
-    ${alternateStyling &&
-    css`
-      &:focus {
-        background-color: var(--colorsActionMinor200);
-      }
-
-      &:hover {
-        background-color: ${isTabSelected
-          ? "var(--colorsActionMinor200)"
-          : "var(--colorsActionMinor250)"};
-      }
-
-      ${isTabSelected &&
+    ${
+      alternateStyling &&
       css`
-        background-color: var(--colorsActionMinor200);
-      `}
-    `}
+        &:focus {
+          background-color: var(--colorsActionMinor200);
+        }
+
+        &:hover {
+          background-color: ${isTabSelected
+            ? "var(--colorsActionMinor200)"
+            : "var(--colorsActionMinor250)"};
+        }
+
+        ${isTabSelected &&
+        css`
+          background-color: var(--colorsActionMinor200);
+        `}
+      `
+    }
+
+    & ${StyledIcon} { {
+      ${validationRedesignOptIn ? "margin-top: 10px;" : "margin-top: 2px;"}
+    }
   `}
 `;
 
@@ -546,7 +613,6 @@ const StyledLayoutWrapper = styled.div<StyledLayoutWrapperProps>`
     hasCustomLayout,
     titlePosition = "before",
     hasCustomSibling,
-    position,
     validationRedesignOptIn,
   }) => css`
     ${hasCustomLayout &&
@@ -627,7 +693,7 @@ const StyledSelectedIndicator = styled.div<StyledSelectedIndicatorProps>`
     `}
     ${position === "top" &&
     css`
-      bottom: 0px;
+      bottom: -1px;
       left: 0px;
       right: 0px;
       box-shadow: inset 0px calc(-1 * var(--sizing050)) 0px
@@ -645,6 +711,12 @@ const StyledSelectedIndicator = styled.div<StyledSelectedIndicatorProps>`
       width: var(--sizing050);
     `}
   `}
+
+  &:focus {
+    bottom: 3px;
+    left: 3px;
+    right: 3px;
+  }
 `;
 
 export {

--- a/src/components/tabs/__internal__/tabs-header/tabs-header.style.ts
+++ b/src/components/tabs/__internal__/tabs-header/tabs-header.style.ts
@@ -1,6 +1,8 @@
 import styled, { css } from "styled-components";
-import { TabHeaderProps } from "./tabs-header.component";
+
 import BaseTheme from "../../../../style/themes/base";
+
+import { TabHeaderProps } from "./tabs-header.component";
 
 const outlineWidth = "3px";
 
@@ -36,27 +38,10 @@ const StyledTabsHeaderWrapper = styled.div<StyledTabsHeaderWrapperProps>`
     `}
 `;
 
-const commonShadowStyles = css`
-  pointer-events: none;
-  content: "";
-  background-repeat: no-repeat;
-  background-size: 16px 48px;
-  background-attachment: scroll;
-  z-index: ${({ theme }) => theme.zIndex.overlay};
-  position: sticky;
-  min-width: 16px;
-  transition: opacity 0.1s ease-in-out;
-`;
-
-export interface StyledTabsHeaderListProps
-  extends Pick<
-    TabHeaderProps,
-    "align" | "extendedLine" | "noRightBorder" | "isInSidebar" | "position"
-  > {
-  leftScrollOpacity?: number;
-  rightScrollOpacity?: number;
-  isScrollable?: boolean;
-}
+export type StyledTabsHeaderListProps = Pick<
+  TabHeaderProps,
+  "align" | "extendedLine" | "noRightBorder" | "isInSidebar" | "position"
+>;
 
 const StyledTabsHeaderList = styled.div<StyledTabsHeaderListProps>`
   display: flex;
@@ -68,60 +53,17 @@ const StyledTabsHeaderList = styled.div<StyledTabsHeaderListProps>`
   cursor: default;
   list-style: none;
   padding: ${outlineWidth};
-  overflow-x: auto;
+  overflow-x: hidden;
   position: relative;
-  ${({ position }) => position === "top" && "white-space: nowrap"};
 
-  ${({ isScrollable, leftScrollOpacity, rightScrollOpacity }) =>
-    isScrollable &&
-    css`
-      &:before {
-        ${commonShadowStyles}
-        background: radial-gradient(
-          farthest-side at 0 50%,
-          rgba(0, 0, 0, 0.2),
-          rgba(0, 0, 0, 0)
-        );
-        background-position: left calc(50% - 4px);
-        left: -${outlineWidth};
-        margin-right: -16px;
-        opacity: ${leftScrollOpacity};
-      }
-
-      &:after {
-        ${commonShadowStyles}
-        background: radial-gradient(
-          farthest-side at 100% 50%,
-          rgba(0, 0, 0, 0.2),
-          rgba(0, 0, 0, 0)
-        );
-        background-position: right calc(50% - 4px);
-        right: -${outlineWidth};
-        margin-left: -16px;
-        opacity: ${rightScrollOpacity};
-      }
-    `}
-
-  &::-webkit-scrollbar {
-    -webkit-appearance: none;
-    background: var(--colorsUtilityMajor025);
-    height: 8px;
-    width: 8px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background-color: var(--colorsUtilityMajor300);
-    cursor: pointer;
-  }
-
-  ${({ align = "left" }) =>
+  ${({ align }) =>
     align === "right" &&
     css`
       justify-content: flex-end;
       text-align: right;
     `}
 
-  ${({ position = "top", noRightBorder, align = "left" }) =>
+  ${({ position, noRightBorder, align }) =>
     position === "left" &&
     css`
       flex-direction: column;
@@ -143,14 +85,6 @@ StyledTabsHeaderList.defaultProps = {
   theme: BaseTheme,
 };
 
-const StyledTabsWrapper = styled.div`
-  margin: 3px;
-  position: relative;
-  min-width: max-content;
-  width: 100%;
-  height: 100%;
-`;
-
 type StyledVerticalTabsWrapperProps = Pick<TabHeaderProps, "isInSidebar">;
 
 const StyledVerticalTabsWrapper = styled.div<StyledVerticalTabsWrapperProps>`
@@ -165,32 +99,98 @@ const StyledVerticalTabsWrapper = styled.div<StyledVerticalTabsWrapperProps>`
   flex-direction: column;
 `;
 
-const StyledTabsBottomBorderWrapper = styled.div<{
-  validationRedesignOptIn?: boolean;
-}>`
-  position: absolute;
-  width: 100%;
-  height: auto;
-  bottom: 0px;
-  ${({ validationRedesignOptIn }) => css`
-    z-index: ${validationRedesignOptIn ? 2 : ""};
+type StyledWrapperProps = {
+  align: string;
+  position: string;
+  role?: string;
+  extendedLine?: boolean;
+  noRightBorder?: boolean;
+  isInSidebar?: boolean;
+};
+
+type StyledNavigationButtonWrapperProps = {
+  position: string;
+  visible: boolean;
+  size: string;
+};
+
+const StyledWrapper = styled.section<StyledWrapperProps>`
+  overflow: hidden;
+  position: relative;
+  display: flex;
+  ${({ extendedLine = true }) =>
+    !extendedLine &&
+    css`
+      width: fit-content;
+    `}
+
+  ${({ position }) => position === "top" && "white-space: nowrap"};
+
+  ${({ align }) =>
+    align === "right" &&
+    css`
+      justify-content: flex-end;
+      text-align: right;
+    `}
+`;
+
+const StyledNavigationButtonWrapper = styled.div<StyledNavigationButtonWrapperProps>`
+  width: 48px;
+
+  ${({ position, visible, size }) => css`
+    height: ${size === "default" ? "48px" : "56px"}
+    z-index: 8;
+    display: ${visible ? "block" : "none"};
+    ${position === "right" && `right: 0; position: absolute;`}
   `}
 `;
 
-const StyledTabsBottomBorder = styled.div`
-  position: sticky;
-  bottom: 2px;
-  left: ${outlineWidth};
-  right: ${outlineWidth};
-  height: 2px;
-  background-color: var(--colorsActionMinor100);
+const StyledNavigationButton = styled.button`
+  position: absolute;
+  height: 100%;
+  width: 48px;
+  top: 0;
+  align-items: center;
+  border: none;
+  border-radius: 0px;
+  background-color: var(--colorsDisabled400);
+  color: var(--colorsActionMinor500);
+  z-index: 6;
+
+  :hover {
+    cursor: pointer;
+    background-color: var(--colorsActionDisabled500);
+    color: var(--colorsComponentsMenuYang100);
+  }
+`;
+
+const StyledContainer = styled.div<{ size: string }>`
+  display: flex;
+  padding: 6px 24px 0px;
+  margin: 0;
+  overflow-x: hidden;
+  ${({ size }) => css`
+    height: ${size === "large" ? "50px" : "42px"};
+  `}
+  align-items: flex-start;
+`;
+
+const StyledBottomBorder = styled.div`
+  height: auto;
+  border-bottom: 2px solid var(--colorsActionMinor100);
+  bottom: 0;
+  left: 24px;
+  right: 24px;
+  position: absolute;
 `;
 
 export {
   StyledTabsHeaderWrapper,
   StyledTabsHeaderList,
-  StyledTabsWrapper,
-  StyledTabsBottomBorderWrapper,
-  StyledTabsBottomBorder,
   StyledVerticalTabsWrapper,
+  StyledWrapper,
+  StyledNavigationButtonWrapper,
+  StyledNavigationButton,
+  StyledContainer,
+  StyledBottomBorder,
 };

--- a/src/components/tabs/tabs-test.stories.tsx
+++ b/src/components/tabs/tabs-test.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Tabs, Tab, TabsProps, TabProps } from ".";
 import DrawerSidebarContext from "../drawer/__internal__/drawer-sidebar.context";
 import Box from "../box";
-import { allModes } from "../../../.storybook/modes";
 
 export default {
   title: "Tabs/Test",
@@ -261,31 +260,5 @@ TabsInSidebarPositionedLeft.parameters = {
   info: { disable: true },
   chromatic: {
     disableSnapshot: false,
-  },
-};
-
-export const WithHorizontalScrollbar = () => {
-  return (
-    <Tabs>
-      {Array.from({ length: 30 }).map((_, index) => (
-        <Tab
-          tabId={`tab-${index + 1}`}
-          title={`Tab ${index + 1}`}
-          key={`tab-${index + 1}`}
-        >
-          Content for tab {index + 1}
-        </Tab>
-      ))}
-    </Tabs>
-  );
-};
-
-WithHorizontalScrollbar.storyName = "With horizontal scrollbar";
-WithHorizontalScrollbar.parameters = {
-  chromatic: {
-    disableSnapshot: false,
-    modes: {
-      desktop: allModes.chromatic,
-    },
   },
 };

--- a/src/components/tabs/tabs.component.tsx
+++ b/src/components/tabs/tabs.component.tsx
@@ -194,7 +194,24 @@ const Tabs = ({
   };
 
   /** Focuses the tab for the reference specified */
-  const focusTab = (ref: React.RefObject<HTMLElement>) => ref.current?.focus();
+  const focusTab = (ref: React.RefObject<HTMLElement>) => {
+    ref.current?.focus();
+    /* istanbul ignore next */
+    const rect = ref.current?.getBoundingClientRect();
+    /* istanbul ignore next */
+    if (rect) {
+      const isVisible =
+        rect.top >= 0 &&
+        rect.left >= 0 &&
+        rect.bottom <=
+          (window.innerHeight || document.documentElement.clientHeight) &&
+        rect.right <=
+          (window.innerWidth || document.documentElement.clientWidth);
+      if (!isVisible) {
+        ref.current?.scrollIntoView({ behavior: "auto", inline: "center" });
+      }
+    }
+  };
 
   /** Will trigger the tab at the given index. */
   const goToTab = (event: React.KeyboardEvent<HTMLElement>, index: number) => {
@@ -207,7 +224,6 @@ const Tabs = ({
       newIndex = 0;
     }
     const nextRef = tabRefs[newIndex];
-
     focusTab(nextRef);
   };
 
@@ -334,6 +350,7 @@ const Tabs = ({
         extendedLine={extendedLine}
         noRightBorder={["no right side", "no sides"].includes(borders)}
         isInSidebar={isInSidebar}
+        size={size || "default"}
       >
         {tabTitles}
       </TabsHeader>

--- a/src/components/tabs/tabs.mdx
+++ b/src/components/tabs/tabs.mdx
@@ -163,10 +163,33 @@ CSS string.
 
 ### Responsive
 
-This story is best viewed in the `canvas` view and by adjusting the size of the window. The position of the `Tabs` component
-will change when the screen size is smaller or larger than `900px`.
+#### Horizontal
+
+__Note: This story is best viewed in the `canvas` view and by adjusting the size of the window.__
+
+The `Tabs` component is responsive and will display navigation buttons to the left and right when the following conditions are met:
+
+- The `position` prop is set to `top`;
+- There are more tabs than can fit in the available space.
+
+When both conditions are met, the `Tabs` component will display navigation buttons to the left and right of the tabs. Clicking on
+these buttons will scroll the tabs in the respective direction. If there are no tabs to scroll to in a given direction, then the
+respective navigation button will not appear.
 
 <Canvas of={TabsStories.Responsive} />
+
+#### Horizontal with validation
+
+<Canvas of={TabsStories.ResponsiveValidation} />
+
+#### Vertical
+
+__Note: This story is best viewed in the `canvas` view and by adjusting the size of the window.__
+
+The `Tabs` component is also responsive when oriented vertically. Please note that the navigation buttons described above will not appear
+when the `position` prop is set to `left`.
+
+<Canvas of={TabsStories.ResponsiveVertical} />
 
 ### With string validations summarised
 

--- a/src/components/tabs/tabs.stories.tsx
+++ b/src/components/tabs/tabs.stories.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import generateStyledSystemProps from "../../../.storybook/utils/styled-system-props";
-import useMediaQuery from "../../hooks/useMediaQuery";
 
 import { Checkbox } from "../checkbox";
 import Pill from "../pill";
@@ -2312,14 +2311,6 @@ WithStringValidationsSummarised.parameters = {
 };
 
 export const Responsive: Story = () => {
-  const fullscreenViewBreakPoint = useMediaQuery("(max-width: 900px)");
-
-  let position: "top" | "left" = "top";
-
-  if (fullscreenViewBreakPoint) {
-    position = "left";
-  }
-
   const tabsData = Array(20)
     .fill(0)
     .map((_, index) => ({
@@ -2331,12 +2322,104 @@ export const Responsive: Story = () => {
 
   return (
     <Box p="4px">
-      <Tabs align="left" position={position}>
+      <Tabs align="left" position="top">
         {tabsData.map((tabData) => (
-          <Tab {...tabData} key={tabData.key} />
+          <Tab role="tab" {...tabData} key={tabData.key}>
+            {tabData.content}
+          </Tab>
         ))}
       </Tabs>
     </Box>
   );
 };
-Responsive.storyName = "Responsive";
+Responsive.storyName = "Responsive - Horizontal";
+
+export const ResponsiveValidation: Story = () => {
+  const tabsData = Array(20)
+    .fill(0)
+    .map((_, index) => ({
+      tabId: `tab-${index + 1}`,
+      title: `Tab ${index + 1}`,
+      key: `tab-${index + 1}`,
+      content: `Content for tab ${index + 1}`,
+      errorMessage: index === 5 ? "error" : undefined,
+    }));
+
+  return (
+    <Box p="4px">
+      <Tabs align="left" position="top">
+        {tabsData.map((tabData) => (
+          <Tab role="tab" {...tabData} key={tabData.key}>
+            {tabData.content}
+            {tabData.errorMessage && (
+              <Checkbox
+                label="Add error"
+                error="error"
+                onChange={() => {}}
+                checked
+              />
+            )}
+          </Tab>
+        ))}
+      </Tabs>
+    </Box>
+  );
+};
+ResponsiveValidation.storyName = "Responsive - Horizontal with validation";
+
+export const ResponsiveVertical: Story = () => {
+  const tabsData = Array(20)
+    .fill(0)
+    .map((_, index) => ({
+      tabId: `tab-${index + 1}`,
+      title: `Tab ${index + 1}`,
+      key: `tab-${index + 1}`,
+      content: `Content for tab ${index + 1}`,
+    }));
+
+  return (
+    <Box p="4px">
+      <Tabs align="left" position="left">
+        {tabsData.map((tabData) => (
+          <Tab role="tab" {...tabData} key={tabData.key}>
+            {tabData.content}
+          </Tab>
+        ))}
+      </Tabs>
+    </Box>
+  );
+};
+ResponsiveVertical.storyName = "Responsive - Vertical";
+
+export const ResponsiveLarge: Story = () => {
+  const tabsData = Array(20)
+    .fill(0)
+    .map((_, index) => ({
+      tabId: `tab-${index + 1}`,
+      title: `Tab ${index + 1}`,
+      key: `tab-${index + 1}`,
+      content: `Content for tab ${index + 1}`,
+      errorMessage: index === 5 ? "error" : undefined,
+    }));
+
+  return (
+    <Box p="4px">
+      <Tabs align="left" size="large" position="top">
+        {tabsData.map((tabData) => (
+          <Tab role="tab" {...tabData} key={tabData.key}>
+            {tabData.content}
+            {tabData.errorMessage && (
+              <Checkbox
+                label="Add error"
+                error="error"
+                onChange={() => {}}
+                checked
+              />
+            )}
+          </Tab>
+        ))}
+      </Tabs>
+    </Box>
+  );
+};
+ResponsiveLarge.storyName = "Responsive - Large Tabs";

--- a/src/components/tabs/tabs.test.tsx
+++ b/src/components/tabs/tabs.test.tsx
@@ -1622,3 +1622,31 @@ test("leaves the same tab content visible when the already-selected tab is click
   expect(screen.getByText("Content for tab 1")).toBeVisible();
   expect(screen.getByText("Content for tab 2")).not.toBeVisible();
 });
+
+test("renders the tabs with the correct size when the `size` prop is set to default", () => {
+  render(
+    <Tabs size="default">
+      <Tab tabId="1" title="Test 1">
+        Content
+      </Tab>
+      <Tab tabId="2" title="Test 2">
+        Content
+      </Tab>
+    </Tabs>,
+  );
+  expect(screen.getByTestId("tab-container")).toHaveStyle("height: 42px");
+});
+
+test("renders the tabs with the correct size when the `size` prop is set to large", () => {
+  render(
+    <Tabs size="large">
+      <Tab tabId="1" title="Test 1">
+        Content
+      </Tab>
+      <Tab tabId="2" title="Test 2">
+        Content
+      </Tab>
+    </Tabs>,
+  );
+  expect(screen.getByTestId("tab-container")).toHaveStyle("height: 50px");
+});


### PR DESCRIPTION
Improves the Tabs component to ensure that it complies to the new Design System concepts, mainly via scroll removal in favour of button navigation control

### Proposed behaviour

Disable horizontal scroll and replace with buttons to allow mouse-only users to be able to navigate the tab list, as per the DS

### Current behaviour

Users must grab the scroll bar and drag it around if they wish to view obscured tabs. This can be quite difficult for users who e.g. experience tremours in their hands, and no alternative navigation approach is provided.

### Checklist

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Using the existing `Tabs` Storybook entry (under the `Responsive` section), resize the screen and ensure that the buttons:
- are shown if there are hidden tabs available to scroll to; or
- are hidden if there are no further tabs to show.

Only horizontal tabs are scrollable. Vertical tabs remain unchanged.