### PR TITLE
 feat(fieldset, label): add de-DE, es-ES, fr-CA, fr-FR locale support for the optional indicators

### DIFF
--- a/src/__internal__/fieldset/fieldset.component.tsx
+++ b/src/__internal__/fieldset/fieldset.component.tsx
@@ -14,6 +14,7 @@ import { InputGroupBehaviour, InputGroupContext } from "../input-behaviour";
 import Help from "../../components/help";
 import Typography from "../../components/typography";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import useLocale from "../../hooks/__internal__/useLocale";
 
 export interface FieldsetProps extends MarginProps {
   /** Role */
@@ -87,6 +88,8 @@ const Fieldset = ({
   const marginProps = filterStyledSystemMarginProps(rest);
   const [ref, setRef] = useState<HTMLFieldSetElement | null>(null);
   const [isFocused, setFocus] = useState(false);
+  const locale = useLocale();
+  const optionalLabel = locale.label.optional();
 
   useEffect(() => {
     if (ref && isRequired) {
@@ -162,6 +165,7 @@ const Fieldset = ({
                 <StyledLegendContent
                   isRequired={isRequired}
                   isOptional={isOptional}
+                  optionalLabel={optionalLabel}
                   isDisabled={isDisabled}
                 >
                   {legend}

--- a/src/__internal__/fieldset/fieldset.style.ts
+++ b/src/__internal__/fieldset/fieldset.style.ts
@@ -25,6 +25,7 @@ type StyledLegendContentProps = {
   isRequired?: boolean;
   isOptional?: boolean;
   isDisabled?: boolean;
+  optionalLabel?: string;
 };
 const StyledLegendContent = styled.span<StyledLegendContentProps>`
   display: flex;
@@ -44,11 +45,11 @@ const StyledLegendContent = styled.span<StyledLegendContentProps>`
       }
     `}
 
-  ${({ isOptional }) =>
+  ${({ isOptional, optionalLabel }) =>
     isOptional &&
     css`
       ::after {
-        content: "(optional)";
+        content: "(${optionalLabel})";
         color: var(--colorsUtilityYin055);
         font-weight: var(--fontWeights400);
         margin-left: var(--spacing050);

--- a/src/__internal__/label/label.component.tsx
+++ b/src/__internal__/label/label.component.tsx
@@ -12,6 +12,7 @@ import { InputContext, InputGroupContext } from "../input-behaviour";
 import { ValidationProps } from "../validations";
 import { IconType } from "../../components/icon";
 import createGuid from "../../__internal__/utils/helpers/guid";
+import useLocale from "../../hooks/__internal__/useLocale";
 
 export interface LabelProps
   extends ValidationProps,
@@ -95,6 +96,8 @@ export const Label = ({
   const { onMouseEnter: onGroupMouseEnter, onMouseLeave: onGroupMouseLeave } =
     useContext(InputGroupContext);
   const guid = useRef(createGuid());
+  const locale = useLocale();
+  const optionalLabel = locale.label.optional();
 
   const handleMouseEnter = () => {
     if (onMouseEnter) onMouseEnter();
@@ -172,6 +175,7 @@ export const Label = ({
       pr={pr}
       pl={pl}
       className={className}
+      optionalLabel={optionalLabel}
     >
       <StyledLabel
         data-element="label"

--- a/src/__internal__/label/label.style.ts
+++ b/src/__internal__/label/label.style.ts
@@ -49,6 +49,8 @@ export interface StyledLabelContainerProps {
   pl?: 1 | 2;
   /** Label width */
   width?: number;
+  /** Text used for the optional label */
+  optionalLabel?: string;
 }
 
 export const StyledLabelContainer = styled.div<StyledLabelContainerProps>`
@@ -76,11 +78,11 @@ export const StyledLabelContainer = styled.div<StyledLabelContainerProps>`
       width: ${width}%;
     `}
 
-  ${({ optional }) =>
+  ${({ optional, optionalLabel }) =>
     optional &&
     css`
       ::after {
-        content: "(optional)";
+        content: "(${optionalLabel})";
         font-weight: var(--fontWeights400);
         margin-left: var(--spacing050);
         color: var(--colorsUtilityYin055);

--- a/src/components/fieldset/fieldset.component.tsx
+++ b/src/components/fieldset/fieldset.component.tsx
@@ -5,6 +5,7 @@ import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 import { FieldsetStyle, StyledLegend } from "./fieldset.style";
 import NewValidationContext from "../carbon-provider/__internal__/new-validation.context";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import useLocale from "../../hooks/__internal__/useLocale";
 
 export interface FieldsetProps extends MarginProps, TagProps {
   /** Child elements */
@@ -27,6 +28,8 @@ export const Fieldset = ({
   const [ref, setRef] = useState<HTMLFieldSetElement | null>(null);
   const marginProps = filterStyledSystemMarginProps(rest);
   const { validationRedesignOptIn } = useContext(NewValidationContext);
+  const locale = useLocale();
+  const optionalLabel = locale.label.optional();
 
   useEffect(() => {
     if (ref && required) {
@@ -51,6 +54,7 @@ export const Fieldset = ({
           data-element="legend"
           isRequired={required}
           isOptional={isOptional}
+          optionalLabel={optionalLabel}
         >
           {legend}
         </StyledLegend>

--- a/src/components/fieldset/fieldset.style.ts
+++ b/src/components/fieldset/fieldset.style.ts
@@ -44,6 +44,8 @@ export interface StyledLegendProps {
   isRequired?: boolean;
   /** Flag to configure fields as optional. */
   isOptional?: boolean;
+  /** Text used for the optional label */
+  optionalLabel?: string;
 }
 
 const StyledLegend = styled.legend<StyledLegendProps>`
@@ -70,11 +72,11 @@ const StyledLegend = styled.legend<StyledLegendProps>`
       }
     `}
 
-  ${({ isOptional }) =>
+  ${({ isOptional, optionalLabel }) =>
     isOptional &&
     css`
       ::after {
-        content: "(optional)";
+        content: "(${optionalLabel})";
         color: var(--colorsUtilityYin055);
         font-weight: var(--fontWeights400);
         margin-left: var(--spacing050);

--- a/src/locales/de-de.ts
+++ b/src/locales/de-de.ts
@@ -90,6 +90,9 @@ const deDE: Partial<Locale> = {
   heading: {
     backLinkAriaLabel: () => "Zurück",
   },
+  label: {
+    optional: () => "optional",
+  },
   link: {
     skipLinkLabel: () => "Zum Hauptinhalt springen",
   },

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -100,6 +100,9 @@ const enGB: Locale = {
   heading: {
     backLinkAriaLabel: () => "Back",
   },
+  label: {
+    optional: () => "optional",
+  },
   link: {
     skipLinkLabel: () => "Skip to main content",
   },

--- a/src/locales/es-es.ts
+++ b/src/locales/es-es.ts
@@ -97,6 +97,9 @@ const esES: Partial<Locale> = {
   heading: {
     backLinkAriaLabel: () => "Volver",
   },
+  label: {
+    optional: () => "opcional",
+  },
   link: {
     skipLinkLabel: () => "Ir al contenido principal",
   },

--- a/src/locales/fr-ca.ts
+++ b/src/locales/fr-ca.ts
@@ -99,6 +99,9 @@ const frCA: Partial<Locale> = {
   heading: {
     backLinkAriaLabel: () => "Retour",
   },
+  label: {
+    optional: () => "facultatif",
+  },
   link: {
     skipLinkLabel: () => "Passer au contenu principal",
   },

--- a/src/locales/fr-fr.ts
+++ b/src/locales/fr-fr.ts
@@ -99,6 +99,9 @@ const frFR: Partial<Locale> = {
   heading: {
     backLinkAriaLabel: () => "Retour",
   },
+  label: {
+    optional: () => "facultatif",
+  },
   link: {
     skipLinkLabel: () => "Passer au contenu principal",
   },

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -74,6 +74,9 @@ interface Locale {
   heading: {
     backLinkAriaLabel: () => string;
   };
+  label: {
+    optional: () => string;
+  };
   link: {
     skipLinkLabel: () => string;
   };


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

add `de-DE`, `es-ES`, `fr-CA`, `fr-FR` locale support for the optional indicators on `Fieldset` (internal & external) and `Label`

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, a hard coded en-GB value for optional is only available, regardless of selected locale

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
