### PR TITLE
feat(password): add translation keys for Hide/Show button

### DIFF
--- a/src/components/password/password.component.tsx
+++ b/src/components/password/password.component.tsx
@@ -34,7 +34,11 @@ export const Password = ({
         {...tagComponent("password", rest)}
       >
         <ButtonMinor
-          aria-label={visibleInput ? "Hide password" : "Show password"}
+          aria-label={
+            visibleInput
+              ? l.password?.ariaLabelHide?.()
+              : l.password?.ariaLabelShow?.()
+          }
           aria-controls={internalInputId.current}
           onClick={() => setPasswordShown(!passwordShown)}
           pr={1}
@@ -45,7 +49,9 @@ export const Password = ({
           disabled={forceObscurity || disabled}
           isInPassword
         >
-          {visibleInput ? "Hide" : "Show"}
+          {visibleInput
+            ? l.password?.buttonLabelHide?.()
+            : l.password?.buttonLabelShow?.()}
         </ButtonMinor>
       </StyledPassword>
       <HiddenAriaLive role="status" aria-live="polite">

--- a/src/components/password/password.mdx
+++ b/src/components/password/password.mdx
@@ -137,6 +137,34 @@ The following keys are available to override the translations for this component
 <TranslationKeysTable
   translationData={[
     {
+      name: "password.buttonLabelHide",
+      description:
+        "The visible label for the button that hides the password.",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "password.buttonLabelShow",
+      description:
+        "The visible label for the button that shows the password.",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "password.ariaLabelHide",
+      description:
+        "The aria-label for the button that hides the password.",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "password.ariaLabelShow",
+      description:
+        "The aria-label for the button that shows the password.",
+      type: "func",
+      returnType: "string",
+    },
+    {
       name: "password.ariaLiveShownMessage",
       description:
         "The message that screen readers will announce when password is made visible.",

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -158,6 +158,10 @@ const enGB: Locale = {
     ofY: (count) => `of ${count}`,
   },
   password: {
+    buttonLabelHide: () => "Hide",
+    buttonLabelShow: () => "Show",
+    ariaLabelHide: () => "Hide password",
+    ariaLabelShow: () => "Show password",
     ariaLiveShownMessage: () =>
       "Your password has been shown. Focus on the password input to have it read to you, if it is safe to do so.",
     ariaLiveHiddenMessage: () => "Your password is currently hidden.",

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -126,6 +126,10 @@ interface Locale {
     ofY: (count: string | number) => string;
   };
   password: {
+    buttonLabelHide?: () => string;
+    buttonLabelShow?: () => string;
+    ariaLabelHide?: () => string;
+    ariaLabelShow?: () => string;
     ariaLiveShownMessage: () => string;
     ariaLiveHiddenMessage: () => string;
   };


### PR DESCRIPTION
fix #7329

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Adds `buttonLabelHide`, `buttonLabelShow`, `ariaLabelHide` and `ariaLabelShow` translation keys to `Password`.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Hide/Show button in `Password` has no translations. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
