### PR TITLE
fix(vertical-menu-full-screen): register Fullscreen subcomponent as a Carbon modal

### DIFF
--- a/src/components/vertical-menu/components.test-pw.tsx
+++ b/src/components/vertical-menu/components.test-pw.tsx
@@ -10,6 +10,7 @@ import {
   VerticalMenuProps,
   VerticalMenuItemProps,
 } from ".";
+import Confirm from "../confirm/confirm.component";
 import Box from "../box";
 import Pill from "../pill";
 
@@ -263,6 +264,105 @@ export const VerticalMenuFullScreenCustom = (
         >
           {menuItems}
         </VerticalMenuFullScreen>
+      </>
+    );
+  }
+  return <VerticalMenu>{menuItems}</VerticalMenu>;
+};
+
+export const VerticalMenuFullScreenCustomWithDialog = (
+  props: Partial<VerticalMenuFullScreenProps>,
+) => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const fullscreenViewBreakPoint = useMediaQuery("(max-width: 1200px)");
+
+  const menuItems = (
+    <>
+      <VerticalMenuItem iconType="analysis" title="Item 1">
+        <VerticalMenuItem
+          title="ChildItem 1"
+          href="/child-item-1"
+          adornment={
+            <Pill borderColor="#fff" fill size="S">
+              10
+            </Pill>
+          }
+        />
+        <VerticalMenuItem href="/child-item-2" title="ChildItem 2" />
+      </VerticalMenuItem>
+
+      <VerticalMenuItem iconType="admin" href="/item1" title="Item 2" />
+
+      <VerticalMenuItem iconType="home" title="Item 3">
+        <VerticalMenuItem
+          title="Very long text that will be wrapped"
+          href="/very-long-text-that-will-be-wrapped"
+          adornment={
+            <Pill borderColor="#fff" fill size="S">
+              100
+            </Pill>
+          }
+        />
+        <VerticalMenuItem
+          title="Active item"
+          href="/active-item"
+          active
+          adornment={
+            <Pill borderColor="#fff" fill size="S">
+              29
+            </Pill>
+          }
+        />
+      </VerticalMenuItem>
+
+      <VerticalMenuItem iconType="alert" title="Item 4" href="/item-4" />
+
+      <VerticalMenuItem iconType="bank" title="Item 5">
+        <VerticalMenuItem title="ChildItem 1" href="/child-item-1" />
+        <VerticalMenuItem title="ChildItem 2" href="/child-item-2" />
+      </VerticalMenuItem>
+
+      <VerticalMenuItem iconType="basket" title="Item 6" href="/item-6" />
+
+      <VerticalMenuItem
+        iconType="calendar"
+        title="Item 7 - More text to wrap the whole title. More text to wrap the whole title. More text to wrap the whole title. More text to wrap the whole title. "
+      >
+        <VerticalMenuItem title="ChildItem 1" href="/child-item-1" />
+        <VerticalMenuItem title="ChildItem 2" href="/child-item-2" />
+      </VerticalMenuItem>
+    </>
+  );
+
+  if (fullscreenViewBreakPoint) {
+    return (
+      <>
+        <VerticalMenuTrigger
+          onClick={() => {
+            setIsMenuOpen(!isMenuOpen);
+            setIsModalOpen(true);
+          }}
+        >
+          Menu
+        </VerticalMenuTrigger>
+        <VerticalMenuFullScreen
+          isOpen={isMenuOpen}
+          onClose={() => setIsMenuOpen(false)}
+          {...props}
+        >
+          {menuItems}
+        </VerticalMenuFullScreen>
+        <Confirm
+          cancelButtonDestructive
+          title="Are you sure?"
+          open={isModalOpen}
+          onConfirm={() => setIsModalOpen(false)}
+          onCancel={() => setIsModalOpen(false)}
+        >
+          Do you want to leave before saving?
+        </Confirm>
       </>
     );
   }

--- a/src/components/vertical-menu/vertical-menu-full-screen/vertical-menu-full-screen.component.tsx
+++ b/src/components/vertical-menu/vertical-menu-full-screen/vertical-menu-full-screen.component.tsx
@@ -15,6 +15,7 @@ import {
 } from "../vertical-menu.style";
 import VerticalMenuFullScreenContext from "./__internal__/vertical-menu-full-screen.context";
 import Events from "../../../__internal__/utils/helpers/events/events";
+import useModalManager from "../../../hooks/__internal__/useModalManager";
 
 export interface VerticalMenuFullScreenProps extends TagProps {
   /** An aria-label attribute for the menu */
@@ -54,6 +55,13 @@ export const VerticalMenuFullScreen = ({
     },
     [onClose],
   );
+
+  useModalManager({
+    open: isOpen,
+    closeModal: handleKeyDown,
+    modalRef: menuWrapperRef,
+    topModalOverride: true,
+  });
 
   // TODO remove this as part of FE-5650
   if (!isOpen) return null;

--- a/src/components/vertical-menu/vertical-menu.pw.tsx
+++ b/src/components/vertical-menu/vertical-menu.pw.tsx
@@ -7,6 +7,7 @@ import {
   VerticalMenuTriggerCustom,
   VerticalMenuItemCustomHref,
   VerticalMenuFullScreenCustom,
+  VerticalMenuFullScreenCustomWithDialog,
   VerticalMenuFullScreenBackgroundScrollTest,
   ClosedVerticalMenuFullScreenWithButtons,
   CustomComponent,
@@ -600,6 +601,33 @@ test.describe("Events test", () => {
     await closeIconButton(page).click();
 
     await expect(callbackCount).toBe(1);
+  });
+
+  test(`should be available when a Dialog is opened in the background`, async ({
+    mount,
+    page,
+  }) => {
+    let callbackCount = 0;
+    await page.setViewportSize({
+      width: 320,
+      height: 599,
+    });
+    await mount(
+      <VerticalMenuFullScreenCustomWithDialog
+        onClose={() => {
+          callbackCount += 1;
+        }}
+      />,
+    );
+
+    await verticalMenuTrigger(page).click();
+
+    await closeIconButton(page).click();
+
+    await expect(callbackCount).toBe(1);
+
+    const dialogText = page.getByText("Do you want to leave before saving?");
+    await expect(dialogText).toBeInViewport();
   });
 
   [...keysToTrigger].forEach((key) => {

--- a/src/components/vertical-menu/vertical-menu.stories.tsx
+++ b/src/components/vertical-menu/vertical-menu.stories.tsx
@@ -14,6 +14,8 @@ import {
   VerticalMenuTrigger,
 } from ".";
 
+import Confirm from "../confirm/confirm.component";
+
 const defaultOpenState = isChromatic();
 
 const meta: Meta<typeof VerticalMenu> = {
@@ -320,3 +322,101 @@ export const FullScreen: Story = () => {
   );
 };
 FullScreen.storyName = "Full Screen";
+
+export const FullScreenWithModal: Story = () => {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [disableAutoFocus, setDisableAutoFocus] = useState(false);
+
+  const menuItems = (
+    <>
+      <VerticalMenuItem iconType="analysis" title="Item 1">
+        <VerticalMenuItem
+          title="ChildItem 1"
+          href="/child-item-1"
+          adornment={
+            <Pill borderColor="#fff" fill size="S">
+              10
+            </Pill>
+          }
+        />
+        <VerticalMenuItem href="/child-item-2" title="ChildItem 2" />
+      </VerticalMenuItem>
+
+      <VerticalMenuItem iconType="admin" href="/item1" title="Item 2" />
+
+      <VerticalMenuItem iconType="home" title="Item 3">
+        <VerticalMenuItem
+          title="Very long text that will be wrapped"
+          href="/very-long-text-that-will-be-wrapped"
+          adornment={
+            <Pill borderColor="#fff" fill size="S">
+              100
+            </Pill>
+          }
+        />
+        <VerticalMenuItem
+          title="Active item"
+          href="/active-item"
+          active
+          adornment={
+            <Pill borderColor="#fff" fill size="S">
+              29
+            </Pill>
+          }
+        />
+      </VerticalMenuItem>
+
+      <VerticalMenuItem iconType="alert" title="Item 4" href="/item-4" />
+
+      <VerticalMenuItem iconType="bank" title="Item 5">
+        <VerticalMenuItem title="ChildItem 1" href="/child-item-1" />
+        <VerticalMenuItem title="ChildItem 2" href="/child-item-2" />
+      </VerticalMenuItem>
+
+      <VerticalMenuItem iconType="basket" title="Item 6" href="/item-6" />
+
+      <VerticalMenuItem
+        iconType="calendar"
+        title="Item 7 - More text to wrap the whole title. More text to wrap the whole title. More text to wrap the whole title. More text to wrap the whole title. "
+      >
+        <VerticalMenuItem title="ChildItem 1" href="/child-item-1" />
+        <VerticalMenuItem title="ChildItem 2" href="/child-item-2" />
+      </VerticalMenuItem>
+    </>
+  );
+
+  return (
+    <>
+      <VerticalMenuTrigger
+        onClick={() => {
+          setDisableAutoFocus(true);
+          setIsModalOpen(true);
+          setIsMenuOpen(true);
+        }}
+      >
+        Menu
+      </VerticalMenuTrigger>
+      <VerticalMenuFullScreen
+        isOpen={isMenuOpen}
+        onClose={() => {
+          setIsMenuOpen(false);
+          setDisableAutoFocus(false);
+        }}
+      >
+        {menuItems}
+      </VerticalMenuFullScreen>
+      <Confirm
+        disableAutoFocus={disableAutoFocus}
+        cancelButtonDestructive
+        title="Are you sure?"
+        open={isModalOpen}
+        onConfirm={() => setIsModalOpen(false)}
+        onCancel={() => setIsModalOpen(false)}
+      >
+        Do you want to leave before saving??
+      </Confirm>
+    </>
+  );
+};
+FullScreenWithModal.storyName = "Full Screen With Modal";


### PR DESCRIPTION
fixes: #7073 

### Proposed behaviour

The vertical menu full screen is now using the `useModalManager` in order to register and a modal. This permits us to interact with the menu when we also have a dialog opened in the background.

https://github.com/user-attachments/assets/9d9eeb4b-0485-454c-b5eb-56ce7a45beac

https://github.com/user-attachments/assets/3d95d901-26d1-4932-9b53-2dfde2f3f990


<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

If there is both a vertical menu full screen and a dialog opened, due to the modal manager interaction with the vertical menu is blocked. Since the vertical menu is on top of the dialog, the user can not close the dialog and all mouse interaction with the menu is blocked.

https://github.com/user-attachments/assets/ad0576b7-92cd-4794-90fb-cfbca77edf3e

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [X] Playwright automation tests added or updated if required
- [X] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
