### PR TITLE
fix:  ensure there is no flash of reduce motion text in Loader components when page is reloaded

### DIFF
--- a/src/components/loader-bar/loader-bar.component.tsx
+++ b/src/components/loader-bar/loader-bar.component.tsx
@@ -21,9 +21,13 @@ export interface LoaderBarProps
 export const LoaderBar = ({ size = "medium", ...rest }: LoaderBarProps) => {
   const l = useLocale();
 
-  const reduceMotion = !useMediaQuery(
+  const allowMotion = useMediaQuery(
     "screen and (prefers-reduced-motion: no-preference)",
   );
+
+  if (allowMotion === undefined) {
+    return null;
+  }
 
   return (
     <StyledLoader
@@ -32,12 +36,12 @@ export const LoaderBar = ({ size = "medium", ...rest }: LoaderBarProps) => {
       {...tagComponent("loader-bar", rest)}
       {...filterStyledSystemMarginProps(rest)}
     >
-      {reduceMotion ? (
-        l.loader.loading()
-      ) : (
+      {allowMotion ? (
         <StyledLoaderBar data-role="outer-bar" size={size}>
           <InnerBar data-role="inner-bar" size={size} />
         </StyledLoaderBar>
+      ) : (
+        l.loader.loading()
       )}
     </StyledLoader>
   );

--- a/src/components/loader-bar/loader-bar.test.tsx
+++ b/src/components/loader-bar/loader-bar.test.tsx
@@ -3,43 +3,59 @@ import { render, screen } from "@testing-library/react";
 import LoaderBar from "./loader-bar.component";
 import useMediaQuery from "../../hooks/useMediaQuery";
 
-jest.mock("../../hooks/useMediaQuery", () => {
-  return {
-    __esModule: true,
-    default: jest.fn().mockReturnValue(true),
-  };
+jest.mock("../../hooks/useMediaQuery", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockUseMediaQuery = useMediaQuery as jest.MockedFunction<
+  typeof useMediaQuery
+>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseMediaQuery.mockReturnValue(true);
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
 });
 
 test("renders", () => {
   render(<LoaderBar />);
-
   const loaderBar = screen.getByRole("progressbar", { name: "Loading" });
   expect(loaderBar).toBeVisible();
 });
 
+test("uses default size when size is undefined", async () => {
+  render(<LoaderBar />);
+
+  const outerBar = await screen.findByTestId("outer-bar");
+  const innerBar = await screen.findByTestId("inner-bar");
+
+  expect(outerBar).toHaveStyle("height: 8px");
+  expect(innerBar).toHaveStyle("height: 8px");
+});
+
 test("renders with custom data role and element", () => {
   render(<LoaderBar data-role="foo" data-component="bar" data-element="baz" />);
-
   const loaderBar = screen.getByTestId("foo");
   expect(loaderBar).toHaveAttribute("data-role", "foo");
   expect(loaderBar).toHaveAttribute("data-element", "baz");
 });
 
 test("renders alternative loading text if user prefers reduced motion", () => {
-  const mockUseMediaQuery = useMediaQuery as jest.MockedFunction<
-    typeof useMediaQuery
-  >;
   mockUseMediaQuery.mockReturnValueOnce(false);
-
   render(<LoaderBar />);
-
   const loaderBar = screen.getByRole("progressbar", { name: "Loading" });
   expect(loaderBar).toHaveTextContent("Loading");
 });
 
 /* Styling test for coverage */
-it.each([
+test.each([
+  [undefined, "8px"],
   ["small", "4px"],
+  ["medium", "8px"],
   ["large", "16px"],
 ] as const)(
   "when size is %s, both the inner and outer bars have the correct height",

--- a/src/components/loader-spinner/loader-spinner.component.tsx
+++ b/src/components/loader-spinner/loader-spinner.component.tsx
@@ -65,9 +65,13 @@ export const LoaderSpinner = ({
 }: LoaderSpinnerProps) => {
   const locale = useLocale();
 
-  const reduceMotion = !useMediaQuery(
+  const allowMotion = useMediaQuery(
     "screen and (prefers-reduced-motion: no-preference)",
   );
+
+  if (allowMotion === undefined) {
+    return null;
+  }
 
   const isLabelDark = variant !== "inverse" && variant !== "gradient-white";
 
@@ -100,7 +104,6 @@ export const LoaderSpinner = ({
     if (animationTime) {
       return animationTime;
     }
-
     return isGradientVariant ? 2 : 1;
   };
 
@@ -111,9 +114,7 @@ export const LoaderSpinner = ({
       {...tagComponent("loader-spinner", rest)}
       {...filterStyledSystemMarginProps(rest)}
     >
-      {reduceMotion ? (
-        renderSpinnerLabel
-      ) : (
+      {allowMotion ? (
         <>
           <StyledSpinnerCircleSvg
             role="presentation"
@@ -128,6 +129,7 @@ export const LoaderSpinner = ({
             <circle data-role="outer-arc" />
             <circle data-role="inner-arc" />
           </StyledSpinnerCircleSvg>
+
           {showSpinnerLabel ? (
             renderSpinnerLabel
           ) : (
@@ -140,6 +142,8 @@ export const LoaderSpinner = ({
             </Typography>
           )}
         </>
+      ) : (
+        renderSpinnerLabel
       )}
     </StyledSpinnerWrapper>
   );

--- a/src/components/loader-star/loader-star.component.tsx
+++ b/src/components/loader-star/loader-star.component.tsx
@@ -23,12 +23,16 @@ export interface LoaderStarProps extends TagProps {
 const LoaderStar = ({
   loaderStarLabel,
   ...rest
-}: LoaderStarProps): JSX.Element => {
+}: LoaderStarProps): JSX.Element | null => {
   const locale = useLocale();
 
-  const reduceMotion = !useMediaQuery(
+  const allowMotion = useMediaQuery(
     "screen and (prefers-reduced-motion: no-preference)",
   );
+
+  if (allowMotion === undefined) {
+    return null;
+  }
 
   const label = (
     <StyledLabel data-role="visible-label" variant="span" fontWeight="400">
@@ -41,9 +45,7 @@ const LoaderStar = ({
       role="status"
       {...tagComponent("loader-star", rest)}
     >
-      {reduceMotion ? (
-        label
-      ) : (
+      {allowMotion ? (
         <>
           <StyledStars>
             <Star starContainerClassName="star-1" gradientId="gradient1" />
@@ -54,6 +56,8 @@ const LoaderStar = ({
             {loaderStarLabel || locale.loaderStar.loading()}
           </Typography>
         </>
+      ) : (
+        label
       )}
     </StyledLoaderStarWrapper>
   );

--- a/src/components/loader-star/loader-star.test.tsx
+++ b/src/components/loader-star/loader-star.test.tsx
@@ -5,8 +5,21 @@ import useMediaQuery from "../../hooks/useMediaQuery";
 
 jest.mock("../../hooks/useMediaQuery", () => ({
   __esModule: true,
-  default: jest.fn().mockReturnValue(true),
+  default: jest.fn(),
 }));
+
+const mockUseMediaQuery = useMediaQuery as jest.MockedFunction<
+  typeof useMediaQuery
+>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseMediaQuery.mockReturnValue(true);
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
 
 test("should render with the expected data- attributes", () => {
   render(<LoaderStar data-element="fish" data-role="chips" />);
@@ -15,6 +28,15 @@ test("should render with the expected data- attributes", () => {
 
   expect(LoaderStarComponent).toHaveAttribute("data-element", "fish");
   expect(LoaderStarComponent).toHaveAttribute("data-role", "chips");
+});
+
+test("should return null and render nothing when useMediaQuery returns undefined", () => {
+  mockUseMediaQuery.mockReturnValueOnce(undefined);
+
+  render(<LoaderStar />);
+
+  const wrapperElement = screen.queryByRole("status");
+  expect(wrapperElement).not.toBeInTheDocument();
 });
 
 test("component should have a visually hidden label for assistive technologies by default", () => {
@@ -35,9 +57,6 @@ test("renders a custom visually hidden label for assistive technologies to use, 
 
 describe("when the component is rendered and the user prefers reduced motion", () => {
   it("should render the the LoaderStar label", () => {
-    const mockUseMediaQuery = useMediaQuery as jest.MockedFunction<
-      typeof useMediaQuery
-    >;
     mockUseMediaQuery.mockReturnValueOnce(false);
 
     render(<LoaderStar />);
@@ -50,9 +69,6 @@ describe("when the component is rendered and the user prefers reduced motion", (
   });
 
   it("should not render the svg stars", () => {
-    const mockUseMediaQuery = useMediaQuery as jest.MockedFunction<
-      typeof useMediaQuery
-    >;
     mockUseMediaQuery.mockReturnValueOnce(false);
 
     render(<LoaderStar />);

--- a/src/components/loader/loader-square.style.ts
+++ b/src/components/loader/loader-square.style.ts
@@ -48,6 +48,11 @@ const getDimensions = (size: StyledLoaderSquareProps["size"]) => {
   `;
 };
 
+export const StyledLoaderPlaceholder = styled.div`
+  display: inline-block;
+  min-width: var(--sizing800);
+`;
+
 const StyledLoaderSquare = styled.div<StyledLoaderSquareProps>`
   ${({ size, isInsideButton, isActive, backgroundColor }) => css`
     animation: ${loaderAnimation} 1s infinite ease-in-out both;
@@ -55,22 +60,18 @@ const StyledLoaderSquare = styled.div<StyledLoaderSquareProps>`
     display: inline-block;
     ${getDimensions(size)}
     border-radius: var(--borderRadiusCircle);
-
     ${isInsideButton &&
     css`
       background-color: ${isActive
         ? "var(--colorsUtilityYang100)"
         : "var(--colorsSemanticNeutral500)"};
     `}
-
     &:nth-of-type(1) {
       animation-delay: 0s;
     }
-
     &:nth-of-type(2) {
       animation-delay: 0.2s;
     }
-
     &:nth-of-type(3) {
       animation-delay: 0.4s;
       margin-right: 0px;
@@ -79,7 +80,6 @@ const StyledLoaderSquare = styled.div<StyledLoaderSquareProps>`
 `;
 
 StyledLoaderSquare.defaultProps = {
-  size: "small",
   isInsideButton: false,
   isActive: true,
   theme: baseTheme,

--- a/src/components/loader/loader-square.test.tsx
+++ b/src/components/loader/loader-square.test.tsx
@@ -1,9 +1,24 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import Loader from ".";
+import useMediaQuery from "../../hooks/useMediaQuery";
 
-jest.mock("../../hooks/useMediaQuery", () => {
-  return jest.fn(() => true);
+jest.mock("../../hooks/useMediaQuery", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockUseMediaQuery = useMediaQuery as jest.MockedFunction<
+  typeof useMediaQuery
+>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseMediaQuery.mockReturnValue(true);
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
 });
 
 it.each([0, 1, 2])("each loader square renders as expected", (index) => {
@@ -84,15 +99,10 @@ test("when inside button and `isActive` prop is false, the expected background c
 
   const loaderSquares = screen.getAllByTestId("loader-square");
 
-  expect(loaderSquares[0]).toHaveStyleRule(
-    "backgroundColor: var(--colorsSemanticNeutral500)",
-  );
-
-  expect(loaderSquares[1]).toHaveStyleRule(
-    "backgroundColor: var(--colorsSemanticNeutral500)",
-  );
-
-  expect(loaderSquares[2]).toHaveStyleRule(
-    "backgroundColor: var(--colorsSemanticNeutral500)",
-  );
+  loaderSquares.forEach((square) => {
+    expect(square).toHaveStyleRule(
+      "background-color",
+      "var(--colorsSemanticNeutral500)",
+    );
+  });
 });

--- a/src/components/loader/loader.component.tsx
+++ b/src/components/loader/loader.component.tsx
@@ -9,6 +9,7 @@ import tagComponent, {
 import StyledLoader from "./loader.style";
 import StyledLoaderSquare, {
   StyledLoaderSquareProps,
+  StyledLoaderPlaceholder,
 } from "./loader-square.style";
 import Typography from "../typography";
 import Logger from "../../__internal__/utils/logger";
@@ -51,9 +52,13 @@ export const Loader = ({
 
   const l = useLocale();
 
-  const reduceMotion = !useMediaQuery(
+  const allowMotion = useMediaQuery(
     "screen and (prefers-reduced-motion: no-preference)",
   );
+
+  if (allowMotion === undefined) {
+    return <StyledLoaderPlaceholder />;
+  }
 
   const loaderSquareProps = {
     isInsideButton,
@@ -68,9 +73,7 @@ export const Loader = ({
       {...tagComponent("loader", rest)}
       {...filterStyledSystemMarginProps(rest)}
     >
-      {reduceMotion ? (
-        loaderLabel || ariaLabel || l.loader.loading()
-      ) : (
+      {allowMotion ? (
         <>
           {["#13A038", "#0092DB", "#8F49FE"].map((color) => (
             <StyledLoaderSquare
@@ -88,6 +91,8 @@ export const Loader = ({
             {loaderLabel || ariaLabel || l.loader.loading()}
           </Typography>
         </>
+      ) : (
+        loaderLabel || ariaLabel || l.loader.loading()
       )}
     </StyledLoader>
   );

--- a/src/components/switch/__internal__/switch-slider-panel.test.tsx
+++ b/src/components/switch/__internal__/switch-slider-panel.test.tsx
@@ -3,15 +3,22 @@ import { render, screen } from "@testing-library/react";
 import Switch from "../switch.component";
 import useMediaQuery from "../../../hooks/useMediaQuery";
 
-jest.mock("../../../hooks/useMediaQuery", () => {
-  return jest.fn(() => true);
-});
+jest.mock("../../../hooks/useMediaQuery", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockUseMediaQuery = useMediaQuery as jest.MockedFunction<
+  typeof useMediaQuery
+>;
 
 beforeEach(() => {
-  const mockUseMediaQuery = useMediaQuery as jest.MockedFunction<
-    typeof useMediaQuery
-  >;
-  mockUseMediaQuery.mockReturnValueOnce(false);
+  jest.clearAllMocks();
+  mockUseMediaQuery.mockReturnValue(true);
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
 });
 
 test("when `loading` is true, the correct Loader styles are applied", () => {

--- a/src/hooks/useMediaQuery/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery/useMediaQuery.ts
@@ -1,17 +1,25 @@
-import React from "react";
+import { useLayoutEffect, useState } from "react";
+import { getWindow } from "../../__internal__/dom/globals";
 
-export default function useMediaQuery(queryInput: string): boolean {
+export default function useMediaQuery(queryInput: string): boolean | undefined {
   const query = queryInput.replace(/^@media( ?)/m, "");
 
-  const [match, setMatch] = React.useState(() => false);
+  const [match, setMatch] = useState<boolean | undefined>(undefined);
 
-  React.useEffect(() => {
-    const queryList = window.matchMedia(query);
-    const updateMatch = () => {
-      setMatch(queryList.matches);
-    };
+  useLayoutEffect(() => {
+    const browserWindow = getWindow();
+
+    /* istanbul ignore if */
+    if (!browserWindow) {
+      return undefined;
+    }
+
+    const queryList = browserWindow.matchMedia(query);
+    const updateMatch = () => setMatch(queryList.matches);
+
     updateMatch();
     queryList.addEventListener("change", updateMatch);
+
     return () => {
       queryList.removeEventListener("change", updateMatch);
     };


### PR DESCRIPTION
fixes #7240

### Proposed behaviour

https://github.com/user-attachments/assets/73d222ff-f8be-45b2-a88d-0fbce17cdcf2


https://github.com/user-attachments/assets/91364182-0fc0-4ae9-96e0-14542e4acb34



<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Initialises `useMediaQuery` as `undefined` to prevent reduced motion `loading` text from rendering when browser motion preferences are yet to be detected when there is latency on the network or a slow page reload

### Current behaviour


<!--

A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
When there is network latency they reduced motion `loading` text flashes on screen as the browser motion preference is yet to be determined and `useMediaQuery` has an initial value of false.


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

In useMediaQuery hook useLayoutEffect has been used to make use the matchMedia value is set synchronously before the browser painting. 

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
Pick any Loader story and set the browser network to 4G or worse and refresh the page, in master you will see the flash of the `loading` text. In this PR you shouldn't see it