### PR TITLE
fix(form): ensure that additional margin-bottom is not applied to NumeralDate component - FE-7057

### DIFF
--- a/src/components/form/form-test.stories.tsx
+++ b/src/components/form/form-test.stories.tsx
@@ -555,3 +555,51 @@ FullWidthWithLeftAndRight.parameters = {
   },
   themeProvider: { chromatic: { theme: "sage" }, viewports: [1200, 900, 320] },
 };
+
+export const DefaultWithNumeralDate: StoryType = ({ ...props }) => (
+  <Form
+    onSubmit={() => console.log("submit")}
+    leftSideButtons={
+      <Button onClick={() => console.log("cancel")}>Cancel</Button>
+    }
+    saveButton={
+      <Button buttonType="primary" type="submit">
+        Save
+      </Button>
+    }
+    {...props}
+  >
+    <Textbox label="Textbox" />
+    <Textbox label="Textbox" />
+    <Textbox label="Textbox" />
+    <NumeralDate
+      defaultValue={{
+        dd: "01",
+        mm: "02",
+        yyyy: "2020",
+      }}
+      label="Numeral Date"
+    />
+    <Textbox label="Textbox" />
+    <Textbox label="Textbox" />
+    <Textbox label="Textbox" />
+    <Textbox label="Textbox" />
+  </Form>
+);
+
+DefaultWithNumeralDate.storyName = "With NumeralDate";
+DefaultWithNumeralDate.parameters = {
+  themeProvider: {
+    chromatic: { theme: "sage" },
+  },
+  chromatic: {
+    disableSnapshot: false,
+  },
+};
+DefaultWithNumeralDate.decorators = [
+  (Story) => (
+    <div style={{ height: "100vh", width: "97vw" }}>
+      <Story />
+    </div>
+  ),
+];

--- a/src/components/form/form.style.ts
+++ b/src/components/form/form.style.ts
@@ -7,6 +7,7 @@ import baseTheme from "../../style/themes/base";
 import { FormButtonAlignment } from "./form.config";
 import StyledSearch from "../search/search.style";
 import StyledTextarea from "../textarea/textarea.style";
+import { StyledNumeralDate } from "../numeral-date/numeral-date.style";
 
 interface StyledFormContentProps {
   stickyFooter?: boolean;
@@ -89,7 +90,10 @@ export const StyledForm = styled.form<StyledFormProps>`
     `}
 
   // field spacing is also applied to form field here so we need to override
-  ${StyledSearch} ${StyledFormField}, ${StyledTextarea} ${StyledFormField}, [data-component="time"] ${StyledFormField} {
+  ${StyledSearch} ${StyledFormField}, 
+  ${StyledTextarea} ${StyledFormField}, 
+  [data-component="time"] ${StyledFormField}, 
+  ${StyledNumeralDate} ${StyledFormField} {
     margin-bottom: var(--spacing000);
   }
 


### PR DESCRIPTION
This fix ensures that the NumeralDate component does not have margin-bottom styles applied twice when used inside a form.

fixes #7171

### Proposed behaviour

![Screenshot 2025-01-23 at 13 43 26](https://github.com/user-attachments/assets/c7ed4444-8b55-4525-b330-36411e4d54bf)

### Current behaviour

![Screenshot 2025-01-23 at 13 44 00](https://github.com/user-attachments/assets/7a004e19-d784-45f5-89ec-ce9d33f85e06)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

I created this PR as a non-draft version initially to check that the Chromatic snapshot is correct before it gets to the QA stage. 

### Testing instructions

- Check that the newly created Chromatic snapshot captures what we need to mitigate a styling regression in the future.
- No other functional or styling regressions relating to Form.