### PR TITLE
docs(select): document how to use leftChildren prop to display an Icon in the input field

### DIFF
--- a/src/components/select/filterable-select/filterable-select.stories.tsx
+++ b/src/components/select/filterable-select/filterable-select.stories.tsx
@@ -835,6 +835,13 @@ export const CustomFilterAndOptionStyle: Story = () => {
         id="custom-filter-and-option-styles"
         label="Color"
         disableDefaultFiltering
+        leftChildren={
+          selectedColor && (
+            <Box display="flex" alignItems="center" ml={1}>
+              <Icon type="favourite" color={selectedColor} />
+            </Box>
+          )
+        }
       >
         {data.map(({ text, color }) => (
           <Option text={text} value={color} key={color}>

--- a/src/components/select/simple-select/simple-select.mdx
+++ b/src/components/select/simple-select/simple-select.mdx
@@ -131,9 +131,8 @@ This prop will be called every time a user scrolls to the bottom of the list.
 
 ### Custom Option content
 
-It is also possible to render non-interactive content within the `Option` component.
-This can be achieved by passing `children` with no `value` or `text` props set. However,
-we recommend checking that there are no accessibility issues with this approach before using it.
+The `Option` component accepts any valid React node as children, which allows for custom content to be rendered inside the option. 
+The `text` value will be used as the displayed value in the input field when selected. You can also use the `leftChildren` prop to render a node to the left of the option text. 
 
 <Canvas of={SimpleSelectStories.CustomOptionChildren} />
 

--- a/src/components/select/simple-select/simple-select.stories.tsx
+++ b/src/components/select/simple-select/simple-select.stories.tsx
@@ -9,7 +9,7 @@ import {
   CustomSelectChangeEvent,
 } from "..";
 import Button from "../../button";
-import Icon from "../../icon";
+import Icon, { IconType } from "../../icon";
 import CarbonProvider from "../../carbon-provider";
 import Box from "../../box";
 import Typography from "../../typography";
@@ -524,23 +524,54 @@ export const TransparentDisabled: Story = () => {
 TransparentDisabled.storyName = "Transparent disabled";
 
 export const CustomOptionChildren: Story = () => {
+  const [value, setValue] = useState("");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  const options = [
+    { value: "1", text: "Orange", iconType: "favourite", iconColor: "orange" },
+    { value: "2", text: "Black", iconType: "bin", iconColor: "black" },
+    { value: "3", text: "Blue", iconType: "individual", iconColor: "blue" },
+    { value: "4", text: "Green", iconType: "tick_circle", iconColor: "green" },
+  ];
+
+  const renderLeftChildren = () => {
+    const option = options.find((opt) => opt.value === value);
+    return (
+      option && (
+        <Icon type={option.iconType as IconType} color={option.iconColor} />
+      )
+    );
+  };
+
   return (
-    <Box height={220}>
+    <Box height={250}>
       <Select
         name="customOptionChildren"
         id="customOptionChildren"
-        defaultValue="4"
         label="Pick your favourite color"
+        value={value}
+        onChange={onChangeHandler}
+        leftChildren={
+          value && (
+            <Box display="flex" alignItems="center" ml={1}>
+              {renderLeftChildren()}
+            </Box>
+          )
+        }
       >
-        <Option text="Orange" value="1">
-          <Icon type="favourite" color="orange" mr={1} /> Orange
-        </Option>
-        <Option text="Black" value="2">
-          <Icon type="favourite" color="black" mr={1} /> Black
-        </Option>
-        <Option text="Blue" value="3">
-          <Icon type="favourite" color="blue" mr={1} /> Blue
-        </Option>
+        {options.map((option) => (
+          <Option key={option.value} text={option.text} value={option.value}>
+            <Icon
+              type={option.iconType as IconType}
+              color={option.iconColor}
+              mr={1}
+            />
+            {option.text}
+          </Option>
+        ))}
       </Select>
     </Box>
   );


### PR DESCRIPTION
fix #5588

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Amend `CustomOptionChildren` storybook example to document how `leftChildren` prop can be used to display an Icon within the input field. 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

No documented example in Select docs to show how an Icon can be displayed within the input field. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
