### PR TITLE
feat(numeral-date, time): add support for labelAlign on non-inline labels

### DIFF
--- a/src/__internal__/fieldset/fieldset.component.tsx
+++ b/src/__internal__/fieldset/fieldset.component.tsx
@@ -6,6 +6,7 @@ import {
   StyledLegend,
   StyledLegendContent,
   StyledIconWrapper,
+  StyledLegendProps,
 } from "./fieldset.style";
 import ValidationIcon from "../validations/validation-icon.component";
 import NewValidationContext from "../../components/carbon-provider/__internal__/new-validation.context";
@@ -67,7 +68,7 @@ const Fieldset = ({
   children,
   inline = false,
   legendWidth,
-  legendAlign = "right",
+  legendAlign,
   legendSpacing = 2,
   error,
   warning,
@@ -127,6 +128,15 @@ const Fieldset = ({
     return null;
   };
 
+  let legendAlignment: StyledLegendProps["align"];
+  if (inline && !legendAlign) {
+    legendAlignment = "right";
+  } else if (!legendAlign) {
+    legendAlignment = "left";
+  } else {
+    legendAlignment = legendAlign;
+  }
+
   return (
     <InputGroupBehaviour blockGroupBehaviour={blockGroupBehaviour}>
       <StyledFieldset
@@ -143,7 +153,7 @@ const Fieldset = ({
                 onMouseLeave={onMouseLeave}
                 inline={inline}
                 width={legendWidth}
-                align={legendAlign}
+                align={legendAlignment}
                 rightPadding={legendSpacing}
                 {...legendMargin}
                 data-element="legend"

--- a/src/__internal__/fieldset/fieldset.style.ts
+++ b/src/__internal__/fieldset/fieldset.style.ts
@@ -64,7 +64,7 @@ const StyledLegendContent = styled.span<StyledLegendContentProps>`
     `}
 `;
 
-type StyledLegendProps = {
+export type StyledLegendProps = {
   inline?: boolean;
   width?: number;
   align?: "left" | "right";
@@ -78,14 +78,26 @@ const StyledLegend = styled.legend<StyledLegendProps>`
   padding: 0;
   font-weight: var(--fontWeights500);
   color: var(--colorsUtilityYin090);
-  ${({ inline, width, align, rightPadding }) =>
+
+  ${({ align, inline }) =>
+    align &&
+    css`
+      text-align: ${align};
+      justify-content: ${align === "right" ? "flex-end" : "flex-start"};
+
+      ${!inline &&
+      css`
+        width: -moz-available;
+      `}
+    `};
+
+  ${({ inline, width, rightPadding }) =>
     inline &&
     css`
       float: left;
       box-sizing: border-box;
       margin: 0;
       ${width && `width: ${width}%`};
-      justify-content: ${align === "right" ? "flex-end" : "flex-start"};
       padding-right: ${rightPadding === 1
         ? "var(--spacing100)"
         : "var(--spacing200)"};

--- a/src/__internal__/fieldset/fieldset.test.tsx
+++ b/src/__internal__/fieldset/fieldset.test.tsx
@@ -123,7 +123,7 @@ test("renders legend with provided `legendWidth` when `inline` is true", () => {
 });
 
 // coverage
-test("renders with expected styles when `inline` is true and `align` is 'left'", () => {
+test("renders with expected styles when `inline` is true and `legendAlign` is 'left'", () => {
   render(
     <Fieldset legend="Legend" inline legendAlign="left">
       <input />

--- a/src/components/checkbox/checkbox-group/checkbox-group.component.tsx
+++ b/src/components/checkbox/checkbox-group/checkbox-group.component.tsx
@@ -56,7 +56,7 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
     isOptional,
     legendInline,
     legendWidth,
-    legendAlign,
+    legendAlign = "left",
     legendSpacing,
     legendHelp,
     tooltipPosition,

--- a/src/components/form/form.stories.tsx
+++ b/src/components/form/form.stories.tsx
@@ -664,6 +664,7 @@ export const FormAlignmentExample: Story = () => {
         legendInline
         legendWidth={10}
         legendSpacing={2}
+        legendAlign="right"
       >
         <RadioButton
           id="group-1-input-1"

--- a/src/components/numeral-date/numeral-date-test.stories.tsx
+++ b/src/components/numeral-date/numeral-date-test.stories.tsx
@@ -224,12 +224,6 @@ export const NewDesignValidations = (args: NumeralDateProps) => {
 
 NewDesignValidations.storyName = "new design validations";
 
-export const Required = () => {
-  return <NumeralDate label="Date of Birth" required />;
-};
-
-Required.storyName = "required";
-
 export const TooltipPosition = () => {
   return (
     <>
@@ -263,3 +257,47 @@ export const InForm = () => {
 };
 
 InForm.storyName = "in form";
+
+export const LabelAlign = ({ ...args }) => {
+  return (
+    <Box ml={2}>
+      <NumeralDate mb={2} label="labelAlign left" {...args} />
+      <NumeralDate
+        mb={2}
+        label="labelAlign right"
+        labelAlign="right"
+        {...args}
+      />
+      <NumeralDate
+        mb={2}
+        label="labelAlign right and fieldLabelsAlign right"
+        labelAlign="right"
+        fieldLabelsAlign="right"
+        {...args}
+      />
+      <NumeralDate
+        mb={2}
+        label="inline labelAlign left"
+        labelAlign="left"
+        labelInline
+        labelWidth={30}
+        {...args}
+      />
+      <NumeralDate
+        label="inline labelAlign right"
+        labelInline
+        labelWidth={30}
+        {...args}
+      />
+    </Box>
+  );
+};
+
+LabelAlign.storyName = "label align";
+LabelAlign.args = {
+  dateFormat: ["dd", "mm", "yyyy"],
+};
+LabelAlign.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};

--- a/src/components/numeral-date/numeral-date-test.stories.tsx
+++ b/src/components/numeral-date/numeral-date-test.stories.tsx
@@ -301,3 +301,23 @@ LabelAlign.parameters = {
   chromatic: { disableSnapshot: false },
   themeProvider: { chromatic: { theme: "sage" } },
 };
+
+export const InlineLabelsSizes = ({ ...args }) => {
+  return (
+    <Box ml={2}>
+      <NumeralDate mb={2} label="inline small" size="small" {...args} />
+      <NumeralDate mb={2} label="inline medium" size="medium" {...args} />
+      <NumeralDate mb={2} label="inline large" size="large" {...args} />
+    </Box>
+  );
+};
+
+InlineLabelsSizes.storyName = "inline labels sizes";
+InlineLabelsSizes.args = {
+  dateFormat: ["dd", "mm", "yyyy"],
+  labelInline: true,
+};
+InlineLabelsSizes.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};

--- a/src/components/numeral-date/numeral-date.component.tsx
+++ b/src/components/numeral-date/numeral-date.component.tsx
@@ -102,8 +102,10 @@ export interface NumeralDateProps<DateType extends NumeralDateObject = FullDate>
   name?: string;
   /** Label */
   label?: string;
-  /** [Legacy] Label alignment. Works only when labelInline is true */
+  /** Label alignment */
   labelAlign?: "left" | "right";
+  /** Field labels alignment */
+  fieldLabelsAlign?: "left" | "right";
   /**
    * Text applied to label help tooltip, will be rendered as
    * hint text when `validationRedesignOptIn` is true.
@@ -242,6 +244,7 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
   labelInline,
   labelWidth,
   labelAlign,
+  fieldLabelsAlign,
   labelHelp,
   labelSpacing,
   fieldHelp,
@@ -470,9 +473,9 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
                 }
               >
                 <Textbox
-                  maxWidth="fit-content"
                   id={inputIds.current[datePart]}
                   label={getDateLabel(datePart, locale)}
+                  labelAlign={fieldLabelsAlign}
                   disabled={disabled}
                   readOnly={readOnly}
                   error={!!internalError}
@@ -512,6 +515,7 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
           data-role={dataRole}
           id={uniqueId}
           legend={label}
+          legendMargin={{ mb: 0 }}
           isRequired={required}
           isOptional={isOptional}
           isDisabled={disabled}
@@ -528,7 +532,7 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
           aria-describedby={ariaDescribedBy}
           {...filterStyledSystemMarginProps(rest)}
         >
-          <Box display="block" mt={1}>
+          <Box display="block" mt={inline ? 0 : 1}>
             {renderInputs()}
             {fieldHelp && <FieldHelp id={fieldHelpId}>{fieldHelp}</FieldHelp>}
           </Box>
@@ -544,6 +548,8 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
       data-role={dataRole}
       id={uniqueId}
       legend={label}
+      legendMargin={{ mb: 0 }}
+      legendAlign={labelAlign}
       isRequired={required}
       isOptional={isOptional}
       isDisabled={disabled}
@@ -555,7 +561,7 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
         <StyledHintText id={inputHintId.current}>{labelHelp}</StyledHintText>
       )}
 
-      <Box position="relative" mt={1}>
+      <Box position="relative" mt={labelHelp ? 0 : 1}>
         {(internalError || internalWarning) && (
           <>
             <ValidationMessage

--- a/src/components/numeral-date/numeral-date.component.tsx
+++ b/src/components/numeral-date/numeral-date.component.tsx
@@ -524,6 +524,7 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
           warning={validationOnLabel && internalWarning}
           info={validationOnLabel && info}
           inline={inline}
+          size={size}
           labelHelp={labelHelp}
           legendAlign={labelAlign}
           legendWidth={labelWidth}
@@ -532,7 +533,7 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
           aria-describedby={ariaDescribedBy}
           {...filterStyledSystemMarginProps(rest)}
         >
-          <Box display="block" mt={inline ? 0 : 1}>
+          <Box display="flex" flexDirection="column" mt={inline ? 0 : 1}>
             {renderInputs()}
             {fieldHelp && <FieldHelp id={fieldHelpId}>{fieldHelp}</FieldHelp>}
           </Box>

--- a/src/components/numeral-date/numeral-date.pw.tsx
+++ b/src/components/numeral-date/numeral-date.pw.tsx
@@ -102,9 +102,6 @@ test.describe("NumeralDate component", () => {
   }) => {
     await mount(<NumeralDateComponent labelInline />);
 
-    const fieldset = page.locator("fieldset");
-    await expect(fieldset).toHaveCSS("display", "flex");
-
     const legend = getDataElementByValue(page, "legend");
     await expect(legend).toHaveCSS("float", "left");
   });
@@ -568,22 +565,25 @@ test.describe("NumeralDate component", () => {
 
   (
     [
-      ["flex", 399],
-      ["flex", 400],
-      ["block", 401],
-    ] as [string, NumeralDateProps["adaptiveLabelBreakpoint"]][]
-  ).forEach(([displayValue, breakpoint]) => {
-    test(`should render NumeralDate with ${displayValue} label alignment when the adaptiveLabelBreakpoint prop is ${breakpoint} with a set viewport of 400`, async ({
+      [399, false],
+      [400, true],
+      [401, true],
+    ] as [number, boolean][]
+  ).forEach(([viewport, isInline]) => {
+    test(`should render NumeralDate with labelInline when the adaptiveLabelBreakpoint prop is 400 with a viewport of ${viewport}`, async ({
       mount,
       page,
     }) => {
-      await page.setViewportSize({ width: 400, height: 300 });
-      await mount(
-        <NumeralDateComponent adaptiveLabelBreakpoint={breakpoint} />,
-      );
+      await page.setViewportSize({ width: viewport, height: 300 });
+      await mount(<NumeralDateComponent adaptiveLabelBreakpoint={400} />);
 
-      const fieldset = page.locator("fieldset");
-      await expect(fieldset).toHaveCSS("display", displayValue);
+      const legend = getDataElementByValue(page, "legend");
+
+      if (isInline) {
+        await expect(legend).toHaveCSS("float", "left");
+      } else {
+        await expect(legend).not.toHaveCSS("float", "left");
+      }
     });
   });
 

--- a/src/components/numeral-date/numeral-date.style.ts
+++ b/src/components/numeral-date/numeral-date.style.ts
@@ -2,7 +2,8 @@ import styled, { css } from "styled-components";
 import StyledIconSpan from "../../__internal__/input-icon-toggle/input-icon-toggle.style";
 import StyledInputPresentation from "../../__internal__/input/input-presentation.style";
 import StyledInput from "../../__internal__/input/input.style";
-import Fieldset from "../../__internal__/fieldset";
+import Fieldset, { FieldsetProps } from "../../__internal__/fieldset";
+import { StyledLegend } from "../../__internal__/fieldset/fieldset.style";
 
 interface StyledDateFieldProps {
   isYearInput?: boolean;
@@ -55,12 +56,26 @@ export const StyledDateField = styled.div<StyledDateFieldProps>`
   `}
 `;
 
-export const StyledFieldset = styled(Fieldset)`
-  ${({ inline }) => css`
+interface StyledFieldsetProps extends FieldsetProps {
+  inline?: boolean;
+  size?: "small" | "medium" | "large";
+}
+
+// We need to match height of the legend to the input container when it is inline to center it vertically,
+// as Safari does not support display: flex on fieldset elements.
+const sizeHeight = {
+  small: "57px",
+  medium: "65px",
+  large: "73px",
+};
+
+export const StyledFieldset = styled(Fieldset)<StyledFieldsetProps>`
+  ${({ inline, size }) => css`
     ${inline &&
     css`
-      display: flex;
-      align-items: center;
+      ${StyledLegend} {
+        height: ${size && sizeHeight[size]};
+      }
     `}
 
     ${!inline &&

--- a/src/components/numeral-date/numeral-date.style.ts
+++ b/src/components/numeral-date/numeral-date.style.ts
@@ -3,7 +3,6 @@ import StyledIconSpan from "../../__internal__/input-icon-toggle/input-icon-togg
 import StyledInputPresentation from "../../__internal__/input/input-presentation.style";
 import StyledInput from "../../__internal__/input/input.style";
 import Fieldset from "../../__internal__/fieldset";
-import { StyledLegend } from "../../__internal__/fieldset/fieldset.style";
 
 interface StyledDateFieldProps {
   isYearInput?: boolean;
@@ -63,9 +62,10 @@ export const StyledFieldset = styled(Fieldset)`
       display: flex;
       align-items: center;
     `}
-  `}
 
-  ${StyledLegend} {
-    margin-bottom: 0;
-  }
+    ${!inline &&
+    css`
+      width: min-content;
+    `}
+  `}
 `;

--- a/src/components/numeral-date/numeral-date.test.tsx
+++ b/src/components/numeral-date/numeral-date.test.tsx
@@ -767,9 +767,9 @@ test("should render with `labelInline` when `adaptiveLabelBreakpoint` set and sc
     </CarbonProvider>,
   );
 
-  expect(screen.getByRole("group")).toHaveStyle({
-    display: "flex",
-    alignItems: "center",
+  expect(screen.getByTestId("legend")).toHaveStyle({
+    float: "left",
+    height: "65px",
   });
 });
 

--- a/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
+++ b/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
@@ -74,7 +74,7 @@ export const RadioButtonGroup = (props: RadioButtonGroupProps) => {
     inline = false,
     legendInline = false,
     legendWidth,
-    legendAlign,
+    legendAlign = "left",
     legendSpacing,
     labelSpacing = 1,
     adaptiveLegendBreakpoint,

--- a/src/components/textbox/textbox-test.stories.tsx
+++ b/src/components/textbox/textbox-test.stories.tsx
@@ -71,13 +71,13 @@ export const commonTextboxArgTypes = (isNewValidation?: boolean) => ({
       type: "select",
     },
   },
-  ...(!isNewValidation && {
-    labelAlign: {
-      options: ["left", "right"],
-      control: {
-        type: "select",
-      },
+  labelAlign: {
+    options: ["left", "right"],
+    control: {
+      type: "select",
     },
+  },
+  ...(!isNewValidation && {
     labelWidth: {
       control: {
         type: "range",

--- a/src/components/time/time-test.stories.tsx
+++ b/src/components/time/time-test.stories.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
+import { TimeInputEvent, TimeValue } from "./time.component";
+import { Time } from ".";
+import Box from "../box";
+
+const meta: Meta<typeof Time> = {
+  component: Time,
+  title: "Time/Test",
+  parameters: {
+    controls: {
+      exclude: ["value", "onChange", "onBlur"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Time>;
+
+export const LabelAlign: Story = ({ ...args }) => {
+  const [value, setValue] = useState<TimeValue>({
+    hours: "",
+    minutes: "",
+    period: "AM",
+  });
+
+  const handleChange = (ev: TimeInputEvent) => {
+    setValue(ev.target.value);
+  };
+
+  return (
+    <Box ml={2}>
+      <Time
+        mb={2}
+        value={value}
+        onChange={handleChange}
+        label="labelAlign left"
+        {...args}
+      />
+      <Time
+        mb={2}
+        value={value}
+        onChange={handleChange}
+        label="labelAlign right"
+        labelAlign="right"
+        {...args}
+      />
+      <Time
+        value={value}
+        onChange={handleChange}
+        label="labelAlign right and fieldLabelsAlign right"
+        labelAlign="right"
+        fieldLabelsAlign="right"
+        {...args}
+      />
+    </Box>
+  );
+};
+LabelAlign.storyName = "Label Align";

--- a/src/components/time/time.component.tsx
+++ b/src/components/time/time.component.tsx
@@ -54,6 +54,10 @@ export interface TimeProps
     MarginProps {
   /** Label text for the component */
   label?: string;
+  /** Label alignment */
+  labelAlign?: "left" | "right";
+  /** Field labels alignment */
+  fieldLabelsAlign?: "left" | "right";
   /** Sets the size of the inputs */
   size?: Sizes;
   /** Additional hint text rendered above the input elements */
@@ -101,6 +105,8 @@ const Time = React.forwardRef<TimeHandle, TimeProps>(
   (
     {
       label,
+      labelAlign,
+      fieldLabelsAlign,
       size = "medium",
       inputHint,
       hoursInputProps = {},
@@ -251,7 +257,8 @@ const Time = React.forwardRef<TimeHandle, TimeProps>(
       <Fieldset
         legend={label}
         legendMargin={{ mb: 0 }}
-        width="fit-content"
+        width="min-content"
+        legendAlign={labelAlign}
         isRequired={required}
         isOptional={isOptional}
         isDisabled={disabled}
@@ -266,7 +273,7 @@ const Time = React.forwardRef<TimeHandle, TimeProps>(
             {inputHint}
           </Hint>
         )}
-        <Box position="relative">
+        <Box position="relative" mt={inputHint ? 0 : 1}>
           <ValidationMessage
             validationId={validationId}
             error={error}
@@ -281,6 +288,7 @@ const Time = React.forwardRef<TimeHandle, TimeProps>(
                 aria-label={hrsAriaLabel}
                 htmlFor={internalHrsId.current}
                 disabled={disabled}
+                align={fieldLabelsAlign}
               >
                 {hrsLabel}
               </Label>
@@ -317,6 +325,7 @@ const Time = React.forwardRef<TimeHandle, TimeProps>(
                 aria-label={minsAriaLabel}
                 htmlFor={internalMinsId.current}
                 disabled={disabled}
+                align={fieldLabelsAlign}
               >
                 {minsLabel}
               </Label>
@@ -341,6 +350,7 @@ const Time = React.forwardRef<TimeHandle, TimeProps>(
                 display="flex"
                 flexDirection="column"
                 justifyContent="flex-end"
+                width="max-content"
               >
                 <TimeToggle
                   toggleProps={toggleProps}

--- a/src/components/time/time.stories.tsx
+++ b/src/components/time/time.stories.tsx
@@ -20,6 +20,11 @@ const styledSystemProps = generateStyledSystemProps({
 const meta: Meta<typeof Time> = {
   title: "Time",
   component: Time,
+  parameters: {
+    controls: {
+      exclude: ["value", "onChange", "onBlur"],
+    },
+  },
   argTypes: {
     ...styledSystemProps,
   },
@@ -28,7 +33,7 @@ const meta: Meta<typeof Time> = {
 export default meta;
 type Story = StoryObj<typeof Time>;
 
-export const Default: Story = () => {
+export const Default: Story = ({ ...args }) => {
   const [value, setValue] = useState<TimeValue>({
     hours: "",
     minutes: "",
@@ -40,7 +45,7 @@ export const Default: Story = () => {
 
   return (
     <Box p={2}>
-      <Time value={value} onChange={handleChange} label="Time" />
+      <Time value={value} onChange={handleChange} label="Time" {...args} />
     </Box>
   );
 };
@@ -50,7 +55,7 @@ Default.parameters = {
   themeProvider: { chromatic: { theme: "sage" } },
 };
 
-export const AmPmToggle: Story = () => {
+export const AmPmToggle: Story = ({ ...args }) => {
   const [value, setValue] = useState<TimeValue>({
     hours: "",
     minutes: "",
@@ -63,7 +68,7 @@ export const AmPmToggle: Story = () => {
 
   return (
     <Box p={2}>
-      <Time value={value} onChange={handleChange} label="Time" />
+      <Time value={value} onChange={handleChange} label="Time" {...args} />
     </Box>
   );
 };

--- a/src/components/time/time.style.ts
+++ b/src/components/time/time.style.ts
@@ -16,7 +16,7 @@ export const StyledHintText = styled.div<{
   }
 
   margin-top: var(--spacing000);
-  margin-bottom: var(--spacing150);
+  margin-bottom: var(--spacing100);
   color: ${({ isDisabled }) =>
     isDisabled ? "var(--colorsUtilityYin030)" : "var(--colorsUtilityYin055)"};
   font-size: 14px;


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- Add support for `labelAlign` prop for non-inline label in NumeralDate.
- Add `labelAlign` prop to Time.
- Add `fieldLabelsAlign` prop to NumeralDate and Time to allow left/right alignment of field labels. 
![image](https://github.com/user-attachments/assets/8e2f1864-5910-41b9-9835-ad0ae4db7778)
![image](https://github.com/user-attachments/assets/72d1cbee-9202-44a3-9d67-ef6069f552e7)

- Ensure inline labels in NumeralDate display as expected in Safari:
<img width="362" alt="image" src="https://github.com/user-attachments/assets/21d5bc09-cc1d-42b3-a162-23b4e26de6d9" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- NumeralDate has `labelAlign` prop that has no effect with non-inline labels. 
- Time does not have `labelAlign` prop. 
- NumeralDate with inline label does not display as expected in Safari.
<img width="353" alt="image" src="https://github.com/user-attachments/assets/31b6db62-167e-4818-9bd5-a28f7c947ea5" />


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
