### PR TITLE
fix: set layout property on chromatic stories to test function

### DIFF
--- a/src/components/accordion/accordion-test.stories.tsx
+++ b/src/components/accordion/accordion-test.stories.tsx
@@ -15,6 +15,7 @@ export default {
   title: "Accordion/Test",
   parameters: {
     info: { disable: true },
+    layout: "fullscreen",
     chromatic: {
       disableSnapshot: true,
     },

--- a/src/components/accordion/accordion-test.stories.tsx
+++ b/src/components/accordion/accordion-test.stories.tsx
@@ -17,7 +17,8 @@ export default {
     info: { disable: true },
     layout: "fullscreen",
     chromatic: {
-      disableSnapshot: true,
+      // disableSnapshot: true,
+      disable: true,
     },
   },
   argTypes: {

--- a/src/components/accordion/accordion.stories.tsx
+++ b/src/components/accordion/accordion.stories.tsx
@@ -37,6 +37,9 @@ export const Default: Story = () => {
   );
 };
 Default.storyName = "Default";
+Default.parameters = {
+  chromatic: { disable: false },
+};
 
 export const WithTitle: Story = () => {
   return (

--- a/src/components/accordion/accordion.stories.tsx
+++ b/src/components/accordion/accordion.stories.tsx
@@ -19,9 +19,9 @@ const meta: Meta<typeof Accordion> = {
   argTypes: {
     ...styledSystemProps,
   },
-  // parameters: {
-  //   chromatic: { disableSnapshot: true },
-  // },
+  parameters: {
+    chromatic: { disable: true },
+  },
 };
 
 export default meta;

--- a/src/components/accordion/accordion.stories.tsx
+++ b/src/components/accordion/accordion.stories.tsx
@@ -19,6 +19,9 @@ const meta: Meta<typeof Accordion> = {
   argTypes: {
     ...styledSystemProps,
   },
+  // parameters: {
+  //   chromatic: { disableSnapshot: true },
+  // },
 };
 
 export default meta;

--- a/src/components/decimal/decimal-test.stories.tsx
+++ b/src/components/decimal/decimal-test.stories.tsx
@@ -15,6 +15,7 @@ export default {
   title: "Decimal Input/Test",
   parameters: {
     info: { disable: true },
+    layout: "fullscreen",
     chromatic: {
       disableSnapshot: true,
     },


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
