### PR TITLE
feat(text-editor): add programmatic focus support for the text editor

### DIFF
--- a/src/components/text-editor/__internal__/plugins/Toolbar/toolbar.test.tsx
+++ b/src/components/text-editor/__internal__/plugins/Toolbar/toolbar.test.tsx
@@ -11,6 +11,7 @@ import React from "react";
 
 import userEvent from "@testing-library/user-event";
 import { ToolbarPlugin } from "..";
+import TextEditor from "../../../text-editor.component";
 
 function headlessEditor() {
   const editor = createHeadlessEditor({
@@ -180,6 +181,22 @@ describe("Events", () => {
     expect(dispatchSpy).toHaveBeenCalledWith(FORMAT_TEXT_COMMAND, "bold");
   });
 
+  /** Have to assert that the onChange mock count has increased by 1 due to the editor attempting to repeatedly create update listeners when the
+   * tests are run, causing the onChange to be fired during initial render. */
+  it("dispatches an 'onChange' event when the bold button is clicked within the TextEditor", async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+
+    render(<TextEditor labelText="foo" onChange={mockOnChange} />);
+
+    const callCountBefore = mockOnChange.mock.calls.length;
+
+    const boldButton = screen.getByRole("button", { name: "Bold" });
+    await user.click(boldButton);
+
+    expect(mockOnChange).toHaveBeenCalledTimes(callCountBefore + 1);
+  });
+
   /** Using the mocked toolbar, test that clicking the italic button fires the correct event */
   it("dispatches the 'italic' event when the italic button is clicked", async () => {
     const user = userEvent.setup();
@@ -207,6 +224,22 @@ describe("Events", () => {
     await user.click(italicButton);
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
     expect(dispatchSpy).toHaveBeenCalledWith(FORMAT_TEXT_COMMAND, "italic");
+  });
+
+  /** Have to assert that the onChange mock count has increased by 1 due to the editor attempting to repeatedly create update listeners when the
+   * tests are run, causing the onChange to be fired during initial render. */
+  it("dispatches an 'onChange' event when the italic button is clicked within the TextEditor", async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+
+    render(<TextEditor labelText="foo" onChange={mockOnChange} />);
+
+    const callCountBefore = mockOnChange.mock.calls.length;
+
+    const italicButton = screen.getByRole("button", { name: "Italic" });
+    await user.click(italicButton);
+
+    expect(mockOnChange).toHaveBeenCalledTimes(callCountBefore + 1);
   });
 
   /** Using the mocked toolbar, test that clicking the ordered list button fires the correct event */
@@ -238,6 +271,24 @@ describe("Events", () => {
     expect(dispatchSpy).toHaveBeenCalledWith(FORMAT_TEXT_COMMAND, "number");
   });
 
+  /** Have to assert that the onChange mock count has increased by 1 due to the editor attempting to repeatedly create update listeners when the
+   * tests are run, causing the onChange to be fired during initial render. */
+  it("dispatches an 'onChange' event when the ordered list button is clicked within the TextEditor", async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+
+    render(<TextEditor labelText="foo" onChange={mockOnChange} />);
+
+    const callCountBefore = mockOnChange.mock.calls.length;
+
+    const orderedListButton = screen.getByRole("button", {
+      name: "Ordered list",
+    });
+    await user.click(orderedListButton);
+
+    expect(mockOnChange).toHaveBeenCalledTimes(callCountBefore + 1);
+  });
+
   /** Using the mocked toolbar, test that clicking the unordered list button fires the correct event */
   it("dispatches the 'unordered list' event when the unordered list button is clicked", async () => {
     const user = userEvent.setup();
@@ -265,5 +316,23 @@ describe("Events", () => {
     await user.click(ulButton);
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
     expect(dispatchSpy).toHaveBeenCalledWith(FORMAT_TEXT_COMMAND, "bullet");
+  });
+
+  /** Have to assert that the onChange mock count has increased by 1 due to the editor attempting to repeatedly create update listeners when the
+   * tests are run, causing the onChange to be fired during initial render. */
+  it("dispatches an 'onChange' event when the unordered ordered list button is clicked within the TextEditor", async () => {
+    const user = userEvent.setup();
+    const mockOnChange = jest.fn();
+
+    render(<TextEditor labelText="foo" onChange={mockOnChange} />);
+
+    const callCountBefore = mockOnChange.mock.calls.length;
+
+    const unorderedListButton = screen.getByRole("button", {
+      name: "Unordered list",
+    });
+    await user.click(unorderedListButton);
+
+    expect(mockOnChange).toHaveBeenCalledTimes(callCountBefore + 1);
   });
 });

--- a/src/components/text-editor/index.ts
+++ b/src/components/text-editor/index.ts
@@ -1,6 +1,7 @@
 export { default } from "./text-editor.component";
 export { createEmpty, createFromHTML } from "./utils";
 export type {
+  TextEditorHandle,
   TextEditorProps,
   EditorFormattedValues,
 } from "./text-editor.component";

--- a/src/components/text-editor/text-editor.mdx
+++ b/src/components/text-editor/text-editor.mdx
@@ -44,6 +44,17 @@ All instances of the Text Editor should have a label that describes the purpose 
 
 <Canvas of={TextEditorStories.Default} />
 
+### Focusing the Text Editor Programmatically
+
+```javascript
+import { TextEditorHandle } from "carbon-react/lib/components/text-editor";
+```
+
+The `TextEditorHandle` type provides an imperative handle for programmatic control over the Text Editor. 
+Using a `ref`, you can access its `focus()` method to set focus on the Text Editor as needed.
+
+<Canvas of={TextEditorStories.ProgrammaticFocus} />
+
 ### With Header
 
 The Text Editor accepts a header property, which can be any valid React node and is rendered above the toolbar, providing space for custom elements such as titles, controls, or contextual information.

--- a/src/components/text-editor/text-editor.stories.tsx
+++ b/src/components/text-editor/text-editor.stories.tsx
@@ -13,6 +13,7 @@ import Link from "../link";
 import enGB from "../../locales/en-gb";
 
 import TextEditor, {
+  TextEditorHandle,
   createEmpty,
   createFromHTML,
   EditorFormattedValues,
@@ -41,6 +42,25 @@ export const Default: Story = () => {
   return <TextEditor namespace="storybook-default" labelText="Text Editor" />;
 };
 Default.storyName = "Default";
+
+export const ProgrammaticFocus = () => {
+  const editorRef = useRef<TextEditorHandle>(null);
+
+  return (
+    <>
+      <Button mb="30px" onClick={() => editorRef.current?.focus()}>
+        Focus the editor
+      </Button>
+
+      <TextEditor
+        ref={editorRef}
+        namespace="storybook-default"
+        labelText="Text Editor"
+      />
+    </>
+  );
+};
+ProgrammaticFocus.storyName = "Focusing the Text Editor Programmatically";
 
 export const Header: Story = () => {
   return (

--- a/src/components/text-editor/text-editor.test.tsx
+++ b/src/components/text-editor/text-editor.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import React from "react";
+import React, { act, createRef } from "react";
 
-import TextEditor, { createEmpty, createFromHTML } from ".";
+import TextEditor, { TextEditorHandle, createEmpty, createFromHTML } from ".";
 import { COMPONENT_PREFIX } from "./__internal__/constants";
 
 import Logger from "../../__internal__/utils/logger";
@@ -387,6 +387,19 @@ test("serialisation of editor", async () => {
   // click the save button and expect the callback to be called
   await user.click(saveButton);
   expect(mockSave).toHaveBeenCalledTimes(1);
+});
+
+test("editor is focused when the focus method is invoked via imperative handle", () => {
+  const editorRef = createRef<TextEditorHandle>();
+
+  render(<TextEditor labelText="Text Editor" ref={editorRef} />);
+
+  act(() => {
+    editorRef.current?.focus();
+  });
+
+  const editor = screen.getByRole("textbox");
+  expect(editor).toHaveFocus();
 });
 
 test("valid data is parsed when HTML is passed into the createFromHTML function", async () => {


### PR DESCRIPTION
fixes #7320 

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

`TextEditor` now accepts a `forwardRef`, and an imperative handle has been introduced which provides consumers with access to a focus method only.

Tests have been added to establish a baseline for `onChange` behaviour being triggered by toolbar buttons.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

`TextEditor` no longer supports a `forwardRef` since its conversion to Lexical, but some consumers rely on passing a ref for programmatic focus control.

Also clicks on toolbar buttons result in `onChange` being triggered, due  previous changes, however there are no tests added to test against this behaviour.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

The new programmatic focus story on `TextEditor` should be sufficient enough to test that the new imperative handle does indeed result in the TextEditor being focused
