### PR TITLE
feat(classname prop): remove className from public props

### DIFF
--- a/src/__internal__/label/label.component.tsx
+++ b/src/__internal__/label/label.component.tsx
@@ -34,7 +34,10 @@ export interface LabelProps
   useValidationIcon?: boolean;
   /** Id of the validation icon */
   validationIconId?: string;
-  /** Sets className for component */
+  /**
+   * @private
+   * @internal
+   * Sets className for component. INTERNAL USE ONLY. */
   className?: string;
   /** Sets aria-label for label element */
   "aria-label"?: string;

--- a/src/components/accordion/accordion-test.stories.tsx
+++ b/src/components/accordion/accordion-test.stories.tsx
@@ -44,12 +44,6 @@ export default {
         type: "select",
       },
     },
-    scheme: {
-      options: ["white", "transparent"],
-      control: {
-        type: "select",
-      },
-    },
     variant: {
       options: ["standard", "subtle"],
       control: {

--- a/src/components/accordion/accordion.component.tsx
+++ b/src/components/accordion/accordion.component.tsx
@@ -4,7 +4,6 @@ import { SpaceProps } from "styled-system";
 import useResizeObserver from "../../hooks/__internal__/useResizeObserver";
 import createGuid from "../../__internal__/utils/helpers/guid";
 import Events from "../../__internal__/utils/helpers/events";
-import Logger from "../../__internal__/utils/logger";
 import {
   StyledAccordionContainer,
   StyledAccordionHeadingsContainer,
@@ -21,8 +20,6 @@ import ValidationIcon from "../../__internal__/validations";
 export interface AccordionProps
   extends StyledAccordionContainerProps,
     SpaceProps {
-  /** Width of the buttonHeading when it's set, defaults to 150px */
-  buttonWidth?: number | string;
   /** Content of the Accordion component */
   children?: React.ReactNode;
   /** Set the default state of expansion of the Accordion if component is meant to be used as uncontrolled */
@@ -69,9 +66,6 @@ export interface AccordionInternalProps {
   index?: number;
 }
 
-let deprecatedSchemeWarnTriggered = false;
-let deprecatedButtonHeadingWarnTriggered = false;
-
 export const Accordion = React.forwardRef<
   HTMLDivElement,
   AccordionProps & AccordionInternalProps
@@ -88,7 +82,6 @@ export const Accordion = React.forwardRef<
       index,
       iconType,
       iconAlign,
-      scheme = "white",
       size = "large",
       subTitle,
       title,
@@ -98,28 +91,12 @@ export const Accordion = React.forwardRef<
       error,
       warning,
       info,
-      buttonHeading,
-      buttonWidth = "150px",
       openTitle,
       variant = "standard",
       ...rest
     }: AccordionProps & AccordionInternalProps,
     ref,
   ) => {
-    if (!deprecatedSchemeWarnTriggered && scheme === "transparent") {
-      deprecatedSchemeWarnTriggered = true;
-      Logger.deprecate(
-        "The `scheme` prop for `Accordion` component is deprecated and will soon be removed.",
-      );
-    }
-
-    if (!deprecatedButtonHeadingWarnTriggered && buttonHeading) {
-      deprecatedButtonHeadingWarnTriggered = true;
-      Logger.deprecate(
-        "The `buttonHeading` prop for `Accordion` component is deprecated and will soon be removed. Please use `subtle` variant instead.",
-      );
-    }
-
     const isControlled = expanded !== undefined;
 
     const [isExpandedInternal, setIsExpandedInternal] = useState(
@@ -185,8 +162,6 @@ export const Accordion = React.forwardRef<
         data-role="accordion-container"
         width={width}
         borders={variant === "subtle" ? "none" : borders}
-        scheme={scheme}
-        buttonHeading={buttonHeading}
         variant={variant}
         {...rest}
       >
@@ -201,34 +176,24 @@ export const Accordion = React.forwardRef<
           iconAlign={iconAlign || (variant === "standard" ? "right" : "left")}
           ref={ref}
           size={size}
-          buttonHeading={buttonHeading}
           isExpanded={isExpanded}
           variant={variant}
-          buttonWidth={buttonWidth}
-          hasButtonProps={
-            buttonHeading && !(typeof headerSpacing === "undefined")
-          }
           role="button"
-          {...(buttonHeading && { p: 0 })}
           {...headerSpacing}
         >
           <StyledAccordionHeadingsContainer
             data-element="accordion-headings-container"
             hasValidationIcon={showValidationIcon}
-            buttonHeading={buttonHeading}
           >
-            {!buttonHeading && typeof title === "string" ? (
-              <StyledAccordionTitle
-                data-element="accordion-title"
-                size={size}
-                variant={variant}
-              >
-                {title}
-              </StyledAccordionTitle>
-            ) : (
-              getTitle()
-            )}
-            {!buttonHeading && variant !== "subtle" && (
+            <StyledAccordionTitle
+              data-element="accordion-title"
+              size={size}
+              variant={variant}
+            >
+              {getTitle()}
+            </StyledAccordionTitle>
+
+            {variant !== "subtle" && (
               <>
                 {showValidationIcon && (
                   <ValidationIcon

--- a/src/components/accordion/accordion.mdx
+++ b/src/components/accordion/accordion.mdx
@@ -84,12 +84,6 @@ The internal padding of the `Accordion` can be removed by setting the `disableCo
 
 <Canvas of={AccordionStories.WithDisableContentPadding} />
 
-### Transparent
-
-The `Accordion` can be rendered with a transparent background by setting the scheme to `transparent`.
-
-<Canvas of={AccordionStories.Transparent} />
-
 ### Small
 
 To use a smaller `Accordion`, set the size prop to `small`. The small version has a smaller heading, less padding and a smaller icon. If this prop is not provided, or set to `large`, the default size will be used.
@@ -158,7 +152,7 @@ An `Accordion`  will automatically adjust its height to fit the content inside i
 
 ### Subtle variant
 
-Setting the `variant` prop to `subtle` will override the default styling of an Accordion. The `subTitle` and `scheme` props will have no effect when used alongside this variant, nor will the validation props (`error`, `warning`, and `info`).
+Setting the `variant` prop to `subtle` will override the default styling of an Accordion. The `subTitle` prop will have no effect when used alongside this variant, nor will the validation props (`error`, `warning`, and `info`).
 
 <Canvas of={AccordionStories.SubtleVariant} />
 

--- a/src/components/accordion/accordion.pw.tsx
+++ b/src/components/accordion/accordion.pw.tsx
@@ -31,7 +31,6 @@ import {
   DynamicContent,
   AccordionDefault,
   AccordionWithBoxAndDifferentPaddings,
-  AccordionOpeningButton,
   AccordionGroupDefault,
   AccordionGroupValidation,
   AccordionWithDefinitionList,
@@ -292,22 +291,6 @@ test.describe("should render Accordion component", () => {
     });
   });
 
-  (
-    [
-      ["white", "rgb(255, 255, 255)"],
-      ["transparent", "rgba(0, 0, 0, 0)"],
-    ] as const
-  ).forEach(([scheme, colour]) => {
-    test(`should check Accordion scheme is ${scheme}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<AccordionComponent scheme={scheme} />);
-
-      await expect(accordion(page)).toHaveCSS("background-color", colour);
-    });
-  });
-
   ["700px", "900px", "1100px", "1300px"].forEach((width) => {
     test(`should check Accordion width is ${width}`, async ({
       mount,
@@ -368,27 +351,11 @@ test.describe("should render Accordion component", () => {
     await expect(accordionIcon(page).nth(0)).toHaveAttribute("type", "info");
   });
 
-  ["100px", "200px", "300px"].forEach((width) => {
-    test(`should check accordion heading is a button with width ${width}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <AccordionComponent title="Button" buttonHeading buttonWidth={width} />,
-      );
-
-      const cssWidth = await getStyle(accordionTitleContainer(page), "width");
-      expect(cssWidth).toContain(width);
-    });
-  });
-
   test("should verify accordion title changes when accordion is opened", async ({
     mount,
     page,
   }) => {
-    await mount(
-      <AccordionComponent buttonHeading title="Closed" openTitle="Open" />,
-    );
+    await mount(<AccordionComponent title="Closed" openTitle="Open" />);
 
     await expect(accordionTitleContainer(page)).toContainText("Closed");
 
@@ -536,15 +503,6 @@ test.describe("Accessibility tests for Accordion", () => {
     await checkAccessibility(page);
   });
 
-  test("should pass accessibility tests for Accordion transparent", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionDefault scheme="transparent" />);
-
-    await checkAccessibility(page);
-  });
-
   test("should pass accessibility tests for Accordion size small", async ({
     mount,
     page,
@@ -640,15 +598,6 @@ test.describe("Accessibility tests for Accordion", () => {
     page,
   }) => {
     await mount(<AccordionWithBoxAndDifferentPaddings />);
-
-    await checkAccessibility(page);
-  });
-
-  test("should pass accessibility tests for Accordion with opening buttons", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionOpeningButton />);
 
     await checkAccessibility(page);
   });

--- a/src/components/accordion/accordion.stories.tsx
+++ b/src/components/accordion/accordion.stories.tsx
@@ -49,18 +49,6 @@ WithDisableContentPadding.parameters = {
   chromatic: { disableSnapshot: false },
 };
 
-export const Transparent: Story = () => {
-  return (
-    <Accordion scheme="transparent" title="Heading">
-      <Box mt={2}>Content</Box>
-      <Box>Content</Box>
-      <Box>Content</Box>
-    </Accordion>
-  );
-};
-Transparent.storyName = "Transparent";
-Transparent.parameters = { chromatic: { disableSnapshot: false } };
-
 export const Small: Story = () => {
   return (
     <Accordion size="small" title="Heading">

--- a/src/components/accordion/accordion.style.ts
+++ b/src/components/accordion/accordion.style.ts
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+
 import { space, margin } from "styled-system";
 
 import Icon from "../icon";
@@ -13,10 +14,6 @@ const StyledAccordionGroup = styled.div`
 export interface StyledAccordionContainerProps {
   /** Toggles left and right borders, set to none when variant is subtle */
   borders?: "default" | "full" | "none";
-  /** (Deprecated) Renders the accordion heading in the style of a tertiary button */
-  buttonHeading?: boolean;
-  /** (Deprecated) Sets background as white or transparent, set to transparent when variant is subtle */
-  scheme?: "white" | "transparent";
   /** Sets accordion width */
   width?: string;
   /** Sets accordion variant */
@@ -26,15 +23,18 @@ export interface StyledAccordionContainerProps {
 const StyledAccordionContainer = styled.div<StyledAccordionContainerProps>`
   ${space}
   display: flex;
-  align-items: ${({ buttonHeading, variant }) =>
-    (!buttonHeading || variant !== "subtle") && "stretch"};
+  ${({ variant }) =>
+    variant &&
+    css`
+      align-items: stretch;
+    `};
   justify-content: center;
   flex-direction: column;
   box-sizing: border-box;
   width: ${({ width }) => width || "100%"};
   color: var(--colorsUtilityYin090);
-  background-color: ${({ scheme, variant }) =>
-    scheme === "white" && variant !== "subtle"
+  background-color: ${({ variant }) =>
+    variant !== "subtle"
       ? "var(--colorsUtilityYang100)"
       : "var(--colorsUtilityMajorTransparent)"};
   border: 1px solid var(--colorsUtilityMajor100);
@@ -105,40 +105,35 @@ const StyledAccordionIcon = styled(Icon)<StyledAccordionIconProps>`
 `;
 
 interface StyledAccordionHeadingsContainerProps {
-  buttonHeading?: boolean;
   hasValidationIcon?: boolean;
 }
 
 const StyledAccordionHeadingsContainer = styled.div<StyledAccordionHeadingsContainerProps>`
-  ${({ buttonHeading, hasValidationIcon }) =>
-    !buttonHeading &&
+  ${({ hasValidationIcon }) => css`
+    display: grid;
+    ${hasValidationIcon &&
     css`
-      display: grid;
-      ${hasValidationIcon &&
-      css`
-        grid-template-columns: min-content auto;
+      grid-template-columns: min-content auto;
 
-        ${StyledAccordionSubTitle} {
-          grid-column: span 3;
-        }
-      `}
-
-      ${!hasValidationIcon &&
-      css`
-        grid-template-rows: auto auto;
-      `}
-
-    ${ValidationIconStyle} {
-        height: 20px;
-        position: relative;
-        top: 2px;
+      ${StyledAccordionSubTitle} {
+        grid-column: span 3;
       }
     `}
+
+    ${!hasValidationIcon &&
+    css`
+      grid-template-rows: auto auto;
+    `}
+
+    ${ValidationIconStyle} {
+      height: 20px;
+      position: relative;
+      top: 2px;
+    }
+  `}
 `;
 
 interface StyledAccordionTitleContainerProps {
-  buttonHeading?: boolean;
-  buttonWidth?: number | string;
   hasButtonProps?: boolean;
   iconAlign?: "left" | "right";
   size?: "large" | "small";
@@ -147,15 +142,7 @@ interface StyledAccordionTitleContainerProps {
 }
 
 const StyledAccordionTitleContainer = styled.div<StyledAccordionTitleContainerProps>`
-  ${({
-    buttonHeading,
-    buttonWidth,
-    iconAlign,
-    size,
-    hasButtonProps,
-    isExpanded,
-    variant,
-  }) => css`
+  ${({ iconAlign, size, isExpanded, variant }) => css`
     padding: ${size === "small" ? "var(--spacing200)" : "var(--spacing300)"};
     ${space}
     display: flex;
@@ -195,55 +182,11 @@ const StyledAccordionTitleContainer = styled.div<StyledAccordionTitleContainerPr
       }
     `}
 
-    ${!buttonHeading &&
-    variant !== "subtle" &&
+    ${variant !== "subtle" &&
     css`
       &:hover {
         background-color: var(--colorsUtilityMajor050);
       }
-    `}
-
-    ${buttonHeading &&
-    css`
-      box-sizing: border-box;
-      font-weight: 500;
-      text-decoration: none;
-      font-size: var(--fontSizes100);
-      min-height: var(--spacing500);
-
-      color: var(--colorsActionMajor500);
-
-      ${!hasButtonProps &&
-      css`
-        ${StyledAccordionHeadingsContainer} {
-          margin-left: ${iconAlign === "right"
-            ? "var(--spacing300)"
-            : "var(--spacing100)"};
-        }
-      `}
-
-      ${StyledAccordionIcon} {
-        color: var(--colorsActionMajor500);
-        ${!hasButtonProps &&
-        css`
-          position: relative;
-          ${iconAlign}: 16px;
-        `}
-      }
-
-      &:hover {
-        color: var(--colorsActionMajor600);
-        ${StyledAccordionIcon} {
-          color: var(--colorsActionMajor600);
-        }
-      }
-
-      ${buttonWidth &&
-      css`
-        width: ${typeof buttonWidth === "number"
-          ? `${buttonWidth}px`
-          : buttonWidth};
-      `}
     `}
   `}
 `;

--- a/src/components/accordion/accordion.test.tsx
+++ b/src/components/accordion/accordion.test.tsx
@@ -2,47 +2,15 @@ import React from "react";
 import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { StyledAccordionHeadingsContainer } from "./accordion.style";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
 import useResizeObserver from "../../hooks/__internal__/useResizeObserver";
 import Textbox from "../textbox";
 import { Accordion } from ".";
 import AccordionGroup from "./accordion-group/accordion-group.component";
-import Logger from "../../__internal__/utils/logger";
 
 jest.mock("../../hooks/__internal__/useResizeObserver");
 
 describe("Accordion", () => {
-  it("should display deprecation warning for `scheme` prop once", () => {
-    const loggerSpy = jest
-      .spyOn(Logger, "deprecate")
-      .mockImplementation(() => {});
-
-    render(<Accordion scheme="transparent" title="Title" />);
-
-    expect(loggerSpy).toHaveBeenCalledWith(
-      "The `scheme` prop for `Accordion` component is deprecated and will soon be removed.",
-    );
-    expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-    loggerSpy.mockReset();
-  });
-
-  it("should display deprecation warning for `buttonHeading` prop once", () => {
-    const loggerSpy = jest
-      .spyOn(Logger, "deprecate")
-      .mockImplementation(() => {});
-
-    render(<Accordion buttonHeading title="Title" />);
-
-    expect(loggerSpy).toHaveBeenCalledWith(
-      "The `buttonHeading` prop for `Accordion` component is deprecated and will soon be removed. Please use `subtle` variant instead.",
-    );
-    expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-    loggerSpy.mockReset();
-  });
-
   it("should render `title` as a React element", () => {
     render(<Accordion title={<div id="customTitle">Title content</div>} />);
 
@@ -210,22 +178,20 @@ describe("Accordion", () => {
     expect(screen.queryByText("a subtitle")).not.toBeInTheDocument();
   });
 
-  it("should display the `title` when closed and the `openTitle` and `buttonHeading` props are provided", () => {
-    render(<Accordion title="Title" buttonHeading openTitle="Less info" />);
+  it("should display the `title` when closed and the `openTitle` props are provided", () => {
+    render(<Accordion title="Title" openTitle="Less info" />);
 
     expect(screen.getByRole("button")).toHaveTextContent("Title");
   });
 
-  it("should display the `openTitle` when open and the `openTitle` and `buttonHeading` props are provided", () => {
-    render(
-      <Accordion title="Title" expanded buttonHeading openTitle="Less info" />,
-    );
+  it("should display the `openTitle` when open and the `openTitle` props are provided", () => {
+    render(<Accordion title="Title" expanded openTitle="Less info" />);
 
     expect(screen.getByRole("button")).toHaveTextContent("Less info");
   });
 
-  it("should display the `title` when open if the `openTitle` prop is not provided and `buttonHeading` is provided", () => {
-    render(<Accordion title="Title" expanded buttonHeading />);
+  it("should display the `title` when open if the `openTitle` prop is not provided", () => {
+    render(<Accordion title="Title" expanded />);
 
     expect(screen.getByRole("button")).toHaveTextContent("Title");
   });
@@ -246,21 +212,6 @@ describe("Accordion", () => {
 
     expect(screen.getByTestId("icon")).toHaveStyle({
       transform: "rotate(-180deg)",
-    });
-  });
-
-  // coverage
-  it('sets the icon position of the button correctly when `iconAlign` prop is set to "left" and `buttonHeading` prop is true', () => {
-    render(<Accordion title="Title" buttonHeading iconAlign="left" />);
-
-    expect(screen.getByRole("button")).toHaveStyleRule(
-      "margin-left",
-      "var(--spacing100)",
-      { modifier: `${StyledAccordionHeadingsContainer}` },
-    );
-    expect(screen.getByTestId("icon")).toHaveStyle({
-      position: "relative",
-      left: "16px",
     });
   });
 
@@ -291,13 +242,6 @@ describe("Accordion", () => {
       "border-left",
       "2px solid var(--colorsUtilityMajor100)",
     );
-  });
-
-  // coverage (buttonWidth is deprecated)
-  it("the `buttonWidth` prop sets the button width when passed as a number and te `buttonHeading` prop is true", () => {
-    render(<Accordion title="Title" buttonHeading buttonWidth={140} />);
-
-    expect(screen.getByRole("button")).toHaveStyle({ width: "140px" });
   });
 
   // coverage - disableContentPadding is tested in Chromatic

--- a/src/components/accordion/components.test-pw.tsx
+++ b/src/components/accordion/components.test-pw.tsx
@@ -1,12 +1,14 @@
 import React from "react";
-import { Accordion, AccordionGroup, AccordionProps } from ".";
-import Textbox from "../textbox";
+
 import Box from "../box";
-import Button from "../button/button.component";
 import { Checkbox } from "../checkbox";
 import { Dl, Dt, Dd } from "../definition-list";
-import Link from "../link/link.component";
 import SplitButton from "../split-button";
+import Textbox from "../textbox";
+import Button from "../button/button.component";
+import Link from "../link/link.component";
+
+import { Accordion, AccordionGroup, AccordionProps } from ".";
 
 const errorVal = "error";
 const warningVal = "warning";
@@ -77,19 +79,15 @@ export const AccordionGroupWithError = () => {
   });
 
   return (
-    <div
-      style={{
-        marginTop: "16px",
-      }}
-    >
+    <Box mt={2}>
       <AccordionGroup>
         <Accordion title="Heading" error={errors.one}>
-          <div style={{ padding: "8px" }}>
+          <Box p={1}>
             <Checkbox label="Add error" error={!!errors.one} />
-          </div>
+          </Box>
         </Accordion>
       </AccordionGroup>
-    </div>
+    </Box>
   );
 };
 
@@ -99,19 +97,15 @@ export const AccordionGroupWithWarning = () => {
   });
 
   return (
-    <div
-      style={{
-        marginTop: "16px",
-      }}
-    >
+    <Box mt={2}>
       <AccordionGroup>
         <Accordion title="Heading" warning={warnings.one}>
-          <div style={{ padding: "8px" }}>
+          <Box p={1}>
             <Checkbox label="Add warning" warning={!!warnings.one} />
-          </div>
+          </Box>
         </Accordion>
       </AccordionGroup>
-    </div>
+    </Box>
   );
 };
 
@@ -121,19 +115,15 @@ export const AccordionGroupWithInfo = () => {
   });
 
   return (
-    <div
-      style={{
-        marginTop: "16px",
-      }}
-    >
+    <Box mt={2}>
       <AccordionGroup>
         <Accordion title="Heading" info={infos.one}>
-          <div style={{ padding: "8px" }}>
+          <Box p={1}>
             <Checkbox label="Add info" info={!!infos.one} />
-          </div>
+          </Box>
         </Accordion>
       </AccordionGroup>
-    </div>
+    </Box>
   );
 };
 
@@ -235,7 +225,7 @@ export const AccordionWithBoxAndDifferentPaddings = () => {
         headerSpacing={{
           p: 3,
         }}
-        title="Accordion with a very long title Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla in ornare neque. Maecenas pellentesque et erat tincidunt mollis. 
+        title="Accordion with a very long title Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla in ornare neque. Maecenas pellentesque et erat tincidunt mollis.
                 Etiam diam nisi, elementum efficitur ipsum et, imperdiet iaculis ligula. "
       >
         <Box p={3} pr="29px">
@@ -259,78 +249,6 @@ export const AccordionWithBoxAndDifferentPaddings = () => {
         </Box>
       </Accordion>
     </Box>
-  );
-};
-
-export const AccordionOpeningButton = () => {
-  return (
-    <div
-      style={{
-        margin: "8px",
-      }}
-    >
-      <Accordion
-        title="More info"
-        openTitle="Less info"
-        scheme="transparent"
-        borders="none"
-        iconAlign="left"
-        buttonHeading
-        buttonWidth="200px"
-        error="hello"
-      >
-        <div>Content</div>
-        <div>Content</div>
-        <div>Content</div>
-      </Accordion>
-      <br />
-      <Accordion
-        title="More info"
-        openTitle="Less info"
-        scheme="transparent"
-        borders="none"
-        iconAlign="right"
-        buttonHeading
-        buttonWidth="200px"
-      >
-        <div>Content</div>
-        <div>Content</div>
-        <div>Content</div>
-      </Accordion>
-      <br />
-      <Accordion
-        scheme="transparent"
-        borders="none"
-        title="More info"
-        openTitle="Less info"
-        buttonHeading
-        headerSpacing={{
-          px: 0,
-        }}
-        buttonWidth="96px"
-      >
-        <div>Content</div>
-        <div>Content</div>
-        <div>Content</div>
-      </Accordion>
-      <br />
-      <Accordion
-        scheme="transparent"
-        borders="none"
-        title="More info"
-        openTitle="Less info"
-        iconAlign="left"
-        buttonHeading
-        buttonWidth="120px"
-        headerSpacing={{
-          px: 1,
-        }}
-      >
-        <div>Content</div>
-        <div>Content</div>
-        <div>Content</div>
-      </Accordion>
-    </div>
   );
 };
 
@@ -406,11 +324,7 @@ export const AccordionGroupValidation = () => {
           warning={warnings.one}
           info={infos.one}
         >
-          <div
-            style={{
-              padding: "8px",
-            }}
-          >
+          <Box p={1}>
             <Checkbox
               label="Add error"
               error={!!errors.one}
@@ -429,7 +343,7 @@ export const AccordionGroupValidation = () => {
               info={!!infos.one}
               onChange={() => handleChange("one", infos, setInfos, "info")}
             />
-          </div>
+          </Box>
         </Accordion>
         <Accordion
           title="Heading"
@@ -445,11 +359,7 @@ export const AccordionGroupValidation = () => {
           warning={warnings.two}
           info={infos.two}
         >
-          <div
-            style={{
-              padding: "8px",
-            }}
-          >
+          <Box p={1}>
             <Checkbox
               label="Add error"
               error={!!errors.two}
@@ -468,7 +378,7 @@ export const AccordionGroupValidation = () => {
               info={!!infos.two}
               onChange={() => handleChange("two", infos, setInfos, "info")}
             />
-          </div>
+          </Box>
         </Accordion>
         <Accordion
           title="Heading"
@@ -484,11 +394,7 @@ export const AccordionGroupValidation = () => {
           warning={warnings.three}
           info={infos.three}
         >
-          <div
-            style={{
-              padding: "8px",
-            }}
-          >
+          <Box p={1}>
             <Checkbox
               label="Add error"
               error={!!errors.three}
@@ -507,7 +413,7 @@ export const AccordionGroupValidation = () => {
               info={!!infos.three}
               onChange={() => handleChange("three", infos, setInfos, "info")}
             />
-          </div>
+          </Box>
         </Accordion>
       </AccordionGroup>
     </Box>

--- a/src/components/box/box.component.tsx
+++ b/src/components/box/box.component.tsx
@@ -17,7 +17,6 @@ import {
 } from "../../style/utils";
 import StyledBox from "./box.style";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
-import Logger from "../../__internal__/utils/logger";
 
 export type OverflowWrap = "break-word" | "anywhere";
 export type ScrollVariant = "light" | "dark";
@@ -51,8 +50,6 @@ export interface BoxProps
   scrollVariant?: ScrollVariant;
   /** Set the box-sizing attribute of the Box component */
   boxSizing?: BoxSizing;
-  /** (Deprecated) Allows a tabindex to be specified */
-  tabIndex?: number;
   /** Gap, an integer multiplier of the base spacing constant (8px) or any valid CSS string." */
   gap?: Gap;
   /** Column gap, an integer multiplier of the base spacing constant (8px) or any valid CSS string." */
@@ -63,7 +60,11 @@ export interface BoxProps
   boxShadow?: BoxShadowsType;
   /** Design Token for Border Radius. Note: please check that the border radius design token you are using is compatible with the Box component. **This prop will not do anything if you have the roundedCornerOptOut flag set in the CarbonProvider** */
   borderRadius?: BorderRadiusType;
-  /** @private @ignore */
+  /**
+   * @private
+   * @ignore
+   * @internal
+   * Sets className for component. INTERNAL USE ONLY. */
   className?: string;
   /** Set the color attribute of the Box component */
   color?: string;
@@ -77,8 +78,6 @@ export interface BoxProps
   "aria-hidden"?: "true" | "false";
 }
 
-let deprecatedTabIndex = false;
-
 export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
   (
     {
@@ -89,7 +88,6 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
       overflowWrap,
       scrollVariant,
       boxSizing,
-      tabIndex,
       gap,
       columnGap,
       rowGap,
@@ -108,13 +106,6 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
     }: BoxProps,
     ref,
   ) => {
-    if (!deprecatedTabIndex && tabIndex !== undefined) {
-      deprecatedTabIndex = true;
-      Logger.deprecate(
-        "The `tabIndex` prop for `Box` component has been deprecated and will soon be removed.",
-      );
-    }
-
     let actualWidth = "";
     if (typeof width === "number") {
       actualWidth = width <= 1 ? `${(width * 100).toFixed(0)}%` : `${width}px`;
@@ -148,7 +139,6 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
         gap={gap}
         columnGap={columnGap}
         rowGap={rowGap}
-        tabIndex={tabIndex}
         className={className}
         ref={ref}
         bg={bg}

--- a/src/components/box/box.stories.tsx
+++ b/src/components/box/box.stories.tsx
@@ -52,7 +52,6 @@ export const Position: Story = () => {
           bg="primary"
           position="sticky"
           top="0"
-          tabIndex={0}
         >
           <Typography color="white">This box has position sticky</Typography>
           <Button buttonType="primary" destructive>
@@ -271,7 +270,7 @@ Layout.storyName = "Layout";
 
 export const OverflowWrap: Story = () => {
   return (
-    <div style={{ display: "inline-flex" }}>
+    <Box display="inline-flex">
       <div
         style={{
           border: "solid 1px #00815D",
@@ -288,7 +287,7 @@ export const OverflowWrap: Story = () => {
           WithoutOverflowWrap
         </Box>
       </div>
-    </div>
+    </Box>
   );
 };
 OverflowWrap.storyName = "OverflowWrap";
@@ -326,9 +325,7 @@ export const Scroll: Story = () => {
           m="5px"
         />
       </Box>
-      <div
-        style={{ backgroundColor: "rgb(0, 26, 37)", display: "inline-block" }}
-      >
+      <Box backgroundColor="rgb(0, 26, 37)" display="inline-block">
         <Box
           display="inline-block"
           size="150px"
@@ -357,7 +354,7 @@ export const Scroll: Story = () => {
             m="5px"
           />
         </Box>
-      </div>
+      </Box>
     </div>
   );
 };

--- a/src/components/box/box.test.tsx
+++ b/src/components/box/box.test.tsx
@@ -11,7 +11,6 @@ import {
   testStyledSystemPosition,
 } from "../../__spec_helper__/__internal__/test-utils";
 import Box from "./box.component";
-import Logger from "../../__internal__/utils/logger";
 
 testStyledSystemSpacing(
   (props) => <Box data-role="box" {...props} />,
@@ -114,23 +113,4 @@ it("applies the correct styling from the cssProps, when the width and height are
     width: "50%",
     height: "50%",
   });
-});
-
-test("logs a deprecation warning when the `tabIndex` prop is passed with a value", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-
-  render(
-    <>
-      <Box tabIndex={6} />
-      <Box tabIndex={-1} />
-    </>,
-  );
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The `tabIndex` prop for `Box` component has been deprecated and will soon be removed.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-  loggerSpy.mockRestore();
 });

--- a/src/components/box/components.test-pw.tsx
+++ b/src/components/box/components.test-pw.tsx
@@ -85,7 +85,6 @@ export const Position = () => {
           bg="primary"
           position="sticky"
           top="0"
-          tabIndex={0}
         >
           <Typography color="white">This box has position sticky</Typography>
           <Button buttonType="primary" destructive>
@@ -251,7 +250,7 @@ export const Layout = () => {
 
 export const OverflowWrap = () => {
   return (
-    <div style={{ display: "inline-flex" }}>
+    <Box display="inline-flex">
       <div
         style={{
           border: "solid 1px #00815D",
@@ -268,7 +267,7 @@ export const OverflowWrap = () => {
           WithoutOverflowWrap
         </Box>
       </div>
-    </div>
+    </Box>
   );
 };
 
@@ -304,9 +303,7 @@ export const Scroll = () => {
           m="5px"
         />
       </Box>
-      <div
-        style={{ backgroundColor: "rgb(0, 26, 37)", display: "inline-block" }}
-      >
+      <Box backgroundColor="rgb(0, 26, 37)" display="inline-block">
         <Box
           display="inline-block"
           size="150px"
@@ -335,7 +332,7 @@ export const Scroll = () => {
             m="5px"
           />
         </Box>
-      </div>
+      </Box>
     </div>
   );
 };

--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.component.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.component.tsx
@@ -15,7 +15,6 @@ import { InputGroupBehaviour } from "../../../__internal__/input-behaviour";
 import Events from "../../../__internal__/utils/helpers/events";
 import NewValidationContext from "../../carbon-provider/__internal__/new-validation.context";
 import ButtonToggleGroupContext from "./__internal__/button-toggle-group.context";
-import Logger from "../../../__internal__/utils/logger";
 
 export interface ButtonToggleGroupProps extends MarginProps, TagProps {
   /** Unique id for the root element of the component */
@@ -54,15 +53,9 @@ export interface ButtonToggleGroupProps extends MarginProps, TagProps {
   allowDeselect?: boolean;
   /** Disable all user interaction. */
   disabled?: boolean;
-  /**
-   * @private @ignore
-   * Set a class on the component
-   */
-  className?: string;
 }
 
 const BUTTON_TOGGLE_SELECTOR = '[data-element="button-toggle-button"]';
-let deprecatedClassNameWarningShown = false;
 
 const ButtonToggleGroup = ({
   children,
@@ -86,16 +79,8 @@ const ButtonToggleGroup = ({
   id,
   allowDeselect,
   disabled,
-  className,
   ...props
 }: ButtonToggleGroupProps) => {
-  if (!deprecatedClassNameWarningShown && className) {
-    Logger.deprecate(
-      "The 'className' prop has been deprecated and will soon be removed from the 'ButtonToggleGroup' component.",
-    );
-    deprecatedClassNameWarningShown = true;
-  }
-
   const hasCorrectItemStructure = useMemo(() => {
     const incorrectChild = React.Children.toArray(children).find(
       (child: React.ReactNode) => {
@@ -234,7 +219,6 @@ const ButtonToggleGroup = ({
               data-role={dataRole}
               data-element={dataElement}
               id={id}
-              className={className}
               disabled={disabled}
             >
               {children}

--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.test.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.test.tsx
@@ -4,7 +4,6 @@ import userEvent from "@testing-library/user-event";
 import { ButtonToggle, ButtonToggleGroup } from "..";
 import CarbonProvider from "../../carbon-provider/carbon-provider.component";
 import { testStyledSystemMargin } from "../../../__spec_helper__/__internal__/test-utils";
-import Logger from "../../../__internal__/utils/logger";
 
 test("should render with provided children", () => {
   render(
@@ -373,28 +372,3 @@ testStyledSystemMargin(
   undefined,
   { modifier: "&&&" },
 );
-
-test("throws a deprecation warning if the 'className' prop is set", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(
-    <ButtonToggleGroup
-      id="button-toggle-group-id"
-      onChange={() => {}}
-      value="bar"
-      className="foo"
-    >
-      <ButtonToggle value="foo">Foo</ButtonToggle>
-      <ButtonToggle value="bar">Bar</ButtonToggle>
-      <ButtonToggle value="baz">Baz</ButtonToggle>
-    </ButtonToggleGroup>,
-  );
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'ButtonToggleGroup' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
-});

--- a/src/components/button-toggle/button-toggle.component.tsx
+++ b/src/components/button-toggle/button-toggle.component.tsx
@@ -13,7 +13,6 @@ import Logger from "../../__internal__/utils/logger";
 import { InputGroupContext } from "../../__internal__/input-behaviour";
 
 let deprecateUncontrolledWarnTriggered = false;
-let deprecateGroupedWarnTriggered = false;
 
 export interface ButtonToggleProps extends Partial<StyledButtonToggleProps> {
   /** Prop to specify the aria-label of the component */
@@ -28,8 +27,6 @@ export interface ButtonToggleProps extends Partial<StyledButtonToggleProps> {
   "data-element"?: string;
   /** Identifier used for testing purposes, applied to the root element of the component. */
   "data-role"?: string;
-  /** DEPRECATED: Remove spacing from between buttons. */
-  grouped?: boolean;
   /** Callback triggered by blur event on the button. */
   onBlur?: (ev: React.FocusEvent<HTMLButtonElement>) => void;
   /** Callback triggered by focus event on the button. */
@@ -52,7 +49,6 @@ export const ButtonToggle = ({
   "data-element": dataElement,
   "data-role": dataRole,
   disabled,
-  grouped,
   onBlur,
   onFocus,
   onClick,
@@ -64,13 +60,6 @@ export const ButtonToggle = ({
     !!(children || buttonIcon),
     "Either prop `buttonIcon` must be defined, or this node must have children",
   );
-
-  if (grouped && !deprecateGroupedWarnTriggered) {
-    deprecateGroupedWarnTriggered = true;
-    Logger.deprecate(
-      "The `grouped` prop in `ButtonToggle` component is deprecated and will soon be removed. Spacing between buttons is no longer no removed.",
-    );
-  }
 
   const buttonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -155,7 +144,6 @@ export const ButtonToggle = ({
       data-component={dataComponent || "button-toggle"}
       data-element={dataElement}
       data-role={dataRole}
-      grouped={grouped}
     >
       <StyledButtonToggle
         aria-label={ariaLabel}
@@ -170,7 +158,6 @@ export const ButtonToggle = ({
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         size={size}
-        grouped={grouped}
         value={value}
         onFocus={handleFocus}
         onBlur={handleBlur}

--- a/src/components/button-toggle/button-toggle.pw.tsx
+++ b/src/components/button-toggle/button-toggle.pw.tsx
@@ -6,7 +6,6 @@ import {
   ButtonToggleGroupComponent,
   ButtonToggleGroupNotInBox,
   WithOutsideButtons,
-  ButtonToggleGroupComponentGroupedChildren,
 } from "./components.test-pw";
 import {
   buttonTogglePreview,
@@ -87,46 +86,6 @@ test.describe("Styling tests", () => {
     await mount(<ButtonToggle>Foo</ButtonToggle>);
 
     await expect(buttonToggleButton(page)).toHaveCSS("border-radius", "4px");
-  });
-
-  test("should render with the expected border-radius styling when the children have the grouped prop set", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<ButtonToggleGroupComponentGroupedChildren />);
-
-    await expect(buttonToggleButton(page).nth(0)).toHaveCSS(
-      "border-radius",
-      "4px 0px 0px 4px",
-    );
-    await expect(buttonToggleButton(page).nth(1)).toHaveCSS(
-      "border-radius",
-      "0px",
-    );
-    await expect(buttonToggleButton(page).nth(2)).toHaveCSS(
-      "border-radius",
-      "0px 4px 4px 0px",
-    );
-  });
-
-  test("should render with the expected border-radius styling when children do not have grouped prop set", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<ButtonToggleComponent />);
-
-    await expect(buttonToggleButton(page).nth(0)).toHaveCSS(
-      "border-radius",
-      "4px",
-    );
-    await expect(buttonToggleButton(page).nth(1)).toHaveCSS(
-      "border-radius",
-      "4px",
-    );
-    await expect(buttonToggleButton(page).nth(2)).toHaveCSS(
-      "border-radius",
-      "4px",
-    );
   });
 });
 
@@ -403,15 +362,6 @@ test.describe("Accessibility tests", () => {
     page,
   }) => {
     await mount(<ButtonToggleComponent disabled />);
-
-    await checkAccessibility(page);
-  });
-
-  test("should pass accessibility tests for Button-Toggle grouped", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<ButtonToggleComponent grouped />);
 
     await checkAccessibility(page);
   });

--- a/src/components/button-toggle/button-toggle.style.ts
+++ b/src/components/button-toggle/button-toggle.style.ts
@@ -1,8 +1,9 @@
 import styled, { css } from "styled-components";
+
 import { IconType } from "../icon";
 import StyledIcon from "../icon/icon.style";
-import addFocusStyling from "../../style/utils/add-focus-styling";
 import baseTheme from "../../style/themes/base";
+import addFocusStyling from "../../style/utils/add-focus-styling";
 
 export type ButtonToggleIconSizes = "small" | "large";
 
@@ -54,7 +55,6 @@ export interface StyledButtonToggleProps {
   disabled?: boolean;
   /** ButtonToggle size */
   size: "small" | "medium" | "large";
-  grouped?: boolean;
   /** Allow button to be deselected when already selected */
   allowDeselect?: boolean;
 }
@@ -93,8 +93,8 @@ const StyledButtonToggle = styled.button<StyledButtonToggleProps>`
       min-height: ${heightLargeIconConfig[size]}px;
       padding: ${paddingLargeIconConfig[size]};
       flex-direction: column;
-    `}  
-    
+    `}
+
   &:focus {
     ${addFocusStyling()}
     z-index: 100;
@@ -176,51 +176,14 @@ const StyledButtonToggleIcon = styled.div<StyledButtonToggleIconProps>`
 
 StyledButtonToggle.defaultProps = { theme: baseTheme };
 
-export interface StyledButtonToggleWrapperProps {
-  grouped?: boolean;
-}
-
-const StyledButtonToggleWrapper = styled.div<StyledButtonToggleWrapperProps>`
+const StyledButtonToggleWrapper = styled.div`
   display: inline-block;
   vertical-align: middle;
-
-  ${({ grouped }) => css`
-    ${!grouped &&
-    css`
-      &&&& {
-        ${StyledButtonToggle} {
-          border-radius: var(--borderRadius050);
-        }
-      }
-    `}
-
-    ${grouped &&
-    css`
-      &&&& {
-        :first-of-type {
-          ${StyledButtonToggle} {
-            border-top-left-radius: var(--borderRadius050);
-            border-bottom-left-radius: var(--borderRadius050);
-          }
-        }
-
-        :last-of-type {
-          ${StyledButtonToggle} {
-            border-top-right-radius: var(--borderRadius050);
-            border-bottom-right-radius: var(--borderRadius050);
-          }
-        }
-      }
-    `}
-  `}
-
-  ${({ grouped }) =>
-    grouped &&
-    css`
-      &:not(:first-of-type) {
-        margin-left: -1px;
-      }
-    `};
+  &&&& {
+    ${StyledButtonToggle} {
+      border-radius: var(--borderRadius050);
+    }
+  }
 `;
 
 export {

--- a/src/components/button-toggle/button-toggle.test.tsx
+++ b/src/components/button-toggle/button-toggle.test.tsx
@@ -18,19 +18,6 @@ test("should display a deprecation warning for uncontrolled behaviour which is t
   loggerSpy.mockRestore();
 });
 
-test("should display a deprecation warning for the `grouped` prop which is triggered only once", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(<ButtonToggle grouped>Button</ButtonToggle>);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The `grouped` prop in `ButtonToggle` component is deprecated and will soon be removed. Spacing between buttons is no longer no removed.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1); // total two times to account for uncontrolled behaviour warning
-  loggerSpy.mockRestore();
-});
-
 test("should call `onClick` when the button is clicked", async () => {
   const onClick = jest.fn();
   const user = userEvent.setup();

--- a/src/components/button-toggle/components.test-pw.tsx
+++ b/src/components/button-toggle/components.test-pw.tsx
@@ -65,15 +65,9 @@ export const ButtonToggleGroupComponent = (
       }}
       {...props}
     >
-      <ButtonToggle value="foo" grouped>
-        Foo
-      </ButtonToggle>
-      <ButtonToggle value="bar" grouped>
-        Bar
-      </ButtonToggle>
-      <ButtonToggle value="baz" grouped>
-        Baz
-      </ButtonToggle>
+      <ButtonToggle value="foo">Foo</ButtonToggle>
+      <ButtonToggle value="bar">Bar</ButtonToggle>
+      <ButtonToggle value="baz">Baz</ButtonToggle>
     </ButtonToggleGroup>
   </Box>
 );
@@ -86,15 +80,9 @@ export const ButtonToggleGroupNotInBox = (
     label="Grouped example"
     {...props}
   >
-    <ButtonToggle value="foo" grouped>
-      Foo
-    </ButtonToggle>
-    <ButtonToggle value="bar" grouped>
-      Bar
-    </ButtonToggle>
-    <ButtonToggle value="baz" grouped>
-      Baz
-    </ButtonToggle>
+    <ButtonToggle value="foo">Foo</ButtonToggle>
+    <ButtonToggle value="bar">Bar</ButtonToggle>
+    <ButtonToggle value="baz">Baz</ButtonToggle>
   </ButtonToggleGroup>
 );
 
@@ -116,33 +104,5 @@ export const WithOutsideButtons = () => {
         button after
       </button>
     </>
-  );
-};
-
-export const ButtonToggleGroupComponentGroupedChildren = ({ ...props }) => {
-  return (
-    <Box>
-      <ButtonToggleGroup
-        id="button-toggle-group-default-id"
-        label="Default example"
-        labelHelp="help message"
-        helpAriaLabel="Help"
-        fieldHelp="field help message"
-        onChange={function noRefCheck() {
-          ("");
-        }}
-        {...props}
-      >
-        <ButtonToggle key="foo" value="foo" grouped>
-          Foo
-        </ButtonToggle>
-        <ButtonToggle key="bar" value="bar" grouped>
-          Bar
-        </ButtonToggle>
-        <ButtonToggle key="baz" value="baz" grouped>
-          Baz
-        </ButtonToggle>
-      </ButtonToggleGroup>
-    </Box>
   );
 };

--- a/src/components/button/button.component.tsx
+++ b/src/components/button/button.component.tsx
@@ -15,7 +15,6 @@ import { TooltipPositions } from "../tooltip/tooltip.config";
 import ButtonBarContext from "../button-bar/__internal__/button-bar.context";
 import SplitButtonContext from "../split-button/__internal__/split-button.context";
 import BatchSelectionContext from "../batch-selection/__internal__/batch-selection.context";
-import Logger from "../../__internal__/utils/logger";
 
 export type ButtonTypes =
   | "primary"
@@ -89,12 +88,11 @@ export interface ButtonProps extends SpaceProps, TagProps {
   /**
    * @private
    * @internal
-   * Set a class name on the button element
+   * @ignore
+   * Set a class name on the button element. INTERNAL USE ONLY.
    */
   className?: string;
 }
-
-let deprecatedClassNameWarningShown = false;
 
 interface RenderChildrenProps
   extends Pick<
@@ -217,13 +215,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     }: ButtonProps,
     ref,
   ) => {
-    if (!deprecatedClassNameWarningShown && rest.className) {
-      Logger.deprecate(
-        "The 'className' prop has been deprecated and will soon be removed from the 'Button' component.",
-      );
-      deprecatedClassNameWarningShown = true;
-    }
-
     const {
       buttonType: buttonTypeContext,
       size: sizeContext,

--- a/src/components/button/button.test.tsx
+++ b/src/components/button/button.test.tsx
@@ -3,18 +3,6 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Button from "./button.component";
 
-import Logger from "../../__internal__/utils/logger";
-
-let loggerSpy: jest.SpyInstance;
-
-beforeEach(() => {
-  loggerSpy = jest.spyOn(Logger, "deprecate").mockImplementation(() => {});
-});
-
-afterEach(() => {
-  loggerSpy.mockRestore();
-});
-
 test("renders with text children", () => {
   render(<Button>foo</Button>);
 
@@ -303,18 +291,6 @@ test("sets the text content of the 'subtext' element when the 'size' prop is 'la
   expect(subtext).toBeVisible();
 });
 
-test("sets the 'className' attribute correctly when a custom value is passed to the 'className' prop", () => {
-  render(<Button className="foo">bar</Button>);
-
-  const button = screen.getByRole("button", { name: "bar" });
-
-  expect(button).toHaveClass("foo");
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'Button' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-});
-
 test("calls onClick when an 'href' is passed and the space key is pressed", async () => {
   const user = userEvent.setup();
   const clickMock = jest.fn();
@@ -379,7 +355,7 @@ test("accepts ref as a ref callback", () => {
 
 test("sets ref to empty after unmount", () => {
   const mockRef = { current: null };
-  const { unmount } = render(<Button className="foo">bar</Button>);
+  const { unmount } = render(<Button>bar</Button>);
 
   unmount();
 

--- a/src/components/decimal/decimal.component.tsx
+++ b/src/components/decimal/decimal.component.tsx
@@ -39,8 +39,6 @@ export interface DecimalProps
   onChange?: (ev: CustomEvent) => void;
   /** Handler for blur event */
   onBlur?: (ev: CustomEvent) => void;
-  /** [Deprecated] Handler for key press event */
-  onKeyPress?: (ev: React.KeyboardEvent<HTMLInputElement>) => void;
   /** The input name */
   name?: string;
   /** The decimal precision of the value in the input */
@@ -70,7 +68,6 @@ export interface DecimalProps
 }
 
 let deprecateUncontrolledWarnTriggered = false;
-let deprecateOnKeyPressWarnTriggered = false;
 
 export const Decimal = React.forwardRef(
   (
@@ -82,7 +79,6 @@ export const Decimal = React.forwardRef(
       readOnly,
       onChange,
       onBlur,
-      onKeyPress,
       id,
       name,
       allowEmptyValue = false,
@@ -117,7 +113,7 @@ export const Decimal = React.forwardRef(
           return valueToFormat;
         }
 
-        /* Guards against any white-space only strings like "   " being 
+        /* Guards against any white-space only strings like "   " being
        mishandled and returned as `NaN` for the value displayed in the textbox */
         if (valueToFormat === "" || valueToFormat.match(/\s+/g)) {
           return valueToFormat;
@@ -206,8 +202,8 @@ export const Decimal = React.forwardRef(
             : i18nValue;
         /* If a value is passed in that is a number but has too many delimiters in succession, we want to handle this
     value without formatting it or removing delimiters. We also want to consider that,
-    if a value consists of only delimiters, we want to treat that 
-    value in the same way as if the value was NaN. We want to pass this value to the 
+    if a value consists of only delimiters, we want to treat that
+    value in the same way as if the value was NaN. We want to pass this value to the
     formatValue function, before the delimiters can be removed. */
         const errorsWithDelimiter = new RegExp(
           `([^A-Za-z0-9]{2,})|(^[^A-Za-z0-9-]+)|([^0-9a-z-,.])|([^0-9-,.]+)|([W,.])$`,
@@ -326,17 +322,9 @@ export const Decimal = React.forwardRef(
       );
     }
 
-    if (!deprecateOnKeyPressWarnTriggered && onKeyPress) {
-      deprecateOnKeyPressWarnTriggered = true;
-      Logger.deprecate(
-        "`onKeyPress` prop in `Decimal` is deprecated and will soon be removed, please use `onKeyDown` instead.",
-      );
-    }
-
     return (
       <>
         <Textbox
-          onKeyPress={onKeyPress}
           align={align}
           readOnly={readOnly}
           inputWidth={inputWidth}

--- a/src/components/decimal/decimal.test.tsx
+++ b/src/components/decimal/decimal.test.tsx
@@ -44,18 +44,6 @@ describe("when the component is uncontrolled", () => {
     loggerSpy.mockRestore();
   });
 
-  it("displays a deprecation warning for `onKeyPress`", () => {
-    const loggerSpy = jest.spyOn(Logger, "deprecate");
-    render(<Decimal onKeyPress={() => {}} />);
-
-    expect(loggerSpy).toHaveBeenCalledWith(
-      "`onKeyPress` prop in `Decimal` is deprecated and will soon be removed, please use `onKeyDown` instead.",
-    );
-    expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-    loggerSpy.mockRestore();
-  });
-
   it("has a default value of 0.00 when no defaultValue prop is provided", () => {
     render(<Decimal />);
     expect(screen.getByRole("textbox")).toHaveValue("0.00");

--- a/src/components/detail/detail.component.tsx
+++ b/src/components/detail/detail.component.tsx
@@ -11,10 +11,13 @@ import {
   StyledDetailIcon,
   StyledDetailFootnote,
 } from "./detail.style";
-import Logger from "../../__internal__/utils/logger";
 
 export interface DetailProps extends MarginProps, TagProps {
-  /** Custom className. */
+  /**
+   * @private
+   * @internal
+   * @ignore
+   * Sets className for component. INTERNAL USE ONLY. */
   className?: string;
   /** The type of icon to use. */
   icon?: IconType;
@@ -24,8 +27,6 @@ export interface DetailProps extends MarginProps, TagProps {
   children?: React.ReactNode;
 }
 
-let deprecatedClassNameWarningShown = false;
-
 export const Detail = ({
   className,
   icon,
@@ -33,13 +34,6 @@ export const Detail = ({
   children,
   ...rest
 }: DetailProps) => {
-  if (!deprecatedClassNameWarningShown && className) {
-    Logger.deprecate(
-      "The 'className' prop has been deprecated and will soon be removed from the 'Detail' component.",
-    );
-    deprecatedClassNameWarningShown = true;
-  }
-
   return (
     <StyledDetail
       className={`carbon-detail ${className}`}

--- a/src/components/detail/detail.test.tsx
+++ b/src/components/detail/detail.test.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { render, screen, within } from "@testing-library/react";
 import Detail from ".";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
-import Logger from "../../__internal__/utils/logger";
 
 test("renders children", () => {
   render(<Detail>foo</Detail>);
@@ -60,17 +59,3 @@ testStyledSystemMargin(
   ),
   () => screen.getByTestId("detail"),
 );
-
-test("throws a deprecation warning if the 'className' prop is set", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(<Detail className="foo">bar</Detail>);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'Detail' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
-});

--- a/src/components/dialog-full-screen/components.test-pw.tsx
+++ b/src/components/dialog-full-screen/components.test-pw.tsx
@@ -129,16 +129,12 @@ export const MultipleDialogsInDifferentProviders = () => {
 export const DialogFullScreenWithHeaderChildren = () => {
   const [isOpen, setIsOpen] = React.useState(true);
   const HeaderChildren = (
-    <div
-      style={{
-        margin: `$min-width: 568px 0 26px`,
-      }}
-    >
+    <Box margin="$min-width: 568px 0 26px">
       <Pill fill>A pill</Pill>
       <Pill fill ml={2} mr={1}>
         Another pill
       </Pill>
-    </div>
+    </Box>
   );
   return (
     <>
@@ -271,23 +267,20 @@ export const WithHideableHeaderChildren = () => {
   const aboveBreakpoint = useMediaQuery("(min-width: 568px)");
   const verticalMargin = aboveBreakpoint ? "26px" : 0;
   const HeaderChildrenAboveBreakpoint = (
-    <div style={{ margin: `${verticalMargin} 0 26px` }}>
+    <Box margin={`$min-width: ${verticalMargin} 0 26px`}>
       <Pill fill>A pill</Pill>
       <Pill fill ml={2} mr={1}>
         Another pill
       </Pill>
-    </div>
+    </Box>
   );
   const HeaderChildrenBelowBreakpoint = (
     <Accordion
       title="More info"
       openTitle="Less info"
-      scheme="transparent"
       borders="none"
       aria-label="aria-label"
       disableContentPadding
-      buttonHeading
-      buttonWidth="120px"
       ml="-13px"
     >
       <Box py="16px" pl="14px">
@@ -394,19 +387,17 @@ export const FocusingADifferentFirstElement = () => {
         subtitle="Subtitle"
       >
         <p>Focus an element that doesnt support autofocus</p>
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "space-around",
-            height: "150px",
-          }}
+        <Box
+          display="flex"
+          flexDirection="column"
+          justifyContent="space-around"
+          height="150px"
         >
           <Button onClick={() => setIsOpenOne(false)}>Not focused</Button>
           <Button ref={ref} onClick={() => setIsOpenOne(false)}>
             This should be focused first now
           </Button>
-        </div>
+        </Box>
         <Textbox label="Not Focused" />
       </DialogFullScreen>
       <Button ml={2} onClick={() => setIsOpenTwo(true)}>
@@ -420,17 +411,15 @@ export const FocusingADifferentFirstElement = () => {
         subtitle="Subtitle"
       >
         <p>Focus an element that supports autoFocus</p>
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "space-around",
-            height: "150px",
-          }}
+        <Box
+          display="flex"
+          flexDirection="column"
+          justifyContent="space-around"
+          height="150px"
         >
           <Button onClick={() => setIsOpenTwo(false)}>Not focused</Button>
           <Button onClick={() => setIsOpenTwo(false)}>Not focused</Button>
-        </div>
+        </Box>
         <Textbox label="This should be focused first now" autoFocus />
       </DialogFullScreen>
     </>
@@ -918,6 +907,8 @@ export const WithComplexExample = () => {
         showCloseIcon
         disableContentPadding
       >
+        {/* Without a h2 in the DOM, the a11y checks fail */}
+        <Typography variant="h2">A11y Heading Order Fix</Typography>
         <Drawer sidebar={SidebarContent}>
           <Box p={5}>{showCorrectContent()}</Box>
         </Drawer>

--- a/src/components/dialog-full-screen/dialog-full-screen.stories.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.stories.tsx
@@ -754,12 +754,11 @@ export const WithHideableHeaderChildren: Story = () => {
     <Accordion
       title="More info"
       openTitle="Less info"
-      scheme="transparent"
       borders="none"
       disableContentPadding
-      buttonHeading
-      buttonWidth="120px"
       ml="-13px"
+      variant="subtle"
+      mb={1}
     >
       <Box py="16px" pl="14px">
         <Pill fill>A pill</Pill>

--- a/src/components/dialog-full-screen/dialog-full-screen.test.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.test.tsx
@@ -69,7 +69,7 @@ test("the contentRef prop is forwarded to the dialog content", () => {
 test("the dialog container should be focused when the dialog opens", async () => {
   render(
     <DialogFullScreen open>
-      <input type="text" />
+      <input type="text" placeholder="input" />
     </DialogFullScreen>,
   );
 
@@ -82,7 +82,7 @@ test("the dialog container should not be focused when the dialog opens if the di
   jest.useFakeTimers();
   render(
     <DialogFullScreen open disableAutoFocus>
-      <input type="text" />
+      <input type="text" placeholder="input" />
     </DialogFullScreen>,
   );
 

--- a/src/components/dialog/dialog.component.tsx
+++ b/src/components/dialog/dialog.component.tsx
@@ -4,7 +4,6 @@ import createGuid from "../../__internal__/utils/helpers/guid";
 import Modal, { ModalProps } from "../modal";
 import Heading from "../heading";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
-import Logger from "../../__internal__/utils/logger";
 
 import {
   StyledDialog,
@@ -29,10 +28,12 @@ export interface ContentPaddingInterface {
   px?: PaddingValues;
 }
 
-let deprecatedClassNameWarningShown = false;
-
 export interface DialogProps extends ModalProps, TagProps {
-  /** Custom class name  */
+  /**
+   * @private
+   * @ignore
+   * @internal
+   * Sets className for component. INTERNAL USE ONLY. */
   className?: string;
   /** Prop to specify the aria-describedby property of the Dialog component */
   "aria-describedby"?: string;
@@ -131,13 +132,6 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
     },
     ref,
   ) => {
-    if (!deprecatedClassNameWarningShown && className) {
-      Logger.deprecate(
-        "The 'className' prop has been deprecated and will soon be removed from the 'Dialog' component.",
-      );
-      deprecatedClassNameWarningShown = true;
-    }
-
     const locale = useLocale();
 
     const containerRef = useRef<HTMLDivElement>(null);

--- a/src/components/dialog/dialog.test.tsx
+++ b/src/components/dialog/dialog.test.tsx
@@ -10,17 +10,12 @@ import userEvent from "@testing-library/user-event";
 
 import CarbonProvider from "../carbon-provider";
 import Dialog, { DialogHandle, DialogProps } from ".";
-import Logger from "../../__internal__/utils/logger";
-
-let loggerSpy: jest.SpyInstance;
 
 beforeEach(() => {
-  loggerSpy = jest.spyOn(Logger, "deprecate").mockImplementation(() => {});
   jest.useFakeTimers();
 });
 
 afterEach(() => {
-  loggerSpy.mockRestore();
   jest.runOnlyPendingTimers();
   jest.useRealTimers();
 });
@@ -310,18 +305,6 @@ test("renders with grey background when greyBackground prop is passed", () => {
   expect(screen.getByRole("dialog")).toHaveStyle({
     backgroundColor: "var(--colorsUtilityMajor025)",
   });
-});
-
-test("dialog is wrapped in a container, which has the correct class names set, when className prop is passed", () => {
-  render(<Dialog open title="My dialog" className="special-dialog" />);
-
-  const modalWrapper = screen.getByTestId("modal");
-  const dialog = within(modalWrapper).getByRole("dialog", {
-    name: /My dialog/i,
-  });
-
-  expect(dialog).toBeInTheDocument();
-  expect(modalWrapper).toHaveClass("carbon-dialog special-dialog");
 });
 
 test("dialog is positioned correctly, when size prop is maximise", () => {

--- a/src/components/help/help.component.tsx
+++ b/src/components/help/help.component.tsx
@@ -9,9 +9,6 @@ import { TooltipContext } from "../../__internal__/tooltip-provider";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { TooltipPositions } from "../tooltip/tooltip.config";
 import guid from "../../__internal__/utils/helpers/guid";
-import Logger from "../../__internal__/utils/logger";
-
-let deprecatedClassNameWarningShown = false;
 
 export interface HelpProps extends MarginProps {
   /** Overrides the default 'as' attribute of the Help component */
@@ -20,8 +17,6 @@ export interface HelpProps extends MarginProps {
   ariaLabel?: string;
   /** The message to be displayed within the tooltip */
   children?: React.ReactNode;
-  /** [Legacy] A custom class name for the component. */
-  className?: string;
   /** The unique id of the component (used with aria-describedby for accessibility) */
   helpId?: string;
   /** A path for the anchor */
@@ -54,7 +49,6 @@ export const Help = ({
   as,
   ariaLabel = "help",
   children,
-  className,
   href,
   helpId,
   isFocused,
@@ -67,13 +61,6 @@ export const Help = ({
   type = "help",
   ...rest
 }: HelpProps): JSX.Element => {
-  if (!deprecatedClassNameWarningShown && className) {
-    Logger.deprecate(
-      "The 'className' prop has been deprecated and will soon be removed from the 'Help' component.",
-    );
-    deprecatedClassNameWarningShown = true;
-  }
-
   const defaultTooltipId = useRef(guid());
   const helpElement = useRef<HTMLDivElement>(null);
   const [isTooltipVisible, updateTooltipVisible] = useState(false);
@@ -110,7 +97,6 @@ export const Help = ({
           : undefined
       }
       aria-label={helpAriaLabel || ariaLabel}
-      className={className}
       as={tagType}
       href={href}
       id={helpId}

--- a/src/components/help/help.test.tsx
+++ b/src/components/help/help.test.tsx
@@ -3,7 +3,6 @@ import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Help from ".";
 import Icon from "../icon";
-import Logger from "../../__internal__/utils/logger";
 
 test("renders tooltip when help button is hovered and removes tooltip when unhovered", async () => {
   const user = userEvent.setup();
@@ -136,22 +135,4 @@ test("renders with provided `helpId` and `tooltipId`", async () => {
     "id",
     "bar",
   );
-});
-
-test("throws a deprecation warning if the 'className' prop is set", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(
-    <Help className="bar" helpId="foo" tooltipId="bar">
-      foo
-    </Help>,
-  );
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'Help' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
 });

--- a/src/components/icon/icon-config.ts
+++ b/src/components/icon/icon-config.ts
@@ -1,4 +1,5 @@
 import { TooltipPositions } from "../tooltip/tooltip.config";
+
 import { IconType } from "./icon-type";
 import { BackgroundShape, BgSize, FontSize } from "./icon.style";
 
@@ -34,13 +35,7 @@ export const ICON_SHAPES: BackgroundShape[] = [
   "rounded-rect",
   "square",
 ];
-export const ICON_SIZES: BgSize[] = [
-  "extra-small",
-  "small",
-  "medium",
-  "large",
-  "extra-large",
-];
+export const ICON_SIZES: BgSize[] = ["small", "medium", "large", "extra-large"];
 export const ICON_FONT_SIZES: FontSize[] = [
   "small",
   "medium",

--- a/src/components/icon/icon.component.tsx
+++ b/src/components/icon/icon.component.tsx
@@ -10,7 +10,6 @@ import { ICON_TOOLTIP_POSITIONS } from "./icon-config";
 import { IconType } from "./icon-type";
 import { TooltipPositions } from "../tooltip/tooltip.config";
 import TabTitleContext from "../tabs/__internal__/tab-title/tab-title.context";
-import Logger from "../../__internal__/utils/logger";
 
 export type LegacyIconTypes =
   | "help"
@@ -61,8 +60,6 @@ export interface IconProps
   tabIndex?: number;
 }
 
-let deprecatedExtraSmallBgSizeTriggered = false;
-
 const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
   (
     {
@@ -100,13 +97,6 @@ const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
       tooltipFlipOverrides.every((override) =>
         ICON_TOOLTIP_POSITIONS.includes(override),
       );
-
-    if (!deprecatedExtraSmallBgSizeTriggered && bgSize === "extra-small") {
-      deprecatedExtraSmallBgSizeTriggered = true;
-      Logger.deprecate(
-        "The `extra-small` variant of the `bgSize` prop for `Icon` component has been deprecated and will soon be removed.",
-      );
-    }
 
     if (tooltipFlipOverrides) {
       invariant(

--- a/src/components/icon/icon.style.ts
+++ b/src/components/icon/icon.style.ts
@@ -1,26 +1,24 @@
 import styled, { css } from "styled-components";
+
 import { shade } from "polished";
+
 import { margin } from "styled-system";
 
-import iconUnicodes from "./icon-unicodes";
 import baseTheme, { ThemeObject } from "../../style/themes/base";
-import iconConfig from "./icon-config";
+import addFocusStyling from "../../style/utils/add-focus-styling";
+import styledColor from "../../style/utils/color";
+import getColorValue from "../../style/utils/get-color-value";
 import browserTypeCheck, {
   isSafari,
 } from "../../__internal__/utils/helpers/browser-type-check";
-import styledColor from "../../style/utils/color";
-import getColorValue from "../../style/utils/get-color-value";
+
+import iconConfig from "./icon-config";
 import { IconType } from "./icon-type";
-import addFocusStyling from "../../style/utils/add-focus-styling";
+import iconUnicodes from "./icon-unicodes";
 
 export type BackgroundShape = "circle" | "rounded-rect" | "square";
 
-export type BgSize =
-  | "extra-small"
-  | "small"
-  | "medium"
-  | "large"
-  | "extra-large";
+export type BgSize = "small" | "medium" | "large" | "extra-large";
 
 export type FontSize = "small" | "medium" | "large" | "extra-large";
 
@@ -59,11 +57,10 @@ export interface StyledIconInternalProps {
 
 function adjustIconBgSize(fontSize?: FontSize, bgSize?: BgSize) {
   const sizeValues: Record<BgSize | FontSize, number> = {
-    "extra-small": 1,
-    small: 2,
-    medium: 3,
-    large: 4,
-    "extra-large": 5,
+    small: 1,
+    medium: 2,
+    large: 3,
+    "extra-large": 4,
   };
 
   if (fontSize && bgSize) {
@@ -81,7 +78,7 @@ function adjustIconBgSize(fontSize?: FontSize, bgSize?: BgSize) {
     return iconConfig.backgroundSize[bgSize];
   }
 
-  /* The below is ignored as removing it may cause regressions as some components import StyledIcon directly from this file 
+  /* The below is ignored as removing it may cause regressions as some components import StyledIcon directly from this file
   however it cannot be tested in the Icon tests as these props always have a value. */
   /* istanbul ignore next */
   return bgSize ? iconConfig.backgroundSize[bgSize] : undefined;
@@ -180,7 +177,7 @@ const StyledIcon = styled.span<StyledIconProps & StyledIconInternalProps>`
         css`
           margin-top: -6px;
         `}
-        
+
         display: block;
       }
 

--- a/src/components/icon/icon.test.tsx
+++ b/src/components/icon/icon.test.tsx
@@ -9,7 +9,6 @@ import iconConfig from "./icon-config";
 import browserTypeCheck from "../../__internal__/utils/helpers/browser-type-check";
 import { IconType } from "./icon-type";
 import { TooltipPositions } from "../tooltip/tooltip.config";
-import Logger from "../../__internal__/utils/logger";
 
 jest.mock("../../__internal__/utils/helpers/browser-type-check");
 
@@ -135,25 +134,6 @@ test("does not render, as an invariant is fired due to the `tooltipFlipOverrides
   );
 
   consoleSpy.mockRestore();
-});
-
-test('logs a deprecation warning once when the `bgSize` prop is passed a value of "extra-small"', () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-
-  render(
-    <>
-      <Icon type="home" bgSize="extra-small" />
-      <Icon type="home" bgSize="extra-small" />
-    </>,
-  );
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The `extra-small` variant of the `bgSize` prop for `Icon` component has been deprecated and will soon be removed.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-  loggerSpy.mockRestore();
 });
 
 test("logs a warning when the `fontSize` props value is larger than the `bgSize` props value", () => {

--- a/src/components/inline-inputs/inline-inputs.component.tsx
+++ b/src/components/inline-inputs/inline-inputs.component.tsx
@@ -10,9 +10,6 @@ import StyledInlineInputs, {
 import FormSpacingProvider from "../../__internal__/form-spacing-provider";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
 import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
-import Logger from "../../__internal__/utils/logger";
-
-let deprecatedClassNameWarningShown = false;
 
 type GutterOptions =
   | "none"
@@ -32,7 +29,11 @@ export interface InlineInputsProps
   adaptiveLabelBreakpoint?: number;
   /** Children elements */
   children?: React.ReactNode;
-  /** [Legacy prop] A custom class name for the component. */
+  /**
+   * @private
+   * @internal
+   * @ignore
+   * Sets className for component. INTERNAL USE ONLY. */
   className?: string;
   /** The id of the corresponding input control for the label */
   htmlFor?: string;
@@ -68,7 +69,6 @@ const InlineInputs = ({
   labelId,
   htmlFor,
   children = null,
-  className = "",
   gutter = "none",
   inputWidth,
   labelInline = true,
@@ -77,13 +77,6 @@ const InlineInputs = ({
   isOptional,
   ...rest
 }: InlineInputsProps) => {
-  if (!deprecatedClassNameWarningShown && className) {
-    Logger.deprecate(
-      "The 'className' prop has been deprecated and will soon be removed from the 'InlineInputs' component.",
-    );
-    deprecatedClassNameWarningShown = true;
-  }
-
   const largeScreen = useIsAboveBreakpoint(adaptiveLabelBreakpoint);
   const ref = useRef<HTMLDivElement>(null);
   let inlineLabel: boolean | undefined = labelInline;
@@ -124,7 +117,6 @@ const InlineInputs = ({
       gutter={gutter}
       data-component="inline-inputs"
       data-role="inline-inputs"
-      className={className}
       labelWidth={labelWidth}
       labelInline={inlineLabel}
       ref={ref}

--- a/src/components/inline-inputs/inline-inputs.pw.tsx
+++ b/src/components/inline-inputs/inline-inputs.pw.tsx
@@ -11,16 +11,12 @@ import {
 import { Default as InlineInputComponent } from "./inline-inputs-test.stories";
 import {
   inlineInputContainer,
-  inlineInputsPreview,
   inlineLabel,
   inlinelabelWidth,
   inlineChildren,
 } from "../../../playwright/components/inline-inputs";
 import { CHARACTERS } from "../../../playwright/support/constants";
-import {
-  containsClass,
-  checkAccessibility,
-} from "../../../playwright/support/helper";
+import { checkAccessibility } from "../../../playwright/support/helper";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
@@ -70,14 +66,6 @@ test.describe("InlineInputs", () => {
       await mount(<InlineInputComponent label={label} />);
 
       await expect(inlineLabel(page)).toHaveText(label);
-    });
-  });
-
-  testData.forEach((classname) => {
-    test(`should check classname as ${classname}`, async ({ mount, page }) => {
-      await mount(<InlineInputComponent className={classname} />);
-
-      await containsClass(inlineInputsPreview(page), classname);
     });
   });
 

--- a/src/components/inline-inputs/inline-inputs.test.tsx
+++ b/src/components/inline-inputs/inline-inputs.test.tsx
@@ -6,7 +6,6 @@ import {
   mockMatchMedia,
   testStyledSystemMargin,
 } from "../../__spec_helper__/__internal__/test-utils";
-import Logger from "../../__internal__/utils/logger";
 
 test("renders single child", () => {
   render(
@@ -133,21 +132,3 @@ testStyledSystemMargin(
   (props) => <InlineInputs label="label" {...props} />,
   () => screen.getByTestId("inline-inputs"),
 );
-
-test("throws a deprecation warning if the 'className' prop is set", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(
-    <InlineInputs className="foo">
-      <Textbox onChange={() => {}} />
-    </InlineInputs>,
-  );
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'InlineInputs' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
-});

--- a/src/components/link/link.component.tsx
+++ b/src/components/link/link.component.tsx
@@ -6,9 +6,6 @@ import { StyledLink, StyledContent, StyledLinkProps } from "./link.style";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import useLocale from "../../hooks/__internal__/useLocale";
 import BatchSelectionContext from "../batch-selection/__internal__/batch-selection.context";
-import Logger from "../../__internal__/utils/logger";
-
-let deprecatedClassNameWarningShown = false;
 
 export interface LinkProps extends StyledLinkProps, React.AriaAttributes {
   /** An href for an anchor tag. */
@@ -42,8 +39,6 @@ export interface LinkProps extends StyledLinkProps, React.AriaAttributes {
   tooltipPosition?: "bottom" | "left" | "right" | "top";
   /** Child content to render in the link. */
   children?: React.ReactNode;
-  /** Classes to apply to the component. */
-  className?: string;
   /** Target property in which link should open ie: _blank, _self, _parent, _top */
   target?: string;
   /** Aria label for accessibility purposes */
@@ -54,6 +49,12 @@ export interface LinkProps extends StyledLinkProps, React.AriaAttributes {
   placeholderTabIndex?: boolean;
   /** @ignore @private internal prop to be set when no aria-label should be specified */
   removeAriaLabelOnIcon?: boolean;
+  /**
+   * @private
+   * @internal
+   * @ignore
+   * Sets className for component. INTERNAL USE ONLY. */
+  className?: string;
 }
 
 export const Link = React.forwardRef<
@@ -63,7 +64,6 @@ export const Link = React.forwardRef<
   (
     {
       children,
-      className,
       onKeyDown,
       href,
       onClick,
@@ -81,17 +81,11 @@ export const Link = React.forwardRef<
       isDarkBackground,
       placeholderTabIndex,
       removeAriaLabelOnIcon,
+      className,
       ...rest
     }: LinkProps,
     ref,
   ) => {
-    if (!deprecatedClassNameWarningShown && className) {
-      Logger.deprecate(
-        "The 'className' prop has been deprecated and will soon be removed from the 'Link' component.",
-      );
-      deprecatedClassNameWarningShown = true;
-    }
-
     const [hasFocus, setHasFocus] = useState(false);
     const l = useLocale();
     const { inMenu } = useContext(MenuContext);
@@ -185,8 +179,8 @@ export const Link = React.forwardRef<
       <StyledLink
         isSkipLink={isSkipLink}
         disabled={isDisabled}
-        className={className}
         iconAlign={iconAlign}
+        className={className}
         hasContent={Boolean(children)}
         variant={variant}
         isDarkBackground={isDarkBackground}

--- a/src/components/link/link.test.tsx
+++ b/src/components/link/link.test.tsx
@@ -6,7 +6,6 @@ import userEvent from "@testing-library/user-event";
 
 import Link from "./link.component";
 import MenuContext from "../menu/__internal__/menu.context";
-import Logger from "../../__internal__/utils/logger";
 
 test("should render `Skip to main content` text inside of Link when `isSkipLink` prop is provided", () => {
   render(
@@ -547,18 +546,4 @@ describe("link display styling", () => {
 
     expect(linkElement).not.toHaveStyle(`display: inline-block`);
   });
-});
-
-test("throws a deprecation warning if the 'className' prop is set", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(<Link className="foo">bar</Link>);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'Link' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
 });

--- a/src/components/loader-spinner/loader-spinner.test.tsx
+++ b/src/components/loader-spinner/loader-spinner.test.tsx
@@ -153,7 +153,6 @@ describe("when custom props are passed", () => {
     (spinnerSizes) => {
       render(<LoaderSpinner size={spinnerSizes} />);
       const visibleLabelElement = screen.getByTestId("visible-label");
-
       expect(visibleLabelElement).toHaveStyle({
         marginTop: `${LOADER_SPINNER_SIZE_PARAMS[spinnerSizes].labelMarginTop}px`,
       });

--- a/src/components/menu/menu-item/menu-item.component.tsx
+++ b/src/components/menu/menu-item/menu-item.component.tsx
@@ -21,9 +21,6 @@ import { StyledMenuItem } from "../menu.style";
 import guid from "../../../__internal__/utils/helpers/guid";
 import { IconType } from "../../icon";
 import { TagProps } from "../../../__internal__/utils/helpers/tags";
-import Logger from "../../../__internal__/utils/logger";
-
-let deprecatedClassNameWarningShown = false;
 
 export type VariantType = "default" | "alternate";
 
@@ -32,8 +29,6 @@ interface MenuItemBaseProps
     Pick<LayoutProps, "width" | "maxWidth" | "minWidth">,
     FlexboxProps,
     PaddingProps {
-  /** Custom className */
-  className?: string;
   /** onClick handler */
   onClick?: (
     event:
@@ -127,13 +122,6 @@ export const MenuItem = ({
   "data-role": dataRole,
   ...rest
 }: MenuWithChildren | MenuWithIcon) => {
-  if (!deprecatedClassNameWarningShown && rest.className) {
-    Logger.deprecate(
-      "The 'className' prop has been deprecated and will soon be removed from the 'MenuItem' component.",
-    );
-    deprecatedClassNameWarningShown = true;
-  }
-
   invariant(
     icon || children,
     "Either prop `icon` must be defined or this node must have `children`.",

--- a/src/components/menu/menu-item/menu-item.test.tsx
+++ b/src/components/menu/menu-item/menu-item.test.tsx
@@ -20,7 +20,6 @@ import menuConfigVariants from "../menu.config";
 import IconButton from "../../icon-button";
 import Search from "../../search";
 import SubmenuContext from "../__internal__/submenu/submenu.context";
-import Logger from "../../../__internal__/utils/logger";
 
 const menuContextValues: MenuContextProps = {
   menuType: "light",
@@ -1119,20 +1118,6 @@ test("should throw when `children` passed and `submenu` is an empty string", () 
   );
 
   consoleSpy.mockRestore();
-});
-
-test("throws a deprecation warning if the 'className' prop is set", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(<MenuItem className="foo">Item One</MenuItem>);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'MenuItem' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
 });
 
 // coverage

--- a/src/components/menu/menu-test.stories.tsx
+++ b/src/components/menu/menu-test.stories.tsx
@@ -489,7 +489,6 @@ export const WhenMenuItemsWrap = () => {
           justifyContent="flex-start"
           width="100px"
           icon="settings"
-          className="foooooo"
           href="#"
         >
           M

--- a/src/components/menu/menu.pw.tsx
+++ b/src/components/menu/menu.pw.tsx
@@ -860,19 +860,6 @@ test.describe("Prop tests for Menu component", () => {
     });
   });
 
-  test(`should render with className as ${CHARACTERS.STANDARD}`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<MenuComponentItems className={CHARACTERS.STANDARD} />);
-
-    const item = menuItem(page).nth(0);
-    const itemClass = await item.evaluate((element) =>
-      element.getAttribute("class"),
-    );
-    expect(itemClass).toContain(CHARACTERS.STANDARD);
-  });
-
   (
     [
       ["selected", true, "rgb(230, 235, 237)"],

--- a/src/components/menu/menu.stories.tsx
+++ b/src/components/menu/menu.stories.tsx
@@ -72,7 +72,7 @@ export const DefaultStory: Story = () => {
             {menuType}
           </Typography>
           <Menu menuType={menuType}>
-            <MenuItem icon="settings" className="foooooo" href="#">
+            <MenuItem icon="settings" href="#">
               Menu Item One
             </MenuItem>
             <MenuItem icon="settings" onClick={() => {}}>

--- a/src/components/message/message.component.tsx
+++ b/src/components/message/message.component.tsx
@@ -10,9 +10,6 @@ import Icon from "../icon";
 import IconButton from "../icon-button";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import useLocale from "../../hooks/__internal__/useLocale";
-import Logger from "../../__internal__/utils/logger";
-
-let deprecatedClassNameWarningShown = false;
 
 export type MessageVariant =
   | "error"
@@ -24,8 +21,6 @@ export type MessageVariant =
 export interface MessageProps extends MarginProps {
   /** set content to component */
   children?: React.ReactNode;
-  /** set custom class to component */
-  className?: string;
   /** set custom aria label for message close button */
   closeButtonAriaLabel?: string;
   /** set custom id to component root */
@@ -58,19 +53,12 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
       children,
       onDismiss,
       id,
-      className,
       closeButtonAriaLabel,
       showCloseIcon = true,
       ...props
     }: MessageProps,
     ref,
   ) => {
-    if (!deprecatedClassNameWarningShown && className) {
-      Logger.deprecate(
-        "The 'className' prop has been deprecated and will soon be removed from the 'Message' component.",
-      );
-      deprecatedClassNameWarningShown = true;
-    }
     const messageRef = useRef<HTMLDivElement | null>(null);
     const refToPass = ref || messageRef;
 
@@ -94,7 +82,6 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
     return open ? (
       <MessageStyle
         {...tagComponent("Message", props)}
-        className={className}
         transparent={transparent}
         variant={variant}
         id={id}

--- a/src/components/message/message.pw.tsx
+++ b/src/components/message/message.pw.tsx
@@ -5,10 +5,7 @@ import {
   MessageComponentWithRef,
 } from "./components.test-pw";
 import Message, { MessageProps } from ".";
-import {
-  checkAccessibility,
-  containsClass,
-} from "../../../playwright/support/helper";
+import { checkAccessibility } from "../../../playwright/support/helper";
 
 import {
   messagePreview,
@@ -56,17 +53,6 @@ test.describe("Tests for Message component properties", () => {
       await mount(<Message>{children}</Message>);
 
       await expect(messageChildren(page)).toHaveText(children);
-    });
-  });
-
-  testData.forEach((className) => {
-    test(`should check ${className} as className for Message component`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<MessageComponent className={className} />);
-
-      await containsClass(messagePreview(page), className);
     });
   });
 
@@ -232,17 +218,6 @@ test.describe("Accessibility tests for Message component", () => {
       page,
     }) => {
       await mount(<Message>{children}</Message>);
-
-      await checkAccessibility(page);
-    });
-  });
-
-  testData.forEach((className) => {
-    test(`should check ${className} as className for accessibility tests`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<MessageComponent className={className} />);
 
       await checkAccessibility(page);
     });

--- a/src/components/message/message.test.tsx
+++ b/src/components/message/message.test.tsx
@@ -5,17 +5,6 @@ import Message from "./message.component";
 import I18nProvider from "../i18n-provider";
 import enGB from "../../locales/en-gb";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
-import Logger from "../../__internal__/utils/logger";
-
-let loggerSpy: jest.SpyInstance;
-
-beforeEach(() => {
-  loggerSpy = jest.spyOn(Logger, "deprecate").mockImplementation(() => {});
-});
-
-afterEach(() => {
-  loggerSpy.mockRestore();
-});
 
 test("renders with provided children", () => {
   render(<Message>Message</Message>);
@@ -125,20 +114,6 @@ test("renders with provided `id`", () => {
   );
 
   expect(screen.getByTestId("my-message")).toHaveAttribute("id", "message-id");
-});
-
-test("renders with provided `className`", () => {
-  render(
-    <Message data-role="my-message" className="message-class">
-      Message
-    </Message>,
-  );
-
-  expect(screen.getByTestId("my-message")).toHaveClass("message-class");
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'Message' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
 });
 
 // coverage

--- a/src/components/modal/modal.component.tsx
+++ b/src/components/modal/modal.component.tsx
@@ -8,12 +8,13 @@ import useModalManager from "../../hooks/__internal__/useModalManager";
 import { StyledModal, StyledModalBackground } from "./modal.style";
 import { TagProps } from "../../__internal__/utils/helpers/tags";
 import ModalContext from "./__internal__/modal.context";
-import Logger from "../../__internal__/utils/logger";
-
-let deprecatedClassNameWarningShown = false;
 
 export interface ModalProps extends Omit<TagProps, "data-component"> {
-  /** Custom class name  */
+  /**
+   * @private
+   * @internal
+   * @ignore
+   * Sets className for component. INTERNAL USE ONLY. */
   className?: string;
   /** Modal content */
   children?: React.ReactNode;
@@ -53,12 +54,6 @@ const Modal = ({
   restoreFocusOnClose = true,
   ...rest
 }: ModalProps) => {
-  if (!deprecatedClassNameWarningShown && rest.className) {
-    Logger.deprecate(
-      "The 'className' prop has been deprecated and will soon be removed from the 'Modal' component.",
-    );
-    deprecatedClassNameWarningShown = true;
-  }
   const ref = useRef<HTMLDivElement>(null);
   const backgroundNodeRef = useRef<HTMLDivElement>(null);
   const contentNodeRef = useRef<HTMLDivElement>(null);

--- a/src/components/modal/modal.test.tsx
+++ b/src/components/modal/modal.test.tsx
@@ -4,7 +4,6 @@ import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Modal from "./modal.component";
 import useScrollBlock from "../../hooks/__internal__/useScrollBlock";
-import Logger from "../../__internal__/utils/logger";
 
 jest.mock("../../hooks/__internal__/useScrollBlock");
 const allowScroll = jest.fn();
@@ -194,20 +193,6 @@ test("increases the default z-index when the topModalOverride prop is set", () =
   render(<Modal data-role="test-modal" open topModalOverride />);
 
   expect(screen.getByTestId("test-modal")).toHaveStyleRule("z-index: 7000");
-});
-
-test("throws a deprecation warning if the 'className' prop is set", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(<Modal open className="foo" />);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'Modal' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
 });
 
 test("should restore focus to the call to action element when `restoreFocusOnClose` is true", async () => {

--- a/src/components/pod/pod.component.tsx
+++ b/src/components/pod/pod.component.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useMemo } from "react";
 import { MarginProps } from "styled-system";
 import useLocale from "../../hooks/__internal__/useLocale";
-import Logger from "../../__internal__/utils/logger";
 
 import {
   StyledBlock,
@@ -21,8 +20,6 @@ import Icon from "../icon";
 import Event from "../../__internal__/utils/helpers/events";
 import { PodAlignment, PodSize, PodVariant } from "./pod.config";
 
-let deprecatedClassNameWarningShown = false;
-
 export interface PodProps extends MarginProps {
   /** Identifier used for testing purposes, applied to the root element of the component. */
   "data-element"?: string;
@@ -34,8 +31,6 @@ export interface PodProps extends MarginProps {
   border?: boolean;
   /** Children elements */
   children?: React.ReactNode;
-  /** Custom className */
-  className?: string;
   /** Determines the padding around the pod */
   size?: PodSize;
   /** Prop to apply a theme to the Pod */
@@ -80,7 +75,6 @@ const Pod = React.forwardRef<HTMLDivElement, PodProps>(
       alignTitle = "left",
       border = true,
       children,
-      className,
       displayEditButtonOnHover,
       editContentFullWidth,
       footer,
@@ -99,13 +93,6 @@ const Pod = React.forwardRef<HTMLDivElement, PodProps>(
     }: PodProps,
     ref,
   ) => {
-    if (!deprecatedClassNameWarningShown && className) {
-      Logger.deprecate(
-        "The 'className' prop has been deprecated and will soon be removed from the 'Pod' component.",
-      );
-      deprecatedClassNameWarningShown = true;
-    }
-
     const [isEditFocused, setEditFocused] = useState(false);
     const [isEditHovered, setEditHovered] = useState(false);
     const [isDeleteFocused, setDeleteFocused] = useState(false);
@@ -155,7 +142,6 @@ const Pod = React.forwardRef<HTMLDivElement, PodProps>(
     return (
       <StyledPod
         alignTitle={alignTitle}
-        className={className}
         internalEditButton={internalEditButton}
         height={typeof height === "number" ? `${height}px` : height}
         ref={ref}

--- a/src/components/pod/pod.pw.tsx
+++ b/src/components/pod/pod.pw.tsx
@@ -28,7 +28,6 @@ import {
   checkCSSOutline,
   assertCssValueIsApproximately,
   checkAccessibility,
-  containsClass,
 } from "../../../playwright/support/helper";
 import { SIZE, CHARACTERS } from "../../../playwright/support/constants";
 import { VariantTypes } from "../typography/typography.component";
@@ -64,17 +63,6 @@ test.describe("Prop tests for Pod", () => {
 
       page.getByText(children);
       await expect(podContent(page)).toHaveCSS("text-align", "left");
-    });
-  });
-
-  specialCharacters.forEach((className) => {
-    test(`should render with ${className} as className`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PodExample className={className} />);
-
-      await containsClass(podComponent(page), className);
     });
   });
 

--- a/src/components/pod/pod.test.tsx
+++ b/src/components/pod/pod.test.tsx
@@ -4,7 +4,6 @@ import userEvent from "@testing-library/user-event";
 import Pod from ".";
 import Typography from "../typography";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
-import Logger from "../../__internal__/utils/logger";
 
 test("renders with `title` as a string", () => {
   render(<Pod title="Title" />);
@@ -516,17 +515,3 @@ testStyledSystemMargin(
   (props) => <Pod data-role="pod" {...props} />,
   () => screen.getByTestId("pod"),
 );
-
-test("throws a deprecation warning if the 'className' prop is set", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(<Pod className="foo">bar</Pod>);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'Pod' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
-});

--- a/src/components/portal/portal.test.tsx
+++ b/src/components/portal/portal.test.tsx
@@ -4,7 +4,6 @@ import { ThemeProvider } from "styled-components";
 import sageTheme from "../../style/themes/sage";
 import PortalContext from "./__internal__/portal.context";
 import Portal from ".";
-import Logger from "../../__internal__/utils/logger";
 
 import guid from "../../__internal__/utils/helpers/guid";
 
@@ -12,16 +11,6 @@ const mockedGuid = "guid-12345";
 jest.mock("../../__internal__/utils/helpers/guid");
 
 (guid as jest.MockedFunction<typeof guid>).mockImplementation(() => mockedGuid);
-
-let loggerSpy: jest.SpyInstance;
-
-beforeEach(() => {
-  loggerSpy = jest.spyOn(Logger, "deprecate").mockImplementation(() => {});
-});
-
-afterEach(() => {
-  loggerSpy.mockRestore();
-});
 
 test("renders and appends to an element with the 'id' attribute set to `root`", () => {
   const rootDiv = document.createElement("div");
@@ -67,11 +56,6 @@ test("renders with the 'class' attribute on the portal exit, via the `className`
 
   const portalExit = screen.getByTestId("carbon-portal-exit");
   expect(portalExit).toHaveClass(`carbon-portal ${className}`);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'Portal' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
 });
 
 test("renders with the 'id' attribute on the portal exit, via the `id` prop", () => {

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -6,9 +6,6 @@ import guid from "../../__internal__/utils/helpers/guid";
 import CarbonScopedTokensProvider from "../../style/design-tokens/carbon-scoped-tokens-provider/carbon-scoped-tokens-provider.component";
 import StyledPortalEntrance from "./portal.style";
 import PortalContext from "./__internal__/portal.context";
-import Logger from "../../__internal__/utils/logger";
-
-let deprecatedClassNameWarningShown = false;
 
 const Container = styled.div`
   ${({ theme }) => css`
@@ -22,7 +19,11 @@ const Container = styled.div`
 export interface PortalProps {
   /** The content of the portal. */
   children?: React.ReactNode;
-  /** Classname attached to portal container. */
+  /**
+   * @private
+   * @internal
+   * @ignore
+   * Sets className for component. INTERNAL USE ONLY. */
   className?: string;
   /** Id attribute attached to portal container. */
   id?: string;
@@ -43,13 +44,6 @@ export const Portal = ({
   onReposition,
   inertOptOut,
 }: PortalProps) => {
-  if (!deprecatedClassNameWarningShown && className) {
-    Logger.deprecate(
-      "The 'className' prop has been deprecated and will soon be removed from the 'Portal' component.",
-    );
-    deprecatedClassNameWarningShown = true;
-  }
-
   const [portalNode, setPortalNode] = useState<HTMLElement | null>(null);
   const uniqueId = useMemo(() => guid(), []);
   const { renderInRoot } = useContext(PortalContext);

--- a/src/components/portrait/portrait-test.stories.tsx
+++ b/src/components/portrait/portrait-test.stories.tsx
@@ -43,7 +43,6 @@ Default.storyName = "default";
 Default.args = {
   alt: "",
   darkBackground: false,
-  gravatar: "",
   src: "",
   initials: "",
   iconType: undefined,

--- a/src/components/portrait/portrait.component.tsx
+++ b/src/components/portrait/portrait.component.tsx
@@ -1,19 +1,15 @@
 import React, { useEffect, useState } from "react";
 import { MarginProps } from "styled-system";
-import MD5 from "crypto-js/md5";
-import invariant from "invariant";
-import Logger from "../../__internal__/utils/logger";
 
 import { IconType } from "../icon";
 import Tooltip from "../tooltip";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
-import { PORTRAIT_SIZE_PARAMS } from "./portrait.config";
+
 import {
   StyledCustomImg,
   StyledIcon,
   StyledPortraitContainer,
   StyledPortraitInitials,
-  StyledPortraitGravatar,
 } from "./portrait.style";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 
@@ -21,11 +17,7 @@ export type PortraitShapes = "circle" | "square";
 
 export type PortraitSizes = "XS" | "S" | "M" | "ML" | "L" | "XL" | "XXL";
 
-let deprecatedGravatarWarnTriggered = false;
-
 export interface PortraitProps extends MarginProps {
-  /** (Deprecated) An email address registered with Gravatar. */
-  gravatar?: string;
   /** A custom image URL. */
   src?: string;
   /** The size of the Portrait. */
@@ -66,7 +58,6 @@ const Portrait = ({
   alt,
   name,
   darkBackground = false,
-  gravatar = "",
   iconType = "individual",
   initials,
   shape = "circle",
@@ -86,34 +77,11 @@ const Portrait = ({
   const [externalError, setExternalError] = useState(false);
   const hasValidImg = Boolean(src) && !externalError;
 
-  invariant(
-    !(src && gravatar),
-    "The `src` prop cannot be used in conjunction with the `gravatar` prop." +
-      " Please use one or the other.",
-  );
-
-  const logGravatarDeprecationWarning = () => {
-    deprecatedGravatarWarnTriggered = true;
-    Logger.deprecate(
-      "The `gravatar` prop has been deprecated and will soon be removed.",
-    );
-  };
-
   useEffect(() => {
     setExternalError(false);
-  }, [gravatar, src]);
+  }, [src]);
 
   const tagProps = tagComponent("portrait", rest);
-
-  const gravatarSrc = () => {
-    const { dimensions } = PORTRAIT_SIZE_PARAMS[size];
-    const base = "https://www.gravatar.com/avatar/";
-    const hash = MD5(gravatar.toLowerCase());
-    const fallbackOption = "404"; // "Return an HTTP 404 File Not Found response"
-
-    /** @see https://en.gravatar.com/site/implement/images/#default-image */
-    return `${base}${hash}?s=${dimensions}&d=${fallbackOption}`;
-  };
 
   const renderComponent = () => {
     let portrait = <StyledIcon type={iconType} size={size} />;
@@ -132,19 +100,6 @@ const Portrait = ({
           src={src}
           alt={alt || name || ""}
           data-element="user-image"
-          onError={() => setExternalError(true)}
-        />
-      );
-    }
-
-    if (gravatar && !externalError) {
-      portrait = (
-        <StyledPortraitGravatar
-          src={gravatarSrc()}
-          alt={alt || name || ""}
-          onLoad={() =>
-            !deprecatedGravatarWarnTriggered && logGravatarDeprecationWarning()
-          }
           onError={() => setExternalError(true)}
         />
       );

--- a/src/components/portrait/portrait.pw.tsx
+++ b/src/components/portrait/portrait.pw.tsx
@@ -37,12 +37,10 @@ const colors = [
   ["brown", COLOR.BROWN],
 ];
 
-const testImage =
-  "https://www.gravatar.com/avatar/cceff1ad774bf89b1f75cb6e5005333c?s=40&d=404";
+const testImage = "https://avataaars.io/";
 
 const imageURLs = [
   "https://avataaars.io/?avatarStyle=Transparent&topType=LongHairStraight&accessoriesType=Blank&hairColor=BrownDark&facialHairType=Blank&clotheType=BlazerShirt&eyeType=Default&eyebrowType=Default&mouthType=Default&skinColor=Light",
-  "https://www.gravatar.com/avatar/05c1c705ee45d7ae88b80b3a8866ddaa?s=24&d=404",
 ];
 
 const portraitSizes = PORTRAIT_SIZES.map((size) => [
@@ -76,15 +74,6 @@ test.describe("Prop checks for Portrait component", () => {
 
       await expect(portraitInitials(page)).toHaveText(maxInitials);
     });
-  });
-
-  test("should render with gravatar prop", async ({ mount, page }) => {
-    await mount(<PortraitDefaultComponent gravatar="chris.barber@sage.com" />);
-
-    await expect(portraitPreview(page).locator("img")).toHaveAttribute(
-      "src",
-      testImage,
-    );
   });
 
   imageURLs.forEach((url) => {
@@ -192,29 +181,6 @@ test.describe("Prop checks for Portrait component", () => {
       page,
     }) => {
       await mount(<PortraitDefaultComponent src={testImage} size={size} />);
-
-      await expect(portraitPreview(page)).toHaveCSS(
-        "height",
-        `${heightAndWidth}px`,
-      );
-      await expect(portraitPreview(page)).toHaveCSS(
-        "width",
-        `${heightAndWidth}px`,
-      );
-    });
-  });
-
-  portraitSizes.forEach(([size, heightAndWidth]) => {
-    test(`should render with size prop passed as ${size} - with gravatar`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <PortraitDefaultComponent
-          gravatar="chris.barber@sage.com"
-          size={size}
-        />,
-      );
 
       await expect(portraitPreview(page)).toHaveCSS(
         "height",
@@ -423,15 +389,6 @@ test.describe("Event checks for Portrait component", () => {
 });
 
 test.describe("Accessibility tests for Portrait component", () => {
-  test("should pass accessibility checks when gravatar is passed", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<PortraitDefaultComponent gravatar="chris.barber@sage.com" />);
-
-    await checkAccessibility(page);
-  });
-
   imageURLs.forEach((url) => {
     test(`should pass accessibility checks when src is ${url}`, async ({
       mount,

--- a/src/components/portrait/portrait.style.tsx
+++ b/src/components/portrait/portrait.style.tsx
@@ -29,11 +29,6 @@ export const StyledPortraitInitials = styled.div<
   width: inherit;
 `;
 
-export const StyledPortraitGravatar = styled.img`
-  height: inherit;
-  width: inherit;
-`;
-
 export const StyledCustomImg = styled.img`
   height: inherit;
   min-width: inherit;

--- a/src/components/portrait/portrait.test.tsx
+++ b/src/components/portrait/portrait.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import MD5 from "crypto-js/md5";
-import Logger from "../../__internal__/utils/logger";
 import Portrait from ".";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
 
@@ -31,69 +29,6 @@ test("renders with initials, if the `initials` prop is provided", () => {
   render(<Portrait initials="NM" />);
 
   expect(screen.getByText("NM")).toBeVisible();
-});
-
-test("renders with a gravatar image, if a valid email is passed via the `gravatar` prop", () => {
-  const email = "chris.barber@sage.com";
-  const hash = MD5(email);
-  const src = `https://www.gravatar.com/avatar/${hash}?s=40&d=404`;
-
-  render(<Portrait gravatar={email} alt="foo" />);
-
-  const img = screen.getByRole("img");
-  expect(img).toBeVisible();
-  expect(img).toHaveAttribute("src", src);
-});
-
-test("renders a decorative image, when gravatar prop is provided but alt is not", () => {
-  const email = "chris.barber@sage.com";
-  render(<Portrait gravatar={email} />);
-
-  const decorativeImg = screen.getByAltText("");
-  expect(decorativeImg).toBeVisible();
-});
-
-test("logs a deprecation warning once when the `gravatar` prop is passed, and a gravatar loads", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-
-  render(
-    <>
-      <Portrait gravatar="chris.barber@sage.com" alt="foo" />
-      <Portrait gravatar="chris.barber@sage.com" alt="foo" />
-    </>,
-  );
-
-  const portraits = screen.getAllByRole("img");
-
-  portraits.forEach((portrait) => {
-    fireEvent.load(portrait);
-  });
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The `gravatar` prop has been deprecated and will soon be removed.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-  loggerSpy.mockRestore();
-});
-
-test("if a valid gravatar email is not found and an onError event is triggered, the default individual icon is rendered", async () => {
-  const email = "invalid.email@1973";
-  const hash = MD5(email);
-  const src = `https://www.gravatar.com/avatar/${hash}?s=40&d=404`;
-  render(<Portrait gravatar={email} alt="foo" />);
-
-  const img = screen.getByRole("img");
-  expect(img).toBeVisible();
-  expect(img).toHaveAttribute("src", src);
-
-  fireEvent.error(img);
-
-  await waitFor(() => expect(screen.getByTestId("icon")).toBeVisible());
-  await waitFor(() =>
-    expect(screen.getByTestId("icon")).toHaveAttribute("type", "individual"),
-  );
 });
 
 test("renders a custom image with the correct src and alt attributes", () => {
@@ -126,19 +61,6 @@ test("if a valid src is not found and an onError event is triggered, the default
   await waitFor(() =>
     expect(screen.getByTestId("icon")).toHaveAttribute("type", "individual"),
   );
-});
-
-test("when both the `gravatar` and `src` props are passed simultaneously, an invariant violation is thrown", () => {
-  const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
-  const src = "https://upload.wikimedia.org/wikipedia/en/6/6c/Heatposter.jpg";
-  const email = "chris.barber@sage.com";
-
-  expect(() => render(<Portrait src={src} gravatar={email} />)).toThrow(
-    "The `src` prop cannot be used in conjunction with the `gravatar` prop." +
-      " Please use one or the other.",
-  );
-
-  consoleSpy.mockRestore();
 });
 
 test("renders with a square shape, if the `shape` prop is value is `square`", () => {

--- a/src/components/profile/profile.component.tsx
+++ b/src/components/profile/profile.component.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 
 import { MarginProps } from "styled-system";
+
+import { filterStyledSystemMarginProps } from "../../style/utils";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+
+import { ProfileSize } from "./profile.config";
 import {
   ProfileStyle,
   ProfileNameStyle,
@@ -10,11 +14,6 @@ import {
   ProfileEmailStyle,
   ProfileTextStyle,
 } from "./profile.style";
-import { filterStyledSystemMarginProps } from "../../style/utils";
-import { ProfileSize } from "./profile.config";
-import Logger from "../../__internal__/utils/logger";
-
-let deprecatedClassNameWarningShown = false;
 
 function acronymize(str?: string) {
   if (!str) return "";
@@ -26,7 +25,11 @@ function acronymize(str?: string) {
 let useOfNoNameWarnTriggered = false;
 
 export interface ProfileProps extends MarginProps {
-  /** [Legacy] A custom class name for the component */
+  /**
+   * @private
+   * @internal
+   * @ignore
+   * Sets className for component. INTERNAL USE ONLY. */
   className?: string;
   /** Custom source URL */
   src?: string;
@@ -38,7 +41,7 @@ export interface ProfileProps extends MarginProps {
   email?: string;
   /** Define read-only text to display. */
   text?: string;
-  /** Define initials to display if there is no Gravatar image. */
+  /** Define initials to display image. */
   initials?: string;
   /** Allow to setup size for the component */
   size?: ProfileSize;
@@ -58,13 +61,6 @@ export const Profile = ({
   darkBackground,
   ...props
 }: ProfileProps) => {
-  if (!deprecatedClassNameWarningShown && className) {
-    Logger.deprecate(
-      "The 'className' prop has been deprecated and will soon be removed from the 'Profile' component.",
-    );
-    deprecatedClassNameWarningShown = true;
-  }
-
   const getInitials = () => {
     if (initials) return initials;
     return acronymize(name).slice(0, 3).toUpperCase();
@@ -88,7 +84,7 @@ export const Profile = ({
         />
       );
     }
-    return <ProfileAvatarStyle gravatar={email} {...commonAvatarProps} />;
+    return <ProfileAvatarStyle {...commonAvatarProps} />;
   };
 
   if (!useOfNoNameWarnTriggered && !name && (email || text)) {

--- a/src/components/profile/profile.pw.tsx
+++ b/src/components/profile/profile.pw.tsx
@@ -22,12 +22,11 @@ import {
 
 import profileConfigSizes, { PROFILE_SIZES } from "./profile.config";
 
-const testImage =
-  "https://www.gravatar.com/avatar/05c1c705ee45d7ae88b80b3a8866ddaa?s=24&d=404";
+const testImage = "https://avataaars.io/";
 
 const imageURLs = [
   "https://avataaars.io/?avatarStyle=Transparent&topType=LongHairStraight&accessoriesType=Blank&hairColor=BrownDark&facialHairType=Blank&clotheType=BlazerShirt&eyeType=Default&eyebrowType=Default&mouthType=Default&skinColor=Light",
-  "https://www.gravatar.com/avatar/05c1c705ee45d7ae88b80b3a8866ddaa?s=24&d=404",
+  "https://avataaars.io/",
 ];
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
@@ -67,7 +66,7 @@ test.describe("Prop checks for Profile component", () => {
     ["John Doe", "JD"],
     ["Foo", "F"],
   ].forEach(([name, initials]) => {
-    test(`should render with correct initials when name prop is passed as ${name} and no other icon, src or gravatar is passed`, async ({
+    test(`should render with correct initials when name prop is passed as ${name} and no other icon or src is passed`, async ({
       mount,
       page,
     }) => {

--- a/src/components/profile/profile.test.tsx
+++ b/src/components/profile/profile.test.tsx
@@ -1,20 +1,8 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import MD5 from "crypto-js/md5";
 
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
 import Profile from "./profile.component";
-import Logger from "../../__internal__/utils/logger";
-
-let loggerSpy: jest.SpyInstance;
-
-beforeEach(() => {
-  loggerSpy = jest.spyOn(Logger, "deprecate").mockImplementation(() => {});
-});
-
-afterEach(() => {
-  loggerSpy.mockRestore();
-});
 
 testStyledSystemMargin(
   (props) => <Profile data-role="profile" name="John Doe" {...props} />,
@@ -115,18 +103,6 @@ test("renders with email text when `email` prop is passed", () => {
   expect(emailLink).toHaveAttribute("data-element", "email");
 });
 
-test("renders gravatar avatar if `email` prop is a valid gravatar", () => {
-  const email = "chris.barber@sage.com";
-  const hash = MD5(email);
-  const src = `https://www.gravatar.com/avatar/${hash}?s=40&d=404`;
-
-  render(<Profile name="Chris Barber" email={email} />);
-
-  const avatar = screen.getByRole("img");
-  expect(avatar).toBeVisible();
-  expect(avatar).toHaveAttribute("src", src);
-});
-
 test("renders with additional text when `text` prop is passed", () => {
   render(<Profile name="John Doe" text="Software Engineer" />);
 
@@ -201,16 +177,4 @@ test("renders with dark background styling when `darkBackground` prop is passed"
   expect(emailLink).toHaveStyleRule("color", "var(--colorsActionMajor350)", {
     modifier: "a",
   });
-});
-
-test("applies the `className` prop to the component wrapper", () => {
-  render(<Profile data-role="profile" className="custom-class" />);
-
-  const profile = screen.getByTestId("profile");
-  expect(profile).toHaveClass("custom-class");
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'Profile' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
 });

--- a/src/components/settings-row/settings-row.component.tsx
+++ b/src/components/settings-row/settings-row.component.tsx
@@ -3,15 +3,12 @@ import { MarginProps } from "styled-system";
 import Heading, { HeadingType } from "../heading";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import { filterStyledSystemMarginProps } from "../../style/utils";
-import Logger from "../../__internal__/utils/logger";
 
 import {
   StyledSettingsRow,
   StyledSettingsRowHeader,
   StyledSettingsRowInput,
 } from "./settings-row.style";
-
-let deprecatedClassNameWarningShown = false;
 
 export interface SettingsRowProps extends MarginProps {
   /**  A title for this group of settings. */
@@ -24,7 +21,11 @@ export interface SettingsRowProps extends MarginProps {
   description?: React.ReactNode;
   /** Shows a divider below the component. */
   divider?: boolean;
-  /**  The CSS classes to apply to the component. */
+  /**
+   * @private
+   * @internal
+   * @ignore
+   * Sets className for component. INTERNAL USE ONLY. */
   className?: string;
 }
 
@@ -34,16 +35,8 @@ export const SettingsRow = ({
   children,
   description,
   divider = true,
-  className,
   ...rest
 }: SettingsRowProps) => {
-  if (!deprecatedClassNameWarningShown && className) {
-    Logger.deprecate(
-      "The 'className' prop has been deprecated and will soon be removed from the 'SettingsRow' component.",
-    );
-    deprecatedClassNameWarningShown = true;
-  }
-
   const heading = () => {
     if (!title) return null;
 
@@ -60,7 +53,6 @@ export const SettingsRow = ({
 
   return (
     <StyledSettingsRow
-      className={className}
       hasDivider={divider}
       data-role="settings-row"
       {...tagComponent("settings-row", rest)}

--- a/src/components/settings-row/settings-row.pw.tsx
+++ b/src/components/settings-row/settings-row.pw.tsx
@@ -13,10 +13,7 @@ import {
 } from "../../../playwright/components/settings-row/index";
 import { CHARACTERS } from "../../../playwright/support/constants";
 import { HeadingType } from "../heading";
-import {
-  checkAccessibility,
-  containsClass,
-} from "../../../playwright/support/helper";
+import { checkAccessibility } from "../../../playwright/support/helper";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const headingType: HeadingType[] = ["h1", "h2", "h3", "h4", "h5"];
@@ -115,17 +112,6 @@ test.describe("should check SettingsRow component properties", () => {
           "30px",
         );
       }
-    });
-  });
-
-  testData.forEach((characterVals) => {
-    test(`should check ${characterVals} as className for SettingsRow component`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<SettingsRowDefault className={characterVals} />);
-
-      await containsClass(settingsRowPreview(page), characterVals);
     });
   });
 

--- a/src/components/settings-row/settings-row.test.tsx
+++ b/src/components/settings-row/settings-row.test.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { HeadingType } from "../heading";
 import SettingsRow from ".";
-import Logger from "../../__internal__/utils/logger";
 
 test("renders with children", () => {
   render(<SettingsRow>hello world</SettingsRow>);
@@ -73,18 +72,4 @@ test("renders a divider when the `divider` prop is passed", () => {
     "1px solid var(--colorsUtilityMajor050)",
   );
   expect(settingsRow).toHaveStyleRule("padding-bottom", "30px");
-});
-
-test("throws a deprecation warning if the 'className' prop is set", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(<SettingsRow className="foo" />);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'SettingsRow' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
 });

--- a/src/components/simple-color-picker/simple-color-picker.component.tsx
+++ b/src/components/simple-color-picker/simple-color-picker.component.tsx
@@ -3,7 +3,6 @@ import React, {
   useState,
   useRef,
   useMemo,
-  useEffect,
   RefAttributes,
   useImperativeHandle,
 } from "react";
@@ -23,15 +22,12 @@ import { ValidationProps } from "../../__internal__/validations";
 import Logger from "../../__internal__/utils/logger";
 
 let deprecateUncontrolledWarnTriggered = false;
-const isBlurBlockedDeprecateWarnTriggered = false;
 
 export interface SimpleColorPickerProps extends ValidationProps, MarginProps {
   /** The SimpleColor components to be rendered in the group */
   children?: React.ReactNode;
   /** prop that represents childWidth */
   childWidth?: string | number;
-  /** Should the onBlur callback prop be initially blocked? */
-  isBlurBlocked?: boolean;
   /** The content for the Legend */
   legend: string;
   /** prop that sets max-width in css */
@@ -72,7 +68,6 @@ export const SimpleColorPicker = React.forwardRef<
     onBlur,
     onKeyDown,
     value,
-    isBlurBlocked = false,
     maxWidth = 300,
     childWidth = 58,
     validationOnLegend,
@@ -112,7 +107,6 @@ export const SimpleColorPicker = React.forwardRef<
   );
 
   const internalRef = useRef<HTMLDivElement | null>(null);
-  const [blurBlocked, setIsBlurBlocked] = useState(isBlurBlocked);
   const [focusedElement, setFocusedElement] = useState<EventTarget | null>(
     null,
   );
@@ -239,25 +233,6 @@ export const SimpleColorPicker = React.forwardRef<
     [onKeyDown, navigationGrid, getElementPosition],
   );
 
-  const handleClickOutside = (ev: MouseEvent | KeyboardEvent) => {
-    if (
-      internalRef.current &&
-      ev.target &&
-      !internalRef.current.contains(ev.target as Node)
-    ) {
-      setIsBlurBlocked(false);
-    }
-  };
-
-  useEffect(() => {
-    document.addEventListener("mousedown", handleClickOutside);
-    document.addEventListener("keydown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleClickOutside);
-    };
-  });
-
   const handleOnBlur = (ev: React.FocusEvent<HTMLInputElement>) => {
     ev.preventDefault();
 
@@ -266,15 +241,13 @@ export const SimpleColorPicker = React.forwardRef<
         (colorRef) => colorRef === document.activeElement,
       );
       /* istanbul ignore else */
-      if (onBlur && hasBlurred && !blurBlocked) {
+      if (onBlur && hasBlurred) {
         onBlur(ev);
       }
     }, 5);
   };
 
   const handleOnMouseDown = (ev: React.MouseEvent<HTMLElement>) => {
-    setIsBlurBlocked(true);
-
     // If the mousedown event occurred on the currently-focused <SimpleColor>
     if (focusedElement !== null && focusedElement === ev.target) {
       ev.preventDefault();
@@ -282,12 +255,10 @@ export const SimpleColorPicker = React.forwardRef<
       // If a different <SimpleColor> is currently focused
     } else if (focusedElement !== null) {
       ev.preventDefault();
-      setIsBlurBlocked(false);
       setFocusedElement(ev.target);
 
       // If no <SimpleColor> is currently focused
     } else {
-      setIsBlurBlocked(true);
       setFocusedElement(ev.target);
     }
   };
@@ -302,13 +273,6 @@ export const SimpleColorPicker = React.forwardRef<
     deprecateUncontrolledWarnTriggered = true;
     Logger.deprecate(
       "Uncontrolled behaviour in `Simple Color Picker` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-    );
-  }
-
-  if (!isBlurBlockedDeprecateWarnTriggered && isBlurBlocked) {
-    deprecateUncontrolledWarnTriggered = true;
-    Logger.deprecate(
-      `The 'isBlurBlocked' prop in ${SimpleColorPicker.displayName} is deprecated and support will soon be removed.`,
     );
   }
 

--- a/src/components/simple-color-picker/simple-color-picker.pw.tsx
+++ b/src/components/simple-color-picker/simple-color-picker.pw.tsx
@@ -14,7 +14,6 @@ import simpleColorPickerLegend from "../../../playwright/components/simple-color
 import { CHARACTERS, VALIDATION } from "../../../playwright/support/constants";
 import {
   checkAccessibility,
-  containsClass,
   getStyle,
   verifyRequiredAsteriskForLegend,
 } from "../../../playwright/support/helper";
@@ -370,15 +369,6 @@ test.describe("Check functionality for SimpleColor component", () => {
     );
   });
 
-  test("should render with className prop", async ({ mount, page }) => {
-    await mount(<SimpleColorCustom className={testPropValue} />);
-
-    await containsClass(
-      simpleColorPickerInput(page, 0).locator(".."),
-      testPropValue,
-    );
-  });
-
   [true, false].forEach((isChecked) => {
     test(`should render with checked as ${isChecked}`, async ({
       mount,
@@ -539,14 +529,5 @@ test.describe("Check accessibility for SimpleColorPicker component", () => {
 
       await checkAccessibility(page);
     });
-  });
-
-  test("should check accessibility with className prop", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SimpleColorCustom className={testPropValue} />);
-
-    await checkAccessibility(page);
   });
 });

--- a/src/components/simple-color-picker/simple-color-picker.test.tsx
+++ b/src/components/simple-color-picker/simple-color-picker.test.tsx
@@ -470,24 +470,6 @@ test("empty children are accepted without error", () => {
   }).not.toThrow();
 });
 
-test("should display deprecation warning once when the `isBlurBlocked` prop is `true`", () => {
-  const loggerSpy = jest.spyOn(Logger, "deprecate");
-  render(
-    <SimpleColorPicker
-      isBlurBlocked
-      legend="SimpleColorPicker Legend"
-      name="test"
-    />,
-  );
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'isBlurBlocked' prop in SimpleColorPicker is deprecated and support will soon be removed.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockClear();
-});
-
 // for coverage only (validation styles covered by Playwright)
 test.each(["error", "warning", "info"])(
   "renders validation icon when `%s` prop is passed as string and `validationOnLegend` is `true`",

--- a/src/components/simple-color-picker/simple-color/simple-color.component.tsx
+++ b/src/components/simple-color-picker/simple-color/simple-color.component.tsx
@@ -8,9 +8,6 @@ import {
   StyledTickIcon,
   StyledSimpleColorInput,
 } from "./simple-color.style";
-import Logger from "../../../__internal__/utils/logger";
-
-let deprecatedClassNameWarningShown = false;
 
 export interface SimpleColorProps {
   /** the value of the color that is represented by this SimpleColor */
@@ -31,19 +28,16 @@ export interface SimpleColorProps {
   checked?: boolean;
   /** determines if this color option is selected or unselected when component is used as uncontrolled */
   defaultChecked?: boolean;
-  /** [Legacy] Custom classname */
+  /**
+   * @private
+   * @ignore
+   * @internal
+   * Sets className for component. INTERNAL USE ONLY. */
   className?: string;
 }
 
 export const SimpleColor = React.forwardRef<HTMLInputElement, SimpleColorProps>(
   (props: SimpleColorProps, ref) => {
-    if (!deprecatedClassNameWarningShown && props.className) {
-      Logger.deprecate(
-        "The 'className' prop has been deprecated and will soon be removed from the 'SimpleColor' component.",
-      );
-      deprecatedClassNameWarningShown = true;
-    }
-
     const {
       onChange,
       onBlur,
@@ -51,9 +45,9 @@ export const SimpleColor = React.forwardRef<HTMLInputElement, SimpleColorProps>(
       value,
       name,
       checked = false,
-      className,
       id,
       defaultChecked,
+      className,
       ...rest
     } = props;
 

--- a/src/components/simple-color-picker/simple-color/simple-color.test.tsx
+++ b/src/components/simple-color-picker/simple-color/simple-color.test.tsx
@@ -3,7 +3,6 @@ import { render, screen } from "@testing-library/react";
 
 import SimpleColor from "./simple-color.component";
 import guid from "../../../__internal__/utils/helpers/guid";
-import Logger from "../../../__internal__/utils/logger";
 
 const mockedGuid = "guid-12345";
 jest.mock("../../../__internal__/utils/helpers/guid");
@@ -60,18 +59,4 @@ test("assigns a guid as id to the input element when the `id` prop is not passed
   render(<SimpleColor value="#0073C2" />);
 
   expect(screen.getByRole("radio")).toHaveAttribute("id", mockedGuid);
-});
-
-test("throws a deprecation warning if the 'className' prop is set", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(<SimpleColor value="#0073C2" className="foo" />);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'SimpleColor' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
 });

--- a/src/components/tabs/tab/tab.component.tsx
+++ b/src/components/tabs/tab/tab.component.tsx
@@ -3,16 +3,11 @@ import { PaddingProps } from "styled-system";
 import StyledTab from "./tab.style";
 import tagComponent from "../../../__internal__/utils/helpers/tags/tags";
 import TabContext from "./__internal__/tab.context";
-import Logger from "../../../__internal__/utils/logger";
-
-let deprecatedClassNameWarningShown = false;
 
 export interface TabProps extends PaddingProps {
   title?: string;
   /** A unique ID to identify this specific tab. */
   tabId: string;
-  /** @ignore @private */
-  className?: string;
   /** The child elements of Tab component. */
   children?: React.ReactNode;
   /** @ignore @private Boolean indicating selected state of Tab. */
@@ -55,7 +50,6 @@ export interface TabProps extends PaddingProps {
 
 export const Tab = ({
   ariaLabelledby,
-  className,
   children,
   isTabSelected,
   position = "top",
@@ -73,13 +67,6 @@ export const Tab = ({
   titleProps,
   ...rest
 }: TabProps) => {
-  if (!deprecatedClassNameWarningShown && className) {
-    Logger.deprecate(
-      "The 'className' prop has been deprecated and will soon be removed from the 'Tab' component.",
-    );
-    deprecatedClassNameWarningShown = true;
-  }
-
   const [tabErrors, setTabErrors] = useState<Record<string, string>>({});
   const [tabWarnings, setTabWarnings] = useState<Record<string, string>>({});
   const [tabInfos, setTabInfos] = useState<Record<string, string>>({});
@@ -123,7 +110,6 @@ export const Tab = ({
   return (
     <TabContext.Provider value={{ setError, setWarning, setInfo }}>
       <StyledTab
-        className={className}
         role={role}
         isTabSelected={isTabSelected}
         aria-labelledby={ariaLabelledby}

--- a/src/components/tabs/tab/tab.test.tsx
+++ b/src/components/tabs/tab/tab.test.tsx
@@ -4,17 +4,6 @@ import Tab from ".";
 import Textbox from "../../textbox";
 import StyledTab from "./tab.style";
 import { testStyledSystemPadding } from "../../../__spec_helper__/__internal__/test-utils";
-import Logger from "../../../__internal__/utils/logger";
-
-let loggerSpy: jest.SpyInstance;
-
-beforeEach(() => {
-  loggerSpy = jest.spyOn(Logger, "deprecate").mockImplementation(() => {});
-});
-
-afterEach(() => {
-  loggerSpy.mockRestore();
-});
 
 testStyledSystemPadding(
   (props) => (
@@ -66,24 +55,6 @@ test("renders its children correctly", () => {
   render(<Tab tabId="foo">tab content</Tab>);
 
   expect(screen.getByText("tab content")).toBeInTheDocument();
-});
-
-test("passes the `className` prop to the element", () => {
-  render(
-    <Tab tabId="foo" className="foo-class bar-class">
-      tab content
-    </Tab>,
-  );
-
-  expect(screen.getByRole("tabpanel", { hidden: true })).toHaveClass(
-    "foo-class",
-    "bar-class",
-  );
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'Tab' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
 });
 
 test("can be given a custom role via the `role` prop", () => {

--- a/src/components/tabs/tabs.component.tsx
+++ b/src/components/tabs/tabs.component.tsx
@@ -18,13 +18,8 @@ import StyledTabs from "./tabs.style";
 import TabsHeader from "./__internal__/tabs-header";
 import TabTitle from "./__internal__/tab-title";
 import DrawerSidebarContext from "../drawer/__internal__/drawer-sidebar.context";
-import Logger from "../../__internal__/utils/logger";
-
-let deprecatedClassNameWarningShown = false;
 
 export interface TabsProps extends MarginProps {
-  /** @ignore @private */
-  className?: string;
   /** Prevent rendering of hidden tabs, by default this is set to true and therefore all tabs will be rendered */
   renderHiddenTabs?: boolean;
   /** Allows manual control over the currently selected tab. */
@@ -69,7 +64,6 @@ export interface TabsProps extends MarginProps {
 
 const Tabs = ({
   align = "left",
-  className,
   children,
   onTabChange,
   selectedTabId,
@@ -84,13 +78,6 @@ const Tabs = ({
   showValidationsSummary,
   ...rest
 }: TabsProps) => {
-  if (!deprecatedClassNameWarningShown && className) {
-    Logger.deprecate(
-      "The 'className' prop has been deprecated and will soon be removed from the 'Tabs' component.",
-    );
-    deprecatedClassNameWarningShown = true;
-  }
-
   if (position !== "left" && headerWidth !== undefined) {
     // eslint-disable-next-line no-console
     console.error(
@@ -409,7 +396,6 @@ const Tabs = ({
 
   return (
     <StyledTabs
-      className={className}
       position={isInSidebar ? "left" : position}
       data-role="tabs"
       {...tagComponent("tabs", rest)}

--- a/src/components/tabs/tabs.test.tsx
+++ b/src/components/tabs/tabs.test.tsx
@@ -94,24 +94,6 @@ test("should throw an error if rendered with `headerWidth` prop and `position` p
   consoleSpy.mockRestore();
 });
 
-test("passes the `className` prop down to the element", () => {
-  render(
-    <Tabs className="custom-class-1 custom-class-2">
-      <Tab tabId="foo" />
-    </Tabs>,
-  );
-
-  expect(screen.getByTestId("tabs")).toHaveClass(
-    "custom-class-1",
-    "custom-class-2",
-  );
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'Tabs' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-});
-
 test("the `selectedTabId` prop determines which child `Tab` is displayed", () => {
   render(
     <Tabs selectedTabId="tab-2">

--- a/src/components/tile-select/tile-select.component.tsx
+++ b/src/components/tile-select/tile-select.component.tsx
@@ -7,7 +7,6 @@ import createGuid from "../../__internal__/utils/helpers/guid";
 import Button from "../button";
 import Box from "../box";
 import Accordion from "./__internal__/accordion";
-import Logger from "../../__internal__/utils/logger";
 
 import {
   StyledTileSelectContainer,
@@ -24,8 +23,6 @@ import {
   StyledAccordionFooterWrapper,
 } from "./tile-select.style";
 import { filterStyledSystemMarginProps } from "../../style/utils";
-
-let deprecatedClassNameWarningShown = false;
 
 const checkPropTypeIsNode = (prop: unknown): boolean =>
   typeof prop !== "string";
@@ -66,8 +63,6 @@ export interface TileSelectProps extends MarginProps {
   onFocus?: (ev: React.FocusEvent<HTMLInputElement>) => void;
   /** determines if this tile is selected or unselected */
   checked?: boolean;
-  /** Custom class name passed to the root element of TileSelect */
-  className?: string;
   /** Type of the TileSelect input */
   type?: "radio" | "checkbox";
   /** Render prop that allows overriding the default action button. */
@@ -97,7 +92,6 @@ const TileSelect = React.forwardRef<HTMLInputElement, TileSelectProps>(
       value,
       name,
       checked = false,
-      className,
       disabled,
       title,
       subtitle,
@@ -117,13 +111,6 @@ const TileSelect = React.forwardRef<HTMLInputElement, TileSelectProps>(
     }: TileSelectProps,
     ref,
   ) => {
-    if (!deprecatedClassNameWarningShown && className) {
-      Logger.deprecate(
-        "The 'className' prop has been deprecated and will soon be removed from the 'TileSelect' component.",
-      );
-      deprecatedClassNameWarningShown = true;
-    }
-
     const l = useLocale();
     const [hasFocus, setHasFocus] = useState(false);
     const handleDeselect = () =>
@@ -169,7 +156,6 @@ const TileSelect = React.forwardRef<HTMLInputElement, TileSelectProps>(
     return (
       <StyledTileSelectContainer
         checked={checked}
-        className={className}
         disabled={disabled}
         {...tagComponent("tile-select", rest)}
         {...filterStyledSystemMarginProps(rest)}

--- a/src/components/tile-select/tile-select.pw.tsx
+++ b/src/components/tile-select/tile-select.pw.tsx
@@ -6,10 +6,7 @@ import {
   getElement,
   getDataElementByValue,
 } from "../../../playwright/components";
-import {
-  checkAccessibility,
-  containsClass,
-} from "../../../playwright/support/helper";
+import { checkAccessibility } from "../../../playwright/support/helper";
 import {
   TileSelectComponent,
   MultiTileSelectGroupComponent,
@@ -26,7 +23,6 @@ import {
   WithCustomSpacing,
 } from "./components.test-pw";
 import {
-  tileSelectDataComponent,
   titleElement,
   subtitleElement,
   descElement,
@@ -185,15 +181,6 @@ test.describe("check props for TileSelect component", () => {
     await mount(<TileSelect checked={false} />);
 
     await expect(inputElement(page)).not.toBeChecked();
-  });
-
-  test("should render TileSelect component with className", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TileSelectComponent className="tile-select-classname" />);
-
-    await containsClass(tileSelectDataComponent(page), "tile-select-classname");
   });
 
   test("should check footer prop", async ({ mount, page }) => {

--- a/src/components/tile-select/tile-select.test.tsx
+++ b/src/components/tile-select/tile-select.test.tsx
@@ -9,7 +9,6 @@ import TileSelectGroup, {
 } from "./tile-select-group/tile-select-group.component";
 import Button from "../button";
 import Icon from "../icon";
-import Logger from "../../__internal__/utils/logger";
 
 testStyledSystemMargin(
   (props) => <TileSelect data-role="tile-select-wrapper" {...props} />,
@@ -373,18 +372,4 @@ test("Accordion footer renders the node passed in via the accordionContent prop 
     "rotate(-90deg)",
     { modifier: 'span[data-element="chevron_down"]' },
   );
-});
-
-test("throws a deprecation warning if the 'className' prop is set", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(<TileSelect className="foo" />);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'TileSelect' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
 });

--- a/src/components/toast/toast.component.tsx
+++ b/src/components/toast/toast.component.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
-import Logger from "../../__internal__/utils/logger";
 
 import Icon from "../icon";
 import tagComponent, {
@@ -19,8 +18,6 @@ import useLocale from "../../hooks/__internal__/useLocale";
 import useModalManager from "../../hooks/__internal__/useModalManager";
 import guid from "../../__internal__/utils/helpers/guid";
 import Typography from "../typography";
-
-let deprecatedClassNameWarningShown = false;
 
 type ToastVariants =
   | "error"
@@ -53,8 +50,6 @@ export interface ToastProps {
   children: React.ReactNode;
   /** Sets Toast variant */
   variant?: ToastVariants;
-  /** Custom className */
-  className?: string;
   /** Custom id  */
   id?: string;
   /** Component name */
@@ -86,7 +81,6 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
       align = "center",
       alignY,
       children,
-      className,
       id,
       maxWidth,
       onDismiss,
@@ -100,13 +94,6 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
     }: ToastProps,
     ref,
   ) => {
-    if (!deprecatedClassNameWarningShown && className) {
-      Logger.deprecate(
-        "The 'className' prop has been deprecated and will soon be removed from the 'Toast' component.",
-      );
-      deprecatedClassNameWarningShown = true;
-    }
-
     const isNotice = variant === "notice";
     const isNotification = variant === "notification";
     const locale = useLocale();
@@ -231,7 +218,6 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
             alignY={alignY}
             isNotice={isNotice}
             isNotification={isNotification}
-            className={className}
             {...tagComponent(restProps["data-component"] || "toast", restProps)}
             variant={toastVariant}
             id={id}

--- a/src/components/toast/toast.pw.tsx
+++ b/src/components/toast/toast.pw.tsx
@@ -19,10 +19,7 @@ import {
   getDataComponentByValue,
   button,
 } from "../../../playwright/components";
-import {
-  checkAccessibility,
-  containsClass,
-} from "../../../playwright/support/helper";
+import { checkAccessibility } from "../../../playwright/support/helper";
 import { closeIconButton } from "../../../playwright/components/index";
 import { CHARACTERS } from "../../../playwright/support/constants";
 import { PORTAL } from "../../../playwright/components/locators";
@@ -70,12 +67,6 @@ test.describe("Toast component", () => {
     await mount(<ToastComponent disableAutoFocus />);
 
     await expect(toastComponent(page)).not.toBeFocused();
-  });
-
-  test("should render with className prop", async ({ mount, page }) => {
-    await mount(<ToastComponent className={testData} />);
-
-    await containsClass(toastComponent(page), testData);
   });
 
   test("should render with id prop", async ({ mount, page }) => {

--- a/src/components/toast/toast.test.tsx
+++ b/src/components/toast/toast.test.tsx
@@ -337,24 +337,6 @@ test("should render close button when `onDismiss` prop is set", () => {
   expect(closeButton).toBeVisible();
 });
 
-test("should render with any custom classes passed via the `className` prop", () => {
-  render(
-    <Toast open data-role="toast" className="exampleClass">
-      foobar
-    </Toast>,
-  );
-
-  expect(screen.getByTestId("toast")).toHaveClass("exampleClass");
-
-  // When using Toast messages the logger spy will be called twice: once for the
-  // Toast component and once for the containing Portal component. Because of this,
-  // only the first call to the logger spy is checked.
-  expect(loggerSpy).toHaveBeenNthCalledWith(
-    1,
-    "The 'className' prop has been deprecated and will soon be removed from the 'Toast' component.",
-  );
-});
-
 test("should render with provided custom id passed via `id` prop", () => {
   render(
     <Toast open data-role="toast" id="exampleId">

--- a/src/components/typography/list.component.tsx
+++ b/src/components/typography/list.component.tsx
@@ -1,20 +1,12 @@
 import React, { useContext } from "react";
-import Typography, {
-  TypographyProps,
-  VariantTypes,
-} from "./typography.component";
+import Typography, { TypographyProps } from "./typography.component";
 import ListContext, { ListContextProps } from "./list.context";
-import Logger from "../../__internal__/utils/logger";
-
-let childVariantDeprecationWarning = false;
 
 export interface ListProps extends TypographyProps {
   children?: React.ReactNode;
 }
 
-export interface ListItemProps extends TypographyProps {
-  /** (Deprecated) The visual style to apply to the component */
-  variant?: VariantTypes;
+export interface ListItemProps extends Omit<ListProps, "variant"> {
   children?: React.ReactNode;
 }
 
@@ -37,18 +29,11 @@ const List = ({ children, as = "ul", variant = "p", ...props }: ListProps) => (
 );
 
 const ListItem = ({ children, ...props }: ListItemProps) => {
-  if (props.variant && !childVariantDeprecationWarning) {
-    Logger.deprecate(
-      "The use of `variant` on `ListItem` is deprecated. Please set it via `List` instead.",
-    );
-    childVariantDeprecationWarning = true;
-  }
-
   const { variant: parentListVariant } =
     useContext<ListContextProps>(ListContext);
 
   return (
-    <Typography as="li" variant={parentListVariant} m="0 0 8px 16px" {...props}>
+    <Typography as="li" m="0 0 8px 16px" {...props} variant={parentListVariant}>
       {children}
     </Typography>
   );

--- a/src/components/typography/typography.component.tsx
+++ b/src/components/typography/typography.component.tsx
@@ -6,9 +6,6 @@ import {
   filterStyledSystemPaddingProps,
 } from "../../style/utils";
 import StyledTypography from "./typography.style";
-import Logger from "../../__internal__/utils/logger";
-
-let deprecatedClassNameWarningShown = false;
 
 export const VARIANT_TYPES = [
   "h1-large",
@@ -79,8 +76,6 @@ export interface TypographyProps extends SpaceProps, TagProps {
   bg?: string;
   /** Override the opacity value */
   opacity?: string | number;
-  /** @private @ignore */
-  className?: string;
   /** Set whether it will be visually hidden
    * NOTE: This is for screen readers only and will make a lot of the other props redundant */
   screenReaderOnly?: boolean;
@@ -92,6 +87,12 @@ export interface TypographyProps extends SpaceProps, TagProps {
   isDisabled?: boolean;
   /** @private @ignore Set whether the component should be recognised by assistive technologies */
   "aria-hidden"?: "true" | "false";
+  /**
+   * @private
+   * @internal
+   * @ignore
+   * Sets className for component. INTERNAL USE ONLY. */
+  className?: string;
 }
 
 export const Typography = ({
@@ -117,18 +118,12 @@ export const Typography = ({
   bg,
   opacity,
   children,
-  className,
   screenReaderOnly,
   isDisabled,
   "aria-hidden": ariaHidden,
+  className,
   ...rest
 }: TypographyProps) => {
-  if (!deprecatedClassNameWarningShown && className) {
-    Logger.deprecate(
-      "The 'className' prop has been deprecated and will soon be removed from the 'Typography' component.",
-    );
-    deprecatedClassNameWarningShown = true;
-  }
   return (
     <StyledTypography
       variant={variant}
@@ -151,10 +146,10 @@ export const Typography = ({
       backgroundColor={backgroundColor}
       bg={bg}
       opacity={opacity}
-      className={className}
       screenReaderOnly={screenReaderOnly}
       isDisabled={isDisabled}
       aria-hidden={ariaHidden}
+      className={className}
       {...tagComponent(dataComponent, rest)}
       {...filterStyledSystemMarginProps(rest)}
       {...filterStyledSystemPaddingProps(rest)}

--- a/src/components/typography/typography.stories.tsx
+++ b/src/components/typography/typography.stories.tsx
@@ -188,13 +188,6 @@ export const ListItemInheritance: Story = () => (
       <ListItem>item 2</ListItem>
       <ListItem>item 3</ListItem>
     </List>
-
-    <Typography>H1</Typography>
-    <List variant="h1">
-      <ListItem>item 1</ListItem>
-      <ListItem>item 2</ListItem>
-      <ListItem>item 3</ListItem>
-    </List>
   </>
 );
 ListItemInheritance.storyName = "List Item Inheritance";

--- a/src/components/typography/typography.test.tsx
+++ b/src/components/typography/typography.test.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import Typography, { List, ListItem } from ".";
 import { testStyledSystemSpacing } from "../../__spec_helper__/__internal__/test-utils";
-import Logger from "../../__internal__/utils/logger";
 
 test("should render with variant as 'p' by default", () => {
   render(<Typography>Test</Typography>);
@@ -293,24 +292,6 @@ testStyledSystemSpacing(
   () => screen.getByText("Test"),
 );
 
-test("throws a deprecation warning if the 'className' prop is set", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(
-    <Typography variant="b" display="block" className="foo">
-      bar
-    </Typography>,
-  );
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The 'className' prop has been deprecated and will soon be removed from the 'Typography' component.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
-});
-
 describe("Lists", () => {
   test("should render List with variant as 'ul' by default and listStyleType set to 'square", () => {
     render(
@@ -355,25 +336,5 @@ describe("Lists", () => {
         "line-height": "24px",
       });
     });
-  });
-
-  test("throws a deprecation warning if the 'variant' prop is set on `ListItem`", () => {
-    const loggerSpy = jest
-      .spyOn(Logger, "deprecate")
-      .mockImplementation(() => {});
-    render(
-      <List>
-        <ListItem variant="b">List Item 1</ListItem>
-        <ListItem variant="b">List Item 2</ListItem>
-        <ListItem variant="b">List Item 3</ListItem>
-      </List>,
-    );
-
-    expect(loggerSpy).toHaveBeenCalledWith(
-      "The use of `variant` on `ListItem` is deprecated. Please set it via `List` instead.",
-    );
-    expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-    loggerSpy.mockRestore();
   });
 });

--- a/src/components/vertical-menu/vertical-menu-full-screen/vertical-menu-full-screen.test.tsx
+++ b/src/components/vertical-menu/vertical-menu-full-screen/vertical-menu-full-screen.test.tsx
@@ -5,10 +5,6 @@ import userEvent from "@testing-library/user-event";
 import Portal from "../../portal";
 import FocusTrap from "../../../__internal__/focus-trap/focus-trap.component";
 import { VerticalMenuFullScreen, VerticalMenuItem } from "..";
-import Logger from "../../../__internal__/utils/logger";
-
-// mock Logger.deprecate so that no console warnings occur while running the tests
-const loggerSpy = jest.spyOn(Logger, "deprecate");
 
 jest.mock("../../portal", () =>
   jest.fn(({ children }) => <div>{children}</div>),
@@ -19,14 +15,6 @@ jest.mock("../../../__internal__/focus-trap/focus-trap.component", () =>
 );
 
 describe("VerticalMenuFullScreen", () => {
-  beforeAll(() => {
-    loggerSpy.mockImplementation(() => {});
-  });
-
-  afterAll(() => {
-    loggerSpy.mockRestore();
-  });
-
   it("should accepts aria-label prop", () => {
     render(
       <VerticalMenuFullScreen isOpen onClose={() => {}} aria-label="test">

--- a/src/components/vertical-menu/vertical-menu-item/vertical-menu-item.test.tsx
+++ b/src/components/vertical-menu/vertical-menu-item/vertical-menu-item.test.tsx
@@ -7,10 +7,6 @@ import sageTheme from "../../../style/themes/sage";
 import { testStyledSystemPadding } from "../../../__spec_helper__/__internal__/test-utils";
 import Icon from "../../icon";
 import { VerticalMenuItem, VerticalMenuFullScreen } from "..";
-import Logger from "../../../__internal__/utils/logger";
-
-// mock Logger.deprecate so that no console warnings occur while running the tests
-const loggerSpy = jest.spyOn(Logger, "deprecate");
 
 jest.mock("../../icon", () => {
   return jest.fn(() => null);
@@ -19,14 +15,6 @@ jest.mock("../../icon", () => {
 const IconMock = Icon as jest.MockedFunction<typeof Icon>;
 
 describe("VerticalMenuItem", () => {
-  beforeAll(() => {
-    loggerSpy.mockImplementation(() => {});
-  });
-
-  afterAll(() => {
-    loggerSpy.mockRestore();
-  });
-
   testStyledSystemPadding(
     (props) => (
       <ThemeProvider theme={sageTheme}>

--- a/src/components/vertical-menu/vertical-menu.test.tsx
+++ b/src/components/vertical-menu/vertical-menu.test.tsx
@@ -8,20 +8,8 @@ import {
   VerticalMenuItem,
   VerticalMenuTrigger,
 } from ".";
-import Logger from "../../__internal__/utils/logger";
-
-// mock Logger.deprecate so that no console warnings occur while running the tests
-const loggerSpy = jest.spyOn(Logger, "deprecate");
 
 describe("VerticalMenu", () => {
-  beforeAll(() => {
-    loggerSpy.mockImplementation(() => {});
-  });
-
-  afterAll(() => {
-    loggerSpy.mockRestore();
-  });
-
   it("should accept aria-label prop", () => {
     render(
       <VerticalMenu aria-label="test">


### PR DESCRIPTION
The following properties have been removed from the listed components. Ensure any components
in the list below do not contain the associated properties.

BREAKING CHANGE:
- The `className` property has been removed from all components.
- Accordion: `scheme` and `buttonHeading`
- Box: `tabIndex`
- ButtonToggle: `grouped`
- Decimal: `onKeyPress`
- Icon: 'extra-small' variant
- Portrait: `gravatar`
- SimpleColorPicker: `isBlurBlocked`
- ListItem: `variant` (now inherits from parent List component)

### Current behaviour

Some of our components still support className as a prop, which would allow consumers to override the component's CSS styling, which is strongly discouraged for maintenance reasons.

### Checklist

- [x] Commits follow our style guide
- [x] Unit tests added or updated if required
- [x] Storybook added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Ensure that all documentation is free of reference to `className`, ensure that passing custom class names to affected components does not change their styling. 
