### PR TITLE
fix(grouped-character): ensure Delete key works as expected

### DIFF
--- a/src/components/grouped-character/grouped-character.component.tsx
+++ b/src/components/grouped-character/grouped-character.component.tsx
@@ -110,7 +110,9 @@ export const GroupedCharacter = React.forwardRef(
         newCursorPos += separatorDiff;
       } else if (isAtOneBeyondSeparator) {
         const isDeleting = value.length > rawValue.length;
-        newCursorPos += isDeleting ? -1 : 1;
+        if (!isDeleting) {
+          newCursorPos += 1;
+        }
       }
 
       const modifiedEvent = ev as unknown as CustomEvent;
@@ -152,6 +154,20 @@ export const GroupedCharacter = React.forwardRef(
 
       if (isCharacterKey && maxRawLength === value.length && !hasSelection) {
         ev.preventDefault();
+      }
+
+      if (ev.key === "Delete") {
+        const cursorPos = selectionStart ?? /* istanbul ignore next */ 0;
+        const rawValue = sanitizeValue(value);
+        const formattedValue = formatValue(rawValue);
+
+        if (formattedValue[cursorPos] === separator) {
+          ev.preventDefault();
+          const target = ev.target as HTMLInputElement;
+          setTimeout(() =>
+            target.setSelectionRange(cursorPos + 1, cursorPos + 1),
+          );
+        }
       }
 
       if (onKeyDown) {

--- a/src/components/grouped-character/grouped-character.test.tsx
+++ b/src/components/grouped-character/grouped-character.test.tsx
@@ -336,7 +336,7 @@ test("pressing a character at the point where a separator should appear, moves t
   expect(input.selectionEnd).toBe(7);
 });
 
-test("pressing backspace after a separator moves the cursor backwards two positions", async () => {
+test("pressing backspace after a separator moves the cursor backwards one position", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(<ControlledGroupedCharacter initialValue="1231231" />);
@@ -355,8 +355,8 @@ test("pressing backspace after a separator moves the cursor backwards two positi
 
   await user.keyboard("{backspace}");
 
-  expect(input.selectionStart).toBe(2);
-  expect(input.selectionEnd).toBe(2);
+  expect(input.selectionStart).toBe(3);
+  expect(input.selectionEnd).toBe(3);
 });
 
 test("adding a character before a separator moves cursor forwards two positions", async () => {
@@ -428,6 +428,53 @@ test("pressing backspace when the cursor is at one position beyond the separator
 
   expect(input.selectionStart).toBe(7);
   expect(input.selectionEnd).toBe(7);
+});
+
+test("pressing delete when the cursor is at one position before the separator, should move the cursor one position forward", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(<ControlledGroupedCharacter initialValue="1234567" />);
+
+  const input = screen.getByRole("textbox") as HTMLInputElement;
+
+  await user.click(input);
+  await user.keyboard("{arrowLeft}");
+  await user.keyboard("{arrowRight}");
+  await user.keyboard("{arrowRight}");
+
+  expect(input.selectionStart).toBe(2);
+  expect(input.selectionEnd).toBe(2);
+  expect(input).toHaveValue("12-34-567");
+
+  await user.keyboard("{Delete}");
+
+  expect(input.selectionStart).toBe(3);
+  expect(input.selectionEnd).toBe(3);
+  expect(input).toHaveValue("12-34-567");
+});
+
+test("pressing delete when the cursor is at one position after the separator, should keep the cursor in the same position", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(<ControlledGroupedCharacter initialValue="1234567" />);
+
+  const input = screen.getByRole("textbox") as HTMLInputElement;
+
+  await user.click(input);
+  await user.keyboard("{arrowLeft}");
+  await user.keyboard("{arrowRight}");
+  await user.keyboard("{arrowRight}");
+  await user.keyboard("{arrowRight}");
+
+  expect(input.selectionStart).toBe(3);
+  expect(input.selectionEnd).toBe(3);
+  expect(input).toHaveValue("12-34-567");
+
+  await user.keyboard("{Delete}");
+
+  expect(input.selectionStart).toBe(3);
+  expect(input.selectionEnd).toBe(3);
+  expect(input).toHaveValue("12-45-67");
 });
 
 test("the required prop is passed to the input", () => {


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

When `Delete` key is pressed in `GroupedCharacter`:
- moves one position forward when cursor is before a separator
- maintains the position when cursor is after a separator

https://github.com/user-attachments/assets/02595c0f-43cd-4707-b21a-4779d7e06666

When `Backspace` is pressed in `GroupedCharacter` the cursor moves one position if character is after separator:
(will still remove the separator character if it is at the end of the value)

https://github.com/user-attachments/assets/37e36410-dfdf-4b32-8548-258177d2aee4

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
When `Delete` key is pressed in `GroupedCharacter`:
- has no effect when cursor is before separator
- moves back a position when cursor is after the separator

https://github.com/user-attachments/assets/f03104b9-775f-4292-a5e8-3b0fd2ea1293

When `Backspace` is pressed in `GroupedCharacter` the cursor moves two positions if character is after separator:

https://github.com/user-attachments/assets/26be502d-603d-4379-a01a-4c2fb7b6d1e3

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

`BackSpace` and `Delete` should would the same but inversed. 

`BackSpace` key should:
- remove single character backwards and only move one position backwards.
- removes separator once the character after it has been removed too.
- if pressed with cursor position after separator, cursor should move one position backwards and separator stays.

`Delete` key should:
- remove single character forwards and maintain cursor position.
- remove separator once the character after it has been removed too.
- if pressed with cursor position before separator, cursor should move one position forwards and separator stays.
