### PR TITLE
feat(carbon-provider): add deprecation warning for roundedCornersOptOut & focusRedesignOptOut

### DIFF
--- a/src/components/carbon-provider/__internal__/new-validation.context.ts
+++ b/src/components/carbon-provider/__internal__/new-validation.context.ts
@@ -5,10 +5,13 @@ export interface NewValidationContextProps {
    *
    * NOTE - Will eventually be set to `true` by default in the future. */
   validationRedesignOptIn?: boolean;
-  /** Feature flag for opting out of styling components to have rounded corners.
+  /** (Deprecated) Feature flag for opting out of styling components to have rounded corners.
    *
-   * NOTE - Will eventually be set to `false` by default in the future. */
+   * NOTE - This feature flag will soon be removed, along with the legacy styling. */
   roundedCornersOptOut?: boolean;
+  /** (Deprecated) Feature flag for opting out of the focus redesign.
+   *
+   * NOTE -  This feature flag will soon be removed, along with the legacy styling. */
   focusRedesignOptOut?: boolean;
 }
 

--- a/src/components/carbon-provider/carbon-provider.component.tsx
+++ b/src/components/carbon-provider/carbon-provider.component.tsx
@@ -9,6 +9,7 @@ import NewValidationContext, {
   NewValidationContextProps,
 } from "./__internal__/new-validation.context";
 import TopModalProvider from "./__internal__/top-modal-provider.component";
+import Logger from "../../__internal__/utils/logger";
 
 export interface CarbonProviderProps extends NewValidationContextProps {
   /* Content for the provider to wrap */
@@ -16,6 +17,9 @@ export interface CarbonProviderProps extends NewValidationContextProps {
   /** Theme which specifies styles to apply to all child components. Set to `sageTheme` by default. */
   theme?: Partial<ThemeObject>;
 }
+
+let deprecatedRoundedCornersOptOut = false;
+let deprecatedFocusRedesignOptOut = false;
 
 export const CarbonProvider = ({
   children,
@@ -33,6 +37,23 @@ export const CarbonProvider = ({
     existingRoundedCornersOptOut || roundedCornersOptOut;
   const focusRedesignOptOutValue =
     existingFocusRedesignOptOut || focusRedesignOptOut;
+
+  if (!deprecatedRoundedCornersOptOut && roundedCornersOptOutValue) {
+    deprecatedRoundedCornersOptOut = true;
+    Logger.deprecate(
+      "The `roundedCornersOptOut` feature flag has been deprecated and will soon be removed. " +
+        "Along with this feature flag, the legacy pre-rounded corners styling will also be removed. ",
+    );
+  }
+
+  if (!deprecatedFocusRedesignOptOut && focusRedesignOptOutValue) {
+    deprecatedFocusRedesignOptOut = true;
+    Logger.deprecate(
+      "The `focusRedesignOptOut` feature flag has been deprecated and will soon be removed. " +
+        "Along with this feature flag, the legacy focus styling will also be removed. ",
+    );
+  }
+
   return (
     <ThemeProvider
       theme={{

--- a/src/components/carbon-provider/carbon-provider.test.tsx
+++ b/src/components/carbon-provider/carbon-provider.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import CarbonProvider from ".";
+import Logger from "../../__internal__/utils/logger";
+
+test("logs a deprecation warning once when the `roundedCornersOptOut` feature flag is `true`", () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+
+  render(
+    <>
+      <CarbonProvider roundedCornersOptOut>
+        <CarbonProvider>Hello World!</CarbonProvider>
+      </CarbonProvider>
+      <CarbonProvider roundedCornersOptOut>
+        <CarbonProvider>Hello World!</CarbonProvider>
+      </CarbonProvider>
+    </>,
+  );
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The `roundedCornersOptOut` feature flag has been deprecated and will soon be removed. " +
+      "Along with this feature flag, the legacy pre-rounded corners styling will also be removed. ",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+  loggerSpy.mockRestore();
+});
+
+test("logs a deprecation warning once when the `focusRedesignOptOut` feature flag is `true`", () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+
+  render(
+    <>
+      <CarbonProvider focusRedesignOptOut>
+        <CarbonProvider>Hello World!</CarbonProvider>
+      </CarbonProvider>
+      <CarbonProvider focusRedesignOptOut>
+        <CarbonProvider>Hello World!</CarbonProvider>
+      </CarbonProvider>
+    </>,
+  );
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The `focusRedesignOptOut` feature flag has been deprecated and will soon be removed. " +
+      "Along with this feature flag, the legacy focus styling will also be removed. ",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+  loggerSpy.mockRestore();
+});


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Deprecates both feature flags and each respective flag's previous styling.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, no deprecation warning exists for both feature flags. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
