### PR TITLE
feat(draggable-container): add flexDirection prop

### DIFF
--- a/src/components/draggable/draggable-container.component.tsx
+++ b/src/components/draggable/draggable-container.component.tsx
@@ -23,6 +23,11 @@ export interface DraggableContainerProps
    * `<DraggableItem />` is required to make `Draggable` works
    */
   children?: React.ReactNode;
+  /**
+   * Defines the direction in which the draggable items contents are placed.
+   * Can be either "row" or "row-reverse".
+   */
+  flexDirection?: "row" | "row-reverse";
 }
 
 const DraggableContainer = ({
@@ -30,6 +35,7 @@ const DraggableContainer = ({
   "data-role": dataRole = "draggable-container",
   children,
   getOrder,
+  flexDirection = "row",
   ...rest
 }: DraggableContainerProps): JSX.Element => {
   const [draggableItems, setDraggableItems] = useState(
@@ -117,6 +123,7 @@ const DraggableContainer = ({
                 id: `${item.props.id}`,
                 findItem,
                 moveItem,
+                flexDirection,
               },
               [item.props.children],
             )

--- a/src/components/draggable/draggable-item/draggable-item.component.tsx
+++ b/src/components/draggable/draggable-item/draggable-item.component.tsx
@@ -3,7 +3,8 @@ import { useDrop, useDrag } from "react-dnd";
 import { PaddingProps } from "styled-system";
 
 import { filterStyledSystemPaddingProps } from "../../../style/utils";
-import { StyledDraggableItem, StyledIcon } from "./draggable-item.style";
+import { StyledDraggableItem } from "./draggable-item.style";
+import Icon from "../../icon";
 
 export interface DraggableItemProps extends PaddingProps {
   /**
@@ -30,6 +31,11 @@ export interface DraggableItemProps extends PaddingProps {
     droppedId: string | number,
     overIndex: number | undefined,
   ) => void;
+  /**
+   * @private
+   * @ignore
+   */
+  flexDirection?: "row" | "row-reverse";
 }
 
 const DraggableItem = ({
@@ -38,6 +44,7 @@ const DraggableItem = ({
   moveItem,
   children,
   py = 1,
+  flexDirection,
   ...rest
 }: DraggableItemProps): JSX.Element => {
   let originalIndex;
@@ -88,10 +95,11 @@ const DraggableItem = ({
       isDragging={isDragging}
       ref={(node) => drag(drop(node))}
       py={py}
+      flexDirection={flexDirection}
       {...paddingProps}
     >
       {children}
-      <StyledIcon type="drag" />
+      <Icon type="drag" />
     </StyledDraggableItem>
   );
 };

--- a/src/components/draggable/draggable-item/draggable-item.style.ts
+++ b/src/components/draggable/draggable-item/draggable-item.style.ts
@@ -2,7 +2,6 @@ import styled from "styled-components";
 import { padding, margin, PaddingProps } from "styled-system";
 
 import { baseTheme } from "../../../style/themes";
-import Icon from "../../icon";
 
 const StyledDraggableContainer = styled.div`
   ${margin}
@@ -10,6 +9,7 @@ const StyledDraggableContainer = styled.div`
 
 interface StyledDraggableItemProps extends PaddingProps {
   isDragging?: boolean;
+  flexDirection?: "row" | "row-reverse";
 }
 
 const StyledDraggableItem = styled.div<StyledDraggableItemProps>`
@@ -18,12 +18,9 @@ const StyledDraggableItem = styled.div<StyledDraggableItemProps>`
   border-bottom: 1px solid var(--colorsUtilityMajor050);
   ${padding}
   cursor: move;
-
+  justify-content: space-between;
+  flex-direction: ${({ flexDirection }) => flexDirection};
   opacity: ${({ isDragging }) => (isDragging ? "0" : "1")};
-`;
-
-const StyledIcon = styled(Icon)`
-  margin-left: auto;
 `;
 
 StyledDraggableContainer.defaultProps = {
@@ -34,4 +31,4 @@ StyledDraggableItem.defaultProps = {
   theme: baseTheme,
 };
 
-export { StyledDraggableContainer, StyledDraggableItem, StyledIcon };
+export { StyledDraggableContainer, StyledDraggableItem };

--- a/src/components/draggable/draggable-test.stories.tsx
+++ b/src/components/draggable/draggable-test.stories.tsx
@@ -48,6 +48,35 @@ Default.story = {
   name: "default",
 };
 
+export const DraggableFlexDirection = () => {
+  const handleUpdate = (items?: (string | number | undefined)[]) => {
+    action("onUpdate")(items);
+  };
+  return (
+    <DraggableContainer getOrder={handleUpdate} flexDirection="row-reverse">
+      <DraggableItem key="1" id={1}>
+        <Checkbox label="Draggable Label One" />
+      </DraggableItem>
+      <DraggableItem key="2" id={2}>
+        <Checkbox label="Draggable Label Two" />
+      </DraggableItem>
+      <DraggableItem key="3" id={3}>
+        <Checkbox label="Draggable Label Three" />
+      </DraggableItem>
+      <DraggableItem key="4" id={4}>
+        <Checkbox label="Draggable Label Four" />
+      </DraggableItem>
+      <DraggableItem key="5" id={5}>
+        <Textbox label="Draggable Textbox" />
+      </DraggableItem>
+    </DraggableContainer>
+  );
+};
+
+DraggableFlexDirection.story = {
+  name: "Flex Direction",
+};
+
 export const DraggableCustom = ({
   getOrder,
   ...props

--- a/src/components/draggable/draggable.mdx
+++ b/src/components/draggable/draggable.mdx
@@ -40,6 +40,10 @@ import {
 
 <Canvas of={DraggableStories.DefaultStory} />
 
+### With flex direction
+
+<Canvas of={DraggableStories.FlexDirectionStory} />
+
 ### Other components as children
 
 <Canvas of={DraggableStories.ComponentsAsChildrenStory} />

--- a/src/components/draggable/draggable.stories.tsx
+++ b/src/components/draggable/draggable.stories.tsx
@@ -46,6 +46,24 @@ export const DefaultStory: Story = () => (
 );
 DefaultStory.storyName = "Default";
 
+export const FlexDirectionStory: Story = () => (
+  <DraggableContainer flexDirection="row-reverse">
+    <DraggableItem key="1" id={1}>
+      Some first content goes here
+    </DraggableItem>
+    <DraggableItem key="2" id={2}>
+      Some second content goes here
+    </DraggableItem>
+    <DraggableItem key="3" id={3}>
+      Some third content goes here
+    </DraggableItem>
+    <DraggableItem key="4" id={4}>
+      Some fourth content goes here
+    </DraggableItem>
+  </DraggableContainer>
+);
+FlexDirectionStory.storyName = "With Flex Direction";
+
 export const ComponentsAsChildrenStory: Story = () => (
   <DraggableContainer>
     <DraggableItem key="1" id={1}>


### PR DESCRIPTION
fix #7089

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

adds the `flexDirection` prop which provides consumers with the means to change the flex-direction css attribute from row to row-reverse or vice versa

![Screenshot 2024-11-28 at 11 32 39](https://github.com/user-attachments/assets/b0e71a61-0832-40c4-8259-f6142d2e3931)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, consumers have no control over where the "draggable" icon is placed, and it is always rendered on the right-hand side by default

![Screenshot 2024-11-28 at 11 32 32](https://github.com/user-attachments/assets/5e55b24e-2ac0-4ecf-8d21-e14baee8d4e7)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
