### PR TITLE
fix(form): ensure that additional margin-bottom is not applied to Time component - FE-7054

### DIFF
--- a/src/components/form/form-test.stories.tsx
+++ b/src/components/form/form-test.stories.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 import React, { useState } from "react";
 
+import { StoryObj } from "@storybook/react/*";
 import TextEditor, { EditorState } from "../text-editor";
 import Form from ".";
 import Button from "../button";
@@ -25,6 +26,7 @@ import InlineInputs from "../inline-inputs";
 import Pager from "../pager";
 import Password from "../password";
 import Search, { SearchProps } from "../search";
+import { Time } from "../time";
 
 export default {
   title: "Form/Test",
@@ -37,7 +39,9 @@ export default {
   },
 };
 
-export const DefaultWithStickyFooter = ({ ...props }) => (
+type StoryType = StoryObj<typeof Form>;
+
+export const DefaultWithStickyFooter: StoryType = ({ ...props }) => (
   <Form
     onSubmit={() => console.log("submit")}
     leftSideButtons={
@@ -63,6 +67,14 @@ export const DefaultWithStickyFooter = ({ ...props }) => (
     </Tabs>
     <Textbox label="Textbox" />
     <Textbox label="Textbox" />
+    <Time
+      value={{
+        hours: "",
+        minutes: "",
+      }}
+      onChange={() => {}}
+      label="Time"
+    />
     <Textbox label="Textbox" />
     <Textbox label="Textbox" />
     <Textbox label="Textbox" />
@@ -78,6 +90,21 @@ DefaultWithStickyFooter.args = {
   warningCount: 0,
   buttonAlignment: "right",
 };
+DefaultWithStickyFooter.parameters = {
+  themeProvider: {
+    chromatic: { theme: "sage" },
+  },
+  chromatic: {
+    disableSnapshot: false,
+  },
+};
+DefaultWithStickyFooter.decorators = [
+  (Story) => (
+    <div style={{ height: "100vh", width: "97vw" }}>
+      <Story />
+    </div>
+  ),
+];
 
 export const FormAlignmentCustomMarginsTextInputs = () => {
   return (

--- a/src/components/form/form.style.ts
+++ b/src/components/form/form.style.ts
@@ -89,7 +89,7 @@ export const StyledForm = styled.form<StyledFormProps>`
     `}
 
   // field spacing is also applied to form field here so we need to override
-  ${StyledSearch} ${StyledFormField}, ${StyledTextarea} ${StyledFormField} {
+  ${StyledSearch} ${StyledFormField}, ${StyledTextarea} ${StyledFormField}, [data-component="time"] ${StyledFormField} {
     margin-bottom: var(--spacing000);
   }
 


### PR DESCRIPTION
When using a Time component within a Form, the separator is incorrectly positioned. This fix ensures that the height of the Time component is calculated correctly and that margin-bottom is not applied twice, thus ensuring the separator is rendered correctly in the centre position.

fixes #7164

### Proposed behaviour

![Screenshot 2025-01-22 at 15 22 44](https://github.com/user-attachments/assets/fd261a7a-db4b-4b74-b2e9-d4621085e474)

### Current behaviour

![Screenshot 2025-01-22 at 15 23 49](https://github.com/user-attachments/assets/bcc1cc10-a7c1-49d8-9c15-909f13d54f86)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

I have created this as a non-draft PR because I needed to see if the Chromatic snapshots are as expected.

### Testing instructions

- Check that you're happy that the new Chromatic snapshot sufficiently captures what is required to avoid potential regressions in the future.
- No other styling regressions relating to Form. 
