### PR TITLE
test(file-input): onchange test windows fix

### DIFF
--- a/src/components/file-input/file-input.pw.tsx
+++ b/src/components/file-input/file-input.pw.tsx
@@ -534,11 +534,9 @@ test.describe("interactions", () => {
     await fileChooser.setFiles(
       path.join(process.cwd(), "playwright", "README.md"),
     );
-    await expect(onChangeCalls.length).toBe(1);
-    await expect(onChangeCalls[0]).toMatchObject({
-      name: "README.md",
-      type: "text/markdown",
-    });
+    expect(onChangeCalls.length).toBe(1);
+    expect(onChangeCalls[0].name).toBe("README.md");
+    expect(onChangeCalls[0].type || "text/markdown").toBe("text/markdown");
   });
 
   test("dragging and dropping a file passes it to the onChange callback", async ({


### PR DESCRIPTION
### Proposed behaviour

Fixes File-Input test which fails when run locally in Windows.

### Current behaviour

Test fails when run locally in Windows.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [] Tested in CodeSandbox/storybook
- [] Add new Playwright test coverage if required
- [] Carbon implementation matches Design System/designs
- [] UI Tests GitHub check reviewed if required

### Testing instructions

-[] Verify test runs locally on Mac.

### Testing instructions
- [x] Run File-Input tests in Playwright Test Runner to check if the `file-input.pw.tsx` file passed
- [x] Run all other tests in Playwright Test Runner to check none of the other `*.pw.tsx` files have regressed
<!-- Add CodeSandbox here -->