### PR TITLE
chore(github): update carbon version placeholder to request full version number

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -61,7 +61,7 @@ body:
     id: carbon-version
     attributes:
       label: Carbon version
-      placeholder: 125.1.1
+      placeholder: 153.1.0 (please provide full version number not just 'latest')
     validations:
       required: true
 


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- include a note to add the full version number as opposed to just 'latest'

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- many issues are being raised with only 'latest' which is causing issues when reviewing older issues where 'latest' doesn't mean much to the team anymore

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide