### PR TITLE
fix(box): css style properties passed as HTML attributes

### DIFF
--- a/src/components/box/box.component.tsx
+++ b/src/components/box/box.component.tsx
@@ -101,6 +101,8 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
       borderRadius,
       color,
       opacity,
+      height,
+      width,
       "aria-hidden": ariaHidden,
       ...rest
     }: BoxProps,
@@ -112,6 +114,28 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
         "The `tabIndex` prop for `Box` component has been deprecated and will soon be removed.",
       );
     }
+
+    let actualWidth = "";
+    if (typeof width === "number") {
+      actualWidth = width <= 1 ? `${(width * 100).toFixed(0)}%` : `${width}px`;
+    } else if (typeof width === "string") {
+      actualWidth = width;
+    }
+
+    let actualHeight = "";
+    if (typeof height === "number") {
+      actualHeight =
+        height <= 1 ? `${(height * 100).toFixed(0)}%` : `${height}px`;
+    } else if (typeof height === "string") {
+      actualHeight = height;
+    }
+
+    const cssProps = {
+      color,
+      opacity,
+      width: actualWidth,
+      height: actualHeight,
+    };
 
     return (
       <StyledBox
@@ -131,8 +155,6 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
         backgroundColor={backgroundColor}
         boxShadow={boxShadow}
         borderRadius={borderRadius}
-        color={color}
-        opacity={opacity}
         aria-hidden={ariaHidden}
         {...tagComponent(dataComponent, rest)}
         {...filterStyledSystemMarginProps(rest)}
@@ -140,6 +162,7 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
         {...filterStyledSystemFlexboxProps(rest)}
         {...filterStyledSystemGridProps(rest)}
         {...filterStyledSystemLayoutProps(rest)}
+        cssProps={cssProps}
       >
         {children}
       </StyledBox>

--- a/src/components/box/box.pw.tsx
+++ b/src/components/box/box.pw.tsx
@@ -58,7 +58,6 @@ test.describe("should render Box component", () => {
     }) => {
       await mount(<Default color={color} />);
       const boxElement = await getDataElementByValue(page, "box");
-      await expect(boxElement).toHaveAttribute("color", color);
       await expect(boxElement).toHaveCSS("color", rgbValue);
     });
   });
@@ -70,7 +69,6 @@ test.describe("should render Box component", () => {
     }) => {
       await mount(<Default color={rgbValue} />);
       const boxElement = await getDataElementByValue(page, "box");
-      await expect(boxElement).toHaveAttribute("color", rgbValue);
       await expect(boxElement).toHaveCSS("color", rgbValue);
     });
   });
@@ -82,7 +80,6 @@ test.describe("should render Box component", () => {
     }) => {
       await mount(<Default color={hexValue} />);
       const boxElement = await getDataElementByValue(page, "box");
-      await expect(boxElement).toHaveAttribute("color", hexValue);
       await expect(boxElement).toHaveCSS("color", rgbValue);
     });
   });
@@ -168,7 +165,6 @@ test.describe("should render Box component", () => {
     }) => {
       await mount(<Default bg="primary" width={percentage} />);
       const boxElement = await getDataElementByValue(page, "box");
-      await expect(boxElement).toHaveAttribute("width", String(percentage));
       await assertCssValueIsApproximately(boxElement, "width", parseInt(width));
     });
   });
@@ -180,7 +176,6 @@ test.describe("should render Box component", () => {
     }) => {
       await mount(<Default bg="primary" width={number} />);
       const boxElement = await getDataElementByValue(page, "box");
-      await expect(boxElement).toHaveAttribute("width", String(number));
       await assertCssValueIsApproximately(boxElement, "width", parseInt(width));
     });
   });
@@ -192,7 +187,6 @@ test.describe("should render Box component", () => {
     }) => {
       await mount(<Default bg="primary" width={width} />);
       const boxElement = await getDataElementByValue(page, "box");
-      await expect(boxElement).toHaveAttribute("width", width);
       await assertCssValueIsApproximately(boxElement, "width", parseInt(width));
     });
   });
@@ -204,7 +198,6 @@ test.describe("should render Box component", () => {
     }) => {
       await mount(<Default bg="primary" height={number} />);
       const boxElement = await getDataElementByValue(page, "box");
-      await expect(boxElement).toHaveAttribute("height", String(number));
       await assertCssValueIsApproximately(
         boxElement,
         "height",
@@ -220,7 +213,6 @@ test.describe("should render Box component", () => {
     }) => {
       await mount(<Default bg="primary" height={height} />);
       const boxElement = await getDataElementByValue(page, "box");
-      await expect(boxElement).toHaveAttribute("height", height);
       await assertCssValueIsApproximately(
         boxElement,
         "height",

--- a/src/components/box/box.style.ts
+++ b/src/components/box/box.style.ts
@@ -23,7 +23,16 @@ const calculatePosition = (props: Omit<PositionProps, "zIndex">) => {
   };
 };
 
-const StyledBox = styled.div<BoxProps>`
+const StyledBox = styled.div<
+  BoxProps & {
+    cssProps?: {
+      color?: string;
+      opacity?: string;
+      height?: string;
+      width?: string;
+    };
+  }
+>`
   ${space}
   ${layout}
   ${flexbox}
@@ -35,9 +44,13 @@ const StyledBox = styled.div<BoxProps>`
     css`
       border-radius: var(--${borderRadius});
     `}
+  
+  ${({ cssProps, bg, backgroundColor, ...rest }) =>
+    styledColor({ color: cssProps?.color, bg, backgroundColor, ...rest })}
 
-  ${({ color, bg, backgroundColor, ...rest }) =>
-    styledColor({ color, bg, backgroundColor, ...rest })}
+  ${({ cssProps }) => css`
+    opacity: ${cssProps?.opacity};
+  `}
 
   ${({ overflowWrap }) =>
     overflowWrap &&
@@ -45,16 +58,18 @@ const StyledBox = styled.div<BoxProps>`
       overflow-wrap: ${overflowWrap};
     `}
   
-  ${({ height }) =>
-    height &&
+  ${({ cssProps, size }) =>
+    cssProps?.height &&
+    !size &&
     css`
-      height: ${height};
+      height: ${cssProps?.height};
     `}
 
-  ${({ width }) =>
-    width &&
+  ${({ cssProps, size }) =>
+    cssProps?.width &&
+    !size &&
     css`
-      width: ${width};
+      width: ${cssProps?.width};
     `}
 
   ${({ scrollVariant }) =>

--- a/src/components/box/box.test.tsx
+++ b/src/components/box/box.test.tsx
@@ -76,6 +76,46 @@ it("applies the boxShadow styling correctly when a design token is passed in", (
   expect(box).toHaveStyle(`box-shadow: var(--boxShadow100)`);
 });
 
+it("applies the correct styling from the cssProps", () => {
+  render(
+    <Box
+      width="100px"
+      height="100px"
+      opacity="25%"
+      color="yellow"
+      data-role="box"
+    />,
+  );
+
+  const box = screen.getByTestId("box");
+  expect(box).toHaveStyle({
+    width: "100px",
+    height: "100px",
+    opacity: "25%",
+    color: "yellow",
+  });
+});
+
+it("applies the correct styling from the cssProps, when the width and height are numeric", () => {
+  render(<Box width={100} height={100} data-role="box" />);
+
+  const box = screen.getByTestId("box");
+  expect(box).toHaveStyle({
+    width: "100px",
+    height: "100px",
+  });
+});
+
+it("applies the correct styling from the cssProps, when the width and height are percentage", () => {
+  render(<Box width={0.5} height={0.5} data-role="box" />);
+
+  const box = screen.getByTestId("box");
+  expect(box).toHaveStyle({
+    width: "50%",
+    height: "50%",
+  });
+});
+
 test("logs a deprecation warning when the `tabIndex` prop is passed with a value", () => {
   const loggerSpy = jest
     .spyOn(Logger, "deprecate")

--- a/src/components/dismissible-box/dismissible-box.pw.tsx
+++ b/src/components/dismissible-box/dismissible-box.pw.tsx
@@ -46,11 +46,6 @@ test.describe("DismissibleBox component", () => {
     }) => {
       await mount(<DefaultDismissibleBox width={`${width}px`} />);
 
-      await expect(dismissibleBoxDataComponent(page)).toHaveAttribute(
-        "width",
-        `${width}px`,
-      );
-
       await assertCssValueIsApproximately(
         dismissibleBoxDataComponent(page),
         "width",


### PR DESCRIPTION
### Proposed behaviour

The `height`, `width`, `opacity` and `color` are not being passed directly to the `StyledBox` component but instead are placed in the `cssProps` object, and then they are used inside the `StyledBox`. This prevents the props from being applied to the HTML node directly.

Playwright tests that were checking for the attribute being present on the node have been amended since the attribute is no longer present. 

![after](https://github.com/user-attachments/assets/fe2c206f-90fd-49af-9f62-137df52e2e2c)

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

The `height`, `width`, `opacity` and `color`  props are passed directly to the `StyledBox` component which applies them directly to the HTML node.

![before](https://github.com/user-attachments/assets/25af1e57-4f97-4d78-a62d-f556c090e7db)

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
