### PR TITLE
fix(heading): maintain layout when title prop is set to null

### DIFF
--- a/src/components/dialog-full-screen/content.style.ts
+++ b/src/components/dialog-full-screen/content.style.ts
@@ -50,7 +50,6 @@ const StyledContent = styled.div<StyledContentProps>`
     !hasHeader &&
     css`
       padding-top: 0;
-      margin-top: -25px;
     `}
 `;
 

--- a/src/components/dialog-full-screen/dialog-full-screen.component.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.component.tsx
@@ -185,7 +185,7 @@ export const DialogFullScreen = ({
           pagesStyling={pagesStyling}
           role={role}
         >
-          {dialogTitle()}
+          {title || headerChildren ? dialogTitle() : null}
           {closeIcon()}
           <StyledContent
             hasHeader={title !== undefined}

--- a/src/components/dialog-full-screen/dialog-full-screen.style.ts
+++ b/src/components/dialog-full-screen/dialog-full-screen.style.ts
@@ -47,7 +47,6 @@ const StyledDialogFullScreen = styled.div<{ pagesStyling?: boolean }>`
     css`
       ${StyledContent} {
         padding: 0;
-        margin-top: -25px;
       }
 
       ${StyledIconButton} {

--- a/src/components/dialog-full-screen/dialog-full-screen.test.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.test.tsx
@@ -238,6 +238,14 @@ test("renders the element given in the `headerChildren` prop", () => {
   ).toBeVisible();
 });
 
+test("does not render anything if no `headerChildren` prop is provided", () => {
+  render(<DialogFullScreen open />);
+
+  const link = screen.queryByRole("link");
+
+  expect(link).not.toBeInTheDocument();
+});
+
 // test here for coverage only - disableContentPadding prop already tested in both Playwright and Chromatic
 test("padding is removed from the content when the `disableContentPadding` prop is passed", () => {
   render(
@@ -278,11 +286,6 @@ test("applies the appropriate styles when the `pagesStyling` prop is set", () =>
   expect(dialog).toHaveStyleRule("z-index", "1", {
     modifier: `${StyledIconButton}`,
   });
-
-  expect(dialog).toHaveStyleRule("padding", "32px 32px 0", {
-    modifier: `${StyledFullScreenHeading}`,
-  });
-
   expect(dialog).toHaveStyleRule("width", "auto", {
     modifier: `${StyledHeading}`,
   });
@@ -298,6 +301,9 @@ test("applies the appropriate styles when the `pagesStyling` prop is set", () =>
   });
   expect(dialog).toHaveStyleRule("margin", "0 0 0 3px", {
     modifier: `${StyledHeading} ${StyledHeader}`,
+  });
+  expect(dialog).toHaveStyleRule("padding", "32px 32px 0", {
+    modifier: `${StyledFullScreenHeading}`,
   });
 });
 

--- a/src/components/pages/page/page.component.tsx
+++ b/src/components/pages/page/page.component.tsx
@@ -9,7 +9,7 @@ import { filterStyledSystemPaddingProps } from "../../../style/utils";
 
 export interface PageProps extends PaddingProps {
   /** The title for the page, normally a Heading component. */
-  title: React.ReactNode;
+  title?: React.ReactNode;
   /** This component supports children. */
   children: React.ReactNode;
   /** The ARIA role to be applied to the component */
@@ -38,7 +38,9 @@ const Page = ({ role, title, children, ...rest }: PageProps) => {
         ref={styledPageNodeRef}
         role={role}
       >
-        <FullScreenHeading hasContent>{title}</FullScreenHeading>
+        {title ? (
+          <FullScreenHeading hasContent>{title}</FullScreenHeading>
+        ) : null}
         <StyledPageContent
           data-element="carbon-page-content"
           data-role="page-content"

--- a/src/components/pages/pages-test.stories.tsx
+++ b/src/components/pages/pages-test.stories.tsx
@@ -10,7 +10,7 @@ import Box from "../box";
 
 export default {
   title: "Pages/Test",
-  includeStories: ["DefaultStory", "DifferentPageHeights"],
+  includeStories: ["DefaultStory", "DifferentPageHeights", "WithoutTitle"],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -523,5 +523,27 @@ export const DifferentPageHeights = () => {
         </Page>
       </Pages>
     </Box>
+  );
+};
+
+export const WithoutTitle = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const handleCancel = () => {
+    setIsOpen(false);
+  };
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+  return (
+    <div>
+      <Button onClick={handleOpen}>Open Preview</Button>
+      <DialogFullScreen pagesStyling open={isOpen} onCancel={handleCancel}>
+        <Pages pageIndex={0}>
+          <Page>
+            <Button>Example button</Button>
+          </Page>
+        </Pages>
+      </DialogFullScreen>
+    </div>
   );
 };

--- a/src/components/pages/pages.test.tsx
+++ b/src/components/pages/pages.test.tsx
@@ -159,6 +159,16 @@ test("navigating to the next page should render the first page when currently on
   expect(screen.getByRole("heading", { name: "My First Page" })).toBeVisible();
 });
 
+test("component renders correctly with no title prop passed", () => {
+  render(
+    <Pages pageIndex={0}>
+      <Page>First Page</Page>
+    </Pages>,
+  );
+
+  expect(screen.getByTestId("visible-page")).toHaveTextContent("First Page");
+});
+
 test("when attempting to navigate pages and there is only one page, it should not change the rendered content", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
   const WithSinglePage = () => {


### PR DESCRIPTION
### Proposed behaviour
<img width="653" alt="Screenshot 2025-01-30 at 10 47 00" src="https://github.com/user-attachments/assets/a42f7f9d-7b92-40ab-aa3d-0dbb9c1f8eaf" />
<img width="646" alt="Screenshot 2025-01-30 at 10 47 13" src="https://github.com/user-attachments/assets/90d53251-08a5-4b23-81eb-1cb64f6efa50" />

<img width="632" alt="Screenshot 2025-01-30 at 10 47 32" src="https://github.com/user-attachments/assets/8f24b536-1e6b-4a29-bb13-84cb7f68398a" />

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

<img width="815" alt="Screenshot 2025-01-30 at 10 39 50" src="https://github.com/user-attachments/assets/7dceeb79-e7f9-48dd-9e51-832d540dd315" />

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

https://github.com/Sage/carbon/issues/5460

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

https://github.com/user-attachments/assets/fe345453-4408-4289-a363-556272b5249e


<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
