### PR TITLE
feat(message): add de-DE, es-ES, fr-CA and fr-FR locale support for the ai variant

### DIFF
--- a/docs/i18n.mdx
+++ b/docs/i18n.mdx
@@ -225,6 +225,7 @@ export const PolishPlural = (
 | link                  | [Table](?path=/docs/link--docs#translation-keys)                    |
 | loader                | [Table](?path=/docs/loader--docs#translation-keys)                  |
 | loaderSpinner         | [Table](?path=/docs/loader-spinner--docs#translation-keys)          |
+| loaderStar            | [Table](?path=/docs/loader-star--docs#translation-keys)             |
 | menuFullscreen        | [Table](?path=/docs/menu--docs#translation-keys)                    |
 | message               | [Table](?path=/docs/message--docs#translation-keys)                 |
 | numeralDate           | [Table](?path=/docs/numeral-date--docs#translation-keys)            |

--- a/src/components/message/message.component.tsx
+++ b/src/components/message/message.component.tsx
@@ -109,9 +109,7 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
           )}
         </TypeIconStyle>
 
-        <Typography screenReaderOnly>
-          {locale.message?.[variant]?.()}
-        </Typography>
+        <Typography screenReaderOnly>{locale.message[variant]()}</Typography>
         <MessageContent
           data-element="message-content"
           data-role="message-content"

--- a/src/components/message/message.mdx
+++ b/src/components/message/message.mdx
@@ -121,8 +121,44 @@ The following keys are available to override the translations for this component
 <TranslationKeysTable
   translationData={[
     {
-      name: "mssage.closeButtonAriaLabel",
-      description: "The text for the aria-label attribute of the close button",
+      name: "message.closeButtonAriaLabel",
+      description: "Screen reader only text for the aria-label attribute of the close button",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "message.error",
+      description: "Screen reader only text for error message type",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "message.info",
+      description: "Screen reader only text for info message type",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "message.success",
+      description: "Screen reader only text for success message type",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "message.warning",
+      description: "Screen reader only text for warning message type",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "message.neutral",
+      description: "Screen reader only text for neutral message type",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "message.ai",
+      description: "Screen reader only text for AI-related information message type",
       type: "func",
       returnType: "string",
     },

--- a/src/components/message/message.test.tsx
+++ b/src/components/message/message.test.tsx
@@ -158,6 +158,7 @@ test("renders close button aria-label with custom value from translations", () =
           warning: () => "Warning",
           neutral: () => "Neutral",
           error: () => "Error",
+          ai: () => "AI Information",
           closeButtonAriaLabel: () => "test close button",
         },
       }}

--- a/src/hooks/__internal__/useLocale/useLocale.test.tsx
+++ b/src/hooks/__internal__/useLocale/useLocale.test.tsx
@@ -29,6 +29,7 @@ test("when I18nProvider exists, it should return a translation function that pro
           warning: () => "Warning",
           neutral: () => "Neutral",
           error: () => "Error",
+          ai: () => "AI Information",
           closeButtonAriaLabel: () => "test",
         },
       }}

--- a/src/locales/de-de.ts
+++ b/src/locales/de-de.ts
@@ -112,6 +112,7 @@ const deDE: Partial<Locale> = {
     success: () => "Erfolg",
     warning: () => "Warnung",
     neutral: () => "Informationen",
+    ai: () => "Von KI generierte Informationen",
   },
   numeralDate: {
     validation: {

--- a/src/locales/es-es.ts
+++ b/src/locales/es-es.ts
@@ -119,6 +119,7 @@ const esES: Partial<Locale> = {
     success: () => "Acción realizada",
     warning: () => "Aviso",
     neutral: () => "Información",
+    ai: () => "Información generada por IA",
   },
   numeralDate: {
     validation: {

--- a/src/locales/fr-ca.ts
+++ b/src/locales/fr-ca.ts
@@ -121,6 +121,7 @@ const frCA: Partial<Locale> = {
     success: () => "Opération réussie",
     warning: () => "Avertissement",
     neutral: () => "Information",
+    ai: () => "Information générée par l'IA",
   },
   numeralDate: {
     validation: {

--- a/src/locales/fr-fr.ts
+++ b/src/locales/fr-fr.ts
@@ -121,6 +121,7 @@ const frFR: Partial<Locale> = {
     success: () => "Action réussie",
     warning: () => "Avertissement",
     neutral: () => "Information",
+    ai: () => "Information générée par IA",
   },
   numeralDate: {
     validation: {

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -98,7 +98,7 @@ interface Locale {
     success: () => string;
     warning: () => string;
     neutral: () => string;
-    ai?: () => string;
+    ai: () => string;
   };
   numeralDate: {
     validation: {


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Adds non en-gb translation support for the AI variant in `Message`

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, no non en-gb translation support for the AI variant in `Message`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
