### PR TITLE
feat(numeral-date): allow component to be focused programmatically - FE-7067

### DIFF
--- a/src/components/numeral-date/components.test-pw.tsx
+++ b/src/components/numeral-date/components.test-pw.tsx
@@ -1,17 +1,26 @@
 import React from "react";
 import NumeralDate, { NumeralDateProps } from ".";
+import { FullDate, NumeralDateObject } from "./numeral-date.component";
 
-export const NumeralDateComponent = (props: Partial<NumeralDateProps>) => {
+export const NumeralDateComponent = (
+  props: React.JSX.IntrinsicAttributes &
+    NumeralDateProps<NumeralDateObject> &
+    React.RefAttributes<HTMLInputElement>,
+) => {
   return <NumeralDate label="Default" {...props} />;
 };
 
-export const NumeralDateControlled = (props: Partial<NumeralDateProps>) => {
+export const NumeralDateControlled = (
+  props: React.JSX.IntrinsicAttributes &
+    NumeralDateProps<NumeralDateObject> &
+    React.RefAttributes<HTMLInputElement>,
+) => {
   const [value, setValue] = React.useState({ dd: "", mm: "", yyyy: "" });
 
   return (
     <NumeralDate
       value={value}
-      onChange={(e) => setValue(e.target.value)}
+      onChange={(e) => setValue(e.target.value as FullDate)}
       label="Controlled"
       {...props}
     />

--- a/src/components/numeral-date/numeral-date-test.stories.tsx
+++ b/src/components/numeral-date/numeral-date-test.stories.tsx
@@ -8,9 +8,11 @@ import {
   DayMonthDate,
   FullDate,
   NumeralDateEvent,
+  NumeralDateObject,
   NumeralDateProps,
 } from "./numeral-date.component";
 import CarbonProvider from "../carbon-provider";
+import Button from "../button";
 
 export default {
   title: "Numeral Date/Test",
@@ -61,17 +63,21 @@ export default {
   },
 };
 
-export const Default = (args: NumeralDateProps) => {
+export const Default = (
+  args: React.JSX.IntrinsicAttributes &
+    NumeralDateProps<NumeralDateObject> &
+    React.RefAttributes<HTMLInputElement>,
+) => {
   const [dateValue, setDateValue] = useState<FullDate>({
     dd: "",
     mm: "",
     yyyy: "",
   });
-  const handleChange = (event: NumeralDateEvent) => {
+  const handleChange = (event: NumeralDateEvent<NumeralDateObject>) => {
     setDateValue(event.target.value as FullDate);
     action("change")(event.target.value);
   };
-  const handleBlur = (event: NumeralDateEvent) => {
+  const handleBlur = (event: NumeralDateEvent<NumeralDateObject>) => {
     action("blur")(event.target.value);
   };
   return (
@@ -94,17 +100,21 @@ Default.args = {
   dateFormat: ["dd", "mm", "yyyy"],
 };
 
-export const DefaultWithOtherInputs = (args: NumeralDateProps) => {
+export const DefaultWithOtherInputs = (
+  args: React.JSX.IntrinsicAttributes &
+    NumeralDateProps<NumeralDateObject> &
+    React.RefAttributes<HTMLInputElement>,
+) => {
   const [dateValue, setDateValue] = useState<FullDate>({
     dd: "",
     mm: "",
     yyyy: "",
   });
-  const handleChange = (event: NumeralDateEvent) => {
+  const handleChange = (event: NumeralDateEvent<NumeralDateObject>) => {
     setDateValue(event.target.value as FullDate);
     action("change")(event.target.value);
   };
-  const handleBlur = (event: NumeralDateEvent) => {
+  const handleBlur = (event: NumeralDateEvent<NumeralDateObject>) => {
     action("blur")(event.target.value);
   };
   return (
@@ -140,21 +150,27 @@ DefaultWithOtherInputs.story = {
   },
 };
 
-export const Validations = (args: NumeralDateProps<DayMonthDate>) => {
+export const Validations = (
+  args: React.JSX.IntrinsicAttributes &
+    NumeralDateProps<NumeralDateObject> &
+    React.RefAttributes<HTMLInputElement>,
+) => {
   const validationTypes = ["error", "warning", "info"];
   const [dateValue, setDateValue] = useState({ dd: "", mm: "" });
-  const handleChange = (event: NumeralDateEvent<DayMonthDate>) => {
-    setDateValue({ ...dateValue });
+  const handleChange = (event: NumeralDateEvent<NumeralDateObject>) => {
+    const { dd, mm } = event.target.value as DayMonthDate;
+    setDateValue({ dd, mm });
     action("change")(event.target.value);
   };
-  const handleBlur = (event: NumeralDateEvent<DayMonthDate>) => {
-    action("blur")(event.target.value);
+  const handleBlur = (event: NumeralDateEvent<NumeralDateObject>) => {
+    const { dd, mm } = event.target.value as DayMonthDate;
+    action("blur")(dd, mm);
   };
   return (
     <>
       <h4>Validations as string</h4>
       {validationTypes.map((validation) => (
-        <NumeralDate<DayMonthDate>
+        <NumeralDate
           key={`${validation}-string`}
           onChange={handleChange}
           label="Numeral date"
@@ -201,7 +217,11 @@ export const Validations = (args: NumeralDateProps<DayMonthDate>) => {
 
 Validations.storyName = "validations";
 
-export const NewDesignValidations = (args: NumeralDateProps) => {
+export const NewDesignValidations = (
+  args: React.JSX.IntrinsicAttributes &
+    NumeralDateProps<NumeralDateObject> &
+    React.RefAttributes<HTMLInputElement>,
+) => {
   return (
     <CarbonProvider validationRedesignOptIn>
       <h4>New designs validation</h4>
@@ -320,4 +340,44 @@ InlineLabelsSizes.args = {
 InlineLabelsSizes.parameters = {
   chromatic: { disableSnapshot: false },
   themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const ProgrammaticFocus = () => {
+  const ndRef = React.useRef<HTMLInputElement | null>(null);
+  const [dateValue, setDateValue] = useState<FullDate>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
+  const handleChange = (event: NumeralDateEvent<NumeralDateObject>) => {
+    setDateValue(event.target.value as FullDate);
+    action("change")(event.target.value);
+  };
+  const handleBlur = (event: NumeralDateEvent<NumeralDateObject>) => {
+    action("blur")(event.target.value);
+  };
+  const handleClick = () => {
+    ndRef.current?.focus();
+  };
+  return (
+    <>
+      <Button onClick={handleClick}>Click me to focus NumeralDate</Button>
+      <Box mt="120px">
+        <NumeralDate
+          ref={ndRef}
+          onChange={handleChange}
+          label="Numeral date"
+          onBlur={handleBlur}
+          value={dateValue}
+          name="numeralDate_name"
+          id="numeralDate_id"
+        />
+      </Box>
+    </>
+  );
+};
+
+ProgrammaticFocus.storyName = "programmatic focus";
+ProgrammaticFocus.args = {
+  dateFormat: ["dd", "mm", "yyyy"],
 };

--- a/src/components/numeral-date/numeral-date.component.tsx
+++ b/src/components/numeral-date/numeral-date.component.tsx
@@ -1,4 +1,12 @@
-import React, { useContext, useState, useEffect, useRef, useMemo } from "react";
+import React, {
+  useContext,
+  useState,
+  useEffect,
+  useRef,
+  useMemo,
+  useImperativeHandle,
+  forwardRef,
+} from "react";
 import invariant from "invariant";
 import { MarginProps } from "styled-system";
 
@@ -224,359 +232,375 @@ const getDateLabel = (datePart: string, locale: Locale) => {
   }
 };
 
-export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
-  dateFormat = ["dd", "mm", "yyyy"],
-  defaultValue,
-  disabled,
-  error = "",
-  warning = "",
-  "data-component": dataComponent,
-  "data-element": dataElement,
-  "data-role": dataRole,
-  info,
-  id,
-  name,
-  onBlur,
-  onChange,
-  value,
-  validationOnLabel = false,
-  label,
-  labelInline,
-  labelWidth,
-  labelAlign,
-  fieldLabelsAlign,
-  labelHelp,
-  labelSpacing,
-  fieldHelp,
-  adaptiveLabelBreakpoint,
-  required,
-  isOptional,
-  readOnly,
-  size = "medium",
-  enableInternalError,
-  enableInternalWarning,
-  tooltipPosition,
-  helpAriaLabel,
-  dayRef,
-  monthRef,
-  yearRef,
-  ...rest
-}: NumeralDateProps<DateType>) => {
-  const locale = useLocale();
-  const { validationRedesignOptIn } = useContext(NewValidationContext);
-
-  const { current: uniqueId } = useRef(id || guid());
-  const inputIds = useRef({ dd: guid(), mm: guid(), yyyy: guid() });
-  const inputHintId = useRef(guid());
-  const isControlled = useRef(value !== undefined);
-  const initialValue = isControlled.current ? value : defaultValue;
-
-  const refs = useRef<(HTMLInputElement | null)[]>(dateFormat.map(() => null));
-
-  const [internalMessages, setInternalMessages] = useState<DateType>({
-    ...(Object.fromEntries(
-      dateFormat.map((datePart) => [datePart, ""]),
-    ) as Partial<FullDate> as DateType),
-  });
-
-  const hasCorrectDateFormat = useMemo(() => {
-    const isAllowed =
-      !dateFormat ||
-      ALLOWED_DATE_FORMATS.find(
-        (allowedDateFormat) =>
-          JSON.stringify(allowedDateFormat) === JSON.stringify(dateFormat),
-      );
-    return isAllowed;
-  }, [dateFormat]);
-
-  invariant(hasCorrectDateFormat, incorrectDateFormatMessage);
-
-  useEffect(() => {
-    const modeSwitchedMessage =
-      "Input elements should not switch from uncontrolled to controlled (or vice versa). " +
-      "Decide between using a controlled or uncontrolled input element for the lifetime of the component";
-
-    invariant(
-      isControlled.current === (value !== undefined),
-      modeSwitchedMessage,
-    );
-  }, [value]);
-
-  const [dateValue, setDateValue] = useState<DateType>({
-    ...((initialValue ||
-      (Object.fromEntries(
-        dateFormat.map((datePart) => [datePart, ""]),
-      ) as Partial<FullDate>)) as DateType),
-  });
-
-  const createCustomEventObject = (
-    newValue: DateType,
-  ): NumeralDateEvent<DateType> => ({
-    target: {
+export const NumeralDate = forwardRef(
+  <DateType extends NumeralDateObject = FullDate>(
+    {
+      dateFormat = ["dd", "mm", "yyyy"],
+      defaultValue,
+      disabled,
+      error = "",
+      warning = "",
+      "data-component": dataComponent,
+      "data-element": dataElement,
+      "data-role": dataRole,
+      info,
+      id,
       name,
-      id: uniqueId,
-      value: newValue,
-    },
-  });
-
-  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    const isValidKey =
-      Events.isNumberKey(event) ||
-      Events.isTabKey(event) ||
-      Events.isEnterKey(event) ||
-      event.key === "Delete" ||
-      event.key === "Backspace";
-
-    if (!isValidKey) {
-      event.preventDefault();
-    }
-  };
-
-  const handleChange = (
-    event: React.ChangeEvent<HTMLInputElement>,
-    datePart: keyof NumeralDateObject,
+      onBlur,
+      onChange,
+      value,
+      validationOnLabel = false,
+      label,
+      labelInline,
+      labelWidth,
+      labelAlign,
+      fieldLabelsAlign,
+      labelHelp,
+      labelSpacing,
+      fieldHelp,
+      adaptiveLabelBreakpoint,
+      required,
+      isOptional,
+      readOnly,
+      size = "medium",
+      enableInternalError,
+      enableInternalWarning,
+      tooltipPosition,
+      helpAriaLabel,
+      dayRef,
+      monthRef,
+      yearRef,
+      ...rest
+    }: NumeralDateProps<DateType>,
+    ref: React.Ref<HTMLInputElement> | null,
   ) => {
-    const { value: newValue } = event.target;
+    const locale = useLocale();
+    const { validationRedesignOptIn } = useContext(NewValidationContext);
 
-    if (newValue.length <= datePart.length) {
-      const newDateValue: DateType = {
-        ...dateValue,
-        [datePart]: newValue,
-      };
-      setDateValue(newDateValue);
+    const { current: uniqueId } = useRef(id || guid());
+    const inputIds = useRef({ dd: guid(), mm: guid(), yyyy: guid() });
+    const inputHintId = useRef(guid());
+    const isControlled = useRef(value !== undefined);
+    const initialValue = isControlled.current ? value : defaultValue;
 
-      /* istanbul ignore else */
-      if (onChange) {
-        onChange(createCustomEventObject(newDateValue));
-      }
-    }
-  };
+    const refs = useRef<(HTMLInputElement | null)[]>(
+      dateFormat.map(() => null),
+    );
 
-  const handleBlur = () => {
-    const internalValidationEnabled =
-      enableInternalError || enableInternalWarning;
-    /* istanbul ignore else */
-    if (internalValidationEnabled) {
-      setInternalMessages((prev) => ({
-        ...prev,
-        ...validate(locale, dateValue),
-      }));
-    }
-    setTimeout(() => {
-      const hasBlurred = !refs.current.find(
-        (ref) => ref === document.activeElement,
+    useImperativeHandle(
+      ref,
+      () =>
+        ({
+          focus: () => {
+            refs.current[0]?.focus();
+          },
+        }) as HTMLInputElement,
+    );
+
+    const [internalMessages, setInternalMessages] = useState<DateType>({
+      ...(Object.fromEntries(
+        dateFormat.map((datePart) => [datePart, ""]),
+      ) as Partial<FullDate> as DateType),
+    });
+
+    const hasCorrectDateFormat = useMemo(() => {
+      const isAllowed =
+        !dateFormat ||
+        ALLOWED_DATE_FORMATS.find(
+          (allowedDateFormat) =>
+            JSON.stringify(allowedDateFormat) === JSON.stringify(dateFormat),
+        );
+      return isAllowed;
+    }, [dateFormat]);
+
+    invariant(hasCorrectDateFormat, incorrectDateFormatMessage);
+
+    useEffect(() => {
+      const modeSwitchedMessage =
+        "Input elements should not switch from uncontrolled to controlled (or vice versa). " +
+        "Decide between using a controlled or uncontrolled input element for the lifetime of the component";
+
+      invariant(
+        isControlled.current === (value !== undefined),
+        modeSwitchedMessage,
       );
-      /* istanbul ignore else */
-      if (onBlur && hasBlurred) {
-        onBlur(createCustomEventObject(dateValue));
+    }, [value]);
+
+    const [dateValue, setDateValue] = useState<DateType>({
+      ...((initialValue ||
+        (Object.fromEntries(
+          dateFormat.map((datePart) => [datePart, ""]),
+        ) as Partial<FullDate>)) as DateType),
+    });
+
+    const createCustomEventObject = (newValue: DateType) => ({
+      target: {
+        name,
+        id: uniqueId,
+        value: newValue,
+      },
+    });
+
+    const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      const isValidKey =
+        Events.isNumberKey(event) ||
+        Events.isTabKey(event) ||
+        Events.isEnterKey(event) ||
+        event.key === "Delete" ||
+        event.key === "Backspace";
+
+      if (!isValidKey) {
+        event.preventDefault();
       }
-    }, 5);
-  };
+    };
 
-  const internalMessage = (
-    Object.keys(internalMessages) as (keyof DateType)[]
-  ).reduce(
-    (combinedMessage, datePart) =>
-      internalMessages[datePart]
-        ? `${combinedMessage + internalMessages[datePart]}\n`
-        : combinedMessage,
-    "",
-  );
-  const internalError = enableInternalError ? internalMessage + error : error;
+    const handleChange = (
+      event: React.ChangeEvent<HTMLInputElement>,
+      datePart: keyof NumeralDateObject,
+    ) => {
+      const { value: newValue } = event.target;
 
-  const internalWarning = enableInternalWarning
-    ? internalMessage + warning
-    : warning;
+      if (newValue.length <= datePart.length) {
+        const newDateValue: DateType = {
+          ...dateValue,
+          [datePart]: newValue,
+        };
+        setDateValue(newDateValue);
 
-  if (!deprecateUncontrolledWarnTriggered && !isControlled.current) {
-    deprecateUncontrolledWarnTriggered = true;
-    Logger.deprecate(
-      "Uncontrolled behaviour in `Numeral Date` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
+        /* istanbul ignore else */
+        if (onChange) {
+          onChange(createCustomEventObject(newDateValue));
+        }
+      }
+    };
+
+    const handleBlur = () => {
+      const internalValidationEnabled =
+        enableInternalError || enableInternalWarning;
+      /* istanbul ignore else */
+      if (internalValidationEnabled) {
+        setInternalMessages((prev) => ({
+          ...prev,
+          ...validate(locale, dateValue),
+        }));
+      }
+      setTimeout(() => {
+        const hasBlurred = !refs.current.find(
+          (r) => r === document.activeElement,
+        );
+        /* istanbul ignore else */
+        if (onBlur && hasBlurred) {
+          onBlur(createCustomEventObject(dateValue));
+        }
+      }, 5);
+    };
+
+    const internalMessage = (
+      Object.keys(internalMessages) as (keyof DateType)[]
+    ).reduce(
+      (combinedMessage, datePart) =>
+        internalMessages[datePart]
+          ? `${combinedMessage + internalMessages[datePart]}\n`
+          : combinedMessage,
+      "",
     );
-  }
+    const internalError = enableInternalError ? internalMessage + error : error;
 
-  const largeScreen = useIsAboveBreakpoint(adaptiveLabelBreakpoint);
-  let inline: boolean | undefined = labelInline;
-  if (adaptiveLabelBreakpoint) {
-    inline = largeScreen;
-  }
+    const internalWarning = enableInternalWarning
+      ? internalMessage + warning
+      : warning;
 
-  const handleRef = (
-    element: HTMLInputElement | null,
-    index: number,
-    inputRef: React.ForwardedRef<HTMLInputElement> | undefined,
-  ) => {
-    refs.current[index] = element;
-    if (!inputRef) {
-      return;
+    if (!deprecateUncontrolledWarnTriggered && !isControlled.current) {
+      deprecateUncontrolledWarnTriggered = true;
+      Logger.deprecate(
+        "Uncontrolled behaviour in `Numeral Date` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
+      );
     }
-    if (typeof inputRef === "function") {
-      inputRef(element);
-    } else {
-      inputRef.current = element;
+
+    const largeScreen = useIsAboveBreakpoint(adaptiveLabelBreakpoint);
+    let inline: boolean | undefined = labelInline;
+    if (adaptiveLabelBreakpoint) {
+      inline = largeScreen;
     }
-  };
 
-  const { validationId, fieldHelpId, ariaDescribedBy } = useInputAccessibility({
-    id: uniqueId,
-    // we still want to add the validationId to aria-describedby with the legacy validation
-    validationRedesignOptIn: true,
-    error: internalError,
-    warning: internalWarning,
-    info,
-    fieldHelp,
-  });
+    const handleRef = (
+      element: HTMLInputElement | null,
+      index: number,
+      inputRef: React.ForwardedRef<HTMLInputElement> | undefined,
+    ) => {
+      refs.current[index] = element;
+      if (!inputRef) {
+        return;
+      }
+      if (typeof inputRef === "function") {
+        inputRef(element);
+      } else {
+        inputRef.current = element;
+      }
+    };
 
-  const combinedAriaDescribedBy = [ariaDescribedBy, inputHintId.current]
-    .filter(Boolean)
-    .join(" ");
+    const { validationId, fieldHelpId, ariaDescribedBy } =
+      useInputAccessibility({
+        id: uniqueId,
+        // we still want to add the validationId to aria-describedby with the legacy validation
+        validationRedesignOptIn: true,
+        error: internalError,
+        warning: internalWarning,
+        info,
+        fieldHelp,
+      });
 
-  const renderInputs = () => {
-    return (
-      <StyledNumeralDate onKeyDown={onKeyDown}>
-        {dateFormat.map((datePart, index) => {
-          const isEnd = index === dateFormat.length - 1;
-          let inputRef: React.ForwardedRef<HTMLInputElement> | undefined;
+    const combinedAriaDescribedBy = [ariaDescribedBy, inputHintId.current]
+      .filter(Boolean)
+      .join(" ");
 
-          const validation = internalError || internalWarning || info;
-          const validationInField =
-            !validationRedesignOptIn &&
-            typeof validation === "string" &&
-            validation !== "";
+    const renderInputs = () => {
+      return (
+        <StyledNumeralDate onKeyDown={onKeyDown}>
+          {dateFormat.map((datePart, index) => {
+            const isEnd = index === dateFormat.length - 1;
+            let inputRef: React.ForwardedRef<HTMLInputElement> | undefined;
 
-          switch (datePart.slice(0, 2)) {
-            case "dd":
-              inputRef = dayRef;
-              break;
-            case "mm":
-              inputRef = monthRef;
-              break;
-            case "yy":
-              inputRef = yearRef;
-              break;
-            /* istanbul ignore next */
-            default:
-              break;
-          }
+            const validation = internalError || internalWarning || info;
+            const validationInField =
+              !validationRedesignOptIn &&
+              typeof validation === "string" &&
+              validation !== "";
 
-          return (
-            <NumeralDateContext.Provider
-              value={{ disableErrorBorder: true }}
-              key={datePart}
-            >
-              <StyledDateField
+            switch (datePart.slice(0, 2)) {
+              case "dd":
+                inputRef = dayRef;
+                break;
+              case "mm":
+                inputRef = monthRef;
+                break;
+              case "yy":
+                inputRef = yearRef;
+                break;
+              /* istanbul ignore next */
+              default:
+                break;
+            }
+
+            return (
+              <NumeralDateContext.Provider
+                value={{ disableErrorBorder: true }}
                 key={datePart}
-                size={size}
-                isYearInput={datePart.length === 4}
-                hasValidationIconInField={
-                  !validationOnLabel && isEnd && validationInField
-                }
               >
-                <Textbox
-                  id={inputIds.current[datePart]}
-                  label={getDateLabel(datePart, locale)}
-                  labelAlign={fieldLabelsAlign}
-                  disabled={disabled}
-                  readOnly={readOnly}
-                  error={!!internalError}
-                  warning={!!internalWarning}
-                  info={!!info}
+                <StyledDateField
+                  key={datePart}
                   size={size}
-                  value={dateValue[datePart as keyof NumeralDateObject]}
-                  onChange={(e) =>
-                    handleChange(e, datePart as keyof NumeralDateObject)
+                  isYearInput={datePart.length === 4}
+                  hasValidationIconInField={
+                    !validationOnLabel && isEnd && validationInField
                   }
-                  onBlur={handleBlur}
-                  ref={(element) => handleRef(element, index, inputRef)}
-                  {...(isEnd &&
-                    !validationOnLabel &&
-                    !validationRedesignOptIn && {
-                      error: internalError,
-                      warning: internalWarning,
-                      info,
-                    })}
-                  tooltipPosition={tooltipPosition}
-                  tooltipId={validationId}
-                />
-              </StyledDateField>
-            </NumeralDateContext.Provider>
-          );
-        })}
-      </StyledNumeralDate>
-    );
-  };
+                >
+                  <Textbox
+                    id={inputIds.current[datePart]}
+                    label={getDateLabel(datePart, locale)}
+                    labelAlign={fieldLabelsAlign}
+                    disabled={disabled}
+                    readOnly={readOnly}
+                    error={!!internalError}
+                    warning={!!internalWarning}
+                    info={!!info}
+                    size={size}
+                    value={dateValue[datePart as keyof NumeralDateObject]}
+                    onChange={(e) =>
+                      handleChange(e, datePart as keyof NumeralDateObject)
+                    }
+                    onBlur={handleBlur}
+                    ref={(element) => handleRef(element, index, inputRef)}
+                    {...(isEnd &&
+                      !validationOnLabel &&
+                      !validationRedesignOptIn && {
+                        error: internalError,
+                        warning: internalWarning,
+                        info,
+                      })}
+                    tooltipPosition={tooltipPosition}
+                    tooltipId={validationId}
+                  />
+                </StyledDateField>
+              </NumeralDateContext.Provider>
+            );
+          })}
+        </StyledNumeralDate>
+      );
+    };
 
-  if (!validationRedesignOptIn) {
+    if (!validationRedesignOptIn) {
+      return (
+        <TooltipProvider helpAriaLabel={helpAriaLabel}>
+          <StyledFieldset
+            data-component={dataComponent || "numeral-date"}
+            data-element={dataElement}
+            data-role={dataRole}
+            id={uniqueId}
+            legend={label}
+            legendMargin={{ mb: 0 }}
+            isRequired={required}
+            isOptional={isOptional}
+            isDisabled={disabled}
+            name={name}
+            error={validationOnLabel && internalError}
+            warning={validationOnLabel && internalWarning}
+            info={validationOnLabel && info}
+            inline={inline}
+            size={size}
+            labelHelp={labelHelp}
+            legendAlign={labelAlign}
+            legendWidth={labelWidth}
+            legendSpacing={labelSpacing}
+            validationId={validationId}
+            aria-describedby={ariaDescribedBy}
+            {...filterStyledSystemMarginProps(rest)}
+          >
+            <Box display="flex" flexDirection="column" mt={inline ? 0 : 1}>
+              {renderInputs()}
+              {fieldHelp && <FieldHelp id={fieldHelpId}>{fieldHelp}</FieldHelp>}
+            </Box>
+          </StyledFieldset>
+        </TooltipProvider>
+      );
+    }
+
     return (
-      <TooltipProvider helpAriaLabel={helpAriaLabel}>
-        <StyledFieldset
-          data-component={dataComponent || "numeral-date"}
-          data-element={dataElement}
-          data-role={dataRole}
-          id={uniqueId}
-          legend={label}
-          legendMargin={{ mb: 0 }}
-          isRequired={required}
-          isOptional={isOptional}
-          isDisabled={disabled}
-          name={name}
-          error={validationOnLabel && internalError}
-          warning={validationOnLabel && internalWarning}
-          info={validationOnLabel && info}
-          inline={inline}
-          size={size}
-          labelHelp={labelHelp}
-          legendAlign={labelAlign}
-          legendWidth={labelWidth}
-          legendSpacing={labelSpacing}
-          validationId={validationId}
-          aria-describedby={validationOnLabel ? ariaDescribedBy : fieldHelpId}
-          {...filterStyledSystemMarginProps(rest)}
-        >
-          <Box display="flex" flexDirection="column" mt={inline ? 0 : 1}>
-            {renderInputs()}
-            {fieldHelp && <FieldHelp id={fieldHelpId}>{fieldHelp}</FieldHelp>}
-          </Box>
-        </StyledFieldset>
-      </TooltipProvider>
-    );
-  }
-
-  return (
-    <StyledFieldset
-      data-component={dataComponent || "numeral-date"}
-      data-element={dataElement}
-      data-role={dataRole}
-      id={uniqueId}
-      legend={label}
-      legendMargin={{ mb: 0 }}
-      legendAlign={labelAlign}
-      isRequired={required}
-      isOptional={isOptional}
-      isDisabled={disabled}
-      name={name}
-      aria-describedby={combinedAriaDescribedBy}
-      {...filterStyledSystemMarginProps(rest)}
-    >
-      {labelHelp && (
-        <StyledHintText id={inputHintId.current}>{labelHelp}</StyledHintText>
-      )}
-
-      <Box position="relative" mt={labelHelp ? 0 : 1}>
-        {(internalError || internalWarning) && (
-          <>
-            <ValidationMessage
-              error={internalError}
-              warning={internalWarning}
-              validationId={validationId}
-            />
-            <ErrorBorder warning={!!(!internalError && internalWarning)} />
-          </>
+      <StyledFieldset
+        data-component={dataComponent || "numeral-date"}
+        data-element={dataElement}
+        data-role={dataRole}
+        id={uniqueId}
+        legend={label}
+        legendMargin={{ mb: 0 }}
+        legendAlign={labelAlign}
+        isRequired={required}
+        isOptional={isOptional}
+        isDisabled={disabled}
+        name={name}
+        aria-describedby={combinedAriaDescribedBy}
+        {...filterStyledSystemMarginProps(rest)}
+      >
+        {labelHelp && (
+          <StyledHintText id={inputHintId.current}>{labelHelp}</StyledHintText>
         )}
-        {renderInputs()}
-      </Box>
-    </StyledFieldset>
-  );
-};
+
+        <Box position="relative" mt={labelHelp ? 0 : 1}>
+          {(internalError || internalWarning) && (
+            <>
+              <ValidationMessage
+                error={internalError}
+                warning={internalWarning}
+                validationId={validationId}
+              />
+              <ErrorBorder warning={!!(!internalError && internalWarning)} />
+            </>
+          )}
+          {renderInputs()}
+        </Box>
+      </StyledFieldset>
+    );
+  },
+);
 
 export default NumeralDate;

--- a/src/components/numeral-date/numeral-date.mdx
+++ b/src/components/numeral-date/numeral-date.mdx
@@ -111,6 +111,12 @@ You can use the `size` prop to set the size of the field.
 
 <Canvas of={NumeralDateStories.IsOptional} />
 
+### Programmatic Focus
+
+It is possible to focus the `NumeralDate` component programmatically by passing a ref to the component and calling the `focus` method on it.
+
+<Canvas of={NumeralDateStories.ProgrammaticFocus} />
+
 ## Props
 
 ### NumeralDate

--- a/src/components/numeral-date/numeral-date.stories.tsx
+++ b/src/components/numeral-date/numeral-date.stories.tsx
@@ -6,6 +6,7 @@ import generateStyledSystemProps from "../../../.storybook/utils/styled-system-p
 import CarbonProvider from "../carbon-provider";
 import Box from "../box";
 import NumeralDate from ".";
+import Button from "../button";
 
 const styledSystemProps = generateStyledSystemProps({
   margin: true,
@@ -37,7 +38,7 @@ export const Controlled: Story = () => {
 
   return (
     <NumeralDate
-      onChange={(e) => setValue(e.target.value)}
+      onChange={(e) => setValue({ ...value, ...e.target.value })}
       label="Default"
       value={value}
     />
@@ -74,7 +75,7 @@ export const InternalValidationError: Story = () => {
     <>
       <NumeralDate
         enableInternalError
-        onChange={(e) => setValueOld(e.target.value)}
+        onChange={(e) => setValueOld({ ...valueOld, ...e.target.value })}
         label="Default - legacy validation"
         value={valueOld}
       />
@@ -83,7 +84,7 @@ export const InternalValidationError: Story = () => {
         <NumeralDate
           enableInternalError
           label="Default - new validation"
-          onChange={(e) => setValueNew(e.target.value)}
+          onChange={(e) => setValueNew({ ...valueNew, ...e.target.value })}
           value={valueNew}
         />
       </CarbonProvider>
@@ -100,7 +101,7 @@ export const InternalValidationWarning: Story = () => {
       <NumeralDate
         enableInternalWarning
         label="Default - legacy validation"
-        onChange={(e) => setValueOld(e.target.value)}
+        onChange={(e) => setValueOld({ ...valueOld, ...e.target.value })}
         value={valueOld}
       />
       <br />
@@ -108,7 +109,7 @@ export const InternalValidationWarning: Story = () => {
         <NumeralDate
           enableInternalWarning
           label="Default - new validation"
-          onChange={(e) => setValueNew(e.target.value)}
+          onChange={(e) => setValueNew({ ...valueNew, ...e.target.value })}
           value={valueNew}
         />
       </CarbonProvider>
@@ -125,7 +126,7 @@ export const Validation: Story = () => {
         mb={2}
         label="Validation as string"
         error="Error Message (Fix is required)"
-        onChange={(e) => setValue(e.target.value)}
+        onChange={(e) => setValue({ ...value, ...e.target.value })}
         value={value}
       />
 
@@ -134,7 +135,7 @@ export const Validation: Story = () => {
         label="Validation as string on label"
         error="Error Message (Fix is required)"
         validationOnLabel
-        onChange={(e) => setValue(e.target.value)}
+        onChange={(e) => setValue({ ...value, ...e.target.value })}
         value={value}
       />
 
@@ -142,7 +143,7 @@ export const Validation: Story = () => {
         mb={2}
         label="Validation as boolean"
         error
-        onChange={(e) => setValue(e.target.value)}
+        onChange={(e) => setValue({ ...value, ...e.target.value })}
         value={value}
       />
 
@@ -150,7 +151,7 @@ export const Validation: Story = () => {
         mb={2}
         label="Validation as string"
         warning="Warning Message (Fix is optional)"
-        onChange={(e) => setValue(e.target.value)}
+        onChange={(e) => setValue({ ...value, ...e.target.value })}
         value={value}
       />
 
@@ -159,14 +160,14 @@ export const Validation: Story = () => {
         label="Validation as string on label"
         warning="Warning Message (Fix is optional)"
         validationOnLabel
-        onChange={(e) => setValue(e.target.value)}
+        onChange={(e) => setValue({ ...value, ...e.target.value })}
         value={value}
       />
 
       <NumeralDate
         label="Validation as boolean"
         warning
-        onChange={(e) => setValue(e.target.value)}
+        onChange={(e) => setValue({ ...value, ...e.target.value })}
         value={value}
       />
     </>
@@ -184,7 +185,7 @@ export const NewValidation: Story = () => {
           label="Validation as string - Error"
           labelHelp="Label help"
           error="Error Message (Fix is required)"
-          onChange={(e) => setValue(e.target.value)}
+          onChange={(e) => setValue({ ...value, ...e.target.value })}
           value={value}
         />
 
@@ -193,7 +194,7 @@ export const NewValidation: Story = () => {
           label="Validation as boolean - Error"
           labelHelp="Label help"
           error
-          onChange={(e) => setValue(e.target.value)}
+          onChange={(e) => setValue({ ...value, ...e.target.value })}
           value={value}
         />
 
@@ -202,7 +203,7 @@ export const NewValidation: Story = () => {
           label="Validation as string - Warning"
           labelHelp="Label help"
           warning="Warning Message (Fix is optional)"
-          onChange={(e) => setValue(e.target.value)}
+          onChange={(e) => setValue({ ...value, ...e.target.value })}
           value={value}
         />
 
@@ -210,7 +211,7 @@ export const NewValidation: Story = () => {
           label="Validation as boolean - Warning"
           labelHelp="Label help"
           warning
-          onChange={(e) => setValue(e.target.value)}
+          onChange={(e) => setValue({ ...value, ...e.target.value })}
           value={value}
         />
       </Box>
@@ -227,7 +228,7 @@ export const InlineLabel: Story = () => {
       labelInline
       labelAlign="right"
       labelWidth={30}
-      onChange={(e) => setValue(e.target.value)}
+      onChange={(e) => setValue({ ...value, ...e.target.value })}
       value={value}
     />
   );
@@ -243,7 +244,7 @@ export const EnablingAdaptiveBehaviour: Story = () => {
       labelInline
       labelAlign="right"
       labelWidth={30}
-      onChange={(e) => setValue(e.target.value)}
+      onChange={(e) => setValue({ ...value, ...e.target.value })}
       value={value}
     />
   );
@@ -260,7 +261,7 @@ export const WithLabelHelp: Story = () => {
       helpAriaLabel="Label help"
       label="With label help"
       labelHelp="Label help"
-      onChange={(e) => setValue(e.target.value)}
+      onChange={(e) => setValue({ ...value, ...e.target.value })}
       value={value}
     />
   );
@@ -273,7 +274,7 @@ export const WithFieldHelp: Story = () => {
     <NumeralDate
       label="With field help"
       fieldHelp="Field help"
-      onChange={(e) => setValue(e.target.value)}
+      onChange={(e) => setValue({ ...value, ...e.target.value })}
       value={value}
     />
   );
@@ -311,7 +312,7 @@ export const Required: Story = () => {
       id="optional"
       label="Date of Birth"
       labelWidth={30}
-      onChange={(e) => setValue(e.target.value)}
+      onChange={(e) => setValue({ ...value, ...e.target.value })}
       value={value}
       required
     />
@@ -327,10 +328,29 @@ export const IsOptional: Story = () => {
       id="optional"
       label="Date of Birth"
       labelWidth={30}
-      onChange={(e) => setValue(e.target.value)}
+      onChange={(e) => setValue({ ...value, ...e.target.value })}
       value={value}
       isOptional
     />
   );
 };
 IsOptional.storyName = "IsOptional";
+
+export const ProgrammaticFocus: Story = () => {
+  const numeralDateRef = React.useRef<HTMLInputElement | null>(null);
+  const [value, setValue] = useState({ dd: "", mm: "", yyyy: "" });
+  return (
+    <>
+      <Button mb={2} onClick={() => numeralDateRef.current?.focus()}>
+        Click me to focus Numeral Date
+      </Button>
+      <NumeralDate
+        label="Default"
+        ref={numeralDateRef}
+        onChange={(e) => setValue({ ...value, ...e.target.value })}
+        value={value}
+      />
+    </>
+  );
+};
+ProgrammaticFocus.storyName = "Programmatic Focus";

--- a/src/components/numeral-date/numeral-date.test.tsx
+++ b/src/components/numeral-date/numeral-date.test.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useRef } from "react";
 import { render, screen, within, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import Button from "components/button";
 import {
   testStyledSystemMargin,
   mockMatchMedia,
@@ -2155,3 +2156,62 @@ test.each(["error", "warning"])(
     expect(fieldset).toHaveAccessibleDescription("Message labelHelp");
   },
 );
+
+test("should focus the first textbox when the component is programmatically focused when the date format is dd/mm/yyyy", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  const MockComponent = () => {
+    const ndRef = useRef<HTMLInputElement>(null);
+    return (
+      <>
+        <Button onClick={() => ndRef.current?.focus()}>Click me</Button>
+        <NumeralDate
+          ref={ndRef}
+          onChange={() => {}}
+          label="Numeral date"
+          value={{ dd: "", mm: "", yyyy: "" }}
+          name="numeralDate_name"
+          id="numeralDate_id"
+        />
+      </>
+    );
+  };
+
+  render(<MockComponent />);
+
+  const button = screen.getByRole("button", { name: "Click me" });
+  const firstInput = screen.getByRole("textbox", { name: "Day" });
+
+  await user.click(button);
+
+  expect(firstInput).toHaveFocus();
+});
+
+test("should focus the first textbox when the component is programmatically focused when the date format is mm/yyyy", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  const MockComponent = () => {
+    const ndRef = useRef<HTMLInputElement>(null);
+    return (
+      <>
+        <Button onClick={() => ndRef.current?.focus()}>Click me</Button>
+        <NumeralDate
+          ref={ndRef}
+          dateFormat={["mm", "yyyy"]}
+          onChange={() => {}}
+          label="Numeral date"
+          value={{ mm: "", yyyy: "" }}
+          name="numeralDate_name"
+          id="numeralDate_id"
+        />
+      </>
+    );
+  };
+
+  render(<MockComponent />);
+
+  const button = screen.getByRole("button", { name: "Click me" });
+  const firstInput = screen.getByRole("textbox", { name: "Month" });
+
+  await user.click(button);
+
+  expect(firstInput).toHaveFocus();
+});


### PR DESCRIPTION
Currently it is not possible to focus the numeral date component programmatically. This change allows consumers to now do that.

fixes #7180

### Proposed behaviour

Expose a ref so that the `Numeral Date` component is programmatically focusable. 

### Current behaviour

No ref is exposed, so the component is not programmatically focusable. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A
### Testing instructions

Ensure that new `Programmatic Focus` examples work correctly on all browsers and that there are no other functional regressions with `Numeral Date`.

Please note, I will be creating a separate example that includes a `react-hook-form` example so that it can be tested against the issue raised requesting this feature.
