### PR TITLE
feat(numeral-date): allow component to be focused programmatically - FE-7067

### DIFF
--- a/src/components/numeral-date/components.test-pw.tsx
+++ b/src/components/numeral-date/components.test-pw.tsx
@@ -6,7 +6,11 @@ export const NumeralDateComponent = (props: Partial<NumeralDateProps>) => {
 };
 
 export const NumeralDateControlled = (props: Partial<NumeralDateProps>) => {
-  const [value, setValue] = React.useState({ dd: "", mm: "", yyyy: "" });
+  const [value, setValue] = React.useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
 
   return (
     <NumeralDate

--- a/src/components/numeral-date/numeral-date-test.stories.tsx
+++ b/src/components/numeral-date/numeral-date-test.stories.tsx
@@ -4,13 +4,9 @@ import { action } from "@storybook/addon-actions";
 import Textbox from "../textbox";
 import NumeralDate from ".";
 import Box from "../box";
-import {
-  DayMonthDate,
-  FullDate,
-  NumeralDateEvent,
-  NumeralDateProps,
-} from "./numeral-date.component";
+import { NumeralDateProps } from "./numeral-date.component";
 import CarbonProvider from "../carbon-provider";
+import Button from "../button";
 
 export default {
   title: "Numeral Date/Test",
@@ -62,16 +58,16 @@ export default {
 };
 
 export const Default = (args: NumeralDateProps) => {
-  const [dateValue, setDateValue] = useState<FullDate>({
+  const [dateValue, setDateValue] = useState<NumeralDateProps["value"]>({
     dd: "",
     mm: "",
     yyyy: "",
   });
-  const handleChange = (event: NumeralDateEvent) => {
-    setDateValue(event.target.value as FullDate);
+  const handleChange: NumeralDateProps["onChange"] = (event) => {
+    setDateValue(event.target.value);
     action("change")(event.target.value);
   };
-  const handleBlur = (event: NumeralDateEvent) => {
+  const handleBlur: NumeralDateProps["onBlur"] = (event) => {
     action("blur")(event.target.value);
   };
   return (
@@ -95,16 +91,16 @@ Default.args = {
 };
 
 export const DefaultWithOtherInputs = (args: NumeralDateProps) => {
-  const [dateValue, setDateValue] = useState<FullDate>({
+  const [dateValue, setDateValue] = useState<NumeralDateProps["value"]>({
     dd: "",
     mm: "",
     yyyy: "",
   });
-  const handleChange = (event: NumeralDateEvent) => {
-    setDateValue(event.target.value as FullDate);
+  const handleChange: NumeralDateProps["onChange"] = (event) => {
+    setDateValue(event.target.value);
     action("change")(event.target.value);
   };
-  const handleBlur = (event: NumeralDateEvent) => {
+  const handleBlur: NumeralDateProps["onBlur"] = (event) => {
     action("blur")(event.target.value);
   };
   return (
@@ -140,21 +136,21 @@ DefaultWithOtherInputs.story = {
   },
 };
 
-export const Validations = (args: NumeralDateProps<DayMonthDate>) => {
+export const Validations = (args: NumeralDateProps) => {
   const validationTypes = ["error", "warning", "info"];
   const [dateValue, setDateValue] = useState({ dd: "", mm: "" });
-  const handleChange = (event: NumeralDateEvent<DayMonthDate>) => {
+  const handleChange: NumeralDateProps["onChange"] = (event) => {
     setDateValue({ ...dateValue });
     action("change")(event.target.value);
   };
-  const handleBlur = (event: NumeralDateEvent<DayMonthDate>) => {
+  const handleBlur: NumeralDateProps["onBlur"] = (event) => {
     action("blur")(event.target.value);
   };
   return (
     <>
       <h4>Validations as string</h4>
       {validationTypes.map((validation) => (
-        <NumeralDate<DayMonthDate>
+        <NumeralDate
           key={`${validation}-string`}
           onChange={handleChange}
           label="Numeral date"
@@ -206,12 +202,12 @@ export const NewDesignValidations = (args: NumeralDateProps) => {
     <CarbonProvider validationRedesignOptIn>
       <h4>New designs validation</h4>
       {["error", "warning"].map((validationType) =>
-        ["small", "medium", "large"].map((size) => (
+        (["small", "medium", "large"] as const).map((size) => (
           <Box width="296px" key={`${validationType}-${size}`}>
             <NumeralDate
               label={`${size} - ${validationType}`}
               {...{ [validationType]: "Message" }}
-              size={size as NumeralDateProps["size"]}
+              size={size}
               m={4}
               {...args}
             />
@@ -326,10 +322,10 @@ export const WithHintText = ({ ...args }) => {
   return (
     <CarbonProvider validationRedesignOptIn>
       <Box ml={2} width="320px">
-        {["left", "right"].map((labelAlign) => (
+        {(["left", "right"] as const).map((labelAlign) => (
           <NumeralDate
             label="Numeral date"
-            labelAlign={labelAlign as NumeralDateProps["labelAlign"]}
+            labelAlign={labelAlign}
             labelHelp="Hint text."
             {...args}
           />
@@ -337,4 +333,44 @@ export const WithHintText = ({ ...args }) => {
       </Box>
     </CarbonProvider>
   );
+};
+
+export const ProgrammaticFocus = () => {
+  const ndRef = React.useRef<HTMLInputElement | null>(null);
+  const [dateValue, setDateValue] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
+  const handleChange: NumeralDateProps["onChange"] = (event) => {
+    setDateValue(event.target.value);
+    action("change")(event.target.value);
+  };
+  const handleBlur: NumeralDateProps["onBlur"] = (event) => {
+    action("blur")(event.target.value);
+  };
+  const handleClick = () => {
+    ndRef.current?.focus();
+  };
+  return (
+    <>
+      <Button onClick={handleClick}>Click me to focus NumeralDate</Button>
+      <Box mt="120px">
+        <NumeralDate
+          ref={ndRef}
+          onChange={handleChange}
+          label="Numeral date"
+          onBlur={handleBlur}
+          value={dateValue}
+          name="numeralDate_name"
+          id="numeralDate_id"
+        />
+      </Box>
+    </>
+  );
+};
+
+ProgrammaticFocus.storyName = "Programmatic Focus";
+ProgrammaticFocus.args = {
+  dateFormat: ["dd", "mm", "yyyy"],
 };

--- a/src/components/numeral-date/numeral-date.component.tsx
+++ b/src/components/numeral-date/numeral-date.component.tsx
@@ -1,4 +1,12 @@
-import React, { useContext, useState, useEffect, useRef, useMemo } from "react";
+import React, {
+  useContext,
+  useState,
+  useEffect,
+  useRef,
+  useMemo,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
 import invariant from "invariant";
 import { MarginProps } from "styled-system";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
@@ -38,33 +46,21 @@ export const ALLOWED_DATE_FORMATS = [
   ["mm", "yyyy"],
 ] as const;
 
-export interface DayMonthDate {
-  dd: string;
-  mm: string;
+export interface NumeralDateValue {
+  dd?: string;
+  mm?: string;
+  yyyy?: string;
 }
 
-export interface MonthYearDate {
-  mm: string;
-  yyyy: string;
-}
-
-export interface FullDate extends DayMonthDate {
-  yyyy: string;
-}
-
-export type NumeralDateObject = DayMonthDate | MonthYearDate | FullDate;
-
-export interface NumeralDateEvent<
-  DateType extends NumeralDateObject = FullDate,
-> {
+export interface NumeralDateEvent {
   target: {
     name?: string;
     id: string;
-    value: DateType;
+    value: NumeralDateValue;
   };
 }
 
-export interface NumeralDateProps<DateType extends NumeralDateObject = FullDate>
+export interface NumeralDateProps
   extends ValidationProps,
     MarginProps,
     TagProps {
@@ -84,9 +80,9 @@ export interface NumeralDateProps<DateType extends NumeralDateObject = FullDate>
   ['mm', 'yyyy'] */
   dateFormat?: ValidDateFormat;
   /** Default value for use in uncontrolled mode  */
-  defaultValue?: DateType;
+  defaultValue?: NumeralDateValue;
   /**  Value for use in controlled mode  */
-  value?: DateType;
+  value?: NumeralDateValue;
   /** When true, enables the internal errors to be displayed */
   enableInternalError?: boolean;
   /** When true, enables the internal warnings to be displayed */
@@ -115,9 +111,9 @@ export interface NumeralDateProps<DateType extends NumeralDateObject = FullDate>
   /** [Legacy] Spacing between label and a field for inline label, given number will be multiplied by base spacing unit (8) */
   labelSpacing?: 1 | 2;
   /** Blur event handler */
-  onBlur?: (ev: NumeralDateEvent<DateType>) => void;
+  onBlur?: (ev: NumeralDateEvent) => void;
   /** Change event handler */
-  onChange?: (ev: NumeralDateEvent<DateType>) => void;
+  onChange?: (ev: NumeralDateEvent) => void;
   /** Flag to configure component as mandatory */
   required?: boolean;
   /** Size of an input */
@@ -187,7 +183,7 @@ const getDaysInMonth = (month?: string, year?: string) => {
   return new Date(computedYear, +month, 0).getDate();
 };
 
-const validate = (locale: Locale, { dd, mm, yyyy }: Partial<FullDate>) => {
+const validate = (locale: Locale, { dd, mm, yyyy }: NumeralDateValue) => {
   const failed = {
     dd: "",
     mm: "",
@@ -221,354 +217,366 @@ const getDateLabel = (datePart: string, locale: Locale) => {
   }
 };
 
-export const NumeralDate = <DateType extends NumeralDateObject = FullDate>({
-  dateFormat = ["dd", "mm", "yyyy"],
-  defaultValue,
-  disabled,
-  error = "",
-  warning = "",
-  info,
-  id,
-  name,
-  onBlur,
-  onChange,
-  value,
-  validationOnLabel = false,
-  label,
-  labelInline,
-  labelWidth,
-  labelAlign,
-  fieldLabelsAlign,
-  labelHelp,
-  labelSpacing,
-  fieldHelp,
-  adaptiveLabelBreakpoint,
-  required,
-  isOptional,
-  readOnly,
-  size = "medium",
-  enableInternalError,
-  enableInternalWarning,
-  tooltipPosition,
-  helpAriaLabel,
-  dayRef,
-  monthRef,
-  yearRef,
-  ...rest
-}: NumeralDateProps<DateType>) => {
-  const locale = useLocale();
-  const { validationRedesignOptIn } = useContext(NewValidationContext);
-
-  const { current: uniqueId } = useRef(id || guid());
-  const inputIds = useRef({ dd: guid(), mm: guid(), yyyy: guid() });
-  const inputHintId = useRef(guid());
-  const isControlled = useRef(value !== undefined);
-  const initialValue = isControlled.current ? value : defaultValue;
-
-  const refs = useRef<(HTMLInputElement | null)[]>(dateFormat.map(() => null));
-
-  const [internalMessages, setInternalMessages] = useState<DateType>({
-    ...(Object.fromEntries(
-      dateFormat.map((datePart) => [datePart, ""]),
-    ) as Partial<FullDate> as DateType),
-  });
-
-  const hasCorrectDateFormat = useMemo(() => {
-    const isAllowed =
-      !dateFormat ||
-      ALLOWED_DATE_FORMATS.find(
-        (allowedDateFormat) =>
-          JSON.stringify(allowedDateFormat) === JSON.stringify(dateFormat),
-      );
-    return isAllowed;
-  }, [dateFormat]);
-
-  invariant(hasCorrectDateFormat, incorrectDateFormatMessage);
-
-  useEffect(() => {
-    const modeSwitchedMessage =
-      "Input elements should not switch from uncontrolled to controlled (or vice versa). " +
-      "Decide between using a controlled or uncontrolled input element for the lifetime of the component";
-
-    invariant(
-      isControlled.current === (value !== undefined),
-      modeSwitchedMessage,
-    );
-  }, [value]);
-
-  const [dateValue, setDateValue] = useState<DateType>({
-    ...((initialValue ||
-      (Object.fromEntries(
-        dateFormat.map((datePart) => [datePart, ""]),
-      ) as Partial<FullDate>)) as DateType),
-  });
-
-  const createCustomEventObject = (
-    newValue: DateType,
-  ): NumeralDateEvent<DateType> => ({
-    target: {
+export const NumeralDate = forwardRef<HTMLInputElement, NumeralDateProps>(
+  (
+    {
+      dateFormat = ["dd", "mm", "yyyy"],
+      defaultValue,
+      disabled,
+      error = "",
+      warning = "",
+      info,
+      id,
       name,
-      id: uniqueId,
-      value: newValue,
+      onBlur,
+      onChange,
+      value,
+      validationOnLabel = false,
+      label,
+      labelInline,
+      labelWidth,
+      labelAlign,
+      fieldLabelsAlign,
+      labelHelp,
+      labelSpacing,
+      fieldHelp,
+      adaptiveLabelBreakpoint,
+      required,
+      isOptional,
+      readOnly,
+      size = "medium",
+      enableInternalError,
+      enableInternalWarning,
+      tooltipPosition,
+      helpAriaLabel,
+      dayRef,
+      monthRef,
+      yearRef,
+      ...rest
     },
-  });
-
-  const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    const isValidKey =
-      Events.isNumberKey(event) ||
-      Events.isTabKey(event) ||
-      Events.isEnterKey(event) ||
-      event.key === "Delete" ||
-      event.key === "Backspace";
-
-    if (!isValidKey) {
-      event.preventDefault();
-    }
-  };
-
-  const handleChange = (
-    event: React.ChangeEvent<HTMLInputElement>,
-    datePart: keyof NumeralDateObject,
+    ref,
   ) => {
-    const { value: newValue } = event.target;
+    const locale = useLocale();
+    const { validationRedesignOptIn } = useContext(NewValidationContext);
 
-    if (newValue.length <= datePart.length) {
-      const newDateValue: DateType = {
-        ...dateValue,
-        [datePart]: newValue,
-      };
-      setDateValue(newDateValue);
+    const { current: uniqueId } = useRef(id || guid());
+    const inputIds = useRef({ dd: guid(), mm: guid(), yyyy: guid() });
+    const inputHintId = useRef(guid());
+    const isControlled = useRef(value !== undefined);
+    const initialValue = isControlled.current ? value : defaultValue;
 
-      /* istanbul ignore else */
-      if (onChange) {
-        onChange(createCustomEventObject(newDateValue));
-      }
-    }
-  };
+    const refs = useRef<(HTMLInputElement | null)[]>(
+      dateFormat.map(() => null),
+    );
 
-  const handleBlur = () => {
-    const internalValidationEnabled =
-      enableInternalError || enableInternalWarning;
-    /* istanbul ignore else */
-    if (internalValidationEnabled) {
-      setInternalMessages((prev) => ({
-        ...prev,
-        ...validate(locale, dateValue),
-      }));
-    }
-    setTimeout(() => {
-      const hasBlurred = !refs.current.find(
-        (ref) => ref === document.activeElement,
+    useImperativeHandle(
+      ref,
+      () =>
+        ({
+          focus: () => {
+            refs.current[0]?.focus();
+          },
+        }) as HTMLInputElement,
+    );
+
+    const [internalMessages, setInternalMessages] = useState<NumeralDateValue>({
+      ...Object.fromEntries(dateFormat.map((datePart) => [datePart, ""])),
+    });
+
+    const hasCorrectDateFormat = useMemo(() => {
+      const isAllowed =
+        !dateFormat ||
+        ALLOWED_DATE_FORMATS.find(
+          (allowedDateFormat) =>
+            JSON.stringify(allowedDateFormat) === JSON.stringify(dateFormat),
+        );
+      return isAllowed;
+    }, [dateFormat]);
+
+    invariant(hasCorrectDateFormat, incorrectDateFormatMessage);
+
+    useEffect(() => {
+      const modeSwitchedMessage =
+        "Input elements should not switch from uncontrolled to controlled (or vice versa). " +
+        "Decide between using a controlled or uncontrolled input element for the lifetime of the component";
+
+      invariant(
+        isControlled.current === (value !== undefined),
+        modeSwitchedMessage,
       );
-      /* istanbul ignore else */
-      if (onBlur && hasBlurred) {
-        onBlur(createCustomEventObject(dateValue));
+    }, [value]);
+
+    const [dateValue, setDateValue] = useState<NumeralDateValue>({
+      ...(initialValue ||
+        Object.fromEntries(dateFormat.map((datePart) => [datePart, ""]))),
+    });
+
+    const createCustomEventObject = (
+      newValue: NumeralDateValue,
+    ): NumeralDateEvent => ({
+      target: {
+        name,
+        id: uniqueId,
+        value: newValue,
+      },
+    });
+
+    const onKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      const isValidKey =
+        Events.isNumberKey(event) ||
+        Events.isTabKey(event) ||
+        Events.isEnterKey(event) ||
+        event.key === "Delete" ||
+        event.key === "Backspace";
+
+      if (!isValidKey) {
+        event.preventDefault();
       }
-    }, 5);
-  };
+    };
 
-  const internalMessage = (
-    Object.keys(internalMessages) as (keyof DateType)[]
-  ).reduce(
-    (combinedMessage, datePart) =>
-      internalMessages[datePart]
-        ? `${combinedMessage + internalMessages[datePart]}\n`
-        : combinedMessage,
-    "",
-  );
-  const internalError = enableInternalError ? internalMessage + error : error;
+    const handleChange = (
+      event: React.ChangeEvent<HTMLInputElement>,
+      datePart: keyof NumeralDateValue,
+    ) => {
+      const { value: newValue } = event.target;
 
-  const internalWarning = enableInternalWarning
-    ? internalMessage + warning
-    : warning;
+      if (newValue.length <= datePart.length) {
+        const newDateValue = {
+          ...dateValue,
+          [datePart]: newValue,
+        };
+        setDateValue(newDateValue);
 
-  if (!deprecateUncontrolledWarnTriggered && !isControlled.current) {
-    deprecateUncontrolledWarnTriggered = true;
-    Logger.deprecate(
-      "Uncontrolled behaviour in `Numeral Date` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
+        /* istanbul ignore else */
+        if (onChange) {
+          onChange(createCustomEventObject(newDateValue));
+        }
+      }
+    };
+
+    const handleBlur = () => {
+      const internalValidationEnabled =
+        enableInternalError || enableInternalWarning;
+      /* istanbul ignore else */
+      if (internalValidationEnabled) {
+        setInternalMessages((prev) => ({
+          ...prev,
+          ...validate(locale, dateValue),
+        }));
+      }
+      setTimeout(() => {
+        const hasBlurred = !refs.current.find(
+          (r) => r === document.activeElement,
+        );
+        /* istanbul ignore else */
+        if (onBlur && hasBlurred) {
+          onBlur(createCustomEventObject(dateValue));
+        }
+      }, 5);
+    };
+
+    const internalMessage = (
+      Object.keys(internalMessages) as (keyof NumeralDateValue)[]
+    ).reduce(
+      (combinedMessage, datePart) =>
+        internalMessages[datePart]
+          ? `${combinedMessage + internalMessages[datePart]}\n`
+          : combinedMessage,
+      "",
     );
-  }
+    const internalError = enableInternalError ? internalMessage + error : error;
 
-  const largeScreen = useIsAboveBreakpoint(adaptiveLabelBreakpoint);
-  let inline: boolean | undefined = labelInline;
-  if (adaptiveLabelBreakpoint) {
-    inline = largeScreen;
-  }
+    const internalWarning = enableInternalWarning
+      ? internalMessage + warning
+      : warning;
 
-  const handleRef = (
-    element: HTMLInputElement | null,
-    index: number,
-    inputRef: React.ForwardedRef<HTMLInputElement> | undefined,
-  ) => {
-    refs.current[index] = element;
-    if (!inputRef) {
-      return;
+    if (!deprecateUncontrolledWarnTriggered && !isControlled.current) {
+      deprecateUncontrolledWarnTriggered = true;
+      Logger.deprecate(
+        "Uncontrolled behaviour in `Numeral Date` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
+      );
     }
-    if (typeof inputRef === "function") {
-      inputRef(element);
-    } else {
-      inputRef.current = element;
+
+    const largeScreen = useIsAboveBreakpoint(adaptiveLabelBreakpoint);
+    let inline: boolean | undefined = labelInline;
+    if (adaptiveLabelBreakpoint) {
+      inline = largeScreen;
     }
-  };
 
-  const { validationId, fieldHelpId, ariaDescribedBy } = useInputAccessibility({
-    id: uniqueId,
-    // we still want to add the validationId to aria-describedby with the legacy validation
-    validationRedesignOptIn: true,
-    error: internalError,
-    warning: internalWarning,
-    info,
-    fieldHelp,
-  });
+    const handleRef = (
+      element: HTMLInputElement | null,
+      index: number,
+      inputRef: React.ForwardedRef<HTMLInputElement> | undefined,
+    ) => {
+      refs.current[index] = element;
+      if (!inputRef) {
+        return;
+      }
+      if (typeof inputRef === "function") {
+        inputRef(element);
+      } else {
+        inputRef.current = element;
+      }
+    };
 
-  const combinedAriaDescribedBy = [ariaDescribedBy, inputHintId.current]
-    .filter(Boolean)
-    .join(" ");
+    const { validationId, fieldHelpId, ariaDescribedBy } =
+      useInputAccessibility({
+        id: uniqueId,
+        // we still want to add the validationId to aria-describedby with the legacy validation
+        validationRedesignOptIn: true,
+        error: internalError,
+        warning: internalWarning,
+        info,
+        fieldHelp,
+      });
 
-  const renderInputs = () => {
-    return (
-      <StyledNumeralDate onKeyDown={onKeyDown}>
-        {dateFormat.map((datePart, index) => {
-          const isEnd = index === dateFormat.length - 1;
-          let inputRef: React.ForwardedRef<HTMLInputElement> | undefined;
+    const combinedAriaDescribedBy = [ariaDescribedBy, inputHintId.current]
+      .filter(Boolean)
+      .join(" ");
 
-          const validation = internalError || internalWarning || info;
-          const validationInField =
-            !validationRedesignOptIn &&
-            typeof validation === "string" &&
-            validation !== "";
+    const renderInputs = () => {
+      return (
+        <StyledNumeralDate onKeyDown={onKeyDown}>
+          {dateFormat.map((datePart, index) => {
+            const isEnd = index === dateFormat.length - 1;
+            let inputRef: React.ForwardedRef<HTMLInputElement> | undefined;
 
-          switch (datePart.slice(0, 2)) {
-            case "dd":
-              inputRef = dayRef;
-              break;
-            case "mm":
-              inputRef = monthRef;
-              break;
-            case "yy":
-              inputRef = yearRef;
-              break;
-            /* istanbul ignore next */
-            default:
-              break;
-          }
+            const validation = internalError || internalWarning || info;
+            const validationInField =
+              !validationRedesignOptIn &&
+              typeof validation === "string" &&
+              validation !== "";
 
-          return (
-            <NumeralDateContext.Provider
-              value={{ disableErrorBorder: true }}
-              key={datePart}
-            >
-              <StyledDateField
+            switch (datePart.slice(0, 2)) {
+              case "dd":
+                inputRef = dayRef;
+                break;
+              case "mm":
+                inputRef = monthRef;
+                break;
+              case "yy":
+                inputRef = yearRef;
+                break;
+              /* istanbul ignore next */
+              default:
+                break;
+            }
+
+            return (
+              <NumeralDateContext.Provider
+                value={{ disableErrorBorder: true }}
                 key={datePart}
-                size={size}
-                isYearInput={datePart.length === 4}
-                hasValidationIconInField={
-                  !validationOnLabel && isEnd && validationInField
-                }
               >
-                <Textbox
-                  id={inputIds.current[datePart]}
-                  label={getDateLabel(datePart, locale)}
-                  labelAlign={fieldLabelsAlign}
-                  disabled={disabled}
-                  readOnly={readOnly}
-                  error={!!internalError}
-                  warning={!!internalWarning}
-                  info={!!info}
+                <StyledDateField
+                  key={datePart}
                   size={size}
-                  value={dateValue[datePart as keyof NumeralDateObject]}
-                  onChange={(e) =>
-                    handleChange(e, datePart as keyof NumeralDateObject)
+                  isYearInput={datePart.length === 4}
+                  hasValidationIconInField={
+                    !validationOnLabel && isEnd && validationInField
                   }
-                  onBlur={handleBlur}
-                  ref={(element) => handleRef(element, index, inputRef)}
-                  {...(isEnd &&
-                    !validationOnLabel &&
-                    !validationRedesignOptIn && {
-                      error: internalError,
-                      warning: internalWarning,
-                      info,
-                    })}
-                  tooltipPosition={tooltipPosition}
-                  tooltipId={validationId}
-                />
-              </StyledDateField>
-            </NumeralDateContext.Provider>
-          );
-        })}
-      </StyledNumeralDate>
-    );
-  };
+                >
+                  <Textbox
+                    id={inputIds.current[datePart]}
+                    label={getDateLabel(datePart, locale)}
+                    labelAlign={fieldLabelsAlign}
+                    disabled={disabled}
+                    readOnly={readOnly}
+                    error={!!internalError}
+                    warning={!!internalWarning}
+                    info={!!info}
+                    size={size}
+                    value={dateValue[datePart]}
+                    onChange={(e) => handleChange(e, datePart)}
+                    onBlur={handleBlur}
+                    ref={(element) => handleRef(element, index, inputRef)}
+                    {...(isEnd &&
+                      !validationOnLabel &&
+                      !validationRedesignOptIn && {
+                        error: internalError,
+                        warning: internalWarning,
+                        info,
+                      })}
+                    tooltipPosition={tooltipPosition}
+                    tooltipId={validationId}
+                  />
+                </StyledDateField>
+              </NumeralDateContext.Provider>
+            );
+          })}
+        </StyledNumeralDate>
+      );
+    };
 
-  if (!validationRedesignOptIn) {
+    if (!validationRedesignOptIn) {
+      return (
+        <TooltipProvider helpAriaLabel={helpAriaLabel}>
+          <StyledFieldset
+            id={uniqueId}
+            legend={label}
+            legendMargin={{ mb: 0 }}
+            isRequired={required}
+            isOptional={isOptional}
+            isDisabled={disabled}
+            name={name}
+            error={validationOnLabel && internalError}
+            warning={validationOnLabel && internalWarning}
+            info={validationOnLabel && info}
+            inline={inline}
+            size={size}
+            labelHelp={labelHelp}
+            legendAlign={labelAlign}
+            legendWidth={labelWidth}
+            legendSpacing={labelSpacing}
+            validationId={validationId}
+            aria-describedby={validationOnLabel ? ariaDescribedBy : fieldHelpId}
+            {...filterStyledSystemMarginProps(rest)}
+            {...tagComponent("numeral-date", rest)}
+          >
+            <Box display="flex" flexDirection="column" mt={inline ? 0 : 1}>
+              {renderInputs()}
+              {fieldHelp && <FieldHelp id={fieldHelpId}>{fieldHelp}</FieldHelp>}
+            </Box>
+          </StyledFieldset>
+        </TooltipProvider>
+      );
+    }
+
     return (
-      <TooltipProvider helpAriaLabel={helpAriaLabel}>
-        <StyledFieldset
-          id={uniqueId}
-          legend={label}
-          legendMargin={{ mb: 0 }}
-          isRequired={required}
-          isOptional={isOptional}
-          isDisabled={disabled}
-          name={name}
-          error={validationOnLabel && internalError}
-          warning={validationOnLabel && internalWarning}
-          info={validationOnLabel && info}
-          inline={inline}
-          size={size}
-          labelHelp={labelHelp}
-          legendAlign={labelAlign}
-          legendWidth={labelWidth}
-          legendSpacing={labelSpacing}
-          validationId={validationId}
-          aria-describedby={validationOnLabel ? ariaDescribedBy : fieldHelpId}
-          {...filterStyledSystemMarginProps(rest)}
-          {...tagComponent("numeral-date", rest)}
-        >
-          <Box display="flex" flexDirection="column" mt={inline ? 0 : 1}>
-            {renderInputs()}
-            {fieldHelp && <FieldHelp id={fieldHelpId}>{fieldHelp}</FieldHelp>}
-          </Box>
-        </StyledFieldset>
-      </TooltipProvider>
-    );
-  }
-
-  return (
-    <StyledFieldset
-      id={uniqueId}
-      legend={label}
-      legendMargin={{ mb: 0 }}
-      legendAlign={labelAlign}
-      isRequired={required}
-      isOptional={isOptional}
-      isDisabled={disabled}
-      name={name}
-      aria-describedby={combinedAriaDescribedBy}
-      {...filterStyledSystemMarginProps(rest)}
-      {...tagComponent("numeral-date", rest)}
-    >
-      {labelHelp && (
-        <HintText align={labelAlign} id={inputHintId.current}>
-          {labelHelp}
-        </HintText>
-      )}
-
-      <Box position="relative" mt={labelHelp ? 0 : 1}>
-        {(internalError || internalWarning) && (
-          <>
-            <ValidationMessage
-              error={internalError}
-              warning={internalWarning}
-              validationId={validationId}
-            />
-            <ErrorBorder warning={!!(!internalError && internalWarning)} />
-          </>
+      <StyledFieldset
+        id={uniqueId}
+        legend={label}
+        legendMargin={{ mb: 0 }}
+        legendAlign={labelAlign}
+        isRequired={required}
+        isOptional={isOptional}
+        isDisabled={disabled}
+        name={name}
+        aria-describedby={combinedAriaDescribedBy}
+        {...filterStyledSystemMarginProps(rest)}
+        {...tagComponent("numeral-date", rest)}
+      >
+        {labelHelp && (
+          <HintText align={labelAlign} id={inputHintId.current}>
+            {labelHelp}
+          </HintText>
         )}
-        {renderInputs()}
-      </Box>
-    </StyledFieldset>
-  );
-};
+
+        <Box position="relative" mt={labelHelp ? 0 : 1}>
+          {(internalError || internalWarning) && (
+            <>
+              <ValidationMessage
+                error={internalError}
+                warning={internalWarning}
+                validationId={validationId}
+              />
+              <ErrorBorder warning={!!(!internalError && internalWarning)} />
+            </>
+          )}
+          {renderInputs()}
+        </Box>
+      </StyledFieldset>
+    );
+  },
+);
 
 export default NumeralDate;

--- a/src/components/numeral-date/numeral-date.mdx
+++ b/src/components/numeral-date/numeral-date.mdx
@@ -22,7 +22,7 @@ For dates close to today, we advise the use of a standard datepicker. If you req
 Import `NumeralDate` into the project.
 
 ```javascript
-import NumeralDate from "carbon-react/lib/components/numeral-date";
+import NumeralDate, { NumeralDateProps } from "carbon-react/lib/components/numeral-date";
 ```
 
 ## Examples
@@ -110,6 +110,12 @@ You can use the `size` prop to set the size of the field.
 ### isOptional
 
 <Canvas of={NumeralDateStories.IsOptional} />
+
+### Programmatic Focus
+
+It is possible to focus the `NumeralDate` component programmatically by passing a ref to the component and calling the `focus` method on it.
+
+<Canvas of={NumeralDateStories.ProgrammaticFocus} />
 
 ## Props
 

--- a/src/components/numeral-date/numeral-date.stories.tsx
+++ b/src/components/numeral-date/numeral-date.stories.tsx
@@ -5,7 +5,8 @@ import generateStyledSystemProps from "../../../.storybook/utils/styled-system-p
 
 import CarbonProvider from "../carbon-provider";
 import Box from "../box";
-import NumeralDate from ".";
+import NumeralDate, { NumeralDateProps } from ".";
+import Button from "../button";
 
 const styledSystemProps = generateStyledSystemProps({
   margin: true,
@@ -33,7 +34,11 @@ export const Default: Story = () => {
 Default.storyName = "Default";
 
 export const Controlled: Story = () => {
-  const [value, setValue] = useState({ dd: "", mm: "", yyyy: "" });
+  const [value, setValue] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
 
   return (
     <NumeralDate
@@ -60,12 +65,12 @@ export const AllowedDateFormats: Story = () => {
 AllowedDateFormats.storyName = "Allowed Date Formats";
 
 export const InternalValidationError: Story = () => {
-  const [valueOld, setValueOld] = useState({
+  const [valueOld, setValueOld] = useState<NumeralDateProps["value"]>({
     dd: "",
     mm: "",
     yyyy: "",
   });
-  const [valueNew, setValueNew] = useState({
+  const [valueNew, setValueNew] = useState<NumeralDateProps["value"]>({
     dd: "",
     mm: "",
     yyyy: "",
@@ -93,8 +98,16 @@ export const InternalValidationError: Story = () => {
 InternalValidationError.storyName = "Internal Validation Error";
 
 export const InternalValidationWarning: Story = () => {
-  const [valueOld, setValueOld] = useState({ dd: "", mm: "", yyyy: "" });
-  const [valueNew, setValueNew] = useState({ dd: "", mm: "", yyyy: "" });
+  const [valueOld, setValueOld] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
+  const [valueNew, setValueNew] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
   return (
     <>
       <NumeralDate
@@ -118,7 +131,11 @@ export const InternalValidationWarning: Story = () => {
 InternalValidationWarning.storyName = "Internal Validation Warning";
 
 export const Validation: Story = () => {
-  const [value, setValue] = useState({ dd: "", mm: "", yyyy: "" });
+  const [value, setValue] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
   return (
     <>
       <NumeralDate
@@ -175,7 +192,11 @@ export const Validation: Story = () => {
 Validation.storyName = "Validation";
 
 export const NewValidation: Story = () => {
-  const [value, setValue] = useState({ dd: "", mm: "", yyyy: "" });
+  const [value, setValue] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
   return (
     <CarbonProvider validationRedesignOptIn>
       <Box m={2}>
@@ -220,7 +241,11 @@ export const NewValidation: Story = () => {
 NewValidation.storyName = "New Validation";
 
 export const InlineLabel: Story = () => {
-  const [value, setValue] = useState({ dd: "", mm: "", yyyy: "" });
+  const [value, setValue] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
   return (
     <NumeralDate
       label="Inline"
@@ -235,7 +260,11 @@ export const InlineLabel: Story = () => {
 InlineLabel.storyName = "Inline Label";
 
 export const EnablingAdaptiveBehaviour: Story = () => {
-  const [value, setValue] = useState({ dd: "", mm: "", yyyy: "" });
+  const [value, setValue] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
   return (
     <NumeralDate
       adaptiveLabelBreakpoint={960}
@@ -254,7 +283,11 @@ EnablingAdaptiveBehaviour.parameters = {
 };
 
 export const WithLabelHelp: Story = () => {
-  const [value, setValue] = useState({ dd: "", mm: "", yyyy: "" });
+  const [value, setValue] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
   return (
     <NumeralDate
       helpAriaLabel="Label help"
@@ -268,7 +301,11 @@ export const WithLabelHelp: Story = () => {
 WithLabelHelp.storyName = "With Label Help";
 
 export const WithFieldHelp: Story = () => {
-  const [value, setValue] = useState({ dd: "", mm: "", yyyy: "" });
+  const [value, setValue] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
   return (
     <NumeralDate
       label="With field help"
@@ -304,7 +341,11 @@ export const Size: Story = () => {
 Size.storyName = "Size";
 
 export const Required: Story = () => {
-  const [value, setValue] = useState({ dd: "", mm: "", yyyy: "" });
+  const [value, setValue] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
   return (
     <NumeralDate
       name="optional"
@@ -320,7 +361,11 @@ export const Required: Story = () => {
 Required.storyName = "Required";
 
 export const IsOptional: Story = () => {
-  const [value, setValue] = useState({ dd: "", mm: "", yyyy: "" });
+  const [value, setValue] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
   return (
     <NumeralDate
       name="optional"
@@ -334,3 +379,35 @@ export const IsOptional: Story = () => {
   );
 };
 IsOptional.storyName = "IsOptional";
+
+export const ProgrammaticFocus = () => {
+  const ndRef = React.useRef<HTMLInputElement | null>(null);
+  const [dateValue, setDateValue] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
+  const handleChange: NumeralDateProps["onChange"] = (event) => {
+    setDateValue(event.target.value);
+  };
+  const handleClick = () => {
+    ndRef.current?.focus();
+  };
+  return (
+    <>
+      <Button onClick={handleClick}>Click me to focus NumeralDate</Button>
+      <Box mt="120px">
+        <NumeralDate
+          ref={ndRef}
+          onChange={handleChange}
+          label="Numeral date"
+          value={dateValue}
+          name="numeralDate_name"
+          id="numeralDate_id"
+        />
+      </Box>
+    </>
+  );
+};
+
+ProgrammaticFocus.storyName = "Programmatic Focus";

--- a/src/components/numeral-date/numeral-date.test.tsx
+++ b/src/components/numeral-date/numeral-date.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import { render, screen, within, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import {
@@ -9,6 +9,7 @@ import {
 import NumeralDate from "./numeral-date.component";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 import Logger from "../../__internal__/utils/logger";
+import Button from "../button";
 
 jest.mock("../../__internal__/utils/logger");
 
@@ -2153,3 +2154,62 @@ test.each(["error", "warning"])(
     expect(fieldset).toHaveAccessibleDescription("Message labelHelp");
   },
 );
+
+test("should focus the first textbox when the component is programmatically focused when the date format is dd/mm/yyyy", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  const MockComponent = () => {
+    const ndRef = useRef<HTMLInputElement>(null);
+    return (
+      <>
+        <Button onClick={() => ndRef.current?.focus()}>Click me</Button>
+        <NumeralDate
+          ref={ndRef}
+          onChange={() => {}}
+          label="Numeral date"
+          value={{ dd: "", mm: "", yyyy: "" }}
+          name="numeralDate_name"
+          id="numeralDate_id"
+        />
+      </>
+    );
+  };
+
+  render(<MockComponent />);
+
+  const button = screen.getByRole("button", { name: "Click me" });
+  const firstInput = screen.getByRole("textbox", { name: "Day" });
+
+  await user.click(button);
+
+  expect(firstInput).toHaveFocus();
+});
+
+test("should focus the first textbox when the component is programmatically focused when the date format is mm/yyyy", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  const MockComponent = () => {
+    const ndRef = useRef<HTMLInputElement>(null);
+    return (
+      <>
+        <Button onClick={() => ndRef.current?.focus()}>Click me</Button>
+        <NumeralDate
+          ref={ndRef}
+          dateFormat={["mm", "yyyy"]}
+          onChange={() => {}}
+          label="Numeral date"
+          value={{ mm: "", yyyy: "" }}
+          name="numeralDate_name"
+          id="numeralDate_id"
+        />
+      </>
+    );
+  };
+
+  render(<MockComponent />);
+
+  const button = screen.getByRole("button", { name: "Click me" });
+  const firstInput = screen.getByRole("textbox", { name: "Month" });
+
+  await user.click(button);
+
+  expect(firstInput).toHaveFocus();
+});


### PR DESCRIPTION
Currently it is not possible to focus the numeral date component programmatically. This changeallows consumers to now do that.

BREAKING CHANGE: In order to allow NumeralDate to allow a forward ref the typescript interface for the component has had to be changed.

fixes #7180

### Proposed behaviour

Allow component to be focused via the `.focus()` method. 

### Current behaviour

Component is currently not focusable via the `.focus()` method.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Testing instructions will follow once I have created a test repo with `react-hook-form` installed. 
