### PR TITLE
feat(select): update styles of transparent variant to align with frozen design system

### DIFF
--- a/src/components/select/__internal__/select-textbox/select-textbox.style.ts
+++ b/src/components/select/__internal__/select-textbox/select-textbox.style.ts
@@ -25,13 +25,14 @@ const StyledSelectText = styled.span<StyledSelectTextProps>`
     css`
       font-weight: 500;
       text-align: right;
-      flex-direction: row-reverse;
     `}
 
     ${hasPlaceholder &&
     css`
-      color: var(--colorsUtilityYin055);
-      font-weight: normal;
+      color: ${transparent
+        ? `var(--colorsUtilityYin100)`
+        : `var(--colorsUtilityYin055)`};
+      font-weight: ${transparent ? 500 : "normal"};
       user-select: none;
     `}
 

--- a/src/components/select/simple-select/simple-select.mdx
+++ b/src/components/select/simple-select/simple-select.mdx
@@ -125,6 +125,10 @@ This prop will be called every time a user scrolls to the bottom of the list.
 
 <Canvas of={SimpleSelectStories.Transparent} />
 
+### Transparent Disabled
+
+<Canvas of={SimpleSelectStories.TransparentDisabled} />
+
 ### Custom Option content
 
 It is also possible to render non-interactive content within the `Option` component.

--- a/src/components/select/simple-select/simple-select.stories.tsx
+++ b/src/components/select/simple-select/simple-select.stories.tsx
@@ -471,13 +471,13 @@ Readonly.storyName = "Readonly";
 
 export const Transparent: Story = () => {
   return (
-    <Box height={250}>
+    <Box height={250} width={200}>
       <Select
         name="transparent"
         id="transparent"
-        defaultValue="4"
+        placeholder="Please select a colour"
         transparent
-        label="color"
+        label="Choose a colour"
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -495,6 +495,34 @@ export const Transparent: Story = () => {
   );
 };
 Transparent.storyName = "Transparent";
+
+export const TransparentDisabled: Story = () => {
+  return (
+    <Box height={250} width={150}>
+      <Select
+        name="transparent"
+        id="transparent"
+        defaultValue="4"
+        transparent
+        label="Choose a colour"
+        disabled
+      >
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+        <Option text="Brown" value="4" />
+        <Option text="Green" value="5" />
+        <Option text="Orange" value="6" />
+        <Option text="Pink" value="7" />
+        <Option text="Purple" value="8" />
+        <Option text="Red" value="9" />
+        <Option text="White" value="10" />
+        <Option text="Yellow" value="11" />
+      </Select>
+    </Box>
+  );
+};
+TransparentDisabled.storyName = "Transparent disabled";
 
 export const CustomOptionChildren: Story = () => {
   return (


### PR DESCRIPTION
### Proposed behaviour

![Screenshot 2024-11-05 at 16 07 48](https://github.com/user-attachments/assets/0add0e57-d3a3-4d91-ad51-7d693501776a)

![Screenshot 2024-11-05 at 16 24 52](https://github.com/user-attachments/assets/1d2fd47a-927c-4987-9631-93ba748bffb8)

![Screenshot 2024-11-05 at 15 45 44](https://github.com/user-attachments/assets/3fb8e84a-4031-4c44-bc0a-c188cf091879)

### Current behaviour

![Screenshot 2024-11-05 at 16 20 14](https://github.com/user-attachments/assets/4625b425-cbe3-4565-8c83-2ed9d0675d1c)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

I have not added any unit tests for the styling tweaks as Chromatic will be the best way to capture these changes as they are purely visual.

Our `transparent` variant of Select matches up with the `subtle` version in the frozen Design System.

### Testing instructions

- There should be no visual styling regressions with any other type of Select.
- `Transparent` should match the designs provided with this work. 
- There should be no functional changes to the `transparent` variant of Select.
