### PR TITLE
feat(step-flow): add aria props to component - FE-7013

### DIFF
--- a/src/components/step-flow/step-flow-test.stories.tsx
+++ b/src/components/step-flow/step-flow-test.stories.tsx
@@ -1,9 +1,9 @@
 import React from "react";
+import Typography from "../typography";
 import { StepFlow, StepFlowProps } from ".";
 
 export default {
   title: "Step Flow/Test",
-  includeStories: ["Default"],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -11,6 +11,21 @@ export default {
     },
   },
   argTypes: {
+    ariaLabel: {
+      control: {
+        type: "text",
+      },
+    },
+    ariaLabelledby: {
+      control: {
+        type: "text",
+      },
+    },
+    ariaDescribedBy: {
+      control: {
+        type: "text",
+      },
+    },
     category: {
       control: {
         type: "text",
@@ -54,4 +69,49 @@ export const Default = (props: Partial<StepFlowProps>) => (
   <StepFlow title="default" currentStep={1} totalSteps={8} {...props} />
 );
 
-Default.storyName = "default";
+Default.storyName = "Default";
+
+export const DefaultWithAriaLabel = () => (
+  <StepFlow
+    title="default"
+    currentStep={1}
+    totalSteps={8}
+    aria-label="This is step flow"
+  />
+);
+
+DefaultWithAriaLabel.storyName = "Default with aria-label";
+
+export const DefaultWithAriaLabelledBy = () => (
+  <>
+    <StepFlow
+      title="default"
+      currentStep={1}
+      totalSteps={8}
+      aria-labelledby="ariaLabelledBy-text"
+    />
+    <Typography as="span" id="ariaLabelledBy-text">
+      This is step flow
+    </Typography>
+  </>
+);
+
+DefaultWithAriaLabelledBy.storyName = "Default with aria-labelledby";
+
+export const DefaultWithAriaDescribedBy = () => (
+  <>
+    <StepFlow
+      title="default"
+      currentStep={1}
+      totalSteps={8}
+      aria-describedby="ariaDescribedBy-text"
+    />
+    <Typography mt={3} id="ariaDescribedBy-text">
+      This is step flow. A step flow represents an end-to-end journey that a
+      user can complete in one go. It has a specific start and end point. It
+      shows the current step and the total number of steps in the journey
+    </Typography>
+  </>
+);
+
+DefaultWithAriaDescribedBy.storyName = "Default with aria-describedby";

--- a/src/components/step-flow/step-flow.component.tsx
+++ b/src/components/step-flow/step-flow.component.tsx
@@ -20,7 +20,19 @@ import StepFlowTitle from "./step-flow-title/step-flow-title.component";
 
 export type Steps = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
-export interface StepFlowProps extends MarginProps, TagProps {
+interface StepFlowAriaProps {
+  /** Prop to specify the aria-label of the component */
+  "aria-label"?: string;
+  /** Prop to specify the aria-labelledby of the component */
+  "aria-labelledby"?: string;
+  /** Prop to specify the aria-describedby of the component */
+  "aria-describedby"?: string;
+}
+
+export interface StepFlowProps
+  extends StepFlowAriaProps,
+    MarginProps,
+    TagProps {
   /** A category for the user journey.  */
   category?: string;
   /** The title of the current step, this can be a string or a valid React node
@@ -66,6 +78,9 @@ export const StepFlow = forwardRef<StepFlowHandle, StepFlowProps>(
       showProgressIndicator = false,
       showCloseIcon = false,
       onDismiss,
+      "aria-label": ariaLabel,
+      "aria-labelledby": ariaLabelledBy,
+      "aria-describedby": ariaDescribedBy,
       ...rest
     },
     ref,
@@ -180,7 +195,14 @@ export const StepFlow = forwardRef<StepFlowHandle, StepFlowProps>(
     );
 
     return (
-      <StyledStepFlow {...rest} {...tagComponent("step-flow", rest)}>
+      <StyledStepFlow
+        role="group"
+        aria-label={ariaLabel}
+        aria-describedby={ariaDescribedBy}
+        aria-labelledby={ariaLabelledBy}
+        {...rest}
+        {...tagComponent("step-flow", rest)}
+      >
         <StyledStepContent>
           {category ? (
             <StyledStepContentText>

--- a/src/components/step-flow/step-flow.test.tsx
+++ b/src/components/step-flow/step-flow.test.tsx
@@ -46,6 +46,72 @@ function calculateStepStateIndexes(
   return [stepsBefore, stepsAfter];
 }
 
+test("when aria-label is specified, the attribute is applied to the expected element", () => {
+  render(
+    <StepFlow
+      data-role="step-flow"
+      aria-label="foo"
+      title="foo"
+      currentStep={5}
+      totalSteps={6}
+      category="bar"
+      ref={() => {}}
+    />,
+  );
+
+  const stepFlowComponent = screen.getByTestId("step-flow");
+
+  expect(stepFlowComponent).toHaveAccessibleName("foo");
+});
+
+test("when aria-labelledby is specified, the attribute is applied to the expected element", () => {
+  render(
+    <>
+      <StepFlow
+        data-role="step-flow"
+        aria-labelledby="foo"
+        title="foo"
+        currentStep={5}
+        totalSteps={6}
+        category="bar"
+        ref={() => {}}
+      />
+      <span id="foo" role="presentation">
+        This is step flow
+      </span>
+    </>,
+  );
+
+  const stepFlowComponent = screen.getByTestId("step-flow");
+
+  expect(stepFlowComponent).toHaveAccessibleName("This is step flow");
+});
+
+test("when aria-describedby is specified, the attribute is applied to the expected element", () => {
+  render(
+    <>
+      <StepFlow
+        data-role="step-flow"
+        aria-describedby="foo"
+        title="foo"
+        currentStep={5}
+        totalSteps={6}
+        category="bar"
+        ref={() => {}}
+      />
+      <span id="foo" role="presentation">
+        Description of step flow
+      </span>
+    </>,
+  );
+
+  const stepFlowComponent = screen.getByTestId("step-flow");
+
+  expect(stepFlowComponent).toHaveAccessibleDescription(
+    "Description of step flow",
+  );
+});
+
 test("should render the correct element and text when the category prop is passed", () => {
   render(
     <StepFlow


### PR DESCRIPTION
### Proposed behaviour

Aria props are destructured and present in the documentation for `Step Flow`

### Current behaviour

Aria props are not destructured. They are present due to `...rest` being spread on the component. Due to this, they do not appear in the Storybook documentation for the component under the `Props` section. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

New test stories have been created to demonstrate the newly added aria props. These stories are:

- Default with aria-label
- Default with aria-labelledby
- Default with aria-describedby

You should be able to see these attributes in the DOM, on the element for Step Flow. 

There should also be no other functional or styling regressions due to this change. 