### PR TITLE
fix(hr): make width 100% - FE-6662

### DIFF
--- a/src/components/adaptive-sidebar/adaptive-sidebar.stories.tsx
+++ b/src/components/adaptive-sidebar/adaptive-sidebar.stories.tsx
@@ -139,7 +139,7 @@ export const Default: Story = () => {
           <Typography variant="h3">Content</Typography>
           <Button onClick={() => setAdaptiveSidebarOpen(false)}>Close</Button>
         </Box>
-        <Hr my={0} mx={1} />
+        <Hr my={0} mx={0} />
         <Box display="flex" flexDirection="column" p={1}>
           <Typography>
             This is the main content of the adaptive sidebar
@@ -521,7 +521,7 @@ export const WithCustomBorderColor: Story = () => {
           <Typography variant="h3">Content</Typography>
           <Button onClick={() => setAdaptiveSidebarOpen(false)}>Close</Button>
         </Box>
-        <Hr my={0} mx={1} />
+        <Hr my={0} mx={0} />
         <Box display="flex" flexDirection="column" p={1}>
           <Typography>
             This is the main content of the adaptive sidebar

--- a/src/components/form/form.stories.tsx
+++ b/src/components/form/form.stories.tsx
@@ -742,7 +742,9 @@ export const FormAlignmentExample: Story = () => {
         label="Checkbox 2"
         ml="10%"
       />
-      <Hr ml="10%" mr="60%" mb={7} />
+      <Box ml="10%" mr="60%">
+        <Hr mb={7} />
+      </Box>
       <Button buttonType="tertiary" ml="calc(10% - 24px)">
         Tertiary
       </Button>

--- a/src/components/hr/hr-test.stories.tsx
+++ b/src/components/hr/hr-test.stories.tsx
@@ -1,9 +1,11 @@
 import React from "react";
+import { StoryObj } from "@storybook/react/*";
+import Box from "../box";
+import Typography from "../typography";
 import Hr, { HrProps } from ".";
 
 export default {
   title: "Hr/Test",
-  includeStories: ["Default"],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -12,8 +14,47 @@ export default {
   },
 };
 
+type StoryType = StoryObj<typeof Hr>;
+
 export const Default = (props: HrProps) => {
   return <Hr {...props} />;
 };
 
 Default.storyName = "default";
+
+export const InVariousFlexContainers: StoryType = () => {
+  return (
+    <>
+      <Box
+        padding="25px"
+        display="flex"
+        flexDirection="column"
+        minWidth="320px"
+        maxWidth="1024px"
+      >
+        <Typography>Flex container with minWidth and maxWidth</Typography>
+        <Hr my={2} />
+      </Box>
+      <Box padding="25px" display="flex" flexDirection="column" width="500px">
+        <Typography>Flex container with width</Typography>
+        <Hr my={2} />
+      </Box>
+      <Box padding="25px" minWidth="320px" maxWidth="1024px">
+        <Typography>Block container with minWidth and maxWidth</Typography>
+        <Hr my={2} />
+      </Box>
+    </>
+  );
+};
+
+InVariousFlexContainers.storyName = "In Various Flex Containers";
+InVariousFlexContainers.decorators = [
+  (Story) => (
+    <Box width="97vw" height="97vh">
+      <Story />
+    </Box>
+  ),
+];
+InVariousFlexContainers.parameters = {
+  chromatic: { disable: false },
+};

--- a/src/components/hr/hr.mdx
+++ b/src/components/hr/hr.mdx
@@ -32,7 +32,7 @@ By default the hr is 100% width and has top and bottom margins of 24px.
 
 ### With different vertical spacing
 
-The `mb` and `mt` props set the vertical spacing. These props are mulitipliers and are therefore multiplied by the base theme spacing which is `8px`. The default for both is `3` and therefore `24px`.
+The `mb` and `mt` props set the vertical spacing. These props are multipliers and are therefore multiplied by the base theme spacing which is `8px`. The default for both is `3` and therefore `24px`.
 
 <Canvas of={HrStories.DifferentSpacing} />
 

--- a/src/components/hr/hr.stories.tsx
+++ b/src/components/hr/hr.stories.tsx
@@ -103,7 +103,9 @@ export const InsideFormInlineLabels: Story = () => {
         labelWidth={10}
         inputWidth={50}
       />
-      <Hr mb={7} mt={7} ml="10%" mr="40%" />
+      <Box ml="10%" mr="40%">
+        <Hr mb={7} mt={7} />
+      </Box>
       <Textbox
         label="Textbox"
         labelAlign="right"

--- a/src/components/hr/hr.style.ts
+++ b/src/components/hr/hr.style.ts
@@ -12,7 +12,7 @@ const StyledHr = styled.hr<
   MarginProps & { height: "small" | "medium" | "large" }
 >`
   ${margin}
-  width: inherit;
+  width: 100%;
   border: 0;
   height: ${({ height }) => heightMap[height]}px;
   background: var(--colorsUtilityMajor100);


### PR DESCRIPTION
### Proposed behaviour

![Screenshot 2025-03-24 at 15 24 31](https://github.com/user-attachments/assets/bfc139d4-cf43-4e76-b6f0-848a004f4218)

### Current behaviour

![Screenshot 2025-03-24 at 15 25 12](https://github.com/user-attachments/assets/50cedbe7-6256-4aec-a4f8-06eef2db996c)


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

I have forgone adding a unit or PW test for this change as I think a Chromatic snapshot captures this change best.

### Testing instructions

There should be no styling regressions with this component due to this change. 
