### PR TITLE
fix(decimal): ensure invariant message is not thrown when using strict mode - FE-7198

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "@storybook/types": "~8.6.7",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
-        "@testing-library/react": "^16.1.0",
+        "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.5.2",
         "@types/crypto-js": "^4.2.1",
         "@types/glob": "^8.1.0",
@@ -7182,9 +7182,9 @@
       "dev": true
     },
     "node_modules/@testing-library/react": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.1.0.tgz",
-      "integrity": "sha512-Q2ToPvg0KsVL0ohND9A3zLJWcOXXcO8IDu3fj11KhNt0UlCWyFyvnCIBkd12tidB2lkiVRG8VFqdhcqhqnAQtg==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@storybook/types": "~8.6.7",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
-    "@testing-library/react": "^16.1.0",
+    "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.5.2",
     "@types/crypto-js": "^4.2.1",
     "@types/glob": "^8.1.0",

--- a/src/components/decimal/decimal.component.tsx
+++ b/src/components/decimal/decimal.component.tsx
@@ -278,7 +278,7 @@ export const Decimal = React.forwardRef(
     };
 
     const isControlled = value !== undefined;
-    const prevControlledRef = useRef<boolean>();
+    const prevControlledRef = useRef<boolean | null>();
 
     useEffect(() => {
       const message =
@@ -288,6 +288,10 @@ export const Decimal = React.forwardRef(
       invariant(prevControlledRef.current !== isControlled, message);
 
       prevControlledRef.current = isControlled;
+
+      return () => {
+        prevControlledRef.current = null;
+      };
     }, [isControlled]);
 
     const prevValue = usePrevious(value);

--- a/src/components/decimal/decimal.test.tsx
+++ b/src/components/decimal/decimal.test.tsx
@@ -1449,3 +1449,23 @@ test("the `required` prop is not passed to the hidden input", () => {
 
   expect(screen.getByTestId("hidden-input")).not.toBeRequired();
 });
+
+test("component should render without invariant firing in strict mode", () => {
+  const consoleErrorSpy = jest
+    .spyOn(console, "error")
+    .mockImplementation(() => {});
+
+  render(<ControlledDecimal startingValue="123" />, { reactStrictMode: true });
+
+  expect(screen.getByRole("textbox")).toHaveValue("123.00");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("123.00");
+
+  expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+    expect.stringContaining(
+      "Input elements should not switch from uncontrolled to controlled (or vice versa). " +
+        "Decide between using a controlled or uncontrolled input element for the lifetime of the component",
+    ),
+  );
+
+  consoleErrorSpy.mockRestore();
+});


### PR DESCRIPTION
### Proposed behaviour

Decimal should render as expected when using React's strict mode.

### Current behaviour

Invariant warning of `...switch from uncontrolled to controlled (or vice versa)...` is displayed when Decimal is rendered using React's strict mode.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

We decided that we would upgrade RTL during this work so that we could use the `reactStrictMode` render option. Prior to this the solution was the change the global config value of `reactStrictMode: false` to `true` for the test. In v16.3.0 of RTL the `reactStrictMode` render option was released and it is something we can utilise in other unit tests concerning strict mode behaviour. 

### Testing instructions

To boot up Storybook locally in `Strict Mode`, please run the cmd `npm run start:strict-mode`. Decimal should also be checked without strict mode too. 

- There should be no functional regressions for Decimal.
- No invariant message should fire when component is used in strict mode.
