### PR TITLE
fix(dialog): ensure enableBackgroundUI is passed to Modal

### DIFF
--- a/src/components/dialog/dialog.component.tsx
+++ b/src/components/dialog/dialog.component.tsx
@@ -128,6 +128,9 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
       topModalOverride,
       closeButtonDataProps,
       restoreFocusOnClose = true,
+      "aria-labelledby": ariaLabelledBy,
+      "aria-describedby": ariaDescribedBy,
+      "aria-label": ariaLabel,
       ...rest
     },
     ref,
@@ -197,12 +200,10 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
       size,
       dialogHeight,
       "aria-labelledby":
-        title && typeof title === "string" ? titleId : rest["aria-labelledby"],
+        title && typeof title === "string" ? titleId : ariaLabelledBy,
       "aria-describedby":
-        subtitle && typeof subtitle === "string"
-          ? subtitleId
-          : rest["aria-describedby"],
-      "aria-label": rest["aria-label"],
+        subtitle && typeof subtitle === "string" ? subtitleId : ariaDescribedBy,
+      "aria-label": ariaLabel,
     };
 
     return (
@@ -214,6 +215,7 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
         className={className ? `${className} carbon-dialog` : "carbon-dialog"}
         topModalOverride={topModalOverride}
         restoreFocusOnClose={restoreFocusOnClose}
+        {...rest}
       >
         <FocusTrap
           autoFocus={!disableAutoFocus}

--- a/src/components/dialog/dialog.pw.tsx
+++ b/src/components/dialog/dialog.pw.tsx
@@ -29,7 +29,10 @@ import {
   waitForElementFocus,
 } from "../../../playwright/support/helper";
 import { CHARACTERS, SIZE } from "../../../playwright/support/constants";
-import { getDataElementByValue } from "../../../playwright/components";
+import {
+  getDataElementByValue,
+  backgroundUILocator,
+} from "../../../playwright/components";
 
 const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
@@ -99,6 +102,25 @@ test.describe("Testing Dialog component properties", () => {
       await mount(<DialogComponent size={size} />);
 
       await expect(page.getByRole("dialog")).toHaveCSS("width", width);
+    });
+  });
+
+  [true, false].forEach((enableBackgroundUIValue) => {
+    test(`verify visibility of backgroundUILocatorElement when enableBackgroundUI prop is set to ${enableBackgroundUIValue}`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <DialogComponent enableBackgroundUI={enableBackgroundUIValue} />,
+      );
+
+      const backgroundUILocatorElement = backgroundUILocator(page);
+
+      if (enableBackgroundUIValue) {
+        await expect(backgroundUILocatorElement).not.toBeVisible();
+      } else {
+        await expect(backgroundUILocatorElement).toBeVisible();
+      }
     });
   });
 


### PR DESCRIPTION
fix #6023 

adding modal props to Dialog and pass enableBackgroundUI

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour
<img width="524" alt="Screenshot 2025-01-21 at 13 06 28" src="https://github.com/user-attachments/assets/8a09a1ae-d9af-45e0-b8a6-ba189d974a8e" />

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
