### PR TITLE
feat: support server-side rendering

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -109,12 +109,13 @@
     "es6": true,
     "browser": true
   },
-  "plugins": ["react", "react-hooks"],
+  "plugins": ["react", "react-hooks", "ssr-friendly"],
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:react-hooks/recommended",
     "plugin:no-unsanitized/DOM",
+    "plugin:ssr-friendly/recommended",
     "airbnb",
     "prettier"
   ],

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,7 +12,7 @@ const esmOnlyPackages = [
 
 const isCI = process.env.CI === "true";
 
-const config: Config = {
+const clientConfig: Config = {
   notify: false,
   setupFiles: ["raf/polyfill"],
   testEnvironment: "jsdom",
@@ -20,7 +20,10 @@ const config: Config = {
     "<rootDir>/src/__spec_helper__/__internal__/index.ts",
     "jest-canvas-mock",
   ],
-  testMatch: ["**/?(*.)+(spec|test).[jt]s?(x)"],
+  testMatch: [
+    "**/?(*.)+(spec|test).[jt]s?(x)",
+    "!**/*.server.(spec|test).[jt]s?(x)",
+  ],
   testPathIgnorePatterns: ["node_modules", "lib", "esm"],
   moduleDirectories: ["src", "node_modules"],
   collectCoverage: true,
@@ -45,6 +48,17 @@ const config: Config = {
   moduleNameMapper: {
     "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js",
   },
+};
+
+const serverConfig: Config = {
+  ...clientConfig,
+  testMatch: ["**/*.server.(spec|test).[jt]s?(x)"],
+  testPathIgnorePatterns: ["node_modules", "lib", "esm"],
+  testEnvironment: "node",
+};
+
+const config: Config = {
+  projects: [clientConfig, serverConfig],
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,7 @@
         "eslint-plugin-playwright": "^1.6.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-ssr-friendly": "^1.3.0",
         "eslint-plugin-testing-library": "^6.2.2",
         "events": "~1.1.1",
         "fast-glob": "^3.3.2",
@@ -12619,6 +12620,48 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-ssr-friendly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ssr-friendly/-/eslint-plugin-ssr-friendly-1.3.0.tgz",
+      "integrity": "sha512-VOYl9OgK9mSVWxwl3pSTzNmBUMhPYjDGmxgyjSM9Agdve4GHjn0gAcCG/seg1taaW/aBWTkb7Aw4GIBsxVhL9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globals": "^13.8.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint-plugin-ssr-friendly/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-ssr-friendly/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-testing-library": {

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "eslint-plugin-playwright": "^1.6.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-ssr-friendly": "^1.3.0",
     "eslint-plugin-testing-library": "^6.2.2",
     "events": "~1.1.1",
     "fast-glob": "^3.3.2",

--- a/src/__internal__/dom/globals.server.test.ts
+++ b/src/__internal__/dom/globals.server.test.ts
@@ -1,0 +1,28 @@
+import { getWindow, getDocument, getNavigator } from "./globals";
+
+describe("getWindow on server", () => {
+  it("should return undefined if window does not exist", () => {
+    expect(typeof window).toBe("undefined");
+    expect(getWindow()).toBeUndefined();
+  });
+});
+
+describe("getDocument on server", () => {
+  it("should return undefined if document does not exist", () => {
+    expect(typeof document).toBe("undefined");
+    expect(getDocument()).toBeUndefined();
+  });
+});
+
+describe("getNavigator on server", () => {
+  it("should return whether the navigator exists", () => {
+    // Node.js 21 introduced support for navigator, so it may or may not exist depending on the version of Node.js
+    if (typeof navigator === "undefined") {
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(getNavigator()).toBeUndefined();
+    } else {
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(getNavigator()).toBeDefined();
+    }
+  });
+});

--- a/src/__internal__/dom/globals.test.ts
+++ b/src/__internal__/dom/globals.test.ts
@@ -1,0 +1,22 @@
+import { getWindow, getDocument, getNavigator } from "./globals";
+
+describe("getWindow", () => {
+  it("should return the window object if it exists", () => {
+    expect(window).toBeDefined();
+    expect(getWindow()).toBe(window);
+  });
+});
+
+describe("getDocument", () => {
+  it("should return the document object if it exists", () => {
+    expect(document).toBeDefined();
+    expect(getDocument()).toBe(document);
+  });
+});
+
+describe("getNavigator", () => {
+  it("should return the navigator object if it exists", () => {
+    expect(navigator).toBeDefined();
+    expect(getNavigator()).toBe(navigator);
+  });
+});

--- a/src/__internal__/dom/globals.ts
+++ b/src/__internal__/dom/globals.ts
@@ -1,0 +1,59 @@
+/**
+ * Returns the global `window` object in a way that is friendly to SSR.
+ * This check can be avoided if you are sure that the code will only run in the browser.
+ * Some examples where you can ignore this:
+ * - `useEffect` hooks
+ * - `useLayoutEffect` hooks
+ * - Callbacks for event listeners
+ * - Files with the `"use-client"` directive
+ *
+ * Primarily, this is necessary when attempting to access the `window` object during rendering of components.
+ * However, even still, where possible, it is recommended to avoid accessing the `window` object during rendering
+ * because it can lead to hydration mismatches. This happens when the server-rendered HTML differs from what the
+ * client renders due to missing environment-specific data (e.g., `window.innerWidth` being undefined on the server).
+ *
+ * @returns The global `window` object, if it exists.
+ */
+export function getWindow(): (Window & typeof globalThis) | undefined {
+  return typeof window !== "undefined" ? window : undefined;
+}
+
+/**
+ * Returns the global `document` object in a way that is friendly to SSR.
+ * This check can be avoided if you are sure that the code will only run in the browser.
+ * Some examples where you can ignore this:
+ * - `useEffect` hooks
+ * - `useLayoutEffect` hooks
+ * - Callbacks for event listeners
+ * - Files with the `"use-client"` directive
+ *
+ * Primarily, this is necessary when attempting to access the `document` object during rendering of components.
+ * However, even still, where possible, it is recommended to avoid accessing the `document` object during rendering
+ * because it can lead to hydration mismatches. This happens when the server-rendered HTML differs from what the
+ * client renders due to missing environment-specific data (e.g., `document.children` being undefined on the server).
+ *
+ * @returns The global `document` object, if it exists.
+ */
+export function getDocument(): Document | undefined {
+  return typeof document !== "undefined" ? document : undefined;
+}
+
+/**
+ * Returns the global `navigator` object in a way that is friendly to SSR.
+ * This check can be avoided if you are sure that the code will only run in the browser.
+ * Some examples where you can ignore this:
+ * - `useEffect` hooks
+ * - `useLayoutEffect` hooks
+ * - Callbacks for event listeners
+ * - Files with the `"use-client"` directive
+ *
+ * Primarily, this is necessary when attempting to access the `navigator` object during rendering of components.
+ * However, even still, where possible, it is recommended to avoid accessing the `navigator` object during rendering
+ * because it can lead to hydration mismatches. This happens when the server-rendered HTML differs from what the
+ * client renders due to missing environment-specific data (e.g., `navigator.userAgent` being undefined on the server).
+ *
+ * @returns The global `navigator` object, if it exists.
+ */
+export function getNavigator(): Navigator | undefined {
+  return typeof navigator !== "undefined" ? navigator : undefined;
+}

--- a/src/__spec_helper__/mock-element-scrollto.ts
+++ b/src/__spec_helper__/mock-element-scrollto.ts
@@ -1,6 +1,9 @@
 const setupScrollToMock = () => {
   // need to mock the `scrollTo` method, which is undefined in JSDOM. As we're not actually testing this behaviour, just make it
   // do nothing.
+  if (typeof window === "undefined") {
+    return;
+  }
   HTMLElement.prototype.scrollTo = () => {};
 };
 

--- a/src/__spec_helper__/mock-match-media.ts
+++ b/src/__spec_helper__/mock-match-media.ts
@@ -3,7 +3,7 @@ let _matches = false;
 const removeEventListener = jest.fn();
 
 export const setupMatchMediaMock = () => {
-  if (!global.window) {
+  if (typeof window === "undefined") {
     return;
   }
   const noop = () => {};

--- a/src/__spec_helper__/mock-resize-observer.ts
+++ b/src/__spec_helper__/mock-resize-observer.ts
@@ -1,5 +1,5 @@
 const setupResizeObserverMock = () => {
-  if (!window) {
+  if (typeof window === "undefined") {
     return;
   }
   window.ResizeObserver =

--- a/src/components/flat-table/flat-table-row/flat-table-row.style.ts
+++ b/src/components/flat-table/flat-table-row/flat-table-row.style.ts
@@ -10,6 +10,7 @@ import { ThemeObject } from "../../../style/themes/base";
 import { FlatTableProps } from "..";
 import { FlatTableRowProps } from "./flat-table-row.component";
 import addFocusStyling from "../../../style/utils/add-focus-styling";
+import { getNavigator } from "../../../__internal__/dom/globals";
 import { isSafari } from "../../../__internal__/utils/helpers/browser-type-check";
 
 const horizontalBorderSizes = {
@@ -153,6 +154,7 @@ const StyledFlatTableRow = styled.tr<StyledFlatTableRowProps>`
     draggable,
     rowHeight,
   }) => {
+    const nav = getNavigator();
     const backgroundColor = bgColor ? toColor(theme, bgColor) : undefined;
     const customBorderColor = horizontalBorderColor
       ? toColor(theme, horizontalBorderColor)
@@ -278,7 +280,9 @@ const StyledFlatTableRow = styled.tr<StyledFlatTableRowProps>`
           }
 
           /* Styling for safari. Position relative does not work on tr elements on Safari  */
-          ${isSafari(navigator) &&
+          // FIXME: this can cause hydration mismatches during SSR.
+          ${nav &&
+          isSafari(nav) &&
           css`
             position: -webkit-sticky;
             :after {

--- a/src/components/icon/icon.style.ts
+++ b/src/components/icon/icon.style.ts
@@ -8,6 +8,7 @@ import baseTheme, { ThemeObject } from "../../style/themes/base";
 import addFocusStyling from "../../style/utils/add-focus-styling";
 import styledColor from "../../style/utils/color";
 import getColorValue from "../../style/utils/get-color-value";
+import { getNavigator, getWindow } from "../../__internal__/dom/globals";
 import browserTypeCheck, {
   isSafari,
 } from "../../__internal__/utils/helpers/browser-type-check";
@@ -102,6 +103,8 @@ const StyledIcon = styled.span<StyledIconProps & StyledIconInternalProps>`
     let bgColor;
     let bgHoverColor;
 
+    const win = getWindow();
+    const nav = getNavigator();
     const adjustedBgSize = adjustIconBgSize(fontSize, bgSize);
 
     try {
@@ -164,16 +167,18 @@ const StyledIcon = styled.span<StyledIconProps & StyledIconInternalProps>`
           font-size: ${iconConfig.iconSize[fontSize]};
           line-height: ${iconConfig.iconSize[fontSize]};
         `}
-
-        ${type === "services" &&
-        browserTypeCheck(window) &&
+        // FIXME: this can cause hydration mismatches during SSR.
+        ${win &&
+        type === "services" &&
+        browserTypeCheck(win) &&
         css`
           margin-top: ${fontSize === "small" ? "-7px" : "-8px"};
         `}
-
-        ${type === "services" &&
-        isSafari(navigator) &&
-        !browserTypeCheck(window) &&
+        ${nav &&
+        win &&
+        type === "services" &&
+        isSafari(nav) &&
+        !browserTypeCheck(win) &&
         css`
           margin-top: -6px;
         `}

--- a/src/components/menu/menu-full-screen/menu-full-screen.component.tsx
+++ b/src/components/menu/menu-full-screen/menu-full-screen.component.tsx
@@ -15,6 +15,7 @@ import Icon from "../../icon";
 import Portal from "../../portal";
 import FocusTrap from "../../../__internal__/focus-trap";
 import MenuDivider from "../menu-divider/menu-divider.component";
+import { getDocument } from "../../../__internal__/dom/globals";
 import type { TagProps } from "../../../__internal__/utils/helpers/tags";
 import useLocale from "../../../hooks/__internal__/useLocale";
 import useModalAria from "../../../hooks/__internal__/useModalAria";
@@ -91,7 +92,9 @@ export const MenuFullscreen = ({
     closeModal,
     modalRef: menuRef,
     topModalOverride,
-    focusCallToActionElement: document.activeElement as HTMLElement,
+    focusCallToActionElement: getDocument()?.activeElement as
+      | HTMLElement
+      | undefined,
   });
 
   return (

--- a/src/components/modal/__internal__/modal-manager.server.test.tsx
+++ b/src/components/modal/__internal__/modal-manager.server.test.tsx
@@ -1,0 +1,17 @@
+import ModalManager from "./modal-manager";
+
+afterEach(() => {
+  ModalManager.clearList();
+});
+
+test("when the addModal method has been called, then the element passed in an attribute should be the topmost element", () => {
+  const cb1 = jest.fn();
+
+  const mockModal1 = "div";
+
+  ModalManager.addModal(mockModal1 as unknown as HTMLElement, cb1);
+
+  expect(ModalManager.isTopmost(mockModal1 as unknown as HTMLElement)).toBe(
+    true,
+  );
+});

--- a/src/components/modal/__internal__/modal-manager.ts
+++ b/src/components/modal/__internal__/modal-manager.ts
@@ -1,3 +1,5 @@
+import { getWindow } from "../../../__internal__/dom/globals";
+
 type SetTriggerRefocusFlag = (boolean: boolean) => void;
 
 export type ModalList = {
@@ -10,12 +12,17 @@ class ModalManagerInstance {
   private modalList: ModalList;
 
   constructor() {
+    const safeWindow = getWindow();
+    if (!safeWindow) {
+      this.modalList = [];
+      return;
+    }
     // Due to possibility of multiple carbon versions using it
     // it is necessary to maintain same structure in this global variable
-    if (!window.__CARBON_INTERNALS_MODAL_LIST) {
-      window.__CARBON_INTERNALS_MODAL_LIST = [];
+    if (!safeWindow.__CARBON_INTERNALS_MODAL_LIST) {
+      safeWindow.__CARBON_INTERNALS_MODAL_LIST = [];
     }
-    this.modalList = window.__CARBON_INTERNALS_MODAL_LIST;
+    this.modalList = safeWindow.__CARBON_INTERNALS_MODAL_LIST;
   }
 
   private getTopModal(): Record<string, never> | ModalList[number] {
@@ -87,15 +94,20 @@ class ModalManagerInstance {
   }
 
   clearList() {
-    window.__CARBON_INTERNALS_MODAL_LIST = [];
-    this.modalList = window.__CARBON_INTERNALS_MODAL_LIST;
+    const safeWindow = getWindow();
+    const cleared: ModalList = [];
+    if (safeWindow) {
+      safeWindow.__CARBON_INTERNALS_MODAL_LIST = cleared;
+    }
+    this.modalList = cleared;
     this.callTopModalSetters();
   }
 
   callTopModalSetters() {
-    if (window.__CARBON_INTERNALS_MODAL_SETTER_LIST) {
+    const safeWindow = getWindow();
+    if (safeWindow?.__CARBON_INTERNALS_MODAL_SETTER_LIST) {
       const topModal = this.getTopModal()?.modal || null;
-      for (const setTopModal of window.__CARBON_INTERNALS_MODAL_SETTER_LIST) {
+      for (const setTopModal of safeWindow.__CARBON_INTERNALS_MODAL_SETTER_LIST) {
         setTopModal(topModal);
       }
     }

--- a/src/components/modal/modal.component.tsx
+++ b/src/components/modal/modal.component.tsx
@@ -3,6 +3,7 @@ import { TransitionGroup, CSSTransition } from "react-transition-group";
 
 import useScrollBlock from "../../hooks/__internal__/useScrollBlock";
 import Portal from "../portal";
+import { getDocument } from "../../__internal__/dom/globals";
 import Events from "../../__internal__/utils/helpers/events";
 import useModalManager from "../../hooks/__internal__/useModalManager";
 import { StyledModal, StyledModalBackground } from "./modal.style";
@@ -92,15 +93,18 @@ const Modal = ({
     [disableClose, disableEscKey, onCancel],
   );
 
+  const safeDocument = getDocument();
+
   useModalManager({
     open,
     closeModal,
     modalRef: ref,
     setTriggerRefocusFlag,
     topModalOverride,
-    focusCallToActionElement: restoreFocusOnClose
-      ? (document.activeElement as HTMLElement)
-      : undefined,
+    focusCallToActionElement:
+      restoreFocusOnClose && safeDocument
+        ? (safeDocument.activeElement as HTMLElement)
+        : undefined,
   });
 
   let background;

--- a/src/components/vertical-menu/vertical-menu-full-screen/vertical-menu-full-screen.component.tsx
+++ b/src/components/vertical-menu/vertical-menu-full-screen/vertical-menu-full-screen.component.tsx
@@ -14,6 +14,7 @@ import {
   StyledVerticalMenuFullScreen,
 } from "../vertical-menu.style";
 import VerticalMenuFullScreenContext from "./__internal__/vertical-menu-full-screen.context";
+import { getDocument } from "../../../__internal__/dom/globals";
 import Events from "../../../__internal__/utils/helpers/events/events";
 import useModalManager from "../../../hooks/__internal__/useModalManager";
 
@@ -57,12 +58,14 @@ export const VerticalMenuFullScreen = ({
     [onClose],
   );
 
+  const safeDocument = getDocument();
+
   useModalManager({
     open: isOpen,
     closeModal: handleKeyDown,
     modalRef: menuWrapperRef,
     topModalOverride: true,
-    focusCallToActionElement: document.activeElement as HTMLElement,
+    focusCallToActionElement: safeDocument?.activeElement as HTMLElement,
   });
 
   // TODO remove this as part of FE-5650

--- a/src/hooks/__internal__/useScrollBlock/scroll-block-manager.server.test.ts
+++ b/src/hooks/__internal__/useScrollBlock/scroll-block-manager.server.test.ts
@@ -1,0 +1,52 @@
+import ScrollBlockManager from "./scroll-block-manager";
+
+describe("ScrollBlockManager's registerComponent method behavior", () => {
+  const scrollBlockManager = new ScrollBlockManager();
+  const id1 = "id1";
+  scrollBlockManager.registerComponent(id1);
+
+  it("should set isBlocked to true after registering at least one component", () => {
+    expect(scrollBlockManager.isBlocked()).toBe(true);
+  });
+});
+
+describe("ScrollBlockManager behavior with registerComponent and unregisterComponent", () => {
+  it("isBlocked should still return true after unregisterComponent is called with only one of the registered IDs ('id1')", () => {
+    const scrollBlockManager = new ScrollBlockManager();
+    const id1 = "id1";
+    const id2 = "id2";
+    scrollBlockManager.registerComponent(id1);
+    scrollBlockManager.registerComponent(id2);
+    scrollBlockManager.unregisterComponent(id1);
+    expect(scrollBlockManager.isBlocked()).toBe(true);
+  });
+
+  it("isBlocked should return false after unregisterComponent is called with both registered IDs ('id1' and 'id2')", () => {
+    const scrollBlockManager = new ScrollBlockManager();
+    const id1 = "id1";
+    const id2 = "id2";
+    scrollBlockManager.registerComponent(id1);
+    scrollBlockManager.registerComponent(id2);
+    scrollBlockManager.unregisterComponent(id1);
+    scrollBlockManager.unregisterComponent(id2);
+    expect(scrollBlockManager.isBlocked()).toBe(false);
+  });
+});
+
+describe("ScrollBlockManager's saveOriginalValues and getOriginalValues methods interaction", () => {
+  it("should accurately return the array of values previously saved using saveOriginalValues", () => {
+    const scrollBlockManager = new ScrollBlockManager();
+    const someValues = ["value1", "value2"];
+
+    scrollBlockManager.saveOriginalValues(someValues);
+
+    expect(scrollBlockManager.getOriginalValues()).toEqual(someValues);
+  });
+});
+
+describe("Initialization of ScrollBlockManager in an environment without pre-existing window.__CARBON_INTERNALS_SCROLL_BLOCKERS", () => {
+  it("should create the window.__CARBON_INTERNALS_SCROLL_BLOCKERS global variable with default structure if it does not already exist", () => {
+    const scrollBlockManager = new ScrollBlockManager();
+    expect(scrollBlockManager.isBlocked()).toBe(false);
+  });
+});

--- a/src/hooks/__internal__/useScrollBlock/scroll-block-manager.ts
+++ b/src/hooks/__internal__/useScrollBlock/scroll-block-manager.ts
@@ -1,5 +1,6 @@
 // TODO: This component can be refactored to remove redundant code
 // once we can confirm that all Sage products use version 105.0.0^
+import { getWindow } from "../../../__internal__/dom/globals";
 
 class ScrollBlockManager {
   components: {
@@ -9,10 +10,16 @@ class ScrollBlockManager {
   originalValues: string[];
 
   constructor() {
+    const safeWindow = getWindow();
+    if (!safeWindow) {
+      this.components = {};
+      this.originalValues = [];
+      return;
+    }
     // Due to possibility of multiple carbon versions using it
     // it is necessary to maintain same structure in this global variable
-    if (!window.__CARBON_INTERNALS_SCROLL_BLOCKERS) {
-      window.__CARBON_INTERNALS_SCROLL_BLOCKERS = {
+    if (!safeWindow.__CARBON_INTERNALS_SCROLL_BLOCKERS) {
+      safeWindow.__CARBON_INTERNALS_SCROLL_BLOCKERS = {
         components: {},
         // originalValues can be removed
         originalValues: [],
@@ -20,10 +27,10 @@ class ScrollBlockManager {
       };
     }
 
-    this.components = window.__CARBON_INTERNALS_SCROLL_BLOCKERS.components;
+    this.components = safeWindow.__CARBON_INTERNALS_SCROLL_BLOCKERS.components;
     // TODO: originalValues can be removed
     this.originalValues =
-      window.__CARBON_INTERNALS_SCROLL_BLOCKERS.originalValues;
+      safeWindow.__CARBON_INTERNALS_SCROLL_BLOCKERS.originalValues;
   }
 
   registerComponent(id: string) {


### PR DESCRIPTION
This PR supports applications to use SSR with React 18 by checking for `window`, `document`, and `navigator` object availability in places that aren't supported during SSR.

I needed these changes to make our admin portal + react-router@7's new routing API work.

Additionally, I added an ESLint to prevent accidental usage of global objects during React rendering. I went with that instead of the restricted syntax lint rule because that lint rule would require checking for `window` existence when we know it exists (in `useEffect`s, etc.).

FE-7103