### PR TITLE
fix(popover-container): ensure that tab sequence is not lost when container has radio buttons

### DIFF
--- a/src/__internal__/focus-trap/focus-trap.component.tsx
+++ b/src/__internal__/focus-trap/focus-trap.component.tsx
@@ -279,7 +279,7 @@ const FocusTrap = ({
     onFocus: updateCurrentFocusedElement,
   });
 
-  // passes focusProps, sets tabIndex and onBlur if no tabIndex has been expicitly set on child
+  // passes focusProps, sets tabIndex and onBlur if no tabIndex has been explicitly set on child
   const clonedChildren = React.Children.map(children, (child) => {
     const focusableChild = child as React.ReactElement;
     return React.cloneElement(

--- a/src/components/popover-container/components.test-pw.tsx
+++ b/src/components/popover-container/components.test-pw.tsx
@@ -7,6 +7,7 @@ import Pill from "../pill";
 import Badge from "../badge";
 import Box from "../box";
 import { Select, Option } from "../select";
+import RadioButton, { RadioButtonGroup } from "../radio-button";
 import PopoverContainer, {
   PopoverContainerProps,
 } from "./popover-container.component";
@@ -431,6 +432,34 @@ export const PopoverContainerFocusOrder = (
         <button type="button">Inside container</button>
       </PopoverContainer>
       <button type="button">After open button</button>
+    </Box>
+  );
+};
+
+export const WithRadioButtons = () => {
+  const [open1, setOpen1] = useState(false);
+  return (
+    <Box padding="25px" display="inline-flex">
+      <PopoverContainer
+        position="left"
+        onOpen={() => setOpen1(true)}
+        onClose={() => setOpen1(false)}
+        open={open1}
+        renderOpenComponent={({ ref, onClick }) => (
+          <Button aria-label="open" ref={ref} onClick={onClick}>
+            With Radio children
+          </Button>
+        )}
+        p={0}
+      >
+        <Box display="flex" justifyContent="space-between" p={2}>
+          <RadioButtonGroup name="bar">
+            <RadioButton value="1" label="radio 1" />
+            <RadioButton value="2" label="radio 2" />
+          </RadioButtonGroup>
+        </Box>
+      </PopoverContainer>
+      <Button>foo</Button>
     </Box>
   );
 };

--- a/src/components/popover-container/popover-container-test.stories.tsx
+++ b/src/components/popover-container/popover-container-test.stories.tsx
@@ -11,6 +11,7 @@ import Typography from "../typography";
 import Search from "../search";
 import IconButton from "../icon-button";
 import Icon from "../icon";
+import RadioButton, { RadioButtonGroup } from "../radio-button";
 
 export default {
   title: "Popover Container/Test",
@@ -22,6 +23,7 @@ export default {
     "InsideMenu",
     "InsideMenuWithOpenButton",
     "WithFullWidthButton",
+    "WithRadioButtons",
   ],
   parameters: {
     info: { disable: true },
@@ -244,5 +246,34 @@ export const WithFullWidthButton = () => {
     >
       Content
     </PopoverContainer>
+  );
+};
+
+export const WithRadioButtons = () => {
+  const [open1, setOpen1] = useState(false);
+
+  return (
+    <Box padding="25px" display="inline-flex">
+      <PopoverContainer
+        position="left"
+        onOpen={() => setOpen1(true)}
+        onClose={() => setOpen1(false)}
+        open={open1}
+        renderOpenComponent={({ ref, onClick }) => (
+          <Button aria-label="Notifications" ref={ref} onClick={onClick}>
+            With Radio children
+          </Button>
+        )}
+        p={0}
+      >
+        <Box display="flex" justifyContent="space-between" p={2}>
+          <RadioButtonGroup name="bar">
+            <RadioButton value="1" label="radio 1" />
+            <RadioButton value="2" label="radio 2" />
+          </RadioButtonGroup>
+        </Box>
+      </PopoverContainer>
+      <Button>foo</Button>
+    </Box>
   );
 };

--- a/src/components/popover-container/popover-container.pw.tsx
+++ b/src/components/popover-container/popover-container.pw.tsx
@@ -34,6 +34,7 @@ import {
   WithRenderCloseButtonComponent,
   PopoverContainerComponentCoverButton,
   PopoverContainerFocusOrder,
+  WithRadioButtons,
 } from "../popover-container/components.test-pw";
 import Portrait from "../portrait";
 
@@ -622,6 +623,25 @@ test.describe("Check props of Popover Container component", () => {
     await expect(closeButton).toBeFocused();
     await page.keyboard.press("Shift+Tab");
     await expect(third).toBeFocused();
+  });
+
+  test("should focus the next focusable element outside of the container once finished keyboard navigating through the container's content", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<WithRadioButtons />);
+
+    const openButton = page.getByRole("button", { name: "open" });
+    const container = popoverContainerContent(page);
+    const additionalButton = page.getByRole("button", { name: "foo" });
+
+    await openButton.click();
+    await page.keyboard.press("Tab"); // focus on first radio button
+    await page.keyboard.press("Tab"); // focus on close icon
+    await page.keyboard.press("Tab"); // focus outside of container and on to additional button
+
+    await expect(container).not.toBeVisible();
+    await expect(additionalButton).toBeFocused();
   });
 
   test.describe("Accessibility tests", () => {


### PR DESCRIPTION
This fix ensures that if the last focusable element in a popover container is a radio button, that the tab sequence is not affected once focus is outside of the container

fixes #7067

### Proposed behaviour

https://github.com/user-attachments/assets/5343bd1b-345a-4576-95b1-3df40374833a

### Current behaviour

https://github.com/user-attachments/assets/7e741308-4f29-4d7e-96ae-984f19b466ff

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

**Steps to reproduce**
Using the new `With Radio Button` example:
- Press TAB key until you reach the `with Radio children` button.
- Press ENTER to open the popover container.
- Press TAB key until the last element of the list.
- Press TAB key.
- Focus should move to button next to the popover container's opening button.

There should also be no functional regressions or changes to the other `PopoverContainer` examples.