### PR TITLE
fix: ensure data- attributes can be set as expected

### DIFF
--- a/src/__internal__/form-field/form-field.component.tsx
+++ b/src/__internal__/form-field/form-field.component.tsx
@@ -80,6 +80,8 @@ export interface FormFieldProps extends CommonFormFieldProps, TagProps {
   useValidationIcon?: boolean;
   /** String value for max-width of `field-line` element */
   maxWidth?: string;
+  /** @private @internal @ignore */
+  "data-component"?: string;
 }
 
 const FormField = ({

--- a/src/__internal__/utils/helpers/tags/tags.ts
+++ b/src/__internal__/utils/helpers/tags/tags.ts
@@ -4,12 +4,21 @@ interface RestProps {
 }
 
 export interface TagProps {
-  /** @private @ignore Identifier used for testing purposes, applied to the root element of the component. */
-  "data-component"?: string;
   /** Identifier used for testing purposes, applied to the root element of the component. */
   "data-element"?: string;
   /** Identifier used for testing purposes, applied to the root element of the component. */
   "data-role"?: string;
+}
+
+interface InternalTagProps extends TagProps {
+  /**
+   * @private
+   * @internal
+   * @ignore
+   * Identifier used for testing purposes, applied to the root element of the component.
+   * INTERNAL USE ONLY.
+   */
+  "data-component"?: string;
 }
 
 /**
@@ -18,8 +27,8 @@ export interface TagProps {
 function tagComponent(
   componentName: string | undefined,
   props: TagProps & RestProps,
-): TagProps {
-  const tagProps: TagProps = {
+): InternalTagProps {
+  const tagProps: InternalTagProps = {
     "data-component": componentName,
   };
 

--- a/src/components/accordion/accordion-group/accordion-group.component.tsx
+++ b/src/components/accordion/accordion-group/accordion-group.component.tsx
@@ -8,7 +8,9 @@ import Accordion, {
   AccordionProps,
 } from "../accordion.component";
 import { StyledAccordionGroup } from "../accordion.style";
-import { TagProps } from "../../../__internal__/utils/helpers/tags";
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags";
 
 type AccordionGroupChild =
   | React.ReactElement
@@ -20,9 +22,7 @@ type AccordionGroupChild =
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface AccordionGroupChildArray extends Array<AccordionGroupChild> {}
 
-export interface AccordionGroupProps
-  extends MarginProps,
-    Omit<TagProps, "data-component"> {
+export interface AccordionGroupProps extends MarginProps, TagProps {
   /** An Accordion or list of Accordion components to be rendered inside the AccordionGroup */
   children?: AccordionGroupChild;
 }
@@ -101,7 +101,7 @@ export const AccordionGroup = ({ children, ...rest }: AccordionGroupProps) => {
   );
 
   return (
-    <StyledAccordionGroup {...rest} data-component="accordion-group">
+    <StyledAccordionGroup {...rest} {...tagComponent("accordion-group", rest)}>
       {filteredChildren.map((child, index) =>
         // casted to ReactElement as there is no overload for an FunctionComponentElement in cloneElement
         React.cloneElement(child as React.ReactElement, {

--- a/src/components/accordion/accordion.component.tsx
+++ b/src/components/accordion/accordion.component.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { SpaceProps } from "styled-system";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 import useResizeObserver from "../../hooks/__internal__/useResizeObserver";
 import createGuid from "../../__internal__/utils/helpers/guid";
@@ -19,7 +20,8 @@ import ValidationIcon from "../../__internal__/validations";
 
 export interface AccordionProps
   extends StyledAccordionContainerProps,
-    SpaceProps {
+    SpaceProps,
+    TagProps {
   /** Content of the Accordion component */
   children?: React.ReactNode;
   /** Set the default state of expansion of the Accordion if component is meant to be used as uncontrolled */
@@ -160,12 +162,11 @@ export const Accordion = React.forwardRef<
     return (
       <StyledAccordionContainer
         id={accordionId}
-        data-component="accordion"
-        data-role="accordion-container"
         width={width}
         borders={variant === "subtle" ? "none" : borders}
         variant={variant}
         {...rest}
+        {...tagComponent("accordion", rest)}
       >
         <StyledAccordionTitleContainer
           data-element="accordion-title-container"

--- a/src/components/accordion/accordion.test.tsx
+++ b/src/components/accordion/accordion.test.tsx
@@ -11,6 +11,22 @@ import AccordionGroup from "./accordion-group/accordion-group.component";
 jest.mock("../../hooks/__internal__/useResizeObserver");
 
 describe("Accordion", () => {
+  it("renders with expected `data-` attributes on the root element", () => {
+    render(
+      <Accordion
+        title="Title"
+        data-element="accordion-element"
+        data-role="accordion-role"
+      >
+        child content
+      </Accordion>,
+    );
+    const rootElement = screen.getByTestId("accordion-role");
+
+    expect(rootElement).toHaveAttribute("data-component", "accordion");
+    expect(rootElement).toHaveAttribute("data-element", "accordion-element");
+  });
+
   it("should render `title` as a React element", () => {
     render(<Accordion title={<div id="customTitle">Title content</div>} />);
 
@@ -212,7 +228,13 @@ describe("Accordion", () => {
 
   // coverage only - border styles tested in Playwright
   it('has no border when `borders` prop is "none"', () => {
-    render(<Accordion title="Title" borders="none" />);
+    render(
+      <Accordion
+        title="Title"
+        borders="none"
+        data-role="accordion-container"
+      />,
+    );
 
     expect(screen.getByTestId("accordion-container")).toHaveStyleRule(
       "border",

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -9,6 +9,7 @@ import React, {
 } from "react";
 import { MarginProps } from "styled-system";
 import invariant from "invariant";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 import {
   MenuButton,
@@ -46,7 +47,7 @@ export interface RenderButtonProps {
   };
 }
 
-export interface ActionPopoverProps extends MarginProps {
+export interface ActionPopoverProps extends MarginProps, TagProps {
   /** Children for popover component */
   children?: React.ReactNode;
   /** Horizontal alignment of menu items content */
@@ -329,11 +330,10 @@ export const ActionPopover = forwardRef<
     return (
       <MenuButton
         id={parentID}
-        data-component="action-popover-wrapper"
-        data-role="action-popover-wrapper"
         {...{ onKeyDown: onButtonKeyDown, onClick: onButtonClick, isOpen }}
         ref={buttonRef}
         {...rest}
+        {...tagComponent("action-popover-wrapper", rest)}
       >
         {menuButton(menuID)}
         <ActionPopoverContext.Provider

--- a/src/components/action-popover/action-popover.test.tsx
+++ b/src/components/action-popover/action-popover.test.tsx
@@ -38,7 +38,7 @@ afterEach(() => {
 testStyledSystemMargin(
   (props) => (
     <ThemeProvider theme={sageTheme}>
-      <ActionPopover {...props}>
+      <ActionPopover data-role="action-popover-wrapper" {...props}>
         <ActionPopoverItem href="#" download>
           test download
         </ActionPopoverItem>
@@ -102,7 +102,10 @@ test("has proper data attributes applied to elements", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ActionPopover>
+    <ActionPopover
+      data-role="action-popover-role"
+      data-element="action-popover-element"
+    >
       <ActionPopoverItem>example item 1</ActionPopoverItem>
       <ActionPopoverDivider />
       <ActionPopoverItem>example item 2</ActionPopoverItem>
@@ -111,9 +114,13 @@ test("has proper data attributes applied to elements", async () => {
 
   await user.click(screen.getByRole("button"));
 
-  expect(screen.getByTestId("action-popover-wrapper")).toHaveAttribute(
+  expect(screen.getByTestId("action-popover-role")).toHaveAttribute(
     "data-component",
     "action-popover-wrapper",
+  );
+  expect(screen.getByTestId("action-popover-role")).toHaveAttribute(
+    "data-element",
+    "action-popover-element",
   );
   expect(screen.getByRole("list")).toHaveAttribute(
     "data-component",

--- a/src/components/advanced-color-picker/advanced-color-picker.component.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.component.tsx
@@ -15,6 +15,7 @@ import useLocale from "../../hooks/__internal__/useLocale";
 import { Dt, Dd } from "../definition-list";
 import Logger from "../../__internal__/utils/logger";
 import { ModalProps } from "../modal";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 let deprecateUncontrolledWarnTriggered = false;
 export interface AdvancedColor {
@@ -24,7 +25,8 @@ export interface AdvancedColor {
 
 export interface AdvancedColorPickerProps
   extends MarginProps,
-    Pick<ModalProps, "restoreFocusOnClose"> {
+    Pick<ModalProps, "restoreFocusOnClose">,
+    TagProps {
   /** Prop to specify the aria-describedby property of the component */
   "aria-describedby"?: string;
   /**
@@ -33,7 +35,7 @@ export interface AdvancedColorPickerProps
    */
   "aria-label"?: string;
   /**
-   * Prop to specify the aria-labeledby property of the component
+   * Prop to specify the aria-labelledby property of the component
    * To be used when the title prop is a custom React Node,
    * or the component is labelled by an internal element other than the title.
    */
@@ -233,7 +235,7 @@ export const AdvancedColorPicker = ({
     <StyledAdvancedColorPickerWrapper
       m="15px auto auto 15px"
       {...filterStyledSystemMarginProps(props)}
-      data-role="advanced-color-picker-wrapper"
+      {...tagComponent("advanced-color-picker", props)}
     >
       <StyledAdvancedColorPickerCell
         data-element="color-picker-cell"

--- a/src/components/advanced-color-picker/advanced-color-picker.test.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.test.tsx
@@ -43,7 +43,14 @@ afterAll(() => {
 });
 
 testStyledSystemMargin(
-  (props) => <ControlledColorPicker name="advancedPicker" open {...props} />,
+  (props) => (
+    <ControlledColorPicker
+      data-role="advanced-color-picker-wrapper"
+      name="advancedPicker"
+      open
+      {...props}
+    />
+  ),
   () => screen.getByTestId("advanced-color-picker-wrapper"),
 );
 

--- a/src/components/alert/alert.component.tsx
+++ b/src/components/alert/alert.component.tsx
@@ -8,14 +8,14 @@ export const Alert = ({
   topModalOverride,
   closeButtonDataProps,
   ...rest
-}: DialogProps) => (
+}: Omit<DialogProps, "data-component">) => (
   <Dialog
-    data-component="alert"
     role="alertdialog"
     size={size}
     topModalOverride={topModalOverride}
     closeButtonDataProps={closeButtonDataProps}
     {...rest}
+    data-component="alert"
   >
     {children}
   </Dialog>

--- a/src/components/anchor-navigation/anchor-navigation.component.tsx
+++ b/src/components/anchor-navigation/anchor-navigation.component.tsx
@@ -21,8 +21,7 @@ import AnchorNavigationItem, {
   AnchorNavigationItemProps,
 } from "./anchor-navigation-item/anchor-navigation-item.component";
 
-export interface AnchorNavigationProps
-  extends Omit<TagProps, "data-component"> {
+export interface AnchorNavigationProps extends TagProps {
   /** Child elements */
   children?: React.ReactNode;
   /** The AnchorNavigationItems components to be rendered in the sticky navigation.

--- a/src/components/badge/badge.component.tsx
+++ b/src/components/badge/badge.component.tsx
@@ -5,8 +5,9 @@ import {
   StyledCounter,
   StyledBadge,
 } from "./badge.style";
+import { TagProps } from "../../__internal__/utils/helpers/tags";
 
-export interface BadgeProps {
+export interface BadgeProps extends TagProps {
   /** Prop to specify an aria-label for the component */
   "aria-label"?: string;
   /** The badge will be added to this element */
@@ -25,6 +26,8 @@ export const Badge = ({
   counter = 0,
   color = "--colorsActionMajor500",
   onClick,
+  "data-element": dataElement,
+  "data-role": dataRole,
 }: BadgeProps) => {
   const shouldDisplayCounter = +counter > 0;
   const counterToDisplay = +counter > 99 ? 99 : counter;
@@ -44,8 +47,9 @@ export const Badge = ({
     if (shouldDisplayCounter) {
       return (
         <StyledBadge
-          data-role="badge"
           data-component="badge"
+          data-element={dataElement}
+          data-role={dataRole}
           color={color}
           {...props}
           onFocus={() => {

--- a/src/components/badge/badge.test.tsx
+++ b/src/components/badge/badge.test.tsx
@@ -3,7 +3,12 @@ import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Badge from "./badge.component";
 
-const renderComponent = (props = {}) => render(<Badge {...props}>Foo</Badge>);
+const renderComponent = (props = {}) =>
+  render(
+    <Badge data-role="badge" {...props}>
+      Foo
+    </Badge>,
+  );
 
 describe("Badge", () => {
   it("should render number when counter is between 1 and 99", () => {
@@ -94,6 +99,12 @@ describe("Badge", () => {
     });
 
     expect(screen.getByRole("button")).not.toHaveAttribute("aria-label");
+  });
+
+  it("should render with provided data- attributes", () => {
+    renderComponent({ counter: 9, "data-element": "bar", "data-role": "baz" });
+
+    expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
   });
 
   it("calls onClick callback when badge is clicked", async () => {

--- a/src/components/batch-selection/batch-selection.component.tsx
+++ b/src/components/batch-selection/batch-selection.component.tsx
@@ -6,8 +6,9 @@ import {
   StyledSelectionCount,
 } from "./batch-selection.style";
 import BatchSelectionContext from "./__internal__/batch-selection.context";
+import { TagProps } from "../../__internal__/utils/helpers/tags";
 
-export interface BatchSelectionProps {
+export interface BatchSelectionProps extends TagProps {
   /** Content to be rendered after selected count */
   children: React.ReactNode;
   /** Color of the background, transparent if not defined */
@@ -26,6 +27,8 @@ export const BatchSelection = ({
   colorTheme = "transparent",
   selectedCount,
   hidden,
+  "data-element": dataElement,
+  "data-role": dataRole,
 }: BatchSelectionProps) => {
   const l = useLocale();
 
@@ -33,7 +36,8 @@ export const BatchSelection = ({
     <StyledBatchSelection
       colorTheme={colorTheme}
       data-component="batch-selection"
-      data-role="batch-selection"
+      data-element={dataElement}
+      data-role={dataRole}
       disabled={disabled}
       hidden={hidden}
     >

--- a/src/components/batch-selection/batch-selection.test.tsx
+++ b/src/components/batch-selection/batch-selection.test.tsx
@@ -23,9 +23,21 @@ test("Renders with children", () => {
   expect(iconButton).toBeEnabled();
 });
 
+test("Renders with provided data- attributes", () => {
+  render(
+    <BatchSelection data-element="bar" data-role="baz" selectedCount={0}>
+      <IconButton>
+        <Icon type="edit" />
+      </IconButton>
+    </BatchSelection>,
+  );
+
+  expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
 test("Renders as hidden when the `hidden` prop is true", () => {
   render(
-    <BatchSelection selectedCount={0} hidden>
+    <BatchSelection data-role="batch-selection" selectedCount={0} hidden>
       <IconButton>
         <Icon type="bin" />
       </IconButton>

--- a/src/components/box/box.component.tsx
+++ b/src/components/box/box.component.tsx
@@ -76,6 +76,8 @@ export interface BoxProps
   opacity?: string | number;
   /** Set the container to be hidden from screen readers */
   "aria-hidden"?: "true" | "false";
+  /** @private @internal @ignore */
+  "data-component"?: string;
 }
 
 export const Box = React.forwardRef<HTMLDivElement, BoxProps>(

--- a/src/components/breadcrumbs/breadcrumbs.component.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.component.tsx
@@ -20,9 +20,9 @@ export const Breadcrumbs = React.forwardRef<HTMLElement, BreadcrumbsProps>(
         <StyledBreadcrumbs
           ref={ref}
           role="navigation"
-          {...tagComponent("breadcrumbs", rest)}
           aria-label={l.breadcrumbs.ariaLabel()}
           {...rest}
+          {...tagComponent("breadcrumbs", rest)}
         >
           <ol>{children}</ol>
         </StyledBreadcrumbs>

--- a/src/components/breadcrumbs/breadcrumbs.test.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.test.tsx
@@ -29,6 +29,16 @@ test("renders children as expected", () => {
   expect(screen.getByText("Breadcrumb 3")).toBeVisible();
 });
 
+test("renders with provided data- attributes", () => {
+  render(
+    <Breadcrumbs data-element="bar" data-role="baz">
+      <Crumb href="#">Breadcrumb 1</Crumb>
+    </Breadcrumbs>,
+  );
+
+  expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
 // coverage
 test("renders children with expected colour when isDarkBackground is false", () => {
   render(

--- a/src/components/breadcrumbs/crumb/crumb.component.tsx
+++ b/src/components/breadcrumbs/crumb/crumb.component.tsx
@@ -39,8 +39,8 @@ const Crumb = React.forwardRef<HTMLAnchorElement, CrumbProps>(
           isCurrent={isCurrent}
           aria-current={isCurrent ? "page" : undefined}
           isDarkBackground={isDarkBackground}
-          {...tagComponent("crumb", rest)}
           {...rest}
+          {...tagComponent("crumb", rest)}
           {...(!isCurrent && {
             href,
             onClick,

--- a/src/components/breadcrumbs/crumb/crumb.test.tsx
+++ b/src/components/breadcrumbs/crumb/crumb.test.tsx
@@ -52,3 +52,13 @@ test("does not call onClick callback when isCurrent is true", async () => {
 
   expect(onClick).toHaveBeenCalledTimes(0);
 });
+
+test("renders with provided data- attributes", () => {
+  render(
+    <Crumb href="#" data-element="bar" data-role="baz">
+      Link text
+    </Crumb>,
+  );
+
+  expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});

--- a/src/components/button-bar/button-bar.component.tsx
+++ b/src/components/button-bar/button-bar.component.tsx
@@ -4,8 +4,12 @@ import StyledButtonBar from "./button-bar.style";
 import ButtonBarContext, {
   ButtonBarContextProps,
 } from "./__internal__/button-bar.context";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
-export interface ButtonBarProps extends ButtonBarContextProps, SpaceProps {
+export interface ButtonBarProps
+  extends ButtonBarContextProps,
+    SpaceProps,
+    TagProps {
   /** Button or IconButton Elements, to be rendered inside the component */
   children: React.ReactNode;
 }
@@ -17,7 +21,12 @@ export const ButtonBar = ({
   fullWidth = false,
   ...rest
 }: ButtonBarProps) => (
-  <StyledButtonBar {...rest} fullWidth={fullWidth} size={size}>
+  <StyledButtonBar
+    {...rest}
+    {...tagComponent("button-bar", rest)}
+    fullWidth={fullWidth}
+    size={size}
+  >
     <ButtonBarContext.Provider
       value={{ buttonType: "secondary", size, iconPosition, fullWidth }}
     >

--- a/src/components/button-bar/button-bar.test.tsx
+++ b/src/components/button-bar/button-bar.test.tsx
@@ -23,6 +23,18 @@ describe("When ButtonBar children are Button components", () => {
     expect(buttonChildren).toHaveLength(3);
   });
 
+  it("should render with provided data- attributes", () => {
+    render(
+      <ButtonBar data-element="bar" data-role="baz">
+        <Button aria-label="button-in-bar">foo</Button>
+        <Button aria-label="button-in-bar">bar</Button>
+        <Button aria-label="button-in-bar">baz</Button>
+      </ButtonBar>,
+    );
+
+    expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+  });
+
   it("should render the Buttons with icons as expected when the 'iconType' prop is set", () => {
     render(
       <ButtonBar>

--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.component.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.component.tsx
@@ -3,7 +3,9 @@ import invariant from "invariant";
 
 import { MarginProps } from "styled-system";
 import FormField from "../../../__internal__/form-field";
-import { TagProps } from "../../../__internal__/utils/helpers/tags";
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags";
 import guid from "../../../__internal__/utils/helpers/guid";
 import StyledButtonToggleGroup from "./button-toggle-group.style";
 import { ButtonToggle } from "..";
@@ -52,6 +54,8 @@ export interface ButtonToggleGroupProps extends MarginProps, TagProps {
   allowDeselect?: boolean;
   /** Disable all user interaction. */
   disabled?: boolean;
+  /** @private @internal @ignore */
+  "data-component"?: string;
 }
 
 const BUTTON_TOGGLE_SELECTOR = '[data-element="button-toggle-button"]';
@@ -71,9 +75,6 @@ const ButtonToggleGroup = ({
   labelWidth,
   onChange,
   value,
-  "data-component": dataComponent = "button-toggle-group",
-  "data-element": dataElement,
-  "data-role": dataRole,
   helpAriaLabel,
   id,
   allowDeselect,
@@ -174,13 +175,14 @@ const ButtonToggleGroup = ({
           labelInline={computeLabelPropValues(labelInline)}
           labelWidth={computeLabelPropValues(labelWidth)}
           labelId={labelId.current}
-          data-component={dataComponent}
-          data-role={dataRole}
-          data-element={dataElement}
           id={id}
           labelAs="span"
           disabled={disabled}
           {...filterStyledSystemMarginProps(props)}
+          {...tagComponent(
+            props["data-component"] ?? "button-toggle-group",
+            props,
+          )}
         >
           <ButtonToggleGroupContext.Provider
             value={{
@@ -214,9 +216,6 @@ const ButtonToggleGroup = ({
               inputWidth={inputWidth}
               fullWidth={fullWidth}
               role="group"
-              data-component={dataComponent}
-              data-role={dataRole}
-              data-element={dataElement}
               id={id}
               disabled={disabled}
             >

--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.test.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.test.tsx
@@ -367,9 +367,7 @@ testStyledSystemMargin(
       <ButtonToggle value="foo">Foo</ButtonToggle>
     </ButtonToggleGroup>
   ),
-  // we are setting the data- attributes on more than one element
-  // FE-6834 raised to address this
-  () => screen.getAllByTestId("button-toggle-group")[0],
+  () => screen.getByTestId("button-toggle-group"),
   undefined,
   { modifier: "&&&" },
 );

--- a/src/components/button-toggle/button-toggle.component.tsx
+++ b/src/components/button-toggle/button-toggle.component.tsx
@@ -8,25 +8,21 @@ import {
 import guid from "../../__internal__/utils/helpers/guid";
 import ButtonToggleGroupContext from "./button-toggle-group/__internal__/button-toggle-group.context";
 import ButtonToggleIcon from "./button-toggle-icon.component";
-
+import { TagProps } from "../../__internal__/utils/helpers/tags";
 import Logger from "../../__internal__/utils/logger";
 import { InputGroupContext } from "../../__internal__/input-behaviour";
 
 let deprecateUncontrolledWarnTriggered = false;
 
-export interface ButtonToggleProps extends Partial<StyledButtonToggleProps> {
+export interface ButtonToggleProps
+  extends Partial<StyledButtonToggleProps>,
+    TagProps {
   /** Prop to specify the aria-label of the component */
   "aria-label"?: string;
   /** Prop to specify the aria-labelledby property of the component */
   "aria-labelledby"?: string;
   /** Text to display for the button. */
   children?: React.ReactNode;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-component"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-element"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-role"?: string;
   /** Callback triggered by blur event on the button. */
   onBlur?: (ev: React.FocusEvent<HTMLButtonElement>) => void;
   /** Callback triggered by focus event on the button. */
@@ -37,6 +33,8 @@ export interface ButtonToggleProps extends Partial<StyledButtonToggleProps> {
   pressed?: boolean;
   /** An optional string by which to identify the button in either an onClick handler, or an onChange handler on the parent ButtonToggleGroup. */
   value?: string;
+  /** @private @internal @ignore */
+  "data-component"?: string;
 }
 
 export const ButtonToggle = ({

--- a/src/components/button-toggle/button-toggle.pw.tsx
+++ b/src/components/button-toggle/button-toggle.pw.tsx
@@ -129,17 +129,6 @@ test.describe("Prop tests", () => {
     });
   });
 
-  test("should render with data-component prop set to playwright_data", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<ButtonToggleComponent data-component={CHARACTERS.STANDARD} />);
-
-    await expect(
-      buttonToggleButton(page).first().locator(".."),
-    ).toHaveAttribute("data-component", CHARACTERS.STANDARD);
-  });
-
   test("should render with data-element prop set to playwright_data", async ({
     mount,
     page,
@@ -405,25 +394,13 @@ test.describe("Accessibility tests", () => {
 });
 
 test.describe("Prop tests for group component", () => {
-  test("should render with data-component prop set to playwright_data", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<ButtonToggleGroupComponent data-component={testPropValue} />);
-
-    await expect(page.getByRole("group")).toHaveAttribute(
-      "data-component",
-      testPropValue,
-    );
-  });
-
   test("should render with data-element prop set to playwright_data", async ({
     mount,
     page,
   }) => {
     await mount(<ButtonToggleGroupComponent data-element={testPropValue} />);
 
-    await expect(buttonToggleGroup(page).nth(0)).toHaveAttribute(
+    await expect(buttonToggleGroup(page)).toHaveAttribute(
       "data-element",
       testPropValue,
     );
@@ -435,7 +412,7 @@ test.describe("Prop tests for group component", () => {
   }) => {
     await mount(<ButtonToggleGroupComponent data-role={testPropValue} />);
 
-    await expect(buttonToggleGroup(page).nth(0)).toHaveAttribute(
+    await expect(buttonToggleGroup(page)).toHaveAttribute(
       "data-role",
       testPropValue,
     );

--- a/src/components/checkbox/checkbox-group/checkbox-group.component.tsx
+++ b/src/components/checkbox/checkbox-group/checkbox-group.component.tsx
@@ -1,7 +1,9 @@
 import React, { useContext, useRef } from "react";
 import { MarginProps } from "styled-system";
-import tagComponent from "../../../__internal__/utils/helpers/tags/tags";
 import StyledCheckboxGroup from "./checkbox-group.style";
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags/tags";
 import Fieldset from "../../../__internal__/fieldset";
 import { filterStyledSystemMarginProps } from "../../../style/utils";
 import { TooltipProvider } from "../../../__internal__/tooltip-provider";
@@ -16,7 +18,10 @@ import guid from "../../../__internal__/utils/helpers/guid";
 import useInputAccessibility from "../../../hooks/__internal__/useInputAccessibility";
 import HintText from "../../../__internal__/hint-text";
 
-export interface CheckboxGroupProps extends ValidationProps, MarginProps {
+export interface CheckboxGroupProps
+  extends ValidationProps,
+    MarginProps,
+    TagProps {
   /**
    * Unique identifier for the component.
    * Will use a randomly generated GUID if none is provided.

--- a/src/components/checkbox/checkbox.component.tsx
+++ b/src/components/checkbox/checkbox.component.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react";
 import { MarginProps } from "styled-system";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 import CheckboxStyle from "./checkbox.style";
 import CheckableInput, {
@@ -13,17 +14,14 @@ import Logger from "../../__internal__/utils/logger";
 import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
 import NewValidationContext from "../carbon-provider/__internal__/new-validation.context";
 
-export interface CheckboxProps extends CommonCheckableInputProps, MarginProps {
+export interface CheckboxProps
+  extends CommonCheckableInputProps,
+    MarginProps,
+    TagProps {
   /** Breakpoint for adaptive spacing (left margin changes to 0). Enables the adaptive behaviour when set */
   adaptiveSpacingBreakpoint?: number;
   /** Prop to specify the aria-labelledby property of the input */
   "aria-labelledby"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-component"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-element"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-role"?: string;
   /** [Legacy] Aria label for rendered help component */
   helpAriaLabel?: string;
   /** When true label is inline */
@@ -69,7 +67,6 @@ export const Checkbox = React.forwardRef(
       inputWidth,
       size,
       tooltipPosition,
-      "data-component": dataComponent = "checkbox",
       "data-element": dataElement,
       "data-role": dataRole,
       helpAriaLabel,
@@ -123,6 +120,7 @@ export const Checkbox = React.forwardRef(
       labelWidth,
       ref,
       ...rest,
+      "data-component": undefined,
     };
 
     const validationProps = {
@@ -137,9 +135,6 @@ export const Checkbox = React.forwardRef(
 
     const componentToRender = (
       <CheckboxStyle
-        data-component={dataComponent}
-        data-role={dataRole}
-        data-element={dataElement}
         disabled={disabled}
         labelSpacing={labelSpacing}
         inputWidth={inputWidth}
@@ -150,6 +145,10 @@ export const Checkbox = React.forwardRef(
         size={size}
         applyNewValidation={validationRedesignOptIn}
         {...marginProps}
+        {...tagComponent("checkbox", {
+          "data-element": dataElement,
+          "data-role": dataRole,
+        })}
       >
         <CheckableInput {...inputProps} {...validationProps}>
           <CheckboxSvg />

--- a/src/components/checkbox/checkbox.pw.tsx
+++ b/src/components/checkbox/checkbox.pw.tsx
@@ -26,7 +26,6 @@ import {
 } from "../../../playwright/components/checkbox";
 import {
   fieldHelpPreview,
-  getComponent,
   tooltipPreview,
 } from "../../../playwright/components/index";
 import {
@@ -46,7 +45,7 @@ const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const boolVals = [true, false];
 
 test("should have the expected focus styling", async ({ mount, page }) => {
-  await mount(<CheckboxComponent data-component={CHARACTERS.STANDARD} />);
+  await mount(<CheckboxComponent />);
 
   const checkboxElement = checkboxRole(page);
   await checkboxElement.focus();
@@ -62,19 +61,6 @@ test("should have the expected focus styling", async ({ mount, page }) => {
 });
 
 test.describe("should render Checkbox component and check props", () => {
-  test(`should render with data-component set to ${CHARACTERS.STANDARD}`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<CheckboxComponent data-component={CHARACTERS.STANDARD} />);
-
-    const checkbox = getComponent(page, CHARACTERS.STANDARD);
-    await expect(checkbox).toHaveAttribute(
-      "data-component",
-      CHARACTERS.STANDARD,
-    );
-  });
-
   test(`should render with data-element set to ${CHARACTERS.STANDARD}`, async ({
     mount,
     page,

--- a/src/components/confirm/confirm.component.tsx
+++ b/src/components/confirm/confirm.component.tsx
@@ -25,6 +25,7 @@ export interface ConfirmProps
     | "timeout"
     | "enableBackgroundUI"
     | "disableClose"
+    | "data-component"
   > {
   /** Color variants for new business themes: "primary" | "secondary" | "tertiary" | "darkBackground" */
   cancelButtonType?: "primary" | "secondary" | "tertiary" | "darkBackground";
@@ -187,13 +188,13 @@ export const Confirm = ({
       disableClose={disableCancel}
       subtitle={subtitle}
       title={getTitle()}
-      data-component="confirm"
       role="alertdialog"
       size={size}
       showCloseIcon={showCloseIcon}
       topModalOverride={topModalOverride}
       {...ariaProps}
       {...rest}
+      data-component="confirm"
     >
       {children}
       <StyledConfirmButtons>

--- a/src/components/confirm/confirm.test.tsx
+++ b/src/components/confirm/confirm.test.tsx
@@ -149,6 +149,18 @@ test('should render with expected styles when iconType is set to "error"', () =>
   expect(icon).toHaveStyle({ color: "var(--colorsSemanticNegative500)" });
 });
 
+test("should render dialog with expected data tags", () => {
+  render(
+    <Confirm open onConfirm={() => {}} data-element="foo" data-role="bar" />,
+  );
+
+  expect(screen.getByRole("alertdialog")).toHaveAttribute(
+    "data-element",
+    "foo",
+  );
+  expect(screen.getByRole("alertdialog")).toHaveAttribute("data-role", "bar");
+});
+
 test("should render buttons with expected data tags", () => {
   render(
     <Confirm

--- a/src/components/content/content.component.tsx
+++ b/src/components/content/content.component.tsx
@@ -8,11 +8,13 @@ import {
   StyledContentBody,
   StyledContentBodyProps,
 } from "./content.style";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 export interface ContentProps
   extends StyledContentProps,
     StyledContentTitleProps,
-    StyledContentBodyProps {
+    StyledContentBodyProps,
+    TagProps {
   /** The body of the content component */
   children?: React.ReactNode;
   /** The title of the content component */
@@ -34,7 +36,7 @@ export const Content = ({
       align={align}
       bodyFullWidth={bodyFullWidth}
       {...rest}
-      data-component="content"
+      {...tagComponent("content", rest)}
     >
       <StyledContentTitle
         variant={variant}

--- a/src/components/date/date.component.tsx
+++ b/src/components/date/date.component.tsx
@@ -32,6 +32,7 @@ import DateRangeContext, {
 import useClickAwayListener from "../../hooks/__internal__/useClickAwayListener";
 import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
 import guid from "../../__internal__/utils/helpers/guid";
+import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 
 interface CustomDateEvent {
   type: string;
@@ -73,6 +74,7 @@ export interface DateInputProps
     | "warnOverLimit"
     | "iconTabIndex"
     | "inputIcon"
+    | "data-component"
   > {
   /** Boolean to allow the input to have an empty value */
   allowEmptyValue?: boolean;
@@ -117,7 +119,6 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       adaptiveLabelBreakpoint,
       allowEmptyValue,
       autoFocus,
-      "data-component": dataComponent,
       "data-element": dataElement,
       "data-role": dataRole,
       disabled,
@@ -479,16 +480,18 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
         role="presentation"
         size={size}
         labelInline={labelInline}
-        data-component={dataComponent || "date"}
-        data-element={dataElement}
-        data-role={dataRole}
         {...marginProps}
         applyDateRangeStyling={!!inputRefMap}
         maxWidth={maxWidth}
         inputWidth={inputWidth}
+        {...tagComponent("date", {
+          "data-element": dataElement,
+          "data-role": dataRole,
+        })}
       >
         <Textbox
           {...filterOutStyledSystemSpacingProps(rest)}
+          data-component="date-input"
           value={computedValue()}
           onBlur={handleBlur}
           onChange={handleChange}

--- a/src/components/date/date.test.tsx
+++ b/src/components/date/date.test.tsx
@@ -161,6 +161,19 @@ test("should set ref to empty after unmount", () => {
   expect(ref.current).toBe(null);
 });
 
+test("should render with provided data- attributes", () => {
+  render(
+    <DateInput
+      data-element="bar"
+      data-role="baz"
+      onChange={() => {}}
+      value=""
+    />,
+  );
+
+  expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
 test("should render with the input focused and picker visible when `autoFocus` is true", () => {
   render(<DateInput label="label" autoFocus onChange={() => {}} value="" />);
 

--- a/src/components/decimal/decimal.component.tsx
+++ b/src/components/decimal/decimal.component.tsx
@@ -11,6 +11,7 @@ import Textbox, { CommonTextboxProps } from "../textbox";
 import LocaleContext from "../../__internal__/i18n-context";
 import usePrevious from "../../hooks/__internal__/usePrevious";
 import Logger from "../../__internal__/utils/logger";
+import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 
 export interface CustomEvent {
   target: {
@@ -24,7 +25,7 @@ export interface CustomEvent {
 }
 
 export interface DecimalProps
-  extends Omit<CommonTextboxProps, "onChange" | "onBlur"> {
+  extends Omit<CommonTextboxProps, "onChange" | "onBlur" | "data-component"> {
   /** Text alignment of the label */
   align?: "left" | "right";
   /** Allow an empty value instead of defaulting to 0.00 */
@@ -335,6 +336,7 @@ export const Decimal = React.forwardRef(
           id={id}
           ref={ref}
           {...rest}
+          {...tagComponent("decimal", rest)}
         />
         <input
           name={name}

--- a/src/components/decimal/decimal.test.tsx
+++ b/src/components/decimal/decimal.test.tsx
@@ -707,10 +707,16 @@ describe("when the component is uncontrolled", () => {
   });
 
   it("has the correct data tag", () => {
-    render(<Decimal data-role="test-data-tag" />);
-    expect(screen.getByTestId("test-data-tag")).toHaveAttribute(
+    render(
+      <Decimal data-role="test-data-role" data-element="test-data-element" />,
+    );
+    expect(screen.getByTestId("test-data-role")).toHaveAttribute(
       "data-component",
       "decimal",
+    );
+    expect(screen.getByTestId("test-data-role")).toHaveAttribute(
+      "data-element",
+      "test-data-element",
     );
   });
 

--- a/src/components/definition-list/dd/dd.component.tsx
+++ b/src/components/definition-list/dd/dd.component.tsx
@@ -2,8 +2,11 @@ import React, { useContext } from "react";
 import { SpaceProps } from "styled-system";
 import { StyledDd } from "../definition-list.style";
 import DlContext from "../__internal__/dl.context";
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags";
 
-export interface DdProps extends SpaceProps {
+export interface DdProps extends SpaceProps, TagProps {
   /** Prop for what will render in the `<Dd></Dd>` tags */
   children: React.ReactNode;
 }
@@ -19,6 +22,7 @@ const Dd = ({ children, ...rest }: DdProps) => {
       ddTextAlign={ddTextAlign}
       mb={mb || 2}
       {...rest}
+      {...tagComponent("dd", rest)}
     >
       {children}
     </StyledDd>

--- a/src/components/definition-list/definition-list.test.tsx
+++ b/src/components/definition-list/definition-list.test.tsx
@@ -7,13 +7,39 @@ import { testStyledSystemSpacing } from "../../__spec_helper__/__internal__/test
 
 testStyledSystemSpacing(
   (props) => (
-    <Dl {...props}>
+    <Dl data-role="dl" {...props}>
       <Dt>Description</Dt>
       <Dd>This is a test</Dd>
     </Dl>
   ),
   () => screen.getByTestId("dl"),
 );
+
+test("should render with provided data- attributes", () => {
+  render(
+    <Dl data-element="dl-element" data-role="dl-role">
+      <Dt data-element="dt-element" data-role="dt-role">
+        Title
+      </Dt>
+      <Dd data-element="dd-element" data-role="dd-role">
+        Description
+      </Dd>
+    </Dl>,
+  );
+
+  expect(screen.getByTestId("dl-role")).toHaveAttribute(
+    "data-element",
+    "dl-element",
+  );
+  expect(screen.getByTestId("dt-role")).toHaveAttribute(
+    "data-element",
+    "dt-element",
+  );
+  expect(screen.getByTestId("dd-role")).toHaveAttribute(
+    "data-element",
+    "dd-element",
+  );
+});
 
 test("component should render correctly if composed with a React Fragment", () => {
   render(
@@ -119,7 +145,7 @@ test("when mapping from an object, the component should render the correct amoun
 // Required for coverage
 test("when `asSingleColumn` is true, the expected styling is applied to the Dl element", () => {
   render(
-    <Dl asSingleColumn>
+    <Dl data-role="dl" asSingleColumn>
       <Dt>Title</Dt>
       <Dd>Description</Dd>
     </Dl>,

--- a/src/components/definition-list/dl.component.tsx
+++ b/src/components/definition-list/dl.component.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import { SpaceProps } from "styled-system";
 import { StyledDl } from "./definition-list.style";
 import DlContext, { DlContextProps } from "./__internal__/dl.context";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
-export interface DlProps extends SpaceProps, DlContextProps {
+export interface DlProps extends SpaceProps, DlContextProps, TagProps {
   /** HTML id attribute of the input */
   id?: string;
   /** prop to render children. */
@@ -25,10 +26,9 @@ const Dl = ({
   return (
     <StyledDl
       w={w}
-      data-component="dl"
-      data-role="dl"
       asSingleColumn={asSingleColumn}
       {...rest}
+      {...tagComponent("dl", rest)}
     >
       <DlContext.Provider value={{ asSingleColumn, dtTextAlign, ddTextAlign }}>
         {children}

--- a/src/components/definition-list/dt/dt.component.tsx
+++ b/src/components/definition-list/dt/dt.component.tsx
@@ -2,8 +2,11 @@ import React, { useContext } from "react";
 import { SpaceProps } from "styled-system";
 import { StyledDt } from "../definition-list.style";
 import DlContext from "../__internal__/dl.context";
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags";
 
-export interface DtProps extends SpaceProps {
+export interface DtProps extends SpaceProps, TagProps {
   /** Prop for what will render in the `<Dd></Dd>` tags */
   children: React.ReactNode;
 }
@@ -20,6 +23,7 @@ const Dt = ({ children, ...rest }: DtProps) => {
       dtTextAlign={dtTextAlign}
       asSingleColumn={asSingleColumn}
       {...rest}
+      {...tagComponent("dt", rest)}
     >
       {children}
     </StyledDt>

--- a/src/components/dialog-full-screen/dialog-full-screen.component.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.component.tsx
@@ -156,12 +156,6 @@ export const DialogFullScreen = ({
     "aria-label": ariaLabel,
   };
 
-  const componentTags = {
-    "data-component": "dialog-full-screen",
-    "data-element": rest["data-element"],
-    "data-role": rest["data-role"],
-  };
-
   return (
     <Modal
       open={open}
@@ -169,7 +163,7 @@ export const DialogFullScreen = ({
       disableEscKey={disableEscKey}
       topModalOverride={topModalOverride}
       restoreFocusOnClose={restoreFocusOnClose}
-      {...componentTags}
+      {...tagComponent("dialog-full-screen", rest)}
     >
       <FocusTrap
         autoFocus={!disableAutoFocus}

--- a/src/components/dialog/dialog.component.tsx
+++ b/src/components/dialog/dialog.component.tsx
@@ -95,6 +95,8 @@ export interface DialogProps extends ModalProps, TagProps {
   greyBackground?: boolean;
   /** an optional array of refs to containers whose content should also be reachable by tabbing from the dialog */
   focusableContainers?: CustomRefObject<HTMLElement>[];
+  /** @private @internal @ignore */
+  "data-component"?: string;
 }
 
 export type DialogHandle = {

--- a/src/components/dismissible-box/dismissable-box.test.tsx
+++ b/src/components/dismissible-box/dismissable-box.test.tsx
@@ -18,6 +18,14 @@ test("calls the `onClose` callback when the close button is clicked", async () =
   );
 });
 
+test("renders with custom data tags", () => {
+  render(
+    <DismissibleBox onClose={() => {}} data-element="bar" data-role="foo" />,
+  );
+
+  expect(screen.getByTestId("foo")).toHaveAttribute("data-element", "bar");
+});
+
 test("allows custom data props to be assigned to the close button", () => {
   render(
     <DismissibleBox

--- a/src/components/dismissible-box/dismissible-box.component.tsx
+++ b/src/components/dismissible-box/dismissible-box.component.tsx
@@ -15,7 +15,7 @@ export interface DismissibleBoxProps
   extends SpaceProps,
     StyledDismissibleBoxProps,
     Omit<BoxProps, "display" | "justifyContent" | "bg" | "backgroundColor">,
-    Omit<TagProps, "data-component"> {
+    TagProps {
   /** The content to render in the component */
   children?: React.ReactNode;
   /** Data tag prop bag for close Button */
@@ -45,9 +45,9 @@ export const DismissibleBox = ({
   return (
     <StyledDismissibleBox
       p="20px 24px 20px 20px"
-      data-component="dismissible-box"
       borderRadius={borderRadius}
       {...rest}
+      {...tagComponent("dismissible-box", rest)}
     >
       {children}
       <span data-element="close-button-wrapper">

--- a/src/components/draggable/__internal__/drop-target.component.tsx
+++ b/src/components/draggable/__internal__/drop-target.component.tsx
@@ -3,6 +3,7 @@ import { useDrop } from "react-dnd";
 import { DraggableContainerProps } from "../draggable-container.component";
 
 import { StyledDraggableContainer } from "../draggable-item/draggable-item.style";
+import tagComponent from "../../../__internal__/utils/helpers/tags";
 
 interface DropTargetProps extends Omit<DraggableContainerProps, "getOrder"> {
   children?: React.ReactNode;
@@ -14,13 +15,7 @@ interface DropItemProps {
   originalIndex: number;
 }
 
-const DropTarget = ({
-  "data-element": dataElement,
-  "data-role": dataRole,
-  children,
-  getOrder,
-  ...rest
-}: DropTargetProps) => {
+const DropTarget = ({ children, getOrder, ...rest }: DropTargetProps) => {
   const [, drop] = useDrop({
     accept: "draggableItem",
     drop(item: DropItemProps) {
@@ -34,10 +29,8 @@ const DropTarget = ({
   return (
     <StyledDraggableContainer
       ref={drop}
-      data-component="draggable-container"
-      data-element={dataElement}
-      data-role={dataRole}
       {...rest}
+      {...tagComponent("draggable-container", rest)}
     >
       {children}
     </StyledDraggableContainer>

--- a/src/components/draggable/draggable-container.component.tsx
+++ b/src/components/draggable/draggable-container.component.tsx
@@ -9,9 +9,7 @@ import DraggableItem from "./draggable-item/draggable-item.component";
 import DropTarget from "./__internal__/drop-target.component";
 import { TagProps } from "../../__internal__/utils/helpers/tags";
 
-export interface DraggableContainerProps
-  extends MarginProps,
-    Omit<TagProps, "data-component"> {
+export interface DraggableContainerProps extends MarginProps, TagProps {
   /** Callback fired when order is changed */
   getOrder?: (
     draggableItemIds?: (string | number | undefined)[],

--- a/src/components/draggable/draggable-item/draggable-item.component.tsx
+++ b/src/components/draggable/draggable-item/draggable-item.component.tsx
@@ -1,12 +1,15 @@
 import React from "react";
 import { useDrop, useDrag } from "react-dnd";
 import { PaddingProps } from "styled-system";
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags";
 
 import { filterStyledSystemPaddingProps } from "../../../style/utils";
 import { StyledDraggableItem } from "./draggable-item.style";
 import Icon from "../../icon";
 
-export interface DraggableItemProps extends PaddingProps {
+export interface DraggableItemProps extends PaddingProps, TagProps {
   /**
    * The id of the `DraggableItem`.
    *
@@ -45,6 +48,8 @@ const DraggableItem = ({
   children,
   py = 1,
   flexDirection,
+  "data-element": dataElement,
+  "data-role": dataRole = "draggable-item",
   ...rest
 }: DraggableItemProps): JSX.Element => {
   let originalIndex;
@@ -90,13 +95,15 @@ const DraggableItem = ({
 
   return (
     <StyledDraggableItem
-      data-element="draggable"
-      data-role="draggable-item"
       isDragging={isDragging}
       ref={(node) => drag(drop(node))}
       py={py}
       flexDirection={flexDirection}
       {...paddingProps}
+      {...tagComponent("draggable-item", {
+        "data-element": dataElement,
+        "data-role": dataRole,
+      })}
     >
       {children}
       <Icon type="drag" />

--- a/src/components/draggable/draggable.test.tsx
+++ b/src/components/draggable/draggable.test.tsx
@@ -167,6 +167,32 @@ test("throws error when DraggableContainer contains a child which is not Draggab
   jest.restoreAllMocks();
 });
 
+test("renders with provided data- attributes", () => {
+  render(
+    <DraggableContainer
+      data-element="draggable-element"
+      data-role="draggable-role"
+    >
+      <DraggableItem
+        data-element="item-element"
+        data-role="item-role"
+        id="apple"
+      >
+        Apple
+      </DraggableItem>
+    </DraggableContainer>,
+  );
+
+  expect(screen.getByTestId("draggable-role")).toHaveAttribute(
+    "data-element",
+    "draggable-element",
+  );
+  expect(screen.getByTestId("item-role")).toHaveAttribute(
+    "data-element",
+    "item-element",
+  );
+});
+
 testStyledSystemMargin(
   (props) => (
     <DraggableContainer {...props}>

--- a/src/components/drawer/drawer.component.tsx
+++ b/src/components/drawer/drawer.component.tsx
@@ -17,7 +17,7 @@ import StickyFooter from "../../__internal__/sticky-footer";
 import { TagProps } from "../../__internal__/utils/helpers/tags";
 import DrawerSidebarContext from "./__internal__/drawer-sidebar.context";
 
-export interface DrawerProps extends Omit<TagProps, "data-component"> {
+export interface DrawerProps extends TagProps {
   /** Duration of a animation */
   animationDuration?: string;
   /** Specify an aria-label for the Drawer component */

--- a/src/components/duelling-picklist/duelling-picklist.component.tsx
+++ b/src/components/duelling-picklist/duelling-picklist.component.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { MarginProps } from "styled-system";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import {
@@ -15,7 +16,7 @@ import FocusContext, {
   FocusContextType,
 } from "./__internal__/duelling-picklist.context";
 
-export interface DuellingPicklistProps extends MarginProps {
+export interface DuellingPicklistProps extends MarginProps, TagProps {
   /**
    * Content of the component, should contain two Picklist children
    * and a PicklistDivider
@@ -75,9 +76,8 @@ export const DuellingPicklist = ({
   return (
     <StyledDuellingPicklistOverlay
       disabled={disabled}
-      data-component="duelling-picklist"
-      data-role="duelling-picklist-overlay"
       {...filterStyledSystemMarginProps(rest)}
+      {...tagComponent("duelling-picklist", rest)}
     >
       {shouldDisplayLabels && (
         <StyledLabelContainer>

--- a/src/components/duelling-picklist/duelling-picklist.test.tsx
+++ b/src/components/duelling-picklist/duelling-picklist.test.tsx
@@ -620,9 +620,19 @@ test.each([
   },
 );
 
+test("renders with provided data- attributes", () => {
+  render(
+    <DuellingPicklist data-element="bar" data-role="baz">
+      <Picklist />
+    </DuellingPicklist>,
+  );
+
+  expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
 // for coverage (styles are also tested in Playwright)
 test("renders overlay if DuellingPicklistOverlay has disabled prop set", () => {
-  render(<DuellingPicklist disabled />);
+  render(<DuellingPicklist data-role="duelling-picklist-overlay" disabled />);
 
   expect(screen.getByTestId("duelling-picklist-overlay")).toHaveStyle({
     opacity: "0.2",

--- a/src/components/fieldset/fieldset.component.tsx
+++ b/src/components/fieldset/fieldset.component.tsx
@@ -1,13 +1,13 @@
 import React, { useState, useEffect, useContext } from "react";
 import { MarginProps } from "styled-system";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
-import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import { FieldsetStyle, StyledLegend } from "./fieldset.style";
 import NewValidationContext from "../carbon-provider/__internal__/new-validation.context";
 import FormSpacingProvider from "../../__internal__/form-spacing-provider";
 import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
 
-export interface FieldsetProps extends MarginProps {
+export interface FieldsetProps extends MarginProps, TagProps {
   /** Child elements */
   children?: React.ReactNode;
   /** The text for the fieldset's legend element. */
@@ -43,9 +43,9 @@ export const Fieldset = ({
     <FieldsetStyle
       ref={setRef}
       newValidation={validationRedesignOptIn}
-      {...tagComponent("fieldset", rest)}
       {...rest}
       {...marginProps}
+      {...tagComponent("fieldset", rest)}
     >
       {legend && (
         <StyledLegend

--- a/src/components/file-input/file-input.component.tsx
+++ b/src/components/file-input/file-input.component.tsx
@@ -26,7 +26,7 @@ import HintText from "../../__internal__/hint-text";
 export interface FileInputProps
   extends Pick<ValidationProps, "error">,
     Pick<InputProps, "id" | "name" | "required">,
-    Omit<TagProps, "data-component">,
+    TagProps,
     MarginProps {
   /** Which file format(s) to accept. Will be passed to the underlying HTML input.
    * See https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept  */

--- a/src/components/flat-table/flat-table-body-draggable/flat-table-body-draggable.component.tsx
+++ b/src/components/flat-table/flat-table-body-draggable/flat-table-body-draggable.component.tsx
@@ -7,8 +7,7 @@ import StyledIcon from "../../icon/icon.style";
 import StyledFlatTableBodyDraggable from "./flat-table-body-draggable.style";
 import FlatTableCell from "../flat-table-cell/flat-table-cell.component";
 
-export interface FlatTableBodyDraggableProps
-  extends Omit<TagProps, "data-component"> {
+export interface FlatTableBodyDraggableProps extends TagProps {
   /** Array of FlatTableRow. */
   children: React.ReactNode;
   /** Callback fired when order is changed */

--- a/src/components/flat-table/flat-table-body/flat-table-body.component.tsx
+++ b/src/components/flat-table/flat-table-body/flat-table-body.component.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { TagProps } from "../../../__internal__/utils/helpers/tags";
 
-export interface FlatTableBodyProps extends Omit<TagProps, "data-component"> {
+export interface FlatTableBodyProps extends TagProps {
   /** Array of FlatTableRow. */
   children: React.ReactNode;
 }

--- a/src/components/flat-table/flat-table-cell/flat-table-cell.component.tsx
+++ b/src/components/flat-table/flat-table-cell/flat-table-cell.component.tsx
@@ -11,9 +11,7 @@ import Icon from "../../icon";
 import guid from "../../../__internal__/utils/helpers/guid";
 import useTableCell from "../__internal__/use-table-cell";
 
-export interface FlatTableCellProps
-  extends PaddingProps,
-    Omit<TagProps, "data-component"> {
+export interface FlatTableCellProps extends PaddingProps, TagProps {
   /** Content alignment */
   align?: TableCellAlign;
   /** Cell content */

--- a/src/components/flat-table/flat-table-head/flat-table-head.component.tsx
+++ b/src/components/flat-table/flat-table-head/flat-table-head.component.tsx
@@ -4,7 +4,7 @@ import StyledFlatTableHead from "./flat-table-head.style";
 import { buildPositionMap } from "../__internal__";
 import FlatTableHeadContext from "./__internal__/flat-table-head.context";
 
-export interface FlatTableHeadProps extends Omit<TagProps, "data-component"> {
+export interface FlatTableHeadProps extends TagProps {
   /** Array of FlatTableRow. */
   children: React.ReactNode;
 }

--- a/src/components/flat-table/flat-table-header/flat-table-header.component.tsx
+++ b/src/components/flat-table/flat-table-header/flat-table-header.component.tsx
@@ -8,9 +8,7 @@ import FlatTableContext from "../__internal__/flat-table.context";
 import guid from "../../../__internal__/utils/helpers/guid";
 import useTableCell from "../__internal__/use-table-cell";
 
-export interface FlatTableHeaderProps
-  extends PaddingProps,
-    Omit<TagProps, "data-component"> {
+export interface FlatTableHeaderProps extends PaddingProps, TagProps {
   /** Content alignment */
   align?: TableCellAlign;
   /** If true sets alternative background color */

--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.tsx
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.component.tsx
@@ -13,9 +13,7 @@ import tagComponent, {
 } from "../../../__internal__/utils/helpers/tags/tags";
 import useTableCell from "../__internal__/use-table-cell";
 
-export interface FlatTableRowHeaderProps
-  extends PaddingProps,
-    Omit<TagProps, "data-component"> {
+export interface FlatTableRowHeaderProps extends PaddingProps, TagProps {
   /** Content alignment */
   align?: TableCellAlign;
   /** RowHeader content */

--- a/src/components/flat-table/flat-table-row/flat-table-row.component.tsx
+++ b/src/components/flat-table/flat-table-row/flat-table-row.component.tsx
@@ -24,7 +24,7 @@ import SubRowProvider, { SubRowContext } from "./__internal__/sub-row-provider";
 import { buildPositionMap } from "../__internal__";
 import FlatTableHeadContext from "../flat-table-head/__internal__/flat-table-head.context";
 
-export interface FlatTableRowProps extends Omit<TagProps, "data-component"> {
+export interface FlatTableRowProps extends TagProps {
   /** Overrides default cell color, provide design token, any color from palette or any valid css color value. */
   bgColor?: string;
   /** Array of FlatTableHeader or FlatTableCell. FlatTableRowHeader could also be passed. */

--- a/src/components/flat-table/flat-table.component.tsx
+++ b/src/components/flat-table/flat-table.component.tsx
@@ -13,9 +13,7 @@ import Events from "../../__internal__/utils/helpers/events/events";
 import FlatTableContext from "./__internal__/flat-table.context";
 import { TagProps } from "../../__internal__/utils/helpers/tags";
 
-export interface FlatTableProps
-  extends MarginProps,
-    Omit<TagProps, "data-component"> {
+export interface FlatTableProps extends MarginProps, TagProps {
   /** The HTML id of the element that contains a description of this table. */
   ariaDescribedby?: string;
   /** A string to render as the table's caption */

--- a/src/components/flat-table/sort/sort.component.tsx
+++ b/src/components/flat-table/sort/sort.component.tsx
@@ -7,7 +7,7 @@ import guid from "../../../__internal__/utils/helpers/guid";
 import useLocale from "../../../hooks/__internal__/useLocale";
 import FlatTableContext from "../__internal__/flat-table.context";
 
-export interface SortProps extends Omit<TagProps, "data-component"> {
+export interface SortProps extends TagProps {
   /** if `asc` it will show `sort_up` icon, if `desc` it will show `sort_down` */
   sortType?: "ascending" | "descending";
   /** Callback fired when the component is clicked */

--- a/src/components/form/form.component.tsx
+++ b/src/components/form/form.component.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useRef } from "react";
 import { SpaceProps, PaddingProps } from "styled-system";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 import FormSummary from "./__internal__/form-summary.component";
 import {
@@ -13,7 +14,7 @@ import { FormButtonAlignment, formSpacing } from "./form.config";
 import FormSpacingProvider from "../../__internal__/form-spacing-provider";
 import ModalContext from "../modal/__internal__/modal.context";
 
-export interface FormProps extends SpaceProps {
+export interface FormProps extends SpaceProps, TagProps {
   /** Alignment of buttons */
   buttonAlignment?: FormButtonAlignment;
   /** Child elements */
@@ -85,6 +86,7 @@ export const Form = ({
       height={height}
       isInModal={isInModal}
       {...rest}
+      {...tagComponent("form", rest)}
     >
       <StyledFormContent
         data-element="form-content"

--- a/src/components/global-header/global-header.component.tsx
+++ b/src/components/global-header/global-header.component.tsx
@@ -3,8 +3,12 @@ import styled from "styled-components";
 import { PaddingProps, FlexboxProps } from "styled-system";
 import Box from "../box";
 import NavigationBar from "../navigation-bar";
+import { TagProps } from "../../__internal__/utils/helpers/tags";
 
-export interface GlobalHeaderProps extends PaddingProps, FlexboxProps {
+export interface GlobalHeaderProps
+  extends PaddingProps,
+    FlexboxProps,
+    TagProps {
   /** Child elements */
   children?: React.ReactNode;
   /** Logo to render */

--- a/src/components/global-header/global-header.test.tsx
+++ b/src/components/global-header/global-header.test.tsx
@@ -20,6 +20,17 @@ test("should render with 'data-component' set to 'global-header'", () => {
   );
 });
 
+test("should render with provided data- attributes", () => {
+  render(
+    <GlobalHeader data-element="bar" data-role="baz">
+      foobar
+    </GlobalHeader>,
+  );
+
+  expect(screen.getByRole("navigation")).toHaveAttribute("data-element", "bar");
+  expect(screen.getByRole("navigation")).toHaveAttribute("data-role", "baz");
+});
+
 test("should have correct z-index", () => {
   render(<GlobalHeader>foobar</GlobalHeader>);
 

--- a/src/components/grid/grid-container/grid-container.component.tsx
+++ b/src/components/grid/grid-container/grid-container.component.tsx
@@ -1,18 +1,21 @@
 import React from "react";
 import { SpaceProps, GridProps } from "styled-system";
-
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags/tags";
 import StyledGridContainer from "./grid-container.style";
 
 export interface GridContainerProps
   extends SpaceProps,
     GridProps,
-    React.HTMLAttributes<HTMLDivElement> {
+    React.HTMLAttributes<HTMLDivElement>,
+    TagProps {
   /** Defines the Components to be rendered within the GridContainer. Requires GridItemProps */
   children?: React.ReactNode;
 }
 
 export const GridContainer = (props: GridContainerProps) => (
-  <StyledGridContainer data-component="grid" {...props} />
+  <StyledGridContainer {...props} {...tagComponent("grid", props)} />
 );
 
 export default GridContainer;

--- a/src/components/grid/grid-item/grid-item.component.tsx
+++ b/src/components/grid/grid-item/grid-item.component.tsx
@@ -1,10 +1,13 @@
 import React from "react";
-
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags/tags";
 import StyledGridItem, { StyledGridItemProps } from "./grid-item.style";
 
 export interface GridItemProps
   extends StyledGridItemProps,
-    React.HTMLAttributes<HTMLDivElement> {
+    React.HTMLAttributes<HTMLDivElement>,
+    TagProps {
   /** Defines the Component(s) to be rendered within the GridItem */
   children?: React.ReactNode;
 }
@@ -12,7 +15,11 @@ export interface GridItemProps
 export const GridItem = (props: GridItemProps) => {
   const { children, responsiveSettings, ...rest } = props;
   return (
-    <StyledGridItem {...rest} responsiveSettings={responsiveSettings}>
+    <StyledGridItem
+      {...rest}
+      {...tagComponent("grid-item", rest)}
+      responsiveSettings={responsiveSettings}
+    >
       {children}
     </StyledGridItem>
   );

--- a/src/components/grouped-character/grouped-character.component.tsx
+++ b/src/components/grouped-character/grouped-character.component.tsx
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import Textbox, { TextboxProps } from "../textbox";
 import { generateGroups, toSum } from "./grouped-character.utils";
 import Logger from "../../__internal__/utils/logger";
+import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 
 type EventValue = {
   formattedValue: string;
@@ -33,7 +34,7 @@ const buildCustomTarget = (
 };
 
 export interface GroupedCharacterProps
-  extends Omit<TextboxProps, "onChange" | "onBlur"> {
+  extends Omit<TextboxProps, "onChange" | "onBlur" | "data-component"> {
   /** Default input value if component is meant to be used as an uncontrolled component */
   defaultValue?: string;
   /** pattern by which input value should be grouped */
@@ -167,6 +168,7 @@ export const GroupedCharacter = React.forwardRef(
         onBlur={handleBlur}
         onKeyDown={handleKeyDown}
         ref={ref}
+        {...tagComponent("grouped-character", rest)}
       />
     );
   },

--- a/src/components/grouped-character/grouped-character.test.tsx
+++ b/src/components/grouped-character/grouped-character.test.tsx
@@ -77,6 +77,19 @@ test("deprecation warning for uncontrolled should display warning once", () => {
   loggerSpy.mockClear();
 });
 
+test("should render with the provided data- attributes", () => {
+  render(
+    <GroupedCharacter
+      data-element="bar"
+      data-role="baz"
+      groups={[2, 2, 3]}
+      separator="-"
+    />,
+  );
+
+  expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
 test("when component is uncontrolled, it should set the default input value same as defaultValue provided", () => {
   render(
     <GroupedCharacter

--- a/src/components/heading/heading.component.tsx
+++ b/src/components/heading/heading.component.tsx
@@ -132,16 +132,9 @@ export const Heading = ({
   };
 
   const marginProps = filterStyledSystemMarginProps(rest);
-  const dataAttributes = {
-    "data-element": rest["data-element"],
-    "data-role": rest["data-role"],
-  };
 
   return title ? (
-    <StyledHeading
-      {...tagComponent("heading", dataAttributes)}
-      {...marginProps}
-    >
+    <StyledHeading {...tagComponent("heading", rest)} {...marginProps}>
       <StyledHeader
         data-element="header-container"
         divider={divider}

--- a/src/components/heading/heading.test.tsx
+++ b/src/components/heading/heading.test.tsx
@@ -8,15 +8,13 @@ test("renders with custom data tags", () => {
   render(
     <Heading
       title="foo"
-      data-role="heading"
-      data-component="heading"
-      data-element="heading"
+      data-role="heading-role"
+      data-element="heading-element"
     />,
   );
 
-  const headingWrapper = screen.getByTestId("heading");
-  expect(headingWrapper).toHaveAttribute("data-component", "heading");
-  expect(headingWrapper).toHaveAttribute("data-element", "heading");
+  const headingWrapper = screen.getByTestId("heading-role");
+  expect(headingWrapper).toHaveAttribute("data-element", "heading-element");
 });
 
 test("renders a custom title node within the heading using the `title` prop", () => {

--- a/src/components/help/help.component.tsx
+++ b/src/components/help/help.component.tsx
@@ -1,8 +1,8 @@
 import React, { useContext, useEffect, useRef, useState } from "react";
 import { MarginProps } from "styled-system";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 import Icon, { IconType } from "../icon";
-import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import StyledHelp from "./help.style";
 import Events from "../../__internal__/utils/helpers/events";
 import { TooltipContext } from "../../__internal__/tooltip-provider";
@@ -10,7 +10,7 @@ import { filterStyledSystemMarginProps } from "../../style/utils";
 import { TooltipPositions } from "../tooltip/tooltip.config";
 import guid from "../../__internal__/utils/helpers/guid";
 
-export interface HelpProps extends MarginProps {
+export interface HelpProps extends MarginProps, TagProps {
   /** Overrides the default 'as' attribute of the Help component */
   as?: keyof JSX.IntrinsicElements;
   /** Aria label */
@@ -108,7 +108,6 @@ export const Help = ({
       onBlur={handleFocusBlur(false)}
       onMouseOver={handleFocusBlur(true)}
       onMouseLeave={handleFocusBlur(false)}
-      {...tagComponent("help", rest)}
       tabIndex={tabIndex}
       {...(href
         ? {
@@ -120,6 +119,7 @@ export const Help = ({
           })}
       {...filterStyledSystemMarginProps(rest)}
       {...rest}
+      {...tagComponent("help", rest)}
     >
       <Icon
         aria-hidden

--- a/src/components/hr/hr.component.tsx
+++ b/src/components/hr/hr.component.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { MarginProps } from "styled-system";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 import StyledHr from "./hr.style";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
 
-export interface HrProps extends MarginProps {
+export interface HrProps extends MarginProps, TagProps {
   /** Set whether the component should be recognised by assistive technologies */
   "aria-hidden"?: "true" | "false";
   /** Breakpoint for adaptive left and right margins (below the breakpoint they go to 0).
@@ -33,14 +34,13 @@ export const Hr = ({
   return (
     <StyledHr
       aria-hidden={ariaHidden}
-      data-component="hr"
-      data-role="hr"
       height={height}
       ml={marginLeft}
       mr={marginRight}
       mt={rest.mt || 3}
       mb={rest.mb || 3}
       {...rest}
+      {...tagComponent("hr", rest)}
     />
   );
 };

--- a/src/components/hr/hr.test.tsx
+++ b/src/components/hr/hr.test.tsx
@@ -88,7 +88,7 @@ test("when adaptiveMxBreakpoint prop is set and when screen smaller than breakpo
 });
 
 test("should apply the 'aria-hidden' attribute when the `aria-hidden` prop is true", () => {
-  render(<Hr aria-hidden="true" />);
+  render(<Hr data-role="hr" aria-hidden="true" />);
   const hr = screen.getByTestId("hr");
 
   expect(hr).toHaveAttribute("aria-hidden", "true");

--- a/src/components/icon-button/icon-button.component.tsx
+++ b/src/components/icon-button/icon-button.component.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useCallback, useContext } from "react";
 import { SpaceProps } from "styled-system";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
+
 import Events from "../../__internal__/utils/helpers/events";
 import StyledIconButton from "./icon-button.style";
 import { IconProps } from "../icon";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import BatchSelectionContext from "../batch-selection/__internal__/batch-selection.context";
 
-export interface IconButtonProps extends SpaceProps {
+export interface IconButtonProps extends SpaceProps, TagProps {
   /** Prop to specify the aria-label of the icon-button component */
   "aria-label"?: string;
   /** Icon meant to be rendered, should be an Icon component */
@@ -27,6 +29,8 @@ export interface IconButtonProps extends SpaceProps {
       | React.KeyboardEvent<HTMLButtonElement>
       | React.MouseEvent<HTMLButtonElement>,
   ) => void;
+  /** @private @internal @ignore */
+  "data-component"?: string;
 }
 
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
@@ -76,6 +80,7 @@ const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
         onClick={onClick}
         ref={setRefs}
         disabled={isDisabled}
+        {...tagComponent(rest["data-component"] ?? "icon-button", rest)}
       >
         <TooltipProvider
           disabled={isDisabled}

--- a/src/components/icon-button/icon-button.mdx
+++ b/src/components/icon-button/icon-button.mdx
@@ -8,6 +8,12 @@ import * as IconButtonStories from "./icon-button.stories";
 
 A component that can be used when a button with no text is needed
 
+## Contents
+
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Props](#props)
+
 ## Quick Start
 
 ```javascript

--- a/src/components/icon-button/icon-button.test.tsx
+++ b/src/components/icon-button/icon-button.test.tsx
@@ -98,6 +98,16 @@ test("sets ref to empty after unmount", () => {
   expect(mockRef.current).toBe(null);
 });
 
+test("renders with provided data- attributes", () => {
+  render(
+    <IconButton data-element="bar" data-role="baz">
+      <Icon type="bin" />
+    </IconButton>,
+  );
+
+  expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
 testStyledSystemSpacing(
   (props) => (
     <IconButton onClick={() => {}} {...props}>

--- a/src/components/icon/icon.component.tsx
+++ b/src/components/icon/icon.component.tsx
@@ -21,7 +21,7 @@ export type LegacyIconTypes =
 export interface IconProps
   extends Omit<StyledIconProps, "type">,
     MarginProps,
-    Omit<TagProps, "data-component"> {
+    TagProps {
   /** Set whether icon should be recognised by assistive technologies */
   "aria-hidden"?: boolean;
   /** Aria label for accessibility purposes */

--- a/src/components/image/image.component.tsx
+++ b/src/components/image/image.component.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import invariant from "invariant";
 import { StyledImage, StyledImageProps } from "./image.style";
+import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 
 export const Image = ({
   alt,
@@ -35,6 +36,7 @@ export const Image = ({
       bottom={bottom}
       left={left}
       {...rest}
+      {...tagComponent("image", rest)}
     >
       {children}
     </StyledImage>

--- a/src/components/image/image.style.ts
+++ b/src/components/image/image.style.ts
@@ -10,6 +10,7 @@ import {
   PaddingProps,
 } from "styled-system";
 import { baseTheme } from "../../style/themes";
+import { TagProps } from "../../__internal__/utils/helpers/tags/tags";
 
 export type PositionProps =
   | "absolute"
@@ -21,7 +22,8 @@ export interface StyledImageProps
   extends BackgroundProps,
     LayoutProps,
     MarginProps,
-    PaddingProps {
+    PaddingProps,
+    TagProps {
   /** HTML alt property to display when an img fails to load */
   alt?: string;
   /** Prop to specify if the image is decorative  */

--- a/src/components/image/image.test.tsx
+++ b/src/components/image/image.test.tsx
@@ -31,6 +31,12 @@ test("renders", () => {
   expect(screen.getByTestId("image")).toBeVisible();
 });
 
+test("renders with provided data- attributes", () => {
+  render(<Image data-role="foo" data-element="bar" />);
+
+  expect(screen.getByTestId("foo")).toHaveAttribute("data-element", "bar");
+});
+
 test("renders with the 'src' prop", () => {
   render(
     <Image

--- a/src/components/inline-inputs/inline-inputs.component.tsx
+++ b/src/components/inline-inputs/inline-inputs.component.tsx
@@ -10,6 +10,7 @@ import StyledInlineInputs, {
 import FormSpacingProvider from "../../__internal__/form-spacing-provider";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
 import useFormSpacing from "../../hooks/__internal__/useFormSpacing";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 type GutterOptions =
   | "none"
@@ -24,7 +25,8 @@ type GutterOptions =
 export interface InlineInputsProps
   extends MarginProps,
     StyledContentContainerProps,
-    StyledInlineInputsProps {
+    StyledInlineInputsProps,
+    TagProps {
   /** Breakpoint for adaptive label (inline label change to top aligned). Enables the adaptive behaviour when set */
   adaptiveLabelBreakpoint?: number;
   /** Children elements */
@@ -115,12 +117,11 @@ const InlineInputs = ({
   return (
     <StyledInlineInputs
       gutter={gutter}
-      data-component="inline-inputs"
-      data-role="inline-inputs"
       labelWidth={labelWidth}
       labelInline={inlineLabel}
       ref={ref}
       {...marginProps}
+      {...tagComponent("inline-inputs", rest)}
     >
       {renderLabel()}
       <StyledContentContainer

--- a/src/components/inline-inputs/inline-inputs.test.tsx
+++ b/src/components/inline-inputs/inline-inputs.test.tsx
@@ -71,11 +71,25 @@ test("renders required children when required prop is true", () => {
   expect(screen.getByRole("textbox")).toBeRequired();
 });
 
+test("renders with provided data-attributes", () => {
+  render(
+    <InlineInputs data-element="bar" data-role="baz">
+      <Textbox onChange={() => {}} />
+    </InlineInputs>,
+  );
+
+  expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
 // coverage
 test("should render with expected styles when adaptiveLabelBreakpoint set and screen is smaller than the breakpoint", () => {
   mockMatchMedia(false);
   render(
-    <InlineInputs label="Inputs Label" adaptiveLabelBreakpoint={1000}>
+    <InlineInputs
+      data-role="inline-inputs"
+      label="Inputs Label"
+      adaptiveLabelBreakpoint={1000}
+    >
       <Textbox onChange={() => {}} />
     </InlineInputs>,
   );
@@ -92,7 +106,11 @@ test("should render with expected styles when adaptiveLabelBreakpoint set and sc
 test("should render with expected styles when adaptiveLabelBreakpoint set and screen is larger than the breakpoint", () => {
   mockMatchMedia(true);
   render(
-    <InlineInputs label="Inputs Label" adaptiveLabelBreakpoint={1000}>
+    <InlineInputs
+      data-role="inline-inputs"
+      label="Inputs Label"
+      adaptiveLabelBreakpoint={1000}
+    >
       <Textbox onChange={() => {}} />
     </InlineInputs>,
   );
@@ -105,7 +123,11 @@ test("should render with expected styles when adaptiveLabelBreakpoint set and sc
 // coverage
 test("renders with expected styles when labelWidth is provided", () => {
   render(
-    <InlineInputs label="Inputs Label" labelWidth={50}>
+    <InlineInputs
+      data-role="inline-inputs"
+      label="Inputs Label"
+      labelWidth={50}
+    >
       <Textbox onChange={() => {}} />
     </InlineInputs>,
   );
@@ -129,6 +151,8 @@ test("renders with expected styles when inputWidth is provided", () => {
 });
 
 testStyledSystemMargin(
-  (props) => <InlineInputs label="label" {...props} />,
+  (props) => (
+    <InlineInputs data-role="inline-inputs" label="label" {...props} />
+  ),
   () => screen.getByTestId("inline-inputs"),
 );

--- a/src/components/link-preview/link-preview.component.tsx
+++ b/src/components/link-preview/link-preview.component.tsx
@@ -12,6 +12,7 @@ import Preview from "../preview";
 import IconButton from "../icon-button";
 import Icon from "../icon";
 import Placeholder from "./__internal__/placeholder.component";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 interface ImageShape {
   /** The url string to be passed to image src */
@@ -20,7 +21,7 @@ interface ImageShape {
   alt?: string;
 }
 
-export interface LinkPreviewProps {
+export interface LinkPreviewProps extends TagProps {
   /** Used to set the root element to either an anchor link or div container */
   as?: "a" | "div";
   /** The description to be displayed */
@@ -76,11 +77,11 @@ export const LinkPreview = ({
 
   return (
     <StyledLinkPreview
-      data-role="link-preview"
       as={loadingState ? "div" : as}
       tabIndex={loadingState || as === "div" ? -1 : 0}
       {...linkProps}
       {...rest}
+      {...tagComponent("link-preview", rest)}
     >
       {imageProps().src ? <Image {...imageProps()} /> : <Placeholder />}
       <StyledPreviewWrapper isLoading={loadingState}>

--- a/src/components/link-preview/link-preview.test.tsx
+++ b/src/components/link-preview/link-preview.test.tsx
@@ -39,7 +39,7 @@ test("renders with the schema removed in the visible link text, via the `url` pr
 });
 
 test('renders with a div root element, when the `as` prop is passed as "div"', () => {
-  render(<LinkPreview as="div" />);
+  render(<LinkPreview data-role="link-preview" as="div" />);
   const linkPreviewWrapper = screen.getByTestId("link-preview");
 
   expect(linkPreviewWrapper.tagName).toBe("DIV");
@@ -119,4 +119,12 @@ test("renders with four loading preview's when the `isLoading` prop is true", ()
   previews.forEach((preview) => {
     expect(preview).toBeVisible();
   });
+});
+
+test("renders with provided data- attributes", () => {
+  render(<LinkPreview data-element="bar" data-role="baz" />);
+
+  const linkPreviewWrapper = screen.getByTestId("baz");
+
+  expect(linkPreviewWrapper).toHaveAttribute("data-element", "bar");
 });

--- a/src/components/link/link.component.tsx
+++ b/src/components/link/link.component.tsx
@@ -3,11 +3,16 @@ import React, { useContext, useEffect, useMemo, useState } from "react";
 import Icon, { IconType } from "../icon";
 import MenuContext from "../menu/__internal__/menu.context";
 import { StyledLink, StyledContent, StyledLinkProps } from "./link.style";
-import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+import tagComponent, {
+  TagProps,
+} from "../../__internal__/utils/helpers/tags/tags";
 import useLocale from "../../hooks/__internal__/useLocale";
 import BatchSelectionContext from "../batch-selection/__internal__/batch-selection.context";
 
-export interface LinkProps extends StyledLinkProps, React.AriaAttributes {
+export interface LinkProps
+  extends StyledLinkProps,
+    React.AriaAttributes,
+    TagProps {
   /** An href for an anchor tag. */
   href?: string;
   /** An icon to display next to the link. */

--- a/src/components/link/link.test.tsx
+++ b/src/components/link/link.test.tsx
@@ -235,6 +235,12 @@ test("when `removeAriaLabelOnIcon` is true, it should set aria-label as undefine
   expect(iconElement).not.toHaveAttribute("aria-label");
 });
 
+test("renders with custom data tags", () => {
+  render(<Link data-role="foo" data-element="bar" />);
+
+  expect(screen.getByTestId("foo")).toHaveAttribute("data-element", "bar");
+});
+
 // Test is just for coverage
 test("neutral `variant` has the expected styling when `isDarkBackground` is false", () => {
   render(

--- a/src/components/loader-star/loader-star.component.tsx
+++ b/src/components/loader-star/loader-star.component.tsx
@@ -12,7 +12,7 @@ import useMediaQuery from "../../hooks/useMediaQuery";
 import Star from "./internal/star.component";
 import Typography from "../typography";
 
-export interface LoaderStarProps extends Omit<TagProps, "data-component"> {
+export interface LoaderStarProps extends TagProps {
   /**
    * The loaderStarLabel prop allows a specific label to be set.
    * This label will be present if the user has `reduce-motion` enabled and will also be available to assistive technologies.

--- a/src/components/menu/menu-full-screen/menu-full-screen.component.tsx
+++ b/src/components/menu/menu-full-screen/menu-full-screen.component.tsx
@@ -20,7 +20,7 @@ import useLocale from "../../../hooks/__internal__/useLocale";
 import useModalAria from "../../../hooks/__internal__/useModalAria";
 import useModalManager from "../../../hooks/__internal__/useModalManager";
 
-export interface MenuFullscreenProps extends Omit<TagProps, "data-component"> {
+export interface MenuFullscreenProps extends TagProps {
   /** Accessible name that conveys the purpose of the menu   */
   "aria-label"?: string;
   /** The child elements to render */

--- a/src/components/menu/menu-item/menu-item.component.tsx
+++ b/src/components/menu/menu-item/menu-item.component.tsx
@@ -26,7 +26,7 @@ import { TagProps } from "../../../__internal__/utils/helpers/tags";
 export type VariantType = "default" | "alternate";
 
 interface MenuItemBaseProps
-  extends Omit<TagProps, "data-component">,
+  extends TagProps,
     Pick<LayoutProps, "width" | "maxWidth" | "minWidth">,
     FlexboxProps,
     PaddingProps {

--- a/src/components/menu/scrollable-block/scrollable-block.component.tsx
+++ b/src/components/menu/scrollable-block/scrollable-block.component.tsx
@@ -43,10 +43,10 @@ export const ScrollableBlock = ({
 
   return (
     <StyledScrollableBlock
-      {...tagComponent("submenu-scrollable-block", rest)}
       menuType={menuType}
       variant={variant}
       {...rest}
+      {...tagComponent("submenu-scrollable-block", rest)}
     >
       {parent && (
         <MenuItem

--- a/src/components/message/message.component.tsx
+++ b/src/components/message/message.component.tsx
@@ -5,7 +5,9 @@ import Typography from "../typography";
 import MessageStyle from "./message.style";
 import TypeIcon from "./__internal__/type-icon/type-icon.component";
 import MessageContent from "./__internal__/message-content/message-content.component";
-import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+import tagComponent, {
+  TagProps,
+} from "../../__internal__/utils/helpers/tags/tags";
 import Icon from "../icon";
 import IconButton from "../icon-button";
 import { filterStyledSystemMarginProps } from "../../style/utils";
@@ -18,7 +20,7 @@ export type MessageVariant =
   | "warning"
   | "neutral";
 
-export interface MessageProps extends MarginProps {
+export interface MessageProps extends MarginProps, TagProps {
   /** Set the component's content */
   children?: React.ReactNode;
   /** Set custom aria-label for component's close button */

--- a/src/components/message/message.test.tsx
+++ b/src/components/message/message.test.tsx
@@ -18,6 +18,16 @@ test("renders with provided `title`", () => {
   expect(screen.getByText("Title")).toBeVisible();
 });
 
+test("renders with provided data- attributes", () => {
+  render(
+    <Message data-element="bar" data-role="baz">
+      Message
+    </Message>,
+  );
+
+  expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
 test("does not render component when `open` prop is false", () => {
   render(
     <Message data-role="my-message" open={false}>

--- a/src/components/modal/modal.component.tsx
+++ b/src/components/modal/modal.component.tsx
@@ -9,7 +9,7 @@ import { StyledModal, StyledModalBackground } from "./modal.style";
 import { TagProps } from "../../__internal__/utils/helpers/tags";
 import ModalContext from "./__internal__/modal.context";
 
-export interface ModalProps extends Omit<TagProps, "data-component"> {
+export interface ModalProps extends TagProps {
   /**
    * @private
    * @internal

--- a/src/components/navigation-bar/navigation-bar.component.tsx
+++ b/src/components/navigation-bar/navigation-bar.component.tsx
@@ -2,12 +2,16 @@ import React, { useRef } from "react";
 import { PaddingProps, FlexboxProps } from "styled-system";
 import StyledNavigationBar from "./navigation-bar.style";
 import { FixedNavigationBarContextProvider } from "./__internal__/fixed-navigation-bar.context";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 export type Position = "sticky" | "fixed";
 export type Orientation = "top" | "bottom";
 export type NavigationType = "light" | "dark" | "white" | "black";
 
-export interface NavigationBarProps extends PaddingProps, FlexboxProps {
+export interface NavigationBarProps
+  extends PaddingProps,
+    FlexboxProps,
+    TagProps {
   /** Content of the component */
   children?: React.ReactNode;
   /** HTML aria-label attribute */
@@ -42,7 +46,6 @@ export const NavigationBar = ({
   return (
     <StyledNavigationBar
       role="navigation"
-      data-component={isGlobal ? "global-header" : "navigation-bar"}
       aria-label={isGlobal ? "Global Header" : ariaLabel}
       navigationType={isGlobal ? "black" : navigationType}
       orientation={isGlobal ? "top" : orientation}
@@ -51,6 +54,7 @@ export const NavigationBar = ({
       {...props}
       isGlobal={isGlobal}
       ref={navbarRef}
+      {...tagComponent(isGlobal ? "global-header" : "navigation-bar", props)}
     >
       <FixedNavigationBarContextProvider
         orientation={isGlobal ? "top" : orientation}

--- a/src/components/navigation-bar/navigation-bar.test.tsx
+++ b/src/components/navigation-bar/navigation-bar.test.tsx
@@ -40,6 +40,17 @@ test("renders with 'data-component' set to 'navigation-bar'", () => {
   );
 });
 
+test("renders with provided data- attributes", () => {
+  render(
+    <NavigationBar data-element="bar" data-role="baz">
+      <div>test content</div>
+    </NavigationBar>,
+  );
+
+  expect(screen.getByRole("navigation")).toHaveAttribute("data-element", "bar");
+  expect(screen.getByRole("navigation")).toHaveAttribute("data-role", "baz");
+});
+
 test("renders with provided `aria-label` as its accessible name", () => {
   render(
     <NavigationBar ariaLabel="test label">

--- a/src/components/note/note.component.tsx
+++ b/src/components/note/note.component.tsx
@@ -16,8 +16,9 @@ import ReadOnlyEditor from "../text-editor/__internal__";
 import TextEditorContext from "../text-editor/text-editor.context";
 import LinkPreview, { LinkPreviewProps } from "../link-preview";
 import Typography from "../typography";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
-export interface NoteProps extends MarginProps {
+export interface NoteProps extends MarginProps, TagProps {
   /** Adds a created on date to the Note footer */
   createdDate: string;
   /** renders a control for the Note */
@@ -84,7 +85,7 @@ export const Note = ({
 
   return (
     <TextEditorContext.Provider value={{ onLinkAdded, readOnly: true }}>
-      <StyledNote width={width} {...rest} data-component="note">
+      <StyledNote width={width} {...rest} {...tagComponent("note", rest)}>
         <StyledNoteMain>
           <StyledNoteContent>
             {title &&

--- a/src/components/note/note.test.tsx
+++ b/src/components/note/note.test.tsx
@@ -13,6 +13,19 @@ test("should render with required props", () => {
   expect(screen.getByText("23 May 2020, 12:08 PM")).toBeVisible();
 });
 
+test("should render with provided data- attributes", () => {
+  render(
+    <Note
+      createdDate="23 May 2020, 12:08 PM"
+      noteContent=""
+      data-element="bar"
+      data-role="baz"
+    />,
+  );
+
+  expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
 test("renders a Typography component with h2 `variant` and `title` as its child when `title` prop is a string", () => {
   render(
     <Note createdDate="23 May 2020, 12:08 PM" noteContent="" title="Title" />,

--- a/src/components/number/number.component.tsx
+++ b/src/components/number/number.component.tsx
@@ -7,6 +7,7 @@ import {
   LABEL_WIDTH_DEFAULT,
   SIZE_DEFAULT,
 } from "../textbox/textbox.component";
+import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 
 let deprecateUncontrolledWarnTriggered = false;
 
@@ -79,6 +80,7 @@ export const Number = React.forwardRef(
         labelWidth={labelWidth}
         size={size}
         validationOnLabel={validationOnLabel}
+        {...tagComponent(rest["data-component"] ?? "number", rest)}
       />
     );
   },

--- a/src/components/number/number.pw.tsx
+++ b/src/components/number/number.pw.tsx
@@ -272,14 +272,6 @@ test.describe("check props for Number component", () => {
     });
   });
 
-  test("should render with data-component prop", async ({ mount, page }) => {
-    await mount(<NumberInputComponent data-component={CHARACTERS.STANDARD} />);
-
-    await expect(
-      getDataComponentByValue(page, CHARACTERS.STANDARD),
-    ).toBeVisible();
-  });
-
   test("should render with data-element prop", async ({ mount, page }) => {
     await mount(<NumberInputComponent data-element={CHARACTERS.STANDARD} />);
 

--- a/src/components/numeral-date/numeral-date.component.tsx
+++ b/src/components/numeral-date/numeral-date.component.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState, useEffect, useRef, useMemo } from "react";
 import invariant from "invariant";
 import { MarginProps } from "styled-system";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 import { ValidationProps } from "../../__internal__/validations";
 import { filterStyledSystemMarginProps } from "../../style/utils";
@@ -65,15 +66,10 @@ export interface NumeralDateEvent<
 
 export interface NumeralDateProps<DateType extends NumeralDateObject = FullDate>
   extends ValidationProps,
-    MarginProps {
+    MarginProps,
+    TagProps {
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
   adaptiveLabelBreakpoint?: number;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-component"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-element"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-role"?: string;
   /** If true, the component will be disabled */
   disabled?: boolean;
   /** If true, the component will be read-only */
@@ -231,9 +227,6 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
   disabled,
   error = "",
   warning = "",
-  "data-component": dataComponent,
-  "data-element": dataElement,
-  "data-role": dataRole,
   info,
   id,
   name,
@@ -511,9 +504,6 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
     return (
       <TooltipProvider helpAriaLabel={helpAriaLabel}>
         <StyledFieldset
-          data-component={dataComponent || "numeral-date"}
-          data-element={dataElement}
-          data-role={dataRole}
           id={uniqueId}
           legend={label}
           legendMargin={{ mb: 0 }}
@@ -533,6 +523,7 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
           validationId={validationId}
           aria-describedby={validationOnLabel ? ariaDescribedBy : fieldHelpId}
           {...filterStyledSystemMarginProps(rest)}
+          {...tagComponent("numeral-date", rest)}
         >
           <Box display="flex" flexDirection="column" mt={inline ? 0 : 1}>
             {renderInputs()}
@@ -545,9 +536,6 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
 
   return (
     <StyledFieldset
-      data-component={dataComponent || "numeral-date"}
-      data-element={dataElement}
-      data-role={dataRole}
       id={uniqueId}
       legend={label}
       legendMargin={{ mb: 0 }}
@@ -558,6 +546,7 @@ export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
       name={name}
       aria-describedby={combinedAriaDescribedBy}
       {...filterStyledSystemMarginProps(rest)}
+      {...tagComponent("numeral-date", rest)}
     >
       {labelHelp && (
         <HintText align={labelAlign} id={inputHintId.current}>

--- a/src/components/numeral-date/numeral-date.pw.tsx
+++ b/src/components/numeral-date/numeral-date.pw.tsx
@@ -46,17 +46,6 @@ const dynamicValidations: [string, string, string, string][] = [
 ];
 
 test.describe("NumeralDate component", () => {
-  test("should render NumeralDate with data-component prop", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<NumeralDateComponent data-component={CHARACTERS.STANDARD} />);
-
-    await expect(
-      getDataComponentByValue(page, CHARACTERS.STANDARD),
-    ).toBeVisible();
-  });
-
   test("should render NumeralDate with data-element prop", async ({
     mount,
     page,

--- a/src/components/numeral-date/numeral-date.test.tsx
+++ b/src/components/numeral-date/numeral-date.test.tsx
@@ -2058,14 +2058,12 @@ test("should set the passed `data-` props as attributes on the root element", ()
     <NumeralDate
       value={{ dd: "", mm: "", yyyy: "" }}
       onChange={() => {}}
-      data-component="numeral-date-root"
       data-element="numeral-date-element"
       data-role="numeral-date-role"
     />,
   );
   const rootElement = screen.getByTestId("numeral-date-role");
 
-  expect(rootElement).toHaveAttribute("data-component", "numeral-date-root");
   expect(rootElement).toHaveAttribute("data-element", "numeral-date-element");
 });
 

--- a/src/components/pager/pager.component.tsx
+++ b/src/components/pager/pager.component.tsx
@@ -12,13 +12,14 @@ import {
   StyledSelectContainer,
 } from "./pager.style";
 import Events from "../../__internal__/utils/helpers/events";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 type PageSizeOption = {
   id: string;
   name: number;
 };
 
-export interface PagerProps {
+export interface PagerProps extends TagProps {
   /** Function called when pager changes (Current page, Page size, Origin component) */
   onPagination: (currentPage: number, pageSize: number, origin: string) => void;
   /** Callback function for next link */
@@ -270,10 +271,9 @@ export const Pager = ({
 
   return (
     <StyledPagerContainer
-      data-component="pager"
-      data-role="pager"
       variant={variant}
       {...rest}
+      {...tagComponent("pager", rest)}
     >
       <StyledPagerSizeOptions>{renderPageSizeOptions()}</StyledPagerSizeOptions>
       <PagerNavigation

--- a/src/components/pager/pager.test.tsx
+++ b/src/components/pager/pager.test.tsx
@@ -476,9 +476,17 @@ test("the `onPagination` callback prop should not be called when a key other tha
   expect(onPagination).not.toHaveBeenCalled();
 });
 
+test("renders with provided data- attributes", () => {
+  render(<Pager data-element="bar" data-role="baz" onPagination={() => {}} />);
+
+  expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
 // for coverage - "alternate" styles are covered by Playwright tests
 test("renders with correct styles when `variant` is `alternate`", () => {
-  render(<Pager variant="alternate" onPagination={() => {}} />);
+  render(
+    <Pager data-role="pager" variant="alternate" onPagination={() => {}} />,
+  );
 
   expect(screen.getByTestId("pager")).toHaveStyleRule(
     "background-color",

--- a/src/components/pages/page/page.component.tsx
+++ b/src/components/pages/page/page.component.tsx
@@ -1,13 +1,15 @@
 import React, { useRef } from "react";
 import { CSSTransition } from "react-transition-group";
 import { PaddingProps } from "styled-system";
-import tagComponent from "../../../__internal__/utils/helpers/tags/tags";
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags/tags";
 import FullScreenHeading from "../../../__internal__/full-screen-heading";
 import Box from "../../box";
 import { StyledPage, StyledPageContent } from "./page.style";
 import { filterStyledSystemPaddingProps } from "../../../style/utils";
 
-export interface PageProps extends PaddingProps {
+export interface PageProps extends PaddingProps, TagProps {
   /** The title for the page, normally a Heading component. */
   title?: React.ReactNode;
   /** This component supports children. */

--- a/src/components/pages/page/page.test.tsx
+++ b/src/components/pages/page/page.test.tsx
@@ -23,3 +23,12 @@ test("renders both heading and children", () => {
   expect(screen.getByText("My Title")).toBeInTheDocument();
   expect(screen.getByText("My Content")).toBeInTheDocument();
 });
+
+test("renders with provided data- attributes", () => {
+  render(
+    <Page data-role="foo" data-element="bar">
+      Content
+    </Page>,
+  );
+  expect(screen.getByTestId("foo")).toHaveAttribute("data-element", "bar");
+});

--- a/src/components/pages/pages.component.tsx
+++ b/src/components/pages/pages.component.tsx
@@ -1,11 +1,13 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { TransitionGroup } from "react-transition-group";
-import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+import tagComponent, {
+  TagProps,
+} from "../../__internal__/utils/helpers/tags/tags";
 import Page from "./page";
 import { PagesWrapperStyle, PagesContent } from "./pages.style";
 import { ThemeObject } from "../../style/themes/base";
 
-export interface PagesProps {
+export interface PagesProps extends TagProps {
   /** The selected tab on page load */
   initialpageIndex?: number | string;
   /** The current page's index */
@@ -97,7 +99,7 @@ const Pages = ({
 
   /** Renders the Slide Component */
   return (
-    <PagesWrapperStyle {...tagComponent("carousel", props)}>
+    <PagesWrapperStyle {...tagComponent("pages", props)}>
       <PagesContent className="carbon-carousel__content">
         <TransitionGroup>{handleVisiblePage()}</TransitionGroup>
       </PagesContent>

--- a/src/components/pages/pages.test.tsx
+++ b/src/components/pages/pages.test.tsx
@@ -204,7 +204,7 @@ test("accepts `data-element` and `data-role` tags via props, and has the expecte
   );
 
   const pagesWrapper = screen.getByTestId("baz");
-  expect(pagesWrapper).toHaveAttribute("data-component", "carousel");
+  expect(pagesWrapper).toHaveAttribute("data-component", "pages");
   expect(pagesWrapper).toHaveAttribute("data-element", "bar");
 });
 

--- a/src/components/password/password.component.tsx
+++ b/src/components/password/password.component.tsx
@@ -2,13 +2,11 @@ import React, { useRef, useState } from "react";
 import { TextboxProps } from "../textbox";
 import { StyledPassword, HiddenAriaLive } from "./password.style";
 import guid from "../../__internal__/utils/helpers/guid";
-import tagComponent, {
-  TagProps,
-} from "../../__internal__/utils/helpers/tags/tags";
+import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import useLocale from "../../hooks/__internal__/useLocale";
 import ButtonMinor from "../button-minor/button-minor.component";
 
-export interface PasswordProps extends TextboxProps, TagProps {
+export interface PasswordProps extends Omit<TextboxProps, "data-component"> {
   /** When `true` input `type` is `password` and text is obscured. */
   forceObscurity?: boolean;
 }
@@ -27,13 +25,13 @@ export const Password = ({
   return (
     <>
       <StyledPassword
-        {...tagComponent("password", rest)}
         data-element="styled-password-container"
         id={internalInputId.current}
         autoComplete="off"
         type={visibleInput ? "text" : "password"}
         disabled={disabled}
         {...rest}
+        {...tagComponent("password", rest)}
       >
         <ButtonMinor
           aria-label={visibleInput ? "Hide password" : "Show password"}

--- a/src/components/password/password.test.tsx
+++ b/src/components/password/password.test.tsx
@@ -112,6 +112,12 @@ test("should generate the text input's 'id' attribute via a guid when the `id` p
   expect(passwordInput).toHaveAttribute("id", mockedGuid);
 });
 
+test("should render with provided data- attributes", () => {
+  render(<Password label="password" data-role="bar" data-element="baz" />);
+
+  expect(screen.getByTestId("bar")).toHaveAttribute("data-element", "baz");
+});
+
 describe("Show/Hide password Button", () => {
   test("should render the `Show password` button icon with type 'view' initially", () => {
     render(<Password />);

--- a/src/components/pill/pill.component.tsx
+++ b/src/components/pill/pill.component.tsx
@@ -1,10 +1,12 @@
 import React from "react";
 import StyledPill, { StyledPillProps } from "./pill.style";
 import Icon from "../icon";
-import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+import tagComponent, {
+  TagProps,
+} from "../../__internal__/utils/helpers/tags/tags";
 import IconButton from "../icon-button";
 
-export interface PillProps extends StyledPillProps {
+export interface PillProps extends StyledPillProps, TagProps {
   /** The content to display inside of the pill.  */
   children: string;
   /** Change the color of a status pill. */
@@ -17,10 +19,6 @@ export interface PillProps extends StyledPillProps {
     | "neutralWhite";
   /** Sets the colour styling when a status pill is rendered on a dark background. */
   isDarkBackground?: boolean;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-element"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-role"?: string;
   /** Fills the pill background with colour. When fill is false only the border is coloured. */
   fill?: boolean;
   /** Callback function for when the pill is clicked. */
@@ -80,10 +78,10 @@ export const Pill = ({
       size={size}
       borderColor={borderColor}
       onClick={onClick}
-      {...tagComponent("pill", rest)}
       maxWidth={maxWidth}
       wrapText={wrapText}
       {...rest}
+      {...tagComponent("pill", rest)}
     >
       {children}
       {onDelete && (

--- a/src/components/pod/pod.component.tsx
+++ b/src/components/pod/pod.component.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useMemo } from "react";
 import { MarginProps } from "styled-system";
 import useLocale from "../../hooks/__internal__/useLocale";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 import {
   StyledBlock,
@@ -20,11 +21,7 @@ import Icon from "../icon";
 import Event from "../../__internal__/utils/helpers/events";
 import { PodAlignment, PodSize, PodVariant } from "./pod.config";
 
-export interface PodProps extends MarginProps {
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-element"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-role"?: string;
+export interface PodProps extends MarginProps, TagProps {
   /** Aligns the title to left, right or center */
   alignTitle?: PodAlignment;
   /** Enables/disables the border around the pod. */
@@ -70,8 +67,6 @@ export interface PodProps extends MarginProps {
 const Pod = React.forwardRef<HTMLDivElement, PodProps>(
   (
     {
-      "data-element": dataElement,
-      "data-role": dataRole,
       alignTitle = "left",
       border = true,
       children,
@@ -145,10 +140,8 @@ const Pod = React.forwardRef<HTMLDivElement, PodProps>(
         internalEditButton={internalEditButton}
         height={typeof height === "number" ? `${height}px` : height}
         ref={ref}
-        data-component="pod"
-        data-element={dataElement}
-        data-role={dataRole}
         {...rest}
+        {...tagComponent("pod", rest)}
       >
         <StyledBlock
           data-element="block"

--- a/src/components/pod/pod.test.tsx
+++ b/src/components/pod/pod.test.tsx
@@ -511,6 +511,12 @@ test("renders block with correct padding when `border` is false and a button is 
   expect(block).toHaveStyle({ padding: "0" });
 });
 
+test("renders with provided data- attributes", () => {
+  render(<Pod data-element="bar" data-role="baz" title="Title" />);
+
+  expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
 testStyledSystemMargin(
   (props) => <Pod data-role="pod" {...props} />,
   () => screen.getByTestId("pod"),

--- a/src/components/popover-container/popover-container.component.tsx
+++ b/src/components/popover-container/popover-container.component.tsx
@@ -107,7 +107,7 @@ export const renderClose = ({
   </PopoverContainerCloseIcon>
 );
 
-export interface PopoverContainerProps extends PaddingProps {
+export interface PopoverContainerProps extends PaddingProps, TagProps {
   /** A function that will render the open component
    *
    * `({tabIndex, isOpen, data-element, onClick, ref, aria-label}) => ()`
@@ -428,10 +428,9 @@ export const PopoverContainer = forwardRef<
 
     return (
       <PopoverContainerWrapperStyle
-        data-component="popover-container"
-        data-role="popover-container"
         onMouseDown={handleClick}
         hasFullWidth={hasFullWidth}
+        {...tagComponent("popover-container", rest)}
       >
         <div ref={popoverReference}>
           {renderOpenComponent(renderOpenComponentProps)}

--- a/src/components/popover-container/popover-container.test.tsx
+++ b/src/components/popover-container/popover-container.test.tsx
@@ -706,10 +706,24 @@ test("should call the exposed `focusButton` method and focus the open button", a
   expect(openButton).toHaveFocus();
 });
 
+test("renders with provided data- attributes", () => {
+  render(
+    <PopoverContainer data-element="bar" data-role="baz">
+      Content
+    </PopoverContainer>,
+  );
+
+  expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
 // coverage
 test("renders with correct width when hasFullWidth prop is true", () => {
   render(
-    <PopoverContainer title="My popup" hasFullWidth>
+    <PopoverContainer
+      data-role="popover-container"
+      title="My popup"
+      hasFullWidth
+    >
       Ta da!
     </PopoverContainer>,
   );

--- a/src/components/portrait/portrait.component.tsx
+++ b/src/components/portrait/portrait.component.tsx
@@ -19,9 +19,7 @@ export type PortraitShapes = "circle" | "square";
 
 export type PortraitSizes = "XS" | "S" | "M" | "ML" | "L" | "XL" | "XXL";
 
-export interface PortraitProps
-  extends MarginProps,
-    Omit<TagProps, "data-component"> {
+export interface PortraitProps extends MarginProps, TagProps {
   /** A custom image URL. */
   src?: string;
   /** The size of the Portrait. */

--- a/src/components/portrait/portrait.test.tsx
+++ b/src/components/portrait/portrait.test.tsx
@@ -10,6 +10,12 @@ testStyledSystemMargin(
   () => screen.getByTestId("portrait-wrapper"),
 );
 
+test("renders with provided data- attributes", () => {
+  render(<Portrait data-role="foo" data-element="bar" />);
+
+  expect(screen.getByTestId("foo")).toHaveAttribute("data-element", "bar");
+});
+
 test("renders with a default individual icon", () => {
   render(<Portrait />);
 

--- a/src/components/preview/preview.component.tsx
+++ b/src/components/preview/preview.component.tsx
@@ -3,10 +3,13 @@ import { MarginProps } from "styled-system";
 import { StyledPreview, StyledPreviewPlaceholder } from "./preview.style";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import useMediaQuery from "../../hooks/useMediaQuery";
+import tagComponent, {
+  TagProps,
+} from "../../__internal__/utils/helpers/tags/tags";
 
 export type Shapes = "text" | "rectangle" | "rectangle-round" | "circle";
 
-export interface PreviewProps extends MarginProps {
+export interface PreviewProps extends MarginProps, TagProps {
   /** Children content to render in the component. */
   children?: React.ReactNode;
   /** Sets loading state. */
@@ -50,7 +53,6 @@ export const Preview = ({
     for (let i = 0; i < lines; i++) {
       placeholders.push(
         <StyledPreviewPlaceholder
-          data-component="preview"
           data-role="preview-placeholder"
           key={i}
           height={height}
@@ -59,6 +61,7 @@ export const Preview = ({
           shape={shape}
           disableAnimation={disableAnimation || reduceMotion}
           {...props}
+          {...tagComponent("preview", props)}
         />,
       );
     }

--- a/src/components/preview/preview.test.tsx
+++ b/src/components/preview/preview.test.tsx
@@ -41,6 +41,12 @@ test("renders the correct number of placeholders when `lines` prop is set", () =
   expect(screen.getAllByTestId("preview-placeholder")).toHaveLength(3);
 });
 
+test("renders with provided data- attributes", () => {
+  render(<Preview data-role="foo" data-element="bar" />);
+
+  expect(screen.getByTestId("foo")).toHaveAttribute("data-element", "bar");
+});
+
 // coverage
 test("renders with the correct height, width and border-radius when `shape` is set to 'text'", () => {
   render(<Preview shape="text" />);

--- a/src/components/profile/profile.component.tsx
+++ b/src/components/profile/profile.component.tsx
@@ -3,7 +3,9 @@ import React from "react";
 import { MarginProps } from "styled-system";
 
 import { filterStyledSystemMarginProps } from "../../style/utils";
-import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+import tagComponent, {
+  TagProps,
+} from "../../__internal__/utils/helpers/tags/tags";
 
 import { ProfileSize } from "./profile.config";
 import {
@@ -24,7 +26,7 @@ function acronymize(str?: string) {
 
 let useOfNoNameWarnTriggered = false;
 
-export interface ProfileProps extends MarginProps {
+export interface ProfileProps extends MarginProps, TagProps {
   /**
    * @private
    * @internal

--- a/src/components/profile/profile.test.tsx
+++ b/src/components/profile/profile.test.tsx
@@ -10,17 +10,11 @@ testStyledSystemMargin(
 );
 
 test("renders with set data tags", () => {
-  render(
-    <Profile
-      data-role="profile"
-      data-component="profile"
-      data-element="profile"
-    />,
-  );
+  render(<Profile data-role="foo" data-element="bar" />);
 
-  const profile = screen.getByTestId("profile");
+  const profile = screen.getByTestId("foo");
   expect(profile).toHaveAttribute("data-component", "profile");
-  expect(profile).toHaveAttribute("data-element", "profile");
+  expect(profile).toHaveAttribute("data-element", "bar");
 });
 
 test("renders default avatar if no text-based props are passed", () => {

--- a/src/components/progress-tracker/progress-tracker.component.tsx
+++ b/src/components/progress-tracker/progress-tracker.component.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { MarginProps } from "styled-system";
 import useLocale from "../../hooks/__internal__/useLocale";
-import tagComponent from "../../__internal__/utils/helpers/tags";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 import {
   StyledProgressBar,
   InnerBar,
@@ -11,7 +11,7 @@ import {
   StyledDescription,
 } from "./progress-tracker.style";
 
-export interface ProgressTrackerProps extends MarginProps {
+export interface ProgressTrackerProps extends MarginProps, TagProps {
   /** Size of the progress bar. */
   size?: "small" | "medium" | "large";
   /** Length of the component, any valid css string. */

--- a/src/components/progress-tracker/progress-tracker.test.tsx
+++ b/src/components/progress-tracker/progress-tracker.test.tsx
@@ -160,6 +160,12 @@ test("renders with correct colour when progress is '100%'", () => {
   );
 });
 
+test("renders with provided data- attributes", () => {
+  render(<ProgressTracker data-role="bar" data-element="baz" />);
+
+  expect(screen.getByTestId("bar")).toHaveAttribute("data-element", "baz");
+});
+
 testStyledSystemMargin(
   (props) => <ProgressTracker data-role="progress" {...props} />,
   () => screen.getByTestId("progress"),

--- a/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
+++ b/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
@@ -1,6 +1,8 @@
 import React, { useContext, useRef } from "react";
 import { MarginProps } from "styled-system";
-import tagComponent from "../../../__internal__/utils/helpers/tags/tags";
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags/tags";
 import Fieldset from "../../../__internal__/fieldset";
 import RadioButtonGroupStyle from "../radio-button-group/radio-button-group.style";
 import RadioButtonMapper from "../../../__internal__/radio-button-mapper/radio-button-mapper.component";
@@ -18,7 +20,11 @@ import ErrorBorder from "../../textbox/textbox.style";
 import HintText from "../../../__internal__/hint-text";
 
 let deprecateUncontrolledWarnTriggered = false;
-export interface RadioButtonGroupProps extends ValidationProps, MarginProps {
+
+export interface RadioButtonGroupProps
+  extends ValidationProps,
+    MarginProps,
+    TagProps {
   /**
    * Unique identifier for the component.
    * Will use a randomly generated GUID if none is provided.

--- a/src/components/radio-button/radio-button-group/radio-button-group.test.tsx
+++ b/src/components/radio-button/radio-button-group/radio-button-group.test.tsx
@@ -53,6 +53,24 @@ test("renders with RadioButton and non-`RadioButton` children when passed as an 
   expect(screen.getByText("foo")).toBeVisible();
 });
 
+test("renders with provided data- attributes", () => {
+  render(
+    <RadioButtonGroup
+      name="group"
+      data-role="bar"
+      data-element="baz"
+      onChange={() => {}}
+    >
+      <RadioButton value="radio1" label="Radio Button 1" />
+    </RadioButtonGroup>,
+  );
+
+  const fieldset = screen.getByRole("group");
+
+  expect(fieldset).toHaveAttribute("data-role", "bar");
+  expect(fieldset).toHaveAttribute("data-element", "baz");
+});
+
 test("renders fieldset with provided `legend`", () => {
   render(
     <RadioButtonGroup

--- a/src/components/radio-button/radio-button.component.tsx
+++ b/src/components/radio-button/radio-button.component.tsx
@@ -8,6 +8,7 @@ import RadioButtonSvg from "./radio-button-svg.component";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import NewValidationContext from "../carbon-provider/__internal__/new-validation.context";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 interface InternalRadioButtonProps {
   inline?: boolean;
@@ -15,13 +16,8 @@ interface InternalRadioButtonProps {
 
 export interface RadioButtonProps
   extends Omit<CommonCheckableInputProps, "required" | "IsOptional">,
-    MarginProps {
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-component"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-element"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-role"?: string;
+    MarginProps,
+    TagProps {
   /** Accepts a callback function which is triggered on click event */
   onClick?: (ev: React.MouseEvent<HTMLInputElement>) => void;
   /** the value of the Radio Button, passed on form submit */
@@ -61,7 +57,6 @@ export const RadioButton = React.forwardRef<
       warning,
       info,
       tooltipPosition,
-      "data-component": dataComponent = "radio-button",
       "data-element": dataElement,
       "data-role": dataRole,
       helpAriaLabel,
@@ -123,6 +118,7 @@ export const RadioButton = React.forwardRef<
       reverse: !reverse,
       ref,
       ...props,
+      "data-component": undefined,
     };
 
     invariant(
@@ -134,14 +130,15 @@ export const RadioButton = React.forwardRef<
     const componentToRender = (
       <RadioButtonStyle
         applyNewValidation={validationRedesignOptIn}
-        data-component={dataComponent}
-        data-role={dataRole}
-        data-element={dataElement}
         inline={inline}
         reverse={reverse}
         size={size}
         {...commonProps}
         {...marginProps}
+        {...tagComponent("radio-button", {
+          "data-element": dataElement,
+          "data-role": dataRole,
+        })}
       >
         <CheckableInput {...inputProps}>
           <RadioButtonSvg />

--- a/src/components/radio-button/radio-button.pw.tsx
+++ b/src/components/radio-button/radio-button.pw.tsx
@@ -2,7 +2,6 @@ import { expect, test } from "@playwright/experimental-ct-react";
 import React from "react";
 import {
   fieldHelpPreview,
-  getComponent,
   tooltipPreview,
 } from "../../../playwright/components/index";
 import {
@@ -55,15 +54,6 @@ const radioInputWidth = 16;
 const labelContainerWidth = 40;
 
 test.describe("should render RadioButton component", () => {
-  test("should render with data-component", async ({ mount, page }) => {
-    await mount(<RadioButtonComponent data-component={CHARACTERS.STANDARD} />);
-    const component = getComponent(page, CHARACTERS.STANDARD);
-    await expect(component).toHaveAttribute(
-      "data-component",
-      CHARACTERS.STANDARD,
-    );
-  });
-
   test("should render with data-element", async ({ mount, page }) => {
     await mount(<RadioButtonComponent data-element={CHARACTERS.STANDARD} />);
     const radiobuttonElement = radiobuttonComponent(page);

--- a/src/components/radio-button/radio-button.test.tsx
+++ b/src/components/radio-button/radio-button.test.tsx
@@ -176,6 +176,19 @@ test("sets the aria-label of the help icon to the provided `helpAriaLabel`", () 
   expect(helpIcon).toBeVisible();
 });
 
+test("renders with provided data- attributes", () => {
+  render(
+    <RadioButton
+      value="radio1"
+      label="Radio Button 1"
+      data-role="bar"
+      data-element="baz"
+    />,
+  );
+
+  expect(screen.getByTestId("bar")).toHaveAttribute("data-element", "baz");
+});
+
 // coverage
 test("renders with expected styles when `size` is 'large'", () => {
   render(<RadioButton value="radio1" label="Radio Button 1" size="large" />);

--- a/src/components/search/search.component.tsx
+++ b/src/components/search/search.component.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useImperativeHandle } from "react";
 import invariant from "invariant";
 import { MarginProps } from "styled-system";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import StyledSearch from "./search.style";
 import StyledSearchButton from "./search-button.style";
@@ -20,7 +21,7 @@ export interface SearchEvent {
   };
 }
 
-export interface SearchProps extends ValidationProps, MarginProps {
+export interface SearchProps extends ValidationProps, MarginProps, TagProps {
   /** Prop to specify the aria-label of the search component */
   "aria-label"?: string;
   /** Prop to specify the aria-label of the search button */
@@ -257,11 +258,10 @@ export const Search = React.forwardRef<SearchHandle, SearchProps>(
         variant={variant}
         mb={0}
         {...filterStyledSystemMarginProps(rest)}
-        data-component="search"
-        data-role="search"
         id={id}
         name={name}
         {...rest}
+        {...tagComponent("search", rest)}
       >
         <Textbox
           placeholder={placeholder}

--- a/src/components/search/search.test.tsx
+++ b/src/components/search/search.test.tsx
@@ -11,7 +11,7 @@ import I18nProvider from "../i18n-provider";
 jest.mock("../../__internal__/utils/logger");
 
 testStyledSystemMargin(
-  (props) => <Search value="" {...props} />,
+  (props) => <Search data-role="search" value="" {...props} />,
   () => screen.getByTestId("search"),
 );
 
@@ -292,13 +292,13 @@ test("when the component is uncontrolled, the `onClick` callback prop is called 
   );
 });
 
-test("the component's wrapper element has the appropriate `data-component` tag", () => {
-  render(<Search value="" />);
+test("the component's wrapper element has the appropriate `data-` tags", () => {
+  render(<Search data-role="foo" data-element="bar" value="" />);
 
-  expect(screen.getByTestId("search")).toHaveAttribute(
-    "data-component",
-    "search",
-  );
+  const search = screen.getByTestId("foo");
+
+  expect(search).toHaveAttribute("data-component", "search");
+  expect(search).toHaveAttribute("data-element", "bar");
 });
 
 test("do not render remove button when the input is empty", () => {
@@ -390,12 +390,14 @@ test("the input can be programmatically focused using a ref", async () => {
 
 // for coverage - dark variant styles are tested in Playwright
 test("should render the bottom border when variant is dark, the input is not focused and has a value", () => {
-  render(<Search variant="dark" value="search" />);
+  render(<Search data-role="search" variant="dark" value="search" />);
 
-  expect(screen.getByTestId("search")).toHaveStyle({
+  const search = screen.getByTestId("search");
+
+  expect(search).toHaveStyle({
     "background-color": "transparent",
   });
-  expect(screen.getByTestId("search")).toHaveStyleRule(
+  expect(search).toHaveStyleRule(
     "border-bottom",
     "var(--spacing025) solid var(--colorsUtilityYang080)",
   );
@@ -403,28 +405,29 @@ test("should render the bottom border when variant is dark, the input is not foc
 
 // for coverage - `searchWidth` prop is tested in Playwright
 test("applies the correct width specified by the user", () => {
-  render(<Search searchWidth="400px" defaultValue="" />);
+  render(<Search data-role="search" searchWidth="400px" defaultValue="" />);
 
-  expect(screen.getByTestId("search")).toHaveStyle({
+  const search = screen.getByTestId("search");
+
+  expect(search).toHaveStyle({
     display: "inline-flex",
     "font-weight": "500",
     width: "400px",
   });
-  expect(screen.getByTestId("search")).toHaveStyleRule(
+  expect(search).toHaveStyleRule(
     "border-bottom",
     "var(--spacing025) solid var(--colorsUtilityMajor300)",
   );
-  expect(screen.getByTestId("search")).toHaveStyleRule(
-    "font-size",
-    "var(--fontSize100)",
-  );
+  expect(search).toHaveStyleRule("font-size", "var(--fontSize100)");
 });
 
 // for coverage - `maxWidth` prop is tested in Playwright
 test("applies the correct maxWidth specified by the user", () => {
-  render(<Search maxWidth="67%" defaultValue="" />);
+  render(<Search data-role="search" maxWidth="67%" defaultValue="" />);
 
-  expect(screen.getByTestId("search")).toHaveStyle({
+  const search = screen.getByTestId("search");
+
+  expect(search).toHaveStyle({
     "max-width": "67%",
   });
 });

--- a/src/components/select/__internal__/select-textbox/select-textbox.component.tsx
+++ b/src/components/select/__internal__/select-textbox/select-textbox.component.tsx
@@ -12,7 +12,7 @@ import { ValidationProps } from "../../../../__internal__/validations";
 
 export interface FormInputPropTypes
   extends ValidationProps,
-    Omit<CommonTextboxProps, "onClick" | "onChange"> {
+    Omit<CommonTextboxProps, "onClick" | "onChange" | "data-component"> {
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
   adaptiveLabelBreakpoint?: number;
   /** Prop to specify the aria-label attribute of the component input */

--- a/src/components/select/filterable-select/filterable-select.component.tsx
+++ b/src/components/select/filterable-select/filterable-select.component.tsx
@@ -32,12 +32,6 @@ export interface FilterableSelectProps
   "aria-label"?: string;
   /** Prop to specify the aria-labelledby property of the component input */
   "aria-labelledby"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-component"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-element"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-role"?: string;
   /** Child components (such as Option or OptionRow) for the SelectList */
   children: React.ReactNode;
   /** The default selected value(s), when the component is operating in uncontrolled mode */
@@ -130,7 +124,6 @@ export const FilterableSelect = React.forwardRef<
       onListScrollBottom,
       tableHeader,
       multiColumn,
-      "data-component": dataComponent = "filterable-select",
       "data-element": dataElement,
       "data-role": dataRole,
       tooltipPosition,
@@ -677,6 +670,7 @@ export const FilterableSelect = React.forwardRef<
         required,
         isOptional,
         ...filterOutStyledSystemSpacingProps(textboxProps),
+        "data-component": undefined,
       };
     }
 
@@ -734,7 +728,7 @@ export const FilterableSelect = React.forwardRef<
         hasTextCursor
         readOnly={readOnly}
         disabled={disabled}
-        data-component={dataComponent}
+        data-component="filterable-select"
         data-role={dataRole}
         data-element={dataElement}
         isOpen={isOpen}

--- a/src/components/select/filterable-select/filterable-select.pw.tsx
+++ b/src/components/select/filterable-select/filterable-select.pw.tsx
@@ -168,17 +168,6 @@ test.describe("FilterableSelect component", () => {
     await expect(commonDataElementInputPreview(page)).toHaveId(testPropValue);
   });
 
-  test("should render with data-component prop set to test value", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<FilterableSelectComponent data-component={testPropValue} />);
-
-    await expect(
-      selectElementInput(page).locator("..").locator(".."),
-    ).toHaveAttribute("data-component", testPropValue);
-  });
-
   test("should render with data-element prop set to test value", async ({
     mount,
     page,

--- a/src/components/select/multi-select/multi-select.component.tsx
+++ b/src/components/select/multi-select/multi-select.component.tsx
@@ -42,12 +42,6 @@ export interface MultiSelectProps
   "aria-label"?: string;
   /** Prop to specify the aria-labelledby property of the component input */
   "aria-labelledby"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-component"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-element"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-role"?: string;
   /** Size of an input */
   size?: "small" | "medium" | "large";
   /** Child components (such as Option or OptionRow) for the SelectList */
@@ -132,7 +126,6 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
       multiColumn,
       tooltipPosition,
       size,
-      "data-component": dataComponent = "multiselect",
       "data-element": dataElement,
       "data-role": dataRole,
       listPlacement = "bottom",
@@ -677,6 +670,7 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
         required,
         isOptional,
         ...filterOutStyledSystemSpacingProps(textboxProps),
+        "data-component": undefined,
       };
     }
 
@@ -730,7 +724,7 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
         readOnly={readOnly}
         hasTextCursor
         size={size}
-        data-component={dataComponent}
+        data-component="multiselect"
         data-role={dataRole}
         data-element={dataElement}
         isOpen={isOpen}

--- a/src/components/select/multi-select/multi-select.pw.tsx
+++ b/src/components/select/multi-select/multi-select.pw.tsx
@@ -149,17 +149,6 @@ test.describe("MultiSelect component", () => {
     await expect(commonDataElementInputPreview(page)).toHaveId(testPropValue);
   });
 
-  test("should render with data-component prop set to test value", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<MultiSelectComponent data-component={testPropValue} />);
-
-    await expect(
-      selectElementInput(page).locator("..").locator(".."),
-    ).toHaveAttribute("data-component", testPropValue);
-  });
-
   test("should render with data-element prop set to test value", async ({
     mount,
     page,

--- a/src/components/select/option-group-header/option-group-header.component.tsx
+++ b/src/components/select/option-group-header/option-group-header.component.tsx
@@ -5,8 +5,7 @@ import guid from "../../../__internal__/utils/helpers/guid";
 import StyledOptionGroupHeader from "./option-group-header.style";
 import Icon, { IconProps } from "../../icon";
 
-export interface OptionGroupHeaderProps
-  extends Omit<TagProps, "data-component"> {
+export interface OptionGroupHeaderProps extends TagProps {
   /**
    * Unique identifier for the component.
    * Will use a randomly generated GUID if none is provided.

--- a/src/components/select/option-row/option-row.component.tsx
+++ b/src/components/select/option-row/option-row.component.tsx
@@ -5,7 +5,7 @@ import guid from "../../../__internal__/utils/helpers/guid";
 import StyledOptionRow from "./option-row.style";
 import SelectListContext from "../__internal__/select-list/select-list.context";
 
-export interface OptionRowProps extends Omit<TagProps, "data-component"> {
+export interface OptionRowProps extends TagProps {
   /** The option's visible text, displayed within <Textbox> of <Select> */
   text: string;
   /** Row content, should consist of multiple td elements */

--- a/src/components/select/option/option.component.tsx
+++ b/src/components/select/option/option.component.tsx
@@ -15,7 +15,7 @@ export interface OptionProps
       React.InputHTMLAttributes<HTMLLIElement>,
       "value" | "onSelect" | "onClick"
     >,
-    Omit<TagProps, "data-component"> {
+    TagProps {
   /**
    * Unique identifier for the component.
    * Will use a randomly generated GUID if none is provided.

--- a/src/components/select/simple-select/simple-select.component.tsx
+++ b/src/components/select/simple-select/simple-select.component.tsx
@@ -39,12 +39,6 @@ export interface SimpleSelectProps
   "aria-label"?: string;
   /** Prop to specify the aria-labelledby property of the component input */
   "aria-labelledby"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-component"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-element"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-role"?: string;
   /** Child components (such as Option or OptionRow) for the SelectList */
   children: React.ReactNode;
   /** The default selected value(s), when the component is operating in uncontrolled mode */
@@ -127,7 +121,6 @@ export const SimpleSelect = React.forwardRef<
       tableHeader,
       multiColumn,
       tooltipPosition,
-      "data-component": dataComponent = "simple-select",
       "data-element": dataElement,
       "data-role": dataRole,
       listPlacement = "bottom",
@@ -496,6 +489,7 @@ export const SimpleSelect = React.forwardRef<
         isOptional,
         transparent,
         ...filterOutStyledSystemSpacingProps(props),
+        "data-component": undefined,
       };
     }
 
@@ -545,7 +539,7 @@ export const SimpleSelect = React.forwardRef<
         transparent={transparent}
         disabled={disabled}
         readOnly={readOnly}
-        data-component={dataComponent}
+        data-component="simple-select"
         data-role={dataRole}
         data-element={dataElement}
         isOpen={isOpen}

--- a/src/components/select/simple-select/simple-select.pw.tsx
+++ b/src/components/select/simple-select/simple-select.pw.tsx
@@ -110,17 +110,6 @@ test.describe("SimpleSelect component", () => {
     });
   });
 
-  test("should render with data-component prop set to playwright_data", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SimpleSelectComponent data-component={testPropValue} />);
-
-    await expect(
-      selectElementInput(page).locator("..").locator(".."),
-    ).toHaveAttribute("data-component", testPropValue);
-  });
-
   test("should render with data-element prop set to playwright_data", async ({
     mount,
     page,

--- a/src/components/settings-row/settings-row.component.tsx
+++ b/src/components/settings-row/settings-row.component.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { MarginProps } from "styled-system";
 import Heading, { HeadingType } from "../heading";
-import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+import tagComponent, {
+  TagProps,
+} from "../../__internal__/utils/helpers/tags/tags";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 
 import {
@@ -10,7 +12,7 @@ import {
   StyledSettingsRowInput,
 } from "./settings-row.style";
 
-export interface SettingsRowProps extends MarginProps {
+export interface SettingsRowProps extends MarginProps, TagProps {
   /**  A title for this group of settings. */
   title?: string;
   /** Defines the HTML heading element of the `title` within the component. */

--- a/src/components/settings-row/settings-row.test.tsx
+++ b/src/components/settings-row/settings-row.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { HeadingType } from "../heading";
 import SettingsRow from ".";
+import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
 
 test("renders with children", () => {
   render(<SettingsRow>hello world</SettingsRow>);
@@ -73,3 +74,14 @@ test("renders a divider when the `divider` prop is passed", () => {
   );
   expect(settingsRow).toHaveStyleRule("padding-bottom", "30px");
 });
+
+test("renders with provided data- attributes", () => {
+  render(<SettingsRow data-role="bar" data-element="baz" />);
+
+  expect(screen.getByTestId("bar")).toHaveAttribute("data-element", "baz");
+});
+
+testStyledSystemMargin(
+  (props) => <SettingsRow {...props} />,
+  () => screen.getByTestId("settings-row"),
+);

--- a/src/components/sidebar/sidebar.component.tsx
+++ b/src/components/sidebar/sidebar.component.tsx
@@ -21,7 +21,7 @@ type CustomRefObject<T> = {
 
 export interface SidebarProps
   extends PaddingProps,
-    Omit<TagProps, "data-component">,
+    TagProps,
     WidthProps,
     Pick<ModalProps, "topModalOverride" | "restoreFocusOnClose"> {
   /** Prop to specify the aria-describedby property of the component */
@@ -32,7 +32,7 @@ export interface SidebarProps
    */
   "aria-label"?: string;
   /**
-   * Prop to specify the aria-labeledby property of the component
+   * Prop to specify the aria-labelledby property of the component
    * To be used when the header prop is a custom React Node,
    * or the component is labelled by an internal element other than the header.
    */

--- a/src/components/simple-color-picker/simple-color-picker.component.tsx
+++ b/src/components/simple-color-picker/simple-color-picker.component.tsx
@@ -10,7 +10,9 @@ import { MarginProps } from "styled-system";
 import invariant from "invariant";
 
 import Events from "../../__internal__/utils/helpers/events";
-import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+import tagComponent, {
+  TagProps,
+} from "../../__internal__/utils/helpers/tags/tags";
 import Fieldset from "../../__internal__/fieldset";
 import SimpleColor, { SimpleColorProps } from "./simple-color";
 import RadioButtonMapper from "../../__internal__/radio-button-mapper/radio-button-mapper.component";
@@ -23,7 +25,10 @@ import Logger from "../../__internal__/utils/logger";
 
 let deprecateUncontrolledWarnTriggered = false;
 
-export interface SimpleColorPickerProps extends ValidationProps, MarginProps {
+export interface SimpleColorPickerProps
+  extends ValidationProps,
+    MarginProps,
+    TagProps {
   /** The SimpleColor components to be rendered in the group */
   children?: React.ReactNode;
   /** prop that represents childWidth */

--- a/src/components/simple-color-picker/simple-color-picker.test.tsx
+++ b/src/components/simple-color-picker/simple-color-picker.test.tsx
@@ -36,6 +36,26 @@ testStyledSystemMargin(
   () => screen.getByRole("radiogroup"),
 );
 
+test("renders with provided data- attributes", () => {
+  render(
+    <SimpleColorPicker
+      legend="SimpleColorPicker Legend"
+      name="test"
+      data-role="bar"
+      data-element="baz"
+    >
+      <SimpleColor value="#00A376" />
+    </SimpleColorPicker>,
+  );
+
+  const group = screen.getByRole("radiogroup", {
+    name: "SimpleColorPicker Legend",
+  });
+
+  expect(group).toHaveAttribute("data-role", "bar");
+  expect(group).toHaveAttribute("data-element", "baz");
+});
+
 test("the `onKeyDown` callback prop is called when the user presses a key", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
   const onKeyDown = jest.fn();

--- a/src/components/split-button/split-button.component.tsx
+++ b/src/components/split-button/split-button.component.tsx
@@ -24,22 +24,20 @@ import { baseTheme } from "../../style/themes";
 import useChildButtons from "../../hooks/__internal__/useChildButtons";
 import SplitButtonContext from "./__internal__/split-button.context";
 import useLocale from "../../hooks/__internal__/useLocale";
+import { TagProps } from "../../__internal__/utils/helpers/tags";
 
 const CONTENT_WIDTH_RATIO = 0.75;
 
 export interface SplitButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    MarginProps {
+    MarginProps,
+    TagProps {
   /** Set align of the rendered content */
   align?: "left" | "right";
   /** Button type: "primary" | "secondary" */
   buttonType?: "primary" | "secondary";
   /** The additional button to display. */
   children: React.ReactNode;
-  /** A custom value for the data-element attribute */
-  "data-element"?: string;
-  /** A custom value for the data-role attribute */
-  "data-role"?: string;
   /** Prop to specify an aria-label for the component */
   "aria-label"?: string;
   /** Gives the button a disabled state. */

--- a/src/components/step-flow/step-flow.test.tsx
+++ b/src/components/step-flow/step-flow.test.tsx
@@ -589,3 +589,21 @@ describe("console warning checks", () => {
     expect(consoleSpy).toHaveBeenCalledWith(noRefWarnMessage);
   });
 });
+
+test("renders with provided data- attributes", () => {
+  render(
+    <StepFlow
+      title="baz"
+      totalSteps={6}
+      currentStep={1}
+      ref={() => {}}
+      data-role="foo"
+      data-element="bar"
+    />,
+  );
+
+  const stepFlowComponent = screen.getByRole("group");
+
+  expect(stepFlowComponent).toHaveAttribute("data-role", "foo");
+  expect(stepFlowComponent).toHaveAttribute("data-element", "bar");
+});

--- a/src/components/step-sequence/step-sequence-item/step-sequence-item.component.tsx
+++ b/src/components/step-sequence/step-sequence-item/step-sequence-item.component.tsx
@@ -7,8 +7,11 @@ import {
 } from "./step-sequence-item.style";
 import Icon from "../../icon";
 import { StepSequenceContext } from "../step-sequence.component";
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags";
 
-export interface StepSequenceItemProps {
+export interface StepSequenceItemProps extends TagProps {
   /** Aria label */
   ariaLabel?: string;
   /** Hidden label to be displayed if item is complete */
@@ -68,12 +71,12 @@ export const StepSequenceItem = ({
 
   return (
     <StyledStepSequenceItem
-      data-component="step-sequence-item"
       orientation={orientation}
       status={status}
       key={`step-seq-item-${indicator}`}
       aria-label={ariaLabel}
       {...rest}
+      {...tagComponent("step-sequence-item", rest)}
     >
       {hiddenLabel()}
       <StyledStepSequenceItemContent>

--- a/src/components/step-sequence/step-sequence-item/step-sequence-item.test.tsx
+++ b/src/components/step-sequence/step-sequence-item/step-sequence-item.test.tsx
@@ -78,3 +78,16 @@ test("renders with a tick Icon when status is 'complete'", () => {
 
   expect(within(step).getByTestId("icon")).toHaveAttribute("type", "tick");
 });
+
+test("renders with provided data- attributes", () => {
+  render(
+    <StepSequenceItem indicator="1" data-element="bar" data-role="baz">
+      Step
+    </StepSequenceItem>,
+  );
+
+  const step = screen.getByRole("listitem");
+
+  expect(step).toHaveAttribute("data-element", "bar");
+  expect(step).toHaveAttribute("data-role", "baz");
+});

--- a/src/components/step-sequence/step-sequence.component.tsx
+++ b/src/components/step-sequence/step-sequence.component.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { SpaceProps } from "styled-system";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 import StyledStepSequence from "./step-sequence.style";
 
 export const StepSequenceContext = React.createContext<{
   orientation: "horizontal" | "vertical";
 }>({ orientation: "horizontal" });
 
-export interface StepSequenceProps extends SpaceProps {
+export interface StepSequenceProps extends SpaceProps, TagProps {
   /** Step sequence items to be rendered */
   children: React.ReactNode;
   /** The direction that step sequence items should be rendered */
@@ -20,10 +21,10 @@ export const StepSequence = ({
 }: StepSequenceProps) => {
   return (
     <StyledStepSequence
-      data-component="step-sequence"
       orientation={orientation}
       p={0}
       {...props}
+      {...tagComponent("step-sequence", props)}
     >
       <StepSequenceContext.Provider value={{ orientation }}>
         {children}

--- a/src/components/step-sequence/step-sequence.test.tsx
+++ b/src/components/step-sequence/step-sequence.test.tsx
@@ -31,6 +31,17 @@ test("renders with `orientation` prop set to 'vertical'", () => {
   });
 });
 
+test("renders with provided data- attributes", () => {
+  render(
+    <StepSequence data-element="bar" data-role="baz">
+      <StepSequenceItem indicator="1">Step 1</StepSequenceItem>
+    </StepSequence>,
+  );
+
+  expect(screen.getByRole("list")).toHaveAttribute("data-element", "bar");
+  expect(screen.getByRole("list")).toHaveAttribute("data-role", "baz");
+});
+
 testStyledSystemSpacing(
   (props) => (
     <StepSequence {...props}>

--- a/src/components/switch/switch.component.tsx
+++ b/src/components/switch/switch.component.tsx
@@ -5,6 +5,7 @@ import Box from "../box";
 import CheckableInput, {
   CommonCheckableInputProps,
 } from "../../__internal__/checkable-input";
+import { TagProps } from "../../__internal__/utils/helpers/tags";
 import Label from "../../__internal__/label";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import NewValidationContext from "../carbon-provider/__internal__/new-validation.context";
@@ -17,13 +18,10 @@ import SwitchSlider from "./__internal__/switch-slider.component";
 import guid from "../../__internal__/utils/helpers/guid";
 import HintText from "../../__internal__/hint-text";
 
-export interface SwitchProps extends CommonCheckableInputProps, MarginProps {
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-component"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-element"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-role"?: string;
+export interface SwitchProps
+  extends CommonCheckableInputProps,
+    MarginProps,
+    TagProps {
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
   adaptiveLabelBreakpoint?: number;
   /** Set the default value of the Switch if component is meant to be used as uncontrolled */
@@ -75,7 +73,6 @@ export const Switch = React.forwardRef(
       error,
       warning,
       info,
-      "data-component": dataComponent = "switch",
       "data-element": dataElement,
       "data-role": dataRole,
       helpAriaLabel,
@@ -124,7 +121,7 @@ export const Switch = React.forwardRef(
     const marginProps = useFormSpacing(rest);
 
     const switchStyleProps = {
-      "data-component": dataComponent,
+      "data-component": "switch",
       "data-role": dataRole,
       "data-element": dataElement,
       checked: isControlled ? checked : checkedInternal,
@@ -178,12 +175,13 @@ export const Switch = React.forwardRef(
       required,
       isOptional,
       ...rest,
+      "data-component": undefined,
     };
 
     // Created separate const declarations to help when removing the old validation.
     // Not all props utilised by the old validation work or will be needed with the new validation.
     const switchStylePropsForNewValidation = {
-      "data-component": dataComponent,
+      "data-component": "switch",
       "data-role": dataRole,
       "data-element": dataElement,
       checked: isControlled ? checked : checkedInternal,

--- a/src/components/switch/switch.pw.tsx
+++ b/src/components/switch/switch.pw.tsx
@@ -18,7 +18,6 @@ import {
   switchFieldHelp,
 } from "../../../playwright/components/switch/index";
 import {
-  getComponent,
   fieldHelpPreview,
   tooltipPreview,
   getDataElementByValue,
@@ -102,15 +101,6 @@ test.describe("Prop tests for Switch component", () => {
         await expect(switchInput(page)).not.toBeDisabled();
       }
     });
-  });
-
-  test("should render with data-component", async ({ mount, page }) => {
-    await mount(<SwitchComponent data-component={CHARACTERS.STANDARD} />);
-
-    await expect(getComponent(page, CHARACTERS.STANDARD)).toHaveAttribute(
-      "data-component",
-      CHARACTERS.STANDARD,
-    );
   });
 
   test("should render with data-element", async ({ mount, page }) => {
@@ -666,15 +656,6 @@ test.describe("Accessibility tests", () => {
 
       await checkAccessibility(page);
     });
-  });
-
-  test("check accessibility with data-component prop set", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SwitchComponent data-component={CHARACTERS.STANDARD} />);
-
-    await checkAccessibility(page);
   });
 
   test("check accessibility with data-element prop set", async ({

--- a/src/components/tabs/tab/tab.component.tsx
+++ b/src/components/tabs/tab/tab.component.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { PaddingProps } from "styled-system";
 import StyledTab from "./tab.style";
-import tagComponent from "../../../__internal__/utils/helpers/tags/tags";
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags/tags";
 import TabContext from "./__internal__/tab.context";
 
-export interface TabProps extends PaddingProps {
+export interface TabProps extends PaddingProps, TagProps {
   title?: string;
   /** A unique ID to identify this specific tab. */
   tabId: string;
@@ -129,8 +131,8 @@ export const Tab = ({
         isTabSelected={isTabSelected}
         aria-labelledby={ariaLabelledby}
         position={position}
-        {...tagComponent("tab", rest)}
         {...rest}
+        {...tagComponent("tab", rest)}
       >
         {!href && children}
       </StyledTab>

--- a/src/components/tabs/tab/tab.test.tsx
+++ b/src/components/tabs/tab/tab.test.tsx
@@ -124,6 +124,15 @@ test("calls the `updateWarnings` function prop when a warning is present in a ch
   expect(updateWarnings).toHaveBeenCalledWith("foo", { bar: true });
 });
 
+test("renders with provided data- attributes", () => {
+  render(<Tab tabId="foo" data-role="bar" data-element="baz" />);
+
+  const tab = screen.getByRole("tabpanel", { hidden: true });
+
+  expect(tab).toHaveAttribute("data-role", "bar");
+  expect(tab).toHaveAttribute("data-element", "baz");
+});
+
 // coverage - need to render the styled component directly to cover the default prop assignments
 test("renders with correct styles", () => {
   render(<StyledTab data-role="styled-component" />);

--- a/src/components/tabs/tabs.component.tsx
+++ b/src/components/tabs/tabs.component.tsx
@@ -14,13 +14,15 @@ import React, {
 import { MarginProps } from "styled-system";
 import Tab from "./tab";
 import Event from "../../__internal__/utils/helpers/events";
-import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+import tagComponent, {
+  TagProps,
+} from "../../__internal__/utils/helpers/tags/tags";
 import StyledTabs from "./tabs.style";
 import TabsHeader from "./__internal__/tabs-header";
 import TabTitle from "./__internal__/tab-title";
 import DrawerSidebarContext from "../drawer/__internal__/drawer-sidebar.context";
 
-export interface TabsProps extends MarginProps {
+export interface TabsProps extends MarginProps, TagProps {
   /** Prevent rendering of hidden tabs, by default this is set to true and therefore all tabs will be rendered */
   renderHiddenTabs?: boolean;
   /** Allows manual control over the currently selected tab. */
@@ -404,10 +406,10 @@ const Tabs = ({
     <StyledTabs
       position={isInSidebar ? "left" : position}
       data-role="tabs"
-      {...tagComponent("tabs", rest)}
       isInSidebar={isInSidebar}
       headerWidth={headerWidth}
       {...rest}
+      {...tagComponent("tabs", rest)}
     >
       {renderTabHeaders()}
       {renderTabs()}

--- a/src/components/textarea/textarea.component.tsx
+++ b/src/components/textarea/textarea.component.tsx
@@ -9,6 +9,7 @@ import { MarginProps } from "styled-system";
 
 import { IconType } from "../icon";
 import { ValidationProps } from "../../__internal__/validations";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 import { CommonInputProps, InputPresentation } from "../../__internal__/input";
 import FormField from "../../__internal__/form-field";
 import useCharacterCount from "../../hooks/__internal__/useCharacterCount";
@@ -32,15 +33,10 @@ import HintText from "../../__internal__/hint-text";
 export interface TextareaProps
   extends ValidationProps,
     MarginProps,
-    Omit<CommonInputProps, "size"> {
+    Omit<CommonInputProps, "size">,
+    TagProps {
   /** Prop to specify the aria-labelledby property of the component */
   "aria-labelledby"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-component"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-element"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-role"?: string;
   /** id of the input */
   id?: string;
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
@@ -172,7 +168,6 @@ export const Textarea = React.forwardRef(
       labelWidth = 30,
       tooltipPosition,
       value,
-      "data-component": dataComponent,
       "data-element": dataElement,
       "data-role": dataRole,
       helpAriaLabel,
@@ -406,12 +401,13 @@ export const Textarea = React.forwardRef(
         <InputBehaviour>
           <StyledTextarea
             labelInline={labelInlineWithNewValidation}
-            data-component={dataComponent}
-            data-role={dataRole}
-            data-element={dataElement}
             hasIcon={hasIconInside}
             minHeight={textareaMinHeight}
             {...marginProps}
+            {...tagComponent("textarea", {
+              "data-element": dataElement,
+              "data-role": dataRole,
+            })}
           >
             <FormField
               fieldHelp={computeLabelPropValues(fieldHelp)}

--- a/src/components/textarea/textarea.pw.tsx
+++ b/src/components/textarea/textarea.pw.tsx
@@ -54,14 +54,6 @@ import {
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
 test.describe("Props tests for Textarea component", () => {
-  test("should render with data-component prop", async ({ mount, page }) => {
-    await mount(<TextareaComponent data-component={CHARACTERS.STANDARD} />);
-
-    const testElement = getComponent(page, CHARACTERS.STANDARD);
-
-    await expect(testElement).toBeVisible();
-  });
-
   test("should render with data-element prop", async ({ mount, page }) => {
     await mount(<TextareaComponent data-element={CHARACTERS.STANDARD} />);
 

--- a/src/components/textbox/textbox.component.tsx
+++ b/src/components/textbox/textbox.component.tsx
@@ -24,10 +24,9 @@ import useCharacterCount from "../../hooks/__internal__/useCharacterCount";
 import useUniqueId from "../../hooks/__internal__/useUniqueId";
 import guid from "../../__internal__/utils/helpers/guid";
 import useInputAccessibility from "../../hooks/__internal__/useInputAccessibility/useInputAccessibility";
-
 import ErrorBorder from "./textbox.style";
-
 import StyledPrefix from "./__internal__/prefix.style";
+import { TagProps } from "../../__internal__/utils/helpers/tags";
 
 export const ALIGN_DEFAULT = "left";
 export const SIZE_DEFAULT = "medium";
@@ -37,15 +36,10 @@ export const LABEL_VALIDATION_DEFAULT = false;
 export interface CommonTextboxProps
   extends ValidationProps,
     MarginProps,
-    Omit<CommonInputProps, "size" | "inputBorderRadius"> {
+    Omit<CommonInputProps, "size" | "inputBorderRadius">,
+    TagProps {
   /** Prop to specify the aria-labelledby property of the component */
   "aria-labelledby"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-component"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-element"?: string;
-  /** Identifier used for testing purposes, applied to the root element of the component. */
-  "data-role"?: string;
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
   adaptiveLabelBreakpoint?: number;
   /** Integer to determine a timeout for the deferred callback */
@@ -130,6 +124,8 @@ export interface CommonTextboxProps
   isOptional?: boolean;
   /** The id attribute for the validation tooltip */
   tooltipId?: string;
+  /** @private @internal @ignore */
+  "data-component"?: string;
 }
 
 export interface TextboxProps extends CommonTextboxProps {

--- a/src/components/textbox/textbox.pw.tsx
+++ b/src/components/textbox/textbox.pw.tsx
@@ -102,14 +102,6 @@ test.describe("Prop checks for Textbox component", () => {
     expect(contentValue).toContain("(optional)");
   });
 
-  test("should render with data-component prop", async ({ mount, page }) => {
-    await mount(<TextboxComponent data-component={CHARACTERS.STANDARD} />);
-
-    await expect(
-      getDataComponentByValue(page, CHARACTERS.STANDARD),
-    ).toBeVisible();
-  });
-
   test("should render with data-element prop", async ({ mount, page }) => {
     await mount(<TextboxComponent data-element={CHARACTERS.STANDARD} />);
 

--- a/src/components/tile-select/tile-select-group/tile-select-group.component.tsx
+++ b/src/components/tile-select/tile-select-group/tile-select-group.component.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { MarginProps } from "styled-system";
 
-import tagComponent from "../../../__internal__/utils/helpers/tags/tags";
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags/tags";
 import RadioButtonMapper from "../../../__internal__/radio-button-mapper/radio-button-mapper.component";
 import {
   StyledTileSelectFieldset,
@@ -10,7 +12,7 @@ import {
 import { filterStyledSystemMarginProps } from "../../../style/utils";
 import { TileSelectDeselectEvent } from "../tile-select.component";
 
-export interface TileSelectGroupProps extends MarginProps {
+export interface TileSelectGroupProps extends MarginProps, TagProps {
   /** The TileSelect components to be rendered in the group */
   children: React.ReactNode;
   /** The content for the TileSelectGroup Legend */

--- a/src/components/tile-select/tile-select.component.tsx
+++ b/src/components/tile-select/tile-select.component.tsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect, useRef } from "react";
 import { MarginProps } from "styled-system";
 
-import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+import tagComponent, {
+  TagProps,
+} from "../../__internal__/utils/helpers/tags/tags";
 import useLocale from "../../hooks/__internal__/useLocale";
 import createGuid from "../../__internal__/utils/helpers/guid";
 import Button from "../button";
@@ -36,7 +38,7 @@ export interface TileSelectDeselectEvent {
   };
 }
 
-export interface TileSelectProps extends MarginProps {
+export interface TileSelectProps extends MarginProps, TagProps {
   /** title of the TileSelect */
   title?: React.ReactNode;
   /** adornment to be rendered next to the title */
@@ -107,6 +109,8 @@ const TileSelect = React.forwardRef<HTMLInputElement, TileSelectProps>(
       accordionContent,
       accordionControl,
       accordionExpanded,
+      "data-element": dataElement,
+      "data-role": dataRole,
       ...rest
     }: TileSelectProps,
     ref,
@@ -157,7 +161,10 @@ const TileSelect = React.forwardRef<HTMLInputElement, TileSelectProps>(
       <StyledTileSelectContainer
         checked={checked}
         disabled={disabled}
-        {...tagComponent("tile-select", rest)}
+        {...tagComponent("tile-select", {
+          "data-element": dataElement,
+          "data-role": dataRole,
+        })}
         {...filterStyledSystemMarginProps(rest)}
       >
         <StyledFocusWrapper

--- a/src/components/tile-select/tile-select.test.tsx
+++ b/src/components/tile-select/tile-select.test.tsx
@@ -30,6 +30,12 @@ testStyledSystemMargin(
   () => screen.getByTestId("tile-select-group"),
 );
 
+test("should render with provided data- attributes", () => {
+  render(<TileSelect data-element="bar" data-role="baz" />);
+
+  expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
 test("the deselect action button is rendered when TileSelect is checked", () => {
   render(<TileSelect checked />);
 
@@ -268,6 +274,22 @@ describe("TileSelectGroup", () => {
     }).not.toThrow();
 
     expect(consoleSpy).not.toHaveBeenCalled();
+  });
+
+  test("should render with provided data- attributes", () => {
+    render(
+      <TileSelectGroup
+        name="TileSelectGroup"
+        data-element="bar"
+        data-role="baz"
+      >
+        <TileSelect />
+      </TileSelectGroup>,
+    );
+
+    const tileSelectGroup = screen.getByRole("group");
+    expect(tileSelectGroup).toHaveAttribute("data-element", "bar");
+    expect(tileSelectGroup).toHaveAttribute("data-role", "baz");
   });
 });
 

--- a/src/components/tile/flex-tile-divider/flex-tile-divider.component.tsx
+++ b/src/components/tile/flex-tile-divider/flex-tile-divider.component.tsx
@@ -12,7 +12,7 @@ export const FlexTileDivider = (): JSX.Element => {
       width="100vw"
       m="0px 0px -1px 0px"
     >
-      <Hr aria-hidden="true" m={0} />
+      <Hr aria-hidden="true" data-role="hr" m={0} />
     </Box>
   );
 };

--- a/src/components/time/__internal__/time-toggle/time-toggle.component.tsx
+++ b/src/components/time/__internal__/time-toggle/time-toggle.component.tsx
@@ -7,12 +7,12 @@ import useLocale from "../../../../hooks/__internal__/useLocale";
 import { ButtonToggle, ButtonToggleGroup } from "../../../button-toggle";
 
 export interface ToggleDataProps {
-  wrapperProps?: Omit<TagProps, "data-component">;
-  amToggleProps?: Omit<TagProps, "data-component">;
-  pmToggleProps?: Omit<TagProps, "data-component">;
+  wrapperProps?: TagProps;
+  amToggleProps?: TagProps;
+  pmToggleProps?: TagProps;
 }
 
-export interface ToggleProps extends Omit<TagProps, "data-component"> {
+export interface ToggleProps extends TagProps {
   size?: "small" | "medium" | "large";
   onChange: (pressedValue: ToggleValue) => void;
   toggleValue: ToggleValue;

--- a/src/components/time/time.component.tsx
+++ b/src/components/time/time.component.tsx
@@ -41,9 +41,7 @@ export interface TimeInputEvent {
   };
 }
 
-interface TimeInputProps
-  extends Omit<TagProps, "data-component">,
-    Omit<ValidationProps, "info"> {
+interface TimeInputProps extends TagProps, Omit<ValidationProps, "info"> {
   /** Set an id value on the input */
   id?: string;
   /** Override the default label text */
@@ -52,9 +50,7 @@ interface TimeInputProps
   "aria-label"?: string;
 }
 
-export interface TimeProps
-  extends Omit<TagProps, "data-component">,
-    MarginProps {
+export interface TimeProps extends TagProps, MarginProps {
   /** Label text for the component */
   label?: string;
   /** Label alignment */

--- a/src/components/time/time.test.tsx
+++ b/src/components/time/time.test.tsx
@@ -1096,33 +1096,31 @@ test("should apply the custom `data-` attributes on the toggle component wrapper
       label="Time"
       onChange={() => {}}
       toggleProps={{
-        wrapperProps: { "data-element": "foo", "data-role": "bar" },
+        wrapperProps: { "data-element": "foo", "data-role": "wrapper-role" },
         amToggleProps: {
           "data-element": "foo",
-          "data-role": "am-button-wrapper",
+          "data-role": "am-button-wrapper-role",
         },
         pmToggleProps: {
           "data-element": "foo",
-          "data-role": "pm-button-wrapper",
+          "data-role": "pm-button-wrapper-role",
         },
       }}
     />,
   );
 
-  const fieldset = screen.getByRole("group", { name: "Time" });
-  const toggleButtonGroup = within(fieldset).getByRole("group");
+  const toggleButtonGroup = screen.getByTestId("wrapper-role");
   expect(toggleButtonGroup).toHaveAttribute(
     "data-component",
     "time-button-toggle-group",
   );
   expect(toggleButtonGroup).toHaveAttribute("data-element", "foo");
-  expect(toggleButtonGroup).toHaveAttribute("data-role", "bar");
 
-  const amButtonWrapper = screen.getByTestId("am-button-wrapper");
+  const amButtonWrapper = screen.getByTestId("am-button-wrapper-role");
   expect(amButtonWrapper).toHaveAttribute("data-component", "am-button-toggle");
   expect(amButtonWrapper).toHaveAttribute("data-element", "foo");
 
-  const pmButtonWrapper = screen.getByTestId("pm-button-wrapper");
+  const pmButtonWrapper = screen.getByTestId("pm-button-wrapper-role");
   expect(pmButtonWrapper).toHaveAttribute("data-component", "pm-button-toggle");
   expect(pmButtonWrapper).toHaveAttribute("data-element", "foo");
 });

--- a/src/components/toast/toast.component.tsx
+++ b/src/components/toast/toast.component.tsx
@@ -41,7 +41,7 @@ interface IconTypes {
   notice?: "none";
 }
 
-export interface ToastProps {
+export interface ToastProps extends TagProps {
   /** Sets the horizontal alignment of the component. */
   align?: AlignOptions;
   /** Sets the vertical alignment of the component */
@@ -52,8 +52,6 @@ export interface ToastProps {
   variant?: ToastVariants;
   /** Custom id  */
   id?: string;
-  /** Component name */
-  "data-component"?: string;
   /** Determines if the Toast is open. */
   open?: boolean;
   /** Callback for when dismissed. */
@@ -218,7 +216,7 @@ export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
             alignY={alignY}
             isNotice={isNotice}
             isNotification={isNotification}
-            {...tagComponent(restProps["data-component"] || "toast", restProps)}
+            {...tagComponent("toast", restProps)}
             variant={toastVariant}
             id={id}
             maxWidth={maxWidth}

--- a/src/components/toast/toast.pw.tsx
+++ b/src/components/toast/toast.pw.tsx
@@ -15,10 +15,7 @@ import {
 import { alertDialogPreview } from "../../../playwright/components/dialog";
 import { TOAST_COLORS } from "./toast.config";
 
-import {
-  getDataComponentByValue,
-  button,
-} from "../../../playwright/components";
+import { button } from "../../../playwright/components";
 import { checkAccessibility } from "../../../playwright/support/helper";
 import { closeIconButton } from "../../../playwright/components/index";
 import { CHARACTERS } from "../../../playwright/support/constants";
@@ -73,12 +70,6 @@ test.describe("Toast component", () => {
     await mount(<ToastComponent id={testData} />);
 
     await expect(toastComponent(page)).toHaveId(testData);
-  });
-
-  test("should render with data-component prop", async ({ mount, page }) => {
-    await mount(<ToastComponent data-component={testData} />);
-
-    await expect(getDataComponentByValue(page, testData)).toBeVisible();
   });
 
   (

--- a/src/components/tooltip/tooltip.component.tsx
+++ b/src/components/tooltip/tooltip.component.tsx
@@ -20,7 +20,9 @@ import {
 import StyledTooltip from "./tooltip.style";
 import StyledPointer from "./tooltip-pointer.style";
 import { TooltipPositions, TOOLTIP_POSITIONS } from "./tooltip.config";
-import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+import tagComponent, {
+  TagProps,
+} from "../../__internal__/utils/helpers/tags/tags";
 import Portal from "../portal";
 
 function preserveRef<ElementType>(
@@ -40,7 +42,7 @@ const TOOLTIP_DELAY = 100;
 
 export type InputSizes = "small" | "medium" | "large";
 
-export interface TooltipProps {
+export interface TooltipProps extends TagProps {
   /** The message to be displayed within the tooltip */
   message: React.ReactNode;
   /** The id attribute to use for the tooltip */

--- a/src/components/typography/typography.component.tsx
+++ b/src/components/typography/typography.component.tsx
@@ -93,6 +93,8 @@ export interface TypographyProps extends SpaceProps, TagProps {
    * @ignore
    * Sets className for component. INTERNAL USE ONLY. */
   className?: string;
+  /** @private @internal @ignore */
+  "data-component"?: string;
 }
 
 export const Typography = ({

--- a/src/components/vertical-divider/vertical-divider.component.tsx
+++ b/src/components/vertical-divider/vertical-divider.component.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import { SpaceProps } from "styled-system";
 import MenuContext from "../menu/__internal__/menu.context";
 import { StyledVerticalWrapper, StyledDivider } from "./vertical-divider.style";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 type TintRange =
   | 1
@@ -105,7 +106,7 @@ type TintRange =
   | 99
   | 100;
 
-export interface VerticalDividerProps extends SpaceProps {
+export interface VerticalDividerProps extends SpaceProps, TagProps {
   /** Shorthand for the height attribute */
   h?: number | string;
   /** Height attribute of the component */
@@ -136,7 +137,6 @@ export const VerticalDivider = ({
 
   return (
     <StyledVerticalWrapper
-      data-component="vertical-divider"
       data-role="vertical-divider"
       p={props.p || 3}
       height={h || height}
@@ -144,6 +144,7 @@ export const VerticalDivider = ({
       {...props}
       as={inMenu ? "li" : "div"}
       aria-hidden={inMenu ?? ariaHidden}
+      {...tagComponent("vertical-divider", props)}
     >
       <StyledDivider data-role="divider" tint={tint} />
     </StyledVerticalWrapper>

--- a/src/components/vertical-divider/vertical-divider.test.tsx
+++ b/src/components/vertical-divider/vertical-divider.test.tsx
@@ -88,3 +88,9 @@ test("should not allow the `aria-hidden` attribute to be overridden when in a me
 
   expect(verticalDividerElement).toHaveAttribute("aria-hidden", "true");
 });
+
+test("should render with provided data- attributes", () => {
+  render(<VerticalDivider data-role="bar" data-element="baz" />);
+
+  expect(screen.getByTestId("bar")).toHaveAttribute("data-element", "baz");
+});


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- All components should accept data-role and data-element props, set to the root of the component. 
- All component prop table should display supported data-role and data-element props.
- Removed all instances of data-component prop in public interfaces, data-component attribute should only be used internally. 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- Some components do not accept data-role and data-element props. 
- Some component accept  data-role and data-element props but are not documented in our prop tables. 
- Some components support overriding the default data-component attribute. 
- Some component interfaces contain a data-component prop. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
