### PR TITLE
docs(auto-focus): move auto-focus stories to chromatic

### DIFF
--- a/src/components/date/date-test.stories.tsx
+++ b/src/components/date/date-test.stories.tsx
@@ -291,3 +291,16 @@ I18NStory.args = {
   dateFormatOverride: "dd/MM/yyyy",
   ...getCommonTextboxArgs(),
 };
+
+export const AutoFocus = () => {
+  const [state, setState] = useState("01/10/2016");
+  const setValue = (ev: DateChangeEvent) => {
+    setState(ev.target.value.formattedValue);
+  };
+  return <DateInput label="Date" value={state} onChange={setValue} autoFocus />;
+};
+AutoFocus.storyName = "Auto Focus";
+AutoFocus.parameters = {
+  themeProvider: { chromatic: { fourColumnLayout: true, theme: "sage" } },
+  chromatic: { viewports: [1800], disableSnapshot: false },
+};

--- a/src/components/date/date.mdx
+++ b/src/components/date/date.mdx
@@ -53,10 +53,6 @@ be used to set the input value like in the example below, although the component
 
 <Canvas of={DateStories.Sizes} />
 
-### AutoFocus
-
-<Canvas of={DateStories.AutoFocus} />
-
 ### Disabled
 
 <Canvas of={DateStories.Disabled} />
@@ -117,7 +113,7 @@ but the date format has been overridden to `yyyy-M-d` as opposed to the default 
 
 ### With labelInline (legacy)
 
-Use the `labelInline` prop to display the label on the same horizontal row as the input. You can adjust its appearance using the `labelWidth` and 
+Use the `labelInline` prop to display the label on the same horizontal row as the input. You can adjust its appearance using the `labelWidth` and
 `labelAlign` props to control the width and text alignment of the label and the `inputWidth` prop to control the width of the input.
 
 **Note:** This is a legacy feature and will only render if the `validationRedesignOptIn` feature flag on an ancestor [CarbonProvider](../?path=/docs/carbon-provider--docs) is *false*.

--- a/src/components/date/date.stories.tsx
+++ b/src/components/date/date.stories.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React, { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import { zhCN, de } from "date-fns/locale";
@@ -79,19 +80,6 @@ export const Sizes: Story = () => {
   );
 };
 Sizes.storyName = "Sizes";
-
-export const AutoFocus: Story = () => {
-  const [state, setState] = useState("01/10/2016");
-  const setValue = (ev: DateChangeEvent) => {
-    setState(ev.target.value.formattedValue);
-  };
-  return <DateInput label="Date" value={state} onChange={setValue} autoFocus />;
-};
-AutoFocus.storyName = "Auto Focus";
-AutoFocus.parameters = {
-  themeProvider: { chromatic: { fourColumnLayout: true } },
-  chromatic: { viewports: [1800] },
-};
 
 export const Disabled: Story = () => {
   const [state, setState] = useState("01/10/2016");
@@ -299,7 +287,7 @@ export const LocaleOverrideExampleImplementation: Story = () => {
     setState2(ev.target.value.formattedValue);
   };
   return (
-    <div style={{ display: "flex", justifyContent: "space-around" }}>
+    <Box display="flex" justifyContent="space-around">
       <I18nProvider
         locale={{
           locale: () => "de-DE",
@@ -336,7 +324,7 @@ export const LocaleOverrideExampleImplementation: Story = () => {
           onChange={handleChange2}
         />
       </I18nProvider>
-    </div>
+    </Box>
   );
 };
 LocaleOverrideExampleImplementation.storyName =
@@ -354,7 +342,7 @@ export const LocaleFormatOverrideExampleImplementation: Story = ({
     setState(ev.target.value.formattedValue);
   };
   return (
-    <div style={{ display: "flex" }}>
+    <Box display="flex">
       <I18nProvider
         locale={{
           locale: () => "de-DE",
@@ -374,7 +362,7 @@ export const LocaleFormatOverrideExampleImplementation: Story = ({
           onChange={handleChange}
         />
       </I18nProvider>
-    </div>
+    </Box>
   );
 };
 LocaleFormatOverrideExampleImplementation.storyName =

--- a/src/components/grouped-character/grouped-character-test.stories.tsx
+++ b/src/components/grouped-character/grouped-character-test.stories.tsx
@@ -190,3 +190,27 @@ NewValidation.parameters = {
   chromatic: { disableSnapshot: false },
   themeProvider: { chromatic: { theme: "sage" } },
 };
+
+export const AutoFocus = () => {
+  const [state, setState] = useState("1231231");
+
+  const setValue = ({ target }: CustomEvent) => {
+    setState(target.value.rawValue);
+  };
+
+  return (
+    <GroupedCharacter
+      label="GroupedCharacter"
+      value={state}
+      onChange={setValue}
+      groups={[2, 2, 3]}
+      separator="-"
+      autoFocus
+    />
+  );
+};
+AutoFocus.storyName = "Auto Focus";
+AutoFocus.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};

--- a/src/components/grouped-character/grouped-character.mdx
+++ b/src/components/grouped-character/grouped-character.mdx
@@ -40,11 +40,6 @@ before any other announcements, this well help screen reader users understand th
 
 <Canvas of={GroupedCharacterStories.Sizes} />
 
-### AutoFocus
-
-<Canvas of={GroupedCharacterStories.AutoFocus} />
-
-
 ### Disabled
 
 <Canvas of={GroupedCharacterStories.Disabled} />
@@ -69,7 +64,7 @@ You can use the `required` prop to indicate if the field is mandatory.
 
 ### With labelInline (legacy)
 
-Use the `labelInline` prop to display the label on the same horizontal row as the input. You can adjust its appearance using the `labelWidth` and 
+Use the `labelInline` prop to display the label on the same horizontal row as the input. You can adjust its appearance using the `labelWidth` and
 `labelAlign` props to control the width and text alignment of the label and the `inputWidth` prop to control the width of the input.
 
 **Note:** This is a legacy feature and will only render if the `validationRedesignOptIn` feature flag on an ancestor [CarbonProvider](../?path=/docs/carbon-provider--docs) is *false*.

--- a/src/components/grouped-character/grouped-character.stories.tsx
+++ b/src/components/grouped-character/grouped-character.stories.tsx
@@ -66,27 +66,6 @@ export const Sizes: Story = () => {
 };
 Sizes.storyName = "Sizes";
 
-export const AutoFocus: Story = () => {
-  const [state, setState] = useState("1231231");
-
-  const setValue = ({ target }: CustomEvent) => {
-    setState(target.value.rawValue);
-  };
-
-  return (
-    <GroupedCharacter
-      label="GroupedCharacter"
-      value={state}
-      onChange={setValue}
-      groups={[2, 2, 3]}
-      separator="-"
-      autoFocus
-    />
-  );
-};
-AutoFocus.storyName = "Auto Focus";
-AutoFocus.parameters = { chromatic: { disableSnapshot: true } };
-
 export const Disabled: Story = () => {
   const [state, setState] = useState("1231231");
 

--- a/src/components/number/number-test.stories.tsx
+++ b/src/components/number/number-test.stories.tsx
@@ -122,3 +122,12 @@ NewValidation.parameters = {
   chromatic: { disableSnapshot: false },
   themeProvider: { chromatic: { theme: "sage" } },
 };
+
+export const AutoFocus = () => {
+  return <Number label="Number" value="123456" autoFocus />;
+};
+AutoFocus.storyName = "Auto Focus";
+AutoFocus.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};

--- a/src/components/number/number.mdx
+++ b/src/components/number/number.mdx
@@ -46,17 +46,13 @@ before any other announcements, this well help screen reader users understand th
 
 <Canvas of={NumberStories.ReadOnly} />
 
-### AutoFocus
-
-<Canvas of={NumberStories.AutoFocus} />
-
 ### With custom maxWidth
 
 <Canvas of={NumberStories.WithCustomMaxWidth} />
 
 ### With labelInline (legacy)
 
-Use the `labelInline` prop to display the label on the same horizontal row as the input. You can adjust its appearance using the `labelWidth` and 
+Use the `labelInline` prop to display the label on the same horizontal row as the input. You can adjust its appearance using the `labelWidth` and
 `labelAlign` props to control the width and text alignment of the label and the `inputWidth` prop to control the width of the input.
 
 **Note:** This is a legacy feature and will only render if the `validationRedesignOptIn` feature flag on an ancestor [CarbonProvider](../?path=/docs/carbon-provider--docs) is *false*.

--- a/src/components/number/number.stories.tsx
+++ b/src/components/number/number.stories.tsx
@@ -59,12 +59,6 @@ export const ReadOnly: Story = () => {
 };
 ReadOnly.storyName = "Read Only";
 
-export const AutoFocus: Story = () => {
-  return <Number label="Number" value="123456" autoFocus />;
-};
-AutoFocus.storyName = "Auto Focus";
-AutoFocus.parameters = { chromatic: { disableSnapshot: true } };
-
 export const WithLabelInline: Story = () => {
   return <Number label="Number" value="123456" labelInline />;
 };

--- a/src/components/password/password-test.stories.tsx
+++ b/src/components/password/password-test.stories.tsx
@@ -214,3 +214,19 @@ NewValidation.parameters = {
   chromatic: { disableSnapshot: false },
   themeProvider: { chromatic: { theme: "sage" } },
 };
+
+export const AutoFocus = () => {
+  const [state, setState] = useState("Password");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Password autoFocus label="Password" value={state} onChange={setValue} />
+  );
+};
+AutoFocus.storyName = "Auto Focus";
+AutoFocus.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};

--- a/src/components/password/password.mdx
+++ b/src/components/password/password.mdx
@@ -82,10 +82,6 @@ before any other announcements, this well help screen reader users understand th
 
 <Canvas of={PasswordStories.ReadOnly} />
 
-### AutoFocus
-
-<Canvas of={PasswordStories.AutoFocus} />
-
 ### With custom maxWidth
 
 <Canvas of={PasswordStories.WithCustomMaxWidth} />
@@ -96,7 +92,7 @@ before any other announcements, this well help screen reader users understand th
 
 ### With labelInline (legacy)
 
-Use the `labelInline` prop to display the label on the same horizontal row as the input. You can adjust its appearance using the `labelWidth` and 
+Use the `labelInline` prop to display the label on the same horizontal row as the input. You can adjust its appearance using the `labelWidth` and
 `labelAlign` props to control the width and text alignment of the label and the `inputWidth` prop to control the width of the input.
 
 **Note:** This is a legacy feature and will only render if the `validationRedesignOptIn` feature flag on an ancestor [CarbonProvider](../?path=/docs/carbon-provider--docs) is *false*.

--- a/src/components/password/password.stories.tsx
+++ b/src/components/password/password.stories.tsx
@@ -177,19 +177,6 @@ export const ReadOnly: Story = () => {
 };
 ReadOnly.storyName = "Read Only";
 
-export const AutoFocus: Story = () => {
-  const [state, setState] = useState("Password");
-  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
-    setState(target.value);
-  };
-
-  return (
-    <Password autoFocus label="Password" value={state} onChange={setValue} />
-  );
-};
-AutoFocus.storyName = "Auto Focus";
-AutoFocus.parameters = { chromatic: { disable: true } };
-
 export const WithLabelInline: Story = () => {
   const [state, setState] = useState("Password");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/textarea/textarea-test.stories.tsx
+++ b/src/components/textarea/textarea-test.stories.tsx
@@ -3,6 +3,7 @@ import { StoryObj } from "@storybook/react/*";
 import Textarea, { TextareaProps } from ".";
 import Dialog from "../dialog";
 import Form from "../form";
+import Box from "../box";
 import Button from "../button";
 import isChromatic from "../../../.storybook/isChromatic";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
@@ -295,9 +296,9 @@ WithExpandableAndRows.storyName =
   "With expandable and rows in a dialog with form";
 WithExpandableAndRows.decorators = [
   (Story) => (
-    <div style={{ height: "100vh", width: "100vw" }}>
+    <Box height="100vh" width="100vw">
       <Story />
-    </div>
+    </Box>
   ),
 ];
 WithExpandableAndRows.parameters = {
@@ -321,6 +322,15 @@ export const LabelAlign: StoryType = () => {
 };
 LabelAlign.storyName = "With Label Align";
 LabelAlign.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const AutoFocusStory = () => {
+  return <Textarea label="Textarea" autoFocus />;
+};
+AutoFocusStory.storyName = "Auto Focus";
+AutoFocusStory.parameters = {
   chromatic: { disableSnapshot: false },
   themeProvider: { chromatic: { theme: "sage" } },
 };

--- a/src/components/textarea/textarea.mdx
+++ b/src/components/textarea/textarea.mdx
@@ -48,10 +48,6 @@ import Textarea from "carbon-react/lib/components/textarea";
 
 <Canvas of={TextareaStories.ReadOnlyStory} />
 
-### AutoFocus
-
-<Canvas of={TextareaStories.AutoFocusStory} />
-
 ### Expandable
 
 <Canvas of={TextareaStories.ExpandableStory} />
@@ -112,7 +108,7 @@ If you want to remove the borders from the component, you can use the `hideBorde
 
 ### With labelInline (legacy)
 
-Use the `labelInline` prop to display the label on the same horizontal row as the input. You can adjust its appearance using the `labelWidth` and 
+Use the `labelInline` prop to display the label on the same horizontal row as the input. You can adjust its appearance using the `labelWidth` and
 `labelAlign` props to control the width and text alignment of the label and the `inputWidth` prop to control the width of the input.
 
 **Note:** This is a legacy feature and will only render if the `validationRedesignOptIn` feature flag on an ancestor [CarbonProvider](../?path=/docs/carbon-provider--docs) is *false*.

--- a/src/components/textarea/textarea.stories.tsx
+++ b/src/components/textarea/textarea.stories.tsx
@@ -59,12 +59,6 @@ export const ReadOnlyStory: Story = () => {
 };
 ReadOnlyStory.storyName = "Read Only";
 
-export const AutoFocusStory: Story = () => {
-  return <Textarea label="Textarea" autoFocus />;
-};
-AutoFocusStory.storyName = "Auto Focus";
-AutoFocusStory.parameters = { chromatic: { disableSnapshot: true } };
-
 export const ExpandableStory: Story = () => {
   const [value, setValue] = useState("");
   return (

--- a/src/components/textbox/textbox-test.stories.tsx
+++ b/src/components/textbox/textbox-test.stories.tsx
@@ -116,13 +116,6 @@ export default {
       disableSnapshot: true,
     },
   },
-  includeStories: [
-    "Default",
-    "Validation",
-    "NewValidation",
-    "PrefixWithSizes",
-    "LabelAndHintTextAlign",
-  ],
 };
 
 export const Default = (args: CommonTextboxArgs) => {
@@ -255,6 +248,19 @@ export const LabelAndHintTextAlign = () => {
 };
 LabelAndHintTextAlign.storyName = "Label and hint text align";
 LabelAndHintTextAlign.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const AutoFocus = () => {
+  return (
+    <Box>
+      <Textbox label="Textbox" value="Textbox" autoFocus />
+    </Box>
+  );
+};
+AutoFocus.storyName = "Auto Focus";
+AutoFocus.parameters = {
   chromatic: { disableSnapshot: false },
   themeProvider: { chromatic: { theme: "sage" } },
 };

--- a/src/components/textbox/textbox.mdx
+++ b/src/components/textbox/textbox.mdx
@@ -83,10 +83,6 @@ Include the formatted number count wherever makes sense for the language you're 
 
 <Canvas of={TextboxStories.Margins} />
 
-### AutoFocus
-
-<Canvas of={TextboxStories.AutoFocus} />
-
 ### Disabled
 
 <Canvas of={TextboxStories.Disabled} />
@@ -113,7 +109,7 @@ You can use the `isOptional` prop to indicate if the field is mandatory.
 
 ### With labelInline (legacy)
 
-Use the `labelInline` prop to display the label on the same horizontal row as the input. You can adjust its appearance using the `labelWidth` and 
+Use the `labelInline` prop to display the label on the same horizontal row as the input. You can adjust its appearance using the `labelWidth` and
 `labelAlign` props to control the width and text alignment of the label and the `inputWidth` prop to control the width of the input.
 
 **Note:** This is a legacy feature and will only render if the `validationRedesignOptIn` feature flag on an ancestor [CarbonProvider](../?path=/docs/carbon-provider--docs) is *false*.

--- a/src/components/textbox/textbox.stories.tsx
+++ b/src/components/textbox/textbox.stories.tsx
@@ -127,17 +127,6 @@ export const Margins: Story = () => {
 };
 Margins.storyName = "Margins";
 
-export const AutoFocus: Story = () => {
-  return (
-    <Box>
-      <Textbox label="Textbox" value="Textbox" autoFocus />
-      <Textbox label="Textbox" value="Textbox" autoFocus />
-    </Box>
-  );
-};
-AutoFocus.storyName = "Auto Focus";
-AutoFocus.parameters = { chromatic: { disableSnapshot: true } };
-
 export const Disabled: Story = () => {
   return <Textbox label="Textbox" value="Textbox" disabled />;
 };


### PR DESCRIPTION
### Proposed behaviour

- Remove the stories from the main Storybook files and move them into Chromatic;
- Update the documentation to remove the obsolete auto-focus stories.

### Current behaviour

The docs for the following components do not open at the head of the page correctly; they open and then jump to the auto-focus stories:

- Date
- GroupedCharacter
- Number
- Password
- Textarea
- Textbox

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

