### PR TITLE
fix(sidebar): make sidebar-heading element 100% width

### DIFF
--- a/src/components/sidebar/__internal__/sidebar-header/sidebar-header.style.ts
+++ b/src/components/sidebar/__internal__/sidebar-header/sidebar-header.style.ts
@@ -25,6 +25,10 @@ const StyledSidebarHeader = styled.div<{ hasClose?: boolean }>`
         right: 25px;
       }
     `}
+
+    div[data-element="sidebar-heading"] {
+    width: 100%;
+  }
 `;
 
 StyledSidebarHeader.defaultProps = {

--- a/src/components/sidebar/sidebar-test.stories.tsx
+++ b/src/components/sidebar/sidebar-test.stories.tsx
@@ -1,12 +1,16 @@
 import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
 import { Meta, StoryObj } from "@storybook/react";
-import Form from "../form";
-import Textbox from "../textbox";
+import isChromatic from "../../../.storybook/isChromatic";
+import { allModes } from "../../../.storybook/modes";
+
+import Box from "../box";
 import Button from "../button";
+import Form from "../form";
 import Sidebar, { SidebarProps } from ".";
 import { SIDEBAR_ALIGNMENTS, SIDEBAR_SIZES } from "./sidebar.config";
-import Box from "../box";
+import { StepFlow } from "../step-flow";
+import Textbox from "../textbox";
 import Typography from "../typography";
 
 const meta: Meta<typeof Sidebar> = {
@@ -17,9 +21,9 @@ const meta: Meta<typeof Sidebar> = {
   },
   decorators: [
     (Story) => (
-      <div style={{ height: "900px" }}>
+      <Box width="100%" height={900}>
         <Story />
-      </div>
+      </Box>
     ),
   ],
   argTypes: {
@@ -174,4 +178,57 @@ export const WithForm: StoryObj<typeof Sidebar> = {
       </Form>
     </Sidebar>
   ),
+};
+
+const WithStepFlowExample = () => {
+  const [isOpen, setIsOpen] = useState(isChromatic());
+
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
+      <Sidebar
+        aria-label="sidebar"
+        onCancel={() => setIsOpen(false)}
+        header={
+          <Box width="100%">
+            <StepFlow
+              title="My Step Flow"
+              totalSteps={2}
+              currentStep={1}
+              showProgressIndicator
+            />
+          </Box>
+        }
+        open={isOpen}
+      >
+        <Typography variant="p">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed lectus
+          massa, suscipit vitae pellentesque quis, facilisis non ante. Curabitur
+          fringilla sapien non ante elementum venenatis. Curabitur viverra,
+          massa ac congue imperdiet, purus ligula dictum quam, id tincidunt diam
+          risus quis eros. Vivamus semper sem ac tempor malesuada. Proin nec
+          sollicitudin mi. Nunc egestas ipsum ac lorem pretium blandit. Quisque
+          ac ultricies lacus. Phasellus vel enim id est ornare finibus eget
+          vitae ipsum. Maecenas non accumsan dolor. Morbi sed mauris mollis
+          lorem finibus feugiat. Maecenas scelerisque nec orci ac finibus. Nulla
+          dictum, quam vel gravida lobortis, nisl eros vulputate augue, eget
+          malesuada lacus elit sed leo. In a ex id metus vulputate sollicitudin
+          at eget neque. Aliquam cursus quis odio in consequat.
+        </Typography>
+      </Sidebar>
+    </>
+  );
+};
+
+export const WithStepFlow: StoryObj<typeof Sidebar> = {
+  render: (args) => <WithStepFlowExample {...args} />,
+  parameters: {
+    chromatic: {
+      themeProvider: { chromatic: { theme: "sage" } },
+      disableSnapshot: false,
+      modes: {
+        desktop: allModes.chromatic,
+      },
+    },
+  },
 };


### PR DESCRIPTION
A recent bug fix in 144.9.1 prevent the sidebar header component from being 100% width when the sidebar also has an onCancel method provided. Thix fix ensures that the sidebar heading element is 100%.

fixes #7090

### Proposed behaviour

![Screenshot 2024-11-28 at 11 12 36](https://github.com/user-attachments/assets/8657ffd0-facd-4a09-b9d2-0307cbad9dc2)

### Current behaviour

![Screenshot 2024-11-28 at 11 13 18](https://github.com/user-attachments/assets/a2e4d161-2aec-466e-a5e5-0785bf997e50)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Check that new and updated Chromatic snapshots match the expected styles.
- Ensure that the new `WithStepFlow` example renders the `StepFlow` component full width of the header.
- No other visual or functional regressions were introduced in this work. 