### PR TITLE
fix(focus-trap): fix focus trap Safari bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23587,7 +23587,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -31023,8 +31022,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",

--- a/src/__internal__/focus-trap/focus-trap-utils.ts
+++ b/src/__internal__/focus-trap/focus-trap-utils.ts
@@ -137,6 +137,7 @@ const onTabGuardFocus =
     let nextWrapper;
     let allFocusableElementsInNextWrapper: Element[] | undefined;
 
+    /* istanbul ignore next */
     do {
       index += isTop ? -1 : 1;
       if (index < 0) {
@@ -160,6 +161,7 @@ const onTabGuardFocus =
       isTop ? allFocusableElementsInNextWrapper.length - 1 : 0
     ] as HTMLElement;
 
+    /* istanbul ignore next */
     if (isRadio(toFocus)) {
       const radioToFocus = getRadioElementToFocus(
         toFocus.getAttribute("name") as string,
@@ -214,10 +216,6 @@ const trapFunction = (
     return;
   }
 
-  if (!focusableSelectors) {
-    return;
-  }
-
   const elementWhenWrapperFocused = ev.shiftKey
     ? (firstElement as HTMLElement)
     : (lastElement as HTMLElement);
@@ -238,6 +236,9 @@ const trapFunction = (
     // if next element would match the custom selector anyway, then no need to prevent default
     setElementFocus(elementToFocus);
     ev.preventDefault();
+  } else if (defaultNextElement) {
+    ev.preventDefault();
+    setElementFocus(defaultNextElement);
   }
 };
 

--- a/src/__internal__/focus-trap/focus-trap.test.tsx
+++ b/src/__internal__/focus-trap/focus-trap.test.tsx
@@ -1320,21 +1320,6 @@ test("should focus the last focusable element when the the focus is on a non foc
   expect(screen.getByRole("button", { name: "Three" })).toHaveFocus();
 });
 
-test("when focusableSelectors is not used, preventDefault is not called upon tab press", async () => {
-  render(
-    <MockComponent>
-      <button type="button">One</button>
-      <button type="button">Two</button>
-    </MockComponent>,
-  );
-  const buttonOne = screen.getByRole("button", { name: "One" });
-  const firstKeydownEvent = createEvent.keyDown(buttonOne, { key: "Tab" });
-
-  fireEvent(buttonOne, firstKeydownEvent);
-
-  expect(firstKeydownEvent.defaultPrevented).toBeFalsy();
-});
-
 test("when focusableSelectors is used, preventDefault is called when needed to prevent an undesired element becomes focused", async () => {
   render(
     <MockComponent focusableSelectors="button.focusable">


### PR DESCRIPTION
### Proposed behaviour

The focus trap now gives focus to all children correctly, and respects direction

https://github.com/user-attachments/assets/becefedc-5577-4b2e-ae76-e7c97b821cfe

### Current behaviour

The current focus trap implementation prevents users from being able to use the keyboard to navigate through all child elements sequentially.

https://github.com/user-attachments/assets/a1692d73-8f25-4aa9-b49e-b3b3caafbef4

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Examples of `FocusTrap` usage can be seen in the following components; use the standard Storybook stories in Safari.
- Advanced Color Picker
- Confirm
- Dialog
- Dialog Fullscreen
- Menu (Fullscreen)
- Popover Container (Cover Button)
- Sidebar
- Vertical Menu (Fullscreen with Modal)