### PR TITLE
fix(text-editor): ensure that margin props are applied to component - FE-7104

### DIFF
--- a/src/components/text-editor/text-editor-test.stories.tsx
+++ b/src/components/text-editor/text-editor-test.stories.tsx
@@ -115,3 +115,10 @@ export const ReadOnlyEditorForNotes = () => {
     </Box>
   );
 };
+
+export const WithMargin: Story = () => {
+  return (
+    <TextEditor m={5} namespace="storybook-margin" labelText="Text Editor" />
+  );
+};
+WithMargin.storyName = "With Margin";

--- a/src/components/text-editor/text-editor.component.tsx
+++ b/src/components/text-editor/text-editor.component.tsx
@@ -41,14 +41,17 @@ import {
 import TextEditorContext from "./text-editor.context";
 import StyledTextEditor, {
   StyledEditorToolbarWrapper,
+  StyledTextEditorWrapper,
   StyledValidationMessage,
   StyledWrapper,
 } from "./text-editor.style";
 import { SaveCallbackProps } from "./__internal__/plugins/Toolbar/buttons/save.component";
 import { createEmpty } from "./__internal__";
 import HintText from "../../__internal__/hint-text";
+import { filterStyledSystemMarginProps } from "../../style/utils";
+import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
-export interface TextEditorProps extends MarginProps {
+export interface TextEditorProps extends MarginProps, TagProps {
   /** The maximum number of characters allowed in the editor */
   characterLimit?: number;
   /** The message to be shown when the editor is in an error state */
@@ -103,6 +106,7 @@ export const TextEditor = ({
   rows,
   warning,
   value,
+  ...rest
 }: TextEditorProps) => {
   const editorRef = useRef<LexicalEditor | undefined>(undefined);
   const locale = useLocale();
@@ -182,84 +186,90 @@ export const TextEditor = ({
   );
 
   return (
-    <TextEditorContext.Provider value={{ onLinkAdded, readOnly }}>
-      <Label
-        isRequired={required}
-        optional={isOptional}
-        labelId={`${namespace}-label`}
-      >
-        {labelText}
-      </Label>
+    <StyledTextEditorWrapper
+      data-role={`${namespace}-editor-wrapper`}
+      {...filterStyledSystemMarginProps(rest)}
+      {...tagComponent("text-editor", rest)}
+    >
+      <TextEditorContext.Provider value={{ onLinkAdded, readOnly }}>
+        <Label
+          isRequired={required}
+          optional={isOptional}
+          labelId={`${namespace}-label`}
+        >
+          {labelText}
+        </Label>
 
-      {inputHint && (
-        <HintText
-          id={`${namespace}-input-hint`}
-          marginBottom="var(--spacing100)"
-        >
-          {inputHint}
-        </HintText>
-      )}
-      <LexicalComposer initialConfig={initialConfig}>
-        <EditorRefPlugin editorRef={editorRef} />
-        <StyledWrapper
-          data-role={`${namespace}-wrapper`}
-          error={error || undefined}
-          namespace={namespace}
-          warning={characterLimitWarning || warning || undefined}
-        >
-          {(error || characterLimitWarning || warning) && (
-            <StyledValidationMessage
-              error={error}
-              data-role={`${namespace}-validation-message`}
-            >
-              {error || characterLimitWarning || warning}
-            </StyledValidationMessage>
-          )}
-          <StyledEditorToolbarWrapper
-            data-role={`${namespace}-editor-toolbar-wrapper`}
-            id={`${namespace}-editor-toolbar-wrapper`}
-            onBlur={() => setIsFocused(false)}
-            onFocus={() => setIsFocused(true)}
-            focused={isFocused}
+        {inputHint && (
+          <HintText
+            id={`${namespace}-input-hint`}
+            marginBottom="var(--spacing100)"
           >
-            <StyledTextEditor data-role={`${namespace}-editor`}>
-              <RichTextPlugin
-                contentEditable={
-                  <ContentEditor
-                    error={error}
-                    inputHint={inputHint}
-                    namespace={namespace}
-                    previews={previews}
-                    rows={rows}
-                    warning={warning}
-                  />
-                }
-                placeholder={
-                  <Placeholder namespace={namespace} text={placeholder} />
-                }
-                ErrorBoundary={LexicalErrorBoundary}
-              />
-              <ListPlugin />
-              <HistoryPlugin />
-              <MarkdownShortcutPlugin />
-              <OnChangePlugin onChange={handleChange} />
-              <LinkPlugin validateUrl={validateUrl} />
-              <ClickableLinkPlugin newTab />
-              <AutoLinkerPlugin />
-            </StyledTextEditor>
-            {!readOnly && <ToolbarPlugin {...toolbarProps} />}
-            <LinkMonitorPlugin />
-          </StyledEditorToolbarWrapper>
+            {inputHint}
+          </HintText>
+        )}
+        <LexicalComposer initialConfig={initialConfig}>
+          <EditorRefPlugin editorRef={editorRef} />
+          <StyledWrapper
+            data-role={`${namespace}-wrapper`}
+            error={error || undefined}
+            namespace={namespace}
+            warning={characterLimitWarning || warning || undefined}
+          >
+            {(error || characterLimitWarning || warning) && (
+              <StyledValidationMessage
+                error={error}
+                data-role={`${namespace}-validation-message`}
+              >
+                {error || characterLimitWarning || warning}
+              </StyledValidationMessage>
+            )}
+            <StyledEditorToolbarWrapper
+              data-role={`${namespace}-editor-toolbar-wrapper`}
+              id={`${namespace}-editor-toolbar-wrapper`}
+              onBlur={() => setIsFocused(false)}
+              onFocus={() => setIsFocused(true)}
+              focused={isFocused}
+            >
+              <StyledTextEditor data-role={`${namespace}-editor`}>
+                <RichTextPlugin
+                  contentEditable={
+                    <ContentEditor
+                      error={error}
+                      inputHint={inputHint}
+                      namespace={namespace}
+                      previews={previews}
+                      rows={rows}
+                      warning={warning}
+                    />
+                  }
+                  placeholder={
+                    <Placeholder namespace={namespace} text={placeholder} />
+                  }
+                  ErrorBoundary={LexicalErrorBoundary}
+                />
+                <ListPlugin />
+                <HistoryPlugin />
+                <MarkdownShortcutPlugin />
+                <OnChangePlugin onChange={handleChange} />
+                <LinkPlugin validateUrl={validateUrl} />
+                <ClickableLinkPlugin newTab />
+                <AutoLinkerPlugin />
+              </StyledTextEditor>
+              {!readOnly && <ToolbarPlugin {...toolbarProps} />}
+              <LinkMonitorPlugin />
+            </StyledEditorToolbarWrapper>
 
-          {characterLimit > 0 && !readOnly && (
-            <CharacterCounterPlugin
-              maxChars={characterLimit}
-              namespace={namespace}
-            />
-          )}
-        </StyledWrapper>
-      </LexicalComposer>
-    </TextEditorContext.Provider>
+            {characterLimit > 0 && !readOnly && (
+              <CharacterCounterPlugin
+                maxChars={characterLimit}
+                namespace={namespace}
+              />
+            )}
+          </StyledWrapper>
+        </LexicalComposer>
+      </TextEditorContext.Provider>
+    </StyledTextEditorWrapper>
   );
 };
 

--- a/src/components/text-editor/text-editor.pw.tsx
+++ b/src/components/text-editor/text-editor.pw.tsx
@@ -298,6 +298,28 @@ test.describe("Prop tests", () => {
       expect(newParagraph).toBe("New line text");
     });
   });
+
+  test("should correctly apply margin prop as a number", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TextEditorDefaultComponent m={2} />);
+    const textEditorWrapper = await page.locator(
+      `div[data-component='text-editor']`,
+    );
+    await expect(textEditorWrapper).toHaveCSS("margin", "16px");
+  });
+
+  test("should correctly apply margin prop as a string", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TextEditorDefaultComponent m="16px" />);
+    const textEditorWrapper = await page.locator(
+      `div[data-component='text-editor']`,
+    );
+    await expect(textEditorWrapper).toHaveCSS("margin", "16px");
+  });
 });
 
 test.describe("Functionality tests", () => {

--- a/src/components/text-editor/text-editor.style.ts
+++ b/src/components/text-editor/text-editor.style.ts
@@ -1,8 +1,10 @@
 import styled, { css } from "styled-components";
 
+import { margin, MarginProps } from "styled-system";
 import Box from "../box";
 import addFocusStyling from "../../style/utils/add-focus-styling";
 
+type StyledTextEditorWrapperProps = MarginProps;
 interface StyledWrapperProps {
   error?: string;
   namespace: string;
@@ -19,6 +21,10 @@ interface StyledEditorToolbarWrapperProps {
 
 export const StyledTextEditor = styled(Box)`
   position: relative;
+`;
+
+export const StyledTextEditorWrapper = styled.div<StyledTextEditorWrapperProps>`
+  ${margin}
 `;
 
 export const StyledWrapper = styled.div<StyledWrapperProps>`


### PR DESCRIPTION
### Proposed behaviour

- Ensure that margin props are correctly applied to the component.
- Apply `tagComponent`

### Current behaviour

- Margin props are specified but are not applied to the component.
- tagComponent is not applied to the component.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Ensure that margin is applied to `TextEditor` as expected.
- Ensure that no other visual regressions have occurred because of this change.
