### PR TITLE
test(decimal): fix failing test due to Node 20.19.0 change

### DIFF
--- a/src/components/decimal/decimal.test.tsx
+++ b/src/components/decimal/decimal.test.tsx
@@ -1116,7 +1116,10 @@ describe("when the component is uncontrolled", () => {
   it("renders a negative value with correct formatting when the `it` locale is set", () => {
     render(<Decimal defaultValue="-1234.56" locale="it" />);
 
-    expect(screen.getByRole("textbox")).toHaveValue("-1.234,56");
+    const formatter = new Intl.NumberFormat("it", { minimumFractionDigits: 2 });
+    const formatted = formatter.format(-1234.56);
+
+    expect(screen.getByRole("textbox")).toHaveValue(formatted);
     expect(screen.getByTestId("hidden-input")).toHaveValue("-1234.56");
   });
 


### PR DESCRIPTION
### Proposed behaviour

- Update `Decimal` test that asserts decimal formatting

### Current behaviour

- A `Decimal` test consistently fails in Node 20.19.0 onwards. This is due to [an update made to Node's version of the ICU library](https://github.com/nodejs/node/commit/d69107f5a8), which is used by Node's JavaScript engine for internationalisation. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
