### PR TITLE
feat(dialog): add highlight variant prop to dialog

### DIFF
--- a/src/components/dialog/dialog-test.stories.tsx
+++ b/src/components/dialog/dialog-test.stories.tsx
@@ -40,6 +40,12 @@ export default {
         type: "select",
       },
     },
+    highlightVariant: {
+      options: ["default", "ai"],
+      control: {
+        type: "select",
+      },
+    },
   },
 };
 

--- a/src/components/dialog/dialog.component.tsx
+++ b/src/components/dialog/dialog.component.tsx
@@ -70,6 +70,8 @@ export interface DialogProps extends ModalProps, TagProps {
   height?: string;
   /** Adds Help tooltip to Header */
   help?: string;
+  /* Allows developers to specify a highlight variant */
+  highlightVariant?: string;
   /** A custom close event handler */
   onCancel?: (
     ev:
@@ -126,6 +128,7 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
       bespokeFocusTrap,
       disableClose,
       help,
+      highlightVariant = "default",
       role = "dialog",
       contentPadding = {},
       greyBackground = false,
@@ -239,6 +242,7 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
               aria-modal={isTopModal ? true : undefined}
               ref={containerRef}
               {...dialogProps}
+              highlightVariant={highlightVariant}
               role={role}
               tabIndex={-1}
               {...contentPadding}

--- a/src/components/dialog/dialog.mdx
+++ b/src/components/dialog/dialog.mdx
@@ -149,6 +149,12 @@ Please note that setting the background color to grey may cause color contrast a
 
 <Canvas of={DialogStories.GreyBackground} />
 
+### Highlight variants
+
+Setting the `highlightVariant` prop will add a highlight above the Dialog.
+
+<Canvas of={DialogStories.HighlightVariant} />
+
 ## Props
 
 ### Dialog

--- a/src/components/dialog/dialog.stories.tsx
+++ b/src/components/dialog/dialog.stories.tsx
@@ -579,3 +579,12 @@ export const GreyBackground: Story = {
     greyBackground: true,
   },
 };
+
+export const HighlightVariant: Story = {
+  ...DefaultStory,
+  name: "With Highlight Variant",
+  args: {
+    ...DefaultStory.args,
+    highlightVariant: "ai",
+  },
+};

--- a/src/components/dialog/dialog.style.ts
+++ b/src/components/dialog/dialog.style.ts
@@ -28,6 +28,7 @@ const dialogSizes = {
 type StyledDialogProps = Required<Pick<DialogProps, "size">> & {
   dialogHeight?: string;
   backgroundColor: string;
+  highlightVariant?: string;
 };
 
 const DialogPositioner = styled.div`
@@ -66,6 +67,20 @@ const StyledDialog = styled.div<StyledDialogProps & ContentPaddingInterface>`
   &:focus {
     outline: none;
   }
+
+  ${({ highlightVariant }) =>
+    highlightVariant === "ai" &&
+    `
+      &::before {
+        content: "";
+        position: absolute;
+        top: -8px;
+        height: 100px;
+        width: 100%;
+        z-index: -1;
+        background: linear-gradient(90deg, #00D639 0%, #00D6DE 40%, #9D60FF 90%);
+        border-radius: var(--borderRadius200) var(--borderRadius200) 0 0;
+      }`}
 
   ${({ backgroundColor }) => css`
     background-color: ${backgroundColor};

--- a/src/components/dialog/dialog.test.tsx
+++ b/src/components/dialog/dialog.test.tsx
@@ -366,3 +366,22 @@ test("background scroll remains disabled when returning to outer dialog after cl
   expect(screen.getByRole("dialog")).toHaveAccessibleName("Outer dialog");
   expect(document.body).toHaveStyle("overflow: hidden");
 });
+
+test("should render with the highlight when 'ai' is passed in as the `highlightVariant`", () => {
+  render(
+    <Dialog open title="My dialog" highlightVariant="ai">
+      Inner content
+    </Dialog>,
+  );
+
+  const highlightElement = screen.getByRole("dialog");
+  expect(highlightElement).toHaveStyleRule(
+    "background",
+    "linear-gradient(90deg,#00D639 0%,#00D6DE 40%,#9D60FF 90%)",
+    {
+      modifier: "::before",
+    },
+  );
+
+  expect(highlightElement).toBeVisible();
+});


### PR DESCRIPTION
### Proposed behaviour

Add the "ai" highlight variant to showcase the AI gradient

<img width="783" alt="Screenshot 2025-03-21 at 18 33 35" src="https://github.com/user-attachments/assets/93ba6b93-bced-4219-a5d0-2faf3c59d671" />

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

Currently no Highlight Variant capabilities on the Dialog component

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Screenshots are included in the PR if useful
- [x] Unit tests added or updated if required
- [x] Storybook added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

Added Highlight Variant to test story to allow switching between Default (no visual highlight) and AI variants

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
