### PR TITLE
feat(menu-item): fix padding when child of Menu and no icon

### DIFF
--- a/src/components/menu/menu-item/menu-item.style.ts
+++ b/src/components/menu/menu-item/menu-item.style.ts
@@ -1,15 +1,18 @@
 import styled, { css } from "styled-components";
+
 import { padding, PaddingProps } from "styled-system";
-import StyledButton from "../../button/button.style";
-import { StyledContent, StyledLink } from "../../link/link.style";
-import StyledIcon from "../../icon/icon.style";
-import StyledIconButton from "../../icon-button/icon-button.style";
+
 import menuConfigVariants from "../menu.config";
-import { MenuType } from "../__internal__/menu.context";
-import { MenuWithChildren } from "./menu-item.component";
 import Link from "../../link";
-import addFocusStyling from "../../../style/utils/add-focus-styling";
+import { MenuType } from "../__internal__/menu.context";
+import StyledButton from "../../button/button.style";
+import StyledIconButton from "../../icon-button/icon-button.style";
+import StyledIcon from "../../icon/icon.style";
+import { StyledContent, StyledLink } from "../../link/link.style";
 import { baseTheme } from "../../../style/themes";
+import addFocusStyling from "../../../style/utils/add-focus-styling";
+
+import { MenuWithChildren } from "./menu-item.component";
 
 interface StyledMenuItemWrapperProps
   extends Pick<
@@ -197,6 +200,15 @@ const StyledMenuItemWrapper = styled.a.attrs({
           `}
         }
 
+        &
+          li:not(:has([data-component="icon"]):not(:has(button)))
+          ${StyledContent},
+          a:not(:has([data-component="icon"]):not(:has(button)))
+          ${StyledContent} {
+          position: relative;
+          bottom: 1px;
+        }
+
         a:hover,
         button:hover {
           ${!asDiv &&
@@ -227,7 +239,7 @@ const StyledMenuItemWrapper = styled.a.attrs({
 
             > a:has(${StyledButton}:not(.search-button)) {
              height: 100%;
-             
+
              ${StyledContent} {
                 height: inherit;
 
@@ -492,7 +504,7 @@ const StyledMenuItemWrapper = styled.a.attrs({
         `
       }
 
-      
+
       > a, > button {
        min-height: 40px;
        line-height: 40px;


### PR DESCRIPTION
When used alongside menu items with icons, icon-less menu items are misaligned

Resolves #7096

### Proposed behaviour

Adjust the relative positioning of `MenuItem` when not in a fullscreen menu and with no icon to ensure that the text is aligned correctly

### Current behaviour

When a MenuItem has no icon in a Menu, the text compared to other MenuItem components with icons is misaligned

### Checklist

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Crete the following component and ensure that the `Beta` text is aligned with `Alpha` and `Charlie`:

```javascript
<Menu>
  <MenuItem icon="home">Alpha</MenuItem>
  <MenuItem>Beta</MenuItem>
  <MenuItem icon="print">Charlie</MenuItem>
</Menu>
```