### PR TITLE
Add missing `act` wrappers

### DIFF
--- a/src/__internal__/checkable-input/checkable-input.test.tsx
+++ b/src/__internal__/checkable-input/checkable-input.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import CheckableInput from ".";
 
 test("renders `label` with expected id when `id` prop is passed", () => {
@@ -40,7 +40,9 @@ test("renders input with 'aria-describedby' as the id of the validation tooltip 
 
   expect(input).not.toHaveAttribute("aria-describedby");
 
-  input.focus();
+  act(() => {
+    input.focus();
+  });
 
   expect(input).toHaveAttribute("aria-describedby", "foo-validation");
 });
@@ -59,7 +61,9 @@ test("appends the id of the validation tooltip to the input's 'aria-describedby'
 
   expect(input).toHaveAttribute("aria-describedby", "foo-field-help");
 
-  input.focus();
+  act(() => {
+    input.focus();
+  });
 
   expect(input).toHaveAttribute(
     "aria-describedby",

--- a/src/__internal__/fieldset/fieldset.test.tsx
+++ b/src/__internal__/fieldset/fieldset.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import Fieldset from ".";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
 
@@ -96,11 +96,16 @@ test("sets `aria-describedby` on help icon as tooltip content when focused and r
       <input />
     </Fieldset>,
   );
-
   const help = screen.getByRole("button", { name: "help" });
-  help.focus();
+
+  act(() => {
+    help.focus();
+  });
   expect(help).toHaveAccessibleDescription("label help");
-  help.blur();
+
+  act(() => {
+    help.blur();
+  });
   expect(help).not.toHaveAttribute("aria-describedby");
 });
 

--- a/src/__internal__/focus-trap/focus-trap.test.tsx
+++ b/src/__internal__/focus-trap/focus-trap.test.tsx
@@ -5,10 +5,9 @@ import {
   fireEvent,
   createEvent,
   waitFor,
+  act,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-
-import { act } from "react-dom/test-utils";
 
 import FocusTrap, { FocusTrapProps } from "./focus-trap.component";
 import { RadioButton, RadioButtonGroup } from "../../components/radio-button";
@@ -156,8 +155,10 @@ test("refocuses the last element that had focus within the trap when `triggerRef
     }),
   );
   const buttonTwo = screen.getByRole("button", { name: "Two" });
-  buttonTwo.focus();
-  buttonTwo.blur();
+  act(() => {
+    buttonTwo.focus();
+    buttonTwo.blur();
+  });
 
   rerender(
     mockComponentToRender({ autoFocus: false, triggerRefocusFlag: true }),
@@ -209,7 +210,9 @@ test("when `triggerRefocusFlag` is set, the container is refocused if last eleme
     </MockComponent>,
   );
 
-  screen.getByRole("button", { name: "Two" }).focus();
+  act(() => {
+    screen.getByRole("button", { name: "Two" }).focus();
+  });
 
   rerender(
     <MockComponent autoFocus={false} triggerRefocusFlag>
@@ -313,7 +316,9 @@ describe("when FocusTrap wraps an element and element has focusable items inside
     render(mockComponentToRender());
 
     const buttonTwo = screen.getByRole("button", { name: "Two" });
-    buttonTwo.focus();
+    act(() => {
+      buttonTwo.focus();
+    });
     await user.keyboard("{ArrowDown}");
 
     expect(buttonTwo).toHaveFocus();
@@ -324,7 +329,9 @@ describe("when FocusTrap wraps an element and element has focusable items inside
     render(mockComponentToRender());
 
     const buttonOne = screen.getByRole("button", { name: "One" });
-    buttonOne.focus();
+    act(() => {
+      buttonOne.focus();
+    });
     await user.tab({ shift: true });
 
     const buttonTwo = screen.getByRole("button", { name: "Two" });
@@ -336,7 +343,9 @@ describe("when FocusTrap wraps an element and element has focusable items inside
     render(mockComponentToRender());
 
     const buttonTwo = screen.getByRole("button", { name: "Two" });
-    buttonTwo.focus();
+    act(() => {
+      buttonTwo.focus();
+    });
     await user.tab({ shift: true });
 
     const buttonOne = screen.getByRole("button", { name: "One" });
@@ -348,7 +357,9 @@ describe("when FocusTrap wraps an element and element has focusable items inside
     render(mockComponentToRender());
 
     const buttonOne = screen.getByRole("button", { name: "One" });
-    buttonOne.focus();
+    act(() => {
+      buttonOne.focus();
+    });
     await user.tab();
 
     const buttonTwo = screen.getByRole("button", { name: "Two" });
@@ -360,7 +371,9 @@ describe("when FocusTrap wraps an element and element has focusable items inside
     render(mockComponentToRender());
 
     const buttonTwo = screen.getByRole("button", { name: "Two" });
-    buttonTwo.focus();
+    act(() => {
+      buttonTwo.focus();
+    });
     await user.tab();
 
     const buttonOne = screen.getByRole("button", { name: "One" });
@@ -406,7 +419,9 @@ it("only allows non-disabled elements to be focused", async () => {
   );
 
   const buttonOne = screen.getByRole("button", { name: "One" });
-  buttonOne.focus();
+  act(() => {
+    buttonOne.focus();
+  });
   await user.tab();
 
   const buttonTwo = screen.getByRole("button", { name: "Two" });
@@ -432,7 +447,9 @@ describe("when first focusable elements are radio buttons", () => {
     const user = userEvent.setup({ delay: null });
     render(<WithRadioGroup />);
 
-    screen.getByLabelText("Red").focus();
+    act(() => {
+      screen.getByLabelText("Red").focus();
+    });
     await user.tab({ shift: true });
 
     expect(screen.getByRole("button", { name: "Two" })).toHaveFocus();
@@ -442,7 +459,9 @@ describe("when first focusable elements are radio buttons", () => {
     const user = userEvent.setup({ delay: null });
     render(<WithRadioGroup />);
 
-    screen.getByLabelText("Green").focus();
+    act(() => {
+      screen.getByLabelText("Green").focus();
+    });
     await user.tab({ shift: true });
 
     expect(screen.getByRole("button", { name: "Two" })).toHaveFocus();
@@ -469,7 +488,9 @@ describe("with 2 different radio groups", () => {
     const user = userEvent.setup({ delay: null });
     render(<WithTwoGroups />);
 
-    screen.getByLabelText("Apple").focus();
+    act(() => {
+      screen.getByLabelText("Apple").focus();
+    });
     await user.tab({ shift: true });
 
     expect(screen.getByLabelText("Green")).toHaveFocus();
@@ -479,7 +500,9 @@ describe("with 2 different radio groups", () => {
     const user = userEvent.setup({ delay: null });
     render(<WithTwoGroups />);
 
-    screen.getByLabelText("Melon").focus();
+    act(() => {
+      screen.getByLabelText("Melon").focus();
+    });
     await user.tab({ shift: true });
 
     expect(screen.getByLabelText("Green")).toHaveFocus();
@@ -506,7 +529,9 @@ describe("with 2 different focusable radio groups and a custom selector", () => 
     const user = userEvent.setup({ delay: null });
     render(<WithTwoGroups />);
 
-    screen.getByLabelText("Apple").focus();
+    act(() => {
+      screen.getByLabelText("Apple").focus();
+    });
     await user.tab({ shift: true });
 
     expect(screen.getByLabelText("Green")).toHaveFocus();
@@ -516,7 +541,9 @@ describe("with 2 different focusable radio groups and a custom selector", () => 
     const user = userEvent.setup({ delay: null });
     render(<WithTwoGroups />);
 
-    screen.getByLabelText("Melon").focus();
+    act(() => {
+      screen.getByLabelText("Melon").focus();
+    });
     await user.tab({ shift: true });
 
     expect(screen.getByLabelText("Green")).toHaveFocus();
@@ -539,7 +566,9 @@ describe("when last focusable elements are radio buttons", () => {
     const user = userEvent.setup({ delay: null });
     render(<WithRadioGroup />);
 
-    screen.getByLabelText("Red").focus();
+    act(() => {
+      screen.getByLabelText("Red").focus();
+    });
     await user.tab();
 
     expect(screen.getByRole("button", { name: "One" })).toHaveFocus();
@@ -549,7 +578,9 @@ describe("when last focusable elements are radio buttons", () => {
     const user = userEvent.setup({ delay: null });
     render(<WithRadioGroup />);
 
-    screen.getByLabelText("Green").focus();
+    act(() => {
+      screen.getByLabelText("Green").focus();
+    });
     await user.tab();
 
     expect(screen.getByRole("button", { name: "One" })).toHaveFocus();
@@ -572,7 +603,9 @@ describe("when trap contains radio buttons", () => {
     const user = userEvent.setup({ delay: null });
     render(<WithRadioGroup />);
 
-    screen.getByLabelText("Red").focus();
+    act(() => {
+      screen.getByLabelText("Red").focus();
+    });
     await user.tab({ shift: true });
 
     expect(screen.getByRole("button", { name: "One" })).toHaveFocus();
@@ -582,7 +615,9 @@ describe("when trap contains radio buttons", () => {
     const user = userEvent.setup({ delay: null });
     render(<WithRadioGroup />);
 
-    screen.getByLabelText("Green").focus();
+    act(() => {
+      screen.getByLabelText("Green").focus();
+    });
     await user.tab({ shift: true });
 
     expect(screen.getByRole("button", { name: "One" })).toHaveFocus();
@@ -593,7 +628,9 @@ describe("when trap contains radio buttons", () => {
     render(<WithRadioGroup />);
 
     const buttonOne = screen.getByRole("button", { name: "One" });
-    buttonOne.focus();
+    act(() => {
+      buttonOne.focus();
+    });
     await user.tab();
 
     expect(screen.getByLabelText("Red")).toHaveFocus();
@@ -606,7 +643,9 @@ describe("when trap contains radio buttons", () => {
     const greenRadio = screen.getByLabelText("Green");
     await user.click(greenRadio);
     const buttonOne = screen.getByRole("button", { name: "One" });
-    buttonOne.focus();
+    act(() => {
+      buttonOne.focus();
+    });
     await user.tab();
 
     expect(greenRadio).toHaveFocus();
@@ -617,7 +656,9 @@ describe("when trap contains radio buttons", () => {
     render(<WithRadioGroup />);
 
     const buttonTwo = screen.getByRole("button", { name: "Two" });
-    buttonTwo.focus();
+    act(() => {
+      buttonTwo.focus();
+    });
     await user.tab({ shift: true });
 
     expect(screen.getByLabelText("Green")).toHaveFocus();
@@ -630,7 +671,9 @@ describe("when trap contains radio buttons", () => {
     const greenRadio = screen.getByLabelText("Green");
     await user.click(greenRadio);
     const buttonTwo = screen.getByRole("button", { name: "Two" });
-    buttonTwo.focus();
+    act(() => {
+      buttonTwo.focus();
+    });
     await user.tab({ shift: true });
 
     expect(greenRadio).toHaveFocus();
@@ -654,7 +697,9 @@ describe("when trap contains radio buttons when using a custom selector", () => 
     render(<WithRadioGroup />);
 
     const buttonOne = screen.getByRole("button", { name: "One" });
-    buttonOne.focus();
+    act(() => {
+      buttonOne.focus();
+    });
     await user.tab();
 
     expect(screen.getByLabelText("Red")).toHaveFocus();
@@ -667,7 +712,9 @@ describe("when trap contains radio buttons when using a custom selector", () => 
     const greenRadio = screen.getByLabelText("Green");
     await user.click(greenRadio);
     const buttonOne = screen.getByRole("button", { name: "One" });
-    buttonOne.focus();
+    act(() => {
+      buttonOne.focus();
+    });
     await user.tab();
 
     expect(greenRadio).toHaveFocus();
@@ -678,7 +725,9 @@ describe("when trap contains radio buttons when using a custom selector", () => 
     render(<WithRadioGroup />);
 
     const buttonTwo = screen.getByRole("button", { name: "Two" });
-    buttonTwo.focus();
+    act(() => {
+      buttonTwo.focus();
+    });
     await user.tab({ shift: true });
 
     expect(screen.getByLabelText("Green")).toHaveFocus();
@@ -691,7 +740,9 @@ describe("when trap contains radio buttons when using a custom selector", () => 
     const greenRadio = screen.getByLabelText("Green");
     await user.click(greenRadio);
     const buttonTwo = screen.getByRole("button", { name: "Two" });
-    buttonTwo.focus();
+    act(() => {
+      buttonTwo.focus();
+    });
     await user.tab({ shift: true });
 
     expect(greenRadio).toHaveFocus();
@@ -741,7 +792,9 @@ describe("when trap contains only one focusable element according to a custom se
     render(<WithSelector />);
 
     const buttonTwo = screen.getByRole("button", { name: "Two" });
-    buttonTwo.focus();
+    act(() => {
+      buttonTwo.focus();
+    });
     await user.tab();
 
     expect(screen.getByRole("button", { name: "Two" })).toHaveFocus();
@@ -752,7 +805,9 @@ describe("when trap contains only one focusable element according to a custom se
     render(<WithSelector />);
 
     const buttonTwo = screen.getByRole("button", { name: "Two" });
-    buttonTwo.focus();
+    act(() => {
+      buttonTwo.focus();
+    });
     await user.tab({ shift: true });
 
     expect(screen.getByRole("button", { name: "Two" })).toHaveFocus();
@@ -851,7 +906,9 @@ test("when `additionalWrapperRefs` are specified, tab should cycle through focus
   const user = userEvent.setup({ delay: null });
   render(<WithAdditionalWrapperRefs />);
 
-  screen.getByRole("button", { name: BUTTON_IN_WRAPPER }).focus();
+  act(() => {
+    screen.getByRole("button", { name: BUTTON_IN_WRAPPER }).focus();
+  });
 
   await user.tab();
   expect(
@@ -871,7 +928,9 @@ test("when `additionalWrapperRefs` are specified, shift-tab should cycle through
   const user = userEvent.setup({ delay: null });
   render(<WithAdditionalWrapperRefs />);
 
-  screen.getByRole("button", { name: BUTTON_IN_WRAPPER }).focus();
+  act(() => {
+    screen.getByRole("button", { name: BUTTON_IN_WRAPPER }).focus();
+  });
 
   await user.tab({ shift: true });
   expect(
@@ -1087,7 +1146,9 @@ test("only focuses elements which meet the custom selector, when tabbing both fo
 
   const buttonOne = screen.getByRole("button", { name: "One" });
   const buttonThree = screen.getByRole("button", { name: "Three" });
-  buttonOne.focus();
+  act(() => {
+    buttonOne.focus();
+  });
 
   await user.tab();
   expect(buttonThree).toHaveFocus();
@@ -1115,7 +1176,9 @@ test("when multiple focus traps are open at once, focus moves correctly between 
   );
   const buttonOne = screen.getByRole("button", { name: "One" });
   const buttonTwo = screen.getByRole("button", { name: "Two" });
-  buttonOne.focus();
+  act(() => {
+    buttonOne.focus();
+  });
 
   await user.tab();
   expect(buttonTwo).toHaveFocus();
@@ -1125,7 +1188,9 @@ test("when multiple focus traps are open at once, focus moves correctly between 
 
   const buttonThree = screen.getByRole("button", { name: "Three" });
   const buttonFour = screen.getByRole("button", { name: "Four" });
-  buttonThree.focus();
+  act(() => {
+    buttonThree.focus();
+  });
 
   await user.tab();
   expect(buttonFour).toHaveFocus();
@@ -1155,7 +1220,9 @@ test("when multiple focus traps are open at once, focus moves correctly between 
     </>,
   );
   const buttonOne = screen.getByRole("button", { name: "One" });
-  buttonOne.focus();
+  act(() => {
+    buttonOne.focus();
+  });
 
   await user.tab();
   expect(screen.getByRole("button", { name: "Two" })).toHaveFocus();
@@ -1167,7 +1234,9 @@ test("when multiple focus traps are open at once, focus moves correctly between 
   expect(buttonOne).toHaveFocus();
 
   const buttonFour = screen.getByRole("button", { name: "Four" });
-  buttonFour.focus();
+  act(() => {
+    buttonFour.focus();
+  });
 
   await user.tab();
   expect(screen.getByRole("button", { name: "Six" })).toHaveFocus();
@@ -1222,7 +1291,9 @@ test("should focus the first focusable element when the the focus is on a non fo
       </button>
     </MockComponent>,
   );
-  screen.getByRole("button", { name: "Three" }).focus();
+  act(() => {
+    screen.getByRole("button", { name: "Three" }).focus();
+  });
 
   await user.tab();
 
@@ -1240,7 +1311,9 @@ test("should focus the last focusable element when the the focus is on a non foc
       <button type="button">Three</button>
     </MockComponent>,
   );
-  screen.getByRole("button", { name: "One" }).focus();
+  act(() => {
+    screen.getByRole("button", { name: "One" }).focus();
+  });
 
   await user.tab({ shift: true });
 
@@ -1378,7 +1451,7 @@ test("should focus the first input that has the `autoFocus` prop set on it", () 
       <Select onChange={() => {}} autoFocus label="Autofocus me">
         <Option value="1" text="one" />
       </Select>
-      <Checkbox label="Do not autofocus me" autoFocus />
+      <Checkbox label="Do not autofocus me" autoFocus onChange={() => {}} />
     </MockComponent>,
   );
 
@@ -1392,7 +1465,7 @@ test("should loop to the last element when there is elements with tabIndex of -1
       <Select onChange={() => {}} autoFocus label="Autofocus me">
         <Option value="1" text="one" />
       </Select>
-      <Checkbox label="Do not autofocus me" autoFocus />
+      <Checkbox label="Do not autofocus me" autoFocus onChange={() => {}} />
     </MockComponent>,
   );
 

--- a/src/__internal__/input-icon-toggle/input-icon-toggle.test.tsx
+++ b/src/__internal__/input-icon-toggle/input-icon-toggle.test.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { render, screen, createEvent, fireEvent } from "@testing-library/react";
+import {
+  render,
+  screen,
+  createEvent,
+  fireEvent,
+  act,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as floatingUi from "@floating-ui/react-dom";
 import InputIconToggle, { InputIconToggleProps } from ".";
@@ -310,7 +316,9 @@ test("calls `onFocus` handler when the validation icon is focused", async () => 
   );
 
   const validationIcon = screen.getByTestId("icon-error");
-  validationIcon.focus();
+  act(() => {
+    validationIcon.focus();
+  });
 
   expect(mockOnFocus).toHaveBeenCalled();
 });
@@ -323,8 +331,9 @@ test("calls `onBlur` handler when the validation icon loses focus", async () => 
 
   const validationIcon = screen.getByTestId("icon-error");
   const user = userEvent.setup();
-
-  validationIcon.focus();
+  act(() => {
+    validationIcon.focus();
+  });
   await user.tab();
 
   expect(mockOnBlur).toHaveBeenCalled();

--- a/src/__internal__/validations/validation-icon.test.tsx
+++ b/src/__internal__/validations/validation-icon.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ValidationIcon from "./validation-icon.component";
@@ -122,7 +122,9 @@ test("renders a tooltip when the validation icon is focused", () => {
   render(<ValidationIcon error="error" />);
 
   const validationIcon = screen.getByTestId("icon-error");
-  validationIcon.focus();
+  act(() => {
+    validationIcon.focus();
+  });
 
   const tooltip = screen.getByRole("tooltip");
   expect(tooltip).toBeVisible();
@@ -134,7 +136,9 @@ test("renders a tooltip when validation icon is focused, then is not rendered on
   const user = userEvent.setup();
   const validationIcon = screen.getByTestId("icon-error");
 
-  validationIcon.focus();
+  act(() => {
+    validationIcon.focus();
+  });
   const tooltip = screen.getByRole("tooltip");
   expect(tooltip).toBeVisible();
 
@@ -146,7 +150,9 @@ test("sets the 'id' attribute on the tooltip via the `tooltipId` prop on the val
   render(<ValidationIcon tooltipId="foo" error="error" />);
 
   const validationIcon = screen.getByTestId("icon-error");
-  validationIcon.focus();
+  act(() => {
+    validationIcon.focus();
+  });
 
   const tooltip = screen.getByRole("tooltip");
   expect(tooltip).toHaveAttribute("id", "foo");
@@ -157,7 +163,9 @@ test("triggers a passed function via the `onFocus` prop when the validation icon
   render(<ValidationIcon error="error" onFocus={mockOnFocus} />);
 
   const validationIcon = screen.getByTestId("icon-error");
-  validationIcon.focus();
+  act(() => {
+    validationIcon.focus();
+  });
 
   expect(mockOnFocus).toHaveBeenCalled();
 });

--- a/src/components/accordion/accordion.test.tsx
+++ b/src/components/accordion/accordion.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { act } from "react-dom/test-utils";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { StyledAccordionHeadingsContainer } from "./accordion.style";

--- a/src/components/action-popover/action-popover.test.tsx
+++ b/src/components/action-popover/action-popover.test.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { act } from "react-dom/test-utils";
 import { ThemeProvider } from "styled-components";
 import * as floatingUi from "@floating-ui/dom";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
 import sageTheme from "../../style/themes/sage";

--- a/src/components/advanced-color-picker/advanced-color-picker.test.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.test.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import userEvent from "@testing-library/user-event";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import AdvancedColorPicker, {
   AdvancedColorPickerProps,
 } from "./advanced-color-picker.component";
@@ -236,7 +236,9 @@ test.each([
     await user.click(screen.getByRole("button", { name: "Change colour" }));
     expect(await screen.findByRole("dialog")).toBeVisible();
 
-    screen.getByRole("radio", { name: "pink" }).focus();
+    act(() => {
+      screen.getByRole("radio", { name: "pink" }).focus();
+    });
     await user.keyboard(keyCode);
 
     await waitFor(() => {
@@ -255,9 +257,13 @@ test.each(["a", "b", "q", "t", "x", "4", "0"])(
     await user.click(screen.getByRole("button", { name: "Change colour" }));
     expect(await screen.findByRole("dialog")).toBeVisible();
 
-    screen.getByRole("radio", { name: "pink" }).focus();
+    act(() => {
+      screen.getByRole("radio", { name: "pink" }).focus();
+    });
     await user.keyboard(key);
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
 
     expect(screen.getByRole("dialog")).toBeVisible();
   },
@@ -269,8 +275,11 @@ test("tabbing from the close button should focus the selected color input", asyn
   render(<ControlledColorPicker selectedColor="#EBAEDE" />);
   await user.click(screen.getByRole("button", { name: "Change colour" }));
 
-  screen.getByRole("button", { name: "Close" }).focus();
+  act(() => {
+    screen.getByRole("button", { name: "Close" }).focus();
+  });
   await user.keyboard("{Tab}");
+
   expect(screen.getByRole("radio", { name: "orchid" })).toHaveFocus();
 });
 
@@ -294,7 +303,9 @@ test("shift-tabbing from the close button should focus the selected color input"
   render(<ControlledColorPicker selectedColor="#EBAEDE" />);
   await user.click(screen.getByRole("button", { name: "Change colour" }));
 
-  screen.getByRole("button", { name: "Close" }).focus();
+  act(() => {
+    screen.getByRole("button", { name: "Close" }).focus();
+  });
   await user.keyboard("{Shift>}{Tab}");
   expect(screen.getByRole("radio", { name: "orchid" })).toHaveFocus();
 });
@@ -343,7 +354,9 @@ test("when the user closes the component, it does trigger the onBlur callback", 
   expect(await screen.findByRole("radio", { name: "white" })).toHaveFocus();
 
   await user.click(screen.getByRole("button", { name: "Close" }));
-  jest.runAllTimers();
+  act(() => {
+    jest.runAllTimers();
+  });
 
   expect(onBlur).toHaveBeenCalledTimes(1);
   expect(onBlur.mock.calls[0][0].target).toHaveAccessibleName("white");
@@ -363,7 +376,9 @@ test("when another color input is clicked, it does not trigger the onBlur callba
   expect(await screen.findByRole("radio", { name: "white" })).toHaveFocus();
 
   await user.click(screen.getByRole("radio", { name: "pink" }));
-  jest.runAllTimers();
+  act(() => {
+    jest.runAllTimers();
+  });
 
   expect(onBlur).toHaveBeenCalledTimes(0);
 });

--- a/src/components/badge/badge.test.tsx
+++ b/src/components/badge/badge.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Badge from "./badge.component";
 
@@ -43,11 +43,15 @@ describe("Badge", () => {
     const badgeButton = screen.getByRole("button");
     const badgeText = screen.getByText("9");
 
-    badgeButton.focus();
+    act(() => {
+      badgeButton.focus();
+    });
 
     expect(badgeText).not.toBeVisible();
 
-    badgeButton.blur();
+    act(() => {
+      badgeButton.blur();
+    });
 
     expect(badgeText).toBeVisible();
   });

--- a/src/components/batch-selection/batch-selection.test.tsx
+++ b/src/components/batch-selection/batch-selection.test.tsx
@@ -78,6 +78,7 @@ test("`ButtonMinor` children should be automatically disabled via context", () =
 test("`Link` children should be automatically disabled via context", () => {
   render(
     <BatchSelection selectedCount={0} disabled>
+      {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
       <Link>Link as an anchor</Link>
     </BatchSelection>,
   );
@@ -94,6 +95,7 @@ test("`Link` children should be automatically disabled via context", () => {
 test("`Link` children rendered as a button should be automatically disabled via context", () => {
   render(
     <BatchSelection selectedCount={0} disabled>
+      {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
       <Link onClick={() => {}}>Link as a button</Link>
     </BatchSelection>,
   );

--- a/src/components/date/date.test.tsx
+++ b/src/components/date/date.test.tsx
@@ -1668,6 +1668,6 @@ test("should select the correct date when the locale is overridden and a date is
   await user.type(input, "05/04");
   jest.advanceTimersByTime(10);
 
-  const grid = screen.getByRole("status").textContent;
-  expect(grid).toEqual("April 2019");
+  const caption = screen.getByRole("status");
+  expect(caption).toHaveTextContent("April 2019");
 });

--- a/src/components/decimal/decimal.test.tsx
+++ b/src/components/decimal/decimal.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Decimal from "./decimal.component";
@@ -426,7 +426,9 @@ describe("when the component is uncontrolled", () => {
       const user = userEvent.setup();
       render(<Decimal onChange={onChange} />);
 
-      screen.getByRole("textbox").focus();
+      act(() => {
+        screen.getByRole("textbox").focus();
+      });
       (screen.getByRole("textbox") as HTMLInputElement).select();
       await user.paste(pastedText);
 
@@ -473,7 +475,9 @@ describe("when the component is uncontrolled", () => {
 
     const decimalInput = screen.getByRole("textbox");
 
-    decimalInput.focus();
+    act(() => {
+      decimalInput.focus();
+    });
     await user.keyboard("{ArrowLeft}");
     await user.keyboard("-");
 
@@ -487,7 +491,9 @@ describe("when the component is uncontrolled", () => {
 
     const decimalInput = screen.getByRole("textbox");
 
-    decimalInput.focus();
+    act(() => {
+      decimalInput.focus();
+    });
     await user.keyboard("{ArrowRight}");
     await user.keyboard("-");
 
@@ -546,7 +552,9 @@ describe("when the component is uncontrolled", () => {
       render(<Decimal defaultValue="1234.56" />);
 
       const decimalInput = screen.getByRole("textbox") as HTMLInputElement;
-      decimalInput.focus();
+      act(() => {
+        decimalInput.focus();
+      });
       decimalInput.setSelectionRange(selectionStart, selectionEnd);
       await user.keyboard("{Backspace}");
 
@@ -561,7 +569,9 @@ describe("when the component is uncontrolled", () => {
     render(<Decimal defaultValue="1234.56" />);
 
     const decimalInput = screen.getByRole("textbox");
-    decimalInput.focus();
+    act(() => {
+      decimalInput.focus();
+    });
     await user.keyboard("{ArrowLeft}");
     await user.keyboard("{Backspace}");
 
@@ -574,7 +584,9 @@ describe("when the component is uncontrolled", () => {
     render(<Decimal defaultValue="1234.56" />);
 
     const decimalInput = screen.getByRole("textbox");
-    decimalInput.focus();
+    act(() => {
+      decimalInput.focus();
+    });
     await user.keyboard("{ArrowRight}");
     await user.keyboard("{Backspace}");
 
@@ -633,7 +645,9 @@ describe("when the component is uncontrolled", () => {
       render(<Decimal defaultValue="1234.56" />);
 
       const decimalInput = screen.getByRole("textbox") as HTMLInputElement;
-      decimalInput.focus();
+      act(() => {
+        decimalInput.focus();
+      });
       decimalInput.setSelectionRange(selectionStart, selectionEnd);
       await user.keyboard("{Delete}");
 
@@ -648,7 +662,9 @@ describe("when the component is uncontrolled", () => {
     render(<Decimal defaultValue="1234.56" />);
 
     const decimalInput = screen.getByRole("textbox");
-    decimalInput.focus();
+    act(() => {
+      decimalInput.focus();
+    });
     await user.keyboard("{ArrowLeft}");
     await user.keyboard("{Delete}");
 
@@ -661,7 +677,9 @@ describe("when the component is uncontrolled", () => {
     render(<Decimal defaultValue="1234.56" />);
 
     const decimalInput = screen.getByRole("textbox");
-    decimalInput.focus();
+    act(() => {
+      decimalInput.focus();
+    });
     await user.keyboard("{ArrowRight}");
     await user.keyboard("{Delete}");
 
@@ -689,7 +707,9 @@ describe("when the component is uncontrolled", () => {
     const onKeyDown = jest.fn();
     render(<Decimal defaultValue="0.00" onKeyDown={onKeyDown} />);
 
-    screen.getByRole("textbox").focus();
+    act(() => {
+      screen.getByRole("textbox").focus();
+    });
     await user.keyboard("{ArrowRight}");
     await user.keyboard("1");
 
@@ -724,7 +744,9 @@ describe("when the component is uncontrolled", () => {
     const onChange = jest.fn();
     render(<Decimal allowEmptyValue onChange={onChange} />);
 
-    screen.getByRole("textbox").focus();
+    act(() => {
+      screen.getByRole("textbox").focus();
+    });
     await user.tab();
 
     expect(onChange).not.toHaveBeenCalled();
@@ -821,7 +843,9 @@ describe("when the component is uncontrolled", () => {
       />,
     );
 
-    screen.getByRole("textbox").focus();
+    act(() => {
+      screen.getByRole("textbox").focus();
+    });
     await user.keyboard("{Delete}");
     await user.tab();
 
@@ -840,7 +864,9 @@ describe("when the component is uncontrolled", () => {
       />,
     );
 
-    screen.getByRole("textbox").focus();
+    act(() => {
+      screen.getByRole("textbox").focus();
+    });
     await user.keyboard("{Delete}");
     await user.tab();
 
@@ -952,7 +978,9 @@ describe("when the component is uncontrolled", () => {
       />,
     );
 
-    screen.getByRole("textbox").focus();
+    act(() => {
+      screen.getByRole("textbox").focus();
+    });
     await user.keyboard("{Delete}");
     await user.tab();
 
@@ -971,7 +999,9 @@ describe("when the component is uncontrolled", () => {
       />,
     );
 
-    screen.getByRole("textbox").focus();
+    act(() => {
+      screen.getByRole("textbox").focus();
+    });
     await user.keyboard("{Delete}");
     await user.tab();
 
@@ -1011,7 +1041,9 @@ describe("when the component is uncontrolled", () => {
       />,
     );
 
-    screen.getByRole("textbox").focus();
+    act(() => {
+      screen.getByRole("textbox").focus();
+    });
     await user.keyboard("{Delete}");
     await user.tab();
 
@@ -1030,7 +1062,9 @@ describe("when the component is uncontrolled", () => {
       />,
     );
 
-    screen.getByRole("textbox").focus();
+    act(() => {
+      screen.getByRole("textbox").focus();
+    });
     await user.keyboard("{Delete}");
     await user.tab();
 
@@ -1103,7 +1137,9 @@ describe("when the component is uncontrolled", () => {
       />,
     );
 
-    screen.getByRole("textbox").focus();
+    act(() => {
+      screen.getByRole("textbox").focus();
+    });
     await user.keyboard("{Delete}");
     await user.tab();
 
@@ -1122,7 +1158,9 @@ describe("when the component is uncontrolled", () => {
       />,
     );
 
-    screen.getByRole("textbox").focus();
+    act(() => {
+      screen.getByRole("textbox").focus();
+    });
     await user.keyboard("{Delete}");
     await user.tab();
 
@@ -1148,7 +1186,9 @@ describe("when the component is controlled", () => {
     const onChange = jest.fn();
     render(<Decimal value="123" onChange={onChange} />);
 
-    screen.getByRole("textbox").focus();
+    act(() => {
+      screen.getByRole("textbox").focus();
+    });
     await user.tab();
 
     expect(onChange).not.toHaveBeenCalled();
@@ -1176,7 +1216,9 @@ describe("when the component is controlled", () => {
       />,
     );
 
-    screen.getByRole("textbox").focus();
+    act(() => {
+      screen.getByRole("textbox").focus();
+    });
     await user.tab();
 
     expect(screen.getByRole("textbox")).toHaveValue("0");
@@ -1193,7 +1235,9 @@ describe("when the component is controlled", () => {
       />,
     );
 
-    screen.getByRole("textbox").focus();
+    act(() => {
+      screen.getByRole("textbox").focus();
+    });
     await user.tab();
 
     expect(screen.getByRole("textbox")).toHaveValue("0.0");
@@ -1280,7 +1324,9 @@ describe("when the component is controlled", () => {
     );
 
     const decimalInput = screen.getByRole("textbox");
-    decimalInput.focus();
+    act(() => {
+      decimalInput.focus();
+    });
     await user.keyboard("{Backspace}");
     await user.tab();
 
@@ -1304,7 +1350,9 @@ describe("when the component is controlled", () => {
     render(<ControlledDecimal startingValue="1" onBlur={onBlur} />);
 
     const decimalInput = screen.getByRole("textbox");
-    decimalInput.focus();
+    act(() => {
+      decimalInput.focus();
+    });
     await user.keyboard("{Backspace}");
     await user.tab();
 
@@ -1370,7 +1418,9 @@ test("when wrapped in an I18nProvider, the appropriate locale is used, and the f
       <Decimal />
     </I18nProvider>,
   );
-  screen.getByRole("textbox").focus();
+  act(() => {
+    screen.getByRole("textbox").focus();
+  });
   await user.tab();
   expect(screen.getByRole("textbox")).toHaveValue("0.00");
 });

--- a/src/components/dialog-full-screen/dialog-full-screen.test.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.test.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import {
+  act,
   render,
   screen,
   waitFor,
@@ -85,10 +86,12 @@ test("the dialog container should not be focused when the dialog opens if the di
     </DialogFullScreen>,
   );
 
-  // need to use fake timers here rather than waitFor to ensure that the test fails if the disableAutoFocus functionality
-  // gets broken - using waitFor would always pass as the dialog is always initially unfocused. To be sure focus doesn't
-  // happen we need to let all timers run.
-  jest.runAllTimers();
+  act(() => {
+    // need to use fake timers here rather than waitFor to ensure that the test fails if the disableAutoFocus functionality
+    // gets broken - using waitFor would always pass as the dialog is always initially unfocused. To be sure focus doesn't
+    // happen we need to let all timers run.
+    jest.runAllTimers();
+  });
 
   expect(screen.getByRole("dialog")).not.toHaveFocus();
 
@@ -389,7 +392,9 @@ test("the onCancel callback should be called when the enter key is pressed", asy
   const onCancel = jest.fn();
   render(<ControlledDialog onCancel={onCancel} />);
 
-  screen.getByRole("button", { name: "Close" }).focus();
+  act(() => {
+    screen.getByRole("button", { name: "Close" }).focus();
+  });
   await user.keyboard("{Enter}");
 
   await waitForElementToBeRemoved(() => screen.queryByRole("dialog"));
@@ -402,13 +407,17 @@ test("the onCancel callback should not be called when a non-Enter key is pressed
   const onCancel = jest.fn();
   render(<ControlledDialog onCancel={onCancel} />);
 
-  screen.getByRole("button", { name: "Close" }).focus();
+  act(() => {
+    screen.getByRole("button", { name: "Close" }).focus();
+  });
   await user.keyboard("a");
 
-  // need to use fake timers here rather than waitFor to ensure that the test fails if this feature ever
-  // gets broken - using waitFor would always pass as the dialog is already visible (and onCancel not called)
-  // at this point
-  jest.runAllTimers();
+  act(() => {
+    // need to use fake timers here rather than waitFor to ensure that the test fails if this feature ever
+    // gets broken - using waitFor would always pass as the dialog is already visible (and onCancel not called)
+    // at this point
+    jest.runAllTimers();
+  });
   expect(screen.getByRole("dialog")).toBeVisible();
   expect(onCancel).not.toHaveBeenCalled();
 

--- a/src/components/dialog/dialog.test.tsx
+++ b/src/components/dialog/dialog.test.tsx
@@ -4,6 +4,7 @@ import {
   screen,
   within,
   waitForElementToBeRemoved,
+  act,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -185,7 +186,7 @@ describe("closing behaviour", () => {
     );
 
     const closeButton = screen.getByRole("button", { name: /Close/i });
-    closeButton.focus();
+    act(() => closeButton.focus());
     await user.keyboard("{Enter}");
     await waitForElementToBeRemoved(() => screen.queryByRole("dialog"));
 
@@ -202,7 +203,7 @@ describe("closing behaviour", () => {
     );
 
     const closeButton = screen.getByRole("button", { name: /Close/i });
-    closeButton.focus();
+    act(() => closeButton.focus());
     await user.keyboard("{ }");
     await waitForElementToBeRemoved(() => screen.queryByRole("dialog"));
 
@@ -220,7 +221,7 @@ describe("closing behaviour", () => {
     );
 
     const closeButton = screen.getByRole("button", { name: /Close/i });
-    closeButton.focus();
+    act(() => closeButton.focus());
     await user.keyboard("{a}");
 
     expect(onCancel).not.toHaveBeenCalled();
@@ -246,8 +247,6 @@ test("root container is refocused when the focus method of the component's ref h
   );
 
   const button = screen.getByRole("button", { name: /Refocus dialog/i });
-  button.focus();
-
   await user.click(button);
 
   expect(screen.getByRole("dialog")).toHaveFocus();

--- a/src/components/duelling-picklist/duelling-picklist.test.tsx
+++ b/src/components/duelling-picklist/duelling-picklist.test.tsx
@@ -1,5 +1,5 @@
 import React, { useReducer } from "react";
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {
@@ -582,7 +582,9 @@ test.each([
     const allSourceGroupButtons = within(
       screen.getAllByTestId("picklist")[0],
     ).getAllByTestId("picklist-group-button");
-    allSourceGroupButtons[allSourceGroupButtons.length - 1].focus();
+    act(() => {
+      allSourceGroupButtons[allSourceGroupButtons.length - 1].focus();
+    });
     await user.keyboard(key);
 
     expect(
@@ -605,7 +607,9 @@ test.each([
     const allSourceGroupButtons = within(
       screen.getAllByTestId("picklist")[1],
     ).getAllByTestId("picklist-group-button");
-    allSourceGroupButtons[allSourceGroupButtons.length - 1].focus();
+    act(() => {
+      allSourceGroupButtons[allSourceGroupButtons.length - 1].focus();
+    });
     await user.keyboard(key);
 
     expect(

--- a/src/components/duelling-picklist/picklist-group/picklist-group.test.tsx
+++ b/src/components/duelling-picklist/picklist-group/picklist-group.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import PicklistGroup from "./picklist-group.component";
@@ -92,7 +92,9 @@ test("when the enter key is pressed with the group button focused, the onChange 
     </FocusContext.Provider>,
   );
 
-  screen.getByTestId("picklist-group-button").focus();
+  act(() => {
+    screen.getByTestId("picklist-group-button").focus();
+  });
   await user.keyboard("{Enter}");
 
   expect(onChange).toHaveBeenCalledTimes(1);
@@ -119,7 +121,9 @@ test("when the space key is pressed with the group button focused, the onChange 
     </FocusContext.Provider>,
   );
 
-  screen.getByTestId("picklist-group-button").focus();
+  act(() => {
+    screen.getByTestId("picklist-group-button").focus();
+  });
   await user.keyboard(" ");
 
   expect(onChange).toHaveBeenCalledTimes(1);
@@ -146,7 +150,9 @@ test("when a key other than space or enter is pressed with the group button focu
     </FocusContext.Provider>,
   );
 
-  screen.getByTestId("picklist-group-button").focus();
+  act(() => {
+    screen.getByTestId("picklist-group-button").focus();
+  });
   await user.keyboard("a");
 
   expect(onChange).not.toHaveBeenCalled();
@@ -217,7 +223,9 @@ test("when an 'add' button is focused, it should change the background colour of
     </PicklistGroup>,
   );
 
-  screen.getByTestId("picklist-group-button").focus();
+  act(() => {
+    screen.getByTestId("picklist-group-button").focus();
+  });
 
   expect(screen.getAllByRole("listitem")[0]).toHaveStyleRule(
     "background",
@@ -244,7 +252,9 @@ test("when a 'remove' button is focused, it should change the background colour 
     </PicklistGroup>,
   );
 
-  screen.getByTestId("picklist-group-button").focus();
+  act(() => {
+    screen.getByTestId("picklist-group-button").focus();
+  });
 
   expect(screen.getAllByRole("listitem")[0]).toHaveStyleRule(
     "background",

--- a/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.test.tsx
+++ b/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import FlatTableCheckbox from "./flat-table-checkbox.component";
@@ -42,8 +42,9 @@ test("should stop propagation when the user presses a key that is not up or down
       </tbody>
     </table>,
   );
-
-  screen.getByRole("checkbox").focus();
+  act(() => {
+    screen.getByRole("checkbox").focus();
+  });
   await user.keyboard("{a}");
 
   expect(parentOnKeyDown).not.toHaveBeenCalled();
@@ -61,8 +62,9 @@ test("should not stop propagation when the user presses down arrow key", async (
       </tbody>
     </table>,
   );
-
-  screen.getByRole("checkbox").focus();
+  act(() => {
+    screen.getByRole("checkbox").focus();
+  });
   await user.keyboard("{ArrowDown}");
 
   expect(parentOnKeyDown).toHaveBeenCalled();
@@ -80,8 +82,9 @@ test("should not stop propagation when the user presses up arrow key", async () 
       </tbody>
     </table>,
   );
-
-  screen.getByRole("checkbox").focus();
+  act(() => {
+    screen.getByRole("checkbox").focus();
+  });
   await user.keyboard("{ArrowUp}");
 
   expect(parentOnKeyDown).toHaveBeenCalled();

--- a/src/components/flat-table/flat-table.test.tsx
+++ b/src/components/flat-table/flat-table.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 
 import userEvent from "@testing-library/user-event";
 import FlatTable from "./flat-table.component";
@@ -62,7 +62,9 @@ describe("when rows are interactive", () => {
     );
     const tableWrapper = screen.getByRole("region");
     const focusableTableContainer = screen.getByTestId("flat-table-container");
-    focusableTableContainer.focus();
+    act(() => {
+      focusableTableContainer.focus();
+    });
 
     expect(focusableTableContainer).toHaveFocus();
     expect(tableWrapper).toHaveStyleRule("outline", "transparent 3px solid");
@@ -91,7 +93,9 @@ describe("when rows are interactive", () => {
     );
     const tableWrapper = screen.getByRole("region");
     const focusableTableContainer = screen.getByTestId("flat-table-container");
-    focusableTableContainer.focus();
+    act(() => {
+      focusableTableContainer.focus();
+    });
 
     expect(focusableTableContainer).toHaveFocus();
     expect(tableWrapper).toHaveStyleRule(
@@ -117,7 +121,9 @@ describe("when rows are interactive", () => {
       </FlatTable>,
     );
     const focusableTableContainer = screen.getByTestId("flat-table-container");
-    focusableTableContainer.focus();
+    act(() => {
+      focusableTableContainer.focus();
+    });
 
     expect(focusableTableContainer).toHaveFocus();
 
@@ -187,7 +193,9 @@ describe("when rows are interactive", () => {
     const secondRow = screen.getByRole("row", { name: "three four" });
     const thirdRow = screen.getByRole("row", { name: "five six" });
     const fourthRow = screen.getByRole("row", { name: "seven eight" });
-    focusableTableContainer?.focus();
+    act(() => {
+      focusableTableContainer?.focus();
+    });
 
     await user.keyboard("{Tab}");
     expect(firstRow).toHaveFocus();
@@ -374,7 +382,9 @@ describe("when rows are interactive", () => {
     );
     const secondRow = screen.getByRole("row", { name: "three four" });
     const checkbox = screen.getByRole("checkbox");
-    checkbox.focus();
+    act(() => {
+      checkbox.focus();
+    });
 
     expect(checkbox).toHaveFocus();
     await user.keyboard("{ArrowDown}");
@@ -399,7 +409,9 @@ describe("when rows are interactive", () => {
     );
     const firstRow = screen.getByRole("row", { name: "one two" });
     const checkbox = screen.getByRole("checkbox");
-    checkbox.focus();
+    act(() => {
+      checkbox.focus();
+    });
 
     expect(checkbox).toHaveFocus();
     await user.keyboard("{ArrowUp}");

--- a/src/components/help/help.test.tsx
+++ b/src/components/help/help.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Help from ".";
 import Icon from "../icon";
@@ -35,9 +35,11 @@ test("removes tooltip when Escape key is pressed", async () => {
   const user = userEvent.setup();
   render(<Help>foo</Help>);
 
-  screen.getByRole("button", { name: "help" }).focus();
+  act(() => {
+    screen.getByRole("button", { name: "help" }).focus();
+  });
 
-  expect(screen.getByRole("tooltip", { name: "foo" })).toBeVisible();
+  expect(await screen.findByRole("tooltip", { name: "foo" })).toBeVisible();
 
   await user.keyboard("{Escape}");
 
@@ -48,9 +50,11 @@ test("does not remove tooltip when Enter key is pressed", async () => {
   const user = userEvent.setup();
   render(<Help>foo</Help>);
 
-  screen.getByRole("button", { name: "help" }).focus();
+  act(() => {
+    screen.getByRole("button", { name: "help" }).focus();
+  });
 
-  const tooltip = screen.getByRole("tooltip", { name: "foo" });
+  const tooltip = await screen.findByRole("tooltip", { name: "foo" });
 
   expect(tooltip).toBeVisible();
 

--- a/src/components/link/link.test.tsx
+++ b/src/components/link/link.test.tsx
@@ -1,7 +1,7 @@
 /* TODO: FE-6579 To re-enable once button-related props are removed from Link */
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Link from "./link.component";
@@ -158,7 +158,9 @@ describe("when the `onKeyDown` event is triggered", () => {
     render(<Link onKeyDown={onKeyDownFn} onClick={onClickFn} href="#" />);
 
     const linkElement = screen.getByTestId("link-anchor");
-    linkElement.focus();
+    act(() => {
+      linkElement.focus();
+    });
     await user.keyboard("{Enter}");
 
     expect(onKeyDownFn).toHaveBeenCalled();
@@ -170,7 +172,9 @@ describe("when the `onKeyDown` event is triggered", () => {
     render(<Link onKeyDown={onKeyDownFn} href="#" />);
 
     const linkElement = screen.getByTestId("link-anchor");
-    linkElement.focus();
+    act(() => {
+      linkElement.focus();
+    });
     await user.keyboard("{Enter}");
 
     expect(onKeyDownFn).toHaveBeenCalled();
@@ -183,7 +187,9 @@ describe("when the `onKeyDown` event is triggered", () => {
     render(<Link onKeyDown={onKeyDownFn} href="#" />);
 
     const linkElement = screen.getByTestId("link-anchor");
-    linkElement.focus();
+    act(() => {
+      linkElement.focus();
+    });
     await user.keyboard("{Enter}");
 
     expect(onKeyDownFn).toHaveBeenCalled();

--- a/src/components/menu/menu-item/menu-item.test.tsx
+++ b/src/components/menu/menu-item/menu-item.test.tsx
@@ -1,5 +1,12 @@
 import React from "react";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { MenuItem, MenuSegmentTitle } from "..";
@@ -478,7 +485,9 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
 
@@ -505,7 +514,9 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
 
@@ -530,7 +541,9 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
     await user.keyboard("{arrowup}");
     const submenuItems = screen.getAllByRole("link");
 
@@ -557,7 +570,9 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
 
@@ -580,7 +595,9 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
 
@@ -605,7 +622,9 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
     await user.keyboard("{End}");
@@ -639,7 +658,9 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
 
@@ -664,7 +685,9 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
     await user.keyboard("{End}");
@@ -690,7 +713,9 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
 
@@ -715,7 +740,9 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("link", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
     await user.keyboard("{arrowdown}");
     await user.tab();
 
@@ -736,7 +763,9 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("link", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
     await user.keyboard("{arrowdown}");
     await user.keyboard("{a}");
 
@@ -897,7 +926,9 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
     await user.keyboard("{arrowleft}");
 
     expect(screen.queryByRole("list")).not.toBeInTheDocument();
@@ -917,7 +948,9 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
     await user.keyboard("{arrowdown}");
     await user.keyboard("{Escape}");
 
@@ -941,7 +974,9 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
     await user.keyboard("{arrowdown}");
     await user.keyboard("{arrowdown}");
     await user.keyboard("{Enter}");
@@ -968,14 +1003,20 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
 
     await user.keyboard("{arrowdown}");
     await user.keyboard("{Enter}");
 
-    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
 
-    jest.runOnlyPendingTimers();
+    await waitFor(() => {
+      expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    });
     jest.useRealTimers();
   });
 
@@ -1004,7 +1045,9 @@ describe("when MenuItem has a submenu", () => {
       </MenuContext.Provider>,
     );
     const submenuParentItem = screen.getByRole("link", { name: "Item One" });
-    submenuParentItem.focus();
+    act(() => {
+      submenuParentItem.focus();
+    });
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("button");
     await user.click(submenuItems[2]);

--- a/src/components/menu/menu.test.tsx
+++ b/src/components/menu/menu.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen, render } from "@testing-library/react";
+import { screen, render, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { Menu, MenuItem } from ".";
@@ -28,7 +28,9 @@ test("should focus the last item when 'End' key is pressed by user", async () =>
     </Menu>,
   );
   const firstMenuItem = screen.getByRole("link", { name: "test one" });
-  firstMenuItem.focus();
+  act(() => {
+    firstMenuItem.focus();
+  });
   const lastMenuItem = screen.getByRole("link", { name: "test four" });
   await user.keyboard("{End}");
 
@@ -46,7 +48,9 @@ test("should focus the first item when 'Home' key is pressed by user", async () 
     </Menu>,
   );
   const lastMenuItem = screen.getByRole("link", { name: "test four" });
-  lastMenuItem.focus();
+  act(() => {
+    lastMenuItem.focus();
+  });
   const firstMenuItem = screen.getByRole("link", { name: "test one" });
   await user.keyboard("{Home}");
 
@@ -64,7 +68,9 @@ test("should focus the next item in sequence, and remove focus from menu on last
     </Menu>,
   );
   const items = screen.getAllByRole("link");
-  items[0].focus();
+  act(() => {
+    items[0].focus();
+  });
   await user.tab();
 
   expect(items[1]).toHaveFocus();
@@ -87,7 +93,9 @@ test("should focus the previous item in sequence, and remove focus from menu on 
     </Menu>,
   );
   const items = screen.getAllByRole("link");
-  items[3].focus();
+  act(() => {
+    items[3].focus();
+  });
   await user.tab({ shift: true });
 
   expect(items[2]).toHaveFocus();
@@ -110,7 +118,9 @@ test("should not focus the next item in sequence when 'arrowright' key is presse
     </Menu>,
   );
   const items = screen.getAllByRole("link");
-  items[0].focus();
+  act(() => {
+    items[0].focus();
+  });
   await user.keyboard("{arrowright}");
 
   expect(items[0]).toHaveFocus();
@@ -131,7 +141,9 @@ test("should not focus the previous item in sequence when 'arrowleft' key is pre
     </Menu>,
   );
   const items = screen.getAllByRole("link");
-  items[3].focus();
+  act(() => {
+    items[3].focus();
+  });
   await user.keyboard("{arrowleft}");
 
   expect(items[3]).toHaveFocus();

--- a/src/components/modal/modal.test.tsx
+++ b/src/components/modal/modal.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 
 import userEvent from "@testing-library/user-event";
 import Modal from "./modal.component";
@@ -100,7 +100,9 @@ test("closes top modal when the `escape` key is pressed", async () => {
   expect(onCancelFnTwo).toHaveBeenCalled();
   expect(onCancelFn).not.toHaveBeenCalled();
 
-  jest.runOnlyPendingTimers();
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
   jest.useRealTimers();
 });
 
@@ -123,7 +125,9 @@ test("does not fire `onCancel` if the `escape` key is pressed and no modals are 
   expect(onCancelFnTwo).not.toHaveBeenCalled();
   expect(onCancelFn).not.toHaveBeenCalled();
 
-  jest.runOnlyPendingTimers();
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
   jest.useRealTimers();
 });
 
@@ -134,16 +138,16 @@ test("does not fire `onCancel` if the `escape` key is pressed and `disableClose`
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <>
-      <Modal data-role="first-modal" open disableClose onCancel={onCancelFn} />
-    </>,
+    <Modal data-role="first-modal" open disableClose onCancel={onCancelFn} />,
   );
 
   await user.keyboard("{Escape}");
 
   expect(onCancelFn).not.toHaveBeenCalled();
 
-  jest.runOnlyPendingTimers();
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
   jest.useRealTimers();
 });
 
@@ -160,7 +164,9 @@ test("should call the `onCancel` method when the modal is open and the `escape` 
 
   expect(onCancelFn).toHaveBeenCalled();
 
-  jest.runOnlyPendingTimers();
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
   jest.useRealTimers();
 });
 
@@ -177,7 +183,9 @@ test("onCancel method should not have been called with disableEscKey prop set to
 
   expect(onCancelFn).not.toHaveBeenCalled();
 
-  jest.runOnlyPendingTimers();
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
   jest.useRealTimers();
 });
 

--- a/src/components/numeral-date/numeral-date.test.tsx
+++ b/src/components/numeral-date/numeral-date.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, within, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
   testStyledSystemMargin,
@@ -1839,7 +1839,10 @@ test("should call `onBlur` callback if prop is passed and user clicks outside of
   const dayInput = screen.getByRole("textbox", { name: "Day" });
   await user.click(dayInput);
   await user.click(document.body);
-  jest.runAllTimers();
+
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
 
   expect(onBlur).toHaveBeenCalled();
 });
@@ -1860,7 +1863,10 @@ test("should not call `onBlur` callback if prop is passed and user clicks from o
   const monthInput = screen.getByRole("textbox", { name: "Month" });
   await user.click(dayInput);
   await user.click(monthInput);
-  jest.runAllTimers();
+
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
 
   expect(onBlur).not.toHaveBeenCalled();
 });

--- a/src/components/pages/pages.test.tsx
+++ b/src/components/pages/pages.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Pages, { Page, PagesProps } from "./pages.component";
@@ -72,7 +72,9 @@ test.each([
     render(<PagesExample transition={transition} />);
 
     await user.click(screen.getByRole("button", { name: "Go to second page" }));
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
 
     expect(screen.getByTestId("visible-page")).toHaveClass(
       `${expected}-enter-done`,
@@ -105,8 +107,9 @@ test("when the `pageIndex` prop is changed to `undefined`, the currently-rendere
   expect(screen.getByRole("heading")).toHaveTextContent("Page 2");
 
   rerender(<ExampleComponent pageIndex={undefined} />);
-  jest.runAllTimers();
-
+  act(() => {
+    jest.runAllTimers();
+  });
   expect(screen.getByRole("heading")).toHaveTextContent("Page 2");
 });
 
@@ -115,9 +118,10 @@ test("navigating to the next page should render the expected content", async () 
   render(<PagesExample />);
 
   await user.click(screen.getByRole("button", { name: "Go to second page" }));
-  jest.runAllTimers();
-
-  expect(screen.getByRole("heading")).toHaveTextContent("My Second Page");
+  act(() => {
+    jest.runAllTimers();
+  });
+  expect(screen.getByRole("heading", { name: "My Second Page" })).toBeVisible();
 });
 
 test("navigating to the previous page should render the expected content", async () => {
@@ -126,9 +130,10 @@ test("navigating to the previous page should render the expected content", async
   expect(screen.getByRole("heading")).toHaveTextContent("My Second Page");
 
   await user.click(screen.getByRole("button", { name: "Back" }));
-  jest.runAllTimers();
-
-  expect(screen.getByRole("heading")).toHaveTextContent("My First Page");
+  act(() => {
+    jest.runAllTimers();
+  });
+  expect(screen.getByRole("heading", { name: "My First Page" })).toBeVisible();
 });
 
 test("navigating to the previous page should render the last page when currently on the first page", async () => {
@@ -136,9 +141,10 @@ test("navigating to the previous page should render the last page when currently
   render(<PagesExample />);
 
   await user.click(screen.getByRole("button", { name: "Back" }));
-  jest.runAllTimers();
-
-  expect(screen.getByRole("heading")).toHaveTextContent("My Third Page");
+  act(() => {
+    jest.runAllTimers();
+  });
+  expect(screen.getByRole("heading", { name: "My Third Page" })).toBeVisible();
 });
 
 test("navigating to the next page should render the first page when currently on the last page", async () => {
@@ -147,9 +153,10 @@ test("navigating to the next page should render the first page when currently on
   expect(screen.getByRole("heading")).toHaveTextContent("My Third Page");
 
   await user.click(screen.getByRole("button", { name: "Go to next page" }));
-  jest.runAllTimers();
-
-  expect(screen.getByRole("heading")).toHaveTextContent("My First Page");
+  act(() => {
+    jest.runAllTimers();
+  });
+  expect(screen.getByRole("heading", { name: "My First Page" })).toBeVisible();
 });
 
 test("when attempting to navigate pages and there is only one page, it should not change the rendered content", async () => {

--- a/src/components/pod/pod.test.tsx
+++ b/src/components/pod/pod.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Pod from ".";
 import Typography from "../typography";
@@ -94,8 +94,9 @@ test("calls `onEdit` when Enter key is pressed on the edit button", async () => 
   render(<Pod title="Title" onEdit={onEdit} />);
 
   const editButton = screen.getByRole("button", { name: "Edit" });
-  editButton.focus();
-
+  act(() => {
+    editButton.focus();
+  });
   await user.keyboard("{enter}");
 
   expect(onEdit).toHaveBeenCalled();
@@ -107,9 +108,11 @@ test("does not call `onEdit` when non-Enter key is pressed on the edit button", 
   render(<Pod title="Title" onEdit={onEdit} />);
 
   const editButton = screen.getByRole("button", { name: "Edit" });
-  editButton.focus();
-
+  act(() => {
+    editButton.focus();
+  });
   await user.keyboard("a");
+
   expect(onEdit).not.toHaveBeenCalled();
 });
 
@@ -129,9 +132,11 @@ test("calls `onEdit` when `triggerEditOnContent` is true and Enter key is presse
   render(<Pod title="Title" onEdit={onEdit} triggerEditOnContent />);
 
   const content = screen.getByTestId("pod-block");
-  content.focus();
-
+  act(() => {
+    content.focus();
+  });
   await user.keyboard("{enter}");
+
   expect(onEdit).toHaveBeenCalled();
 });
 
@@ -141,9 +146,11 @@ test("does not call `onEdit` when `triggerEditOnContent` is true and non-Enter k
   render(<Pod title="Title" onEdit={onEdit} triggerEditOnContent />);
 
   const content = screen.getByTestId("pod-block");
-  content.focus();
-
+  act(() => {
+    content.focus();
+  });
   await user.keyboard("a");
+
   expect(onEdit).not.toHaveBeenCalled();
 });
 
@@ -169,9 +176,11 @@ test("calls `onDelete` when Enter key is pressed on the delete button", async ()
   render(<Pod title="Title" onDelete={onDelete} />);
 
   const deleteButton = screen.getByRole("button", { name: "Delete" });
-  deleteButton.focus();
-
+  act(() => {
+    deleteButton.focus();
+  });
   await user.keyboard("{enter}");
+
   expect(onDelete).toHaveBeenCalled();
 });
 
@@ -181,9 +190,11 @@ test("does not call `onDelete` when non-Enter key is pressed on the delete butto
   render(<Pod title="Title" onDelete={onDelete} />);
 
   const deleteButton = screen.getByRole("button", { name: "Delete" });
-  deleteButton.focus();
-
+  act(() => {
+    deleteButton.focus();
+  });
   await user.keyboard("a");
+
   expect(onDelete).not.toHaveBeenCalled();
 });
 
@@ -209,9 +220,11 @@ test("calls `onUndo` when Enter key is pressed on the undo button", async () => 
   render(<Pod title="Title" onUndo={onUndo} softDelete />);
 
   const undoButton = screen.getByRole("button", { name: "Undo" });
-  undoButton.focus();
-
+  act(() => {
+    undoButton.focus();
+  });
   await user.keyboard("{enter}");
+
   expect(onUndo).toHaveBeenCalled();
 });
 
@@ -221,9 +234,11 @@ test("does not call `onUndo` when non-Enter key is pressed on the undo button", 
   render(<Pod title="Title" onUndo={onUndo} softDelete />);
 
   const undoButton = screen.getByRole("button", { name: "Undo" });
-  undoButton.focus();
-
+  act(() => {
+    undoButton.focus();
+  });
   await user.keyboard("a");
+
   expect(onUndo).not.toHaveBeenCalled();
 });
 
@@ -232,14 +247,19 @@ test("renders content with focus border when edit button is focused and removes 
   render(<Pod title="Title" onEdit={() => {}} />);
 
   const editButton = screen.getByRole("button", { name: "Edit" });
-  editButton.focus();
-
+  act(() => {
+    editButton.focus();
+  });
   const content = screen.getByTestId("pod-block");
+
   expect(content).toHaveStyleRule(
     "border: 3px solid var(--colorsSemanticFocus500)",
   );
 
-  editButton.blur();
+  act(() => {
+    editButton.blur();
+  });
+
   expect(content).not.toHaveStyleRule(
     "border: 3px solid var(--colorsSemanticFocus500)",
   );
@@ -250,14 +270,19 @@ test("renders content with focus border when delete button is focused and remove
   render(<Pod title="Title" onDelete={() => {}} />);
 
   const deleteButton = screen.getByRole("button", { name: "Delete" });
-  deleteButton.focus();
-
+  act(() => {
+    deleteButton.focus();
+  });
   const content = screen.getByTestId("pod-block");
+
   expect(content).toHaveStyleRule(
     "border: 3px solid var(--colorsSemanticFocus500)",
   );
 
-  deleteButton.blur();
+  act(() => {
+    deleteButton.blur();
+  });
+
   expect(content).not.toHaveStyleRule(
     "border: 3px solid var(--colorsSemanticFocus500)",
   );
@@ -268,14 +293,19 @@ test("renders content with focus border when undo button is focused and removes 
   render(<Pod title="Title" softDelete onUndo={() => {}} />);
 
   const undoButton = screen.getByRole("button", { name: "Undo" });
-  undoButton.focus();
-
+  act(() => {
+    undoButton.focus();
+  });
   const content = screen.getByTestId("pod-block");
+
   expect(content).toHaveStyleRule(
     "border: 3px solid var(--colorsSemanticFocus500)",
   );
 
-  undoButton.blur();
+  act(() => {
+    undoButton.blur();
+  });
+
   expect(content).not.toHaveStyleRule(
     "border: 3px solid var(--colorsSemanticFocus500)",
   );
@@ -459,7 +489,9 @@ test("renders block with correct colour when `variant` is 'tile', `internalEditB
   );
 
   const editButton = screen.getByRole("button", { name: "Edit" });
-  editButton.focus();
+  act(() => {
+    editButton.focus();
+  });
 
   const block = screen.getByTestId("pod-block");
   expect(block).toHaveStyleRule(
@@ -472,7 +504,9 @@ test("renders block with correct padding when `border` is false and a button is 
   render(<Pod title="Title" onEdit={() => {}} border={false} />);
 
   const editButton = screen.getByRole("button", { name: "Edit" });
-  editButton.focus();
+  act(() => {
+    editButton.focus();
+  });
 
   const block = screen.getByTestId("pod-block");
   expect(block).toHaveStyle({ padding: "0" });

--- a/src/components/popover-container/popover-container.test.tsx
+++ b/src/components/popover-container/popover-container.test.tsx
@@ -295,10 +295,14 @@ test.each([
 
     await user.click(screen.getByRole("button"));
 
-    expect(await screen.findByRole("dialog")).toHaveAttribute(
-      "data-floating-placement",
-      placement,
-    );
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    const dialog = await screen.findByRole("dialog");
+
+    await waitFor(() => {
+      expect(dialog).toHaveAttribute("data-floating-placement", placement);
+    });
   },
 );
 
@@ -402,8 +406,9 @@ describe("closing the popup", () => {
     await user.click(screen.getByRole("button"));
 
     const closeButton = await screen.findByRole("button", { name: "close" });
-    closeButton.focus();
-
+    act(() => {
+      closeButton.focus();
+    });
     await user.keyboard("{Enter}");
 
     await waitFor(() => {

--- a/src/components/portrait/portrait.test.tsx
+++ b/src/components/portrait/portrait.test.tsx
@@ -39,7 +39,7 @@ test("renders with a gravatar image, if a valid email is passed via the `gravata
   const hash = MD5(email);
   const src = `https://www.gravatar.com/avatar/${hash}?s=40&d=404`;
 
-  render(<Portrait gravatar={email} />);
+  render(<Portrait gravatar={email} alt="foo" />);
 
   const img = screen.getByRole("img");
   expect(img).toBeVisible();
@@ -53,8 +53,8 @@ test("logs a deprecation warning once when the `gravatar` prop is passed, and a 
 
   render(
     <>
-      <Portrait gravatar="chris.barber@sage.com" />
-      <Portrait gravatar="chris.barber@sage.com" />
+      <Portrait gravatar="chris.barber@sage.com" alt="foo" />
+      <Portrait gravatar="chris.barber@sage.com" alt="foo" />
     </>,
   );
 
@@ -75,7 +75,7 @@ test("if a valid gravatar email is not found and an onError event is triggered, 
   const email = "invalid.email@1973";
   const hash = MD5(email);
   const src = `https://www.gravatar.com/avatar/${hash}?s=40&d=404`;
-  render(<Portrait gravatar={email} />);
+  render(<Portrait gravatar={email} alt="foo" />);
 
   const img = screen.getByRole("img");
   expect(img).toBeVisible();
@@ -91,7 +91,7 @@ test("if a valid gravatar email is not found and an onError event is triggered, 
 
 test("renders with a custom image, if a valid src is passed via the `src` prop", () => {
   const src = "https://upload.wikimedia.org/wikipedia/en/6/6c/Heatposter.jpg";
-  render(<Portrait src={src} />);
+  render(<Portrait src={src} alt="foo" />);
 
   const img = screen.getByRole("img");
   expect(img).toBeVisible();
@@ -100,7 +100,7 @@ test("renders with a custom image, if a valid src is passed via the `src` prop",
 
 test("if a valid src is not found and an onError event is triggered, the default individual icon is rendered", async () => {
   const src = "not-a-url";
-  render(<Portrait src={src} />);
+  render(<Portrait src={src} alt="foo" />);
 
   const img = screen.getByRole("img");
   expect(img).toBeVisible();

--- a/src/components/portrait/portrait.test.tsx
+++ b/src/components/portrait/portrait.test.tsx
@@ -46,6 +46,14 @@ test("renders with a gravatar image, if a valid email is passed via the `gravata
   expect(img).toHaveAttribute("src", src);
 });
 
+test("renders a decorative image, when gravatar prop is provided but alt is not", () => {
+  const email = "chris.barber@sage.com";
+  render(<Portrait gravatar={email} />);
+
+  const decorativeImg = screen.getByAltText("");
+  expect(decorativeImg).toBeVisible();
+});
+
 test("logs a deprecation warning once when the `gravatar` prop is passed, and a gravatar loads", () => {
   const loggerSpy = jest
     .spyOn(Logger, "deprecate")
@@ -89,24 +97,31 @@ test("if a valid gravatar email is not found and an onError event is triggered, 
   );
 });
 
-test("renders with a custom image, if a valid src is passed via the `src` prop", () => {
+test("renders a custom image with the correct src and alt attributes", () => {
   const src = "https://upload.wikimedia.org/wikipedia/en/6/6c/Heatposter.jpg";
-  render(<Portrait src={src} alt="foo" />);
+  render(<Portrait src={src} alt="Movie poster of Heat" />);
 
-  const img = screen.getByRole("img");
-  expect(img).toBeVisible();
-  expect(img).toHaveAttribute("src", src);
+  const image = screen.getByAltText("Movie poster of Heat");
+  expect(image).toHaveAttribute("src", src);
+});
+
+test("renders a decorative image, when src prop is provided but alt is not", () => {
+  const src = "https://upload.wikimedia.org/wikipedia/en/6/6c/Heatposter.jpg";
+  render(<Portrait src={src} />);
+
+  const decorativeImg = screen.getByAltText("");
+  expect(decorativeImg).toBeVisible();
 });
 
 test("if a valid src is not found and an onError event is triggered, the default individual icon is rendered", async () => {
   const src = "not-a-url";
-  render(<Portrait src={src} alt="foo" />);
+  render(<Portrait src={src} alt="foobar" />);
 
-  const img = screen.getByRole("img");
-  expect(img).toBeVisible();
-  expect(img).toHaveAttribute("src", src);
+  const image = screen.getByAltText("foobar");
+  expect(image).toBeVisible();
+  expect(image).toHaveAttribute("src", src);
 
-  fireEvent.error(img);
+  fireEvent.error(image);
 
   await waitFor(() => expect(screen.getByTestId("icon")).toBeVisible());
   await waitFor(() =>
@@ -125,14 +140,6 @@ test("when both the `gravatar` and `src` props are passed simultaneously, an inv
   );
 
   consoleSpy.mockRestore();
-});
-
-test("allows the alt attribute to be set, via the `alt` prop", () => {
-  const src = "https://upload.wikimedia.org/wikipedia/en/6/6c/Heatposter.jpg";
-  render(<Portrait src={src} alt="custom-alt" />);
-
-  const alt = screen.getByAltText("custom-alt");
-  expect(alt).toBeVisible();
 });
 
 test("renders with a square shape, if the `shape` prop is value is `square`", () => {

--- a/src/components/profile/profile.test.tsx
+++ b/src/components/profile/profile.test.tsx
@@ -162,7 +162,7 @@ test("renders avatar with custom initials when `initials` prop is passed", () =>
 
 test("renders avatar with custom image when `src` prop is passed", () => {
   const src = "https://upload.wikimedia.org/wikipedia/en/6/6c/Heatposter.jpg";
-  render(<Profile src={src} />);
+  render(<Profile src={src} alt="foo" />);
 
   const avatar = screen.getByRole("img");
   expect(avatar).toBeVisible();

--- a/src/components/search/search.test.tsx
+++ b/src/components/search/search.test.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Search, { SearchHandle } from "./search.component";
@@ -137,7 +137,9 @@ test("when the input is blurred, the `onBlur` callback prop is called", async ()
   const onBlur = jest.fn();
   render(<Search value="" onBlur={onBlur} />);
 
-  screen.getByRole("textbox").focus();
+  act(() => {
+    screen.getByRole("textbox").focus();
+  });
   await user.tab();
   expect(onBlur).toHaveBeenCalledTimes(1);
 });
@@ -284,24 +286,28 @@ test("the component's wrapper element has the appropriate `data-component` tag",
   );
 });
 
-test("the textbox cross icon can be tabbed to when present", async () => {
-  const user = userEvent.setup();
-  render(<Search defaultValue="" />);
+test("do not render remove button when the input is empty", () => {
+  render(<Search value="" />);
 
-  await user.type(screen.getByRole("textbox"), "Bar");
+  expect(screen.queryByTestId("input-icon-toggle")).not.toBeInTheDocument();
+});
+
+test("render remove button when the input is not empty", () => {
+  render(<Search value="foo" />);
+
+  expect(screen.getByTestId("input-icon-toggle")).toBeVisible();
+});
+
+test("remove button can be reached via keyboard when present", async () => {
+  const user = userEvent.setup();
+  render(<Search value="foo" />);
+
+  act(() => {
+    screen.getByRole("textbox").focus();
+  });
   await user.tab();
 
   expect(screen.getByTestId("input-icon-toggle")).toHaveFocus();
-});
-
-test("the textbox close icon can not be tabbed to when the input is empty", async () => {
-  const user = userEvent.setup();
-  render(<Search defaultValue="" />);
-
-  screen.getByRole("textbox").focus();
-  await user.tab();
-
-  expect(document.body).toHaveFocus();
 });
 
 test("when a character key is pressed, propagation of the event to parent elements is prevented", async () => {

--- a/src/components/select/__internal__/select-list/select-list.test.tsx
+++ b/src/components/select/__internal__/select-list/select-list.test.tsx
@@ -122,11 +122,11 @@ describe("rendered content", () => {
           <Option id="red" value="red" text="red" />
         </SelectListWithInput>,
       );
+      const list = await screen.findByTestId("select-list-wrapper");
 
-      expect(await screen.findByTestId("select-list-wrapper")).toHaveAttribute(
-        "data-floating-placement",
-        listPlacement,
-      );
+      await waitFor(() => {
+        expect(list).toHaveAttribute("data-floating-placement", listPlacement);
+      });
     },
   );
 

--- a/src/components/select/__internal__/select-textbox/select-textbox.test.tsx
+++ b/src/components/select/__internal__/select-textbox/select-textbox.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import SelectTextbox from ".";
@@ -66,7 +66,9 @@ test("calls onFocus callback when combobox is focused", () => {
   const onFocus = jest.fn();
   render(<SelectTextbox label="Textbox" onFocus={onFocus} />);
 
-  screen.getByRole("combobox", { name: "Textbox" }).focus();
+  act(() => {
+    screen.getByRole("combobox", { name: "Textbox" }).focus();
+  });
 
   expect(onFocus).toHaveBeenCalledTimes(1);
 });
@@ -85,8 +87,10 @@ test("calls onBlur callback when combobox is blurred", () => {
   render(<SelectTextbox label="Textbox" onBlur={onBlur} />);
 
   const combobox = screen.getByRole("combobox", { name: "Textbox" });
-  combobox.focus();
-  combobox.blur();
+  act(() => {
+    combobox.focus();
+    combobox.blur();
+  });
 
   expect(onBlur).toHaveBeenCalledTimes(1);
 });
@@ -110,7 +114,9 @@ test("does not call onFocus callback when textbox is read only", () => {
   const onFocus = jest.fn();
   render(<SelectTextbox label="Textbox" onFocus={onFocus} readOnly />);
 
-  screen.getByRole("textbox", { name: "Textbox" }).focus();
+  act(() => {
+    screen.getByRole("textbox", { name: "Textbox" }).focus();
+  });
 
   expect(onFocus).not.toHaveBeenCalled();
 });

--- a/src/components/select/filterable-select/filterable-select.test.tsx
+++ b/src/components/select/filterable-select/filterable-select.test.tsx
@@ -406,7 +406,10 @@ test("should override the default list 'max-height' when `listMaxHeight` passed"
       <Option value="opt1" text="red" />
     </FilterableSelect>,
   );
-  screen.getByRole("combobox").focus();
+  act(() => {
+    screen.getByRole("combobox").focus();
+  });
+
   const listContainer = await screen.findByTestId(
     "select-list-scrollable-container",
   );
@@ -497,8 +500,10 @@ test("should call `onFocus` callback when input is focused", () => {
       <Option value="opt1" text="red" />
     </FilterableSelect>,
   );
-  screen.getByRole("combobox").focus();
-  act(() => jest.runOnlyPendingTimers());
+  act(() => {
+    screen.getByRole("combobox").focus();
+    jest.runOnlyPendingTimers();
+  });
 
   expect(onFocusFn).toHaveBeenCalled();
   jest.useRealTimers();
@@ -518,8 +523,10 @@ test("should call `onFocus` callback when input is focused and `openOnFocus` is 
       <Option value="opt1" text="red" />
     </FilterableSelect>,
   );
-  screen.getByRole("combobox").focus();
-  act(() => jest.runOnlyPendingTimers());
+  act(() => {
+    screen.getByRole("combobox").focus();
+    jest.runOnlyPendingTimers();
+  });
 
   expect(onFocusFn).toHaveBeenCalled();
   jest.useRealTimers();
@@ -537,8 +544,10 @@ test("should call `onBlur` callback when input is blurred", () => {
       <Option value="opt1" text="red" />
     </FilterableSelect>,
   );
-  screen.getByRole("combobox").focus();
-  screen.getByRole("combobox").blur();
+  act(() => {
+    screen.getByRole("combobox").focus();
+    screen.getByRole("combobox").blur();
+  });
 
   expect(onBlurFn).toHaveBeenCalled();
 });
@@ -557,7 +566,10 @@ test("should not call `onBlur` when the user clicks on an option", async () => {
       <Option value="opt1" text="red" />
     </FilterableSelect>,
   );
-  screen.getByRole("combobox").focus();
+  act(() => {
+    screen.getByRole("combobox").focus();
+  });
+
   await user.click(await screen.findByRole("option", { name: "red" }));
 
   expect(onBlurFn).not.toHaveBeenCalled();
@@ -594,7 +606,9 @@ describe("when the input is focused", () => {
         <Option value="opt1" text="red" />
       </FilterableSelect>,
     );
-    screen.getByRole("combobox").focus();
+    act(() => {
+      screen.getByRole("combobox").focus();
+    });
 
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
@@ -611,7 +625,10 @@ describe("when the input is focused", () => {
         <Option value="opt1" text="red" />
       </FilterableSelect>,
     );
-    screen.getByRole("combobox").focus();
+    act(() => {
+      screen.getByRole("combobox").focus();
+    });
+
     act(() => jest.runOnlyPendingTimers());
 
     expect(await screen.findByRole("listbox")).toBeVisible();
@@ -1407,7 +1424,9 @@ describe("when the user selects an option", () => {
         <Option value="opt1" text="green" />
       </FilterableSelect>,
     );
-    screen.getByRole("combobox").focus();
+    act(() => {
+      screen.getByRole("combobox").focus();
+    });
     await user.keyboard("{ArrowDown}");
     await user.keyboard("{ArrowDown}");
     await user.keyboard("{Enter}");
@@ -1428,7 +1447,9 @@ describe("when the user selects an option", () => {
         <Option value="opt1" text="green" />
       </FilterableSelect>,
     );
-    screen.getByRole("combobox").focus();
+    act(() => {
+      screen.getByRole("combobox").focus();
+    });
     await user.keyboard("{ArrowDown}");
     await user.keyboard("{ArrowDown}");
     await user.keyboard(" ");
@@ -1450,7 +1471,9 @@ describe("when the user selects an option", () => {
         <Option value="opt2" text="blue" />
       </FilterableSelect>,
     );
-    screen.getByRole("combobox").focus();
+    act(() => {
+      screen.getByRole("combobox").focus();
+    });
     await user.keyboard("{ArrowDown}");
 
     expect(onSelectFn).toHaveBeenCalled();
@@ -1473,7 +1496,9 @@ describe("when the user selects an option", () => {
         <Option value="opt2" text="blue" />
       </FilterableSelect>,
     );
-    screen.getByRole("combobox").focus();
+    act(() => {
+      screen.getByRole("combobox").focus();
+    });
     await user.keyboard("{ArrowUp}");
 
     expect(onSelectFn).toHaveBeenCalled();
@@ -1495,7 +1520,9 @@ test("should close the list when the user presses `Escape` key", async () => {
       <Option value="opt1" text="green" />
     </FilterableSelect>,
   );
-  screen.getByRole("combobox").focus();
+  act(() => {
+    screen.getByRole("combobox").focus();
+  });
   await user.keyboard("{ArrowDown}");
   await user.keyboard("{Escape}");
 
@@ -1509,7 +1536,9 @@ test("should close the list when the user clicks outside the component", async (
       <Option value="opt1" text="green" />
     </FilterableSelect>,
   );
-  screen.getByRole("combobox").focus();
+  act(() => {
+    screen.getByRole("combobox").focus();
+  });
   await user.keyboard("{ArrowDown}");
   await user.click(document.body);
 
@@ -1529,7 +1558,9 @@ test("should call the `onKeyDown` callback when the user presses a key and the i
       <Option value="opt1" text="green" />
     </FilterableSelect>,
   );
-  screen.getByRole("combobox").focus();
+  act(() => {
+    screen.getByRole("combobox").focus();
+  });
   await user.keyboard("{ArrowDown}");
 
   expect(onKeyDownFn).toHaveBeenCalled();
@@ -1549,7 +1580,9 @@ describe("when the `listActionButton` is passed", () => {
         <Option value="opt1" text="green" />
       </FilterableSelect>,
     );
-    screen.getByRole("combobox").focus();
+    act(() => {
+      screen.getByRole("combobox").focus();
+    });
 
     expect(
       await screen.findByRole("button", { name: "mock button" }),
@@ -1571,7 +1604,9 @@ describe("when the `listActionButton` is passed", () => {
         <Option value="opt1" text="green" />
       </FilterableSelect>,
     );
-    screen.getByRole("combobox").focus();
+    act(() => {
+      screen.getByRole("combobox").focus();
+    });
     await user.click(
       await screen.findByRole("button", { name: "mock button" }),
     );
@@ -1593,7 +1628,9 @@ describe("when the `listActionButton` is passed", () => {
         <Option value="opt1" text="green" />
       </FilterableSelect>,
     );
-    screen.getByRole("combobox").focus();
+    act(() => {
+      screen.getByRole("combobox").focus();
+    });
     await user.tab();
 
     expect(
@@ -1616,7 +1653,9 @@ describe("when the `listActionButton` is passed", () => {
         <Option value="opt1" text="green" />
       </FilterableSelect>,
     );
-    screen.getByRole("combobox").focus();
+    act(() => {
+      screen.getByRole("combobox").focus();
+    });
     await user.tab();
     await user.keyboard("{Enter}");
 
@@ -1638,7 +1677,9 @@ describe("when the `listActionButton` is passed", () => {
         <Option value="opt1" text="green" />
       </FilterableSelect>,
     );
-    screen.getByRole("combobox").focus();
+    act(() => {
+      screen.getByRole("combobox").focus();
+    });
     await user.tab();
     await user.keyboard(" ");
 
@@ -1662,7 +1703,9 @@ describe("when the `listActionButton` is passed", () => {
         <Option value="opt1" text="green" />
       </FilterableSelect>,
     );
-    screen.getByRole("combobox").focus();
+    act(() => {
+      screen.getByRole("combobox").focus();
+    });
     await user.tab();
     await user.tab();
 
@@ -1699,7 +1742,9 @@ test("should not be call `onListScrollBottom` callback when an option is clicked
       <Option value="opt1" text="green" />
     </FilterableSelect>,
   );
-  screen.getByRole("combobox").focus();
+  act(() => {
+    screen.getByRole("combobox").focus();
+  });
   await user.click(await screen.findByRole("option", { name: "green" }));
 
   expect(onListScrollBottomFn).not.toHaveBeenCalled();
@@ -1716,7 +1761,9 @@ test("should apply the expected border radius styling to the list element", () =
       <Option value="opt1" text="green" />
     </FilterableSelect>,
   );
-  screen.getByRole("combobox").focus();
+  act(() => {
+    screen.getByRole("combobox").focus();
+  });
 
   expect(screen.getByTestId("select-list-wrapper")).toHaveStyleRule(
     "border-radius",

--- a/src/components/select/multi-select/multi-select.test.tsx
+++ b/src/components/select/multi-select/multi-select.test.tsx
@@ -1140,7 +1140,10 @@ test("should not be call `onListScrollBottom` callback when an option is clicked
       <Option value="opt1" text="green" />
     </MultiSelect>,
   );
-  screen.getByRole("combobox").focus();
+
+  act(() => {
+    screen.getByRole("combobox").focus();
+  });
   await user.click(await screen.findByRole("option", { name: "green" }));
 
   expect(onListScrollBottomFn).not.toHaveBeenCalled();
@@ -1239,7 +1242,10 @@ test("should call `onOpen` callback if prop is passed and navigation key opens s
     </MultiSelect>,
   );
   const input = screen.getByRole("combobox");
-  input.focus();
+
+  act(() => {
+    input.focus();
+  });
 
   await user.keyboard("{ArrowDown}");
 
@@ -1259,7 +1265,9 @@ test("should call `onFocus` callback when input is focused and `openOnFocus` is 
       <Option value="opt1" text="red" />
     </MultiSelect>,
   );
-  screen.getByRole("combobox").focus();
+  act(() => {
+    screen.getByRole("combobox").focus();
+  });
   act(() => jest.runOnlyPendingTimers());
 
   expect(onFocusFn).toHaveBeenCalled();

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  act,
   render,
   screen,
   waitFor,
@@ -152,7 +153,9 @@ describe("closing behaviour", () => {
       </CarbonProvider>,
     );
 
-    screen.getByRole("button", { name: "Close" }).focus();
+    act(() => {
+      screen.getByRole("button", { name: "Close" }).focus();
+    });
     await user.keyboard("{Enter}");
 
     await waitForElementToBeRemoved(() => screen.queryByRole("dialog"));
@@ -168,7 +171,9 @@ describe("closing behaviour", () => {
       </CarbonProvider>,
     );
 
-    screen.getByRole("button", { name: "Close" }).focus();
+    act(() => {
+      screen.getByRole("button", { name: "Close" }).focus();
+    });
     await user.keyboard("{ }");
 
     await waitForElementToBeRemoved(() => screen.queryByRole("dialog"));
@@ -184,7 +189,9 @@ describe("closing behaviour", () => {
       </CarbonProvider>,
     );
 
-    screen.getByRole("button", { name: "Close" }).focus();
+    act(() => {
+      screen.getByRole("button", { name: "Close" }).focus();
+    });
     await user.keyboard("{a}");
 
     expect(screen.getByRole("dialog")).toBeVisible();
@@ -217,8 +224,9 @@ test("focus is trapped within sidebar when opened", async () => {
     </CarbonProvider>,
   );
   const firstButton = screen.getByRole("button", { name: "First" });
-  firstButton.focus();
-
+  act(() => {
+    firstButton.focus();
+  });
   await user.tab();
 
   expect(screen.getByRole("button", { name: "Second" })).toHaveFocus();
@@ -239,8 +247,9 @@ test("focus is not trapped within sidebar when enableBackgroundUI is true", asyn
     </CarbonProvider>,
   );
   const firstButton = screen.getByRole("button", { name: "First" });
-  firstButton.focus();
-
+  act(() => {
+    firstButton.focus();
+  });
   await user.tab();
 
   expect(screen.getByRole("button", { name: "Second" })).toHaveFocus();

--- a/src/components/simple-color-picker/simple-color-picker.test.tsx
+++ b/src/components/simple-color-picker/simple-color-picker.test.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SimpleColor, SimpleColorPicker } from ".";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
@@ -50,8 +50,9 @@ test("the `onKeyDown` callback prop is called when the user presses a key", asyn
       <SimpleColor value="#582C83" />
     </SimpleColorPicker>,
   );
-
-  screen.getAllByRole("radio")[0].focus();
+  act(() => {
+    screen.getAllByRole("radio")[0].focus();
+  });
   await user.keyboard("a");
 
   expect(onKeyDown).toHaveBeenCalledTimes(1);
@@ -114,8 +115,9 @@ test("pressing the left arrow key when focused on the first color changes select
       <SimpleColor value="#582C83" />
     </SimpleColorPicker>,
   );
-
-  screen.getAllByRole("radio")[0].focus();
+  act(() => {
+    screen.getAllByRole("radio")[0].focus();
+  });
   await user.keyboard("{ArrowLeft}");
 
   expect(onChange).toHaveBeenCalledTimes(1);
@@ -141,8 +143,9 @@ test("pressing the right arrow key changes selection to the next color", async (
       <SimpleColor value="#582C83" />
     </SimpleColorPicker>,
   );
-
-  screen.getAllByRole("radio")[1].focus();
+  act(() => {
+    screen.getAllByRole("radio")[1].focus();
+  });
   await user.keyboard("{ArrowRight}");
 
   expect(onChange).toHaveBeenCalledTimes(1);
@@ -168,8 +171,9 @@ test("pressing the right arrow key when focused on the last color changes select
       <SimpleColor value="#582C83" />
     </SimpleColorPicker>,
   );
-
-  screen.getAllByRole("radio")[2].focus();
+  act(() => {
+    screen.getAllByRole("radio")[2].focus();
+  });
   await user.keyboard("{ArrowRight}");
 
   expect(onChange).toHaveBeenCalledTimes(1);
@@ -197,8 +201,9 @@ test("when the input has multiple rows, pressing the up arrow key changes select
       <SimpleColor value="#582C83" />
     </SimpleColorPicker>,
   );
-
-  screen.getAllByRole("radio")[1].focus();
+  act(() => {
+    screen.getAllByRole("radio")[1].focus();
+  });
   await user.keyboard("{ArrowUp}");
 
   expect(onChange).toHaveBeenCalledTimes(1);
@@ -226,8 +231,9 @@ test("when focus is already on the top row, pressing the up arrow key does not c
       <SimpleColor value="#582C83" />
     </SimpleColorPicker>,
   );
-
-  screen.getAllByRole("radio")[1].focus();
+  act(() => {
+    screen.getAllByRole("radio")[1].focus();
+  });
   await user.keyboard("{ArrowUp}");
 
   expect(onChange).not.toHaveBeenCalled();
@@ -250,8 +256,9 @@ test("when the input has multiple rows, pressing the down arrow key changes sele
       <SimpleColor value="#582C83" />
     </SimpleColorPicker>,
   );
-
-  screen.getAllByRole("radio")[1].focus();
+  act(() => {
+    screen.getAllByRole("radio")[1].focus();
+  });
   await user.keyboard("{ArrowDown}");
 
   expect(onChange).toHaveBeenCalledTimes(1);
@@ -280,8 +287,9 @@ test("when focus is already on the bottom row, pressing the down arrow key does 
       <SimpleColor value="#ABCDEF" />
     </SimpleColorPicker>,
   );
-
-  screen.getAllByRole("radio")[3].focus();
+  act(() => {
+    screen.getAllByRole("radio")[3].focus();
+  });
   await user.keyboard("{ArrowDown}");
 
   expect(onChange).not.toHaveBeenCalled();
@@ -302,8 +310,9 @@ test("focus is not changed if a non-arrow key is pressed", async () => {
       <SimpleColor value="#582C83" />
     </SimpleColorPicker>,
   );
-
-  screen.getAllByRole("radio")[0].focus();
+  act(() => {
+    screen.getAllByRole("radio")[0].focus();
+  });
   await user.keyboard("{Control}");
 
   expect(onChange).not.toHaveBeenCalled();

--- a/src/components/tabs/__internal__/tab-title/tab-title.test.tsx
+++ b/src/components/tabs/__internal__/tab-title/tab-title.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TabTitle from "./tab-title.component";
 
@@ -76,7 +76,9 @@ test.each([
       <TabTitle href="randomUrl" onClick={() => {}} onKeyDown={() => {}} />,
     );
 
-    screen.getByRole("tab").focus();
+    act(() => {
+      screen.getByRole("tab").focus();
+    });
     await user.keyboard(key);
 
     expect(globalOpenMock).toHaveBeenCalledWith("randomUrl", "_blank");
@@ -109,7 +111,9 @@ test.each([
     const user = userEvent.setup();
     render(<TabTitle onClick={() => {}} onKeyDown={() => {}} />);
 
-    screen.getByRole("tab").focus();
+    act(() => {
+      screen.getByRole("tab").focus();
+    });
     await user.keyboard(key);
 
     expect(globalOpenMock).not.toHaveBeenCalled();
@@ -195,7 +199,7 @@ test("calls the `onClick` prop when clicked", async () => {
 
 test.each(["error", "warning", "info"])(
   "displays a tooltip on focus when %s validation is failed",
-  (validationType) => {
+  async (validationType) => {
     render(
       <TabTitle
         position="left"
@@ -208,10 +212,12 @@ test.each(["error", "warning", "info"])(
       />,
     );
 
-    screen.getByRole("tab").focus();
+    act(() => {
+      screen.getByRole("tab").focus();
+    });
 
-    expect(screen.getByTestId("tooltip")).toBeVisible();
-    expect(screen.getByTestId("tooltip")).toHaveTextContent(
+    expect(await screen.findByRole("tooltip")).toBeVisible();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
       "validation message",
     );
   },
@@ -234,10 +240,12 @@ test.each(["error", "warning", "info"])(
       />,
     );
 
-    screen.getByRole("tab").focus();
+    act(() => {
+      screen.getByRole("tab").focus();
+    });
     await user.tab();
 
-    expect(screen.queryByTestId("tooltip")).not.toBeInTheDocument();
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
     expect(screen.queryByText("validation message")).not.toBeInTheDocument();
   },
 );
@@ -259,8 +267,8 @@ test.each(["error", "warning", "info"])(
 
     await user.hover(screen.getByRole("tab"));
 
-    expect(screen.getByTestId("tooltip")).toBeVisible();
-    expect(screen.getByTestId("tooltip")).toHaveTextContent(
+    expect(await screen.findByRole("tooltip")).toBeVisible();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
       "validation message",
     );
   },
@@ -303,13 +311,14 @@ test.each(["error", "warning", "info"])(
         }}
       />,
     );
-
     await user.hover(screen.getByRole("tab"));
-    screen.getByRole("tab").focus();
+    act(() => {
+      screen.getByRole("tab").focus();
+    });
     await user.tab();
 
-    expect(screen.getByTestId("tooltip")).toBeVisible();
-    expect(screen.getByTestId("tooltip")).toHaveTextContent(
+    expect(await screen.findByRole("tooltip")).toBeVisible();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
       "validation message",
     );
   },

--- a/src/components/tabs/tabs.test.tsx
+++ b/src/components/tabs/tabs.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Tabs, Tab } from ".";
 import { StyledTabsHeaderWrapper } from "./__internal__/tabs-header/tabs-header.style";
@@ -304,7 +304,9 @@ test("blurs the previously-selected tab title when the `selectedTabId` prop is u
       </Tab>
     </Tabs>,
   );
-  screen.getByRole("tab", { name: "Tab 1" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "Tab 1" }).focus();
+  });
 
   rerender(
     <Tabs selectedTabId="tab-2">
@@ -373,7 +375,9 @@ test("when the position is `top` (the default), pressing the right arrow key foc
     </Tabs>,
   );
 
-  screen.getByRole("tab", { name: "Tab 1" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "Tab 1" }).focus();
+  });
 
   await user.keyboard("{ArrowRight}");
   expect(screen.getByRole("tab", { name: "Tab 2" })).toHaveFocus();
@@ -398,7 +402,9 @@ test("when the position is `top` (the default), pressing the right arrow key whe
     </Tabs>,
   );
 
-  screen.getByRole("tab", { name: "Tab 3" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "Tab 3" }).focus();
+  });
 
   await user.keyboard("{ArrowRight}");
   expect(screen.getByRole("tab", { name: "Tab 1" })).toHaveFocus();
@@ -420,7 +426,9 @@ test("when the position is `top` (the default), pressing the left arrow key focu
     </Tabs>,
   );
 
-  screen.getByRole("tab", { name: "Tab 3" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "Tab 3" }).focus();
+  });
 
   await user.keyboard("{ArrowLeft}");
   expect(screen.getByRole("tab", { name: "Tab 2" })).toHaveFocus();
@@ -445,7 +453,9 @@ test("when the position is `top` (the default), pressing the left arrow key when
     </Tabs>,
   );
 
-  screen.getByRole("tab", { name: "Tab 1" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "Tab 1" }).focus();
+  });
 
   await user.keyboard("{ArrowLeft}");
   expect(screen.getByRole("tab", { name: "Tab 3" })).toHaveFocus();
@@ -467,7 +477,9 @@ test("when the position is `left`, pressing the down arrow key focuses the next 
     </Tabs>,
   );
 
-  screen.getByRole("tab", { name: "Tab 1" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "Tab 1" }).focus();
+  });
 
   await user.keyboard("{ArrowDown}");
   expect(screen.getByRole("tab", { name: "Tab 2" })).toHaveFocus();
@@ -492,7 +504,9 @@ test("when the position is `left`, pressing the down arrow key when focused on t
     </Tabs>,
   );
 
-  screen.getByRole("tab", { name: "Tab 3" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "Tab 3" }).focus();
+  });
 
   await user.keyboard("{ArrowDown}");
   expect(screen.getByRole("tab", { name: "Tab 1" })).toHaveFocus();
@@ -514,7 +528,9 @@ test("when the position is `left`, pressing the up arrow key focuses the previou
     </Tabs>,
   );
 
-  screen.getByRole("tab", { name: "Tab 3" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "Tab 3" }).focus();
+  });
 
   await user.keyboard("{ArrowUp}");
   expect(screen.getByRole("tab", { name: "Tab 2" })).toHaveFocus();
@@ -539,7 +555,9 @@ test("when the position is `left`, pressing the up arrow key when focused on the
     </Tabs>,
   );
 
-  screen.getByRole("tab", { name: "Tab 1" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "Tab 1" }).focus();
+  });
 
   await user.keyboard("{ArrowUp}");
   expect(screen.getByRole("tab", { name: "Tab 3" })).toHaveFocus();
@@ -563,7 +581,9 @@ test("when the Enter key is pressed on a tab title, the associated tab becomes t
   expect(screen.getByText("Content for tab 1")).toBeVisible();
   expect(screen.getByText("Content for tab 2")).not.toBeVisible();
 
-  screen.getByRole("tab", { name: "Tab 2" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "Tab 2" }).focus();
+  });
   await user.keyboard("{Enter}");
   expect(screen.getByText("Content for tab 1")).not.toBeVisible();
   expect(screen.getByText("Content for tab 2")).toBeVisible();
@@ -587,7 +607,9 @@ test("when a non-Enter, non-arrow key is pressed on a tab title, neither the vis
   expect(screen.getByText("Content for tab 1")).toBeVisible();
   expect(screen.getByText("Content for tab 2")).not.toBeVisible();
   expect(screen.getByText("Content for tab 3")).not.toBeVisible();
-  screen.getByRole("tab", { name: "Tab 1" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "Tab 1" }).focus();
+  });
 
   await user.keyboard("a");
   expect(screen.getByText("Content for tab 1")).toBeVisible();
@@ -617,7 +639,9 @@ test("when rendered in a Drawer sidebar, pressing the down arrow key focuses the
       drawer content
     </Drawer>,
   );
-  screen.getByRole("tab", { name: "Tab 1" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "Tab 1" }).focus();
+  });
 
   await user.keyboard("{ArrowDown}");
   expect(screen.getByRole("tab", { name: "Tab 2" })).toHaveFocus();
@@ -648,7 +672,9 @@ test("when rendered in a Drawer sidebar`, pressing the down arrow key when focus
     </Drawer>,
   );
 
-  screen.getByRole("tab", { name: "Tab 3" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "Tab 3" }).focus();
+  });
 
   await user.keyboard("{ArrowDown}");
   expect(screen.getByRole("tab", { name: "Tab 1" })).toHaveFocus();
@@ -676,7 +702,9 @@ test("when rendered in a Drawer sidebar, pressing the up arrow key focuses the p
     </Drawer>,
   );
 
-  screen.getByRole("tab", { name: "Tab 3" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "Tab 3" }).focus();
+  });
 
   await user.keyboard("{ArrowUp}");
   expect(screen.getByRole("tab", { name: "Tab 2" })).toHaveFocus();
@@ -707,7 +735,9 @@ test("when rendered in a Drawer sidebar, pressing the up arrow key when focused 
     </Drawer>,
   );
 
-  screen.getByRole("tab", { name: "Tab 1" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "Tab 1" }).focus();
+  });
 
   await user.keyboard("{ArrowUp}");
   expect(screen.getByRole("tab", { name: "Tab 3" })).toHaveFocus();
@@ -1348,7 +1378,9 @@ test("arrow key navigation remains consistent when tab children are added and re
   };
   render(<WithConditionalChildren />);
 
-  screen.getByRole("tab", { name: "tab-1" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "tab-1" }).focus();
+  });
 
   expect(screen.getByRole("tab", { name: "tab-1" })).toHaveFocus();
   await user.keyboard("{ArrowLeft}");
@@ -1365,7 +1397,9 @@ test("arrow key navigation remains consistent when tab children are added and re
   await user.click(screen.getByRole("button", { name: "Toggle children" }));
   expect(screen.getAllByRole("tab")).toHaveLength(3);
 
-  screen.getByRole("tab", { name: "tab-1" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "tab-1" }).focus();
+  });
 
   expect(screen.getByRole("tab", { name: "tab-1" })).toHaveFocus();
   await user.keyboard("{ArrowLeft}");
@@ -1381,7 +1415,9 @@ test("arrow key navigation remains consistent when tab children are added and re
   await user.click(screen.getByRole("button", { name: "Toggle children" }));
   expect(screen.getAllByRole("tab")).toHaveLength(3);
 
-  screen.getByRole("tab", { name: "tab-1" }).focus();
+  act(() => {
+    screen.getByRole("tab", { name: "tab-1" }).focus();
+  });
 
   expect(screen.getByRole("tab", { name: "tab-1" })).toHaveFocus();
   await user.keyboard("{ArrowRight}");

--- a/src/components/text-editor/__internal__/toolbar/toolbar.test.tsx
+++ b/src/components/text-editor/__internal__/toolbar/toolbar.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Toolbar from "./toolbar.component";
 import Button from "../../../button/button.component";
@@ -31,8 +31,9 @@ test("when the `canFocus` prop is true, pressing the right arrow key cycles focu
       setBlockStyle={() => {}}
     />,
   );
-  screen.getByRole("button", { name: "bold" }).focus();
-
+  act(() => {
+    screen.getByRole("button", { name: "bold" }).focus();
+  });
   await user.keyboard("{ArrowRight}");
   expect(screen.getByRole("button", { name: "italic" })).toHaveFocus();
 
@@ -61,8 +62,9 @@ test("when the `canFocus` prop is true, pressing the left arrow key wraps focus 
       setBlockStyle={() => {}}
     />,
   );
-  screen.getByRole("button", { name: "bold" }).focus();
-
+  act(() => {
+    screen.getByRole("button", { name: "bold" }).focus();
+  });
   await user.keyboard("{ArrowLeft}");
   expect(screen.getByRole("button", { name: "number-list" })).toHaveFocus();
 
@@ -96,7 +98,9 @@ test.each(["bold", "italic", "bullet-list", "number-list"])(
         <button type="button">I will receive focus</button>
       </>,
     );
-    screen.getByRole("button", { name: buttonName }).focus();
+    act(() => {
+      screen.getByRole("button", { name: buttonName }).focus();
+    });
 
     await user.tab();
     expect(
@@ -187,7 +191,9 @@ test.each(["bold", "italic"])(
       />,
     );
 
-    screen.getByRole("button", { name: buttonName }).focus();
+    act(() => {
+      screen.getByRole("button", { name: buttonName }).focus();
+    });
     await user.keyboard("{Enter}");
 
     expect(setInlineStyle).toHaveBeenCalledWith(
@@ -222,7 +228,9 @@ test.each([
       />,
     );
 
-    screen.getByRole("button", { name: buttonName }).focus();
+    act(() => {
+      screen.getByRole("button", { name: buttonName }).focus();
+    });
     await user.keyboard("{Enter}");
 
     expect(setBlockStyle).toHaveBeenCalledWith(expect.anything(), blockType);
@@ -251,7 +259,9 @@ test.each(["bold", "italic"])(
       />,
     );
 
-    screen.getByRole("button", { name: buttonName }).focus();
+    act(() => {
+      screen.getByRole("button", { name: buttonName }).focus();
+    });
     await user.keyboard(" ");
 
     expect(setInlineStyle).toHaveBeenCalledWith(
@@ -286,7 +296,9 @@ test.each([
       />,
     );
 
-    screen.getByRole("button", { name: buttonName }).focus();
+    act(() => {
+      screen.getByRole("button", { name: buttonName }).focus();
+    });
     await user.keyboard(" ");
 
     expect(setBlockStyle).toHaveBeenCalledWith(expect.anything(), blockType);
@@ -315,7 +327,9 @@ test.each(["bold", "italic", "bullet-list", "number-list"])(
       />,
     );
 
-    screen.getByRole("button", { name: buttonName }).focus();
+    act(() => {
+      screen.getByRole("button", { name: buttonName }).focus();
+    });
     await user.keyboard("d");
 
     expect(setInlineStyle).not.toHaveBeenCalled();
@@ -378,13 +392,18 @@ test.each([
       />,
     );
 
-    screen.getByRole("button", { name: buttonName }).focus();
+    act(() => {
+      screen.getByRole("button", { name: buttonName }).focus();
+    });
 
     expect(
       await screen.findByRole("tooltip", { name: tooltipText }),
     ).toBeVisible();
 
-    screen.getByRole("button", { name: buttonName }).blur();
+    act(() => {
+      screen.getByRole("button", { name: buttonName }).blur();
+    });
+
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   },
 );

--- a/src/components/text-editor/text-editor.test.tsx
+++ b/src/components/text-editor/text-editor.test.tsx
@@ -1,6 +1,12 @@
 import React, { useState } from "react";
 import { EditorState } from "draft-js";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
 import TextEditor, {
@@ -93,7 +99,9 @@ test("pressing Tab with the text editor focused moves focus to the first Toolbar
     />,
   );
 
-  screen.getByRole("textbox", { name: "Text Editor Label" }).focus();
+  act(() => {
+    screen.getByRole("textbox", { name: "Text Editor Label" }).focus();
+  });
   await user.tab();
 
   expect(screen.getByRole("button", { name: "bold" })).toHaveFocus();
@@ -126,7 +134,9 @@ test("pressing shift+Tab with the text editor focused does not move focus to the
     />,
   );
 
-  screen.getByRole("textbox", { name: "Text Editor Label" }).focus();
+  act(() => {
+    screen.getByRole("textbox", { name: "Text Editor Label" }).focus();
+  });
   await user.tab({ shift: true });
 
   expect(document.body).toHaveFocus();
@@ -531,7 +541,9 @@ test("has correct styles when focused and `focusRedesignOptOut` is true", () => 
     </CarbonProvider>,
   );
 
-  screen.getByRole("textbox", { name: "Text Editor Label" }).focus();
+  act(() => {
+    screen.getByRole("textbox", { name: "Text Editor Label" }).focus();
+  });
 
   expect(screen.getByTestId("editor-outline")).toHaveStyleRule(
     "outline",
@@ -555,7 +567,9 @@ test("has correct styles when focused and `focusRedesignOptOut` is true when the
     </CarbonProvider>,
   );
 
-  screen.getByRole("textbox", { name: "Text Editor Label" }).focus();
+  act(() => {
+    screen.getByRole("textbox", { name: "Text Editor Label" }).focus();
+  });
 
   expect(screen.getByTestId("editor-outline")).toHaveStyleRule(
     "outline",
@@ -572,7 +586,9 @@ test("can enter text after using the keyboard shortcut for bold styling", async 
   const user = userEvent.setup();
   render(<ControlledTextEditor />);
 
-  screen.getByRole("textbox", { name: "Text Editor Label" }).focus();
+  act(() => {
+    screen.getByRole("textbox", { name: "Text Editor Label" }).focus();
+  });
   await user.keyboard("{Control>}b{/Control}");
   await user.type(
     screen.getByRole("textbox", { name: "Text Editor Label" }),
@@ -873,7 +889,9 @@ test("can enter text after using the keyboard shortcut for bold styling when han
   const user = userEvent.setup();
   render(<ControlledTextEditor />);
 
-  screen.getByRole("textbox", { name: "Text Editor Label" }).focus();
+  act(() => {
+    screen.getByRole("textbox", { name: "Text Editor Label" }).focus();
+  });
   fireEvent.keyDown(
     screen.getByRole("textbox", { name: "Text Editor Label" }),
     {

--- a/src/components/textarea/textarea.test.tsx
+++ b/src/components/textarea/textarea.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as floatingUi from "@floating-ui/react-dom";
 
@@ -219,7 +219,10 @@ test("should set the aria-label on the Help component to the value of the helpAr
 test("should set the Help component's text content to the value of the labelHelp prop", async () => {
   render(<Textarea label="foo" labelHelp="bar" helpAriaLabel="baz" />);
 
-  screen.getByRole("button").focus();
+  act(() => {
+    screen.getByRole("button").focus();
+  });
+
   expect(await screen.findByRole("tooltip", { name: "bar" })).toBeVisible();
 });
 
@@ -228,7 +231,9 @@ test.each(["info", "warning", "error"])(
   (validationType) => {
     render(<Textarea id="foo" label="bar" {...{ [validationType]: "test" }} />);
     const textarea = screen.getByRole("textbox");
-    textarea.focus();
+    act(() => {
+      textarea.focus();
+    });
 
     expect(textarea).toHaveAccessibleDescription("test");
   },
@@ -239,7 +244,9 @@ test.each(["info", "warning", "error"])(
   (validationType) => {
     render(<Textarea label="bar" {...{ [validationType]: "test" }} />);
     const textarea = screen.getByRole("textbox");
-    textarea.focus();
+    act(() => {
+      textarea.focus();
+    });
 
     expect(textarea).toHaveAccessibleDescription("test");
   },
@@ -289,7 +296,9 @@ test.each(["info", "warning", "error"])(
       />,
     );
     const textarea = screen.getByRole("textbox");
-    textarea.focus();
+    act(() => {
+      textarea.focus();
+    });
 
     expect(textarea).toHaveAccessibleDescription("baz test");
   },
@@ -306,7 +315,9 @@ test.each(["info", "warning", "error"])(
       />,
     );
     const textarea = screen.getByRole("textbox");
-    textarea.focus();
+    act(() => {
+      textarea.focus();
+    });
 
     expect(textarea).toHaveAccessibleDescription("baz test");
   },

--- a/src/components/textbox/textbox.test.tsx
+++ b/src/components/textbox/textbox.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as floatingUi from "@floating-ui/react-dom";
 import Textbox, { TextboxProps } from ".";
@@ -406,7 +406,9 @@ test.each(validationTypes)(
   async (validationType) => {
     render(<Textbox label="bar" id="foo" {...{ [validationType]: "test" }} />);
     const input = screen.getByRole("textbox");
-    input.focus();
+    act(() => {
+      input.focus();
+    });
 
     expect(await screen.findByRole("tooltip")).toHaveAttribute(
       "id",
@@ -421,7 +423,9 @@ test.each(validationTypes)(
   async (validationType) => {
     render(<Textbox label="bar" {...{ [validationType]: "test" }} />);
     const input = screen.getByRole("textbox");
-    input.focus();
+    act(() => {
+      input.focus();
+    });
 
     expect(await screen.findByRole("tooltip")).toHaveAttribute(
       "id",
@@ -469,7 +473,9 @@ test.each(validationTypes)(
       />,
     );
     const input = screen.getByRole("textbox");
-    input.focus();
+    act(() => {
+      input.focus();
+    });
 
     expect(await screen.findByRole("tooltip")).toHaveAttribute(
       "id",
@@ -490,7 +496,9 @@ test.each(validationTypes)(
       <Textbox label="bar" fieldHelp="baz" {...{ [validationType]: "test" }} />,
     );
     const input = screen.getByRole("textbox");
-    input.focus();
+    act(() => {
+      input.focus();
+    });
 
     expect(await screen.findByRole("tooltip")).toHaveAttribute(
       "id",
@@ -509,8 +517,11 @@ test.each(validationTypes)(
 
 test("renders validation tooltip with provided 'tooltipId' prop", async () => {
   render(<Textbox label="bar" error="baz" tooltipId="foo" />);
+
   const input = screen.getByRole("textbox");
-  input.focus();
+  act(() => {
+    input.focus();
+  });
 
   expect(await screen.findByRole("tooltip")).toHaveAttribute("id", "foo");
   expect(input).toHaveAccessibleDescription("baz");

--- a/src/components/tile-select/__internal__/accordion/accordion.test.tsx
+++ b/src/components/tile-select/__internal__/accordion/accordion.test.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
+import { render, screen, act } from "@testing-library/react";
 import Accordion from "./accordion.component";
 import useResizeObserver from "../../../../hooks/__internal__/useResizeObserver";
 

--- a/src/components/time/time.test.tsx
+++ b/src/components/time/time.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Time, TimeHandle } from ".";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
@@ -165,8 +165,9 @@ test("should focus each input in the expected order when user is shift tabbing",
   const minsInput = screen.getByDisplayValue("30");
   const amToggle = screen.getByRole("button", { name: "AM" });
 
-  amToggle.focus();
-
+  act(() => {
+    amToggle.focus();
+  });
   await user.tab({ shift: true });
 
   expect(minsInput).toHaveFocus();
@@ -466,7 +467,9 @@ test("should call onBlur when the hours input is focused and the user presses sh
 
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-  screen.getByDisplayValue("12").focus();
+  act(() => {
+    screen.getByDisplayValue("12").focus();
+  });
   await user.tab({ shift: true });
 
   expect(onBlurMock).toHaveBeenCalled();
@@ -484,7 +487,9 @@ test("should not call onBlur when the hours input is focused and the user presse
 
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-  screen.getByDisplayValue("12").focus();
+  act(() => {
+    screen.getByDisplayValue("12").focus();
+  });
   await user.tab();
 
   expect(onBlurMock).not.toHaveBeenCalled();
@@ -502,7 +507,9 @@ test("should call onBlur when the minutes input is focused and the user presses 
 
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-  screen.getByDisplayValue("12").focus();
+  act(() => {
+    screen.getByDisplayValue("12").focus();
+  });
   await user.tab();
 
   expect(onBlurMock).toHaveBeenCalled();
@@ -520,7 +527,9 @@ test("should not call onBlur when the minutes input is focused and the user pres
 
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-  screen.getByDisplayValue("12").focus();
+  act(() => {
+    screen.getByDisplayValue("12").focus();
+  });
   await user.tab({ shift: true });
 
   expect(onBlurMock).not.toHaveBeenCalled();

--- a/src/components/toast/toast.test.tsx
+++ b/src/components/toast/toast.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Toast, { ToastProps } from "./toast.component";
 import ModalManager from "../modal/__internal__/modal-manager";
@@ -138,7 +138,9 @@ describe("Event tests", () => {
 
     await user.tab();
     await user.keyboard("{enter}");
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
 
     expect(onDismissMock).toHaveBeenCalled();
   });
@@ -150,7 +152,9 @@ describe("Event tests", () => {
 
     await user.tab();
     await user.keyboard(" ");
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
 
     expect(onDismissMock).toHaveBeenCalled();
   });
@@ -199,7 +203,9 @@ describe("Event tests", () => {
       </Toast>,
     );
 
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
     const toast = screen.getByTestId("toast");
 
     expect(toast).toHaveFocus();
@@ -212,7 +218,9 @@ describe("Event tests", () => {
       </Toast>,
     );
 
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
     const toast = screen.getByRole("region");
 
     expect(toast).not.toHaveAttribute("tabIndex");
@@ -242,7 +250,9 @@ describe("Event tests", () => {
 
     const button = screen.getByRole("button", { name: "Show toast" });
     await user.click(button);
-    jest.runAllTimers();
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
 
     const toast = await screen.findByTestId("toast");
     const closeButton = screen.getByRole("button", { name: "Close" });
@@ -250,7 +260,9 @@ describe("Event tests", () => {
     expect(toast).toHaveFocus();
 
     await user.click(closeButton);
-    jest.runAllTimers();
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
 
     expect(button).toHaveFocus();
   });
@@ -261,7 +273,9 @@ describe("Event tests", () => {
 
     const button = screen.getByRole("button", { name: "Show toast" });
     await user.click(button);
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
 
     const toast = await screen.findByTestId("toast");
     const closeButton = screen.getByRole("button", { name: "Close" });
@@ -269,12 +283,16 @@ describe("Event tests", () => {
     expect(toast).toHaveFocus();
 
     await user.click(closeButton);
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
 
     expect(button).toHaveFocus();
 
     await user.click(button);
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
 
     expect(await screen.findByTestId("toast")).toHaveFocus();
   });
@@ -285,11 +303,15 @@ describe("Event tests", () => {
 
     const button = screen.getByRole("button", { name: "Show toast" });
     await user.click(button);
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
 
     const closeButton = await screen.findByRole("button", { name: "Close" });
     await user.click(closeButton);
-    jest.runAllTimers();
+    act(() => {
+      jest.runAllTimers();
+    });
 
     expect(button).not.toHaveFocus();
   });

--- a/src/hooks/__internal__/useScrollBlock/useScrollBlock.test.tsx
+++ b/src/hooks/__internal__/useScrollBlock/useScrollBlock.test.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from "react";
-import { render } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
+import { render, act } from "@testing-library/react";
 
 import useScrollBlock from "./useScrollBlock";
 import ScrollBlockManager from "./scroll-block-manager";


### PR DESCRIPTION
### Proposed behaviour

- In each RTL test, wrap all interactions that could update state with an `act` wrapper

### Current behaviour

- In our RTL tests, some state-updating actions aren't wrapped with `act`. Currently, no warnings are thrown, but they will be when RTL and React are upgraded

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

This PR implements essential changes required for Carbon to support React 18. These changes have been addressed now to minimise the complexity of the upcoming React 18 upgrade PR.

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
