### PR TITLE
Deprecate "optional" prop

### DIFF
--- a/src/__internal__/checkable-input/checkable-input.component.tsx
+++ b/src/__internal__/checkable-input/checkable-input.component.tsx
@@ -41,7 +41,10 @@ export interface CommonCheckableInputProps
   labelWidth?: number;
   /** Flag to configure component as mandatory */
   required?: boolean;
-  /** Flag to configure component as optional. */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
   /** If true the label switches position with the input */
   reverse?: boolean;

--- a/src/__internal__/fieldset/fieldset.component.tsx
+++ b/src/__internal__/fieldset/fieldset.component.tsx
@@ -51,7 +51,10 @@ export interface FieldsetProps extends MarginProps {
   legendMargin?: Pick<MarginProps, "mb">;
   /** Any valid CSS string to set the component's width */
   width?: string;
-  /** Flag to configure component as optional in Form */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `isRequired` prop and set it to false instead.
+   */
   isOptional?: boolean;
   /** Apply disabled styling to the legend content */
   isDisabled?: boolean;

--- a/src/__internal__/fieldset/fieldset.style.ts
+++ b/src/__internal__/fieldset/fieldset.style.ts
@@ -23,6 +23,10 @@ StyledFieldset.defaultProps = {
 
 type StyledLegendContentProps = {
   isRequired?: boolean;
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `isRequired` prop and set it to false instead.
+   */
   isOptional?: boolean;
   isDisabled?: boolean;
   optionalLabel?: string;

--- a/src/__internal__/fieldset/fieldset.test.tsx
+++ b/src/__internal__/fieldset/fieldset.test.tsx
@@ -6,7 +6,7 @@ import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-
 test("renders with provided `children`", () => {
   render(
     <Fieldset>
-      <input />
+      <input title="Test" placeholder="Placeholder" />
     </Fieldset>,
   );
 
@@ -18,7 +18,7 @@ test("renders with provided `children`", () => {
 test("renders fieldset with provided `legend`", () => {
   render(
     <Fieldset legend="Legend">
-      <input />
+      <input title="Test" placeholder="Placeholder" />
     </Fieldset>,
   );
 
@@ -30,8 +30,8 @@ test("renders fieldset with provided `legend`", () => {
 test("sets child inputs as required when `isRequired` is true", () => {
   render(
     <Fieldset isRequired>
-      <input />
-      <input />
+      <input title="Test" placeholder="Placeholder" />
+      <input title="Test" placeholder="Placeholder" />
     </Fieldset>,
   );
 
@@ -44,7 +44,7 @@ test("sets child inputs as required when `isRequired` is true", () => {
 test("renders validation icon and hidden message when `legend` and `error` are provided", () => {
   render(
     <Fieldset legend="Legend" error="error message">
-      <input />
+      <input title="Test" placeholder="Placeholder" />
     </Fieldset>,
   );
 
@@ -58,7 +58,7 @@ test("renders validation icon and hidden message when `legend` and `error` are p
 test("renders validation icon and hidden message when `legend` and `warning` are provided", () => {
   render(
     <Fieldset legend="Legend" warning="warning message">
-      <input />
+      <input title="Test" placeholder="Placeholder" />
     </Fieldset>,
   );
 
@@ -72,7 +72,7 @@ test("renders validation icon and hidden message when `legend` and `warning` are
 test("renders validation icon and hidden message when `legend` and `info` are provided", () => {
   render(
     <Fieldset legend="Legend" info="info message">
-      <input />
+      <input title="Test" placeholder="Placeholder" />
     </Fieldset>,
   );
 
@@ -86,7 +86,7 @@ test("renders validation icon and hidden message when `legend` and `info` are pr
 test("renders help icon when `labelHelp` is provided", () => {
   render(
     <Fieldset legend="Legend" labelHelp="label help">
-      <input />
+      <input title="Test" placeholder="Placeholder" />
     </Fieldset>,
   );
 
@@ -99,7 +99,7 @@ test("renders help icon when `labelHelp` is provided", () => {
 test("sets `aria-describedby` on help icon as tooltip content when focused and removes it on blur", () => {
   render(
     <Fieldset legend="Legend" labelHelp="label help">
-      <input />
+      <input title="Test" placeholder="Placeholder" />
     </Fieldset>,
   );
   const help = screen.getByRole("button", { name: "help" });
@@ -119,7 +119,7 @@ test("sets `aria-describedby` on help icon as tooltip content when focused and r
 test("renders legend with provided `legendWidth` when `inline` is true", () => {
   render(
     <Fieldset legend="Legend" inline legendWidth={30}>
-      <input />
+      <input title="Test" placeholder="Placeholder" />
     </Fieldset>,
   );
 
@@ -132,7 +132,7 @@ test("renders legend with provided `legendWidth` when `inline` is true", () => {
 test("renders with expected styles when `inline` is true and `legendAlign` is 'left'", () => {
   render(
     <Fieldset legend="Legend" inline legendAlign="left">
-      <input />
+      <input title="Test" placeholder="Placeholder" />
     </Fieldset>,
   );
 
@@ -145,7 +145,7 @@ test("renders with expected styles when `inline` is true and `legendAlign` is 'l
 test("renders with expected padding when `inline` is true and `legendSpacing` is 1", () => {
   render(
     <Fieldset legend="Legend" inline legendSpacing={1}>
-      <input />
+      <input title="Test" placeholder="Placeholder" />
     </Fieldset>,
   );
 
@@ -157,7 +157,7 @@ test("renders with expected padding when `inline` is true and `legendSpacing` is
 testStyledSystemMargin(
   (props) => (
     <Fieldset {...props}>
-      <input />
+      <input title="Test" placeholder="Placeholder" />
     </Fieldset>
   ),
   () => screen.getByRole("group"),

--- a/src/__internal__/form-field/form-field.component.tsx
+++ b/src/__internal__/form-field/form-field.component.tsx
@@ -72,7 +72,10 @@ export interface FormFieldProps extends CommonFormFieldProps, TagProps {
   fieldHelpInline?: boolean;
   /** Id of the element a label should be bound to */
   id: string;
-  /** Flag to configure component as optional in Form */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `isRequired` prop and set it to false instead.
+   */
   isOptional?: boolean;
   /** Flag to configure component as mandatory */
   isRequired?: boolean;

--- a/src/components/checkbox/checkbox-group/checkbox-group.component.tsx
+++ b/src/components/checkbox/checkbox-group/checkbox-group.component.tsx
@@ -16,6 +16,7 @@ import CheckboxGroupContext from "./__internal__/checkbox-group.context";
 import guid from "../../../__internal__/utils/helpers/guid";
 import useInputAccessibility from "../../../hooks/__internal__/useInputAccessibility";
 import HintText from "../../../__internal__/hint-text";
+import Logger from "../../../__internal__/utils/logger";
 
 export interface CheckboxGroupProps
   extends ValidationProps,
@@ -47,13 +48,18 @@ export interface CheckboxGroupProps
   labelSpacing?: 1 | 2;
   /** Flag to configure component as mandatory */
   required?: boolean;
-  /** Flag to configure component as optional. */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
   /** [Legacy] Overrides the default tooltip */
   tooltipPosition?: "top" | "bottom" | "left" | "right";
   /** When true, Checkboxes are inline */
   inline?: boolean;
 }
+
+let deprecateOptionalWarnTriggered = false;
 
 export const CheckboxGroup = ({
   children,
@@ -73,6 +79,12 @@ export const CheckboxGroup = ({
   id,
   ...rest
 }: CheckboxGroupProps) => {
+  if (!deprecateOptionalWarnTriggered && isOptional) {
+    deprecateOptionalWarnTriggered = true;
+    Logger.deprecate(
+      "`isOptional` is deprecated in CheckboxGroup and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+    );
+  }
   const { validationRedesignOptIn } = useContext(NewValidationContext);
   const internalId = useRef(guid());
   const uniqueId = id || internalId.current;

--- a/src/components/checkbox/checkbox-group/checkbox-group.test.tsx
+++ b/src/components/checkbox/checkbox-group/checkbox-group.test.tsx
@@ -4,6 +4,37 @@ import { Checkbox, CheckboxGroup } from "..";
 import CarbonProvider from "../../carbon-provider";
 import { testStyledSystemMargin } from "../../../__spec_helper__/__internal__/test-utils";
 
+import Logger from "../../../__internal__/utils/logger";
+
+jest.mock("../../../__internal__/utils/logger");
+
+test("should display deprecation warning once when rendered as optional", () => {
+  const loggerSpy = jest.spyOn(Logger, "deprecate");
+
+  render(
+    <>
+      <CheckboxGroup isOptional>
+        <Checkbox value="1" label="label-1" onChange={() => {}} />
+        <Checkbox value="2" label="label-2" onChange={() => {}} />
+      </CheckboxGroup>
+      <CheckboxGroup isOptional>
+        <Checkbox value="1" label="label-1" onChange={() => {}} />
+        <Checkbox value="2" label="label-2" onChange={() => {}} />
+      </CheckboxGroup>
+    </>,
+  );
+
+  // Ensure the deprecation warning is logged only once
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  expect(loggerSpy).toHaveBeenNthCalledWith(
+    1,
+    "`isOptional` is deprecated in CheckboxGroup and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+  );
+
+  loggerSpy.mockRestore();
+});
+
 test("should render with the provided children", () => {
   render(
     <CheckboxGroup>

--- a/src/components/date-range/date-range.component.tsx
+++ b/src/components/date-range/date-range.component.tsx
@@ -28,6 +28,7 @@ import DateRangeContext, {
   SetInputRefMapValue,
 } from "./__internal__/date-range.context";
 import NewValidationContext from "../carbon-provider/__internal__/new-validation.context";
+import Logger from "../../__internal__/utils/logger";
 
 interface DateInputValue {
   formattedValue: string;
@@ -114,7 +115,10 @@ export interface DateRangeProps
   tooltipPosition?: "top" | "bottom" | "left" | "right";
   /** Flag to configure component as mandatory. */
   required?: boolean;
-  /** Flag to configure component as optional. */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
   /** Date format string to be applied to the date inputs */
   dateFormatOverride?: string;
@@ -127,6 +131,8 @@ export interface DateRangeProps
   /** Prop to specify the aria-labelledby attribute of the end date picker */
   datePickerEndAriaLabelledBy?: string;
 }
+
+let deprecateOptionalWarnTriggered = false;
 
 export const DateRange = ({
   endDateProps = {},
@@ -149,6 +155,12 @@ export const DateRange = ({
   datePickerEndAriaLabelledBy,
   ...rest
 }: DateRangeProps) => {
+  if (!deprecateOptionalWarnTriggered && isOptional) {
+    deprecateOptionalWarnTriggered = true;
+    Logger.deprecate(
+      "`isOptional` is deprecated in DateRange and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+    );
+  }
   const { validationRedesignOptIn } = useContext(NewValidationContext);
   const labelsInlineWithNewValidation = validationRedesignOptIn
     ? false

--- a/src/components/date-range/date-range.test.tsx
+++ b/src/components/date-range/date-range.test.tsx
@@ -9,6 +9,40 @@ import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-
 import CarbonProvider from "../carbon-provider";
 import I18nProvider from "../i18n-provider";
 
+import Logger from "../../__internal__/utils/logger";
+
+jest.mock("../../__internal__/utils/logger");
+
+test("should display deprecation warning once when rendered as optional", () => {
+  const loggerSpy = jest.spyOn(Logger, "deprecate");
+
+  render(
+    <>
+      <DateRange
+        startLabel="start"
+        endLabel="end"
+        value={["2016-10-10", "2016-11-11"]}
+        onChange={() => {}}
+        isOptional
+      />
+      <DateRange
+        startLabel="start"
+        endLabel="end"
+        value={["2016-10-10", "2016-11-11"]}
+        onChange={() => {}}
+        isOptional
+      />
+    </>,
+  );
+
+  expect(loggerSpy).toHaveBeenNthCalledWith(
+    1,
+    "`isOptional` is deprecated in DateRange and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+  );
+
+  loggerSpy.mockRestore();
+});
+
 testStyledSystemMargin(
   (props) => (
     <DateRange

--- a/src/components/fieldset/fieldset.component.tsx
+++ b/src/components/fieldset/fieldset.component.tsx
@@ -6,6 +6,7 @@ import { FieldsetStyle, StyledLegend } from "./fieldset.style";
 import NewValidationContext from "../carbon-provider/__internal__/new-validation.context";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import useLocale from "../../hooks/__internal__/useLocale";
+import Logger from "../../__internal__/utils/logger";
 
 export interface FieldsetProps extends MarginProps, TagProps {
   /** Child elements */
@@ -14,9 +15,14 @@ export interface FieldsetProps extends MarginProps, TagProps {
   legend?: string;
   /** Flag to configure fields as mandatory. */
   required?: boolean;
-  /** Flag to configure fields as optional. */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
 }
+
+let deprecateOptionalWarnTriggered = false;
 
 export const Fieldset = ({
   children,
@@ -25,6 +31,12 @@ export const Fieldset = ({
   isOptional,
   ...rest
 }: FieldsetProps) => {
+  if (!deprecateOptionalWarnTriggered && isOptional) {
+    deprecateOptionalWarnTriggered = true;
+    Logger.deprecate(
+      "`isOptional` is deprecated in Fieldset and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+    );
+  }
   const [ref, setRef] = useState<HTMLFieldSetElement | null>(null);
   const marginProps = filterStyledSystemMarginProps(rest);
   const { validationRedesignOptIn } = useContext(NewValidationContext);

--- a/src/components/fieldset/fieldset.style.ts
+++ b/src/components/fieldset/fieldset.style.ts
@@ -42,7 +42,10 @@ FieldsetStyle.defaultProps = {
 export interface StyledLegendProps {
   /** Flag to configure fields as mandatory. */
   isRequired?: boolean;
-  /** Flag to configure fields as optional. */
+  /**
+   * [Legacy] Flag to configure fields as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
   /** Text used for the optional label */
   optionalLabel?: string;

--- a/src/components/fieldset/fieldset.test.tsx
+++ b/src/components/fieldset/fieldset.test.tsx
@@ -4,6 +4,36 @@ import Fieldset from "./fieldset.component";
 import Textbox from "../textbox";
 import CarbonProvider from "../carbon-provider";
 
+import Logger from "../../__internal__/utils/logger";
+
+jest.mock("../../__internal__/utils/logger");
+
+test("should display deprecation warning once when rendered as optional", () => {
+  const loggerSpy = jest.spyOn(Logger, "deprecate");
+
+  render(
+    <>
+      <Fieldset isOptional>
+        <input title="Test" placeholder="Placeholder" />
+        <input title="Test" placeholder="Placeholder" />
+      </Fieldset>
+      <Fieldset isOptional>
+        <input title="Test" placeholder="Placeholder" />
+        <input title="Test" placeholder="Placeholder" />
+      </Fieldset>
+    </>,
+  );
+
+  // Ensure the deprecation warning is logged only once
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+  expect(loggerSpy).toHaveBeenNthCalledWith(
+    1,
+    "`isOptional` is deprecated in Fieldset and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+  );
+
+  loggerSpy.mockRestore();
+});
+
 test("Fieldset Legend is rendered if supplied", () => {
   render(<Fieldset legend="Legend" />);
   expect(screen.getByText("Legend")).toBeVisible();
@@ -17,8 +47,8 @@ test("Fieldset Legend is not rendered if omitted", () => {
 test("Fieldset adds the required attribute to any child inputs when isRequired is true", () => {
   render(
     <Fieldset required>
-      <input />
-      <input />
+      <input title="Test" placeholder="Placeholder" />
+      <input title="Test" placeholder="Placeholder" />
     </Fieldset>,
   );
   const inputs = screen.getAllByRole("textbox");
@@ -28,8 +58,8 @@ test("Fieldset adds the required attribute to any child inputs when isRequired i
 test("Fieldset does not add the required attribute to any child inputs when isRequired is falsy", () => {
   render(
     <Fieldset>
-      <input />
-      <input />
+      <input title="Test" placeholder="Placeholder" />
+      <input title="Test" placeholder="Placeholder" />
     </Fieldset>,
   );
   const inputs = screen.getAllByRole("textbox");

--- a/src/components/file-input/file-input.component.tsx
+++ b/src/components/file-input/file-input.component.tsx
@@ -22,6 +22,7 @@ import FileUploadStatus, {
 import Box from "../box";
 import useLocale from "../../hooks/__internal__/useLocale";
 import HintText from "../../__internal__/hint-text";
+import Logger from "../../__internal__/utils/logger";
 
 export interface FileInputProps
   extends Pick<ValidationProps, "error">,
@@ -56,9 +57,14 @@ export interface FileInputProps
   uploadStatus?: FileUploadStatusProps | FileUploadStatusProps[];
   /** Flag to configure component as mandatory. */
   required?: boolean;
-  /** Flag to configure component as optional. */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
 }
+
+let deprecateOptionalWarnTriggered = false;
 
 export const FileInput = React.forwardRef(
   (
@@ -86,6 +92,12 @@ export const FileInput = React.forwardRef(
     }: FileInputProps,
     ref: React.ForwardedRef<HTMLInputElement>,
   ) => {
+    if (!deprecateOptionalWarnTriggered && isOptional) {
+      deprecateOptionalWarnTriggered = true;
+      Logger.deprecate(
+        "`isOptional` is deprecated in FileInput and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+      );
+    }
     const locale = useLocale();
     const textOnButton = buttonText || locale.fileInput.selectFile();
     const mainText = dragAndDropText || locale.fileInput.dragAndDrop();

--- a/src/components/file-input/file-input.test.tsx
+++ b/src/components/file-input/file-input.test.tsx
@@ -4,6 +4,31 @@ import userEvent from "@testing-library/user-event";
 
 import FileInput, { FileUploadStatusProps } from ".";
 
+import Logger from "../../__internal__/utils/logger";
+
+jest.mock("../../__internal__/utils/logger");
+
+test("should display deprecation warning once when rendered as optional", () => {
+  const loggerSpy = jest.spyOn(Logger, "deprecate");
+
+  render(
+    <>
+      <FileInput label="file input" onChange={() => {}} isOptional />
+      <FileInput label="file input" onChange={() => {}} isOptional />
+    </>,
+  );
+
+  // Ensure the deprecation warning is logged only once
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  expect(loggerSpy).toHaveBeenNthCalledWith(
+    1,
+    "`isOptional` is deprecated in FileInput and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+  );
+
+  loggerSpy.mockRestore();
+});
+
 describe("rendering with no file uploaded", () => {
   it("renders a hidden HTML file input element", () => {
     render(<FileInput label="file input" onChange={() => {}} />);

--- a/src/components/inline-inputs/inline-inputs.component.tsx
+++ b/src/components/inline-inputs/inline-inputs.component.tsx
@@ -10,6 +10,7 @@ import StyledInlineInputs, {
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import Logger from "../../__internal__/utils/logger";
 
 type GutterOptions =
   | "none"
@@ -49,7 +50,10 @@ export interface InlineInputsProps
   labelId?: string;
   /** Flag to configure component as mandatory. */
   required?: boolean;
-  /** Flag to configure component as optional. */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
 }
 
@@ -62,6 +66,8 @@ const columnWrapper = (children: React.ReactNode, gutter: GutterOptions) => {
     );
   });
 };
+
+let deprecateOptionalWarnTriggered = false;
 
 const InlineInputs = ({
   adaptiveLabelBreakpoint,
@@ -78,6 +84,12 @@ const InlineInputs = ({
   isOptional,
   ...rest
 }: InlineInputsProps) => {
+  if (!deprecateOptionalWarnTriggered && isOptional) {
+    deprecateOptionalWarnTriggered = true;
+    Logger.deprecate(
+      "`isOptional` is deprecated in InlineInputs and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+    );
+  }
   const largeScreen = useIsAboveBreakpoint(adaptiveLabelBreakpoint);
   const ref = useRef<HTMLDivElement>(null);
   let inlineLabel: boolean | undefined = labelInline;

--- a/src/components/inline-inputs/inline-inputs.test.tsx
+++ b/src/components/inline-inputs/inline-inputs.test.tsx
@@ -7,6 +7,36 @@ import {
   testStyledSystemMargin,
 } from "../../__spec_helper__/__internal__/test-utils";
 
+import Logger from "../../__internal__/utils/logger";
+
+jest.mock("../../__internal__/utils/logger");
+
+test("should display deprecation warning once when rendered as optional", () => {
+  const loggerSpy = jest.spyOn(Logger, "deprecate");
+
+  render(
+    <>
+      <InlineInputs isOptional>
+        <Textbox onChange={() => {}} />
+      </InlineInputs>
+      <InlineInputs isOptional>
+        <Textbox onChange={() => {}} />
+      </InlineInputs>
+    </>,
+  );
+
+  // Ensure the deprecation warning is logged only once
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  expect(loggerSpy).toHaveBeenNthCalledWith(
+    1,
+
+    "`isOptional` is deprecated in InlineInputs and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+  );
+
+  loggerSpy.mockRestore();
+});
+
 test("renders single child", () => {
   render(
     <InlineInputs>

--- a/src/components/numeral-date/numeral-date.component.tsx
+++ b/src/components/numeral-date/numeral-date.component.tsx
@@ -136,7 +136,10 @@ export interface NumeralDateProps
    * A React ref to pass to the input corresponding to the year
    */
   yearRef?: React.ForwardedRef<HTMLInputElement>;
-  /** Flag to configure component as optional. */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
 }
 
@@ -222,6 +225,8 @@ const getDateLabel = (datePart: string, locale: Locale) => {
   }
 };
 
+let deprecateOptionalWarnTriggered = false;
+
 export const NumeralDate = forwardRef<NumeralDateHandle, NumeralDateProps>(
   (
     {
@@ -261,6 +266,12 @@ export const NumeralDate = forwardRef<NumeralDateHandle, NumeralDateProps>(
     },
     ref,
   ) => {
+    if (!deprecateOptionalWarnTriggered && isOptional) {
+      deprecateOptionalWarnTriggered = true;
+      Logger.deprecate(
+        "`isOptional` is deprecated in NumeralDate and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+      );
+    }
     const locale = useLocale();
     const { validationRedesignOptIn } = useContext(NewValidationContext);
 

--- a/src/components/numeral-date/numeral-date.test.tsx
+++ b/src/components/numeral-date/numeral-date.test.tsx
@@ -39,6 +39,35 @@ test("should display deprecation warning once when used in an uncontrolled manne
   loggerSpy.mockClear();
 });
 
+test("should display deprecation warning once when rendered as optional", () => {
+  const loggerSpy = jest.spyOn(Logger, "deprecate");
+
+  render(
+    <>
+      <NumeralDate
+        isOptional
+        value={{ dd: "", mm: "", yyyy: "" }}
+        onChange={() => {}}
+      />
+      <NumeralDate
+        isOptional
+        value={{ dd: "", mm: "", yyyy: "" }}
+        onChange={() => {}}
+      />
+    </>,
+  );
+
+  // Ensure the deprecation warning is logged only once
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  expect(loggerSpy).toHaveBeenNthCalledWith(
+    1,
+    "`isOptional` is deprecated in NumeralDate and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+  );
+
+  loggerSpy.mockRestore();
+});
+
 test("should display an error when invalid `dateFormat` prop passed", () => {
   const consoleSpy = jest
     .spyOn(global.console, "error")

--- a/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
+++ b/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
@@ -63,13 +63,18 @@ export interface RadioButtonGroupProps
   onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   /** Flag to configure component as mandatory */
   required?: boolean;
-  /** Flag to configure component as optional. */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
   /** value of the selected RadioButton */
   value?: string;
   /** [Legacy] Overrides the default tooltip position */
   tooltipPosition?: "top" | "bottom" | "left" | "right";
 }
+
+let deprecateOptionalWarnTriggered = false;
 
 export const RadioButtonGroup = ({
   children,
@@ -96,6 +101,12 @@ export const RadioButtonGroup = ({
   tooltipPosition,
   ...rest
 }: RadioButtonGroupProps) => {
+  if (!deprecateOptionalWarnTriggered && isOptional) {
+    deprecateOptionalWarnTriggered = true;
+    Logger.deprecate(
+      "`isOptional` is deprecated in RadioButtonGroup and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+    );
+  }
   const { validationRedesignOptIn } = useContext(NewValidationContext);
   const internalId = useRef(guid());
   const uniqueId = id || internalId.current;

--- a/src/components/radio-button/radio-button-group/radio-button-group.test.tsx
+++ b/src/components/radio-button/radio-button-group/radio-button-group.test.tsx
@@ -24,6 +24,29 @@ test("logs a deprecation warning for uncontrolled behaviour", () => {
   loggerSpy.mockRestore();
 });
 
+test("logs a deprecation warning for optional prop", () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+  render(
+    <>
+      <RadioButtonGroup name="group" isOptional>
+        <RadioButton value="radio1" label="Radio Button 1" />
+      </RadioButtonGroup>
+      <RadioButtonGroup name="group2" isOptional>
+        <RadioButton value="radio2" label="Radio Button 2" />
+      </RadioButtonGroup>
+    </>,
+  );
+
+  expect(loggerSpy).toHaveBeenNthCalledWith(
+    1,
+    "`isOptional` is deprecated in RadioButtonGroup and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+  );
+
+  loggerSpy.mockRestore();
+});
+
 test("renders with provided `RadioButton` children", () => {
   render(
     <RadioButtonGroup name="group" onChange={() => {}}>

--- a/src/components/select/__internal__/select-textbox/select-textbox.component.tsx
+++ b/src/components/select/__internal__/select-textbox/select-textbox.component.tsx
@@ -67,7 +67,10 @@ export interface FormInputPropTypes
    *
    */
   labelId?: string;
-  /** Flag to configure component as optional in Form */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
 }
 

--- a/src/components/select/filterable-select/filterable-select.component.tsx
+++ b/src/components/select/filterable-select/filterable-select.component.tsx
@@ -82,7 +82,10 @@ export interface FilterableSelectProps
   /** Boolean to disable automatic filtering and highlighting of options.
    * This allows custom filtering and option styling to be performed outside of the component when the filter text changes. */
   disableDefaultFiltering?: boolean;
-  /** Flag to configure component as optional. */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
   /** Flag to configure component as mandatory */
   required?: boolean;
@@ -93,6 +96,8 @@ export interface FilterableSelectProps
   /** Override the default width of the list element. Number passed is converted into pixel value */
   listWidth?: number;
 }
+
+let deprecateOptionalWarnTriggered = false;
 
 export const FilterableSelect = React.forwardRef<
   HTMLInputElement,
@@ -141,6 +146,12 @@ export const FilterableSelect = React.forwardRef<
     },
     ref,
   ) => {
+    if (!deprecateOptionalWarnTriggered && isOptional) {
+      deprecateOptionalWarnTriggered = true;
+      Logger.deprecate(
+        "`isOptional` is deprecated in FilterableSelect and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+      );
+    }
     const [activeDescendantId, setActiveDescendantId] = useState<string>("");
     const selectListId = useRef(guid());
     const containerRef = useRef<HTMLDivElement>(null);

--- a/src/components/select/filterable-select/filterable-select.test.tsx
+++ b/src/components/select/filterable-select/filterable-select.test.tsx
@@ -101,6 +101,38 @@ const FilterableSelectWithDefaultValueStateAndObjects = ({
   );
 };
 
+test("should display deprecation warning once when rendered as optional", () => {
+  const loggerSpy = jest.spyOn(Logger, "deprecate");
+
+  render(
+    <>
+      <FilterableSelect
+        label="one"
+        defaultValue="opt1"
+        isOptional
+        onChange={() => {}}
+      >
+        <Option value="opt1" text="red" />
+      </FilterableSelect>
+      <FilterableSelect
+        label="one"
+        defaultValue="opt1"
+        isOptional
+        onChange={() => {}}
+      >
+        <Option value="opt1" text="red" />
+      </FilterableSelect>
+    </>,
+  );
+
+  expect(loggerSpy).toHaveBeenNthCalledWith(
+    1,
+    "`isOptional` is deprecated in FilterableSelect and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+  );
+
+  loggerSpy.mockRestore();
+});
+
 test("should display a deprecation warning only once for all instances of component when they are uncontrolled", () => {
   const loggerSpy = jest.spyOn(Logger, "deprecate");
   render(

--- a/src/components/select/multi-select/multi-select.component.tsx
+++ b/src/components/select/multi-select/multi-select.component.tsx
@@ -89,7 +89,10 @@ export interface MultiSelectProps
    * Higher values make for smoother scrolling but may impact performance.
    * Only used if the `enableVirtualScroll` prop is set. */
   virtualScrollOverscan?: number;
-  /** Flag to configure component as optional. */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
   /** Specify a callback triggered on change */
   onChange?: (
@@ -98,6 +101,8 @@ export interface MultiSelectProps
   /** Override the default width of the list element. Number passed is converted into pixel value */
   listWidth?: number;
 }
+
+let deprecateOptionalWarnTriggered = false;
 
 export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
   (
@@ -143,6 +148,12 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
     },
     ref,
   ) => {
+    if (!deprecateOptionalWarnTriggered && isOptional) {
+      deprecateOptionalWarnTriggered = true;
+      Logger.deprecate(
+        "`isOptional` is deprecated in MultiSelect and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+      );
+    }
     const [activeDescendantId, setActiveDescendantId] = useState<string>("");
     const selectListId = useRef(guid());
     const accessibilityLabelId = useRef(guid());

--- a/src/components/select/multi-select/multi-select.test.tsx
+++ b/src/components/select/multi-select/multi-select.test.tsx
@@ -1064,6 +1064,28 @@ describe("forwarded ref", () => {
 });
 
 describe("deprecation warnings", () => {
+  it("raises deprecation warning when component is used with optional prop", () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const loggerSpy = jest.spyOn(Logger, "deprecate");
+    render(
+      <>
+        <MultiSelect label="Colour" isOptional>
+          <Option text="amber" value="amber" />
+        </MultiSelect>
+        <MultiSelect label="Colour" isOptional>
+          <Option text="amber" value="amber" />
+        </MultiSelect>
+      </>,
+    );
+
+    expect(loggerSpy).toHaveBeenNthCalledWith(
+      1,
+
+      "`isOptional` is deprecated in MultiSelect and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+    );
+  });
+
   it("raises deprecation warning when component is used with defaultValue and no onChange (uncontrolled usage)", () => {
     jest.spyOn(console, "warn").mockImplementation(() => {});
 

--- a/src/components/select/simple-select/simple-select.component.tsx
+++ b/src/components/select/simple-select/simple-select.component.tsx
@@ -80,7 +80,10 @@ export interface SimpleSelectProps
    * Higher values make for smoother scrolling but may impact performance.
    * Only used if the `enableVirtualScroll` prop is set. */
   virtualScrollOverscan?: number;
-  /** Flag to configure component as optional in Form */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `isRequired` prop and set it to false instead.
+   */
   isOptional?: boolean;
   /** Flag to configure component as mandatory */
   isRequired?: boolean;
@@ -91,6 +94,8 @@ export interface SimpleSelectProps
   /** Override the default width of the list element. Number passed is converted into pixel value */
   listWidth?: number;
 }
+
+let deprecateOptionalWarnTriggered = false;
 
 export const SimpleSelect = React.forwardRef<
   HTMLInputElement,
@@ -136,6 +141,12 @@ export const SimpleSelect = React.forwardRef<
     },
     ref,
   ) => {
+    if (!deprecateOptionalWarnTriggered && isOptional) {
+      deprecateOptionalWarnTriggered = true;
+      Logger.deprecate(
+        "`isOptional` is deprecated in SimpleSelect and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+      );
+    }
     const selectListId = useRef(guid());
     const containerRef = useRef<HTMLDivElement>(null);
     const listboxRef = useRef<HTMLDivElement>(null);

--- a/src/components/select/simple-select/simple-select.test.tsx
+++ b/src/components/select/simple-select/simple-select.test.tsx
@@ -796,6 +796,27 @@ describe("forwarded ref", () => {
 });
 
 describe("deprecation warnings", () => {
+  it("raises deprecation warning when component is used with optional prop", () => {
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const loggerSpy = jest.spyOn(Logger, "deprecate");
+    render(
+      <>
+        <SimpleSelect label="Colour" isOptional>
+          <Option text="amber" value="amber" />
+        </SimpleSelect>
+        <SimpleSelect label="Colour" isOptional>
+          <Option text="amber" value="amber" />
+        </SimpleSelect>
+      </>,
+    );
+
+    expect(loggerSpy).toHaveBeenNthCalledWith(
+      1,
+      "`isOptional` is deprecated in SimpleSelect and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+    );
+  });
+
   it("raises deprecation warning when component is used with defaultValue and no onChange (uncontrolled usage)", () => {
     jest.spyOn(console, "warn").mockImplementation(() => {});
 

--- a/src/components/text-editor/text-editor.component.tsx
+++ b/src/components/text-editor/text-editor.component.tsx
@@ -23,6 +23,7 @@ import { SerializeLexical, validateUrl } from "./__internal__/helpers";
 import Label from "../../__internal__/label";
 import useDebounce from "../../hooks/__internal__/useDebounce";
 import useLocale from "../../hooks/__internal__/useLocale";
+import Logger from "../../__internal__/utils/logger";
 
 import {
   COMPONENT_PREFIX,
@@ -66,7 +67,10 @@ export interface TextEditorProps extends MarginProps, TagProps {
   header?: React.ReactNode;
   /** A hint string rendered before the editor but after the label. Intended to describe the purpose or content of the input. */
   inputHint?: string;
-  /** Whether the content of the editor can be empty */
+  /**
+   * [Legacy] Whether the content of the editor can be empty
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
   /** The label to display above the editor */
   labelText: string;
@@ -96,6 +100,8 @@ export interface TextEditorProps extends MarginProps, TagProps {
   value?: string | undefined;
 }
 
+let deprecateOptionalWarnTriggered = false;
+
 export const TextEditor = ({
   characterLimit = 3000,
   error,
@@ -118,6 +124,12 @@ export const TextEditor = ({
   value,
   ...rest
 }: TextEditorProps) => {
+  if (!deprecateOptionalWarnTriggered && isOptional) {
+    deprecateOptionalWarnTriggered = true;
+    Logger.deprecate(
+      "`isOptional` is deprecated in TextEditor and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+    );
+  }
   const editorRef = useRef<LexicalEditor | undefined>(undefined);
   const locale = useLocale();
   const [characterLimitWarning, setCharacterLimitWarning] = useState<

--- a/src/components/text-editor/text-editor.test.tsx
+++ b/src/components/text-editor/text-editor.test.tsx
@@ -6,6 +6,8 @@ import React from "react";
 import TextEditor, { createEmpty, createFromHTML } from ".";
 import { COMPONENT_PREFIX } from "./__internal__/constants";
 
+import Logger from "../../__internal__/utils/logger";
+
 /**
  * Mock the OnChangePlugin whilst testing the full editor. This is to prevent
  * the editor from attempting to repeatedly create update listeners when the
@@ -16,6 +18,8 @@ import { COMPONENT_PREFIX } from "./__internal__/constants";
 jest.mock("./__internal__/plugins/OnChange/on-change.plugin", () => {
   return jest.fn().mockReturnValue(null);
 });
+
+jest.mock("../../__internal__/utils/logger");
 
 // Reusable JSON object for testing the default state
 const initialValue = {
@@ -49,6 +53,27 @@ const initialValue = {
     version: 1,
   },
 };
+
+test("should display deprecation warning once when rendered as optional", () => {
+  const loggerSpy = jest.spyOn(Logger, "deprecate");
+
+  render(
+    <>
+      <TextEditor labelText="label" isOptional />
+      <TextEditor labelText="label" isOptional />
+    </>,
+  );
+
+  // Ensure the deprecation warning is logged only once
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  expect(loggerSpy).toHaveBeenNthCalledWith(
+    1,
+    "`isOptional` is deprecated in TextEditor and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+  );
+
+  loggerSpy.mockRestore();
+});
 
 test("rendering and basic functionality", async () => {
   const user = userEvent.setup();

--- a/src/components/textarea/textarea.component.tsx
+++ b/src/components/textarea/textarea.component.tsx
@@ -106,7 +106,10 @@ export interface TextareaProps
   placeholder?: string;
   /** Adds readOnly property */
   readOnly?: boolean;
-  /** Flag to configure component as optional */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
   /** The number of visible text lines for the control. When set, this determines the height of the textarea, and the minHeight property is ignored. */
   rows?: number;
@@ -130,8 +133,9 @@ export interface TextareaProps
   minHeight?: number;
 }
 
-let deprecateUncontrolledWarnTriggered = false;
 let deprecatedAriaDescribedByWarnTriggered = false;
+let deprecateOptionalWarnTriggered = false;
+let deprecateUncontrolledWarnTriggered = false;
 let warnBorderRadiusArrayTooLarge = false;
 
 export const Textarea = React.forwardRef(
@@ -183,6 +187,12 @@ export const Textarea = React.forwardRef(
     }: TextareaProps,
     ref: React.ForwardedRef<HTMLTextAreaElement>,
   ) => {
+    if (!deprecateOptionalWarnTriggered && isOptional) {
+      deprecateOptionalWarnTriggered = true;
+      Logger.deprecate(
+        "`isOptional` is deprecated in TextArea and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+      );
+    }
     const { validationRedesignOptIn } = useContext(NewValidationContext);
 
     const labelInlineWithNewValidation = validationRedesignOptIn

--- a/src/components/textarea/textarea.test.tsx
+++ b/src/components/textarea/textarea.test.tsx
@@ -17,6 +17,27 @@ jest.mock("../../__internal__/utils/helpers/guid");
 const mockedGuid = "guid-12345";
 (guid as jest.MockedFunction<typeof guid>).mockImplementation(() => mockedGuid);
 
+test("should display deprecation warning once when rendered as optional", () => {
+  const loggerSpy = jest.spyOn(Logger, "deprecate");
+
+  render(
+    <>
+      <Textarea name="my-textarea" onChange={() => {}} isOptional />
+      <Textarea name="my-textarea" onChange={() => {}} isOptional />
+    </>,
+  );
+
+  // Ensure the deprecation warning is logged only once
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  expect(loggerSpy).toHaveBeenNthCalledWith(
+    1,
+    "`isOptional` is deprecated in TextArea and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+  );
+
+  loggerSpy.mockRestore();
+});
+
 test("should display deprecation warning once when rendered as uncontrolled", () => {
   const loggerSpy = jest.spyOn(Logger, "deprecate");
 

--- a/src/components/textbox/textbox.component.tsx
+++ b/src/components/textbox/textbox.component.tsx
@@ -120,7 +120,10 @@ export interface CommonTextboxProps
   tooltipPosition?: "top" | "bottom" | "left" | "right";
   /** [Legacy] Aria label for rendered help component. */
   helpAriaLabel?: string;
-  /** Flag to configure component as optional. */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
   /** The id attribute for the validation tooltip */
   tooltipId?: string;
@@ -137,8 +140,9 @@ export interface TextboxProps extends CommonTextboxProps {
   characterLimit?: number;
 }
 
-let deprecateUncontrolledWarnTriggered = false;
 let deprecatedAriaDescribedByWarnTriggered = false;
+let deprecateOptionalWarnTriggered = false;
+let deprecateUncontrolledWarnTriggered = false;
 
 export const Textbox = React.forwardRef(
   (
@@ -200,6 +204,12 @@ export const Textbox = React.forwardRef(
     }: TextboxProps,
     ref: React.ForwardedRef<HTMLInputElement>,
   ) => {
+    if (!deprecateOptionalWarnTriggered && isOptional) {
+      deprecateOptionalWarnTriggered = true;
+      Logger.deprecate(
+        "`isOptional` is deprecated in Textbox and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+      );
+    }
     const characterCountValue = typeof value === "string" ? value : "";
 
     const [uniqueId, uniqueName] = useUniqueId(id, name);

--- a/src/components/textbox/textbox.test.tsx
+++ b/src/components/textbox/textbox.test.tsx
@@ -55,6 +55,23 @@ test("should display deprecation warning once for `ariaDescribedby`", () => {
   expect(loggerSpy).toHaveBeenCalledTimes(1);
 });
 
+test("should display deprecation warning once for optional prop", () => {
+  render(
+    <>
+      <Textbox onChange={() => {}} isOptional />
+      <Textbox onChange={() => {}} isOptional />
+    </>,
+  );
+
+  // Ensure the deprecation warning is logged only once
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  expect(loggerSpy).toHaveBeenNthCalledWith(
+    1,
+    "`isOptional` is deprecated in Textbox and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+  );
+});
+
 testStyledSystemMargin(
   (props) => <Textbox data-role="textbox-wrapper" {...props} />,
   () => screen.getByTestId("textbox-wrapper"),

--- a/src/components/time/time.component.tsx
+++ b/src/components/time/time.component.tsx
@@ -14,6 +14,7 @@ import useLocale from "../../hooks/__internal__/useLocale";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 import useInputAccessibility from "../../hooks/__internal__/useInputAccessibility";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import Logger from "../../__internal__/utils/logger";
 
 import Fieldset from "../../__internal__/fieldset";
 import Box from "../box";
@@ -85,7 +86,10 @@ export interface TimeProps extends TagProps, MarginProps {
   onBlur?: (ev?: React.FocusEvent<HTMLInputElement>, value?: TimeValue) => void;
   /** Flag to configure component as mandatory */
   required?: boolean;
-  /** Flag to configure component as optional */
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
   isOptional?: boolean;
   /** If true, the component will be disabled */
   disabled?: boolean;
@@ -101,6 +105,8 @@ export type TimeHandle = {
   /** Programmatically focus the minutes input. */
   focusMinutesInput: () => void;
 } | null;
+
+let deprecateOptionalWarnTriggered = false;
 
 const Time = React.forwardRef<TimeHandle, TimeProps>(
   (
@@ -125,6 +131,12 @@ const Time = React.forwardRef<TimeHandle, TimeProps>(
     },
     ref,
   ) => {
+    if (!deprecateOptionalWarnTriggered && isOptional) {
+      deprecateOptionalWarnTriggered = true;
+      Logger.deprecate(
+        "`isOptional` is deprecated in Time and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+      );
+    }
     const {
       id: hoursInputId,
       label: hoursLabel,

--- a/src/components/time/time.test.tsx
+++ b/src/components/time/time.test.tsx
@@ -13,6 +13,10 @@ import I18nProvider from "../i18n-provider";
 import { TimeInputEvent, TimeValue } from "./time.component";
 import Button from "../button";
 
+import Logger from "../../__internal__/utils/logger";
+
+jest.mock("../../__internal__/utils/logger");
+
 const localeMock = {
   time: {
     amText: () => "foo-toggle",
@@ -167,6 +171,27 @@ testStyledSystemMargin(
   ),
   () => screen.getByRole("group"),
 );
+
+test("should display deprecation warning once when rendered as optional", () => {
+  const loggerSpy = jest.spyOn(Logger, "deprecate");
+
+  render(
+    <>
+      <Time value={{ hours: "", minutes: "" }} onChange={() => {}} isOptional />
+      <Time value={{ hours: "", minutes: "" }} onChange={() => {}} isOptional />
+    </>,
+  );
+
+  // Ensure the deprecation warning is logged only once
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  expect(loggerSpy).toHaveBeenNthCalledWith(
+    1,
+    "`isOptional` is deprecated in Time and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+  );
+
+  loggerSpy.mockRestore();
+});
 
 test("should not display the AM/PM toggle by default", () => {
   render(<Time value={{ hours: "", minutes: "" }} onChange={() => {}} />);


### PR DESCRIPTION
### Proposed behaviour

Add deprecation warnings to all impacted components to indicate that the property will be removed in a future update.

### Current behaviour

We currently offer an "optional" property on components.

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required
