### PR TITLE
build(jest): fix validation warnings in test output

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -15,7 +15,6 @@ const isCI = process.env.CI === "true";
 
 const baseProjectConfig: Config = {
   rootDir,
-  setupFiles: ["raf/polyfill"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "mjs"],
   transform: {
     "^.+\\.(js|mjs|jsx|ts|tsx)$": "babel-jest",

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,7 +1,9 @@
 import { Config } from "jest";
+import { resolve } from "path";
 
 import coverageThresholds from "./coverage-thresholds.json";
 
+const rootDir = resolve(__dirname, ".");
 const esmOnlyPackages = [
   "react-dnd",
   "core-dnd",
@@ -9,34 +11,11 @@ const esmOnlyPackages = [
   "dnd-core",
   "react-dnd-html5-backend",
 ];
-
 const isCI = process.env.CI === "true";
 
-const clientConfig: Config = {
-  notify: false,
+const baseProjectConfig: Config = {
+  rootDir,
   setupFiles: ["raf/polyfill"],
-  testEnvironment: "jsdom",
-  setupFilesAfterEnv: [
-    "<rootDir>/src/__spec_helper__/__internal__/index.ts",
-    "jest-canvas-mock",
-  ],
-  testMatch: [
-    "**/?(*.)+(spec|test).[jt]s?(x)",
-    "!**/*.server.(spec|test).[jt]s?(x)",
-  ],
-  testPathIgnorePatterns: ["node_modules", "lib", "esm"],
-  moduleDirectories: ["src", "node_modules"],
-  collectCoverage: true,
-  coveragePathIgnorePatterns: [
-    "node_modules",
-    "src/__spec_helper__",
-    "src/locales",
-    "lib",
-    "esm",
-  ],
-  coverageReporters: ["text-summary", "html", "json"],
-  coverageDirectory: "<rootDir>/coverage",
-  coverageThreshold: isCI ? undefined : coverageThresholds,
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "mjs"],
   transform: {
     "^.+\\.(js|mjs|jsx|ts|tsx)$": "babel-jest",
@@ -45,20 +24,50 @@ const clientConfig: Config = {
   transformIgnorePatterns: [
     `<rootDir>/node_modules/(?!(${esmOnlyPackages.join("|")}))`,
   ],
+  moduleDirectories: ["src", "node_modules"],
   moduleNameMapper: {
     "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js",
   },
+  coveragePathIgnorePatterns: [
+    "<rootDir>/node_modules",
+    "<rootDir>/src/__spec_helper__",
+    "<rootDir>/src/locales",
+    "<rootDir>/lib",
+    "<rootDir>/esm",
+  ],
+  coverageDirectory: "<rootDir>/coverage",
+  testPathIgnorePatterns: [
+    "<rootDir>/node_modules",
+    "<rootDir>/lib",
+    "<rootDir>/esm",
+  ],
+};
+
+const clientConfig: Config = {
+  displayName: "Client",
+  testMatch: ["**/!(*.server).+(spec|test).[jt]s?(x)"],
+  testEnvironment: "jsdom",
+  setupFilesAfterEnv: [
+    "<rootDir>/src/__spec_helper__/__internal__/index.ts",
+    "jest-canvas-mock",
+  ],
+  ...baseProjectConfig,
 };
 
 const serverConfig: Config = {
-  ...clientConfig,
+  displayName: { name: "Server", color: "blue" },
   testMatch: ["**/*.server.(spec|test).[jt]s?(x)"],
-  testPathIgnorePatterns: ["node_modules", "lib", "esm"],
   testEnvironment: "node",
+  setupFilesAfterEnv: ["<rootDir>/src/__spec_helper__/__internal__/index.ts"],
+  ...baseProjectConfig,
 };
 
-const config: Config = {
+const globalConfig: Config = {
   projects: [clientConfig, serverConfig],
+  notify: false,
+  collectCoverage: true,
+  coverageReporters: ["text-summary", "html", "json"],
+  coverageThreshold: isCI ? undefined : coverageThresholds,
 };
 
-export default config;
+export default globalConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -135,7 +135,6 @@
         "node-fetch": "^3.3.2",
         "nyc": "^17.1.0",
         "prettier": "~3.3.3",
-        "raf": "^3.4.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^8.0.7",
@@ -24226,12 +24225,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true
-    },
     "node_modules/picocolors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
@@ -24885,15 +24878,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "dev": true,
-      "dependencies": {
-        "performance-now": "^2.1.0"
       }
     },
     "node_modules/randombytes": {

--- a/package.json
+++ b/package.json
@@ -153,7 +153,6 @@
     "node-fetch": "^3.3.2",
     "nyc": "^17.1.0",
     "prettier": "~3.3.3",
-    "raf": "^3.4.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^8.0.7",


### PR DESCRIPTION
### Proposed behaviour

- Prevent validation warnings from appearing in jest test output
- Remove legacy `raf` polyfill used by jest tests

### Current behaviour


### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
