### PR TITLE
fix(flat-table-row-header): correct icon size for expandable rows

### DIFF
--- a/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.ts
+++ b/src/components/flat-table/flat-table-row-header/flat-table-row-header.style.ts
@@ -122,8 +122,8 @@ const StyledFlatTableRowHeaderContent = styled.div<{ expandable?: boolean }>`
       line-height: 1em;
 
       ${StyledIcon} {
-        width: 16px;
-        height: 16px;
+        width: 20px;
+        height: 20px;
       }
     `}
 `;

--- a/src/components/flat-table/flat-table-test.stories.tsx
+++ b/src/components/flat-table/flat-table-test.stories.tsx
@@ -29,6 +29,8 @@ import {
   ActionPopover,
   ActionPopoverItem,
   ActionPopoverDivider,
+  ActionPopoverMenuButton,
+  ActionPopoverMenuButtonProps,
 } from "../../components/action-popover";
 import SplitButton from "../../components/split-button";
 import MultiActionButton from "../../components/multi-action-button";
@@ -40,6 +42,7 @@ export default {
   includeStories: [
     "FlatTableStory",
     "ExpandableWithLink",
+    "ExpandableWithActionPopover",
     "SortableStory",
     "SubRowsAsAComponentStory",
     "FlatTableSizeFocus",
@@ -419,6 +422,90 @@ export const ExpandableWithLink = () => {
           <FlatTableCell>Newcastle</FlatTableCell>
           <FlatTableCell>Married</FlatTableCell>
           <FlatTableCell>5</FlatTableCell>
+        </FlatTableRow>
+      </FlatTableBody>
+    </FlatTable>
+  );
+};
+
+export const ExpandableWithActionPopover = () => {
+  const SubRows = [
+    <FlatTableRow key="subrow-1">
+      <FlatTableRowHeader>Child one</FlatTableRowHeader>
+      <FlatTableCell>York</FlatTableCell>
+      <FlatTableCell>Married</FlatTableCell>
+      <FlatTableCell>2</FlatTableCell>
+    </FlatTableRow>,
+    <FlatTableRow key="subrow-2">
+      <FlatTableRowHeader>Child two</FlatTableRowHeader>
+      <FlatTableCell>Edinburgh</FlatTableCell>
+      <FlatTableCell>Single</FlatTableCell>
+      <FlatTableCell>1</FlatTableCell>
+    </FlatTableRow>,
+  ];
+
+  const renderMenuButton = (props: ActionPopoverMenuButtonProps) => (
+    <ActionPopoverMenuButton
+      buttonType="tertiary"
+      iconType="ellipsis_vertical"
+      iconPosition="after"
+      size="small"
+      {...props}
+    >
+      Action
+    </ActionPopoverMenuButton>
+  );
+
+  return (
+    <FlatTable>
+      <FlatTableHead>
+        <FlatTableRow>
+          <FlatTableRowHeader>Name</FlatTableRowHeader>
+          <FlatTableHeader>Location</FlatTableHeader>
+          <FlatTableHeader>Relationship Status</FlatTableHeader>
+          <FlatTableHeader>Actions</FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+      <FlatTableBody>
+        <FlatTableRow expandable subRows={SubRows}>
+          <FlatTableRowHeader>John Doe</FlatTableRowHeader>
+          <FlatTableCell>London</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableRowHeader stickyAlignment="right" px={1}>
+            <ActionPopover renderButton={renderMenuButton}>
+              <ActionPopoverItem onClick={() => {}}>action</ActionPopoverItem>
+            </ActionPopover>
+          </FlatTableRowHeader>
+        </FlatTableRow>
+        <FlatTableRow expandable subRows={SubRows}>
+          <FlatTableRowHeader>Jane Doe</FlatTableRowHeader>
+          <FlatTableCell>York</FlatTableCell>
+          <FlatTableCell>Married</FlatTableCell>
+          <FlatTableRowHeader stickyAlignment="right" px={1}>
+            <ActionPopover renderButton={renderMenuButton}>
+              <ActionPopoverItem onClick={() => {}}>action</ActionPopoverItem>
+            </ActionPopover>
+          </FlatTableRowHeader>
+        </FlatTableRow>
+        <FlatTableRow expandable subRows={SubRows}>
+          <FlatTableRowHeader>John Smith</FlatTableRowHeader>
+          <FlatTableCell>Edinburgh</FlatTableCell>
+          <FlatTableCell>Single</FlatTableCell>
+          <FlatTableRowHeader stickyAlignment="right" px={1}>
+            <ActionPopover renderButton={renderMenuButton}>
+              <ActionPopoverItem onClick={() => {}}>action</ActionPopoverItem>
+            </ActionPopover>
+          </FlatTableRowHeader>
+        </FlatTableRow>
+        <FlatTableRow expandable subRows={SubRows}>
+          <FlatTableRowHeader>Jane Smith</FlatTableRowHeader>
+          <FlatTableCell>Newcastle</FlatTableCell>
+          <FlatTableCell>Married</FlatTableCell>
+          <FlatTableRowHeader stickyAlignment="right" px={1}>
+            <ActionPopover renderButton={renderMenuButton}>
+              <ActionPopoverItem onClick={() => {}}>action</ActionPopoverItem>
+            </ActionPopover>
+          </FlatTableRowHeader>
         </FlatTableRow>
       </FlatTableBody>
     </FlatTable>


### PR DESCRIPTION
fix #6774

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Update Icon size to 20px in expandable `FlatTableRowHeader`.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Icon size is overridden to 16px in expandable `FlatTableRowHeader`.  

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

See new test story `ExpandableWithActionPopover`. 
