### PR TITLE
fix(menu-item): ensure list style is none in Safari

### DIFF
--- a/src/components/menu/menu.style.ts
+++ b/src/components/menu/menu.style.ts
@@ -63,6 +63,7 @@ interface StyledMenuItemProps
 
 const StyledMenuItem = styled.li<StyledMenuItemProps>`
   display: flex;
+  list-style: none;
   ${({ maxWidth }) =>
     maxWidth &&
     css`


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Ensure list style on MenuItem is none. 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Default list style on MenuItem still appears in Safari. 


https://github.com/user-attachments/assets/d5263a70-dd29-4d64-8b85-338088aab6ab


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Go to https://carbon.sage.com/?path=/story/menu--scrollable-submenu-with-parent in Safari. 
