### PR TITLE
docs: update old React v17 import in usage guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,14 @@
 
 ### ⚠ BREAKING CHANGES
 
-* Temporary incompatibility with React Strict Mode. In React v18, Strict Mode
-now intentionally re-renders components and re-executes their effects and callbacks an extra time.
-This leads to unintended side effects in several Carbon components.
+* **Temporary incompatibility with React Strict Mode.**
+  In React v18, Strict Mode now intentionally re-renders components and re-executes their effects and callbacks an extra time. This leads to unintended side effects in several Carbon components.
 
-A fix will be provided in advance of introducing React v19 support.
-
-If you encounter issues, you can either disable Strict Mode globally, or apply it selectively to
-specific parts of your application.
-* Both packages are now ESM-only, which may affect tools like Jest
-that run your project code in a Node.js environment. Adjust your bundler configuration
-to handle ESM code if issues arise.
+  A fix will be provided in advance of introducing React v19 support.
+  
+  If you encounter issues, you can either disable Strict Mode globally, or apply it selectively to specific parts of your application.
+* **Both `react-dnd` and `react-dnd-html5-backend` are now ESM-only.**
+  This may affect tools like Jest that run your project code in a Node.js environment. Adjust your bundler configuration to handle ESM code if issues arise.
 
 ### Features
 
@@ -27,7 +24,7 @@ to handle ESM code if issues arise.
 * **menu:** prevent showing hover styling for non-focusable menu items ([db8f54c](https://github.com/Sage/carbon/commit/db8f54c65f581c465b20cd43013d42f99cf1b725))
 * **menu:** skip non-focusable submenu items when moving focus with Up, Down, Home and End keys ([824115f](https://github.com/Sage/carbon/commit/824115f66ebdff55bc5039117ee82786a5263384))
 * **portrait:** add `data-element` and `data-role` props for testing purposes ([fad5723](https://github.com/Sage/carbon/commit/fad5723b109f6cffc653a3f417238f87bafe474a))
-* update @tanstack/react-virtual to version ^3.11.2 ([30581d7](https://github.com/Sage/carbon/commit/30581d7712a40ddba93307bb181171721c8a59a1))
+* update `@tanstack/react-virtual` to version ^3.11.2 ([30581d7](https://github.com/Sage/carbon/commit/30581d7712a40ddba93307bb181171721c8a59a1))
 * upgrade `react-dnd` and `react-dnd-html5-backend` to v16 ([3d495ec](https://github.com/Sage/carbon/commit/3d495ec7ff9f5e28c3712a8cec3c46c5daa00025))
 
 ### Bug Fixes

--- a/docs/usage.mdx
+++ b/docs/usage.mdx
@@ -52,10 +52,11 @@ We recommend using our global stylesheet, which can be used by including the glo
 
 ```ts
 import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import GlobalStyle from 'carbon-react/lib/style/global-style';
 
-ReactDOM.render(
+const root = createRoot(document.getElementById('app')!);
+root.render(
   <CarbonProvider>
     <GlobalStyle/>
     ...


### PR DESCRIPTION
### Proposed behaviour

- Update old React v17 import in "Usage" docs
- Make breaking change to `react-dnd` as part of v148.0.0 clearer in the changelog

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
