### PR TITLE
[Button] additional secondary style

### DIFF
--- a/src/components/button/button-types.style.ts
+++ b/src/components/button/button-types.style.ts
@@ -37,7 +37,11 @@ const gradientSharedStyle = `
   }
 `;
 
-export default (isDisabled?: boolean, destructive?: boolean) => ({
+export default (
+  isDisabled?: boolean,
+  destructive?: boolean,
+  isWhite?: boolean,
+) => ({
   primary: `
     background: var(--colorsActionMajor500);
     border-color: transparent;
@@ -106,7 +110,7 @@ export default (isDisabled?: boolean, destructive?: boolean) => ({
           `
           : ""
       }
-      
+
       ${
         isDisabled
           ? `
@@ -118,6 +122,51 @@ export default (isDisabled?: boolean, destructive?: boolean) => ({
               ${makeColors("var(--colorsActionMajorYin030)")};
             }
             ${disabledImageStyle}
+          `
+          : ""
+      }
+
+      ${
+        isWhite
+          ? `
+            border-color: var(--colorsActionMajorYang100);
+            ${makeColors("var(--colorsActionMajorYang100)")}
+            &:hover {
+              background: var(--colorsActionMajorYang100);
+              ${makeColors("var(--colorsUtilityYin100)")};
+            }
+
+
+            ${
+              destructive
+                ? `
+                  border-color: var(--colorsSemanticNegative450);
+                  ${makeColors("var(--colorsSemanticNegative450)")}
+                  &:hover {
+                    background: var(--colorsSemanticNegative600);
+                    border-color: var(--colorsSemanticNegativeTransparent);
+                    ${makeColors("var(--colorsSemanticNegativeYang100)")};
+                  }
+                `
+                : ""
+            }
+
+            ${
+              isDisabled
+                ? `
+                  border-color: #4B4B4B;
+                  ${makeColors("#4B4B4B")};
+                  &:hover {
+                    background: transparent;
+                    border-color: #4B4B4B;
+                    ${makeColors("#4B4B4B")};
+
+                  }
+                  ${disabledImageStyle}
+                `
+                : ""
+            }
+          }
           `
           : ""
       }
@@ -164,7 +213,7 @@ export default (isDisabled?: boolean, destructive?: boolean) => ({
       background: var(--colorsActionMajor600);
       ${makeColors("var(--colorsActionMajorYang100)")}
     }
-    
+
     ${
       isDisabled
         ? `
@@ -184,7 +233,7 @@ export default (isDisabled?: boolean, destructive?: boolean) => ({
       isDisabled
         ? gradientDisabledStyle
         : `
-          background: linear-gradient(#F2F5F6, #F2F5F6) padding-box, linear-gradient(to right, #00D639, #11AFFF, #8F49FE) border-box;          
+          background: linear-gradient(#F2F5F6, #F2F5F6) padding-box, linear-gradient(to right, #00D639, #11AFFF, #8F49FE) border-box;
           ${gradientSharedStyle}
         `
     }
@@ -194,7 +243,7 @@ export default (isDisabled?: boolean, destructive?: boolean) => ({
       isDisabled
         ? gradientDisabledStyle
         : `
-          background: linear-gradient(#FFFFFF, #FFFFFF) padding-box, linear-gradient(to right, #00D639, #11AFFF, #8F49FE) border-box;          
+          background: linear-gradient(#FFFFFF, #FFFFFF) padding-box, linear-gradient(to right, #00D639, #11AFFF, #8F49FE) border-box;
           ${gradientSharedStyle}
         `
     }

--- a/src/components/button/button.component.tsx
+++ b/src/components/button/button.component.tsx
@@ -61,6 +61,8 @@ export interface ButtonProps extends SpaceProps, TagProps {
   iconType?: IconType;
   /** id attribute */
   id?: string;
+  /** Whether to use the white-on-dark colour variant */
+  isWhite?: boolean;
   /** If provided, the text inside a button will not wrap */
   noWrap?: boolean;
   /** Specify a callback triggered on blur */
@@ -201,6 +203,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       iconTooltipMessage,
       iconTooltipPosition,
       iconType,
+      isWhite = false,
       m = 0,
       noWrap,
       onClick,
@@ -292,6 +295,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         buttonType={buttonType}
         disabled={isDisabled}
         destructive={destructive}
+        isWhite={isWhite}
         type={href ? undefined : "button"}
         iconType={iconType}
         size={size}

--- a/src/components/button/button.mdx
+++ b/src/components/button/button.mdx
@@ -85,6 +85,10 @@ Secondary buttons can be set into `noWrap` mode to prevent text wrapping.
 
 <Canvas of={ButtonStories.SecondaryButtonNoWrap} />
 
+Secondary buttons offer a white variant via the `isWhite` prop. Disabled and destructive states take precedence when applied.
+
+<Canvas of={ButtonStories.SecondaryButtonWhite} />
+
 ### Tertiary Buttons
 
 Tertiary or ‘ghost’ buttons are used for reversing actions, like ‘Cancel’ or ‘Back’.

--- a/src/components/button/button.pw.tsx
+++ b/src/components/button/button.pw.tsx
@@ -36,6 +36,7 @@ import {
   SecondaryButtonIconBefore,
   SecondaryFullWidth,
   SecondaryNoWrap,
+  SecondaryButtonWhite,
   TertiaryButtonDestructive,
   TertiaryButtonDisabled,
   TertiaryButtonFullWidth,
@@ -410,6 +411,15 @@ test.describe("Accessibility tests for Button", () => {
     page,
   }) => {
     await mount(<SecondaryNoWrap />);
+
+    await checkAccessibility(page);
+  });
+
+  test("should pass accessibility tests for SecondaryButtonWhite example", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<SecondaryButtonWhite />);
 
     await checkAccessibility(page);
   });

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -217,6 +217,86 @@ export const SecondaryButtonNoWrap: Story = () => {
 };
 SecondaryButtonNoWrap.storyName = "Secondary/No Wrap";
 
+export const SecondaryButtonWhite: Story = () => {
+  return (
+    <Box
+      display="flex"
+      flexDirection="column"
+      gap={2}
+      backgroundColor="var(--colorsUtilityYin100)"
+    >
+      <Box
+        height="80px"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        gap={2}
+      >
+        <Button size="small" isWhite>
+          Small White
+        </Button>
+        <Button isWhite>Medium White</Button>
+        <Button size="large" isWhite>
+          Large White
+        </Button>
+      </Box>
+      <Box
+        height="80px"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        gap={2}
+      >
+        <Button size="small" iconType="square_dot" isWhite>
+          Small White & Icon
+        </Button>
+        <Button iconType="square_dot" isWhite>
+          Medium White & Icon
+        </Button>
+        <Button iconType="square_dot" size="large" isWhite>
+          Large White & Icon
+        </Button>
+      </Box>
+      <Box
+        height="80px"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        gap={2}
+      >
+        <Button disabled isWhite>
+          Disabled & White
+        </Button>
+        <Button destructive isWhite>
+          Destructive & White
+        </Button>
+        <Button disabled destructive isWhite>
+          Disabled, Destructive & White
+        </Button>
+      </Box>
+      <Box
+        height="80px"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        gap={2}
+      >
+        <Button disabled isWhite iconType="square_dot">
+          Disabled & White
+        </Button>
+        <Button destructive isWhite iconType="square_dot">
+          Destructive & White
+        </Button>
+        <Button disabled destructive isWhite iconType="square_dot">
+          Disabled, Destructive & White
+        </Button>
+      </Box>
+    </Box>
+  );
+};
+SecondaryButtonWhite.storyName = "Secondary/White";
+SecondaryButtonWhite.parameters = { chromatic: { disableSnapshot: false } };
+
 export const TertiaryButton: Story = () => {
   return (
     <Box>
@@ -323,99 +403,159 @@ TertiaryButtonNoWrap.storyName = "Tertiary/No Wrap";
 
 export const DarkBackgroundButton: Story = () => {
   return (
-    <Box>
-      <Button mt={2} buttonType="darkBackground" size="small">
-        Small
-      </Button>
-      <Button mt={2} buttonType="darkBackground" ml={2}>
-        Medium
-      </Button>
-      <Button mt={2} buttonType="darkBackground" size="large" ml={2}>
-        Large
-      </Button>
+    <Box
+      display="flex"
+      flexDirection="column"
+      gap={2}
+      backgroundColor="var(--colorsUtilityYin100)"
+    >
+      <Box
+        height="80px"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        gap={2}
+      >
+        <Button my={2} buttonType="darkBackground" size="small">
+          Small
+        </Button>
+        <Button my={2} buttonType="darkBackground">
+          Medium
+        </Button>
+        <Button my={2} buttonType="darkBackground" size="large">
+          Large
+        </Button>
+      </Box>
     </Box>
   );
 };
 DarkBackgroundButton.storyName = "Dark Background";
+DarkBackgroundButton.parameters = { chromatic: { disableSnapshot: false } };
 
 export const DarkBackgroundButtonDisabled: Story = () => {
   return (
-    <Box>
-      <Button mt={2} buttonType="darkBackground" disabled size="small">
-        Small
-      </Button>
-      <Button mt={2} buttonType="darkBackground" disabled ml={2}>
-        Medium
-      </Button>
-      <Button mt={2} buttonType="darkBackground" disabled size="large" ml={2}>
-        Large
-      </Button>
+    <Box
+      display="flex"
+      flexDirection="column"
+      gap={2}
+      backgroundColor="var(--colorsUtilityYin100)"
+    >
+      <Box
+        height="80px"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        gap={2}
+      >
+        <Button my={2} buttonType="darkBackground" disabled size="small">
+          Small
+        </Button>
+        <Button my={2} buttonType="darkBackground" disabled>
+          Medium
+        </Button>
+        <Button my={2} buttonType="darkBackground" disabled size="large">
+          Large
+        </Button>
+      </Box>
     </Box>
   );
 };
 DarkBackgroundButtonDisabled.storyName = "Dark Background/Disabled";
+DarkBackgroundButtonDisabled.parameters = {
+  chromatic: { disableSnapshot: false },
+};
 
 export const DarkBackgroundButtonIcon: Story = () => {
   return (
-    <Box>
-      <Button mt={2} buttonType="darkBackground" iconType="add" size="small">
-        Small
-      </Button>
-      <Button
-        mt={2}
-        buttonType="darkBackground"
-        iconType="add"
-        iconPosition="after"
-        ml={2}
+    <Box
+      display="flex"
+      flexDirection="column"
+      gap={2}
+      backgroundColor="var(--colorsUtilityYin100)"
+    >
+      <Box
+        height="80px"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        gap={2}
       >
-        Medium
-      </Button>
-      <Button
-        mt={2}
-        buttonType="darkBackground"
-        disabled
-        iconType="add"
-        size="small"
-        ml={2}
-      >
-        Small
-      </Button>
-      <Button
-        mt={2}
-        buttonType="darkBackground"
-        disabled
-        iconType="add"
-        iconPosition="after"
-        ml={2}
-      >
-        Medium
-      </Button>
+        <Button my={2} buttonType="darkBackground" iconType="add" size="small">
+          Small
+        </Button>
+        <Button
+          my={2}
+          buttonType="darkBackground"
+          iconType="add"
+          iconPosition="after"
+        >
+          Medium
+        </Button>
+        <Button
+          my={2}
+          buttonType="darkBackground"
+          disabled
+          iconType="add"
+          size="small"
+        >
+          Small
+        </Button>
+        <Button
+          my={2}
+          buttonType="darkBackground"
+          disabled
+          iconType="add"
+          iconPosition="after"
+        >
+          Medium
+        </Button>
+      </Box>
     </Box>
   );
 };
 DarkBackgroundButtonIcon.storyName = "Dark Background/Icon";
+DarkBackgroundButtonIcon.parameters = { chromatic: { disableSnapshot: false } };
 
 export const DarkBackgroundButtonFullWidth: Story = () => {
   return (
-    <Box>
-      <Button mt={2} buttonType="darkBackground" fullWidth>
-        Full Width
-      </Button>
+    <Box
+      display="flex"
+      flexDirection="column"
+      gap={2}
+      backgroundColor="var(--colorsUtilityYin100)"
+    >
+      <Box
+        height="80px"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        gap={2}
+      >
+        <Button my={2} buttonType="darkBackground" fullWidth>
+          Full Width
+        </Button>
+      </Box>
     </Box>
   );
 };
 DarkBackgroundButtonFullWidth.storyName = "Dark Background/Full Width";
+DarkBackgroundButtonFullWidth.parameters = {
+  chromatic: { disableSnapshot: false },
+};
 
 export const DarkBackgroundButtonNoWrap: Story = () => {
   return (
-    <Box width="40px">
-      <Button mt={2} buttonType="darkBackground" noWrap>
+    <Box backgroundColor="var(--colorsUtilityYin100)" width="80px">
+      <Button my={2} buttonType="darkBackground" noWrap>
         Long button text
       </Button>
     </Box>
   );
 };
 DarkBackgroundButtonNoWrap.storyName = "Dark Background/No Wrap";
+DarkBackgroundButtonNoWrap.parameters = {
+  chromatic: { disableSnapshot: false },
+};
 
 export const ButtonAsALink: Story = () => {
   return (

--- a/src/components/button/button.style.ts
+++ b/src/components/button/button.style.ts
@@ -1,12 +1,14 @@
 import styled, { css } from "styled-components";
-import { space, SpaceProps } from "styled-system";
-import { IconType } from "../icon";
 
-import BaseTheme from "../../style/themes/base";
-import buttonTypes from "./button-types.style";
+import { space, SpaceProps } from "styled-system";
+
+import { IconType } from "../icon";
 import StyledIcon from "../icon/icon.style";
-import { ButtonProps, SizeOptions } from "./button.component";
+import BaseTheme from "../../style/themes/base";
 import addFocusStyling from "../../style/utils/add-focus-styling";
+
+import buttonTypes from "./button-types.style";
+import { ButtonProps, SizeOptions } from "./button.component";
 
 function additionalIconStyle(iconType?: IconType) {
   if (iconType === "services") return "6px";
@@ -26,8 +28,8 @@ function stylingForIconOnly(size?: SizeOptions) {
       dimension = "40px";
   }
   return `
-  padding: 0px; 
-  width: ${dimension}; 
+  padding: 0px;
+  width: ${dimension};
   min-height: ${dimension}`;
 }
 
@@ -37,12 +39,13 @@ function stylingForType({
   buttonType,
   size,
   destructive,
-}: Pick<ButtonProps, "disabled" | "size" | "destructive"> & {
+  isWhite,
+}: Pick<ButtonProps, "disabled" | "size" | "destructive" | "isWhite"> & {
   iconOnly?: boolean;
   buttonType: Required<ButtonProps>["buttonType"];
 }) {
   return css`
-    ${buttonTypes(disabled, destructive)[buttonType]};
+    ${buttonTypes(disabled, destructive, isWhite)[buttonType]};
 
     ${size === "small" &&
     css`
@@ -55,7 +58,7 @@ function stylingForType({
       font-size: var(--fontSizes100);
       min-height: 40px;
     `}
-    
+
     ${size === "large" &&
     css`
       font-size: var(--fontSizes200);
@@ -100,7 +103,7 @@ const StyledButton = styled.button<StyledButtonProps>`
     css`
       width: 100%;
     `}
-    
+
   ${({ iconOnly, iconPosition, iconType }) => css`
     ${StyledIcon} {
       margin-left: ${!iconOnly && iconPosition === "after"

--- a/src/components/button/button.test.tsx
+++ b/src/components/button/button.test.tsx
@@ -225,6 +225,89 @@ test("renders with the correct white-space when the 'noWrap' prop is 'true'", ()
   expect(button).toHaveStyle("white-space: nowrap");
 });
 
+/** Styling tests for `isWhite` prop coverage */
+describe("when the `isWhite` prop is passed", () => {
+  it("renders a secondary button with white text and a white border", () => {
+    render(<Button isWhite>foo</Button>);
+
+    const button = screen.getByRole("button", { name: "foo" });
+
+    expect(button).toHaveStyleRule("color", "var(--colorsActionMajorYang100)");
+    expect(button).toHaveStyleRule(
+      "border-color",
+      "var(--colorsActionMajorYang100)",
+    );
+  });
+
+  it("renders a disabled secondary button if the `disabled` prop is set", () => {
+    render(
+      <Button isWhite disabled>
+        foo
+      </Button>,
+    );
+
+    const button = screen.getByRole("button", { name: "foo" });
+
+    expect(button).toHaveStyleRule("color", "#4B4B4B");
+    expect(button).toHaveStyleRule("border-color", "#4B4B4B");
+  });
+
+  it("renders a destructive secondary button if the `destructive` prop is set", () => {
+    render(
+      <Button isWhite destructive>
+        foo
+      </Button>,
+    );
+
+    const button = screen.getByRole("button", { name: "foo" });
+
+    expect(button).toHaveStyleRule("color", "var(--colorsSemanticNegative450)");
+    expect(button).toHaveStyleRule(
+      "border-color",
+      "var(--colorsSemanticNegative450)",
+    );
+  });
+
+  it("renders a disabled secondary button if the `disabled` and `destructive` props are set", () => {
+    render(
+      <Button isWhite disabled destructive>
+        foo
+      </Button>,
+    );
+
+    const button = screen.getByRole("button", { name: "foo" });
+
+    expect(button).toHaveStyleRule("color", "#4B4B4B");
+    expect(button).toHaveStyleRule("border-color", "#4B4B4B");
+  });
+
+  it("renders with expected styling if the button type is 'primary'", () => {
+    render(
+      <Button buttonType="primary" isWhite>
+        foo
+      </Button>,
+    );
+    const button = screen.getByRole("button", { name: "foo" });
+
+    expect(button).toHaveStyleRule("color", "var(--colorsActionMajorYang100)");
+    expect(button).toHaveStyleRule("background", "var(--colorsActionMajor500)");
+    expect(button).toHaveStyleRule("border-color", "transparent");
+  });
+
+  it("renders with expected styling if the button type is 'tertiary'", () => {
+    render(
+      <Button buttonType="tertiary" isWhite>
+        foo
+      </Button>,
+    );
+    const button = screen.getByRole("button", { name: "foo" });
+
+    expect(button).toHaveStyleRule("color", "var(--colorsActionMajor500)");
+    expect(button).toHaveStyleRule("background", "transparent");
+    expect(button).toHaveStyleRule("border-color", "transparent");
+  });
+});
+
 test("renders an anchor element when a custom value is passed to the 'href' prop", () => {
   render(<Button href="https://www.warnerbros.com/movies/heat">bar</Button>);
 

--- a/src/components/button/components.test-pw.tsx
+++ b/src/components/button/components.test-pw.tsx
@@ -641,6 +641,27 @@ export const SecondaryNoWrap = () => {
   );
 };
 
+export const SecondaryButtonWhite = () => {
+  return (
+    <Box
+      display="flex"
+      flexDirection="row"
+      gap={2}
+      backgroundColor="var(--colorsUtilityYin100)"
+    >
+      <Button size="small" isWhite>
+        Small
+      </Button>
+      <Button ml={2} isWhite>
+        Medium
+      </Button>
+      <Button size="large" isWhite>
+        Large
+      </Button>
+    </Box>
+  );
+};
+
 export const TertiaryButton = () => {
   return (
     <Box>


### PR DESCRIPTION
### Proposed behaviour

As part of the work for the Help and Support sidebar, we need to add an option for secondary buttons to make them use a white border/text with transparent background.

The `Dark Background` stories of `Button` have also been updated to actually have a dark background to show the buttons against...

### Current behaviour

The current styling options available for the `secondary` button type do not allow for the required white styling to be used.

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

View the new `Secondary/White` story under `Button`