### PR TITLE
fix(switch): correct z-index in switch-slider

### DIFF
--- a/src/components/switch/__internal__/switch-slider.style.ts
+++ b/src/components/switch/__internal__/switch-slider.style.ts
@@ -33,26 +33,22 @@ const StyledSwitchSlider = styled.div`
     position: relative;
     text-transform: uppercase;
     top: 0;
-    width: 100%
-    z-index: 2;
+    width: 100%;
+    z-index: 1;
     border-radius: var(--borderRadius400);
     border-style: solid;
-    border-color: ${
-      isDarkBackground
-        ? "var(--colorsUtilityYang100)"
-        : "var(--colorsActionMinor400)"
-    };
+    border-color: ${isDarkBackground
+      ? "var(--colorsUtilityYang100)"
+      : "var(--colorsActionMinor400)"};
     border-width: var(--borderWidth200);
     box-sizing: border-box;
     margin-top: ${size === "large" ? "-47px" : "-28px"};
     align-items: center;
 
     &::before {
-      background-color: ${
-        isDarkBackground
-          ? "var(--colorsUtilityYang100)"
-          : "var(--colorsActionMinor400)"
-      };
+      background-color: ${isDarkBackground
+        ? "var(--colorsUtilityYang100)"
+        : "var(--colorsActionMinor400)"};
       bottom: 4px;
       content: "";
       height: ${size === "large" ? "var(--spacing400)" : "var(--spacing200)"};
@@ -64,80 +60,69 @@ const StyledSwitchSlider = styled.div`
       border-radius: 50%;
     }
 
-    ${
-      checked &&
-      css`
+    ${checked &&
+    css`
+      background-color: ${isDarkBackground
+        ? "var(--colorsUtilityYang100)"
+        : "var(--colorsActionMinor500)"};
+      border-color: var(--colorsActionMinorTransparent);
+
+      &::before {
+        margin-left: calc(
+          100% - ${size === "large" ? "var(--spacing500)" : "var(--spacing300)"}
+        );
         background-color: ${isDarkBackground
-          ? "var(--colorsUtilityYang100)"
-          : "var(--colorsActionMinor500)"};
+          ? "var(--colorsUtilityYin100)"
+          : "var(--colorsActionMinorYang100)"};
+      }
+    `}
+
+    ${disabled &&
+    !isLoading &&
+    css`
+      border-color: var(--colorsActionDisabled600);
+
+      &::before {
+        background-color: var(--colorsActionDisabled600);
+      }
+
+      ${SwitchSliderPanel} {
+        color: var(--colorsUtilityYin030);
+      }
+
+      ${checked &&
+      css`
+        background-color: var(--colorsActionDisabled500);
         border-color: var(--colorsActionMinorTransparent);
 
         &::before {
-          margin-left: calc(
-            100% -
-              ${size === "large" ? "var(--spacing500)" : "var(--spacing300)"}
-          );
-          background-color: ${isDarkBackground
-            ? "var(--colorsUtilityYin100)"
-            : "var(--colorsActionMinorYang100)"};
-        }
-      `
-    }
-
-    ${
-      disabled &&
-      !isLoading &&
-      css`
-        border-color: var(--colorsActionDisabled600);
-
-        &::before {
-          background-color: var(--colorsActionDisabled600);
+          background-color: var(--colorsActionMinorYang100);
         }
 
         ${SwitchSliderPanel} {
           color: var(--colorsUtilityYin030);
         }
+      `}
+    `}
 
-        ${checked &&
-        css`
-          background-color: var(--colorsActionDisabled500);
-          border-color: var(--colorsActionMinorTransparent);
+    ${isLoading &&
+    css`
+      &::before {
+        display: none;
+      }
+    `}
 
-          &::before {
-            background-color: var(--colorsActionMinorYang100);
-          }
+    ${warning &&
+    !disabled &&
+    css`
+      border-color: var(--colorsSemanticCaution500);
+    `}
 
-          ${SwitchSliderPanel} {
-            color: var(--colorsUtilityYin030);
-          }
-        `}
-      `
-    }
-
-    ${
-      isLoading &&
-      css`
-        &::before {
-          display: none;
-        }
-      `
-    }
-
-    ${
-      warning &&
-      !disabled &&
-      css`
-        border-color: var(--colorsSemanticCaution500);
-      `
-    }
-
-    ${
-      error &&
-      !disabled &&
-      css`
-        border-color: var(--colorsSemanticNegative500);
-      `
-    }
+    ${error &&
+    !disabled &&
+    css`
+      border-color: var(--colorsSemanticNegative500);
+    `}
 
     ${StyledValidationIcon} {
       position: absolute;


### PR DESCRIPTION
fix #7326

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Correct z-index to be lower than the input so that `Switch` is clickable. 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
`Switch` components in consuming projects using styled-components v4 are not clickable. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

The style above `z-index: 2;` in switch-slider style file was missing semi-colon and causing this style to not be applied in any projects using using styled-components v5, this was missed as v5 does not handle missing semi-colons. 

In projects using v4, the style is being applied, causing the slider to render over the input. 

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
