### PR TITLE
fix(date): fix focus loss when using navbar with keyboard

### DIFF
--- a/playwright/index.tsx
+++ b/playwright/index.tsx
@@ -25,10 +25,7 @@ const mountedTheme = (theme: string) => {
 
 // Setup required providers on mounted component before running test. See https://playwright.dev/docs/test-components#hooks
 beforeMount<HooksConfig>(async ({ App, hooksConfig }) => {
-  const {
-    theme = "sage",
-    validationRedesignOptIn,
-  } = hooksConfig || {};
+  const { theme = "sage", validationRedesignOptIn } = hooksConfig || {};
   return (
     <CarbonProvider
       theme={mountedTheme(theme)}

--- a/src/components/date/__internal__/date-picker/date-picker.component.tsx
+++ b/src/components/date/__internal__/date-picker/date-picker.component.tsx
@@ -6,6 +6,7 @@ import React, {
   useMemo,
   useRef,
   useState,
+  memo,
 } from "react";
 import {
   DayPicker,
@@ -71,6 +72,17 @@ const popoverMiddleware = [
     fallbackStrategy: "initialPlacement",
   }),
 ];
+
+/** The Navbar has been lifted out of the main component to ensure that it can be properly
+ * memoized and not re-rendered on every update of the DatePicker component.
+ *
+ * Resolves https://jira.sage.com/browse/FE-7047
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Nav = (props: any) => {
+  return <Navbar {...props} />;
+};
+const MemoizedNav = memo(Nav);
 
 export const DatePicker = ({
   inputElement,
@@ -257,9 +269,10 @@ export const DatePicker = ({
               handleDayClick(date, e);
             }}
             components={{
-              Nav: (props) => {
-                return <Navbar {...props} />;
-              },
+              // TODO: Fix this. It's a horrible approach to take.
+              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+              // @ts-ignore: Type 'MemoizedNav' is not assignable to type 'ComponentType<NavbarProps>'.
+              Nav: MemoizedNav,
               Weekday: (props) => {
                 const fixedDays = {
                   Sunday: 0,


### PR DESCRIPTION
The Navbar of the internal date picker component has been memoized to ensure that it doesn't rerender unless it absolutely needs to (which should be never as it's just two buttons; the month name isn't part of the navbar, it's just styled that way)

Resolves [7158](https://github.com/Sage/carbon/issues/7158)

### Proposed behaviour

Prevent the  month navigation buttons from losing focus when activated via keyboard

### Current behaviour

The buttons of the navigation bar in the Date Picker lose focus when activated using keyboard controls

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Use the Storybook examples to ensure that the buttons don't lose focus when navigating between months using the keyboard