### PR TITLE
fix(search): search button has a default aria label

### DIFF
--- a/src/components/search/search.component.tsx
+++ b/src/components/search/search.component.tsx
@@ -96,7 +96,7 @@ export const Search = React.forwardRef<SearchHandle, SearchProps>(
       searchWidth,
       maxWidth,
       searchButton,
-      searchButtonAriaLabel = "search button",
+      searchButtonAriaLabel,
       placeholder,
       variant = "default",
       "aria-label": ariaLabel = "search",
@@ -275,7 +275,7 @@ export const Search = React.forwardRef<SearchHandle, SearchProps>(
         {searchButton && (
           <StyledSearchButton>
             <Button
-              aria-label={searchButtonAriaLabel}
+              aria-label={searchButtonAriaLabel || searchButtonText}
               size="medium"
               px={2}
               buttonType="primary"

--- a/src/components/search/search.test.tsx
+++ b/src/components/search/search.test.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from "react";
 import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+import { enGB } from "locales";
 import Search, { SearchHandle } from "./search.component";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
 import Logger from "../../__internal__/utils/logger";
@@ -38,7 +39,9 @@ test("the `aria-label` prop passes a custom accessible name to the search input"
 });
 
 test("when the `searchButton` prop is `true`, a button with search icon is shown, and no icon appears in the textbox", () => {
-  render(<Search searchButton value="" />);
+  render(
+    <Search searchButton value="" searchButtonAriaLabel="search button" />,
+  );
 
   const searchButton = screen.getByRole("button", { name: "search button" });
   expect(searchButton).toBeVisible();
@@ -54,7 +57,13 @@ test("when the `searchButton` prop is `true`, a button with search icon is shown
 });
 
 test("when the `searchButton` prop is a string value, a button with search icon is shown, and no icon appears in the textbox", () => {
-  render(<Search searchButton="custom search button" value="" />);
+  render(
+    <Search
+      searchButton="custom search button"
+      value=""
+      searchButtonAriaLabel="search button"
+    />,
+  );
 
   const searchButton = screen.getByRole("button", { name: "search button" });
   expect(searchButton).toBeVisible();
@@ -71,7 +80,7 @@ test("when the `searchButton` prop is a string value, a button with search icon 
 });
 
 test("when the `searchButton` prop is not passed, no button with is shown, and an icon is rendered in the textbox", () => {
-  render(<Search value="" />);
+  render(<Search value="" searchButtonAriaLabel="search button" />);
 
   expect(
     screen.queryByRole("button", { name: "search button" }),
@@ -95,10 +104,14 @@ test("the search button text can be overridden via the locale context", () => {
   expect(screen.getByRole("button")).toHaveTextContent("text override");
 });
 
-test("the search button has a default accessible name of `search button`", () => {
-  render(<Search defaultValue="" searchButton />);
+test("the search button uses the value from the locale context as a default accessible name", () => {
+  render(
+    <I18nProvider locale={enGB}>
+      <Search defaultValue="" value="" searchButton />
+    </I18nProvider>,
+  );
 
-  expect(screen.getByRole("button")).toHaveAccessibleName("search button");
+  expect(screen.getByRole("button")).toHaveAccessibleName("Search");
 });
 
 test("the `searchButtonAriaLabel` prop passes a custom accessible name to the search button", () => {
@@ -243,6 +256,7 @@ test("when the component is controlled, the `onClick` callback prop is called wi
       name="Search"
       onClick={onClick}
       searchButton
+      searchButtonAriaLabel="search button"
     />,
   );
 
@@ -265,6 +279,7 @@ test("when the component is uncontrolled, the `onClick` callback prop is called 
       name="Search"
       onClick={onClick}
       searchButton
+      searchButtonAriaLabel="search button"
     />,
   );
 


### PR DESCRIPTION
fixes: #7147

### Proposed behaviour

When a button includes an `aria-label` attribute, screen readers prioritize the `aria-label` text over any visible content inside the button. This means the `aria-label` effectively replaces the visible text for accessibility purposes. If no `aria-label` attribute is present, it defaults to reading the button's visible text or any accessible content within it.

With this in mind, I’ve removed the default value of  `"search button"` for the `searchButtonAriaLabel` prop and opted to use the button’s visible text instead. 

This approach ensures that, in the absence of a specified value for `searchButtonAriaLabel`, the screen reader will read the button text by default. However, if a more explicit description is required, developers can set the `searchButtonAriaLabel` prop, and the screen reader will prioritize that instead.

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

Currently if we do not provide a value for `searchButtonAriaLabel` the screen readers will read out the default value of `search button` instead of the button's text.

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
