### PR TITLE
fix(text-editor): allow custom plugins to be passed to the text editor

### DIFF
--- a/src/components/text-editor/text-editor.component.tsx
+++ b/src/components/text-editor/text-editor.component.tsx
@@ -108,6 +108,8 @@ export interface TextEditorProps extends MarginProps, TagProps {
   warning?: string;
   /** The initial value of the editor, as a HTML string, or JSON */
   value?: string | undefined;
+  // Allows the injection of one or more Lexical-compatible React components into the editor to extend its functionality. This prop is optional and supports a single plugin, multiple plugins (via fragments or arrays), or `null`.
+  customPlugins?: React.ReactNode;
 }
 
 let deprecateOptionalWarnTriggered = false;
@@ -136,6 +138,7 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
       rows,
       warning,
       value,
+      customPlugins,
       ...rest
     },
     ref,
@@ -359,6 +362,7 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
                   <LinkPlugin validateUrl={validateUrl} />
                   <ClickableLinkPlugin newTab />
                   <AutoLinkerPlugin />
+                  {customPlugins}
                 </StyledTextEditor>
                 {footer && (
                   <StyledFooterWrapper

--- a/src/components/text-editor/text-editor.mdx
+++ b/src/components/text-editor/text-editor.mdx
@@ -246,6 +246,58 @@ the editor when monitoring for formatting changes, accessible navigation, etc.
 
 <Canvas of={TextEditorStories.MultipleEditors} />
 
+### With Custom Plugins
+
+The `customPlugins` prop allows consumers of the `TextEditor` component to inject one or more custom [Lexical](https://lexical.dev/) plugins. This provides flexibility to extend the editor with features like mentions, emoji pickers, custom toolbars, and more — without modifying the core editor. This prop is optional and supports a single plugin, multiple plugins (via fragments or arrays), or `null`.
+
+#### Example: Creating and Using a Custom Plugin
+
+```tsx
+// CustomWordCountPlugin.tsx
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+import { useEffect } from 'react';
+import { $getRoot } from 'lexical';
+
+const CustomWordCountPlugin = () => {
+  // Get the Lexical editor instance from context
+  const [editor] = useLexicalComposerContext();
+  // Local state to store the current word count
+  const [wordCount, setWordCount] = useState(0);
+  useEffect(() => {
+    // Register a listener to run every time the editor updates
+    return editor.registerUpdateListener(({ editorState }) => {
+      // Read the editor state in a read-only context
+      editorState.read(() => {
+        // Get the full text content from the root of the editor
+        const text = $getRoot().getTextContent();
+        // Split the text by whitespace and count non-empty words
+        const count = text.trim().split(/\s+/).filter(Boolean).length;
+        // Update local word count state
+        setWordCount(count);
+      });
+    });
+  }, [editor]); // Only run this effect once per editor instance
+  // Render the word count UI with styled container
+  return (
+    <Typography ml={1} mb={0}>
+      Word Count: {wordCount}
+    </Typography>
+  );
+};
+```
+
+```tsx
+// Using it with TextEditor
+import TextEditor from './TextEditor';
+import { CustomWordCountPlugin } from './CustomWordCountPlugin';
+
+const App = () => (
+  <TextEditor labelText="Text Editor" customPlugins={<CustomWordCountPlugin />} />
+);
+```
+
+<Canvas of={TextEditorStories.WithCustomPlugins} />
+
 ## Validation States
 
 This component supports input validation, see our [Validations](../?path=/docs/documentation-validations--docs) documentation page for more information.

--- a/src/components/text-editor/text-editor.stories.tsx
+++ b/src/components/text-editor/text-editor.stories.tsx
@@ -3,6 +3,9 @@ import { Meta, StoryObj } from "@storybook/react";
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $getRoot } from "lexical";
+
 import Box from "../box";
 import Button from "../button";
 import I18nProvider from "../i18n-provider";
@@ -707,3 +710,34 @@ export const MultipleEditors: Story = () => {
   );
 };
 MultipleEditors.storyName = "Multiple Editors";
+
+export const WithCustomPlugins: Story = () => {
+  const CustomWordCountPlugin = () => {
+    const [editor] = useLexicalComposerContext();
+    const [wordCount, setWordCount] = useState(0);
+    useEffect(() => {
+      return editor.registerUpdateListener(({ editorState }) => {
+        editorState.read(() => {
+          const text = $getRoot().getTextContent();
+          const count = text.trim().split(/\s+/).filter(Boolean).length;
+          setWordCount(count);
+        });
+      });
+    }, [editor]);
+    return (
+      <Typography ml={1} mb={0}>
+        Word Count: {wordCount}
+      </Typography>
+    );
+  };
+
+  return (
+    <TextEditor
+      placeholder="Example of a custom word count plugin that updates in real time, showing the number of words at the bottom left of the editor as you type."
+      namespace="storybook-default"
+      labelText="Text Editor"
+      customPlugins={<CustomWordCountPlugin />}
+    />
+  );
+};
+WithCustomPlugins.storyName = "With Custom Plugin";

--- a/src/components/text-editor/text-editor.test.tsx
+++ b/src/components/text-editor/text-editor.test.tsx
@@ -677,4 +677,19 @@ describe("shortcut keys", () => {
       "font-style: italic",
     );
   });
+
+  it("should load a custom plugin correctly", async () => {
+    const MockPlugin = () => <div data-role="mock-plugin">Plugin loaded</div>;
+
+    // render the TextEditor component
+    render(
+      <TextEditor
+        labelText="Example"
+        characterLimit={20}
+        customPlugins={<MockPlugin />}
+      />,
+    );
+
+    expect(screen.getByTestId("mock-plugin")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
fixes: #7261

### Proposed behaviour
A new optional plugin `customPlugins` has been added to the `TextEditor` which will allow the user to provide their own plugins.

https://github.com/user-attachments/assets/c95be12d-9a48-4ed7-b6e5-a36820a9a36b

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour
The users can not inject their own plugins into the `TextEditor`
<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [X] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
