### PR TITLE
fix(time): adding zero-padding to returned hour and minute input values via onChange and onBlur

### DIFF
--- a/src/components/time/time-test.stories.tsx
+++ b/src/components/time/time-test.stories.tsx
@@ -26,7 +26,15 @@ export const LabelAlign: Story = ({ ...args }) => {
   });
 
   const handleChange = (ev: TimeInputEvent) => {
+    console.log("onChange:", ev);
     setValue(ev.target.value);
+  };
+
+  const handleBlur = (
+    ev?: React.FocusEvent<HTMLInputElement>,
+    timeValue?: TimeValue,
+  ) => {
+    console.log("onBlur:", ev, timeValue);
   };
 
   return (
@@ -35,6 +43,7 @@ export const LabelAlign: Story = ({ ...args }) => {
         mb={2}
         value={value}
         onChange={handleChange}
+        onBlur={handleBlur}
         label="labelAlign left"
         {...args}
       />
@@ -42,6 +51,7 @@ export const LabelAlign: Story = ({ ...args }) => {
         mb={2}
         value={value}
         onChange={handleChange}
+        onBlur={handleBlur}
         label="labelAlign right"
         labelAlign="right"
         {...args}
@@ -49,6 +59,7 @@ export const LabelAlign: Story = ({ ...args }) => {
       <Time
         value={value}
         onChange={handleChange}
+        onBlur={handleBlur}
         label="labelAlign right and fieldLabelsAlign right"
         labelAlign="right"
         fieldLabelsAlign="right"

--- a/src/components/time/time.test.tsx
+++ b/src/components/time/time.test.tsx
@@ -314,7 +314,13 @@ test("should call onChange when a user types in the hours input and toggle is re
       target: {
         name: undefined,
         id: "foo bar",
-        value: { hours: "1", minutes: "", period: "AM" },
+        value: {
+          hours: "1",
+          minutes: "",
+          period: "AM",
+          formattedHours: "01",
+          formattedMinutes: "",
+        },
       },
     }),
   );
@@ -340,7 +346,12 @@ test("should call onChange when a user types in the hours input and toggle is no
       target: {
         name: undefined,
         id: "foo bar",
-        value: { hours: "1", minutes: "" },
+        value: {
+          hours: "1",
+          minutes: "",
+          formattedHours: "01",
+          formattedMinutes: "",
+        },
       },
     }),
   );
@@ -370,7 +381,13 @@ test("should call onChange when a user types in the minutes input and toggle is 
       target: {
         name: undefined,
         id: "foo bar",
-        value: { hours: "", minutes: "1", period: "AM" },
+        value: {
+          hours: "",
+          minutes: "1",
+          period: "AM",
+          formattedHours: "",
+          formattedMinutes: "01",
+        },
       },
     }),
   );
@@ -397,7 +414,12 @@ test("should call onChange when a user types in the minutes input and toggle is 
       target: {
         name: undefined,
         id: "foo bar",
-        value: { hours: "", minutes: "1" },
+        value: {
+          hours: "",
+          minutes: "1",
+          formattedHours: "",
+          formattedMinutes: "01",
+        },
       },
     }),
   );
@@ -427,7 +449,49 @@ test("should call onChange when a user clicks the toggle that is not currently s
       target: {
         name: undefined,
         id: "foo bar",
-        value: { hours: "", minutes: "", period: "PM" },
+        value: {
+          hours: "",
+          minutes: "",
+          period: "PM",
+          formattedHours: "",
+          formattedMinutes: "",
+        },
+      },
+    }),
+  );
+});
+
+test("should call onChange with the correct formatted valueswhen a user clicks the toggle that is not currently selected", async () => {
+  const onChangeMock = jest.fn();
+  const user = userEvent.setup({
+    advanceTimers: jest.advanceTimersByTime,
+    delay: null,
+  });
+  render(
+    <Time
+      value={{ hours: "1", minutes: "1", period: "AM" }}
+      onChange={onChangeMock}
+      hoursInputProps={{ id: "foo" }}
+      minutesInputProps={{ id: "bar" }}
+    />,
+  );
+
+  const pmToggle = screen.getByRole("button", { name: "PM" });
+
+  await user.click(pmToggle);
+
+  expect(onChangeMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      target: {
+        name: undefined,
+        id: "foo bar",
+        value: {
+          hours: "1",
+          minutes: "1",
+          period: "PM",
+          formattedHours: "01",
+          formattedMinutes: "01",
+        },
       },
     }),
   );
@@ -453,6 +517,61 @@ test("should not call onChange when a user clicks the toggle that is currently s
   await user.click(amToggle);
 
   expect(onChangeMock).not.toHaveBeenCalled();
+});
+
+test("should call onChange with the correct formatted values when a user types in the inputs", async () => {
+  const onChangeMock = jest.fn();
+  render(
+    <Time
+      value={{ hours: "", minutes: "", period: "AM" }}
+      onChange={onChangeMock}
+      hoursInputProps={{ id: "foo" }}
+      minutesInputProps={{ id: "bar" }}
+    />,
+  );
+
+  const user = userEvent.setup({
+    advanceTimers: jest.advanceTimersByTime,
+    delay: null,
+  });
+
+  const minutesInput = screen.getByLabelText("Mins.");
+  await user.type(minutesInput, "1");
+
+  expect(onChangeMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      target: {
+        name: undefined,
+        id: "foo bar",
+        value: {
+          hours: "",
+          minutes: "1",
+          period: "AM",
+          formattedHours: "",
+          formattedMinutes: "01",
+        },
+      },
+    }),
+  );
+
+  const hourInput = screen.getByLabelText("Hrs.");
+  await user.type(hourInput, "1");
+
+  expect(onChangeMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      target: {
+        name: undefined,
+        id: "foo bar",
+        value: {
+          hours: "1",
+          minutes: "1",
+          period: "AM",
+          formattedHours: "01",
+          formattedMinutes: "01",
+        },
+      },
+    }),
+  );
 });
 
 test("should call onBlur when the hours input is focused and the user presses shift + tab", async () => {
@@ -499,7 +618,7 @@ test("should call onBlur when the minutes input is focused and the user presses 
   const onBlurMock = jest.fn();
   render(
     <Time
-      value={{ hours: "", minutes: "12" }}
+      value={{ hours: "", minutes: "2" }}
       onChange={() => {}}
       onBlur={onBlurMock}
     />,
@@ -508,11 +627,20 @@ test("should call onBlur when the minutes input is focused and the user presses 
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   act(() => {
-    screen.getByDisplayValue("12").focus();
+    screen.getByDisplayValue("2").focus();
   });
   await user.tab();
 
-  expect(onBlurMock).toHaveBeenCalled();
+  expect(onBlurMock).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.objectContaining({
+      hours: "",
+      minutes: "2",
+      period: undefined,
+      formattedHours: "",
+      formattedMinutes: "02",
+    }),
+  );
 });
 
 test("should not call onBlur when the minutes input is focused and the user presses shift + tab", async () => {


### PR DESCRIPTION
fixes: #7183

### Proposed behaviour

In order to provide formatted values for the hours and minutes which include zero-padding, without introducing any breaking changes, the following modifications have been performed:
- `TimeValue` type has received two new properties: `formattedHours?: string` and `formattedMinutes?: string`
- `onChange` handler has been updated to include these two values on the `TimeInputEvent`.
- `onBlur` handler has been updated with a second optional parameter: `value?: TimeValue` which allows us to pass the formatted values without making any breaking changes.

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

Currently the values for the hours and minutes do not include a zero-padding which can lead to some confusion.

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [X] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

Go to the story: http://localhost:9001/?path=/story/time-test--label-align
Open the development tools
Check the output of the `onChange` handler when updating the inputs
Check the output of the `onBlur` handler when switching focus

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
