### PR TITLE
fix(action-popover): aria label has default value despite visible text on open button

### DIFF
--- a/src/components/action-popover/__internal__/action-popover-utils.tsx
+++ b/src/components/action-popover/__internal__/action-popover-utils.tsx
@@ -28,3 +28,15 @@ export const findLastFocusableItem = (items: ReactItem[]): number => {
   }
   return -1;
 };
+
+export const checkChildrenForString = (children: React.ReactNode): boolean => {
+  return React.Children.toArray(children).some((child) => {
+    if (typeof child === "string") {
+      return true;
+    }
+
+    return React.isValidElement(child)
+      ? checkChildrenForString(child.props.children)
+      : false;
+  });
+};

--- a/src/components/action-popover/action-popover-menu-button/action-popover-menu-button.component.tsx
+++ b/src/components/action-popover/action-popover-menu-button/action-popover-menu-button.component.tsx
@@ -11,7 +11,7 @@ import { IconType } from "../../icon";
 
 export type ActionPopoverMenuButtonAria = {
   "aria-haspopup": string;
-  "aria-label": string;
+  "aria-label"?: string;
   "aria-labelledby"?: string;
   "aria-describedby"?: string;
   "aria-controls": string;

--- a/src/components/action-popover/action-popover-test.stories.tsx
+++ b/src/components/action-popover/action-popover-test.stories.tsx
@@ -22,7 +22,12 @@ import Box from "../box";
 
 export default {
   title: "Action Popover/Test",
-  includeStories: ["Default", "LongMenuExample", "WithAriaAttributes"],
+  includeStories: [
+    "Default",
+    "LongMenuExample",
+    "WithAriaAttributes",
+    "WithoutDefaultAriaLabel",
+  ],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -848,5 +853,41 @@ export const WithAriaAttributes = () => {
         <ActionPopoverItem onClick={() => {}}>foo</ActionPopoverItem>
       </ActionPopover>
     </>
+  );
+};
+
+export const WithoutDefaultAriaLabel = () => {
+  return (
+    <Box height={250}>
+      <ActionPopover
+        renderButton={(props) => {
+          return (
+            <ActionPopoverMenuButton
+              buttonType="tertiary"
+              iconType="ellipsis_vertical"
+              iconPosition="after"
+              size="small"
+              {...props}
+            >
+              Button Text
+            </ActionPopoverMenuButton>
+          );
+        }}
+      >
+        <ActionPopoverItem icon="email" onClick={() => {}}>
+          Email Invoice
+        </ActionPopoverItem>
+        <ActionPopoverItem disabled icon="csv" onClick={() => {}}>
+          Download CSV
+        </ActionPopoverItem>
+        <ActionPopoverItem icon="pdf" onClick={() => {}}>
+          Download PDF
+        </ActionPopoverItem>
+        <ActionPopoverDivider />
+        <ActionPopoverItem onClick={() => {}} icon="delete">
+          Delete
+        </ActionPopoverItem>
+      </ActionPopover>
+    </Box>
   );
 };

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -30,6 +30,7 @@ import {
   findFirstFocusableItem,
   findLastFocusableItem,
   getItems,
+  checkChildrenForString,
 } from "./__internal__/action-popover-utils";
 
 export interface RenderButtonProps {
@@ -37,7 +38,7 @@ export interface RenderButtonProps {
   "data-element": string;
   ariaAttributes: {
     "aria-haspopup": string;
-    "aria-label": string;
+    "aria-label"?: string;
     "aria-labelledby"?: string;
     "aria-describedby"?: string;
     "aria-controls": string;
@@ -260,12 +261,29 @@ export const ActionPopover = forwardRef<
 
     const menuButton = (menuID: string) => {
       if (renderButton) {
-        return renderButton({
+        const renderButtonComponent = renderButton({
           tabIndex: isOpen ? -1 : 0,
           "data-element": "action-popover-button",
           ariaAttributes: {
             "aria-haspopup": "true",
             "aria-label": ariaLabel || l.actionPopover.ariaLabel(),
+            "aria-labelledby": ariaLabelledBy,
+            "aria-describedby": ariaDescribedBy,
+            "aria-controls": menuID,
+            "aria-expanded": `${isOpen}`,
+          },
+        });
+
+        const buttonHasString = checkChildrenForString(renderButtonComponent);
+
+        return renderButton({
+          tabIndex: isOpen ? -1 : 0,
+          "data-element": "action-popover-button",
+          ariaAttributes: {
+            "aria-haspopup": "true",
+            "aria-label": buttonHasString
+              ? undefined
+              : ariaLabel || l.actionPopover.ariaLabel(),
             "aria-labelledby": ariaLabelledBy,
             "aria-describedby": ariaDescribedBy,
             "aria-controls": menuID,

--- a/src/components/action-popover/action-popover.test.tsx
+++ b/src/components/action-popover/action-popover.test.tsx
@@ -132,6 +132,73 @@ test("has a default aria-label", () => {
   expect(screen.getByRole("button")).toHaveAccessibleName("actions");
 });
 
+test("has a default aria-label if the renderButton prop contains a button without text", () => {
+  render(
+    <ActionPopover
+      renderButton={(props) => {
+        return (
+          <ActionPopoverMenuButton
+            buttonType="tertiary"
+            iconType="ellipsis_vertical"
+            iconPosition="after"
+            size="small"
+            {...props}
+          />
+        );
+      }}
+    >
+      <ActionPopoverItem>example item</ActionPopoverItem>
+    </ActionPopover>,
+  );
+  expect(screen.getByRole("button")).toHaveAccessibleName("actions");
+});
+
+test("has a default aria-label if the renderButton prop contains a button with children other than string", () => {
+  render(
+    <ActionPopover
+      renderButton={(props) => {
+        return (
+          <ActionPopoverMenuButton
+            buttonType="tertiary"
+            iconType="ellipsis_vertical"
+            iconPosition="after"
+            size="small"
+            {...props}
+          >
+            {42 as unknown as string}
+          </ActionPopoverMenuButton>
+        );
+      }}
+    >
+      <ActionPopoverItem>example item</ActionPopoverItem>
+    </ActionPopover>,
+  );
+  expect(screen.getByRole("button")).toHaveAccessibleName("actions");
+});
+
+test("does not have a default aria-label if the renderButton prop contains a button with text", () => {
+  render(
+    <ActionPopover
+      renderButton={(props) => {
+        return (
+          <ActionPopoverMenuButton
+            buttonType="tertiary"
+            iconType="ellipsis_vertical"
+            iconPosition="after"
+            size="small"
+            {...props}
+          >
+            Button text
+          </ActionPopoverMenuButton>
+        );
+      }}
+    >
+      <ActionPopoverItem>example item</ActionPopoverItem>
+    </ActionPopover>,
+  );
+  expect(screen.getByRole("button")).not.toHaveAccessibleName("actions");
+});
+
 test("uses the aria-label prop if provided", () => {
   render(
     <ActionPopover aria-label="test aria label">


### PR DESCRIPTION
fixes: #7143

### Proposed behaviour

If the button passed to `renderButton` prop contains a child of type `string` we will not add an `aria-label` attribute and the text reader will read the text from the open button.

If the button does not contain a child of type `string` it will receive a default `aria-label` based on the current locale.


![action-popover-after](https://github.com/user-attachments/assets/87daa7a3-c6e3-450d-96b9-f7095514cbc1)

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

Currently a default `aria-label` is applied regardless if the open button contains or not any text.

![action-popover-before](https://github.com/user-attachments/assets/e0ad5029-c8fc-4e99-985a-0e6c063ad961)

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [X] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

1. Open the storybook
2. Go to Action Popover -> Custom Menu Button story (action-popover--custom-menu-button)
3. When the first button is focused the screen reader will read the button text: "menu"
Inspecting the button you can see that the <button> element does not have the aria-label="actions" attribute, because the button contains a text.
4. When the second button is focused the screen reader will read the text : "actions".
Inspecting the button you can see that the <button> element has the aria-label="actions" attribute set, because it does not contain any text.


<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
