### PR TITLE
fix(form): correct pluralisation on form summary when single error and warning

### DIFF
--- a/src/components/form/form-test.stories.tsx
+++ b/src/components/form/form-test.stories.tsx
@@ -527,7 +527,7 @@ export const FullWidthWithLeftAndRight = () => {
           Other
         </Button>
       }
-      errorCount={3}
+      errorCount={1}
       warningCount={2}
     >
       <Textbox label="Textbox" />

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -71,7 +71,7 @@ const enGB: Locale = {
         (errors, warnings, type) => {
           const errorPlural = isSingular(errors) ? "error" : "errors";
           const warningPlural = isSingular(warnings) ? "warning" : "warnings";
-          const isErrorPlural = isSingular(errors) && !warnings ? "is" : "are";
+          const isErrorPlural = isSingular(errors) ? "is" : "are";
           const isWarningPlural = isSingular(warnings) ? "is" : "are";
 
           if (errors && warnings && type === "warning") {


### PR DESCRIPTION
fix #7238

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

![image](https://github.com/user-attachments/assets/faef788c-62f0-4d16-9f6e-9f1b4bce8f6a)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

![image](https://github.com/user-attachments/assets/76a7e5c0-46e2-4f04-88a0-b9135ec29985)

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
