### PR TITLE
docs(portrait): resolve missing prop table in storybook docs

### DIFF
--- a/src/components/portrait/portrait.component.tsx
+++ b/src/components/portrait/portrait.component.tsx
@@ -58,7 +58,7 @@ export interface PortraitProps extends MarginProps {
   foregroundColor?: string;
 }
 
-const Portrait = ({
+export const Portrait = ({
   alt,
   backgroundColor,
   foregroundColor = undefined,


### PR DESCRIPTION
### Proposed behaviour

Ensure `Portrait` prop table correctly dislays:
![Screenshot 2025-02-20 at 09 43 06](https://github.com/user-attachments/assets/0f31ccd4-af95-4f36-b051-adb3763bf5eb)


### Current behaviour

`Portrait` prop table is missing from its docs:
![Screenshot 2025-02-20 at 09 37 15](https://github.com/user-attachments/assets/998d2232-53d5-49db-a1a8-4140204955ea)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

After investigating, the issue appears to be caused by a bug in the Storybook plugin we use for parsing React components, `react-docgen-typescript` ([link to docs](https://storybook.js.org/docs/api/arg-types#automatic-argtype-inference)).

Debugging revealed that changing the Portrait component to a named export within its `*.component.tsx` file fixes the issue, with the component's storybook metadata correctly containing the generated arg types. This seems to signify a bug with the plugin's parsing ability.
