### PR TITLE
fix(menu): ensure that the correct focus and hover styling is applied to popover-container button - FE-7061

### DIFF
--- a/src/components/menu/menu-item/menu-item.style.ts
+++ b/src/components/menu/menu-item/menu-item.style.ts
@@ -181,6 +181,11 @@ const StyledMenuItemWrapper = styled.a.attrs({
 
         a:hover,
         button:hover {
+          ${StyledButton} {
+            border-radius: 0;
+            background-color: transparent;
+          }
+
           ${!asDiv &&
           css`
             background-color: var(--colorsComponentsMenuAutumnStandard600);

--- a/src/components/menu/menu.pw.tsx
+++ b/src/components/menu/menu.pw.tsx
@@ -2436,4 +2436,22 @@ test.describe("Styling, Scrolling & Navigation Bar Tests for Menu Component", ()
     await expect(menuItemAnchor).toHaveCSS("height", "40px");
     await expect(buttonChild).toHaveCSS("height", "40px");
   });
+
+  test("should render the menu with the expected hover styling when menu item has a PopoverContainer child with renderOpenComponent passed", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<MenuItemWithPopoverContainerChild />);
+
+    const popoverContainerButton = page.getByRole("button", {
+      name: "notification",
+    });
+    await popoverContainerButton.hover();
+
+    await expect(popoverContainerButton).toHaveCSS("border-radius", "0px");
+    await expect(popoverContainerButton).toHaveCSS(
+      "background-color",
+      "rgba(0, 0, 0, 0)",
+    );
+  });
 });


### PR DESCRIPTION
### Proposed behaviour
Hover styling in Safari:
<img width="782" alt="Screenshot 2025-02-06 at 16 40 16" src="https://github.com/user-attachments/assets/3dc4298d-2948-4b27-a26e-3e44c21fdf6c" />

Focus and hovered styling in Safari:
<img width="781" alt="Screenshot 2025-02-06 at 16 41 32" src="https://github.com/user-attachments/assets/5cd8e9d7-9c4c-418c-bc4f-0b68e6bca154" />

### Current behaviour

Less than ideal styling currently in Safari:
<img width="758" alt="Screenshot 2025-02-06 at 16 41 03" src="https://github.com/user-attachments/assets/8630fb29-c8b0-4306-9cd0-a250c8e88221" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Using Safari: 
- Navigate to `Menu` -> `Test` -> `as link with alternate variant`.
- Click and hover over the `Notification` menu-item. 
- Focus styling and hover styling should be correctly applied.

On all browsers:
- Check that no regressions have occurred to any button styling in menu-items.