### PR TITLE
feat(text-editor): add header and footer support and align with DS

### DIFF
--- a/src/components/note/note.component.tsx
+++ b/src/components/note/note.component.tsx
@@ -84,7 +84,7 @@ export const Note = ({
   };
 
   return (
-    <TextEditorContext.Provider value={{ onLinkAdded, readOnly: true }}>
+    <TextEditorContext.Provider value={{ onLinkAdded }}>
       <StyledNote width={width} {...rest} {...tagComponent("note", rest)}>
         <StyledNoteMain>
           <StyledNoteContent>

--- a/src/components/text-editor/__internal__/plugins/ContentEditor/content-editor.component.tsx
+++ b/src/components/text-editor/__internal__/plugins/ContentEditor/content-editor.component.tsx
@@ -3,15 +3,11 @@
  * as per their documentation. It also uses the `LinkPreviewerPlugin` to render link previews.
  */
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
-
-import React from "react";
-
+import React, { forwardRef } from "react";
 import StyledContentEditable from "./content-editor.style";
 import { LinkPreviewerPlugin, useCursorAtEnd } from "..";
 
 export interface ContentEditorProps {
-  /** The active error message of the editor */
-  error?: string;
   /** A hint string rendered before the editor but after the label. Intended to describe the purpose or content of the input. */
   inputHint?: string;
   /** The namespace of the editor that this content editor belongs to */
@@ -20,54 +16,45 @@ export interface ContentEditorProps {
   previews?: React.JSX.Element[];
   /** The number of rows to render in the editor */
   rows?: number;
-  /** The active warning message of the editor */
-  warning?: string;
+  /** Whether the editor is read-only */
+  readOnly?: boolean;
 }
 
-const ContentEditor = ({
-  error,
-  inputHint,
-  namespace,
-  previews = [],
-  rows,
-  warning,
-}: ContentEditorProps) => {
-  const focusAtEnd = useCursorAtEnd();
+const ContentEditor = forwardRef<HTMLDivElement, ContentEditorProps>(
+  ({ inputHint, namespace, previews = [], rows, readOnly }, ref) => {
+    const focusAtEnd = useCursorAtEnd();
 
-  return (
-    <StyledContentEditable
-      data-role={`${namespace}-content-editable`}
-      error={error}
-      namespace={namespace}
-      rows={rows}
-      warning={warning}
-    >
-      <ContentEditable
-        aria-describedby={inputHint && `${namespace}-input-hint`}
-        aria-labelledby={`${namespace}-label`}
-        className={`${namespace}-editable`}
-        data-role={`${namespace}-editable`}
-        onFocus={(event) => {
-          // If the related target is not a toolbar button, focus at the end of the editor
-          /* istanbul ignore next */
-          if (
-            !event.relatedTarget ||
-            !event.relatedTarget.classList.contains("toolbar-button")
-          ) {
-            focusAtEnd(event);
-          }
-        }}
-        /** The following are automatically added by Lexical but violate WCAG 4.1.2 Name, Role, Value and so have been overriden */
-        aria-autocomplete={undefined}
-        aria-readonly={undefined}
-      />
-      <LinkPreviewerPlugin
-        error={error}
-        previews={previews}
-        warning={warning}
-      />
-    </StyledContentEditable>
-  );
-};
+    return (
+      <StyledContentEditable
+        data-role={`${namespace}-content-editable`}
+        namespace={namespace}
+        rows={rows}
+        readOnly={readOnly}
+      >
+        <ContentEditable
+          ref={ref}
+          aria-describedby={inputHint && `${namespace}-input-hint`}
+          aria-labelledby={`${namespace}-label`}
+          className={`${namespace}-editable`}
+          data-role={`${namespace}-editable`}
+          onFocus={(event) => {
+            // If the related target is not a toolbar button, focus at the end of the editor
+            /* istanbul ignore next */
+            if (
+              !event.relatedTarget ||
+              !event.relatedTarget.classList.contains("toolbar-button")
+            ) {
+              focusAtEnd(event);
+            }
+          }}
+          /** The following are automatically added by Lexical but violate WCAG 4.1.2 Name, Role, Value and so have been overriden */
+          aria-autocomplete={undefined}
+          aria-readonly={undefined}
+        />
+        <LinkPreviewerPlugin previews={previews} />
+      </StyledContentEditable>
+    );
+  },
+);
 
 export default ContentEditor;

--- a/src/components/text-editor/__internal__/plugins/ContentEditor/content-editor.style.ts
+++ b/src/components/text-editor/__internal__/plugins/ContentEditor/content-editor.style.ts
@@ -7,30 +7,26 @@ const FIXED_LINE_HEIGHT = 21;
 
 interface StyledContentEditableProps extends ContentEditorProps {
   showBorders?: boolean;
+  readOnly?: boolean;
 }
 
 const StyledContentEditable = styled.div<StyledContentEditableProps>`
-  ${({ error, namespace, rows, warning }) => css`
+  ${({ namespace, rows, readOnly }) => css`
     .${namespace}-editable {
       min-height: ${rows && rows > 2
         ? rows * FIXED_LINE_HEIGHT
         : DEFAULT_EDITOR_HEIGHT}px;
       background-color: var(--colorsUtilityYang100);
-      border-top: 1px solid var(--colorsUtilityMajor200);
-      border-left: 1px solid var(--colorsUtilityMajor200);
-      border-right: 1px solid var(--colorsUtilityMajor200);
+      ${!readOnly && "border-top: 1px solid var(--colorsUtilityMajor200);"}
+      ${readOnly &&
+      `
+      border-top-left-radius: var(--borderRadius100);
+      border-top-right-radius: var(--borderRadius100);      
+      `}
       margin: 0;
       padding: 2px 8px;
-      border-top-left-radius: var(--borderWidth600);
-      border-top-right-radius: var(--borderWidth600);
-      border-bottom-left-radius: 0;
-      border-bottom-right-radius: 0;
-
-      ${(error || warning) &&
-      css`
-        border: none;
-      `}
-
+      border-bottom-right-radius: var(--borderRadius100);
+      border-bottom-left-radius: var(--borderRadius100);
       :focus {
         outline: none;
       }

--- a/src/components/text-editor/__internal__/plugins/LinkPreviewer/link-previewer.component.tsx
+++ b/src/components/text-editor/__internal__/plugins/LinkPreviewer/link-previewer.component.tsx
@@ -1,30 +1,11 @@
-import React, { useContext } from "react";
-
-import TextEditorContext from "../../../text-editor.context";
+import React from "react";
 
 import StyledLinkPreviewer from "./link-previewer.style";
 
-export interface LinkPreviewerProps {
-  /** The active error message of the editor */
-  error?: string;
-  /** The link previews to render at the foot of the editor */
-  previews?: React.JSX.Element[];
-  /** The active warning message of the editor */
-  warning?: string;
-}
-
 const LinkPreviewer = ({
-  error,
   previews = [],
-  warning,
-}: LinkPreviewerProps) => {
-  const { readOnly } = useContext(TextEditorContext);
-
-  return (
-    <StyledLinkPreviewer error={error} readOnly={readOnly} warning={warning}>
-      {previews}
-    </StyledLinkPreviewer>
-  );
-};
+}: {
+  previews?: React.JSX.Element[];
+}) => <StyledLinkPreviewer>{previews}</StyledLinkPreviewer>;
 
 export default LinkPreviewer;

--- a/src/components/text-editor/__internal__/plugins/LinkPreviewer/link-previewer.style.ts
+++ b/src/components/text-editor/__internal__/plugins/LinkPreviewer/link-previewer.style.ts
@@ -1,34 +1,7 @@
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 
-import { LinkPreviewerProps } from "./link-previewer.component";
-
-interface StyledLinkPreviewerProps extends LinkPreviewerProps {
-  readOnly?: boolean;
-}
-
-const StyledLinkPreviewer = styled.div<StyledLinkPreviewerProps>`
-  ${({ error, readOnly, warning }) => css`
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-    background-color: var(--colorsUtilityYang100);
-    border-bottom: 1px solid var(--colorsUtilityMajor200);
-    border-left: 1px solid var(--colorsUtilityMajor200);
-    border-right: 1px solid var(--colorsUtilityMajor200);
-    margin: 0;
-    padding: 2px 8px;
-
-    ${(error || warning) &&
-    css`
-      border-left: none;
-      border-right: none;
-      border-bottom: none;
-    `}
-
-    ${readOnly &&
-    css`
-      border-bottom-left-radius: var(--borderWidth600);
-      border-bottom-right-radius: var(--borderWidth600);
-    `}
-  `}
+const StyledLinkPreviewer = styled.div`
+  margin: 0;
+  padding: 2px 8px;
 `;
 export default StyledLinkPreviewer;

--- a/src/components/text-editor/__internal__/plugins/Toolbar/toolbar.component.tsx
+++ b/src/components/text-editor/__internal__/plugins/Toolbar/toolbar.component.tsx
@@ -25,13 +25,15 @@ import SaveButton, { EditorFormattedValues } from "./buttons/save.component";
 interface ToolbarProps {
   /** The namespace of the editor that this toolbar belongs to */
   namespace: string;
+  /** Determines if the Text Editor has a header */
+  hasHeader?: boolean;
   /** The callback to call when the cancel button is clicked */
   onCancel?: () => void;
   /** The callback to call when the save button is clicked */
   onSave?: (value: EditorFormattedValues) => void;
 }
 
-const Toolbar = ({ namespace, onCancel, onSave }: ToolbarProps) => {
+const Toolbar = ({ namespace, hasHeader, onCancel, onSave }: ToolbarProps) => {
   // Get the editor instance
   const [editor] = useLexicalComposerContext();
 
@@ -107,6 +109,7 @@ const Toolbar = ({ namespace, onCancel, onSave }: ToolbarProps) => {
   return (
     <StyledToolbar
       role="toolbar"
+      hasHeader={hasHeader}
       aria-label={locale.textEditor.toolbarAriaLabel()}
       data-role={`${namespace}-toolbar`}
       id={`${namespace}-toolbar`}

--- a/src/components/text-editor/__internal__/plugins/Toolbar/toolbar.style.ts
+++ b/src/components/text-editor/__internal__/plugins/Toolbar/toolbar.style.ts
@@ -7,16 +7,18 @@ interface FormattingButtonProps extends ButtonProps {
   isActive?: boolean;
 }
 
-const StyledToolbar = styled.div`
+const StyledToolbar = styled.div<{ hasHeader?: boolean }>`
   display: flex;
   flex-direction: row;
   gap: 8px;
-  background-color: var(--colorsUtilityMajor025);
-  outline: 1px solid var(--colorsUtilityMajor200);
+  background-color: var(--colorsActionMajorYang100);
   padding: 12px;
-  border-radius: var(--borderRadius100);
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
+  border-top-left-radius: ${({ hasHeader }) =>
+    hasHeader ? "0" : "var(--borderRadius100)"};
+  border-top-right-radius: ${({ hasHeader }) =>
+    hasHeader ? "0" : "var(--borderRadius100)"};
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
   justify-content: space-between;
   align-items: center;
   margin-left: 1px;

--- a/src/components/text-editor/components.test-pw.tsx
+++ b/src/components/text-editor/components.test-pw.tsx
@@ -8,3 +8,109 @@ const TextEditorDefaultComponent = ({ ...props }) => {
 };
 
 export default TextEditorDefaultComponent;
+
+export const TextEditorWithHeader = () => {
+  const headerButtons = (
+    <>
+      <button type="button">foo</button>
+      <button type="button">bar</button>
+      <button type="button">baz</button>
+    </>
+  );
+  return (
+    <TextEditor
+      labelText="Playwright Example"
+      namespace="pw-rte"
+      header={headerButtons}
+    />
+  );
+};
+
+export const TextEditorWithHeaderOnSave = () => {
+  const headerButtons = (
+    <>
+      <button type="button">foo</button>
+      <button type="button">bar</button>
+      <button type="button">baz</button>
+    </>
+  );
+  return (
+    <TextEditor
+      labelText="Playwright Example"
+      namespace="pw-rte"
+      header={headerButtons}
+      onSave={() => {}}
+    />
+  );
+};
+
+export const TextEditorWithHeaderOnCancel = () => {
+  const headerButtons = (
+    <>
+      <button type="button">foo</button>
+      <button type="button">bar</button>
+      <button type="button">baz</button>
+    </>
+  );
+  return (
+    <TextEditor
+      labelText="Playwright Example"
+      namespace="pw-rte"
+      header={headerButtons}
+      onCancel={() => {}}
+    />
+  );
+};
+
+export const TextEditorWithFooter = () => {
+  const footerButtons = (
+    <>
+      <button type="button">foo</button>
+      <button type="button">bar</button>
+      <button type="button">baz</button>
+    </>
+  );
+  return (
+    <TextEditor
+      labelText="Playwright Example"
+      namespace="pw-rte"
+      footer={footerButtons}
+    />
+  );
+};
+
+export const TextEditorWithFooterOnSave = () => {
+  const footerButtons = (
+    <>
+      <button type="button">foo</button>
+      <button type="button">bar</button>
+      <button type="button">baz</button>
+    </>
+  );
+  return (
+    <TextEditor
+      labelText="Playwright Example"
+      namespace="pw-rte"
+      footer={footerButtons}
+      onSave={() => {}}
+    />
+  );
+};
+
+export const TextEditorWithFooterOnCancel = () => {
+  const footerButtons = (
+    <>
+      <button type="button">foo</button>
+      <button type="button">bar</button>
+      <button type="button">baz</button>
+    </>
+  );
+  return (
+    <TextEditor
+      labelText="Playwright Example"
+      namespace="pw-rte"
+      footer={footerButtons}
+      onCancel={() => {}}
+    />
+  );
+};

--- a/src/components/text-editor/text-editor.component.tsx
+++ b/src/components/text-editor/text-editor.component.tsx
@@ -41,6 +41,8 @@ import {
 import TextEditorContext from "./text-editor.context";
 import StyledTextEditor, {
   StyledEditorToolbarWrapper,
+  StyledHeaderWrapper,
+  StyledFooterWrapper,
   StyledTextEditorWrapper,
   StyledValidationMessage,
   StyledWrapper,
@@ -58,6 +60,10 @@ export interface TextEditorProps extends MarginProps, TagProps {
   characterLimit?: number;
   /** The message to be shown when the editor is in an error state */
   error?: string;
+  /** Custom footer content to be displayed below the editor */
+  footer?: React.ReactNode;
+  /** Custom header content to be displayed above the editor */
+  header?: React.ReactNode;
   /** A hint string rendered before the editor but after the label. Intended to describe the purpose or content of the input. */
   inputHint?: string;
   /** Whether the content of the editor can be empty */
@@ -93,6 +99,8 @@ export interface TextEditorProps extends MarginProps, TagProps {
 export const TextEditor = ({
   characterLimit = 3000,
   error,
+  footer,
+  header,
   inputHint,
   isOptional = false,
   labelText,
@@ -115,7 +123,31 @@ export const TextEditor = ({
   const [characterLimitWarning, setCharacterLimitWarning] = useState<
     string | undefined
   >(undefined);
+  const hasWarningOrError = Boolean(error || characterLimitWarning || warning);
+  const contentEditorRef = useRef<HTMLDivElement>(null);
   const [isFocused, setIsFocused] = useState<boolean>(false);
+
+  useEffect(() => {
+    const editorElement = contentEditorRef?.current;
+
+    const handleFocus = () => {
+      setIsFocused(true);
+    };
+    const handleBlur = () => {
+      setIsFocused(false);
+    };
+
+    editorElement?.addEventListener("focus", handleFocus);
+    editorElement?.addEventListener("blur", handleBlur);
+
+    const cleanup = () => {
+      editorElement?.removeEventListener("focus", handleFocus);
+      editorElement?.removeEventListener("blur", handleBlur);
+    };
+
+    return cleanup;
+  }, [contentEditorRef]);
+
   const [cancelTrigger, setCancelTrigger] = useState<boolean>(false);
 
   const debounceWaitTime = 500;
@@ -196,7 +228,7 @@ export const TextEditor = ({
       {...filterStyledSystemMarginProps(rest)}
       {...tagComponent("text-editor", rest)}
     >
-      <TextEditorContext.Provider value={{ onLinkAdded, readOnly }}>
+      <TextEditorContext.Provider value={{ onLinkAdded }}>
         <Label
           isRequired={required}
           optional={isOptional}
@@ -232,20 +264,27 @@ export const TextEditor = ({
             <StyledEditorToolbarWrapper
               data-role={`${namespace}-editor-toolbar-wrapper`}
               id={`${namespace}-editor-toolbar-wrapper`}
-              onBlur={() => setIsFocused(false)}
-              onFocus={() => setIsFocused(true)}
               focused={isFocused}
+              hasWarningOrError={hasWarningOrError}
             >
+              {header && (
+                <StyledHeaderWrapper data-role={`${namespace}-header-wrapper`}>
+                  {header}
+                </StyledHeaderWrapper>
+              )}
+              {!readOnly && (
+                <ToolbarPlugin hasHeader={Boolean(header)} {...toolbarProps} />
+              )}
               <StyledTextEditor data-role={`${namespace}-editor`}>
                 <RichTextPlugin
                   contentEditable={
                     <ContentEditor
-                      error={error}
+                      ref={contentEditorRef}
                       inputHint={inputHint}
                       namespace={namespace}
                       previews={previews}
                       rows={rows}
-                      warning={warning}
+                      readOnly={readOnly}
                     />
                   }
                   placeholder={
@@ -261,7 +300,11 @@ export const TextEditor = ({
                 <ClickableLinkPlugin newTab />
                 <AutoLinkerPlugin />
               </StyledTextEditor>
-              {!readOnly && <ToolbarPlugin {...toolbarProps} />}
+              {footer && (
+                <StyledFooterWrapper data-role={`${namespace}-footer-wrapper`}>
+                  {footer}
+                </StyledFooterWrapper>
+              )}
               <LinkMonitorPlugin />
             </StyledEditorToolbarWrapper>
 

--- a/src/components/text-editor/text-editor.context.ts
+++ b/src/components/text-editor/text-editor.context.ts
@@ -3,5 +3,4 @@ import React from "react";
 // This is the context that is used to enable cross-component communication
 export default React.createContext<{
   onLinkAdded?: (link: string, state: string) => void;
-  readOnly?: boolean;
 }>({});

--- a/src/components/text-editor/text-editor.mdx
+++ b/src/components/text-editor/text-editor.mdx
@@ -44,6 +44,24 @@ All instances of the Text Editor should have a label that describes the purpose 
 
 <Canvas of={TextEditorStories.Default} />
 
+### With Header
+
+The Text Editor accepts a header property, which can be any valid React node and is rendered above the toolbar, providing space for custom elements such as titles, controls, 
+or contextual information.
+
+<Canvas of={TextEditorStories.Header} />
+
+### With Footer
+
+The Text Editor accepts a footer property, which can be any valid React node and is rendered below the editor, providing space for custom elements such as titles, controls, 
+or contextual information.
+
+<Canvas of={TextEditorStories.Footer} />
+
+### With Header and Footer
+
+<Canvas of={TextEditorStories.HeaderAndFooter} />
+
 ### Using CreateEmpty
 
 You can use the `CreateEmpty` function to create an empty editor state. This function should be called with no arguments, and the result should

--- a/src/components/text-editor/text-editor.pw.tsx
+++ b/src/components/text-editor/text-editor.pw.tsx
@@ -1,8 +1,16 @@
 import React from "react";
 import { test, expect } from "../../../playwright/helpers/base-test";
+
 import { checkAccessibility } from "../../../playwright/support/helper";
 
-import TextEditorDefaultComponent from "./components.test-pw";
+import TextEditorDefaultComponent, {
+  TextEditorWithHeader,
+  TextEditorWithHeaderOnSave,
+  TextEditorWithHeaderOnCancel,
+  TextEditorWithFooter,
+  TextEditorWithFooterOnSave,
+  TextEditorWithFooterOnCancel,
+} from "./components.test-pw";
 import { EditorFormattedValues } from "./text-editor.component";
 
 const preformattedJSON = {
@@ -170,6 +178,285 @@ test.describe("Prop tests", () => {
           await page.locator("div[data-role='pw-rte-validation-message']"),
         ).toHaveCSS("color", "rgb(191, 82, 0)");
       });
+    });
+  });
+
+  test.describe("header", () => {
+    test("basic focus order: header elements → toolbar button → editor", async ({
+      mount,
+      page,
+    }) => {
+      await mount(<TextEditorWithHeader />);
+
+      await page.keyboard.press("Tab");
+      const button1 = page.getByRole("button", { name: "foo" });
+      await expect(button1).toBeFocused();
+
+      await page.keyboard.press("Tab");
+      const button2 = page.getByRole("button", { name: "bar" });
+      await expect(button2).toBeFocused();
+
+      await page.keyboard.press("Tab");
+      const button3 = page.getByRole("button", { name: "baz" });
+      await expect(button3).toBeFocused();
+
+      const editorWrapper = page.locator(
+        `div[data-role='pw-rte-editor-toolbar-wrapper']`,
+      );
+      const editor = page.getByRole("textbox");
+
+      await expect(editorWrapper).not.toHaveCSS(
+        "box-shadow",
+        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      );
+      await expect(editor).not.toBeFocused();
+
+      await page.keyboard.press("Tab");
+
+      const boldButton = page.getByLabel("Bold");
+      await expect(boldButton).toBeFocused();
+
+      await page.keyboard.press("Tab");
+
+      await expect(editorWrapper).toHaveCSS(
+        "box-shadow",
+        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      );
+      await expect(editor).toBeFocused();
+    });
+
+    test("focus order with onSave: header elements → toolbar button → save button → editor", async ({
+      mount,
+      page,
+    }) => {
+      await mount(<TextEditorWithHeaderOnSave />);
+
+      await page.keyboard.press("Tab");
+      const button1 = page.getByRole("button", { name: "foo" });
+      await expect(button1).toBeFocused();
+
+      await page.keyboard.press("Tab");
+      const button2 = page.getByRole("button", { name: "bar" });
+      await expect(button2).toBeFocused();
+
+      await page.keyboard.press("Tab");
+      const button3 = page.getByRole("button", { name: "baz" });
+      await expect(button3).toBeFocused();
+
+      const editorWrapper = page.locator(
+        `div[data-role='pw-rte-editor-toolbar-wrapper']`,
+      );
+      const editor = page.getByRole("textbox");
+
+      await expect(editorWrapper).not.toHaveCSS(
+        "box-shadow",
+        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      );
+      await expect(editor).not.toBeFocused();
+
+      await page.keyboard.press("Tab");
+
+      const boldButton = page.getByLabel("Bold");
+      await expect(boldButton).toBeFocused();
+
+      await page.keyboard.press("Tab");
+
+      const saveButton = page.getByRole("button", { name: "Save" });
+      await expect(saveButton).toBeFocused();
+
+      await page.keyboard.press("Tab");
+
+      await expect(editorWrapper).toHaveCSS(
+        "box-shadow",
+        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      );
+      await expect(editor).toBeFocused();
+    });
+
+    test("focus order with onCancel: header elements → toolbar button → cancel button → editor", async ({
+      mount,
+      page,
+    }) => {
+      await mount(<TextEditorWithHeaderOnCancel />);
+
+      await page.keyboard.press("Tab");
+      const button1 = page.getByRole("button", { name: "foo" });
+      await expect(button1).toBeFocused();
+
+      await page.keyboard.press("Tab");
+      const button2 = page.getByRole("button", { name: "bar" });
+      await expect(button2).toBeFocused();
+
+      await page.keyboard.press("Tab");
+      const button3 = page.getByRole("button", { name: "baz" });
+      await expect(button3).toBeFocused();
+
+      const editorWrapper = page.locator(
+        `div[data-role='pw-rte-editor-toolbar-wrapper']`,
+      );
+      const editor = page.getByRole("textbox");
+
+      await expect(editorWrapper).not.toHaveCSS(
+        "box-shadow",
+        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      );
+      await expect(editor).not.toBeFocused();
+
+      await page.keyboard.press("Tab");
+
+      const boldButton = page.getByLabel("Bold");
+      await expect(boldButton).toBeFocused();
+
+      await page.keyboard.press("Tab");
+
+      const cancelButton = page.getByRole("button", { name: "Cancel" });
+      await expect(cancelButton).toBeFocused();
+
+      await page.keyboard.press("Tab");
+
+      await expect(editorWrapper).toHaveCSS(
+        "box-shadow",
+        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      );
+      await expect(editor).toBeFocused();
+    });
+  });
+
+  test.describe("footer", () => {
+    test("basic focus order: toolbar button → editor → footer elements", async ({
+      mount,
+      page,
+    }) => {
+      await mount(<TextEditorWithFooter />);
+
+      await page.keyboard.press("Tab");
+
+      const boldButton = page.getByLabel("Bold");
+      await expect(boldButton).toBeFocused();
+
+      await page.keyboard.press("Tab");
+
+      const editorWrapper = page.locator(
+        `div[data-role='pw-rte-editor-toolbar-wrapper']`,
+      );
+      await expect(editorWrapper).toHaveCSS(
+        "box-shadow",
+        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      );
+      const editor = page.getByRole("textbox");
+      await expect(editor).toBeFocused();
+
+      await page.keyboard.press("Tab");
+      const button1 = page.getByRole("button", { name: "foo" });
+      await expect(button1).toBeFocused();
+
+      await page.keyboard.press("Tab");
+      const button2 = page.getByRole("button", { name: "bar" });
+      await expect(button2).toBeFocused();
+
+      await page.keyboard.press("Tab");
+      const button3 = page.getByRole("button", { name: "baz" });
+      await expect(button3).toBeFocused();
+
+      await expect(editorWrapper).not.toHaveCSS(
+        "box-shadow",
+        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      );
+      await expect(editor).not.toBeFocused();
+    });
+
+    test("focus order with onSave: toolbar button → save button → editor → footer elements", async ({
+      mount,
+      page,
+    }) => {
+      await mount(<TextEditorWithFooterOnSave />);
+
+      await page.keyboard.press("Tab");
+
+      const boldButton = page.getByLabel("Bold");
+      await expect(boldButton).toBeFocused();
+
+      await page.keyboard.press("Tab");
+
+      const saveButton = page.getByRole("button", { name: "Save" });
+      await expect(saveButton).toBeFocused();
+
+      await page.keyboard.press("Tab");
+
+      const editorWrapper = page.locator(
+        `div[data-role='pw-rte-editor-toolbar-wrapper']`,
+      );
+      await expect(editorWrapper).toHaveCSS(
+        "box-shadow",
+        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      );
+      const editor = page.getByRole("textbox");
+      await expect(editor).toBeFocused();
+
+      await page.keyboard.press("Tab");
+      const button1 = page.getByRole("button", { name: "foo" });
+      await expect(button1).toBeFocused();
+
+      await page.keyboard.press("Tab");
+      const button2 = page.getByRole("button", { name: "bar" });
+      await expect(button2).toBeFocused();
+
+      await page.keyboard.press("Tab");
+      const button3 = page.getByRole("button", { name: "baz" });
+      await expect(button3).toBeFocused();
+
+      await expect(editorWrapper).not.toHaveCSS(
+        "box-shadow",
+        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      );
+      await expect(editor).not.toBeFocused();
+    });
+
+    test("focus order with onCancel: toolbar button → cancel button → editor → footer elements", async ({
+      mount,
+      page,
+    }) => {
+      await mount(<TextEditorWithFooterOnCancel />);
+
+      await page.keyboard.press("Tab");
+
+      const boldButton = page.getByLabel("Bold");
+      await expect(boldButton).toBeFocused();
+
+      await page.keyboard.press("Tab");
+
+      const cancelButton = page.getByRole("button", { name: "Cancel" });
+      await expect(cancelButton).toBeFocused();
+
+      await page.keyboard.press("Tab");
+
+      const editorWrapper = page.locator(
+        `div[data-role='pw-rte-editor-toolbar-wrapper']`,
+      );
+      await expect(editorWrapper).toHaveCSS(
+        "box-shadow",
+        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      );
+      const editor = page.getByRole("textbox");
+      await expect(editor).toBeFocused();
+
+      await page.keyboard.press("Tab");
+      const button1 = page.getByRole("button", { name: "foo" });
+      await expect(button1).toBeFocused();
+
+      await page.keyboard.press("Tab");
+      const button2 = page.getByRole("button", { name: "bar" });
+      await expect(button2).toBeFocused();
+
+      await page.keyboard.press("Tab");
+      const button3 = page.getByRole("button", { name: "baz" });
+      await expect(button3).toBeFocused();
+
+      await expect(editorWrapper).not.toHaveCSS(
+        "box-shadow",
+        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      );
+      await expect(editor).not.toBeFocused();
     });
   });
 

--- a/src/components/text-editor/text-editor.stories.tsx
+++ b/src/components/text-editor/text-editor.stories.tsx
@@ -8,6 +8,7 @@ import Button from "../button";
 import I18nProvider from "../i18n-provider";
 import EditorLinkPreview from "../link-preview";
 import Typography from "../typography";
+import Link from "../link";
 
 import enGB from "../../locales/en-gb";
 
@@ -40,6 +41,56 @@ export const Default: Story = () => {
   return <TextEditor namespace="storybook-default" labelText="Text Editor" />;
 };
 Default.storyName = "Default";
+
+export const Header: Story = () => {
+  return (
+    <TextEditor
+      namespace="storybook-header"
+      labelText="Text Editor"
+      header={<Button buttonType="gradient-white">Button</Button>}
+    />
+  );
+};
+Header.storyName = "With Header";
+
+export const Footer: Story = () => {
+  return (
+    <TextEditor
+      namespace="storybook-footer"
+      labelText="Text Editor"
+      footer={
+        <Typography color="--colorsUtilityYin055">
+          Lorem Ipsum is simply dummy text of the printing and typesetting
+          industry. Lorem Ipsum has been the industry's standard dummy text{" "}
+          <Link href="https://carbon.sage.com/?path=/story/welcome--welcome-page">
+            ever since the 1500s
+          </Link>
+        </Typography>
+      }
+    />
+  );
+};
+Footer.storyName = "With Footer";
+
+export const HeaderAndFooter: Story = () => {
+  return (
+    <TextEditor
+      namespace="storybook-header-and-footer"
+      labelText="Text Editor"
+      header={<Button buttonType="gradient-white">Button</Button>}
+      footer={
+        <Typography color="--colorsUtilityYin055">
+          Lorem Ipsum is simply dummy text of the printing and typesetting
+          industry. Lorem Ipsum has been the industry's standard dummy text{" "}
+          <Link href="https://carbon.sage.com/?path=/story/welcome--welcome-page">
+            ever since the 1500s
+          </Link>
+        </Typography>
+      }
+    />
+  );
+};
+HeaderAndFooter.storyName = "With Header and Footer";
 
 export const UsingCreateEmpty: Story = () => {
   const value = createEmpty();

--- a/src/components/text-editor/text-editor.style.ts
+++ b/src/components/text-editor/text-editor.style.ts
@@ -17,6 +17,7 @@ interface StyledValidationMessageProps {
 
 interface StyledEditorToolbarWrapperProps {
   focused?: boolean;
+  hasWarningOrError?: boolean;
 }
 
 export const StyledTextEditor = styled(Box)`
@@ -55,22 +56,29 @@ export const StyledWrapper = styled.div<StyledWrapperProps>`
         .${namespace}-editable, #${namespace}-toolbar {
           outline: none;
         }
-
-        #${namespace}-toolbar {
-          border-top: 1px solid var(--colorsUtilityMajor200);
-        }
       }
     `}
   `};
 `;
 
 export const StyledEditorToolbarWrapper = styled.div<StyledEditorToolbarWrapperProps>`
-  ${({ focused }) => css`
+  ${({ focused, hasWarningOrError }) => css`
     border-radius: var(--borderRadius100);
-    outline: none;
+    outline: ${hasWarningOrError
+      ? "none"
+      : "1px solid var(--colorsUtilityMajor200)"};
 
     ${focused && addFocusStyling()}
   `}
+`;
+
+export const StyledHeaderWrapper = styled.div`
+  padding: var(--spacing200);
+`;
+
+export const StyledFooterWrapper = styled.div`
+  border-top: 1px solid var(--colorsUtilityMajor200);
+  padding: var(--spacing200);
 `;
 
 export const StyledValidationMessage = styled.div<StyledValidationMessageProps>`

--- a/src/components/text-editor/text-editor.test.tsx
+++ b/src/components/text-editor/text-editor.test.tsx
@@ -209,6 +209,59 @@ test("character limit is not rendered when characterLimit prop is provided with 
   expect(characterCounter).not.toBeInTheDocument();
 });
 
+test("renders header content wrapped in a container when the `header` prop is provided", () => {
+  render(
+    <TextEditor
+      characterLimit={0}
+      labelText="Example"
+      namespace="test"
+      header={<span>foo</span>}
+    />,
+  );
+
+  const headerWrapper = screen.getByTestId("test-header-wrapper");
+
+  expect(headerWrapper).toBeVisible();
+  expect(headerWrapper).toHaveTextContent("foo");
+});
+
+test("renders footer content wrapped in a container when the `footer` prop is provided", () => {
+  render(
+    <TextEditor
+      characterLimit={0}
+      labelText="Example"
+      namespace="test"
+      footer={<span>foo</span>}
+    />,
+  );
+
+  const footerWrapper = screen.getByTestId("test-footer-wrapper");
+
+  expect(footerWrapper).toBeVisible();
+  expect(footerWrapper).toHaveTextContent("foo");
+});
+
+test("allows the simultaneous rendering of header and footer content wrapped in respective containers when the `header` and `footer` props are provided", () => {
+  render(
+    <TextEditor
+      characterLimit={0}
+      labelText="Example"
+      namespace="test"
+      header={<span>foo</span>}
+      footer={<span>bar</span>}
+    />,
+  );
+
+  const footerWrapper = screen.getByTestId("test-footer-wrapper");
+  const headerWrapper = screen.getByTestId("test-header-wrapper");
+
+  expect(headerWrapper).toBeVisible();
+  expect(headerWrapper).toHaveTextContent("foo");
+
+  expect(footerWrapper).toBeVisible();
+  expect(footerWrapper).toHaveTextContent("bar");
+});
+
 test("required prop renders correctly when required prop is provided", () => {
   // render the TextEditor component with the required prop
   render(<TextEditor labelText="Example" required />);

--- a/src/locales/de-de.ts
+++ b/src/locales/de-de.ts
@@ -155,6 +155,24 @@ const deDE: Partial<Locale> = {
   pod: {
     undo: () => "Rückgängig",
   },
+  textEditor: {
+    boldAria: () => "Fett",
+    cancelButton: () => "Abbrechen",
+    cancelButtonAria: () => "Abbrechen",
+    characterCounter(count: number | string) {
+      return `Noch ${typeof count === "number" ? count.toString() : count} Zeichen`;
+    },
+    characterLimit(count: number) {
+      return `Sie sind ${count} Zeichen über dem Zeichenlimit`;
+    },
+    contentEditorAria: () => "Editor für Rich-Text-Inhalte",
+    italicAria: () => "Kursiv",
+    orderedListAria: () => "Sortierte Liste",
+    saveButton: () => "Speichern",
+    saveButtonAria: () => "Speichern",
+    toolbarAriaLabel: () => "Formatierung",
+    unorderedListAria: () => "Unsortierte Liste",
+  },
   search: {
     searchButtonText: () => "Suchen",
   },

--- a/src/locales/es-es.ts
+++ b/src/locales/es-es.ts
@@ -162,6 +162,24 @@ const esES: Partial<Locale> = {
   pod: {
     undo: () => "Deshacer",
   },
+  textEditor: {
+    boldAria: () => "Negrita",
+    cancelButton: () => "Cancelar",
+    cancelButtonAria: () => "Cancelar",
+    characterCounter(count: number | string) {
+      return `Quedan ${typeof count === "number" ? count.toString() : count} caracteres`;
+    },
+    characterLimit(count: number) {
+      return `El límite de ${count} caracteres se ha superado.`;
+    },
+    contentEditorAria: () => "Editor de contenidos de texto enriquecido",
+    italicAria: () => "Cursiva",
+    orderedListAria: () => "Lista ordenada",
+    saveButton: () => "Guardar",
+    saveButtonAria: () => "Guardar",
+    toolbarAriaLabel: () => "Formato",
+    unorderedListAria: () => "Lista no ordenada",
+  },
   search: {
     searchButtonText: () => "Buscar",
   },

--- a/src/locales/fr-ca.ts
+++ b/src/locales/fr-ca.ts
@@ -164,6 +164,24 @@ const frCA: Partial<Locale> = {
   pod: {
     undo: () => "Annuler",
   },
+  textEditor: {
+    boldAria: () => "Gras",
+    cancelButton: () => "Annuler",
+    cancelButtonAria: () => "Annuler",
+    characterCounter(count: number | string) {
+      return `${typeof count === "number" ? count.toString() : count} caractères restants`;
+    },
+    characterLimit(count: number) {
+      return `Vous avez dépassé de ${count} caractères la limite autorisée`;
+    },
+    contentEditorAria: () => "Éditeur de texte enrichi",
+    italicAria: () => "Italique",
+    orderedListAria: () => "Liste ordonnée",
+    saveButton: () => "Enregistrer",
+    saveButtonAria: () => "Enregistrer",
+    toolbarAriaLabel: () => "Mise en forme",
+    unorderedListAria: () => "Liste non ordonnée",
+  },
   search: {
     searchButtonText: () => "Chercher",
   },

--- a/src/locales/fr-fr.ts
+++ b/src/locales/fr-fr.ts
@@ -164,6 +164,24 @@ const frFR: Partial<Locale> = {
   pod: {
     undo: () => "Annuler",
   },
+  textEditor: {
+    boldAria: () => "Gras",
+    cancelButton: () => "Annuler",
+    cancelButtonAria: () => "Annuler",
+    characterCounter(count: number | string) {
+      return `${typeof count === "number" ? count.toString() : count} caractères restants`;
+    },
+    characterLimit(count: number) {
+      return `Vous avez dépassé de ${count} caractères la limite autorisée`;
+    },
+    contentEditorAria: () => "Éditeur de texte enrichi",
+    italicAria: () => "Italique",
+    orderedListAria: () => "Liste ordonnée",
+    saveButton: () => "Enregistrer",
+    saveButtonAria: () => "Enregistrer",
+    toolbarAriaLabel: () => "Mise en forme",
+    unorderedListAria: () => "Liste non ordonnée",
+  },
   search: {
     searchButtonText: () => "Rechercher",
   },


### PR DESCRIPTION
adds the `header` and `footer` props, both accept valid react nodes, providing consumers with the ability to pass any elements to assist with control, labelling or additional context above and/or below the editor. The Text editor toolbar has also been moved above the editor, and now has a white background to match recent designs

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

**Toolbar moved above the editor, background colour changed from grey -> white**

<img width="969" alt="Screenshot 2025-04-14 at 16 23 00" src="https://github.com/user-attachments/assets/91190990-d940-423b-a9ee-4e2935c90929" />

<img width="972" alt="Screenshot 2025-04-14 at 16 23 12" src="https://github.com/user-attachments/assets/d9334096-b06f-48ef-a295-187cffe60039" />

<img width="960" alt="Screenshot 2025-04-14 at 16 23 24" src="https://github.com/user-attachments/assets/60a53183-5a42-422e-8655-dca7445ae151" />

**Added support for a `header` prop which accepts a valid node, passed node(s) are then wrapped and rendered above the editor** 

<img width="975" alt="Screenshot 2025-04-14 at 16 25 49" src="https://github.com/user-attachments/assets/64f37248-f087-410e-a58b-c20899042ffb" />

**Added support for a `footer` prop which accepts a valid node, passed node(s) are then wrapped and rendered below the editor** 

<img width="964" alt="Screenshot 2025-04-14 at 16 26 21" src="https://github.com/user-attachments/assets/929939f5-d431-4196-99ea-15f989ebdb71" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

**Toolbar is below the editor, has a grey background colour**

<img width="959" alt="Screenshot 2025-04-14 at 16 27 25" src="https://github.com/user-attachments/assets/2f9ad9ef-8bd3-49ac-b9f6-6e8090694f88" />

<img width="966" alt="Screenshot 2025-04-14 at 16 27 36" src="https://github.com/user-attachments/assets/4d8b212f-a4cf-4685-942e-c727810ac75f" />

<img width="961" alt="Screenshot 2025-04-14 at 16 27 52" src="https://github.com/user-attachments/assets/4eebc415-0159-4f9d-9075-24f937206286" />

**No support for header/footer custom rendering**

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
