### PR TITLE
fix(menu-item): ensure consistent padding within menu-full-screen

### DIFF
--- a/src/components/menu/menu-item/menu-item.style.ts
+++ b/src/components/menu/menu-item/menu-item.style.ts
@@ -262,7 +262,7 @@ const StyledMenuItemWrapper = styled.a.attrs({
       `
       : `
         ${
-          hasSubmenu || maxWidth
+          hasSubmenu || (maxWidth && !inFullscreenView)
             ? `
               a,
               ${StyledLink} a,
@@ -481,7 +481,10 @@ const StyledMenuItemWrapper = styled.a.attrs({
         asPassiveItem &&
         css`
           cursor: default;
-          padding: 0 16px;
+
+          a {
+            padding: 0 16px;
+          }
 
           :hover {
             background: transparent;

--- a/src/components/menu/menu-test.stories.tsx
+++ b/src/components/menu/menu-test.stories.tsx
@@ -37,6 +37,7 @@ const meta: Meta<typeof Menu> = {
     "AsLinkWithAlternateVariant",
     "MenuWithSubmenuCustomPadding",
     "WhenMenuItemsWrap",
+    "MenuFullScreenWithMaxWidth",
   ],
   parameters: {
     info: { disable: true },
@@ -509,3 +510,35 @@ export const WhenMenuItemsWrap = () => {
   );
 };
 WhenMenuItemsWrap.storyName = "When menu items wrap";
+
+export const MenuFullScreenWithMaxWidth = () => {
+  return (
+    <Menu menuType="black">
+      <MenuFullscreen isOpen onClose={() => {}}>
+        <MenuItem href="#">Menu item with href set</MenuItem>
+        <MenuItem onClick={() => {}}>Menu with onClick set</MenuItem>
+        <MenuItem href="#" maxWidth="300px">
+          Menu with Max Width and href set
+        </MenuItem>
+        <MenuItem onClick={() => {}} maxWidth="300px">
+          Menu with Max Width and onClick set
+        </MenuItem>
+        <MenuItem maxWidth="300px">Menu with only Max Width set</MenuItem>
+        <MenuItem>Menu item on its own</MenuItem>
+        <MenuItem submenu="Submenu">
+          <MenuItem href="#">Menu item with href set</MenuItem>
+          <MenuItem onClick={() => {}}>Menu with onClick set</MenuItem>
+          <MenuItem href="#" maxWidth="300px">
+            Menu with Max Width and href set
+          </MenuItem>
+          <MenuItem onClick={() => {}} maxWidth="300px">
+            Menu with Max Width and onClick set
+          </MenuItem>
+          <MenuItem maxWidth="300px">Menu with only Max Width set</MenuItem>
+          <MenuItem>Menu item on its own</MenuItem>
+        </MenuItem>
+      </MenuFullscreen>
+    </Menu>
+  );
+};
+MenuFullScreenWithMaxWidth.storyName = "Menu Full Screen with Max Width";


### PR DESCRIPTION
When maxWidth is set on menu-item within menu-full-screen, paddings are insconsistent. This fix ensures paddings are consistent, and maxWidth should have no effect in a menu-full-screen.

fix #7078

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Paddings are consistent across all `MenuItem`s. 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Inconsistent paddings on `MenuItem` within a `MenuFullScreen` when `maxWidth` is set. 

![image](https://github.com/user-attachments/assets/8ce2ddad-5047-429b-a59f-ef519bad26c6)

![image](https://github.com/user-attachments/assets/43ab30f5-2037-42d2-8fdd-7a59a24d6d16)

![image](https://github.com/user-attachments/assets/1ba678a2-2904-4b63-b1aa-fcbcff92050d)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

- See added test story "Menu Full Screen with Max Width"
