### PR TITLE
fix(date-range): date range axe issue

### DIFF
--- a/src/components/date-range/date-range-test.stories.tsx
+++ b/src/components/date-range/date-range-test.stories.tsx
@@ -64,6 +64,10 @@ DateRangeStory.args = {
   allowEmptyValueOnStartDate: undefined,
   allowEmptyValueOnEndDate: undefined,
   labelsInline: false,
+  datePickerStartAriaLabel: "start aria-label",
+  datePickerStartAriaLabelledBy: "start aria-labelledby",
+  datePickerEndAriaLabel: "end aria-label",
+  datePickerEndAriaLabelledBy: "end aria-labelledby",
 };
 
 export const DateRangeCustom = ({

--- a/src/components/date-range/date-range.component.tsx
+++ b/src/components/date-range/date-range.component.tsx
@@ -118,6 +118,14 @@ export interface DateRangeProps
   isOptional?: boolean;
   /** Date format string to be applied to the date inputs */
   dateFormatOverride?: string;
+  /** Prop to specify the aria-label attribute of the start date picker */
+  datePickerStartAriaLabel?: string;
+  /** Prop to specify the aria-labelledby attribute of the start date picker */
+  datePickerStartAriaLabelledBy?: string;
+  /** Prop to specify the aria-label attribute of the end date picker */
+  datePickerEndAriaLabel?: string;
+  /** Prop to specify the aria-labelledby attribute of the end date picker */
+  datePickerEndAriaLabelledBy?: string;
 }
 
 export const DateRange = ({
@@ -135,6 +143,10 @@ export const DateRange = ({
   endRef,
   required,
   isOptional,
+  datePickerStartAriaLabel,
+  datePickerStartAriaLabelledBy,
+  datePickerEndAriaLabel,
+  datePickerEndAriaLabelledBy,
   ...rest
 }: DateRangeProps) => {
   const { validationRedesignOptIn } = useContext(NewValidationContext);
@@ -373,6 +385,8 @@ export const DateRange = ({
           labelWidth={inlineLabelWidth} // Textbox only applies this when labelsInLine prop is true
           tooltipPosition={tooltipPosition}
           ref={startRef}
+          datePickerAriaLabel={datePickerStartAriaLabel}
+          datePickerAriaLabelledBy={datePickerStartAriaLabelledBy}
         />
         <DateInput
           my={0} // prevents any form spacing being applied
@@ -383,6 +397,8 @@ export const DateRange = ({
           labelWidth={inlineLabelWidth} // Textbox only applies this when labelsInLine prop is true
           tooltipPosition={tooltipPosition}
           ref={endRef}
+          datePickerAriaLabel={datePickerEndAriaLabel}
+          datePickerAriaLabelledBy={datePickerEndAriaLabelledBy}
         />
       </DateRangeContext.Provider>
     </StyledDateRange>

--- a/src/components/date-range/date-range.test.tsx
+++ b/src/components/date-range/date-range.test.tsx
@@ -679,6 +679,50 @@ test("should close the open 'start' picker when the user moves focus to the `end
   expect(within(startDate).queryByRole("grid")).not.toBeInTheDocument();
 });
 
+test("should apply aria-label and aria-labelledby to the date picker region", async () => {
+  const user = userEvent.setup();
+  render(
+    <DateRange
+      startLabel="start"
+      endLabel="end"
+      value={["10/10/2016", "11/11/2016"]}
+      onChange={() => {}}
+      startDateProps={{ disablePortal: true, "data-role": "start" }}
+      endDateProps={{ disablePortal: true, "data-role": "end" }}
+      datePickerStartAriaLabel="start aria-label"
+      datePickerStartAriaLabelledBy="start aria-labelledby"
+      datePickerEndAriaLabel="end aria-label"
+      datePickerEndAriaLabelledBy="end aria-labelledby"
+    />,
+  );
+  const startDate = screen.getByTestId("start");
+  const endDate = screen.getByTestId("end");
+
+  await user.click(screen.getByRole("textbox", { name: "start" }));
+
+  expect(within(startDate).getByRole("region")).toBeVisible();
+  expect(within(startDate).getByRole("region")).toHaveAttribute(
+    "aria-label",
+    "start aria-label",
+  );
+  expect(within(startDate).getByRole("region")).toHaveAttribute(
+    "aria-labelledby",
+    "start aria-labelledby",
+  );
+
+  await user.click(screen.getByRole("textbox", { name: "end" }));
+
+  expect(within(endDate).getByRole("region")).toBeVisible();
+  expect(within(endDate).getByRole("region")).toHaveAttribute(
+    "aria-label",
+    "end aria-label",
+  );
+  expect(within(endDate).getByRole("region")).toHaveAttribute(
+    "aria-labelledby",
+    "end aria-labelledby",
+  );
+});
+
 test("should close the open 'end' picker when the user moves focus to the `start` input", async () => {
   const user = userEvent.setup();
   render(

--- a/src/components/date/__internal__/date-picker/date-picker.component.tsx
+++ b/src/components/date/__internal__/date-picker/date-picker.component.tsx
@@ -63,6 +63,10 @@ export interface DatePickerProps {
   pickerTabGuardId?: string;
   /** Callback triggered when the picker is closed */
   onPickerClose?: () => void;
+  /** Prop to specify the aria-label attribute of the date picker */
+  ariaLabel?: string;
+  /** Prop to specify the aria-labelledby attribute of the date picker */
+  ariaLabelledBy?: string;
 }
 
 const popoverMiddleware = [
@@ -85,6 +89,8 @@ export const DatePicker = ({
   setOpen,
   pickerTabGuardId,
   onPickerClose,
+  ariaLabel: datePickerAriaLabel,
+  ariaLabelledBy: datePickerAriaLabelledBy,
 }: DatePickerProps) => {
   const [focusedMonth, setFocusedMonth] = useState<Date | undefined>(
     selectedDays || new Date(),
@@ -226,6 +232,9 @@ export const DatePicker = ({
           onMouseDown={pickerMouseDown}
           onKeyUp={handleKeyUp}
           onKeyDown={handleOnKeyDown}
+          role="region"
+          aria-label={datePickerAriaLabel}
+          aria-labelledby={datePickerAriaLabelledBy}
         >
           <div
             id={pickerTabGuardId}

--- a/src/components/date/date.component.tsx
+++ b/src/components/date/date.component.tsx
@@ -104,6 +104,10 @@ export interface DateInputProps
   onPickerClose?: () => void;
   /** Date format string to be applied to the date inputs */
   dateFormatOverride?: string;
+  /** Prop to specify the aria-label attribute of the date picker */
+  datePickerAriaLabel?: string;
+  /** Prop to specify the aria-labelledby attribute of the date picker */
+  datePickerAriaLabelledBy?: string;
 }
 
 export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
@@ -137,6 +141,8 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       inputName,
       onPickerClose,
       onPickerOpen,
+      datePickerAriaLabel,
+      datePickerAriaLabelledBy,
       ...rest
     }: DateInputProps,
     ref,
@@ -541,6 +547,8 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
           setOpen={setOpen}
           pickerTabGuardId={pickerTabGuardId.current}
           onPickerClose={onPickerClose}
+          ariaLabel={datePickerAriaLabel}
+          ariaLabelledBy={datePickerAriaLabelledBy}
         />
       </StyledDateInput>
     );


### PR DESCRIPTION
fixes: #7116

### Proposed behaviour

When the `DateRange` component is used an accessibility violation is reported by the Axe Dev Tool scan, more precisely: _All page content should be contained by landmarks_

In order to solve this the `role='region'` has been used to group the elements from the `DatePicker` along with the possibility to add either `aria-label` or `aria-labelledby` in order to describe the purpose or content for the region.

![start-after](https://github.com/user-attachments/assets/7946f1e0-4974-491a-bbc5-dab295f4e0ba)

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

The `DatePicker` component is used an accessibility violation is reported by the Axe Dev Tool scan, more precisely: _All page content should be contained by landmarks_ as it can be seen in the screenshot below:

![error-before](https://github.com/user-attachments/assets/1c67f367-f62e-4e4b-a508-a31775c2dba2)

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

1. Open: https://carbon.sage.com/iframe.html?globals=&args=&id=date-range--default-story&viewMode=story in a new tab
2. Run an Axe Dev Tools full page scan , making sure the `DatePicker` is opened while the scan is running.

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
