### PR TITLE
FE-7010 className prop: deprecation warning

### DIFF
--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.component.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.component.tsx
@@ -15,6 +15,7 @@ import { InputGroupBehaviour } from "../../../__internal__/input-behaviour";
 import Events from "../../../__internal__/utils/helpers/events";
 import NewValidationContext from "../../carbon-provider/__internal__/new-validation.context";
 import ButtonToggleGroupContext from "./__internal__/button-toggle-group.context";
+import Logger from "../../../__internal__/utils/logger";
 
 export interface ButtonToggleGroupProps extends MarginProps, TagProps {
   /** Unique id for the root element of the component */
@@ -61,6 +62,7 @@ export interface ButtonToggleGroupProps extends MarginProps, TagProps {
 }
 
 const BUTTON_TOGGLE_SELECTOR = '[data-element="button-toggle-button"]';
+let deprecatedClassNameWarningShown = false;
 
 const ButtonToggleGroup = ({
   children,
@@ -87,6 +89,13 @@ const ButtonToggleGroup = ({
   className,
   ...props
 }: ButtonToggleGroupProps) => {
+  if (!deprecatedClassNameWarningShown && className) {
+    Logger.deprecate(
+      "The 'className' prop has been deprecated and will soon be removed from the 'ButtonToggleGroup' component.",
+    );
+    deprecatedClassNameWarningShown = true;
+  }
+
   const hasCorrectItemStructure = useMemo(() => {
     const incorrectChild = React.Children.toArray(children).find(
       (child: React.ReactNode) => {

--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.test.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { ButtonToggle, ButtonToggleGroup } from "..";
 import CarbonProvider from "../../carbon-provider/carbon-provider.component";
 import { testStyledSystemMargin } from "../../../__spec_helper__/__internal__/test-utils";
+import Logger from "../../../__internal__/utils/logger";
 
 test("should render with provided children", () => {
   render(
@@ -372,3 +373,28 @@ testStyledSystemMargin(
   undefined,
   { modifier: "&&&" },
 );
+
+test("throws a deprecation warning if the 'className' prop is set", () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+  render(
+    <ButtonToggleGroup
+      id="button-toggle-group-id"
+      onChange={() => {}}
+      value="bar"
+      className="foo"
+    >
+      <ButtonToggle value="foo">Foo</ButtonToggle>
+      <ButtonToggle value="bar">Bar</ButtonToggle>
+      <ButtonToggle value="baz">Baz</ButtonToggle>
+    </ButtonToggleGroup>,
+  );
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'ButtonToggleGroup' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
+});

--- a/src/components/button/button.component.tsx
+++ b/src/components/button/button.component.tsx
@@ -15,6 +15,7 @@ import { TooltipPositions } from "../tooltip/tooltip.config";
 import ButtonBarContext from "../button-bar/__internal__/button-bar.context";
 import SplitButtonContext from "../split-button/__internal__/split-button.context";
 import BatchSelectionContext from "../batch-selection/__internal__/batch-selection.context";
+import Logger from "../../__internal__/utils/logger";
 
 export type ButtonTypes =
   | "primary"
@@ -92,6 +93,8 @@ export interface ButtonProps extends SpaceProps, TagProps {
    */
   className?: string;
 }
+
+let deprecatedClassNameWarningShown = false;
 
 interface RenderChildrenProps
   extends Pick<
@@ -214,6 +217,13 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     }: ButtonProps,
     ref,
   ) => {
+    if (!deprecatedClassNameWarningShown && rest.className) {
+      Logger.deprecate(
+        "The 'className' prop has been deprecated and will soon be removed from the 'Button' component.",
+      );
+      deprecatedClassNameWarningShown = true;
+    }
+
     const {
       buttonType: buttonTypeContext,
       size: sizeContext,

--- a/src/components/button/button.test.tsx
+++ b/src/components/button/button.test.tsx
@@ -3,6 +3,18 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Button from "./button.component";
 
+import Logger from "../../__internal__/utils/logger";
+
+let loggerSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  loggerSpy = jest.spyOn(Logger, "deprecate").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  loggerSpy.mockRestore();
+});
+
 test("renders with text children", () => {
   render(<Button>foo</Button>);
 
@@ -297,6 +309,10 @@ test("sets the 'className' attribute correctly when a custom value is passed to 
   const button = screen.getByRole("button", { name: "bar" });
 
   expect(button).toHaveClass("foo");
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'Button' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
 });
 
 test("calls onClick when an 'href' is passed and the space key is pressed", async () => {

--- a/src/components/detail/detail.component.tsx
+++ b/src/components/detail/detail.component.tsx
@@ -11,6 +11,7 @@ import {
   StyledDetailIcon,
   StyledDetailFootnote,
 } from "./detail.style";
+import Logger from "../../__internal__/utils/logger";
 
 export interface DetailProps extends MarginProps, TagProps {
   /** Custom className. */
@@ -23,34 +24,45 @@ export interface DetailProps extends MarginProps, TagProps {
   children?: React.ReactNode;
 }
 
+let deprecatedClassNameWarningShown = false;
+
 export const Detail = ({
   className,
   icon,
   footnote,
   children,
   ...rest
-}: DetailProps) => (
-  <StyledDetail
-    className={`carbon-detail ${className}`}
-    {...tagComponent("detail", rest)}
-    {...filterStyledSystemMarginProps(rest)}
-  >
-    {icon && <StyledDetailIcon type={icon} data-element="icon" />}
-    <StyledDetailContent data-element="detail-content" hasIcon={!!icon}>
-      {children}
-    </StyledDetailContent>
+}: DetailProps) => {
+  if (!deprecatedClassNameWarningShown && className) {
+    Logger.deprecate(
+      "The 'className' prop has been deprecated and will soon be removed from the 'Detail' component.",
+    );
+    deprecatedClassNameWarningShown = true;
+  }
 
-    {footnote && (
-      <StyledDetailFootnote
-        data-element="footnote"
-        data-role="footnote"
-        hasIcon={!!icon}
-      >
-        {footnote}
-      </StyledDetailFootnote>
-    )}
-  </StyledDetail>
-);
+  return (
+    <StyledDetail
+      className={`carbon-detail ${className}`}
+      {...tagComponent("detail", rest)}
+      {...filterStyledSystemMarginProps(rest)}
+    >
+      {icon && <StyledDetailIcon type={icon} data-element="icon" />}
+      <StyledDetailContent data-element="detail-content" hasIcon={!!icon}>
+        {children}
+      </StyledDetailContent>
+
+      {footnote && (
+        <StyledDetailFootnote
+          data-element="footnote"
+          data-role="footnote"
+          hasIcon={!!icon}
+        >
+          {footnote}
+        </StyledDetailFootnote>
+      )}
+    </StyledDetail>
+  );
+};
 
 Detail.displayName = "Detail";
 

--- a/src/components/detail/detail.test.tsx
+++ b/src/components/detail/detail.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, within } from "@testing-library/react";
 import Detail from ".";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
+import Logger from "../../__internal__/utils/logger";
 
 test("renders children", () => {
   render(<Detail>foo</Detail>);
@@ -59,3 +60,17 @@ testStyledSystemMargin(
   ),
   () => screen.getByTestId("detail"),
 );
+
+test("throws a deprecation warning if the 'className' prop is set", () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+  render(<Detail className="foo">bar</Detail>);
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'Detail' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
+});

--- a/src/components/dialog/dialog.component.tsx
+++ b/src/components/dialog/dialog.component.tsx
@@ -4,6 +4,7 @@ import createGuid from "../../__internal__/utils/helpers/guid";
 import Modal, { ModalProps } from "../modal";
 import Heading from "../heading";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
+import Logger from "../../__internal__/utils/logger";
 
 import {
   StyledDialog,
@@ -27,6 +28,8 @@ export interface ContentPaddingInterface {
   py?: PaddingValues;
   px?: PaddingValues;
 }
+
+let deprecatedClassNameWarningShown = false;
 
 export interface DialogProps extends ModalProps, TagProps {
   /** Custom class name  */
@@ -127,6 +130,13 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
     },
     ref,
   ) => {
+    if (!deprecatedClassNameWarningShown && className) {
+      Logger.deprecate(
+        "The 'className' prop has been deprecated and will soon be removed from the 'Dialog' component.",
+      );
+      deprecatedClassNameWarningShown = true;
+    }
+
     const locale = useLocale();
 
     const containerRef = useRef<HTMLDivElement>(null);

--- a/src/components/dialog/dialog.test.tsx
+++ b/src/components/dialog/dialog.test.tsx
@@ -9,9 +9,17 @@ import userEvent from "@testing-library/user-event";
 
 import CarbonProvider from "../carbon-provider";
 import Dialog, { DialogHandle, DialogProps } from ".";
+import Logger from "../../__internal__/utils/logger";
 
-beforeEach(() => jest.useFakeTimers());
+let loggerSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  loggerSpy = jest.spyOn(Logger, "deprecate").mockImplementation(() => {});
+  jest.useFakeTimers();
+});
+
 afterEach(() => {
+  loggerSpy.mockRestore();
   jest.runOnlyPendingTimers();
   jest.useRealTimers();
 });

--- a/src/components/help/help.component.tsx
+++ b/src/components/help/help.component.tsx
@@ -9,6 +9,9 @@ import { TooltipContext } from "../../__internal__/tooltip-provider";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { TooltipPositions } from "../tooltip/tooltip.config";
 import guid from "../../__internal__/utils/helpers/guid";
+import Logger from "../../__internal__/utils/logger";
+
+let deprecatedClassNameWarningShown = false;
 
 export interface HelpProps extends MarginProps {
   /** Overrides the default 'as' attribute of the Help component */
@@ -64,6 +67,13 @@ export const Help = ({
   type = "help",
   ...rest
 }: HelpProps): JSX.Element => {
+  if (!deprecatedClassNameWarningShown && className) {
+    Logger.deprecate(
+      "The 'className' prop has been deprecated and will soon be removed from the 'Help' component.",
+    );
+    deprecatedClassNameWarningShown = true;
+  }
+
   const defaultTooltipId = useRef(guid());
   const helpElement = useRef<HTMLDivElement>(null);
   const [isTooltipVisible, updateTooltipVisible] = useState(false);

--- a/src/components/help/help.test.tsx
+++ b/src/components/help/help.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Help from ".";
 import Icon from "../icon";
+import Logger from "../../__internal__/utils/logger";
 
 test("renders tooltip when help button is hovered and removes tooltip when unhovered", async () => {
   const user = userEvent.setup();
@@ -131,4 +132,22 @@ test("renders with provided `helpId` and `tooltipId`", async () => {
     "id",
     "bar",
   );
+});
+
+test("throws a deprecation warning if the 'className' prop is set", () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+  render(
+    <Help className="bar" helpId="foo" tooltipId="bar">
+      foo
+    </Help>,
+  );
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'Help' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
 });

--- a/src/components/inline-inputs/inline-inputs.component.tsx
+++ b/src/components/inline-inputs/inline-inputs.component.tsx
@@ -10,6 +10,9 @@ import StyledInlineInputs, {
 import FormSpacingProvider from "../../__internal__/form-spacing-provider";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
 import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
+import Logger from "../../__internal__/utils/logger";
+
+let deprecatedClassNameWarningShown = false;
 
 type GutterOptions =
   | "none"
@@ -74,6 +77,13 @@ const InlineInputs = ({
   isOptional,
   ...rest
 }: InlineInputsProps) => {
+  if (!deprecatedClassNameWarningShown && className) {
+    Logger.deprecate(
+      "The 'className' prop has been deprecated and will soon be removed from the 'InlineInputs' component.",
+    );
+    deprecatedClassNameWarningShown = true;
+  }
+
   const largeScreen = useIsAboveBreakpoint(adaptiveLabelBreakpoint);
   const ref = useRef<HTMLDivElement>(null);
   let inlineLabel: boolean | undefined = labelInline;

--- a/src/components/inline-inputs/inline-inputs.test.tsx
+++ b/src/components/inline-inputs/inline-inputs.test.tsx
@@ -6,6 +6,7 @@ import {
   mockMatchMedia,
   testStyledSystemMargin,
 } from "../../__spec_helper__/__internal__/test-utils";
+import Logger from "../../__internal__/utils/logger";
 
 test("renders single child", () => {
   render(
@@ -132,3 +133,21 @@ testStyledSystemMargin(
   (props) => <InlineInputs label="label" {...props} />,
   () => screen.getByTestId("inline-inputs"),
 );
+
+test("throws a deprecation warning if the 'className' prop is set", () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+  render(
+    <InlineInputs className="foo">
+      <Textbox onChange={() => {}} />
+    </InlineInputs>,
+  );
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'InlineInputs' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
+});

--- a/src/components/link/link.component.tsx
+++ b/src/components/link/link.component.tsx
@@ -6,6 +6,9 @@ import { StyledLink, StyledContent, StyledLinkProps } from "./link.style";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import useLocale from "../../hooks/__internal__/useLocale";
 import BatchSelectionContext from "../batch-selection/__internal__/batch-selection.context";
+import Logger from "../../__internal__/utils/logger";
+
+let deprecatedClassNameWarningShown = false;
 
 export interface LinkProps extends StyledLinkProps, React.AriaAttributes {
   /** An href for an anchor tag. */
@@ -82,6 +85,13 @@ export const Link = React.forwardRef<
     }: LinkProps,
     ref,
   ) => {
+    if (!deprecatedClassNameWarningShown && className) {
+      Logger.deprecate(
+        "The 'className' prop has been deprecated and will soon be removed from the 'Link' component.",
+      );
+      deprecatedClassNameWarningShown = true;
+    }
+
     const [hasFocus, setHasFocus] = useState(false);
     const l = useLocale();
     const { inMenu } = useContext(MenuContext);

--- a/src/components/link/link.test.tsx
+++ b/src/components/link/link.test.tsx
@@ -6,6 +6,7 @@ import userEvent from "@testing-library/user-event";
 
 import Link from "./link.component";
 import MenuContext from "../menu/__internal__/menu.context";
+import Logger from "../../__internal__/utils/logger";
 
 test("should render `Skip to main content` text inside of Link when `isSkipLink` prop is provided", () => {
   render(
@@ -540,4 +541,18 @@ describe("link display styling", () => {
 
     expect(linkElement).not.toHaveStyle(`display: inline-block`);
   });
+});
+
+test("throws a deprecation warning if the 'className' prop is set", () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+  render(<Link className="foo">bar</Link>);
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'Link' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
 });

--- a/src/components/menu/menu-item/menu-item.component.tsx
+++ b/src/components/menu/menu-item/menu-item.component.tsx
@@ -18,6 +18,9 @@ import { StyledMenuItem } from "../menu.style";
 import guid from "../../../__internal__/utils/helpers/guid";
 import { IconType } from "../../icon";
 import { TagProps } from "../../../__internal__/utils/helpers/tags";
+import Logger from "../../../__internal__/utils/logger";
+
+let deprecatedClassNameWarningShown = false;
 
 export type VariantType = "default" | "alternate";
 
@@ -62,7 +65,7 @@ interface MenuItemBaseProps
   onSubmenuOpen?: () => void;
   /** Callback triggered when submenu closes. Only valid with submenu prop */
   onSubmenuClose?: () => void;
-  /** 
+  /**
     @ignore @private
     private prop, used inside ScrollableBlock to ensure the MenuItem's color variant overrides the CSS
     for other MenuItems inside the block
@@ -121,6 +124,13 @@ export const MenuItem = ({
   "data-role": dataRole,
   ...rest
 }: MenuWithChildren | MenuWithIcon) => {
+  if (!deprecatedClassNameWarningShown && rest.className) {
+    Logger.deprecate(
+      "The 'className' prop has been deprecated and will soon be removed from the 'MenuItem' component.",
+    );
+    deprecatedClassNameWarningShown = true;
+  }
+
   invariant(
     icon || children,
     "Either prop `icon` must be defined or this node must have `children`.",

--- a/src/components/menu/menu-item/menu-item.test.tsx
+++ b/src/components/menu/menu-item/menu-item.test.tsx
@@ -13,6 +13,7 @@ import menuConfigVariants from "../menu.config";
 import IconButton from "../../icon-button";
 import Search from "../../search";
 import SubmenuContext from "../__internal__/submenu/submenu.context";
+import Logger from "../../../__internal__/utils/logger";
 
 const menuContextValues: MenuContextProps = {
   menuType: "light",
@@ -1075,4 +1076,18 @@ test("should throw when `children` passed and `submenu` is an empty string", () 
   );
 
   consoleSpy.mockRestore();
+});
+
+test("throws a deprecation warning if the 'className' prop is set", () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+  render(<MenuItem className="foo">Item One</MenuItem>);
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'MenuItem' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
 });

--- a/src/components/message/message.component.tsx
+++ b/src/components/message/message.component.tsx
@@ -10,6 +10,9 @@ import Icon from "../icon";
 import IconButton from "../icon-button";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import useLocale from "../../hooks/__internal__/useLocale";
+import Logger from "../../__internal__/utils/logger";
+
+let deprecatedClassNameWarningShown = false;
 
 export type MessageVariant =
   | "error"
@@ -62,6 +65,12 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
     }: MessageProps,
     ref,
   ) => {
+    if (!deprecatedClassNameWarningShown && className) {
+      Logger.deprecate(
+        "The 'className' prop has been deprecated and will soon be removed from the 'Message' component.",
+      );
+      deprecatedClassNameWarningShown = true;
+    }
     const messageRef = useRef<HTMLDivElement | null>(null);
     const refToPass = ref || messageRef;
 

--- a/src/components/message/message.test.tsx
+++ b/src/components/message/message.test.tsx
@@ -5,6 +5,17 @@ import Message from "./message.component";
 import I18nProvider from "../i18n-provider";
 import enGB from "../../locales/en-gb";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
+import Logger from "../../__internal__/utils/logger";
+
+let loggerSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  loggerSpy = jest.spyOn(Logger, "deprecate").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  loggerSpy.mockRestore();
+});
 
 test("renders with provided children", () => {
   render(<Message>Message</Message>);
@@ -124,6 +135,10 @@ test("renders with provided `className`", () => {
   );
 
   expect(screen.getByTestId("my-message")).toHaveClass("message-class");
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'Message' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
 });
 
 // coverage

--- a/src/components/modal/modal.component.tsx
+++ b/src/components/modal/modal.component.tsx
@@ -8,6 +8,9 @@ import useModalManager from "../../hooks/__internal__/useModalManager";
 import { StyledModal, StyledModalBackground } from "./modal.style";
 import { TagProps } from "../../__internal__/utils/helpers/tags";
 import ModalContext from "./__internal__/modal.context";
+import Logger from "../../__internal__/utils/logger";
+
+let deprecatedClassNameWarningShown = false;
 
 export interface ModalProps extends Omit<TagProps, "data-component"> {
   /** Custom class name  */
@@ -45,6 +48,12 @@ const Modal = ({
   topModalOverride,
   ...rest
 }: ModalProps) => {
+  if (!deprecatedClassNameWarningShown && rest.className) {
+    Logger.deprecate(
+      "The 'className' prop has been deprecated and will soon be removed from the 'Modal' component.",
+    );
+    deprecatedClassNameWarningShown = true;
+  }
   const ref = useRef<HTMLDivElement>(null);
   const backgroundNodeRef = useRef<HTMLDivElement>(null);
   const contentNodeRef = useRef<HTMLDivElement>(null);

--- a/src/components/modal/modal.test.tsx
+++ b/src/components/modal/modal.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Modal from "./modal.component";
 import useScrollBlock from "../../hooks/__internal__/useScrollBlock";
+import Logger from "../../__internal__/utils/logger";
 
 jest.mock("../../hooks/__internal__/useScrollBlock");
 const allowScroll = jest.fn();
@@ -164,4 +165,18 @@ test("increases the default z-index when the topModalOverride prop is set", () =
   render(<Modal data-role="test-modal" open topModalOverride />);
 
   expect(screen.getByTestId("test-modal")).toHaveStyleRule("z-index: 7000");
+});
+
+test("throws a deprecation warning if the 'className' prop is set", () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+  render(<Modal open className="foo" />);
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'Modal' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
 });

--- a/src/components/pod/pod.component.tsx
+++ b/src/components/pod/pod.component.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from "react";
 import { MarginProps } from "styled-system";
 import useLocale from "../../hooks/__internal__/useLocale";
+import Logger from "../../__internal__/utils/logger";
 
 import {
   StyledBlock,
@@ -19,6 +20,8 @@ import Icon from "../icon";
 
 import Event from "../../__internal__/utils/helpers/events";
 import { PodAlignment, PodSize, PodVariant } from "./pod.config";
+
+let deprecatedClassNameWarningShown = false;
 
 export interface PodProps extends MarginProps {
   /** Identifier used for testing purposes, applied to the root element of the component. */
@@ -96,6 +99,13 @@ const Pod = React.forwardRef<HTMLDivElement, PodProps>(
     }: PodProps,
     ref,
   ) => {
+    if (!deprecatedClassNameWarningShown && className) {
+      Logger.deprecate(
+        "The 'className' prop has been deprecated and will soon be removed from the 'Pod' component.",
+      );
+      deprecatedClassNameWarningShown = true;
+    }
+
     const [isEditFocused, setEditFocused] = useState(false);
     const [isEditHovered, setEditHovered] = useState(false);
     const [isDeleteFocused, setDeleteFocused] = useState(false);

--- a/src/components/pod/pod.test.tsx
+++ b/src/components/pod/pod.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import Pod from ".";
 import Typography from "../typography";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
+import Logger from "../../__internal__/utils/logger";
 
 test("renders with `title` as a string", () => {
   render(<Pod title="Title" />);
@@ -481,3 +482,17 @@ testStyledSystemMargin(
   (props) => <Pod data-role="pod" {...props} />,
   () => screen.getByTestId("pod"),
 );
+
+test("throws a deprecation warning if the 'className' prop is set", () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+  render(<Pod className="foo">bar</Pod>);
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'Pod' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
+});

--- a/src/components/portal/portal.test.tsx
+++ b/src/components/portal/portal.test.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "styled-components";
 import sageTheme from "../../style/themes/sage";
 import PortalContext from "./__internal__/portal.context";
 import Portal from ".";
+import Logger from "../../__internal__/utils/logger";
 
 import guid from "../../__internal__/utils/helpers/guid";
 
@@ -11,6 +12,16 @@ const mockedGuid = "guid-12345";
 jest.mock("../../__internal__/utils/helpers/guid");
 
 (guid as jest.MockedFunction<typeof guid>).mockImplementation(() => mockedGuid);
+
+let loggerSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  loggerSpy = jest.spyOn(Logger, "deprecate").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  loggerSpy.mockRestore();
+});
 
 test("renders and appends to an element with the 'id' attribute set to `root`", () => {
   const rootDiv = document.createElement("div");
@@ -56,6 +67,11 @@ test("renders with the 'class' attribute on the portal exit, via the `className`
 
   const portalExit = screen.getByTestId("carbon-portal-exit");
   expect(portalExit).toHaveClass(`carbon-portal ${className}`);
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'Portal' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
 });
 
 test("renders with the 'id' attribute on the portal exit, via the `id` prop", () => {

--- a/src/components/portal/portal.tsx
+++ b/src/components/portal/portal.tsx
@@ -6,6 +6,9 @@ import guid from "../../__internal__/utils/helpers/guid";
 import CarbonScopedTokensProvider from "../../style/design-tokens/carbon-scoped-tokens-provider/carbon-scoped-tokens-provider.component";
 import StyledPortalEntrance from "./portal.style";
 import PortalContext from "./__internal__/portal.context";
+import Logger from "../../__internal__/utils/logger";
+
+let deprecatedClassNameWarningShown = false;
 
 const Container = styled.div`
   ${({ theme }) => css`
@@ -40,6 +43,13 @@ export const Portal = ({
   onReposition,
   inertOptOut,
 }: PortalProps) => {
+  if (!deprecatedClassNameWarningShown && className) {
+    Logger.deprecate(
+      "The 'className' prop has been deprecated and will soon be removed from the 'Portal' component.",
+    );
+    deprecatedClassNameWarningShown = true;
+  }
+
   const [portalNode, setPortalNode] = useState<HTMLElement | null>(null);
   const uniqueId = useMemo(() => guid(), []);
   const { renderInRoot } = useContext(PortalContext);

--- a/src/components/profile/profile.component.tsx
+++ b/src/components/profile/profile.component.tsx
@@ -12,6 +12,9 @@ import {
 } from "./profile.style";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { ProfileSize } from "./profile.config";
+import Logger from "../../__internal__/utils/logger";
+
+let deprecatedClassNameWarningShown = false;
 
 function acronymize(str?: string) {
   if (!str) return "";
@@ -55,6 +58,13 @@ export const Profile = ({
   darkBackground,
   ...props
 }: ProfileProps) => {
+  if (!deprecatedClassNameWarningShown && className) {
+    Logger.deprecate(
+      "The 'className' prop has been deprecated and will soon be removed from the 'Profile' component.",
+    );
+    deprecatedClassNameWarningShown = true;
+  }
+
   const getInitials = () => {
     if (initials) return initials;
     return acronymize(name).slice(0, 3).toUpperCase();

--- a/src/components/profile/profile.test.tsx
+++ b/src/components/profile/profile.test.tsx
@@ -4,6 +4,17 @@ import MD5 from "crypto-js/md5";
 
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
 import Profile from "./profile.component";
+import Logger from "../../__internal__/utils/logger";
+
+let loggerSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  loggerSpy = jest.spyOn(Logger, "deprecate").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  loggerSpy.mockRestore();
+});
 
 testStyledSystemMargin(
   (props) => <Profile data-role="profile" name="John Doe" {...props} />,
@@ -197,4 +208,9 @@ test("applies the `className` prop to the component wrapper", () => {
 
   const profile = screen.getByTestId("profile");
   expect(profile).toHaveClass("custom-class");
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'Profile' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
 });

--- a/src/components/settings-row/settings-row.component.tsx
+++ b/src/components/settings-row/settings-row.component.tsx
@@ -3,12 +3,15 @@ import { MarginProps } from "styled-system";
 import Heading, { HeadingType } from "../heading";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import Logger from "../../__internal__/utils/logger";
 
 import {
   StyledSettingsRow,
   StyledSettingsRowHeader,
   StyledSettingsRowInput,
 } from "./settings-row.style";
+
+let deprecatedClassNameWarningShown = false;
 
 export interface SettingsRowProps extends MarginProps {
   /**  A title for this group of settings. */
@@ -34,6 +37,13 @@ export const SettingsRow = ({
   className,
   ...rest
 }: SettingsRowProps) => {
+  if (!deprecatedClassNameWarningShown && className) {
+    Logger.deprecate(
+      "The 'className' prop has been deprecated and will soon be removed from the 'SettingsRow' component.",
+    );
+    deprecatedClassNameWarningShown = true;
+  }
+
   const heading = () => {
     if (!title) return null;
 

--- a/src/components/settings-row/settings-row.test.tsx
+++ b/src/components/settings-row/settings-row.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { HeadingType } from "../heading";
 import SettingsRow from ".";
+import Logger from "../../__internal__/utils/logger";
 
 test("renders with children", () => {
   render(<SettingsRow>hello world</SettingsRow>);
@@ -72,4 +73,18 @@ test("renders a divider when the `divider` prop is passed", () => {
     "1px solid var(--colorsUtilityMajor050)",
   );
   expect(settingsRow).toHaveStyleRule("padding-bottom", "30px");
+});
+
+test("throws a deprecation warning if the 'className' prop is set", () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+  render(<SettingsRow className="foo" />);
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'SettingsRow' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
 });

--- a/src/components/simple-color-picker/simple-color/simple-color.component.tsx
+++ b/src/components/simple-color-picker/simple-color/simple-color.component.tsx
@@ -8,6 +8,9 @@ import {
   StyledTickIcon,
   StyledSimpleColorInput,
 } from "./simple-color.style";
+import Logger from "../../../__internal__/utils/logger";
+
+let deprecatedClassNameWarningShown = false;
 
 export interface SimpleColorProps {
   /** the value of the color that is represented by this SimpleColor */
@@ -34,6 +37,13 @@ export interface SimpleColorProps {
 
 export const SimpleColor = React.forwardRef<HTMLInputElement, SimpleColorProps>(
   (props: SimpleColorProps, ref) => {
+    if (!deprecatedClassNameWarningShown && props.className) {
+      Logger.deprecate(
+        "The 'className' prop has been deprecated and will soon be removed from the 'SimpleColor' component.",
+      );
+      deprecatedClassNameWarningShown = true;
+    }
+
     const {
       onChange,
       onBlur,

--- a/src/components/simple-color-picker/simple-color/simple-color.test.tsx
+++ b/src/components/simple-color-picker/simple-color/simple-color.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 
 import SimpleColor from "./simple-color.component";
 import guid from "../../../__internal__/utils/helpers/guid";
+import Logger from "../../../__internal__/utils/logger";
 
 const mockedGuid = "guid-12345";
 jest.mock("../../../__internal__/utils/helpers/guid");
@@ -59,4 +60,18 @@ test("assigns a guid as id to the input element when the `id` prop is not passed
   render(<SimpleColor value="#0073C2" />);
 
   expect(screen.getByRole("radio")).toHaveAttribute("id", mockedGuid);
+});
+
+test("throws a deprecation warning if the 'className' prop is set", () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+  render(<SimpleColor value="#0073C2" className="foo" />);
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'SimpleColor' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
 });

--- a/src/components/tabs/tab/tab.component.tsx
+++ b/src/components/tabs/tab/tab.component.tsx
@@ -3,6 +3,9 @@ import { PaddingProps } from "styled-system";
 import StyledTab from "./tab.style";
 import tagComponent from "../../../__internal__/utils/helpers/tags/tags";
 import TabContext from "./__internal__/tab.context";
+import Logger from "../../../__internal__/utils/logger";
+
+let deprecatedClassNameWarningShown = false;
 
 export interface TabProps extends PaddingProps {
   title?: string;
@@ -70,6 +73,13 @@ export const Tab = ({
   titleProps,
   ...rest
 }: TabProps) => {
+  if (!deprecatedClassNameWarningShown && className) {
+    Logger.deprecate(
+      "The 'className' prop has been deprecated and will soon be removed from the 'Tab' component.",
+    );
+    deprecatedClassNameWarningShown = true;
+  }
+
   const [tabErrors, setTabErrors] = useState<Record<string, string>>({});
   const [tabWarnings, setTabWarnings] = useState<Record<string, string>>({});
   const [tabInfos, setTabInfos] = useState<Record<string, string>>({});

--- a/src/components/tabs/tab/tab.test.tsx
+++ b/src/components/tabs/tab/tab.test.tsx
@@ -4,6 +4,17 @@ import Tab from ".";
 import Textbox from "../../textbox";
 import StyledTab from "./tab.style";
 import { testStyledSystemPadding } from "../../../__spec_helper__/__internal__/test-utils";
+import Logger from "../../../__internal__/utils/logger";
+
+let loggerSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  loggerSpy = jest.spyOn(Logger, "deprecate").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  loggerSpy.mockRestore();
+});
 
 testStyledSystemPadding(
   (props) => (
@@ -68,6 +79,11 @@ test("passes the `className` prop to the element", () => {
     "foo-class",
     "bar-class",
   );
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'Tab' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
 });
 
 test("can be given a custom role via the `role` prop", () => {

--- a/src/components/tabs/tabs.component.tsx
+++ b/src/components/tabs/tabs.component.tsx
@@ -18,6 +18,9 @@ import StyledTabs from "./tabs.style";
 import TabsHeader from "./__internal__/tabs-header";
 import TabTitle from "./__internal__/tab-title";
 import DrawerSidebarContext from "../drawer/__internal__/drawer-sidebar.context";
+import Logger from "../../__internal__/utils/logger";
+
+let deprecatedClassNameWarningShown = false;
 
 export interface TabsProps extends MarginProps {
   /** @ignore @private */
@@ -81,6 +84,13 @@ const Tabs = ({
   showValidationsSummary,
   ...rest
 }: TabsProps) => {
+  if (!deprecatedClassNameWarningShown && className) {
+    Logger.deprecate(
+      "The 'className' prop has been deprecated and will soon be removed from the 'Tabs' component.",
+    );
+    deprecatedClassNameWarningShown = true;
+  }
+
   if (position !== "left" && headerWidth !== undefined) {
     // eslint-disable-next-line no-console
     console.error(

--- a/src/components/tabs/tabs.test.tsx
+++ b/src/components/tabs/tabs.test.tsx
@@ -9,6 +9,17 @@ import Drawer from "../drawer";
 import Textbox from "../textbox";
 import NumeralDate from "../numeral-date";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
+import Logger from "../../__internal__/utils/logger";
+
+let loggerSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  loggerSpy = jest.spyOn(Logger, "deprecate").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  loggerSpy.mockRestore();
+});
 
 testStyledSystemMargin(
   (props) => (
@@ -94,6 +105,11 @@ test("passes the `className` prop down to the element", () => {
     "custom-class-1",
     "custom-class-2",
   );
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'Tabs' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
 });
 
 test("the `selectedTabId` prop determines which child `Tab` is displayed", () => {

--- a/src/components/tile-select/tile-select.component.tsx
+++ b/src/components/tile-select/tile-select.component.tsx
@@ -7,6 +7,7 @@ import createGuid from "../../__internal__/utils/helpers/guid";
 import Button from "../button";
 import Box from "../box";
 import Accordion from "./__internal__/accordion";
+import Logger from "../../__internal__/utils/logger";
 
 import {
   StyledTileSelectContainer,
@@ -23,6 +24,8 @@ import {
   StyledAccordionFooterWrapper,
 } from "./tile-select.style";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+
+let deprecatedClassNameWarningShown = false;
 
 const checkPropTypeIsNode = (prop: unknown): boolean =>
   typeof prop !== "string";
@@ -114,6 +117,13 @@ const TileSelect = React.forwardRef<HTMLInputElement, TileSelectProps>(
     }: TileSelectProps,
     ref,
   ) => {
+    if (!deprecatedClassNameWarningShown && className) {
+      Logger.deprecate(
+        "The 'className' prop has been deprecated and will soon be removed from the 'TileSelect' component.",
+      );
+      deprecatedClassNameWarningShown = true;
+    }
+
     const l = useLocale();
     const [hasFocus, setHasFocus] = useState(false);
     const handleDeselect = () =>

--- a/src/components/tile-select/tile-select.test.tsx
+++ b/src/components/tile-select/tile-select.test.tsx
@@ -9,6 +9,7 @@ import TileSelectGroup, {
 } from "./tile-select-group/tile-select-group.component";
 import Button from "../button";
 import Icon from "../icon";
+import Logger from "../../__internal__/utils/logger";
 
 testStyledSystemMargin(
   (props) => <TileSelect data-role="tile-select-wrapper" {...props} />,
@@ -372,4 +373,18 @@ test("Accordion footer renders the node passed in via the accordionContent prop 
     "rotate(-90deg)",
     { modifier: 'span[data-element="chevron_down"]' },
   );
+});
+
+test("throws a deprecation warning if the 'className' prop is set", () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+  render(<TileSelect className="foo" />);
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'TileSelect' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
 });

--- a/src/components/toast/toast.component.tsx
+++ b/src/components/toast/toast.component.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { TransitionGroup, CSSTransition } from "react-transition-group";
+import Logger from "../../__internal__/utils/logger";
 
 import Icon from "../icon";
 import tagComponent, {
@@ -18,6 +19,8 @@ import useLocale from "../../hooks/__internal__/useLocale";
 import useModalManager from "../../hooks/__internal__/useModalManager";
 import guid from "../../__internal__/utils/helpers/guid";
 import Typography from "../typography";
+
+let deprecatedClassNameWarningShown = false;
 
 type ToastVariants =
   | "error"
@@ -97,6 +100,13 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
     }: ToastProps,
     ref,
   ) => {
+    if (!deprecatedClassNameWarningShown && className) {
+      Logger.deprecate(
+        "The 'className' prop has been deprecated and will soon be removed from the 'Toast' component.",
+      );
+      deprecatedClassNameWarningShown = true;
+    }
+
     const isNotice = variant === "notice";
     const isNotification = variant === "notification";
     const locale = useLocale();

--- a/src/components/toast/toast.test.tsx
+++ b/src/components/toast/toast.test.tsx
@@ -3,6 +3,17 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Toast, { ToastProps } from "./toast.component";
 import ModalManager from "../modal/__internal__/modal-manager";
+import Logger from "../../__internal__/utils/logger";
+
+let loggerSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  loggerSpy = jest.spyOn(Logger, "deprecate").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  loggerSpy.mockRestore();
+});
 
 const MockToast = ({
   open = false,
@@ -312,6 +323,14 @@ test("should render with any custom classes passed via the `className` prop", ()
   );
 
   expect(screen.getByTestId("toast")).toHaveClass("exampleClass");
+
+  // When using Toast messages the logger spy will be called twice: once for the
+  // Toast component and once for the containing Portal component. Because of this,
+  // only the first call to the logger spy is checked.
+  expect(loggerSpy).toHaveBeenNthCalledWith(
+    1,
+    "The 'className' prop has been deprecated and will soon be removed from the 'Toast' component.",
+  );
 });
 
 test("should render with provided custom id passed via `id` prop", () => {

--- a/src/components/typography/typography.component.tsx
+++ b/src/components/typography/typography.component.tsx
@@ -6,6 +6,9 @@ import {
   filterStyledSystemPaddingProps,
 } from "../../style/utils";
 import StyledTypography from "./typography.style";
+import Logger from "../../__internal__/utils/logger";
+
+let deprecatedClassNameWarningShown = false;
 
 export const VARIANT_TYPES = [
   "h1-large",
@@ -118,6 +121,12 @@ export const Typography = ({
   "aria-hidden": ariaHidden,
   ...rest
 }: TypographyProps) => {
+  if (!deprecatedClassNameWarningShown && className) {
+    Logger.deprecate(
+      "The 'className' prop has been deprecated and will soon be removed from the 'Typography' component.",
+    );
+    deprecatedClassNameWarningShown = true;
+  }
   return (
     <StyledTypography
       variant={variant}

--- a/src/components/typography/typography.test.tsx
+++ b/src/components/typography/typography.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import Typography, { List, ListItem } from ".";
 import { testStyledSystemSpacing } from "../../__spec_helper__/__internal__/test-utils";
+import Logger from "../../__internal__/utils/logger";
 
 test("should render with variant as 'p' by default", () => {
   render(<Typography>Test</Typography>);
@@ -317,3 +318,21 @@ testStyledSystemSpacing(
   (props) => <Typography {...props}>Test</Typography>,
   () => screen.getByText("Test"),
 );
+
+test("throws a deprecation warning if the 'className' prop is set", () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+  render(
+    <Typography variant="b" display="block" className="foo">
+      bar
+    </Typography>,
+  );
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The 'className' prop has been deprecated and will soon be removed from the 'Typography' component.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
+});


### PR DESCRIPTION
### Proposed behaviour

Throw a deprecation warning when any of the components listed below utilise the `className` prop:

- Button
- ButtonToggleGroup
- Detail
- Dialog
- Help
- Icon
- InlineInputs
- Link
- Menu
- Message
- Modal
- Pod
- Portal
- Profile
- SettingsRow
- SimpleColorPicker
- Tabs
- TileSelect
- Toast
- Typography

### Current behaviour

Customers are not aware that we intend to deprecate `className`

### Checklist

- [x] Commits follow our style guide
- [x] Unit tests added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Use Storybook to view (or create a new story with) a component that utilises `className` and make sure the warning is logged to the console
