### PR TITLE
feat(date-input, date-range): upgrade react-day-picker to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "lodash": "^4.17.21",
         "polished": "^4.2.2",
         "prop-types": "^15.8.1",
-        "react-day-picker": "~7.4.10",
+        "react-day-picker": "^9.3.2",
         "react-dnd": "^15.1.2",
         "react-dnd-html5-backend": "^15.1.3",
         "react-is": "^17.0.2",
@@ -2695,6 +2695,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@date-fns/tz": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.2.0.tgz",
+      "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==",
+      "license": "MIT"
+    },
     "node_modules/@emotion/is-prop-valid": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
@@ -4548,17 +4554,20 @@
     "node_modules/@react-dnd/asap": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.1.tgz",
-      "integrity": "sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg=="
+      "integrity": "sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==",
+      "license": "MIT"
     },
     "node_modules/@react-dnd/invariant": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-3.0.1.tgz",
-      "integrity": "sha512-blqduwV86oiKw2Gr44wbe3pj3Z/OsXirc7ybCv9F/pLAR+Aih8F3rjeJzK0ANgtYKv5lCpkGVoZAeKitKDaD/g=="
+      "integrity": "sha512-blqduwV86oiKw2Gr44wbe3pj3Z/OsXirc7ybCv9F/pLAR+Aih8F3rjeJzK0ANgtYKv5lCpkGVoZAeKitKDaD/g==",
+      "license": "MIT"
     },
     "node_modules/@react-dnd/shallowequal": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-3.0.1.tgz",
-      "integrity": "sha512-XjDVbs3ZU16CO1h5Q3Ew2RPJqmZBDE/EVf1LYp6ePEffs3V/MX9ZbL5bJr8qiK5SbGmUMuDoaFgyKacYz8prRA=="
+      "integrity": "sha512-XjDVbs3ZU16CO1h5Q3Ew2RPJqmZBDE/EVf1LYp6ePEffs3V/MX9ZbL5bJr8qiK5SbGmUMuDoaFgyKacYz8prRA==",
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.24.0",
@@ -10782,6 +10791,7 @@
       "version": "15.1.2",
       "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-15.1.2.tgz",
       "integrity": "sha512-EOec1LyJUuGRFg0LDa55rSRAUe97uNVKVkUo8iyvzQlcECYTuPblVQfRWXWj1OyPseFIeebWpNmKFy0h6BcF1A==",
+      "license": "MIT",
       "dependencies": {
         "@react-dnd/asap": "4.0.1",
         "@react-dnd/invariant": "3.0.1",
@@ -24215,20 +24225,40 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "7.4.10",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-7.4.10.tgz",
-      "integrity": "sha512-/QkK75qLKdyLmv0kcVzhL7HoJPazoZXS8a6HixbVoK6vWey1Od1WRLcxfyEiUsRfccAlIlf6oKHShqY2SM82rA==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.3.2.tgz",
+      "integrity": "sha512-Rj2gPPVYKqZbSF8DxaLteHY+45zd6swf5yE3hmJ8m6VEqPI2ve9CuZsDvQ10tIt3ckRJ9hmLa5t0SsmLlXllhw==",
+      "license": "MIT",
       "dependencies": {
-        "prop-types": "^15.6.2"
+        "@date-fns/tz": "^1.2.0",
+        "date-fns": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
       },
       "peerDependencies": {
-        "react": "~0.13.x || ~0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0"
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/react-day-picker/node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/react-dnd": {
       "version": "15.1.2",
       "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-15.1.2.tgz",
       "integrity": "sha512-EaSbMD9iFJDY/o48T3c8wn3uWU+2uxfFojhesZN3LhigJoAIvH2iOjxofSA9KbqhAKP6V9P853G6XG8JngKVtA==",
+      "license": "MIT",
       "dependencies": {
         "@react-dnd/invariant": "3.0.1",
         "@react-dnd/shallowequal": "3.0.1",
@@ -24258,6 +24288,7 @@
       "version": "15.1.3",
       "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-15.1.3.tgz",
       "integrity": "sha512-HH/8nOEmrrcRGHMqJR91FOwhnLlx5SRLXmsQwZT3IPcBjx88WT+0pWC5A4tDOYDdoooh9k+KMPvWfxooR5TcOA==",
+      "license": "MIT",
       "dependencies": {
         "dnd-core": "15.1.2"
       }
@@ -25283,6 +25314,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "lodash": "^4.17.21",
     "polished": "^4.2.2",
     "prop-types": "^15.8.1",
-    "react-day-picker": "~7.4.10",
+    "react-day-picker": "^9.3.2",
     "react-dnd": "^15.1.2",
     "react-dnd-html5-backend": "^15.1.3",
     "react-is": "^17.0.2",

--- a/playwright/components/date-input/index.ts
+++ b/playwright/components/date-input/index.ts
@@ -1,4 +1,5 @@
 import type { Page } from "@playwright/test";
+
 import { DAY_PICKER_WRAPPER, DAY_PICKER_HEADING } from "./locators";
 
 // component preview locators
@@ -6,4 +7,4 @@ import { DAY_PICKER_WRAPPER, DAY_PICKER_HEADING } from "./locators";
 export const dayPickerWrapper = (page: Page) =>
   page.locator(DAY_PICKER_WRAPPER);
 export const dayPickerHeading = (page: Page) =>
-  page.locator(DAY_PICKER_HEADING).locator("div");
+  page.locator(DAY_PICKER_HEADING);

--- a/playwright/components/date-input/locators.ts
+++ b/playwright/components/date-input/locators.ts
@@ -1,3 +1,3 @@
 // component preview locators
-export const DAY_PICKER_WRAPPER = 'div[class="DayPicker-wrapper"]';
-export const DAY_PICKER_HEADING = ".DayPicker-Caption";
+export const DAY_PICKER_WRAPPER = 'div[class="rdp-root"]';
+export const DAY_PICKER_HEADING = 'span[class="rdp-caption_label"]';

--- a/src/__internal__/utils/logger/logger.test.ts
+++ b/src/__internal__/utils/logger/logger.test.ts
@@ -1,6 +1,6 @@
 import Logger from ".";
 
-test("should not output a warning to the console when logging is disabled", () => {
+test("should not output a warning to the console when logging is disabled and a deprecation message is fired", () => {
   Logger.setEnabledState(false);
   const consoleWarnSpy = jest
     .spyOn(console, "warn")

--- a/src/components/date/__internal__/date-fns-fp/index.ts
+++ b/src/components/date/__internal__/date-fns-fp/index.ts
@@ -3,5 +3,7 @@
 export { default as format } from "date-fns/fp/format";
 export { default as formatISO } from "date-fns/fp/formatISO";
 export { default as isMatch } from "date-fns/fp/isMatch";
+export { default as isValid } from "date-fns/fp/isValid";
 export { default as parse } from "date-fns/fp/parse";
+export { default as parseWithOptions } from "date-fns/fp/parseWithOptions";
 export { default as parseISO } from "date-fns/fp/parseISO";

--- a/src/components/date/__internal__/date-picker/date-picker.test.tsx
+++ b/src/components/date/__internal__/date-picker/date-picker.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-
 import enGBLocale from "date-fns/locale/en-GB";
 import deLocale from "date-fns/locale/de";
 import esLocale from "date-fns/locale/es";
@@ -10,6 +9,7 @@ import enZALocale from "date-fns/locale/en-ZA";
 import frLocale from "date-fns/locale/fr";
 import frCALocale from "date-fns/locale/fr-CA";
 import enUSLocale from "date-fns/locale/en-US";
+import zhCNLocale from "date-fns/locale/zh-CN";
 
 import DatePicker, { DatePickerProps } from "./date-picker.component";
 import I18nProvider from "../../../i18n-provider";
@@ -22,7 +22,7 @@ const DatePickerWithInput = (props: MockProps) => {
   const ref = React.useRef<HTMLDivElement>(null);
   const Input = () => (
     <div ref={ref}>
-      <input name="foo" id="bar" />
+      <input title="foobar" name="foo" id="bar" />
     </div>
   );
   return (
@@ -60,9 +60,15 @@ test("should render the day element that matches the `selectedDate` when prop is
       open
     />,
   );
-  const selectedDay = screen.getByRole("gridcell", { name: "Thu 4 Apr 2019" });
 
-  expect(selectedDay).toHaveAttribute("aria-selected", "true");
+  const selectedDay = screen.getByLabelText("Thursday, April 4th, 2019", {
+    exact: false,
+  });
+
+  expect(selectedDay).toHaveAttribute(
+    "aria-label",
+    "Thursday, April 4th, 2019, selected",
+  );
 });
 
 test("should render the expected weekday with `aria-disabled=true` attribute when `minDate` is '2019-04-02'", () => {
@@ -74,11 +80,11 @@ test("should render the expected weekday with `aria-disabled=true` attribute whe
       open
     />,
   );
-  const disabledDay = screen.getByRole("gridcell", { name: "Mon 1 Apr 2019" });
-  const activeDay = screen.getByRole("gridcell", { name: "Tue 2 Apr 2019" });
+  const disabledDay = screen.getByLabelText("Monday, April 1st, 2019");
+  const activeDay = screen.getByLabelText("Tuesday, April 2nd, 2019");
 
-  expect(disabledDay).toHaveAttribute("aria-disabled", "true");
-  expect(activeDay).toHaveAttribute("aria-disabled", "false");
+  expect(disabledDay).toBeDisabled();
+  expect(activeDay).toBeEnabled();
 });
 
 test("should not render any of the current month's weekdays with `aria-disabled=true` attribute when `minDate` is invalid", () => {
@@ -91,12 +97,10 @@ test("should not render any of the current month's weekdays with `aria-disabled=
     />,
   );
   // need to filter out the weekdays that are not in the current month
-  const currentMonthDays = screen.getAllByRole("gridcell", {
-    name: new RegExp("Apr", "i"),
-  });
+  const currentMonthDays = screen.getAllByLabelText("April", { exact: false });
 
   currentMonthDays.forEach((day) => {
-    expect(day).toHaveAttribute("aria-disabled", "false");
+    expect(day).toBeEnabled();
   });
 });
 
@@ -110,12 +114,10 @@ test("should not render any of the current month's weekdays with `aria-disabled=
     />,
   );
   // need to filter out the weekdays that are not in the current month
-  const currentMonthDays = screen.getAllByRole("gridcell", {
-    name: new RegExp("Apr", "i"),
-  });
+  const currentMonthDays = screen.getAllByLabelText("April", { exact: false });
 
   currentMonthDays.forEach((day) => {
-    expect(day).toHaveAttribute("aria-disabled", "false");
+    expect(day).toBeEnabled();
   });
 });
 
@@ -128,11 +130,11 @@ test("should render the expected weekday with `aria-disabled=true` attribute whe
       open
     />,
   );
-  const disabledDay = screen.getByRole("gridcell", { name: "Sat 6 Apr 2019" });
-  const activeDay = screen.getByRole("gridcell", { name: "Fri 5 Apr 2019" });
+  const disabledDay = screen.getByLabelText("Saturday, April 6th, 2019");
+  const activeDay = screen.getByLabelText("Friday, April 5th, 2019");
 
-  expect(disabledDay).toHaveAttribute("aria-disabled", "true");
-  expect(activeDay).toHaveAttribute("aria-disabled", "false");
+  expect(disabledDay).toBeDisabled();
+  expect(activeDay).toBeEnabled();
 });
 
 test("should not render any of the current month's weekdays with `aria-disabled=true` attribute when `maxDate` is invalid", () => {
@@ -145,12 +147,10 @@ test("should not render any of the current month's weekdays with `aria-disabled=
     />,
   );
   // need to filter out the weekdays that are not in the current month
-  const currentMonthDays = screen.getAllByRole("gridcell", {
-    name: new RegExp("Apr", "i"),
-  });
+  const currentMonthDays = screen.getAllByLabelText("April", { exact: false });
 
   currentMonthDays.forEach((day) => {
-    expect(day).toHaveAttribute("aria-disabled", "false");
+    expect(day).toBeEnabled();
   });
 });
 
@@ -164,12 +164,10 @@ test("should not render any of the current month's weekdays with `aria-disabled=
     />,
   );
   // need to filter out the weekdays that are not in the current month
-  const currentMonthDays = screen.getAllByRole("gridcell", {
-    name: new RegExp("Apr", "i"),
-  });
+  const currentMonthDays = screen.getAllByLabelText("April", { exact: false });
 
   currentMonthDays.forEach((day) => {
-    expect(day).toHaveAttribute("aria-disabled", "false");
+    expect(day).toBeEnabled();
   });
 });
 
@@ -185,7 +183,7 @@ test("should not call `onDayClick` callback when a user clicks a disabled day", 
       onDayClick={onDayClick}
     />,
   );
-  const disabledDay = screen.getByRole("gridcell", { name: "Mon 1 Apr 2019" });
+  const disabledDay = screen.getByLabelText("Monday, April 1st, 2019");
   await user.click(disabledDay);
 
   expect(onDayClick).not.toHaveBeenCalled();
@@ -202,7 +200,7 @@ test("should call `onDayClick` callback when a user clicks a day that is not dis
       onDayClick={onDayClick}
     />,
   );
-  const activeDay = screen.getByRole("gridcell", { name: "Tue 2 Apr 2019" });
+  const activeDay = screen.getByLabelText("Tuesday, April 2nd, 2019");
   await user.click(activeDay);
 
   expect(onDayClick).toHaveBeenCalled();
@@ -401,4 +399,58 @@ test("should render with 'fr-CA' translations when the `locale` is passed via I1
   });
   expect(screen.getByRole("button", { name: "fr-CA-previous" })).toBeVisible();
   expect(screen.getByRole("button", { name: "fr-CA-next" })).toBeVisible();
+});
+
+test("should correctly translate the month caption for the given locale (fr-FR)", () => {
+  render(
+    <I18nProvider
+      locale={{
+        locale: () => "fr-FR",
+        date: {
+          dateFnsLocale: () => frLocale,
+          ariaLabels: {
+            previousMonthButton: () => "fr-FR-previous",
+            nextMonthButton: () => "fr-FR-next",
+          },
+        },
+      }}
+    >
+      <DatePickerWithInput
+        setOpen={() => {}}
+        open
+        selectedDays={new Date(2019, 2, 4)}
+      />
+    </I18nProvider>,
+  );
+
+  const monthCaption = screen.getByRole("status");
+  expect(monthCaption).toBeVisible();
+  expect(monthCaption).toHaveTextContent("mars 2019");
+});
+
+test("should correctly translate the month caption for the given locale (zh-CN)", () => {
+  render(
+    <I18nProvider
+      locale={{
+        locale: () => "zh-CN",
+        date: {
+          dateFnsLocale: () => zhCNLocale,
+          ariaLabels: {
+            previousMonthButton: () => "zh-CN-previous",
+            nextMonthButton: () => "zh-CN-next",
+          },
+        },
+      }}
+    >
+      <DatePickerWithInput
+        setOpen={() => {}}
+        open
+        selectedDays={new Date(2019, 2, 4)}
+      />
+    </I18nProvider>,
+  );
+
+  const monthCaption = screen.getByRole("status");
+  expect(monthCaption).toBeVisible();
+  expect(monthCaption).toHaveTextContent("三月 2019");
 });

--- a/src/components/date/__internal__/date-picker/day-picker.style.ts
+++ b/src/components/date/__internal__/date-picker/day-picker.style.ts
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+
 import baseTheme from "../../../../style/themes/base";
 import addFocusStyling from "../../../../style/utils/add-focus-styling";
 
@@ -6,196 +7,308 @@ const oldFocusStyling = `
   outline: solid 3px var(--colorsSemanticFocus500);
 `;
 
-// Styles copied from https://github.com/gpbl/react-day-picker/blob/v6.1.1/src/style.css
-const addReactDayPickerStyles = () => `
-  .DayPicker {
-    display: inline-block;
+const officialReactDayPickerStyling = () => css`
+  /* Variables declaration */
+  /* prettier-ignore */
+  .rdp-root {
+    --rdp-accent-color: blue; /* The accent color used for selected days and UI elements. */
+    --rdp-accent-background-color: #f0f0ff; /* The accent background color used for selected days and UI elements. */
+
+    --rdp-day-height: 2.75rem; /* The height of the day cells. */
+    --rdp-day-width: 2.75rem; /* The width of the day cells. */
+
+    --rdp-day_button-border-radius: 100%; /* The border radius of the day cells. */
+    --rdp-day_button-border: 2px solid transparent; /* The border of the day cells. */
+    --rdp-day_button-height: var(--rdp-day-height); /* The height of the day cells. */
+    --rdp-day_button-width: var(--rdp-day-width); /* The width of the day cells. */
+
+    --rdp-selected-border: 2px solid var(--rdp-accent-color); /* The border of the selected days. */
+    --rdp-disabled-opacity: 0.5; /* The opacity of the disabled days. */
+    --rdp-outside-opacity: 0.75; /* The opacity of the days outside the current month. */
+    --rdp-today-color: var(--rdp-accent-color); /* The color of the today's date. */
+
+    --rdp-dropdown-gap: 0.5rem;/* The gap between the dropdowns used in the month captons. */
+
+    --rdp-months-gap: 2rem; /* The gap between the months in the multi-month view. */
+
+    --rdp-nav_button-disabled-opacity: 0.5; /* The opacity of the disabled navigation buttons. */
+    --rdp-nav_button-height: 2.25rem; /* The height of the navigation buttons. */
+    --rdp-nav_button-width: 2.25rem; /* The width of the navigation buttons. */
+    --rdp-nav-height: 2.75rem; /* The height of the navigation bar. */
+
+    --rdp-range_middle-background-color: var(--rdp-accent-background-color); /* The color of the background for days in the middle of a range. */
+    --rdp-range_middle-foreground-color: white; /* The foregraound color for days in the middle of a range. */
+    --rdp-range_middle-color: inherit;/* The color of the range text. */
+
+    --rdp-range_start-color: white; /* The color of the range text. */
+    --rdp-range_start-background: linear-gradient(var(--rdp-gradient-direction), transparent 50%, var(--rdp-range_middle-background-color) 50%); /* Used for the background of the start of the selected range. */
+    --rdp-range_start-date-background-color: var(--rdp-accent-color); /* The background color of the date when at the start of the selected range. */
+
+    --rdp-range_end-background: linear-gradient(var(--rdp-gradient-direction), var(--rdp-range_middle-background-color) 50%, transparent 50%); /* Used for the background of the end of the selected range. */
+    --rdp-range_end-color: white;/* The color of the range text. */
+    --rdp-range_end-date-background-color: var(--rdp-accent-color); /* The background color of the date when at the end of the selected range. */
+
+    --rdp-week_number-border-radius: 100%; /* The border radius of the week number. */
+    --rdp-week_number-border: 2px solid transparent; /* The border of the week number. */
+
+    --rdp-week_number-height: var(--rdp-day-height); /* The height of the week number cells. */
+    --rdp-week_number-opacity: 0.75; /* The opacity of the week number. */
+    --rdp-week_number-width: var(--rdp-day-width); /* The width of the week number cells. */
+    --rdp-weeknumber-text-align: center; /* The text alignment of the weekday cells. */
+
+    --rdp-weekday-opacity: 0.75; /* The opacity of the weekday. */
+    --rdp-weekday-padding: 0.5rem 0rem; /* The padding of the weekday. */
+    --rdp-weekday-text-align: center; /* The text alignment of the weekday cells. */
+
+    --rdp-gradient-direction: 90deg;
   }
 
-  .DayPicker-wrapper {
+  .rdp-root[dir="rtl"] {
+    --rdp-gradient-direction: -90deg;
+  }
+
+  /* Root of the component. */
+  .rdp-root {
+    position: relative; /* Required to position the navigation toolbar. */
+    box-sizing: border-box;
+  }
+
+  .rdp-root * {
+    box-sizing: border-box;
+  }
+
+  .rdp-day {
+    width: var(--sizing500);
+    height: var(--sizing450);
+    text-align: center;
+  }
+
+  .rdp-day_button {
+    background: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+    justify-content: center;
+    align-items: center;
     display: flex;
-    flex-wrap: wrap;
+    min-width: var(--sizing500);
+    height: var(--sizing450);
+    border: var(--rdp-day_button-border);
+    border-radius: var(--rdp-day_button-border-radius);
+  }
+
+  .rdp-day_button:disabled {
+    cursor: revert;
+  }
+
+  .rdp-day_button {
+    outline: none;
+  }
+
+  .rdp-caption_label {
+    z-index: 1;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .rdp-button_next,
+  .rdp-button_previous {
+    border: none;
+    background: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    font: inherit;
+    color: inherit;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    display: inline-flex;
+    align-items: center;
     justify-content: center;
     position: relative;
-    user-select: none;
-    flex-direction: row;
-    padding: 1rem 0;
+    appearance: none;
+    width: var(--rdp-nav_button-width);
+    height: var(--rdp-nav_button-height);
   }
 
-  .DayPicker-Month {
-    display: table;
-    border-collapse: collapse;
-    border-spacing: 0;
-    user-select: none;
-    margin: 0 1rem;
+  .rdp-button_next:disabled,
+  .rdp-button_previous:disabled {
+    cursor: revert;
+    opacity: var(--rdp-nav_button-disabled-opacity);
   }
 
-  .DayPicker-NavBar {
-    position: absolute;
-    left: 0;
-    right: 0;
-  }
-
-  .DayPicker-NavButton {
-    position: absolute;
-    width: 1.5rem;
-    height: 1.5rem;
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: contain;
-    cursor: pointer;
-  }
-
-  .DayPicker-NavButton--prev {
-    left: 1rem;
-    background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjI2cHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDI2IDUwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOnNrZXRjaD0iaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoL25zIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggMy4zLjIgKDEyMDQzKSAtIGh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaCAtLT4KICAgIDx0aXRsZT5wcmV2PC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSI+CiAgICAgICAgPGcgaWQ9InByZXYiIHNrZXRjaDp0eXBlPSJNU0xheWVyR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDEzLjM5MzE5MywgMjUuMDAwMDAwKSBzY2FsZSgtMSwgMSkgdHJhbnNsYXRlKC0xMy4zOTMxOTMsIC0yNS4wMDAwMDApIHRyYW5zbGF0ZSgwLjg5MzE5MywgMC4wMDAwMDApIiBmaWxsPSIjNTY1QTVDIj4KICAgICAgICAgICAgPHBhdGggZD0iTTAsNDkuMTIzNzMzMSBMMCw0NS4zNjc0MzQ1IEwyMC4xMzE4NDU5LDI0LjcyMzA2MTIgTDAsNC4yMzEzODMxNCBMMCwwLjQ3NTA4NDQ1OSBMMjUsMjQuNzIzMDYxMiBMMCw0OS4xMjM3MzMxIEwwLDQ5LjEyMzczMzEgWiIgaWQ9InJpZ2h0IiBza2V0Y2g6dHlwZT0iTVNTaGFwZUdyb3VwIj48L3BhdGg+CiAgICAgICAgPC9nPgogICAgPC9nPgo8L3N2Zz4K");
-  }
-
-  .DayPicker-NavButton--next {
-    right: 1rem;
-    background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+Cjxzdmcgd2lkdGg9IjI2cHgiIGhlaWdodD0iNTBweCIgdmlld0JveD0iMCAwIDI2IDUwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHhtbG5zOnNrZXRjaD0iaHR0cDovL3d3dy5ib2hlbWlhbmNvZGluZy5jb20vc2tldGNoL25zIj4KICAgIDwhLS0gR2VuZXJhdG9yOiBTa2V0Y2ggMy4zLjIgKDEyMDQzKSAtIGh0dHA6Ly93d3cuYm9oZW1pYW5jb2RpbmcuY29tL3NrZXRjaCAtLT4KICAgIDx0aXRsZT5uZXh0PC90aXRsZT4KICAgIDxkZXNjPkNyZWF0ZWQgd2l0aCBTa2V0Y2guPC9kZXNjPgogICAgPGRlZnM+PC9kZWZzPgogICAgPGcgaWQ9IlBhZ2UtMSIgc3Ryb2tlPSJub25lIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCIgc2tldGNoOnR5cGU9Ik1TUGFnZSI+CiAgICAgICAgPGcgaWQ9Im5leHQiIHNrZXRjaDp0eXBlPSJNU0xheWVyR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDAuOTUxNDUxLCAwLjAwMDAwMCkiIGZpbGw9IiM1NjVBNUMiPgogICAgICAgICAgICA8cGF0aCBkPSJNMCw0OS4xMjM3MzMxIEwwLDQ1LjM2NzQzNDUgTDIwLjEzMTg0NTksMjQuNzIzMDYxMiBMMCw0LjIzMTM4MzE0IEwwLDAuNDc1MDg0NDU5IEwyNSwyNC43MjMwNjEyIEwwLDQ5LjEyMzczMzEgTDAsNDkuMTIzNzMzMSBaIiBpZD0icmlnaHQiIHNrZXRjaDp0eXBlPSJNU1NoYXBlR3JvdXAiPjwvcGF0aD4KICAgICAgICA8L2c+CiAgICA8L2c+Cjwvc3ZnPgo=");
-  }
-
-  .DayPicker-NavButton--interactionDisabled {
-    display: none;
-  }
-
-  .DayPicker-Caption {
-    display: table-caption;
-    height: 1.5rem;
-    text-align: center;
-  }
-
-  .DayPicker-Weekdays {
-    display: table-header-group;
-  }
-
-  .DayPicker-WeekdaysRow {
-    display: table-row;
-  }
-
-  .DayPicker-Weekday {
-    display: table-cell;
-
-    abbr {
-      text-decoration: none;
-    }
-  }
-
-  .DayPicker-Body {
-    display: table-row-group;
-  }
-
-  .DayPicker-Week {
-    display: table-row;
-  }
-
-  .DayPicker-Day {
-    display: table-cell;
-    padding: 0.5rem;
-    border: 1px solid #eaecec;
-    text-align: center;
-    cursor: pointer;
-    vertical-align: middle;
-  }
-
-  .DayPicker-WeekNumber {
-    display: table-cell;
-    padding: 0.5rem;
-    text-align: right;
-    vertical-align: middle;
-    min-width: 1rem;
-    font-size: 0.75em;
-    cursor: pointer;
-    color: #8b9898;
-  }
-
-  .DayPicker--interactionDisabled .DayPicker-Day {
-    cursor: default;
-  }
-
-  .DayPicker-Footer {
-    display: table-caption;
-    caption-side: bottom;
-    padding-top: 0.5rem;
-  }
-
-  .DayPicker-TodayButton {
-    border: none;
-    background-image: none;
-    background-color: transparent;
-    box-shadow: none;
-    cursor: pointer;
-    color: #4a90e2;
-    font-size: 0.875em;
-  }
-
-  /* Default modifiers */
-
-  .DayPicker-Day--today {
-    color: #d0021b;
-    font-weight: 500;
-  }
-
-  .DayPicker-Day--disabled {
-    color: #dce0e0;
-    cursor: default;
-    background-color: #eff1f1;
-  }
-
-  .DayPicker-Day--outside {
-    cursor: default;
-    color: #dce0e0;
-  }
-
-  /* Example modifiers */
-
-  .DayPicker-Day--sunday {
-    background-color: #f7f8f8;
-  }
-
-  .DayPicker-Day--sunday:not(.DayPicker-Day--today) {
-    color: #dce0e0;
-  }
-
-  .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
-    color: #fff;
-    background-color: #4a90e2;
-  }
-
-  /* DayPickerInput */
-
-  .DayPickerInput {
+  .rdp-chevron {
     display: inline-block;
+    fill: var(--rdp-accent-color);
   }
 
-  .DayPickerInput-OverlayWrapper {
+  .rdp-root[dir="rtl"] .rdp-nav .rdp-chevron {
+    transform: rotate(180deg);
+  }
+
+  .rdp-root[dir="rtl"] .rdp-nav .rdp-chevron {
+    transform: rotate(180deg);
+    transform-origin: 50%;
+  }
+
+  .rdp-dropdowns {
     position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--rdp-dropdown-gap);
+  }
+  .rdp-dropdown {
+    z-index: 2;
+    /* Reset */
+    opacity: 0;
+    appearance: none;
+    position: absolute;
+    inset-block-start: 0;
+    inset-block-end: 0;
+    inset-inline-start: 0;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    cursor: inherit;
+    border: none;
+    line-height: inherit;
   }
 
-  .DayPickerInput-Overlay {
-    left: 0;
+  .rdp-dropdown_root {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .rdp-dropdown_root[data-disabled="true"] .rdp-chevron {
+    opacity: var(--rdp-disabled-opacity);
+  }
+
+  .rdp-month_caption {
+    display: flex;
+    align-content: center;
+    height: var(--rdp-nav-height);
+    font-weight: bold;
+    font-size: large;
+  }
+
+  .rdp-months {
+    position: relative;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--rdp-months-gap);
+    max-width: fit-content;
+  }
+
+  .rdp-month_grid {
+    border-collapse: collapse;
+  }
+
+  .rdp-nav {
     position: absolute;
-    background: white;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+    inset-block-start: 0;
+    inset-inline-end: 0;
+    display: flex;
+    align-items: center;
+    height: var(--rdp-nav-height);
+    width: 100%;
+  }
+
+  .rdp-weekday {
+    opacity: var(--rdp-weekday-opacity);
+    padding: var(--rdp-weekday-padding);
+    font-weight: 500;
+    font-size: smaller;
+    text-align: var(--rdp-weekday-text-align);
+    text-transform: var(--rdp-weekday-text-transform);
+  }
+
+  .rdp-week_number {
+    opacity: var(--rdp-week_number-opacity);
+    font-weight: 400;
+    font-size: small;
+    height: var(--rdp-week_number-height);
+    width: var(--rdp-week_number-width);
+    border: var(--rdp-week_number-border);
+    border-radius: var(--rdp-week_number-border-radius);
+    text-align: var(--rdp-weeknumber-text-align);
+  }
+
+  /* DAY MODIFIERS */
+  .rdp-today:not(.rdp-outside) {
+    color: var(--rdp-today-color);
+  }
+
+  .rdp-selected {
+    font-weight: bold;
+    font-size: large;
+  }
+
+  .rdp-selected .rdp-day_button {
+    border: var(--rdp-selected-border);
+  }
+
+  .rdp-outside {
+    opacity: var(--rdp-outside-opacity);
+  }
+
+  .rdp-disabled {
+    opacity: var(--rdp-disabled-opacity);
+  }
+
+  .rdp-hidden {
+    visibility: hidden;
+    color: var(--rdp-range_start-color);
+  }
+
+  .rdp-range_start {
+    background: var(--rdp-range_start-background);
+  }
+
+  .rdp-range_start .rdp-day_button {
+    background-color: var(--rdp-range_start-date-background-color);
+    color: var(--rdp-range_start-color);
+  }
+
+  .rdp-range_middle {
+    background-color: var(--rdp-range_middle-background-color);
+  }
+
+  .rdp-range_middle .rdp-day_button {
+    border-color: transparent;
+    border: unset;
+    border-radius: unset;
+    color: var(--rdp-range_middle-color);
+  }
+
+  .rdp-range_end {
+    background: var(--rdp-range_end-background);
+    color: var(--rdp-range_end-color);
+  }
+
+  .rdp-range_end .rdp-day_button {
+    color: var(--rdp-range_start-color);
+    background-color: var(--rdp-range_end-date-background-color);
+  }
+
+  .rdp-range_start.rdp-range_end {
+    background: revert;
+  }
+
+  .rdp-focusable {
+    cursor: pointer;
   }
 `;
 
 const StyledDayPicker = styled.div`
-  ${addReactDayPickerStyles}
+  ${officialReactDayPickerStyling}
 
-  position: absolute;
-  height: 346px;
-  width: 352px;
-  ${({ theme }) => css`
-    z-index: ${theme.zIndex.popover};
-    ${!theme.focusRedesignOptOut &&
-    `
-      margin-top: var(--spacing050);
-    `}
-  `}
-
-  .DayPicker {
+  .rdp-root {
     z-index: 1000;
     top: calc(100% + 1px);
     left: 0;
@@ -209,46 +322,40 @@ const StyledDayPicker = styled.div`
     border-radius: var(--borderRadius050);
   }
 
-  .DayPicker * {
+  .rdp-root * {
     box-sizing: border-box;
   }
 
-  .DayPicker:focus {
+  .rdp-root:focus {
     outline: none;
   }
 
-  .DayPicker abbr[title] {
+  .rdp-root abbr[title] {
     border: none;
     cursor: initial;
   }
 
-  .DayPicker-wrapper {
+  .rdp-months {
     padding: 0;
-    &:focus {
-      ${({ theme }) =>
-        !theme.focusRedesignOptOut
-          ? addFocusStyling()
-          : /* istanbul ignore next */ oldFocusStyling}
-      border-radius: var(--borderRadius050);
-    }
   }
 
-  .DayPicker-Month {
+  .rdp-month {
     margin: 0 0 2px;
   }
 
-  .DayPicker-Body,
-  .DayPicker-Week {
+  .rdp-month_grid,
+  .rdp_weeks {
     width: 100%;
+    margin-top: 8px;
   }
 
-  .DayPicker-Caption {
+  .rdp-month_caption {
     color: var(--colorsActionMajorYin090);
     line-height: var(--sizing500);
     height: var(--sizing500);
-    //font: var(--typographyDatePickerCalendarMonthM); font assets to be updated part of FE-4975
     font-size: 16px;
     font-weight: 800;
+    display: block;
 
     > div {
       margin: 0 auto;
@@ -256,15 +363,24 @@ const StyledDayPicker = styled.div`
     }
   }
 
-  .DayPicker-Day {
+  .rdp-weekday {
+    border: medium;
+    width: var(--sizing500);
+    height: var(--sizing450);
+    font-weight: 800;
+    color: var(--colorsActionMinor500);
+    text-transform: uppercase;
+    font-size: 12px;
+    text-align: center;
+  }
+
+  .rdp-day {
     min-width: var(--sizing500);
     height: var(--sizing450);
     padding: 0;
-    background-color: var(--colorsUtilityYang100);
+    background-color: transparent;
     cursor: pointer;
     border: none;
-    //font-family: var(--fontFamiliesDefault); font assets to be updated part of FE-4975
-    //font: var(--typographyDatePickerCalendarDateM); font assets to be updated part of FE-4975
     font-weight: var(--fontWeights500);
     font-size: var(--fontSizes100);
     line-height: var(--lineHeights500);
@@ -275,17 +391,6 @@ const StyledDayPicker = styled.div`
       color: var(--colorsActionMajorYin090);
     }
 
-    ${({ theme }) =>
-      `
-      &:focus {
-        ${
-          !theme.focusRedesignOptOut
-            ? addFocusStyling(true)
-            : /* istanbul ignore next */ oldFocusStyling
-        }
-      }
-    `}
-
     + * {
       border-left: 1px;
     }
@@ -295,41 +400,75 @@ const StyledDayPicker = styled.div`
     }
   }
 
-  .DayPicker-Day--today,
-  .DayPicker-Day--today.DayPicker-Day--outside {
+  .rdp-today,
+  .rdp-today.rdp-outside {
     color: var(--colorsActionMajorYin090);
     background-color: var(--colorsActionMinor200);
   }
 
-  .DayPicker-Day--outside {
+  .rdp-outside {
     color: var(--colorsActionMajorYin055);
-    background-color: var(--colorsUtilityYang100);
+    background-color: transparent;
   }
 
-  .DayPicker-Day--disabled,
-  .DayPicker-Day--disabled:hover {
+  .rdp-today:not(.rdp-outside) {
+    font-weight: var(--fontWeights500);
+    border-radius: var(--borderRadius400);
+    color: inherit;
+  }
+
+  .rdp-disabled,
+  .rdp-disabled:hover {
     color: var(--colorsActionMajorYin030);
     background-color: var(--colorsUtilityYang100);
     cursor: default;
 
-    &.DayPicker-Day--today {
+    &.rdp-today {
       background-color: var(--colorsActionMinor200);
     }
   }
 
-  .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(
-      .DayPicker-Day--outside
-    ) {
+  .rdp-selected:not(.rdp-disabled):not(.rdp-outside) {
     background-color: var(--colorsActionMajor500);
     color: var(--colorsUtilityYang100);
     border-radius: var(--borderRadius400);
   }
 
-  .DayPicker-Day--selected.DayPicker-Day--disabled:not(
-      .DayPicker-Day--outside
-    ) {
+  .rdp-selected.rdp-disabled:not(.rdp-outside) {
     background-color: var(--colorsActionMajor500);
     color: var(--colorsUtilityYang100);
+  }
+
+  .rdp-selected {
+    &:focus-visible {
+      outline: none;
+    }
+  }
+
+  .rdp-selected .rdp-day_button {
+    border: none;
+    &:focus-visible {
+      outline: none;
+    }
+  }
+
+  .rdp-focused:not(.rdp-disabled):not(.rdp-outside) {
+    ${({ theme }) => css`
+      ${!theme.focusRedesignOptOut
+        ? addFocusStyling(true)
+        : /* istanbul ignore next */ oldFocusStyling}
+    `}
+    border-radius: var(--borderRadius400);
+  }
+
+  .rdp-day.rdp-selected {
+    ${({ theme }) => css`
+      &:focus {
+        ${!theme.focusRedesignOptOut
+          ? addFocusStyling(true)
+          : /* istanbul ignore next */ oldFocusStyling}
+      }
+    `}
   }
 `;
 

--- a/src/components/date/__internal__/navbar/navbar.component.tsx
+++ b/src/components/date/__internal__/navbar/navbar.component.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { NavProps } from "react-day-picker";
+
 import StyledButton from "./button.style";
 import StyledNavbar from "./navbar.style";
 import Icon from "../../../icon";
@@ -15,7 +17,7 @@ export const Navbar = ({
   onPreviousClick,
   onNextClick,
   className,
-}: NavbarProps) => {
+}: NavProps) => {
   const locale = useLocale();
   const { previousMonthButton, nextMonthButton } = locale.date.ariaLabels;
 
@@ -35,14 +37,16 @@ export const Navbar = ({
     <StyledNavbar className={className} data-role="date-navbar">
       <StyledButton
         aria-label={previousMonthButton()}
-        onClick={() => onPreviousClick?.()}
+        onClick={(e) => {
+          onPreviousClick?.(e);
+        }}
         onKeyDown={handleKeyDown}
       >
         <Icon type="chevron_left" />
       </StyledButton>
       <StyledButton
         aria-label={nextMonthButton()}
-        onClick={() => onNextClick?.()}
+        onClick={(e) => onNextClick?.(e)}
         onKeyDown={handleKeyDown}
       >
         <Icon type="chevron_right" />

--- a/src/components/date/__internal__/navbar/navbar.style.ts
+++ b/src/components/date/__internal__/navbar/navbar.style.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 const StyledNavbar = styled.div`
-  &.DayPicker-NavBar {
+  &.rdp-nav {
     display: flex;
     justify-content: space-between;
     padding: 0;

--- a/src/components/date/__internal__/utils.test.ts
+++ b/src/components/date/__internal__/utils.test.ts
@@ -1,4 +1,7 @@
 import MockDate from "mockdate";
+
+import { de, enGB, enUS, hu } from "date-fns/locale";
+
 import {
   isDateValid,
   parseDate,
@@ -9,6 +12,7 @@ import {
   parseISODate,
   getDisabledDays,
   checkISOFormatAndLength,
+  isValidLocaleDate,
 } from "./utils";
 
 const formats = [
@@ -446,3 +450,61 @@ test.each(["foo", "2022-1-1", "2022-01-1", "22-01-01", " "])(
     expect(checkISOFormatAndLength(value)).toEqual(false);
   },
 );
+
+describe("isValidLocaleDate", () => {
+  describe("with UK date formats", () => {
+    test("should return true when valid UK date string passed to `isValidLocaleDate`", () => {
+      expect(isValidLocaleDate("30/04/2022", enGB)).toEqual(true);
+    });
+
+    test("should return false when invalid UK date string passed to `isValidLocaleDate`", () => {
+      expect(isValidLocaleDate("31/04/2022", enGB)).toEqual(false); // April 31st is invalid
+    });
+
+    test("should return false when non-date string passed to `isValidLocaleDate`", () => {
+      expect(isValidLocaleDate("invalid-date", enGB)).toEqual(false);
+    });
+  });
+
+  describe("with US date formats", () => {
+    test("should return true when valid US date string passed to `isValidLocaleDate`", () => {
+      expect(isValidLocaleDate("04/30/2022", enUS)).toEqual(true);
+    });
+
+    test("should return false when invalid US date string passed to `isValidLocaleDate`", () => {
+      expect(isValidLocaleDate("04/31/2022", enUS)).toEqual(false); // April 31st is invalid
+    });
+
+    test("should return false when non-date string passed to `isValidLocaleDate`", () => {
+      expect(isValidLocaleDate("invalid-date", enUS)).toEqual(false);
+    });
+  });
+
+  describe("with German date formats", () => {
+    test("should return true when valid German date string passed to `isValidLocaleDate`", () => {
+      expect(isValidLocaleDate("30.04.2022", de)).toEqual(true);
+    });
+
+    test("should return false when invalid German date string passed to `isValidLocaleDate`", () => {
+      expect(isValidLocaleDate("31.04.2022", de)).toEqual(false); // April 31st is invalid
+    });
+
+    test("should return false when non-date string passed to `isValidLocaleDate`", () => {
+      expect(isValidLocaleDate("invalid-date", de)).toEqual(false);
+    });
+  });
+
+  describe("with Hungarian date formats", () => {
+    test("should return true when valid Hungarian date string passed to `isValidLocaleDate`", () => {
+      expect(isValidLocaleDate("2022. 04. 30.", hu)).toEqual(true);
+    });
+
+    test("should return false when invalid Hungarian date string passed to `isValidLocaleDate`", () => {
+      expect(isValidLocaleDate("2022. 04. 31.", hu)).toEqual(false); // April 31st is invalid
+    });
+
+    test("should return false when non-date string passed to `isValidLocaleDate`", () => {
+      expect(isValidLocaleDate("invalid-date", hu)).toEqual(false);
+    });
+  });
+});

--- a/src/components/date/__internal__/utils.ts
+++ b/src/components/date/__internal__/utils.ts
@@ -1,8 +1,26 @@
-import { Modifier } from "react-day-picker";
-import { format, formatISO, isMatch, parse, parseISO } from "./date-fns-fp";
+import { Matcher } from "react-day-picker";
+
+import {
+  format,
+  formatISO,
+  isMatch,
+  isValid,
+  parse,
+  parseISO,
+  parseWithOptions,
+} from "./date-fns-fp";
 
 const DATE_STRING_LENGTH = 10;
 const THRESHOLD_FOR_ADDITIONAL_YEARS = 69;
+
+export function isValidLocaleDate(date: string, locale: Locale) {
+  const dateFormat = "P";
+  const parseDateWithLocale = parseWithOptions({ locale });
+  const parsedDate = parseDateWithLocale(new Date(), dateFormat, date);
+  const isValidDate = isValid(parsedDate);
+
+  return isValidDate;
+}
 
 export function parseDate(formatString?: string, valueString?: string) {
   if (!valueString || !formatString) return undefined;
@@ -220,7 +238,7 @@ export function checkISOFormatAndLength(value: string) {
 export function getDisabledDays(
   minDate = "",
   maxDate = "",
-): Modifier | Modifier[] {
+): NonNullable<Matcher> | NonNullable<Matcher[]> | undefined {
   const days = [];
 
   if (!minDate && !maxDate) {

--- a/src/components/date/__internal__/weekday/weekday.style.ts
+++ b/src/components/date/__internal__/weekday/weekday.style.ts
@@ -1,8 +1,10 @@
 import styled from "styled-components";
 
-const StyledWeekday = styled.div`
+import StyledAbbr from "./abbr.style";
+
+const StyledWeekday = styled.th`
   &,
-  &.DayPicker-Weekday {
+  & ${StyledAbbr} {
     border: none;
     height: var(--sizing500);
     min-width: var(--sizing500);

--- a/src/components/date/__internal__/weekday/weekday.test.tsx
+++ b/src/components/date/__internal__/weekday/weekday.test.tsx
@@ -3,8 +3,22 @@ import { screen, render } from "@testing-library/react";
 
 import Weekday from "./weekday.component";
 
+const Component = (props: {
+  children: React.ReactNode;
+  className?: string;
+  title?: string;
+}) => (
+  <table>
+    <thead>
+      <tr>
+        <Weekday {...props}>Foo</Weekday>
+      </tr>
+    </thead>
+  </table>
+);
+
 test("should render the passed `title` as the attribute on the `abbr` element", () => {
-  render(<Weekday title="title">Foo</Weekday>);
+  render(<Component title="title">Foo</Component>);
   const abbr = screen.getByTitle("title");
 
   expect(abbr).toBeInTheDocument();
@@ -12,7 +26,7 @@ test("should render the passed `title` as the attribute on the `abbr` element", 
 });
 
 test("should render the passed `className` on the `div` element", () => {
-  render(<Weekday className="custom-class">Foo</Weekday>);
+  render(<Component className="custom-class">Foo</Component>);
   const weekday = screen.getByRole("columnheader", { name: "Foo" });
 
   expect(weekday).toHaveClass("custom-class");

--- a/src/components/date/date.component.tsx
+++ b/src/components/date/date.component.tsx
@@ -17,6 +17,7 @@ import {
   parseISODate,
   checkISOFormatAndLength,
   getSeparator,
+  isValidLocaleDate,
 } from "./__internal__/utils";
 import useLocale from "../../hooks/__internal__/useLocale";
 import Events from "../../__internal__/utils/helpers/events";
@@ -125,7 +126,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       onClick,
       onFocus,
       onKeyDown,
-      pickerProps = {},
+      pickerProps,
       readOnly,
       size = "medium",
       tooltipPosition,
@@ -155,11 +156,16 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
     );
     const { inputRefMap, setInputRefMap } = useContext(DateRangeContext);
     const [open, setOpen] = useState(false);
-    const [selectedDays, setSelectedDays] = useState(
-      checkISOFormatAndLength(value)
+    const [selectedDays, setSelectedDays] = useState(() => {
+      const isValidDate = isValidLocaleDate(value, dateFnsLocale());
+      if (!isValidDate) {
+        return undefined;
+      }
+
+      return checkISOFormatAndLength(value)
         ? parseISODate(value)
-        : parseDate(format, value),
-    );
+        : parseDate(format, value);
+    });
     const isInitialValue = useRef(true);
     const pickerTabGuardId = useRef(guid());
 
@@ -220,7 +226,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       return function cleanup() {
         document.removeEventListener("mousedown", handleClick);
       };
-    }, [open]);
+    }, [open, onPickerClose]);
 
     const handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
       isInitialValue.current = false;

--- a/src/components/date/date.mdx
+++ b/src/components/date/date.mdx
@@ -64,6 +64,12 @@ be used to set the input value like in the example below, although the component
 
 <Canvas of={DateStories.Empty} />
 
+### With disabled dates
+
+You can configure the available dates by passing a `minDate` and `maxDate` prop to the component.
+
+<Canvas of={DateStories.DisabledDates} />
+
 ### With labelInline
 
 **Note:** The `labelInline` prop is not supported if the `validationRedesignOptIn` flag on the `CarbonProvider` is true.

--- a/src/components/date/date.pw.tsx
+++ b/src/components/date/date.pw.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { expect, test } from "@playwright/experimental-ct-react17";
 import dayjs from "dayjs";
+import advancedFormat from "dayjs/plugin/advancedFormat";
 import {
   DateInputCustom,
   DateInputValidationNewDesign,
@@ -33,9 +34,11 @@ import {
 import { HooksConfig } from "../../../playwright";
 import { alertDialogPreview } from "../../../playwright/components/dialog";
 
+dayjs.extend(advancedFormat);
+
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
-const DAY_PICKER_PREFIX = "DayPicker-Day--";
-const TODAY = dayjs().format("ddd D MMM YYYY");
+const DAY_PICKER_PREFIX = "rdp-";
+const TODAY = dayjs().format("dddd, MMMM Do, YYYY");
 const DATE_INPUT = dayjs("2022-05-01").format("DD/MM/YYYY");
 const TODAY_DATE_INPUT = dayjs().format("DD/MM/YYYY");
 const NEXT_MONTH = dayjs("2022-05-01").add(1, "months").format("MMMM YYYY");
@@ -44,8 +47,8 @@ const PREVIOUS_MONTH = dayjs("2022-05-01")
   .subtract(1, "months")
   .format("MMMM YYYY");
 const MIN_DATE = "04/04/2030";
-const DAY_BEFORE_MIN_DATE = "Wed 3 Apr 2030";
-const DAY_AFTER_MAX_DATE = "Fri 5 Apr 2030";
+const DAY_BEFORE_MIN_DATE = "Wednesday, April 3rd, 2030";
+const DAY_AFTER_MAX_DATE = "Friday, April 5th, 2030";
 const DDMMYYY_DATE_TO_ENTER = "27,05,2022";
 const MMDDYYYY_DATE_TO_ENTER = "05,27,2022";
 const YYYYMMDD_DATE_TO_ENTER = "2022,05,27";
@@ -104,11 +107,10 @@ test.describe("Functionality tests", () => {
     const input = getDataElementByValue(page, "input");
     await input.fill(MIN_DATE);
 
-    const dayPicker = page
-      .getByRole("row")
-      .locator(`div[aria-label="${DAY_BEFORE_MIN_DATE}"]`);
-    await expect(dayPicker).toHaveAttribute("aria-disabled", "true");
-    await expect(dayPicker).toHaveAttribute("aria-selected", "false");
+    const dayPicker = page.locator(
+      `button[aria-label="${DAY_BEFORE_MIN_DATE}"]`,
+    );
+    await expect(dayPicker).toHaveAttribute("disabled", "");
   });
 
   test(`should check the maxDate prop`, async ({ mount, page }) => {
@@ -117,11 +119,10 @@ test.describe("Functionality tests", () => {
     const input = getDataElementByValue(page, "input");
     await input.fill(MIN_DATE);
 
-    const dayPicker = page
-      .getByRole("row")
-      .locator(`div[aria-label="${DAY_AFTER_MAX_DATE}"]`);
-    await expect(dayPicker).toHaveAttribute("aria-disabled", "true");
-    await expect(dayPicker).toHaveAttribute("aria-selected", "false");
+    const dayPicker = page.locator(
+      `button[aria-label="${DAY_AFTER_MAX_DATE}"]`,
+    );
+    await expect(dayPicker).toHaveAttribute("disabled", "");
   });
 
   test(`should check the date is set to today's day`, async ({
@@ -130,15 +131,17 @@ test.describe("Functionality tests", () => {
   }) => {
     await mount(<DateInputCustom />);
 
-    const dayClass = `DayPicker-Day ${DAY_PICKER_PREFIX}selected ${DAY_PICKER_PREFIX}today`;
+    const dayClass = `rdp-day rdp-today`;
     const input = getDataElementByValue(page, "input");
     await input.fill(TODAY_DATE_INPUT);
 
-    const dayPicker = page
-      .getByRole("row")
-      .locator(`div[aria-label="${TODAY}"]`);
-    await expect(dayPicker).toHaveAttribute("aria-label", TODAY);
-    await expect(dayPicker).toHaveClass(dayClass);
+    const todayButton = page.getByRole("button", { name: `Today, ${TODAY}` });
+    const todayCell = page.getByRole("gridcell").filter({
+      has: todayButton,
+    });
+
+    await expect(todayButton).toBeVisible();
+    await expect(todayCell).toHaveClass(dayClass);
   });
 
   test(`should open dayPicker after click on input`, async ({
@@ -202,7 +205,7 @@ test.describe("Functionality tests", () => {
 
       const inputParent = getDataElementByValue(page, "input").locator("..");
       await inputParent.click();
-      const wrapperParent = dayPickerWrapper(page).locator("..").locator("..");
+      const wrapperParent = dayPickerWrapper(page).locator("..");
       await expect(wrapperParent).toHaveAttribute(
         "data-floating-placement",
         `${position}-start`,
@@ -293,7 +296,7 @@ test.describe("Functionality tests", () => {
     );
     await expect(arrowRight).toBeFocused();
     await page.keyboard.press("Tab");
-    const dayPicker = page.locator(`.${DAY_PICKER_PREFIX}selected`);
+    const dayPicker = page.locator(`.rdp-selected`).locator("button");
     await expect(dayPicker).toBeFocused();
   });
 
@@ -316,7 +319,9 @@ test.describe("Functionality tests", () => {
     );
     await expect(arrowRight).toBeFocused();
     await page.keyboard.press("Tab");
-    const dayPicker = page.locator(`.${DAY_PICKER_PREFIX}selected`);
+    const dayPicker = page
+      .locator(`.${DAY_PICKER_PREFIX}selected`)
+      .locator("button");
     await expect(dayPicker).toBeFocused();
     await page.keyboard.press("Tab");
     const wrapper = dayPickerWrapper(page);
@@ -336,7 +341,9 @@ test.describe("Functionality tests", () => {
     await page.keyboard.press("Tab");
     await page.keyboard.press("Tab");
     await page.keyboard.press("Tab");
-    const dayPicker = page.locator(`.${DAY_PICKER_PREFIX}today`);
+    const dayPicker = page
+      .locator(`.${DAY_PICKER_PREFIX}today`)
+      .locator("button");
     await expect(dayPicker).toBeFocused();
     await page.keyboard.press("Tab");
     const wrapper = dayPickerWrapper(page);
@@ -347,7 +354,7 @@ test.describe("Functionality tests", () => {
     mount,
     page,
   }) => {
-    await mount(<DateInputCustom />);
+    await mount(<DateInputCustom value="14/04/2022" />);
 
     await page.focus("body");
     await page.keyboard.press("Tab");
@@ -356,62 +363,54 @@ test.describe("Functionality tests", () => {
     await page.keyboard.press("Tab");
     await page.keyboard.press(arrowKeys[3]);
     const focusedElement1 = page
-      .getByRole("row")
-      .nth(2)
-      .locator("div")
-      .filter({ hasText: "8" });
+      .locator(`.${DAY_PICKER_PREFIX}focused`)
+      .locator("button")
+      .filter({ hasText: "21" });
     await expect(focusedElement1).toBeFocused();
     await page.keyboard.press(arrowKeys[3]);
     const focusedElement2 = page
-      .getByRole("row")
-      .nth(3)
-      .locator("div")
-      .filter({ hasText: "15" });
+      .locator(`.${DAY_PICKER_PREFIX}focused`)
+      .locator("button")
+      .filter({ hasText: "28" });
     await expect(focusedElement2).toBeFocused();
 
     await page.keyboard.press(arrowKeys[1]);
     const focusedElement3 = page
-      .getByRole("row")
-      .nth(3)
-      .locator("div")
-      .filter({ hasText: "14" });
+      .locator(`.${DAY_PICKER_PREFIX}focused`)
+      .locator("button")
+      .filter({ hasText: "27" });
     await expect(focusedElement3).toBeFocused();
     await page.keyboard.press(arrowKeys[1]);
     const focusedElement4 = page
-      .getByRole("row")
-      .nth(3)
-      .locator("div")
-      .filter({ hasText: "13" });
+      .locator(`.${DAY_PICKER_PREFIX}focused`)
+      .locator("button")
+      .filter({ hasText: "26" });
     await expect(focusedElement4).toBeFocused();
 
     await page.keyboard.press(arrowKeys[0]);
     const focusedElement5 = page
-      .getByRole("row")
-      .nth(3)
-      .locator("div")
-      .filter({ hasText: "14" });
+      .locator(`.${DAY_PICKER_PREFIX}focused`)
+      .locator("button")
+      .filter({ hasText: "27" });
     await expect(focusedElement5).toBeFocused();
     await page.keyboard.press(arrowKeys[0]);
     const focusedElement6 = page
-      .getByRole("row")
-      .nth(3)
-      .locator("div")
-      .filter({ hasText: "15" });
+      .locator(`.${DAY_PICKER_PREFIX}focused`)
+      .locator("button")
+      .filter({ hasText: "28" });
     await expect(focusedElement6).toBeFocused();
 
     await page.keyboard.press(arrowKeys[2]);
     const focusedElement7 = page
-      .getByRole("row")
-      .nth(2)
-      .locator("div")
-      .filter({ hasText: "8" });
+      .locator(`.${DAY_PICKER_PREFIX}focused`)
+      .locator("button")
+      .filter({ hasText: "21" });
     await expect(focusedElement7).toBeFocused();
     await page.keyboard.press(arrowKeys[2]);
     const focusedElement8 = page
-      .getByRole("row")
-      .nth(1)
-      .locator("div")
-      .filter({ hasText: "1" });
+      .locator(`.${DAY_PICKER_PREFIX}focused`)
+      .locator("button")
+      .filter({ hasText: "14" });
     await expect(focusedElement8).toBeFocused();
   });
 
@@ -419,7 +418,7 @@ test.describe("Functionality tests", () => {
     mount,
     page,
   }) => {
-    await mount(<DateInputCustom />);
+    await mount(<DateInputCustom value="14/04/2022" />);
 
     await page.focus("body");
     await page.keyboard.press("Tab");
@@ -428,10 +427,9 @@ test.describe("Functionality tests", () => {
     await page.keyboard.press("Tab");
     await page.keyboard.press(arrowKeys[1]);
     const focusedElement = page
-      .getByRole("row")
-      .nth(5)
-      .locator("div")
-      .filter({ hasText: "30" });
+      .locator(`.${DAY_PICKER_PREFIX}focused`)
+      .locator("button")
+      .filter({ hasText: "13" });
     await expect(focusedElement).toBeFocused();
     const pickerHeading = dayPickerHeading(page);
     await expect(pickerHeading).toHaveText(PREVIOUS_MONTH);
@@ -460,16 +458,14 @@ test.describe("Functionality tests", () => {
       await page.keyboard.press(arrowKeys[2]);
       if (day === "1") {
         const focusedElement = page
-          .getByRole("row")
-          .nth(4)
-          .locator("div")
+          .locator(`.${DAY_PICKER_PREFIX}focused`)
+          .locator("button")
           .filter({ hasText: result });
         await expect(focusedElement).toBeFocused();
       } else {
         const focusedElement = page
-          .getByRole("row")
-          .nth(5)
-          .locator("div")
+          .locator(`.${DAY_PICKER_PREFIX}focused`)
+          .locator("button")
           .filter({ hasText: result });
         await expect(focusedElement).toBeFocused();
       }
@@ -501,16 +497,14 @@ test.describe("Functionality tests", () => {
       await page.keyboard.press(arrowKeys[3]);
       if (day === "30" || day === "31") {
         const focusedElement = page
-          .getByRole("row")
-          .nth(2)
-          .locator("div")
+          .locator(`.${DAY_PICKER_PREFIX}focused`)
+          .locator("button")
           .filter({ hasText: result });
         await expect(focusedElement).toBeFocused();
       } else {
         const focusedElement = page
-          .getByRole("row")
-          .nth(1)
-          .locator("div")
+          .locator(`.${DAY_PICKER_PREFIX}focused`)
+          .locator("button")
           .filter({ hasText: result })
           .filter({ hasNotText: "30" })
           .filter({ hasNotText: "31" });
@@ -526,7 +520,7 @@ test.describe("Functionality tests", () => {
       mount,
       page,
     }) => {
-      await mount(<DateInputCustom />);
+      await mount(<DateInputCustom value="14/04/2022" />);
 
       await page.focus("body");
       await page.keyboard.press("Tab");
@@ -535,14 +529,13 @@ test.describe("Functionality tests", () => {
       await page.keyboard.press("Tab");
       await page.keyboard.press(arrowKeys[1]);
       const focusedElement = page
-        .getByRole("row")
-        .nth(5)
-        .locator("div")
-        .filter({ hasText: "30" });
+        .locator(`.${DAY_PICKER_PREFIX}focused`)
+        .locator("button")
+        .filter({ hasText: "13" });
       await expect(focusedElement).toBeFocused();
       await page.keyboard.press(key);
       await expect(getDataElementByValue(page, "input")).toHaveValue(
-        "30/04/2022",
+        "13/04/2022",
       );
     });
   });
@@ -606,9 +599,8 @@ test.describe("Functionality tests", () => {
     await page.keyboard.press("Tab");
     await page.keyboard.press(arrowKeys[0]);
     const focusedElement = page
-      .getByRole("row")
-      .nth(1)
-      .locator("div")
+      .locator(`.${DAY_PICKER_PREFIX}focused`)
+      .locator("button")
       .filter({ hasText: "1" })
       .filter({ hasNotText: "31" });
     await expect(focusedElement).toBeFocused();
@@ -752,17 +744,17 @@ test.describe("Functionality tests", () => {
 
     const input = getDataElementByValue(page, "input");
     await input.click();
-    const months = page.locator("div[class=DayPicker-Month]");
+    const months = page.locator("div[class=rdp-month]");
     await expect(months).toHaveCount(2);
     const pickerHeading1 = page
-      .locator(".DayPicker-Caption")
-      .locator("div")
+      .locator(".rdp-month_caption")
+      .locator("span")
       .nth(0);
     await expect(pickerHeading1).toBeVisible();
     await expect(pickerHeading1).toHaveText(ACTUAL_MONTH);
     const pickerHeading2 = page
-      .locator(".DayPicker-Caption")
-      .locator("div")
+      .locator(".rdp-month_caption")
+      .locator("span")
       .nth(1);
     await expect(pickerHeading2).toBeVisible();
     await expect(pickerHeading2).toHaveText(NEXT_MONTH);
@@ -836,9 +828,11 @@ test.describe("Functionality tests", () => {
     const input = getDataElementByValue(page, "input");
     await input.click();
     await expect(input).toHaveCSS("border-radius", "4px");
-    const dayPicker1 = page.getByLabel("Sun 1 May 2022");
+    const dayPicker1 = page
+      .getByLabel("Sunday, May 1st, 2022, selected")
+      .locator("..");
     await expect(dayPicker1).toHaveCSS("border-radius", "32px");
-    const dayPicker2 = page.getByLabel("Mon 2 May 2022");
+    const dayPicker2 = page.getByLabel("Monday, May 2nd, 2022").locator("..");
     await expect(dayPicker2).toHaveCSS("border-radius", "32px");
     const dayPickerNavButton1 = page.getByLabel("Previous month");
     await expect(dayPickerNavButton1).toHaveCSS("border-radius", "4px");
@@ -858,18 +852,37 @@ test.describe("Functionality tests", () => {
     await page.keyboard.press("Tab");
     const inputParent = getDataElementByValue(page, "input").locator("..");
     await checkGoldenOutline(inputParent);
-    const dayPicker1 = page.getByLabel("Sun 1 May 2022");
-    await dayPicker1.focus();
-    await checkGoldenOutline(dayPicker1);
-    const dayPicker2 = page.getByLabel("Mon 2 May 2022");
-    await dayPicker2.focus();
-    await checkGoldenOutline(dayPicker2);
+    await page.keyboard.press("Tab");
     const dayPickerNavButton1 = page.getByLabel("Previous month");
     await dayPickerNavButton1.focus();
-    await checkGoldenOutline(dayPickerNavButton1);
+    await expect(dayPickerNavButton1).toHaveCSS(
+      "outline",
+      "rgb(255, 188, 25) solid 3px",
+    );
+    await page.keyboard.press("Tab");
     const dayPickerNavButton2 = page.getByLabel("Next month");
     await dayPickerNavButton2.focus();
-    await checkGoldenOutline(dayPickerNavButton2);
+    await expect(dayPickerNavButton2).toHaveCSS(
+      "outline",
+      "rgb(255, 188, 25) solid 3px",
+    );
+    await page.keyboard.press("Tab");
+    const dayPicker1 = page
+      .getByLabel("Sunday, May 1st, 2022, selected")
+      .locator("..");
+    await dayPicker1.focus();
+    await expect(dayPicker1).toHaveCSS(
+      "outline",
+      "rgb(255, 188, 25) solid 3px",
+    );
+
+    await page.keyboard.press("ArrowRight");
+    const dayPicker2 = page.getByLabel("Monday, May 2nd, 2022").locator("..");
+    await dayPicker2.focus();
+    await expect(dayPicker2).toHaveCSS(
+      "outline",
+      "rgb(255, 188, 25) solid 3px",
+    );
   });
 
   test(`should have the expected styling when opt out flag is false`, async ({
@@ -880,8 +893,6 @@ test.describe("Functionality tests", () => {
 
     await page.focus("body");
     await page.keyboard.press("Tab");
-    const wrapperParent = dayPickerWrapper(page).locator("..").locator("..");
-    await expect(wrapperParent).toHaveCSS("margin-top", "4px");
     const inputParent = getDataElementByValue(page, "input").locator("..");
     await expect(inputParent).toHaveCSS(
       "box-shadow",
@@ -891,20 +902,8 @@ test.describe("Functionality tests", () => {
       "outline",
       "rgba(0, 0, 0, 0) solid 3px",
     );
-    const dayPicker1 = page.getByLabel("Sun 1 May 2022");
-    await dayPicker1.focus();
-    await expect(dayPicker1).toHaveCSS(
-      "box-shadow",
-      "rgba(0, 0, 0, 0.9) 0px 0px 0px 3px inset, rgb(255, 188, 25) 0px 0px 0px 6px inset",
-    );
-    await expect(dayPicker1).toHaveCSS("outline", "rgba(0, 0, 0, 0) solid 3px");
-    const dayPicker2 = page.getByLabel("Mon 2 May 2022");
-    await dayPicker2.focus();
-    await expect(dayPicker2).toHaveCSS(
-      "box-shadow",
-      "rgba(0, 0, 0, 0.9) 0px 0px 0px 3px inset, rgb(255, 188, 25) 0px 0px 0px 6px inset",
-    );
-    await expect(dayPicker2).toHaveCSS("outline", "rgba(0, 0, 0, 0) solid 3px");
+
+    await page.keyboard.press("Tab");
     const dayPickerNavButton1 = page.getByLabel("Previous month");
     await dayPickerNavButton1.focus();
     await expect(dayPickerNavButton1).toHaveCSS(
@@ -915,6 +914,8 @@ test.describe("Functionality tests", () => {
       "outline",
       "rgba(0, 0, 0, 0) solid 3px",
     );
+
+    await page.keyboard.press("Tab");
     const dayPickerNavButton2 = page.getByLabel("Next month");
     await dayPickerNavButton2.focus();
     await expect(dayPickerNavButton2).toHaveCSS(
@@ -925,6 +926,24 @@ test.describe("Functionality tests", () => {
       "outline",
       "rgba(0, 0, 0, 0) solid 3px",
     );
+
+    await page.keyboard.press("Tab");
+    const dayPicker1 = page.getByLabel("Sunday, May 1st, 2022").locator("..");
+    await dayPicker1.focus();
+    await expect(dayPicker1).toHaveCSS(
+      "box-shadow",
+      "rgba(0, 0, 0, 0.9) 0px 0px 0px 3px inset, rgb(255, 188, 25) 0px 0px 0px 6px inset",
+    );
+    await expect(dayPicker1).toHaveCSS("outline", "rgba(0, 0, 0, 0) solid 3px");
+
+    await page.keyboard.press("ArrowRight");
+    const dayPicker2 = page.getByLabel("Monday, May 2nd, 2022").locator("..");
+    await dayPicker2.focus();
+    await expect(dayPicker2).toHaveCSS(
+      "box-shadow",
+      "rgba(0, 0, 0, 0.9) 0px 0px 0px 3px inset, rgb(255, 188, 25) 0px 0px 0px 6px inset",
+    );
+    await expect(dayPicker2).toHaveCSS("outline", "rgba(0, 0, 0, 0) solid 3px");
   });
 
   (["top", "bottom", "left", "right"] as const).forEach((position) => {

--- a/src/components/date/date.stories.tsx
+++ b/src/components/date/date.stories.tsx
@@ -124,6 +124,26 @@ export const Empty: Story = () => {
 };
 Empty.storyName = "Empty";
 
+export const DisabledDates: Story = () => {
+  const [state, setState] = useState("04/04/2019");
+  const setValue = (ev: DateChangeEvent) => {
+    setState(ev.target.value.formattedValue);
+  };
+  return (
+    <DateInput
+      label="Date"
+      name="date-input"
+      value={state}
+      minDate="2019-04-04"
+      maxDate="2019-05-31"
+      onChange={setValue}
+      onBlur={(ev) => console.log("blur")}
+    />
+  );
+};
+DisabledDates.storyName = "Disabled Dates";
+DisabledDates.parameters = { chromatic: { disableSnapshot: true } };
+
 export const WithLabelInline: Story = () => {
   const [state, setState] = useState("01/10/2016");
   const setValue = (ev: DateChangeEvent) => {

--- a/src/components/date/date.test.tsx
+++ b/src/components/date/date.test.tsx
@@ -68,7 +68,7 @@ const MockComponent = ({
   );
 };
 
-// temporatrily running timers on every spec as we have issues
+// temporarily running timers on every spec as we have issues
 // around how slow the tests that open the calendar are.
 // FE-6724 raised to investigate and implement a better solution
 beforeAll(() => {
@@ -479,23 +479,21 @@ test("should not close the picker or call the `onChange` and `onBlur` callbacks 
 test("should not close the picker or call the `onChange` and `onBlur` callbacks when the user clicks on a disabled day", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
   const onChange = jest.fn();
-  const onBlur = jest.fn();
   render(
     <DateInput
       onChange={onChange}
-      onBlur={onBlur}
       value="04/04/2019"
       minDate="2019-04-04"
+      maxDate="2019-05-31"
     />,
   );
   const input = screen.getByRole("textbox");
   await user.click(input);
   jest.advanceTimersByTime(10);
-  await user.click(screen.getByRole("gridcell", { name: "Wed 3 Apr 2019" }));
+  await user.click(screen.getByLabelText("Wednesday, April 3rd, 2019"));
 
   expect(screen.queryByRole("grid")).toBeVisible();
   expect(onChange).not.toHaveBeenCalled();
-  expect(onBlur).not.toHaveBeenCalled();
 });
 
 test("should close the open picker when a user presses the 'Escape' key", async () => {
@@ -609,7 +607,7 @@ test("should focus the next button and then the selected day element when the us
   expect(screen.getByRole("button", { name: "Next month" })).toHaveFocus();
   await user.tab();
   expect(
-    screen.getByRole("gridcell", { name: "Thu 4 Apr 2019" }),
+    screen.getByLabelText("Thursday, April 4th, 2019", { exact: false }),
   ).toHaveFocus();
   await user.tab();
   expect(screen.queryByRole("grid")).not.toBeInTheDocument();
@@ -621,10 +619,12 @@ test("should close the picker, update the value and refocus the input element wh
   const input = screen.getByRole("textbox");
   await user.click(input);
   jest.advanceTimersByTime(10);
-  await user.click(screen.getByRole("gridcell", { name: "Thu 11 Apr 2019" }));
+  await user.click(screen.getByLabelText("Thursday, April 11th, 2019"));
 
   expect(screen.queryByRole("grid")).not.toBeInTheDocument();
-  expect(input).toHaveFocus();
+  await waitFor(() => {
+    expect(input).toHaveFocus();
+  });
   expect(input).toHaveValue("11/04/2019");
 });
 
@@ -1668,6 +1668,6 @@ test("should select the correct date when the locale is overridden and a date is
   await user.type(input, "05/04");
   jest.advanceTimersByTime(10);
 
-  const grid = screen.getByRole("grid").childNodes[0].textContent;
+  const grid = screen.getByRole("status").textContent;
   expect(grid).toEqual("April 2019");
 });


### PR DESCRIPTION
Upgrades react-day-picker to remove the dependency on React 18

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
