### PR TITLE
docs(dialog, form): make respective textareas controlled 

### DIFF
--- a/src/components/dialog/dialog.mdx
+++ b/src/components/dialog/dialog.mdx
@@ -127,6 +127,18 @@ This may occasionally be useful with things like Toasts where they persist on th
 
 <Canvas of={DialogStories.Responsive} />
 
+
+### Focusing Dialog Container Programmatically
+
+```javascript
+import { DialogHandle } from "carbon-react/lib/components/dialog";
+```
+
+The `DialogHandle` type provides an imperative handle for programmatic control over the `Dialog`'s container focus. 
+Using a `ref`, you can access its `focus()` method to set focus on the container when needed.
+
+<Canvas of={DialogStories.UsingHandle} />
+
 ### Top modal override
 
 When multiple modals are open on a page Carbon manages the order internally so that the last one mounted in the DOM

--- a/src/components/dialog/dialog.stories.tsx
+++ b/src/components/dialog/dialog.stories.tsx
@@ -543,11 +543,16 @@ export const UsingHandle: Story = () => {
 
   const [isOpen, setIsOpen] = useState(defaultOpenState);
   const [isSubmitted, setIsSubmitted] = useState(false);
+  const [state, setState] = useState("");
 
   function handleSubmit(ev: React.FormEvent<HTMLFormElement>) {
     ev.preventDefault();
     setIsSubmitted(true);
     dialogHandle.current?.focus();
+  }
+
+  function setValue(ev: React.ChangeEvent<HTMLInputElement>) {
+    setState(ev.target.value);
   }
 
   return (
@@ -573,6 +578,8 @@ export const UsingHandle: Story = () => {
             <Textarea
               label="What would you like to tell us?"
               characterLimit={1000}
+              value={state}
+              onChange={setValue}
             />
           </Form>
         )}

--- a/src/components/form/form.stories.tsx
+++ b/src/components/form/form.stories.tsx
@@ -116,25 +116,38 @@ WithFullWidthButtons.parameters = {
   themeProvider: { chromatic: { theme: "sage" } },
 };
 
-export const WithDifferentSpacing: Story = () => (
-  <Form
-    onSubmit={() => console.log("submit")}
-    leftSideButtons={
-      <Button onClick={() => console.log("cancel")}>Cancel</Button>
-    }
-    saveButton={
-      <Button buttonType="primary" type="submit">
-        Save
-      </Button>
-    }
-    fieldSpacing={5}
-  >
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textarea label="Textarea with Character Limit" characterLimit={50} />
-  </Form>
-);
+export const WithDifferentSpacing: Story = () => {
+  const [state, setState] = useState("");
+
+  const setValue = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    setState(ev.target.value);
+  };
+
+  return (
+    <Form
+      onSubmit={() => console.log("submit")}
+      leftSideButtons={
+        <Button onClick={() => console.log("cancel")}>Cancel</Button>
+      }
+      saveButton={
+        <Button buttonType="primary" type="submit">
+          Save
+        </Button>
+      }
+      fieldSpacing={5}
+    >
+      <Textbox label="Textbox" />
+      <Textbox label="Textbox" />
+      <Textbox label="Textbox" />
+      <Textarea
+        label="Textarea with Character Limit"
+        characterLimit={50}
+        value={state}
+        onChange={setValue}
+      />
+    </Form>
+  );
+};
 WithDifferentSpacing.storyName = "With Different Spacing";
 
 export const OverrideFieldSpacing: Story = () => (


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Makes respective textareas in `Form` (different spacing) & `Dialog` (using handles) story examples controlled. Also ensures the using handle example on `Dialog` is documented correctly.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, the handle example on `Dialog` does not display on docs navigation & textarea is uncontrolled. Textarea is also uncontrolled in different spacing example in `Form` docs.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
