### PR TITLE
fix(button): ensure button focuses on click for Safari compatibility

### DIFF
--- a/src/components/button/button.component.tsx
+++ b/src/components/button/button.component.tsx
@@ -273,6 +273,18 @@ const Button = React.forwardRef<
       }
     };
 
+    const handleClick = (
+      event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>,
+    ) => {
+      internalRef?.focus();
+
+      if (inSplitButton) {
+        onChildButtonClick?.(onClick)?.(event);
+      } else if (onClick) {
+        onClick(event);
+      }
+    };
+
     switch (size) {
       case "small":
         paddingX = 2;
@@ -305,7 +317,7 @@ const Button = React.forwardRef<
         aria-describedby={ariaDescribedBy}
         as={!isDisabled && href ? "a" : "button"}
         onKeyDown={href ? handleLinkKeyDown : undefined}
-        onClick={inSplitButton ? onChildButtonClick?.(onClick) : onClick}
+        onClick={handleClick}
         draggable={false}
         buttonType={buttonType}
         disabled={isDisabled}


### PR DESCRIPTION
### Proposed behaviour

handleClick function inside Button component was introduced to:
    * First, manually call internalRef.focus().
    * Then, invoke either the SplitButton's onChildButtonClick handler (if the button is inside a SplitButton) or the normal onClick prop.

The Button no longer directly uses the provided onClick inside the JSX; it wraps it with the handleClick.

Buttons properly receive focus on mouse clicks in Safari, which does not automatically focus buttons after mouse interactions by default.

Focus behaviour via keyboard (Tab navigation) remains unchanged.

SplitButton children, which rely on onChildButtonClick, are also automatically covered because the new handleClick preserves the correct event forwarding.

Components like ButtonBar component, which renders child Buttons, and the Button component now ensures correct focus behaviour on click, ButtonBar automatically inherits the improved focus behaviour without needing any internal modification.

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

The Button and related components that are passing button as a child (apart from Split Button) are not displaying focus border, when clicked on Safari browser. 

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [x] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
