### PR TITLE
fix(button-bar): ensure disabled buttons have correct styles

### DIFF
--- a/src/components/button-bar/button-bar-test.stories.tsx
+++ b/src/components/button-bar/button-bar-test.stories.tsx
@@ -11,7 +11,6 @@ import ButtonMinor from "../button-minor";
 
 export default {
   title: "Button Bar/Test",
-  includeStories: ["Default", "Preview"],
   parameters: {
     info: { disable: true },
     chromatic: { disableSnapshot: true },
@@ -35,50 +34,66 @@ const commonArgsButtonBar = {
   iconPosition: "before",
 };
 
-export const DefaultWithWrapper = (args: Partial<ButtonBarProps>) => {
-  const WrappedComponent = () => {
-    return (
-      <>
-        <Button iconType="bin">bar</Button>
-        <Button iconType="csv">bar</Button>
-        <Button iconType="pdf">bar</Button>
-      </>
-    );
-  };
-
-  return (
-    <ButtonBar {...args}>
-      <WrappedComponent />
-      <IconButton onClick={() => undefined}>
-        <Icon type="csv" />
-      </IconButton>
+export const Default = (args: Partial<ButtonBarProps>) => (
+  <>
+    <ButtonBar {...args} mb={2}>
+      <Button iconType="search">Example Button</Button>
+      <Button iconType="pdf">Example Button</Button>
+      <Button iconType="csv">Example Button</Button>
     </ButtonBar>
-  );
+    <ButtonBar {...args}>
+      <ButtonMinor iconType="search">Example ButtonMinor</ButtonMinor>
+      <ButtonMinor iconType="pdf">Example ButtonMinor</ButtonMinor>
+      <ButtonMinor iconType="csv">Example ButtonMinor</ButtonMinor>
+    </ButtonBar>
+  </>
+);
+Default.story = {
+  args: {
+    ...commonArgsButtonBar,
+  },
+  argTypes: {
+    ...commonArgTypesButtonBar,
+  },
 };
 
-export const ButtonBarWithMinorButtonChildren = () => (
-  <ButtonBar>
-    <ButtonMinor iconType="search">Example ButtonMinor</ButtonMinor>
-    <ButtonMinor iconType="pdf">Example ButtonMinor</ButtonMinor>
-    <ButtonMinor iconType="csv">Example ButtonMinor</ButtonMinor>
-  </ButtonBar>
+export const WithDisabledButtons = (args: Partial<ButtonBarProps>) => (
+  <>
+    <ButtonBar {...args} mb={2}>
+      <IconButton disabled onClick={() => {}}>
+        <Icon type="pdf" />
+      </IconButton>
+      <IconButton onClick={() => {}}>
+        <Icon type="csv" />
+      </IconButton>
+      <IconButton onClick={() => {}}>
+        <Icon type="search" />
+      </IconButton>
+    </ButtonBar>
+    <ButtonBar {...args} mb={2}>
+      <Button iconType="search" disabled>
+        Example Button
+      </Button>
+      <Button iconType="pdf">Example Button</Button>
+      <Button iconType="csv">Example Button</Button>
+    </ButtonBar>
+    <ButtonBar {...args}>
+      <ButtonMinor iconType="search" disabled>
+        Example ButtonMinor
+      </ButtonMinor>
+      <ButtonMinor iconType="pdf">Example ButtonMinor</ButtonMinor>
+      <ButtonMinor iconType="csv">Example ButtonMinor</ButtonMinor>
+    </ButtonBar>
+  </>
 );
-
-export const Default = (args: Partial<ButtonBarProps>) => (
-  <ButtonBar {...args}>
-    <Button iconType="search">Example Button</Button>
-    <Button iconType="pdf">Example Button</Button>
-    <Button iconType="csv">Example Button</Button>
-  </ButtonBar>
-);
-
-export const DefaultWithButtonMinor = (args: Partial<ButtonBarProps>) => (
-  <ButtonBar {...args}>
-    <ButtonMinor iconType="search">Example Button</ButtonMinor>
-    <ButtonMinor iconType="pdf">Example Button</ButtonMinor>
-    <ButtonMinor iconType="csv">Example Button</ButtonMinor>
-  </ButtonBar>
-);
+WithDisabledButtons.story = {
+  args: {
+    ...commonArgsButtonBar,
+  },
+  argTypes: {
+    ...commonArgTypesButtonBar,
+  },
+};
 
 export const Preview = () => {
   return (
@@ -191,19 +206,7 @@ export const Preview = () => {
     </>
   );
 };
-
-Default.story = {
-  name: "default",
-  args: {
-    ...commonArgsButtonBar,
-  },
-  argTypes: {
-    ...commonArgTypesButtonBar,
-  },
-};
-
 Preview.story = {
-  name: "visual",
   parameters: {
     chromatic: {
       disableSnapshot: false,

--- a/src/components/button-bar/button-bar.pw.tsx
+++ b/src/components/button-bar/button-bar.pw.tsx
@@ -4,6 +4,7 @@ import {
   Default as ButtonBarCustom,
   DefaultWithWrapper as ButtonBarWithWrapper,
   DefaultWithButtonMinor as ButtonBarMinor,
+  ButtonBarWithDisabledIconButton,
 } from "./components.test-pw";
 
 import {
@@ -15,7 +16,10 @@ import {
   buttonDataComponent,
   buttonMinorComponent,
 } from "../../../playwright/components/button/index";
-import { icon } from "../../../playwright/components/index";
+import {
+  button as iconButton,
+  icon,
+} from "../../../playwright/components/index";
 import {
   checkAccessibility,
   getStyle,
@@ -200,10 +204,7 @@ test.describe("renders with ButtonMinor children", async () => {
       );
 
       await minorButton.hover();
-      await expect(minorButton).toHaveCSS(
-        "background-color",
-        "rgb(51, 91, 112)",
-      );
+      await expect(minorButton).toHaveCSS("background-color", "rgb(0, 50, 76)");
     });
 
     test(`should apply the correct color to the ${index} ButtonMinor children`, async ({
@@ -228,7 +229,71 @@ test.describe("renders with ButtonMinor children", async () => {
       await expect(minorButton).toHaveCSS("border-color", colorByIndex);
 
       await minorButton.hover();
-      await expect(minorButton).toHaveCSS("border-color", "rgb(51, 91, 112)");
+      await expect(minorButton).toHaveCSS("border-color", "rgba(0, 0, 0, 0)");
     });
+  });
+});
+
+test.describe("renders with IconButton children", async () => {
+  test("should render IconButton with correct styles on hover", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<ButtonBarWithDisabledIconButton />);
+
+    const iconButtonComponent = iconButton(page).nth(1);
+    const iconComponent = icon(page).nth(1);
+
+    await expect(iconButtonComponent).toHaveCSS(
+      "background-color",
+      "rgba(0, 0, 0, 0)",
+    );
+    await expect(iconButtonComponent).toHaveCSS(
+      "border-color",
+      "rgb(0, 126, 69)",
+    );
+    await expect(iconComponent).toHaveCSS("color", "rgb(0, 126, 69)");
+
+    await iconButtonComponent.hover();
+    await expect(iconButtonComponent).toHaveCSS(
+      "background-color",
+      "rgb(0, 103, 56)",
+    );
+    await expect(iconButtonComponent).toHaveCSS(
+      "border-color",
+      "rgb(0, 103, 56)",
+    );
+    await expect(iconComponent).toHaveCSS("color", "rgb(255, 255, 255)");
+  });
+
+  test("should render IconButton with correct styles when disabled", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<ButtonBarWithDisabledIconButton />);
+
+    const disabledIconButton = iconButton(page).nth(0);
+    const disabledIcon = icon(page).nth(0);
+
+    await expect(disabledIconButton).toHaveCSS(
+      "background-color",
+      "rgba(0, 0, 0, 0)",
+    );
+    await expect(disabledIconButton).toHaveCSS(
+      "border-color",
+      "rgb(230, 235, 237)",
+    );
+    await expect(disabledIcon).toHaveCSS("color", "rgba(0, 0, 0, 0.3)");
+
+    await disabledIconButton.hover();
+    await expect(disabledIconButton).toHaveCSS(
+      "background-color",
+      "rgba(0, 0, 0, 0)",
+    );
+    await expect(disabledIconButton).toHaveCSS(
+      "border-color",
+      "rgb(230, 235, 237)",
+    );
+    await expect(disabledIcon).toHaveCSS("color", "rgba(0, 0, 0, 0.3)");
   });
 });

--- a/src/components/button-bar/button-bar.style.ts
+++ b/src/components/button-bar/button-bar.style.ts
@@ -1,18 +1,12 @@
 import styled, { css } from "styled-components";
 import { space, SpaceProps } from "styled-system";
 import BaseTheme from "../../style/themes/base";
-import StyledButton from "../button/button.style";
 import StyledIcon from "../icon/icon.style";
 import { ButtonBarProps } from "./button-bar.component";
 import StyledIconButton from "../icon-button/icon-button.style";
 
 type StyledButtonBarProps = SpaceProps &
   Pick<ButtonBarProps, "size" | "fullWidth">;
-
-const commonHoverStyles = `
-  background-color: var(--colorsActionMajor600);
-  border-color: var(--colorsActionMajor600);
-`;
 
 const StyledButtonBar = styled.div<StyledButtonBarProps>`
   ${space}
@@ -58,59 +52,32 @@ const StyledButtonBar = styled.div<StyledButtonBarProps>`
         position: relative;
         z-index: 2;
       }
-
-      &:hover {
-        background-color: var(--colorsActionMajor600);
-        border-color: var(--colorsActionMajor600);
-
-        & + button {
-          border-left-color: var(--colorsActionMajor600);
-        }
-
-        & ${StyledIcon} {
-          ${commonHoverStyles}
-          color: white;
-        }
-      }
-
-      & ${StyledIcon} {
-        color: var(--colorsActionMajor500);
-      }
     }
 
-    [data-component="button"] {
-      :hover {
-        ${commonHoverStyles}
-        & + ${StyledButton} {
-          border-left-color: var(--colorsActionMajor600);
-        }
-      }
-    }
-
-    [data-component="button-minor"] {
-      & ${StyledIcon} {
-        color: var(--colorsActionMinor500);
-      }
-    }
-
-    [data-component="button-minor"] {
-      :hover {
-        color: var(--colorsActionMinorYang100);
-        background-color: var(--colorsActionMinor500);
-        border-color: var(--colorsActionMinor500);
-
-        & + ${StyledButton} {
-          border-left-color: var(--colorsActionMinor500);
-        }
-      }
-    }
-
-    ${StyledIconButton} {
+    ${StyledIconButton}:not(:disabled) {
       border: 2px solid var(--colorsActionMajor500);
 
       :focus {
         border-right-color: var(--colorsActionMajor500);
       }
+
+      :hover {
+        background-color: var(--colorsActionMajor600);
+        border-color: var(--colorsActionMajor600);
+        color: var(--colorsActionMajorYang100);
+      }
+
+      ${StyledIcon} {
+        color: var(--colorsActionMajor500);
+
+        :hover {
+          color: var(--colorsActionMajorYang100);
+        }
+      }
+    }
+
+    ${StyledIconButton}:disabled {
+      border: 2px solid var(--colorsActionDisabled500);
     }
   `}
 `;

--- a/src/components/button-bar/components.test-pw.tsx
+++ b/src/components/button-bar/components.test-pw.tsx
@@ -50,9 +50,26 @@ const DefaultWithButtonMinor = (args: Partial<ButtonBarProps>) => (
   </ButtonBar>
 );
 
+const ButtonBarWithDisabledIconButton = () => {
+  return (
+    <ButtonBar>
+      <IconButton disabled onClick={() => {}}>
+        <Icon type="pdf" />
+      </IconButton>
+      <IconButton onClick={() => {}}>
+        <Icon type="csv" />
+      </IconButton>
+      <IconButton onClick={() => {}}>
+        <Icon type="bin" />
+      </IconButton>
+    </ButtonBar>
+  );
+};
+
 export {
   Default,
   DefaultWithWrapper,
   ButtonBarWithMinorButtonChildren,
   DefaultWithButtonMinor,
+  ButtonBarWithDisabledIconButton,
 };


### PR DESCRIPTION
fix #6292

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- Disabled buttons with icons have correct colour:

![image](https://github.com/user-attachments/assets/fec8f7d6-5717-4b63-af8b-b59c039adc8c)


- Disabled buttons have correct hover styles:
<img width="540" alt="image" src="https://github.com/user-attachments/assets/0f9f54cd-c177-4d84-ba84-9b890dc7ddcc" />
<img width="585" alt="image" src="https://github.com/user-attachments/assets/0b851cff-7829-4347-bdc4-2442f8eb1c8c" />

- `ButtonBar` with `ButtonMinor` has correct styles on hover:
<img width="488" alt="image" src="https://github.com/user-attachments/assets/a1615e33-3b75-46cc-8fda-013d063de989" />


### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- `ButtonBar` with disabled buttons with icons have incorrect colour:
<img width="464" alt="image" src="https://github.com/user-attachments/assets/0767292b-aba8-40cf-b6d7-f65a6ea92456" />

- `ButtonBar` with disabled buttons have incorrect styles on hover:
<img width="605" alt="image" src="https://github.com/user-attachments/assets/9f70dcb8-0455-4685-ac1f-8a1e0b0b8d19" />
<img width="480" alt="image" src="https://github.com/user-attachments/assets/906e971a-a8b9-45d6-9d84-771b8e066119" />

- `ButtonBar` with `ButtonMinor` has incorrect styles on hover:
<img width="482" alt="image" src="https://github.com/user-attachments/assets/9edd2bb8-016b-4840-9b55-32acc35f72fc" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
