### PR TITLE
chore: build script no longer uses cross-env and args can be passed t…

### DIFF
--- a/scripts/build-storybook.js
+++ b/scripts/build-storybook.js
@@ -2,11 +2,41 @@ const dotenv = require("dotenv");
 const fs = require("fs");
 const { execSync } = require("child_process");
 
+const whitelistArgs = [
+  "-h",
+  "--help",
+  "-V",
+  "--version",
+  "-o",
+  "--output-dir",
+  "-c",
+  "--config-dir",
+  "--loglevel",
+  "--quiet",
+  "--debug",
+  "--debug-webpack",
+  "--stats-json",
+  "--docs",
+  "--test",
+  "--ci",
+  "--smoke-test",
+  "--preview-url",
+  "--force-build-preview",
+  "--disable-telemetry",
+  "--enable-crash-reports",
+  "--webpack-stats-json",
+];
 const envConfig = dotenv.parse(fs.readFileSync(".env"));
 process.env.STORYBOOK_BUILD = envConfig.STORYBOOK_BUILD;
+const args = process.argv.slice(2);
+const storybookArgs = args
+  .filter((arg) => whitelistArgs.includes(arg.split("=")[0]))
+  .join(" ");
 
 try {
-  execSync("storybook build -c .storybook", { stdio: "inherit" });
+  execSync(`storybook build -c .storybook ${storybookArgs}`, {
+    stdio: "inherit",
+  });
 } catch (error) {
   // eslint-disable-next-line no-console
   console.error("Failed to start the application:", error);

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -33,7 +33,7 @@ async function run(bundle) {
     {
       cjs: "./lib",
       esm: "./esm",
-    }[bundle]
+    }[bundle],
   );
 
   const babelArgs = [
@@ -48,7 +48,7 @@ async function run(bundle) {
     `"${ignore.join('","')}"`,
   ];
 
-  const command = ["cross-env babel", ...babelArgs].join(" ");
+  const command = ["babel", ...babelArgs].join(" ");
 
   const { stderr } = await exec(command, {
     env: { ...process.env, ...env },


### PR DESCRIPTION
…o build-storybook script

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Removes `cross-env` call in `build` script as environment variables are being set inside the function's scope so should work avoid cross-platform issues without the need for cross-env or dot-env etc.

Ensures `build-storybook` scrip can receive `args`.
 
### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
The `build` script still calls `cross-env`.
The `build-storybook` cannot receive any args passed when it is called.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
Run `npm run build` on a windows machine to test it works cross-platform after `cross-env` removed
