### PR TITLE
feat(decimal, grouped-character): deprecate onKeyPress

### DIFF
--- a/src/components/decimal/decimal.component.tsx
+++ b/src/components/decimal/decimal.component.tsx
@@ -39,7 +39,7 @@ export interface DecimalProps
   onChange?: (ev: CustomEvent) => void;
   /** Handler for blur event */
   onBlur?: (ev: CustomEvent) => void;
-  /** Handler for key press event */
+  /** [Deprecated] Handler for key press event */
   onKeyPress?: (ev: React.KeyboardEvent<HTMLInputElement>) => void;
   /** The input name */
   name?: string;
@@ -70,6 +70,7 @@ export interface DecimalProps
 }
 
 let deprecateUncontrolledWarnTriggered = false;
+let deprecateOnKeyPressWarnTriggered = false;
 
 export const Decimal = React.forwardRef(
   (
@@ -322,6 +323,13 @@ export const Decimal = React.forwardRef(
       deprecateUncontrolledWarnTriggered = true;
       Logger.deprecate(
         "Uncontrolled behaviour in `Decimal` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
+      );
+    }
+
+    if (!deprecateOnKeyPressWarnTriggered && onKeyPress) {
+      deprecateOnKeyPressWarnTriggered = true;
+      Logger.deprecate(
+        "`onKeyPress` prop in `Decimal` is deprecated and will soon be removed, please use `onKeyDown` instead.",
       );
     }
 

--- a/src/components/decimal/decimal.test.tsx
+++ b/src/components/decimal/decimal.test.tsx
@@ -32,12 +32,24 @@ testStyledSystemMargin(
 );
 
 describe("when the component is uncontrolled", () => {
-  it("displays a deprecation warning", () => {
+  it("displays a deprecation warning for uncontrolled", () => {
     const loggerSpy = jest.spyOn(Logger, "deprecate");
     render(<Decimal defaultValue="0.01" />);
 
     expect(loggerSpy).toHaveBeenCalledWith(
       "Uncontrolled behaviour in `Decimal` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
+    );
+    expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+    loggerSpy.mockRestore();
+  });
+
+  it("displays a deprecation warning for `onKeyPress`", () => {
+    const loggerSpy = jest.spyOn(Logger, "deprecate");
+    render(<Decimal onKeyPress={() => {}} />);
+
+    expect(loggerSpy).toHaveBeenCalledWith(
+      "`onKeyPress` prop in `Decimal` is deprecated and will soon be removed, please use `onKeyDown` instead.",
     );
     expect(loggerSpy).toHaveBeenCalledTimes(1);
 
@@ -672,16 +684,16 @@ describe("when the component is uncontrolled", () => {
     },
   );
 
-  it("calls the onKeyPress callback when a key is pressed", async () => {
+  it("calls the onKeyDown callback when a key is pressed", async () => {
     const user = userEvent.setup();
-    const onKeyPress = jest.fn();
-    render(<Decimal defaultValue="0.00" onKeyPress={onKeyPress} />);
+    const onKeyDown = jest.fn();
+    render(<Decimal defaultValue="0.00" onKeyDown={onKeyDown} />);
 
     screen.getByRole("textbox").focus();
     await user.keyboard("{ArrowRight}");
     await user.keyboard("1");
 
-    expect(onKeyPress).toHaveBeenCalledWith(
+    expect(onKeyDown).toHaveBeenCalledWith(
       expect.objectContaining({ key: "1" }),
     );
   });

--- a/src/components/grouped-character/grouped-character.component.tsx
+++ b/src/components/grouped-character/grouped-character.component.tsx
@@ -57,6 +57,7 @@ export const GroupedCharacter = React.forwardRef(
       groups,
       onBlur,
       onChange,
+      onKeyDown,
       separator: rawSeparator,
       value: externalValue,
       ...rest
@@ -139,14 +140,21 @@ export const GroupedCharacter = React.forwardRef(
       }
     };
 
-    const handleKeyPress = (ev: React.KeyboardEvent<HTMLInputElement>) => {
+    const handleKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {
       const { selectionStart, selectionEnd } = ev.target as HTMLInputElement;
 
       /* istanbul ignore next */
       const hasSelection = (selectionEnd ?? 0) - (selectionStart ?? 0) > 0;
 
-      if (maxRawLength === value.length && !hasSelection) {
+      // check if the key pressed is a character key
+      const isCharacterKey = ev.key.length === 1;
+
+      if (isCharacterKey && maxRawLength === value.length && !hasSelection) {
         ev.preventDefault();
+      }
+
+      if (onKeyDown) {
+        onKeyDown(ev);
       }
     };
 
@@ -157,7 +165,7 @@ export const GroupedCharacter = React.forwardRef(
         formattedValue={formatValue(value)}
         onChange={handleChange}
         onBlur={handleBlur}
-        onKeyPress={handleKeyPress}
+        onKeyDown={handleKeyDown}
         ref={ref}
       />
     );

--- a/src/components/grouped-character/grouped-character.test.tsx
+++ b/src/components/grouped-character/grouped-character.test.tsx
@@ -238,6 +238,27 @@ test("does nothing if onBlur is not provided", async () => {
   expect(onBlur.mock.calls[0]).toBe(undefined);
 });
 
+test("calls provided onKeyDown handler", async () => {
+  const onKeyDown = jest.fn();
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(
+    <GroupedCharacter
+      separator="-"
+      value="12345678"
+      groups={[2, 2, 4]}
+      onKeyDown={onKeyDown}
+    />,
+  );
+
+  const input = screen.getByRole("textbox");
+  await user.click(input);
+  await user.clear(input);
+  await user.type(screen.getByRole("textbox"), "123456");
+
+  expect(onKeyDown).toHaveBeenCalledTimes(6);
+});
+
 test("does not allow values of length greater than that allowed by the group config", () => {
   render(
     <GroupedCharacter separator="-" value="1234567890" groups={[2, 2, 4]} />,


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- `Decimal` - deprecates `onKeyPress` prop.
- `GroupedCharacter` - replaces use of `onKeyPress` with `onKeyDown`. 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- `Decimal` - has `onKeyPress` prop.
- `GroupedCharacter` - uses `onKeyPress` internally. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
