### PR TITLE
fix(switch): fixes the invalid design token when using hint text on dark backgrounds

### DIFF
--- a/src/components/switch/switch.stories.tsx
+++ b/src/components/switch/switch.stories.tsx
@@ -387,3 +387,20 @@ export const NewValidationInlineWithDarkModeAndError: Story = () => {
 };
 NewValidationInlineWithDarkModeAndError.storyName =
   "New Validation - Inline with dark background support and error";
+
+export const NewValidationInlineWithDarkModeAndHint: Story = () => {
+  return (
+    <Box m={2} padding={3} backgroundColor="#000000">
+      <CarbonProvider validationRedesignOptIn>
+        <Switch
+          label="Example switch (error state)"
+          labelInline
+          isDarkBackground
+          labelHelp="Hint text to show on the Switch"
+        />
+      </CarbonProvider>
+    </Box>
+  );
+};
+NewValidationInlineWithDarkModeAndHint.storyName =
+  "New Validation - Inline with dark background support and hint text";

--- a/src/components/switch/switch.style.ts
+++ b/src/components/switch/switch.style.ts
@@ -67,7 +67,7 @@ export const StyledHintText = styled.div<StyledHintTextProps>`
   max-width: 160px;
   ${({ isDarkBackground }) => css`
     color: ${isDarkBackground
-      ? "var(--colorsUtilityYang065)"
+      ? "var(--colorsUtilityYang080)"
       : "var(--colorsUtilityYin055)"};
   `}
 `;


### PR DESCRIPTION
Resolves #7086

### Proposed behaviour

Use `var(--colorsUtilityYang080)` for `Switch` hint text when `darkBackground` is true.

### Current behaviour

The design token for the colour of `Switch` hint text on a dark background is non-existant.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Storybook added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Use the new Storybook example found under `Switch` to verify that the hint text appears on dark backgrounds.