### PR TITLE
feat(content): reduce margin of content body to 24px when inline

### DIFF
--- a/src/components/content/content.style.ts
+++ b/src/components/content/content.style.ts
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+
 import { MarginProps, margin } from "styled-system";
 
 import { baseTheme } from "../../style/themes";
@@ -116,12 +117,12 @@ const StyledContentBody = styled.div<StyledContentBodyProps>`
       css`
         margin-top: 15px;
       `}
-      
+
       ${inline &&
       !bodyFullWidth &&
       css`
         margin-top: 0;
-        margin-left: 30px;
+        margin-left: var(--spacing300);
         text-align: left;
       `}
     `;


### PR DESCRIPTION
### Proposed behaviour

The margin between the content title and the content body is 24px;

### Current behaviour

The margin between the content title and the content body is 30px;

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required
