### PR TITLE
refactor(action-popover): simplify styling logic to reduce amount of internal prop drilling

### DIFF
--- a/src/components/action-popover/__internal__/action-popover.context.ts
+++ b/src/components/action-popover/__internal__/action-popover.context.ts
@@ -7,7 +7,6 @@ type ActionPopoverContextType = {
   setOpenPopover: (isOpen: boolean) => void;
   focusButton: () => void;
   submenuPosition: Alignment;
-  isOpenPopover: boolean;
 };
 
 const ActionPopoverContext = createContext<ActionPopoverContextType | null>(

--- a/src/components/action-popover/__internal__/action-popover.context.ts
+++ b/src/components/action-popover/__internal__/action-popover.context.ts
@@ -6,6 +6,7 @@ export type Alignment = "left" | "right";
 type ActionPopoverContextType = {
   setOpenPopover: (isOpen: boolean) => void;
   focusButton: () => void;
+  horizontalAlignment: Alignment;
   submenuPosition: Alignment;
 };
 

--- a/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
+++ b/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
@@ -6,7 +6,6 @@ import {
   SubMenuItemIcon,
   StyledMenuItem,
   StyledMenuItemInnerText,
-  StyledMenuItemOuterContainer,
   StyledMenuItemWrapper,
 } from "../action-popover.style";
 import Events from "../../../__internal__/utils/helpers/events";
@@ -47,19 +46,9 @@ export interface ActionPopoverItemProps {
   /** @ignore @private */
   horizontalAlignment?: Alignment;
   /** @ignore @private */
-  childHasSubmenu?: boolean;
-  /** @ignore @private */
-  childHasIcon?: boolean;
-  /** @ignore @private */
   currentSubmenuPosition?: Alignment;
   /** @ignore @private */
-  setChildHasSubmenu?: (value: boolean) => void;
-  /** @ignore @private */
-  setChildHasIcon?: (value: boolean) => void;
-  /** @ignore @private */
   setCurrentSubmenuPosition?: (value: Alignment) => void;
-  /** @ignore @private */
-  isASubmenu?: boolean;
 }
 
 const INTERVAL = 150;
@@ -107,13 +96,8 @@ export const ActionPopoverItem = ({
   download,
   href,
   horizontalAlignment,
-  childHasSubmenu,
-  childHasIcon,
   currentSubmenuPosition,
-  setChildHasSubmenu,
-  setChildHasIcon,
   setCurrentSubmenuPosition,
-  isASubmenu = false,
   ...rest
 }: ActionPopoverItemProps) => {
   invariant(
@@ -142,15 +126,6 @@ export const ActionPopoverItem = ({
       setOpen(false);
     }
   }, [isOpenPopover]);
-
-  useEffect(() => {
-    if (icon) {
-      setChildHasIcon?.(true);
-    }
-    if (submenu) {
-      setChildHasSubmenu?.(true);
-    }
-  }, [icon, setChildHasSubmenu, setChildHasIcon, submenu]);
 
   const alignSubmenu = useCallback(() => {
     const checkCalculatedSubmenuPosition = calculateSubmenuPosition(
@@ -330,90 +305,60 @@ export const ActionPopoverItem = ({
     }),
   };
 
-  const renderMenuItemIcon = () => {
-    return (
-      icon && (
-        <MenuItemIcon
-          type={icon}
-          data-element="action-popover-menu-item-icon"
-          horizontalAlignment={horizontalAlignment}
-          submenuPosition={currentSubmenuPosition}
-          childHasIcon={childHasIcon}
-          childHasSubmenu={childHasSubmenu}
-          hasIcon={!!icon}
-          hasSubmenu={!!submenu}
-          isASubmenu={isASubmenu}
-        />
-      )
-    );
-  };
-
   return (
-    <StyledMenuItemWrapper {...(submenu && wrapperProps)}>
-      <div onKeyDown={onKeyDown} role="presentation">
-        <StyledMenuItem
-          {...rest}
-          ref={ref}
-          onClick={onClick}
-          type="button"
-          tabIndex={0}
-          isDisabled={disabled}
-          horizontalAlignment={horizontalAlignment}
-          submenuPosition={currentSubmenuPosition}
-          hasSubmenu={!!submenu}
-          childHasSubmenu={childHasSubmenu}
-          {...(disabled && { "aria-disabled": true })}
-          {...(isHref && { as: "a" as unknown as undefined, download, href })}
-          {...(submenu && itemSubmenuProps)}
-        >
-          {submenu && checkRef(ref) && currentSubmenuPosition === "left" ? (
-            <SubMenuItemIcon
-              data-element="action-popover-menu-item-chevron"
-              type="chevron_left_thick"
-            />
-          ) : null}
-          <StyledMenuItemOuterContainer>
-            {horizontalAlignment === "left" ? renderMenuItemIcon() : null}
-            <StyledMenuItemInnerText
-              data-element="action-popover-menu-item-inner-text"
-              horizontalAlignment={horizontalAlignment}
-              submenuPosition={currentSubmenuPosition}
-              isASubmenu={isASubmenu}
-              childHasSubmenu={childHasSubmenu}
-              childHasIcon={childHasIcon}
-              hasIcon={!!icon}
-              hasSubmenu={!!submenu}
-            >
-              {children}
-            </StyledMenuItemInnerText>
-            {horizontalAlignment === "right" ? renderMenuItemIcon() : null}
-          </StyledMenuItemOuterContainer>
-          {submenu && checkRef(ref) && currentSubmenuPosition === "right" ? (
-            <SubMenuItemIcon
-              data-element="action-popover-menu-item-chevron"
-              type="chevron_right_thick"
-            />
-          ) : null}
-        </StyledMenuItem>
-        {React.isValidElement(submenu)
-          ? React.cloneElement<ActionPopoverMenuProps>(
-              submenu as React.ReactElement<ActionPopoverMenuProps>,
-              {
-                parentID: `ActionPopoverItem_${guid}`,
-                menuID: `ActionPopoverMenu_${guid}`,
-                "data-element": "action-popover-submenu",
-                isOpen,
-                ref: submenuRef,
-                style: containerPosition,
-                setOpen,
-                setFocusIndex,
-                focusIndex,
-                isASubmenu: true,
-                horizontalAlignment,
-              },
-            )
-          : null}
-      </div>
+    <StyledMenuItemWrapper onKeyDown={onKeyDown} {...(submenu && wrapperProps)}>
+      <StyledMenuItem
+        {...rest}
+        ref={ref}
+        onClick={onClick}
+        type="button"
+        tabIndex={0}
+        isDisabled={disabled}
+        {...(disabled && { "aria-disabled": true })}
+        {...(isHref && { as: "a" as unknown as undefined, download, href })}
+        {...(submenu && itemSubmenuProps)}
+      >
+        {submenu && checkRef(ref) && (
+          <SubMenuItemIcon
+            aria-hidden
+            data-element="action-popover-menu-item-chevron"
+            data-role="chevron-icon"
+            type={
+              currentSubmenuPosition === "left"
+                ? "chevron_left_thick"
+                : "chevron_right_thick"
+            }
+          />
+        )}
+        {icon && (
+          <MenuItemIcon
+            aria-hidden
+            type={icon}
+            data-element="action-popover-menu-item-icon"
+            data-role="item-icon"
+          />
+        )}
+        <StyledMenuItemInnerText data-element="action-popover-menu-item-inner-text">
+          {children}
+        </StyledMenuItemInnerText>
+      </StyledMenuItem>
+      {React.isValidElement(submenu)
+        ? React.cloneElement<ActionPopoverMenuProps>(
+            submenu as React.ReactElement<ActionPopoverMenuProps>,
+            {
+              parentID: `ActionPopoverItem_${guid}`,
+              menuID: `ActionPopoverMenu_${guid}`,
+              "data-element": "action-popover-submenu",
+              isOpen,
+              ref: submenuRef,
+              style: containerPosition,
+              setOpen,
+              setFocusIndex,
+              focusIndex,
+              horizontalAlignment,
+            },
+          )
+        : null}
     </StyledMenuItemWrapper>
   );
 };

--- a/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
+++ b/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
@@ -105,7 +105,7 @@ export const ActionPopoverItem = ({
     "ActionPopoverItem only accepts submenu of type `ActionPopoverMenu`",
   );
 
-  const { setOpenPopover, isOpenPopover, focusButton, submenuPosition } =
+  const { setOpenPopover, focusButton, submenuPosition } =
     useActionPopoverContext();
   const isHref = !!href;
   const [containerPosition, setContainerPosition] = useState<
@@ -119,13 +119,6 @@ export const ActionPopoverItem = ({
   const ref = useRef<HTMLButtonElement>(null);
   const mouseEnterTimer = useRef<NodeJS.Timeout | null>(null);
   const mouseLeaveTimer = useRef<NodeJS.Timeout | null>(null);
-
-  useEffect(() => {
-    /* istanbul ignore if - doesn't seem to actually run as the child item is unmounted before the context updates */
-    if (!isOpenPopover) {
-      setOpen(false);
-    }
-  }, [isOpenPopover]);
 
   const alignSubmenu = useCallback(() => {
     const checkCalculatedSubmenuPosition = calculateSubmenuPosition(

--- a/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
+++ b/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
@@ -44,8 +44,6 @@ export interface ActionPopoverItemProps {
   /** @ignore @private */
   focusItem?: boolean;
   /** @ignore @private */
-  horizontalAlignment?: Alignment;
-  /** @ignore @private */
   currentSubmenuPosition?: Alignment;
   /** @ignore @private */
   setCurrentSubmenuPosition?: (value: Alignment) => void;
@@ -95,7 +93,6 @@ export const ActionPopoverItem = ({
   focusItem,
   download,
   href,
-  horizontalAlignment,
   currentSubmenuPosition,
   setCurrentSubmenuPosition,
   ...rest
@@ -348,7 +345,6 @@ export const ActionPopoverItem = ({
               setOpen,
               setFocusIndex,
               focusIndex,
-              horizontalAlignment,
             },
           )
         : null}

--- a/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
+++ b/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
@@ -40,8 +40,6 @@ export interface ActionPopoverItemProps {
   /** Submenu component for item */
   submenu?: React.ReactNode;
   /** @ignore @private */
-  placement?: "top" | "bottom";
-  /** @ignore @private */
   focusItem?: boolean;
   /** @ignore @private */
   currentSubmenuPosition?: Alignment;
@@ -89,7 +87,6 @@ export const ActionPopoverItem = ({
   disabled = false,
   onClick: onClickProp,
   submenu,
-  placement = "bottom",
   focusItem,
   download,
   href,
@@ -145,19 +142,14 @@ export const ActionPopoverItem = ({
       const leftAlignedSubmenu = currentSubmenuPosition === "left";
       const leftValue = leftAlignedSubmenu ? -submenuWidth : "auto";
       const rightValue = leftAlignedSubmenu ? "auto" : -submenuWidth;
-      const yPositionName =
-        placement === "top"
-          ? /* istanbul ignore next - tested in Playwright */ "bottom"
-          : "top";
 
       return {
         left: leftValue,
-        [yPositionName]: "calc(-1 * var(--spacing100))",
         right: rightValue,
       };
     };
     setContainerPosition(getContainerPosition);
-  }, [submenu, currentSubmenuPosition, placement]);
+  }, [submenu, currentSubmenuPosition]);
 
   useEffect(() => {
     if (submenu) {

--- a/src/components/action-popover/action-popover-menu/action-popover-menu.component.tsx
+++ b/src/components/action-popover/action-popover-menu/action-popover-menu.component.tsx
@@ -41,8 +41,6 @@ export interface ActionPopoverMenuBaseProps {
   setOpen?: (args: boolean) => void;
   /** Unique ID for the menu's parent */
   parentID?: string;
-  /** Horizontal alignment of menu items content */
-  horizontalAlignment?: Alignment;
   /** Set whether the menu should open above or below the button */
   placement?: "bottom" | "top";
   /** @ignore @private */
@@ -76,12 +74,12 @@ const ActionPopoverMenu = React.forwardRef<
       setOpen,
       setFocusIndex,
       placement = "bottom",
-      horizontalAlignment = "left",
       ...rest
     }: ActionPopoverMenuBaseProps,
     ref,
   ) => {
-    const { focusButton, submenuPosition } = useActionPopoverContext();
+    const { focusButton, submenuPosition, horizontalAlignment } =
+      useActionPopoverContext();
 
     invariant(
       setOpen && setFocusIndex && typeof focusIndex !== "undefined",
@@ -218,7 +216,6 @@ const ActionPopoverMenu = React.forwardRef<
             {
               focusItem: isOpen && focusIndex === index - 1,
               placement: child.props.submenu ? placement : undefined,
-              horizontalAlignment,
               currentSubmenuPosition,
               setCurrentSubmenuPosition,
             },
@@ -227,14 +224,7 @@ const ActionPopoverMenu = React.forwardRef<
 
         return child;
       });
-    }, [
-      children,
-      focusIndex,
-      isOpen,
-      placement,
-      horizontalAlignment,
-      currentSubmenuPosition,
-    ]);
+    }, [children, focusIndex, isOpen, placement, currentSubmenuPosition]);
 
     return (
       <Menu

--- a/src/components/action-popover/action-popover-menu/action-popover-menu.component.tsx
+++ b/src/components/action-popover/action-popover-menu/action-popover-menu.component.tsx
@@ -215,7 +215,6 @@ const ActionPopoverMenu = React.forwardRef<
             child as React.ReactElement<ActionPopoverItemProps>,
             {
               focusItem: isOpen && focusIndex === index - 1,
-              placement: child.props.submenu ? placement : undefined,
               currentSubmenuPosition,
               setCurrentSubmenuPosition,
             },
@@ -224,11 +223,12 @@ const ActionPopoverMenu = React.forwardRef<
 
         return child;
       });
-    }, [children, focusIndex, isOpen, placement, currentSubmenuPosition]);
+    }, [children, focusIndex, isOpen, currentSubmenuPosition]);
 
     return (
       <Menu
         data-component="action-popover"
+        data-submenu-placement={placement}
         isOpen={!!isOpen}
         onKeyDown={onKeyDown}
         id={menuID}

--- a/src/components/action-popover/action-popover-menu/action-popover-menu.component.tsx
+++ b/src/components/action-popover/action-popover-menu/action-popover-menu.component.tsx
@@ -48,8 +48,6 @@ export interface ActionPopoverMenuBaseProps {
   /** @ignore @private */
   role?: string;
   /** @ignore @private */
-  isASubmenu?: boolean;
-  /** @ignore @private */
   "data-element"?: string;
   /** @ignore @private */
   style?: {
@@ -78,8 +76,7 @@ const ActionPopoverMenu = React.forwardRef<
       setOpen,
       setFocusIndex,
       placement = "bottom",
-      horizontalAlignment,
-      isASubmenu,
+      horizontalAlignment = "left",
       ...rest
     }: ActionPopoverMenuBaseProps,
     ref,
@@ -208,8 +205,6 @@ const ActionPopoverMenu = React.forwardRef<
       ],
     );
 
-    const [childHasSubmenu, setChildHasSubmenu] = useState(false);
-    const [childHasIcon, setChildHasIcon] = useState(false);
     const [currentSubmenuPosition, setCurrentSubmenuPosition] =
       useState<Alignment>(submenuPosition);
 
@@ -224,13 +219,8 @@ const ActionPopoverMenu = React.forwardRef<
               focusItem: isOpen && focusIndex === index - 1,
               placement: child.props.submenu ? placement : undefined,
               horizontalAlignment,
-              childHasSubmenu,
-              setChildHasSubmenu,
-              childHasIcon,
-              setChildHasIcon,
               currentSubmenuPosition,
               setCurrentSubmenuPosition,
-              isASubmenu,
             },
           );
         }
@@ -243,21 +233,20 @@ const ActionPopoverMenu = React.forwardRef<
       isOpen,
       placement,
       horizontalAlignment,
-      childHasSubmenu,
-      childHasIcon,
       currentSubmenuPosition,
-      isASubmenu,
     ]);
 
     return (
       <Menu
         data-component="action-popover"
-        isOpen={isOpen}
+        isOpen={!!isOpen}
         onKeyDown={onKeyDown}
         id={menuID}
         aria-labelledby={parentID}
         ref={ref}
         role="list"
+        submenuLeft={currentSubmenuPosition === "left"}
+        iconLeft={horizontalAlignment === "left"}
         {...rest}
       >
         {clonedChildren}

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -345,7 +345,6 @@ export const ActionPopover = forwardRef<
             setOpenPopover: setOpen,
             focusButton,
             submenuPosition,
-            isOpenPopover: isOpen,
           }}
         >
           {isOpen && (

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -333,6 +333,7 @@ export const ActionPopover = forwardRef<
             setOpenPopover: setOpen,
             focusButton,
             submenuPosition,
+            horizontalAlignment,
           }}
         >
           {isOpen && (
@@ -351,7 +352,6 @@ export const ActionPopover = forwardRef<
                 isOpen={isOpen}
                 setOpen={setOpen}
                 placement={placement}
-                horizontalAlignment={horizontalAlignment}
               >
                 {children}
               </ActionPopoverMenu>

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -318,18 +318,6 @@ export const ActionPopover = forwardRef<
 
     const parentID = id || `ActionPopoverButton_${guid}`;
     const menuID = `ActionPopoverMenu_${guid}`;
-    const menuProps = {
-      buttonRef,
-      parentID,
-      setFocusIndex,
-      focusIndex,
-      menuID,
-      isOpen,
-      setOpen,
-      rightAlignMenu,
-      placement,
-      horizontalAlignment,
-    };
 
     return (
       <MenuButton
@@ -356,7 +344,14 @@ export const ActionPopover = forwardRef<
               <ActionPopoverMenu
                 data-component="action-popover"
                 ref={menu}
-                {...menuProps}
+                parentID={parentID}
+                menuID={menuID}
+                focusIndex={focusIndex}
+                setFocusIndex={setFocusIndex}
+                isOpen={isOpen}
+                setOpen={setOpen}
+                placement={placement}
+                horizontalAlignment={horizontalAlignment}
               >
                 {children}
               </ActionPopoverMenu>

--- a/src/components/action-popover/action-popover.style.ts
+++ b/src/components/action-popover/action-popover.style.ts
@@ -45,6 +45,16 @@ const Menu = styled.ul<{
   background-color: var(--colorsUtilityYang100);
   z-index: ${({ theme }) =>
     `${theme.zIndex?.popover}`}; // TODO (tokens): implement elevation tokens - FE-4437
+
+  &[data-submenu-placement="top"] & {
+    bottom: calc(-1 * var(--spacing100));
+    top: auto;
+  }
+
+  &[data-submenu-placement="bottom"] & {
+    top: calc(-1 * var(--spacing100));
+    bottom: auto;
+  }
 `;
 
 const StyledMenuItemInnerText = styled.div`

--- a/src/components/action-popover/action-popover.style.ts
+++ b/src/components/action-popover/action-popover.style.ts
@@ -7,9 +7,35 @@ import StyledButton from "../button/button.style";
 import addFocusStyling from "../../style/utils/add-focus-styling";
 import baseTheme from "../../style/themes/base";
 
-const Menu = styled.ul`
-  ${({ isOpen }: { isOpen?: boolean }) =>
-    isOpen ? "display: block;" : "visibility: hidden;"}
+const Menu = styled.ul<{
+  isOpen: boolean;
+  submenuLeft: boolean;
+  iconLeft: boolean;
+}>`
+  visibility: ${({ isOpen }) => (isOpen ? "visible" : "hidden")};
+
+  display: grid;
+
+  ${({ submenuLeft, iconLeft }) => {
+    const chevronColumn = "[chevron_column] auto";
+    const iconColumn = "[icon_column] auto";
+    const textColumn = "[text_column] auto";
+
+    return css`
+      grid-template-columns:
+        ${submenuLeft ? chevronColumn : ""}
+        ${iconLeft
+          ? `${iconColumn} ${textColumn}`
+          : `${textColumn} ${iconColumn}`}
+        ${!submenuLeft ? chevronColumn : ""};
+    `;
+  }}
+
+  align-items: center;
+  min-width: fit-content;
+  text-align: ${({ iconLeft }) => (iconLeft ? "left" : "right")};
+  justify-content: ${({ iconLeft }) => (iconLeft ? "left" : "right")};
+
   margin: 0;
   list-style: none;
   padding: var(--spacing100) 0;
@@ -21,139 +47,25 @@ const Menu = styled.ul`
     `${theme.zIndex?.popover}`}; // TODO (tokens): implement elevation tokens - FE-4437
 `;
 
-function getPaddingValues(
-  childHasSubmenu?: boolean,
-  childHasIcon?: boolean,
-  hasIcon?: boolean,
-  hasSubmenu?: boolean,
-) {
-  // computing padding for "inner text" element of a menu item.
-  // childHasSubmenu - ANY sibling (including itself?) has the 'submenu' prop
-  // childHasIcon - ANY sibling (including itself?) has the 'icon' prop
-  // hasIcon - has the 'icon' prop
-  // hasSubmenu - has the 'submenu' prop
-  if (!childHasIcon && childHasSubmenu && !hasIcon && !hasSubmenu) {
-    return "var(--spacing400)";
-  }
-  if (childHasIcon && childHasSubmenu && !hasIcon && hasSubmenu) {
-    return "var(--spacing600)";
-  }
-  if (childHasIcon && childHasSubmenu && !hasIcon && !hasSubmenu) {
-    return "var(--spacing900)";
-  }
-  return "var(--spacing100)";
-}
+const StyledMenuItemInnerText = styled.div`
+  grid-column: text_column;
 
-function getIconPaddingValues(
-  index: 1 | 2,
-  horizontalAlignment?: "left" | "right",
-  submenuPosition?: "left" | "right",
-  siblingsHaveIconAndSubmenu?: boolean,
-  isASubmenu?: boolean,
-) {
-  const sameAlignment =
-    (horizontalAlignment === "left" && submenuPosition === "left") ||
-    (horizontalAlignment === "right" && submenuPosition === "right");
-
-  if (siblingsHaveIconAndSubmenu && sameAlignment) {
-    if (horizontalAlignment === "left") {
-      return index === 1 ? "var(--spacing100)" : "var(--spacing400)";
-    }
-    return index === 1 ? "var(--spacing400)" : "var(--spacing100)";
+  &:only-child {
+    padding: 0;
   }
 
-  if (isASubmenu) {
-    if (horizontalAlignment === "left") {
-      return index === 1 ? "var(--spacing100)" : "var(--spacing000)";
-    }
-    return index === 1 ? "var(--spacing000)" : "var(--spacing100)";
-  }
-
-  return "var(--spacing100)";
-}
-
-type StyledMenuItemProps = {
-  isDisabled: boolean;
-  horizontalAlignment?: "left" | "right";
-  submenuPosition?: "left" | "right";
-  childHasSubmenu?: boolean;
-  childHasIcon?: boolean;
-  hasSubmenu?: boolean;
-  hasIcon?: boolean;
-  isASubmenu?: boolean;
-};
-
-const StyledMenuItemInnerText = styled.div<
-  Omit<StyledMenuItemProps, "isDisabled">
->`
-  ${({
-    childHasSubmenu,
-    childHasIcon,
-    hasIcon,
-    hasSubmenu,
-    submenuPosition,
-    horizontalAlignment,
-    isASubmenu,
-  }) => css`
-    padding-left: ${isASubmenu ? `var(--spacing000)` : `var(--spacing100)`};
-    padding-right: ${isASubmenu ? `var(--spacing000)` : `var(--spacing100)`};
-
-    ${horizontalAlignment === "left" &&
-    submenuPosition === "left" &&
-    !isASubmenu &&
-    css`
-      padding-left: ${getPaddingValues(
-        childHasSubmenu,
-        childHasIcon,
-        hasIcon,
-        hasSubmenu,
-      )};
-    `}
-
-    ${horizontalAlignment === "right" &&
-    submenuPosition === "right" &&
-    !isASubmenu &&
-    css`
-      padding-right: ${getPaddingValues(
-        childHasSubmenu,
-        childHasIcon,
-        hasIcon,
-        hasSubmenu,
-      )};
-    `}
-  `}
+  padding: 0 var(--spacing100);
 `;
 
-const StyledMenuItemOuterContainer = styled.div`
-  display: inherit;
-`;
-const StyledMenuItem = styled.button<Omit<StyledMenuItemProps, "variant">>`
-  ${({
-    horizontalAlignment,
-    submenuPosition,
-    childHasSubmenu,
-    hasSubmenu,
-  }) => css`
-    justify-content: ${horizontalAlignment === "left"
-      ? "flex-start"
-      : "flex-end"};
+const StyledMenuItem = styled.button<{ isDisabled: boolean }>`
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-template-rows: subgrid;
+  grid-column: span 3;
 
-    ${horizontalAlignment === "left" &&
-    submenuPosition === "right" &&
-    css`
-      justify-content: space-between;
-    `}
-
-    ${horizontalAlignment === "right" &&
-    submenuPosition === "left" &&
-    css`
-      ${childHasSubmenu &&
-      hasSubmenu &&
-      css`
-        justify-content: space-between;
-      `}
-    `}
-  `}
+  align-items: inherit;
+  text-align: inherit;
+  justify-content: inherit;
 
   text-decoration: none;
   background-color: var(--colorsActionMajorYang100);
@@ -164,10 +76,7 @@ const StyledMenuItem = styled.button<Omit<StyledMenuItemProps, "variant">>`
   line-height: 40px;
   white-space: nowrap;
   user-select: none;
-  display: flex;
-  align-items: center;
   border: none;
-  width: 100%;
   color: var(--colorsUtilityYin090);
   font-size: 14px;
   font-weight: 500;
@@ -216,12 +125,23 @@ StyledMenuItem.defaultProps = {
 };
 
 const StyledMenuItemWrapper = styled.li`
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-template-rows: subgrid;
+  grid-column: span 3;
+
+  text-align: inherit;
+  align-items: inherit;
+  justify-content: inherit;
+
   position: relative;
 `;
 
 const MenuItemDivider = styled.li.attrs({
   "data-element": "action-popover-divider",
 })`
+  grid-column: span 3;
+
   background-color: var(--colorsUtilityMajor050);
   height: var(--borderWidth100);
   margin: var(--spacing100) var(--spacing150);
@@ -252,35 +172,12 @@ const StyledButtonIcon = styled.div`
   border-radius: var(--borderRadius050);
 `;
 
-const MenuItemIcon = styled(Icon)<Omit<StyledMenuItemProps, "isDisabled">>`
-  ${({
-    horizontalAlignment,
-    submenuPosition,
-    childHasIcon,
-    childHasSubmenu,
-    hasIcon,
-    hasSubmenu,
-    isASubmenu,
-  }) => css`
-    justify-content: ${horizontalAlignment};
-    padding: var(--spacing100)
-      ${getIconPaddingValues(
-        1,
-        horizontalAlignment,
-        submenuPosition,
-        childHasIcon && childHasSubmenu && hasIcon && !hasSubmenu,
-        isASubmenu,
-      )}
-      var(--spacing100)
-      ${getIconPaddingValues(
-        2,
-        horizontalAlignment,
-        submenuPosition,
-        childHasIcon && childHasSubmenu && hasIcon && !hasSubmenu,
-        isASubmenu,
-      )};
-    color: var(--colorsUtilityYin065);
-  `}
+const MenuItemIcon = styled(Icon)`
+  justify-content: inherit;
+  grid-column: icon_column;
+
+  padding: var(--spacing100);
+  color: var(--colorsUtilityYin065);
 `;
 
 StyledButtonIcon.defaultProps = {
@@ -288,6 +185,8 @@ StyledButtonIcon.defaultProps = {
 };
 
 const SubMenuItemIcon = styled(ButtonIcon)`
+  grid-column: chevron_column;
+
   ${({ type }) => css`
     ${type === "chevron_left_thick" &&
     css`
@@ -328,7 +227,6 @@ export {
   SubMenuItemIcon,
   MenuButtonOverrideWrapper,
   StyledMenuItemInnerText,
-  StyledMenuItemOuterContainer,
   StyledMenuItem,
   StyledMenuItemWrapper,
 };

--- a/src/components/action-popover/action-popover.test.tsx
+++ b/src/components/action-popover/action-popover.test.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ThemeProvider } from "styled-components";
 import * as floatingUi from "@floating-ui/dom";
@@ -13,7 +13,6 @@ import {
   ActionPopoverItem,
   ActionPopoverMenu,
   ActionPopoverMenuButton,
-  ActionPopoverProps,
   ActionPopoverHandle,
 } from ".";
 
@@ -1035,7 +1034,7 @@ test("should call the exposed `focusButton` method and focus the toggle button",
 });
 
 describe("when an item has a submenu with default (left) alignment", () => {
-  it("renders the appropriate icon with the correct alignment", async () => {
+  it("renders a chevron icon that points left", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     render(
@@ -1057,16 +1056,12 @@ describe("when an item has a submenu with default (left) alignment", () => {
 
     await user.click(screen.getByRole("button"));
 
-    // there are 2 elements with data-role="icon", the other being the main menu button.
-    // Unfortunately there seems to be no way with the RTL options for getByTestId to select the correct one, so we have to index
-    // into the array of all such elements
-    const submenuIcon = screen.getAllByTestId("icon")[1];
-    expect(submenuIcon).toHaveStyleRule(
+    const chevronIcon = screen.getByTestId("chevron-icon");
+    expect(chevronIcon).toHaveStyleRule(
       "content",
       `"${iconUnicodes.chevron_left_thick}"`,
       { modifier: "&::before" },
     );
-    expect(submenuIcon).toHaveStyle({ left: "-5px" });
   });
 
   it("opens the submenu on mouseenter", async () => {
@@ -1090,7 +1085,6 @@ describe("when an item has a submenu with default (left) alignment", () => {
     );
 
     await user.click(screen.getByRole("button"));
-
     expect(
       screen.queryByRole("button", { name: "submenu item 1" }),
     ).not.toBeInTheDocument();
@@ -1616,7 +1610,7 @@ describe("when there isn't enough space on the screen to render a submenu on the
     getBoundingClientRectSpy.mockRestore();
   });
 
-  it("renders the appropriate icon with the correct alignment", async () => {
+  it("renders a chevron icon that points right", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     render(
@@ -1638,16 +1632,12 @@ describe("when there isn't enough space on the screen to render a submenu on the
 
     await user.click(screen.getByRole("button"));
 
-    // there are 2 elements with data-role="icon", the other being the main menu button.
-    // Unfortunately there seems to be no way with the RTL options for getByTestId to select the correct one, so we have to index
-    // into the array of all such elements
-    const submenuIcon = screen.getAllByTestId("icon")[1];
-    expect(submenuIcon).toHaveStyleRule(
+    const chevronIcon = screen.getByTestId("chevron-icon");
+    expect(chevronIcon).toHaveStyleRule(
       "content",
       `"${iconUnicodes.chevron_right_thick}"`,
       { modifier: "&::before" },
     );
-    expect(submenuIcon).toHaveStyle({ right: "-5px" });
   });
 
   it("opens the submenu and focuses the first item when right arrow key is pressed", async () => {
@@ -1725,7 +1715,7 @@ describe("when there isn't enough space on the screen to render a submenu on the
 });
 
 describe("when the submenuPosition prop is set to 'right'", () => {
-  it("renders the appropriate icon with the correct alignment", async () => {
+  it("renders a chevron icon that points right", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     render(
@@ -1747,16 +1737,12 @@ describe("when the submenuPosition prop is set to 'right'", () => {
 
     await user.click(screen.getByRole("button"));
 
-    // there are 2 elements with data-role="icon", the other being the main menu button.
-    // Unfortunately there seems to be no way with the RTL options for getByTestId to select the correct one, so we have to index
-    // into the array of all such elements
-    const submenuIcon = screen.getAllByTestId("icon")[1];
-    expect(submenuIcon).toHaveStyleRule(
+    const chevronIcon = screen.getByTestId("chevron-icon");
+    expect(chevronIcon).toHaveStyleRule(
       "content",
       `"${iconUnicodes.chevron_right_thick}"`,
       { modifier: "&::before" },
     );
-    expect(submenuIcon).toHaveStyle({ right: "-5px" });
   });
 
   it("opens the submenu and focuses the first item when right arrow key is pressed", async () => {
@@ -1851,7 +1837,7 @@ describe("when the submenuPosition prop is set to 'right' and there isn't enough
     getBoundingClientRectSpy.mockRestore();
   });
 
-  it("renders the appropriate icon with the correct alignment", async () => {
+  it("renders a chevron icon that points left", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     render(
@@ -1873,16 +1859,12 @@ describe("when the submenuPosition prop is set to 'right' and there isn't enough
 
     await user.click(screen.getByRole("button"));
 
-    // there are 2 elements with data-role="icon", the other being the main menu button.
-    // Unfortunately there seems to be no way with the RTL options for getByTestId to select the correct one, so we have to index
-    // into the array of all such elements
-    const submenuIcon = screen.getAllByTestId("icon")[1];
-    expect(submenuIcon).toHaveStyleRule(
+    const chevronIcon = screen.getByTestId("chevron-icon");
+    expect(chevronIcon).toHaveStyleRule(
       "content",
       `"${iconUnicodes.chevron_left_thick}"`,
       { modifier: "&::before" },
     );
-    expect(submenuIcon).toHaveStyle({ left: "-5px" });
   });
 
   it("opens the submenu and focuses the first item when left arrow key is pressed", async () => {
@@ -2301,347 +2283,74 @@ describe("When ActionPopoverMenu contains multiple disabled items", () => {
   });
 });
 
-// The styling checks in the rest of this file are purely for coverage - these styles are already tested with Playwright
+test("when horizontalAlignment is set to 'left', menu displays icon before text", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-describe("padding checks on 'StyledMenuItemInnerText'", () => {
-  it.each([
-    ["left", "left"],
-    ["left", "right"],
-    ["right", "left"],
-    ["right", "right"],
-  ] as const)(
-    "should render menu items with left and right padding as var(--spacing100) when horizontalAlignment is %s and submenuPosition is %, if there are no submenus anywhere in the menu",
-    async (alignment, position) => {
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-      render(
-        <ActionPopover
-          horizontalAlignment={alignment}
-          submenuPosition={position}
-        >
-          <ActionPopoverItem>example item 1</ActionPopoverItem>
-          <ActionPopoverItem>example item 2</ActionPopoverItem>
-          <ActionPopoverItem>example item 3</ActionPopoverItem>
-          <ActionPopoverItem>example item 4</ActionPopoverItem>
-        </ActionPopover>,
-      );
-
-      await user.click(screen.getByRole("button"));
-
-      expect(screen.getByText("example item 1")).toHaveStyleRule(
-        "padding-left",
-        "var(--spacing100)",
-      );
-      expect(screen.getByText("example item 1")).toHaveStyleRule(
-        "padding-right",
-        "var(--spacing100)",
-      );
-    },
+  render(
+    <ActionPopover horizontalAlignment="left">
+      <ActionPopoverItem icon="add">Apple</ActionPopoverItem>
+    </ActionPopover>,
   );
 
-  it.each([
-    ["var(--spacing400)", "var(--spacing100)", "left", "left"],
-    ["var(--spacing100)", "var(--spacing400)", "right", "right"],
-  ] as [
-    string,
-    string,
-    ActionPopoverProps["horizontalAlignment"],
-    ActionPopoverProps["submenuPosition"],
-  ][])(
-    "should render a menu item with no icon or submenu with padding-left as %s and padding-right as %s when horizontalAlignment is %s, submenuPosition is %s and some other menu items have a submenu",
-    async (paddingLeft, paddingRight, alignment, position) => {
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  const menuButton = screen.getByRole("button");
+  await user.click(menuButton);
 
-      render(
-        <ActionPopover
-          horizontalAlignment={alignment}
-          submenuPosition={position}
-        >
-          <ActionPopoverItem>example item 1</ActionPopoverItem>
-          <ActionPopoverItem
-            submenu={
-              <ActionPopoverMenu>
-                <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-                <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-              </ActionPopoverMenu>
-            }
-          >
-            example item 2
-          </ActionPopoverItem>
-          <ActionPopoverItem>example item 3</ActionPopoverItem>
-          <ActionPopoverItem
-            submenu={
-              <ActionPopoverMenu>
-                <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-                <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-              </ActionPopoverMenu>
-            }
-          >
-            example item 4
-          </ActionPopoverItem>
-        </ActionPopover>,
-      );
+  const menu = await screen.findByRole("list");
 
-      await user.click(screen.getByRole("button"));
-
-      expect(screen.getByText("example item 1")).toHaveStyleRule(
-        "padding-left",
-        paddingLeft,
-      );
-      expect(screen.getByText("example item 1")).toHaveStyleRule(
-        "padding-right",
-        paddingRight,
-      );
-    },
-  );
-
-  it.each([
-    ["var(--spacing600)", "var(--spacing100)", "left", "left"],
-    ["var(--spacing100)", "var(--spacing600)", "right", "right"],
-  ] as [
-    string,
-    string,
-    ActionPopoverProps["horizontalAlignment"],
-    ActionPopoverProps["submenuPosition"],
-  ][])(
-    "should render a menu item with a submenu but no icon with padding-left as %s and padding-right as %s when horizontalAlignment is %s, submenuPosition is %s and some other menu items have an icon",
-    async (paddingLeft, paddingRight, alignment, position) => {
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-      render(
-        <ActionPopover
-          horizontalAlignment={alignment}
-          submenuPosition={position}
-        >
-          <ActionPopoverItem
-            submenu={
-              <ActionPopoverMenu>
-                <ActionPopoverItem icon="bin">submenu item 1</ActionPopoverItem>
-                <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-              </ActionPopoverMenu>
-            }
-          >
-            example item 1
-          </ActionPopoverItem>
-          <ActionPopoverItem>example item 2</ActionPopoverItem>
-          <ActionPopoverItem icon="alert">example item 3</ActionPopoverItem>
-          <ActionPopoverItem
-            submenu={
-              <ActionPopoverMenu>
-                <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-                <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-              </ActionPopoverMenu>
-            }
-          >
-            example item 4
-          </ActionPopoverItem>
-        </ActionPopover>,
-      );
-
-      await user.click(screen.getByRole("button"));
-
-      expect(screen.getByText("example item 1")).toHaveStyleRule(
-        "padding-left",
-        paddingLeft,
-      );
-      expect(screen.getByText("example item 1")).toHaveStyleRule(
-        "padding-right",
-        paddingRight,
-      );
-    },
-  );
-
-  it.each([
-    ["var(--spacing900)", "var(--spacing100)", "left", "left"],
-    ["var(--spacing100)", "var(--spacing900)", "right", "right"],
-  ] as [
-    string,
-    string,
-    ActionPopoverProps["horizontalAlignment"],
-    ActionPopoverProps["submenuPosition"],
-  ][])(
-    "should render a menu item with no icon or submenu with padding-left as %s and padding-right as %s when horizontalAlignment is %s submenuPosition is %s and both icons and submenus exist elsewhere in the menu",
-    async (paddingLeft, paddingRight, alignment, position) => {
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-      render(
-        <ActionPopover
-          horizontalAlignment={alignment}
-          submenuPosition={position}
-        >
-          <ActionPopoverItem>example item 1</ActionPopoverItem>
-          <ActionPopoverItem
-            submenu={
-              <ActionPopoverMenu>
-                <ActionPopoverItem icon="bin">submenu item 1</ActionPopoverItem>
-                <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-              </ActionPopoverMenu>
-            }
-          >
-            example item 2
-          </ActionPopoverItem>
-          <ActionPopoverItem icon="alert">example item 3</ActionPopoverItem>
-          <ActionPopoverItem
-            submenu={
-              <ActionPopoverMenu>
-                <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-                <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-              </ActionPopoverMenu>
-            }
-          >
-            example item 4
-          </ActionPopoverItem>
-        </ActionPopover>,
-      );
-
-      await user.click(screen.getByRole("button"));
-
-      expect(screen.getByText("example item 1")).toHaveStyleRule(
-        "padding-left",
-        paddingLeft,
-      );
-      expect(screen.getByText("example item 1")).toHaveStyleRule(
-        "padding-right",
-        paddingRight,
-      );
-    },
-  );
-
-  it.each([
-    ["left", "left"],
-    ["left", "right"],
-    ["right", "left"],
-    ["right", "right"],
-  ] as const)(
-    "should render a menu item in a submenu with left and right padding as var(--spacing000), when horizontalAlignment is %s, submenuPosition is %s and child is a submenu",
-    async (alignment, position) => {
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-      render(
-        <ActionPopover
-          horizontalAlignment={alignment}
-          submenuPosition={position}
-        >
-          <ActionPopoverItem>example item 1</ActionPopoverItem>
-          <ActionPopoverItem
-            submenu={
-              <ActionPopoverMenu>
-                <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-                <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-              </ActionPopoverMenu>
-            }
-          >
-            example item 2
-          </ActionPopoverItem>
-          <ActionPopoverItem>example item 3</ActionPopoverItem>
-          <ActionPopoverItem>example item 4</ActionPopoverItem>
-        </ActionPopover>,
-      );
-
-      await user.click(screen.getByRole("button"));
-
-      expect(screen.getByText("submenu item 1")).toHaveStyleRule(
-        "padding-left",
-        "var(--spacing000)",
-      );
-      expect(screen.getByText("submenu item 1")).toHaveStyleRule(
-        "padding-right",
-        "var(--spacing000)",
-      );
-    },
+  const { gridTemplateColumns } = getComputedStyle(menu);
+  expect(gridTemplateColumns).toContain(
+    "[icon_column] auto [text_column] auto",
   );
 });
 
-describe("justify-content checks on 'StyledMenuItem'", () => {
-  it.each([
-    ["flex-start", "left", "left"],
-    ["flex-end", "right", "left"],
-    ["space-between", "left", "right"],
-    ["flex-end", "right", "right"],
-  ] as const)(
-    "renders menu item with justify-content %s when horizontalAlignment is %s and submenuPosition is %s",
-    async (justifyContent, alignment, position) => {
-      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+test("when horizontalAlignment is set to 'right', menu displays icon after text", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-      render(
-        <ActionPopover
-          horizontalAlignment={alignment}
-          submenuPosition={position}
-        >
-          <ActionPopoverItem>example item 1</ActionPopoverItem>
-          <ActionPopoverItem>example item 2</ActionPopoverItem>
-          <ActionPopoverItem>example item 3</ActionPopoverItem>
-          <ActionPopoverItem>example item 4</ActionPopoverItem>
-        </ActionPopover>,
-      );
-
-      await user.click(screen.getByRole("button"));
-
-      expect(
-        screen.getByRole("button", { name: "example item 1" }),
-      ).toHaveStyle({ justifyContent });
-    },
+  render(
+    <ActionPopover horizontalAlignment="right">
+      <ActionPopoverItem icon="add">Apple</ActionPopoverItem>
+    </ActionPopover>,
   );
 
-  it("renders menu with justify-content space-between when horizontalAlignment is left, submenuPosition is right and any menu item has a submenu", async () => {
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  const menuButton = screen.getByRole("button");
+  await user.click(menuButton);
 
-    render(
-      <ActionPopover horizontalAlignment="left" submenuPosition="right">
-        <ActionPopoverItem
-          submenu={
-            <ActionPopoverMenu>
-              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-            </ActionPopoverMenu>
-          }
-        >
-          example item 1
-        </ActionPopoverItem>
-        <ActionPopoverItem>example item 2</ActionPopoverItem>
-        <ActionPopoverItem>example item 3</ActionPopoverItem>
-        <ActionPopoverItem>example item 4</ActionPopoverItem>
-      </ActionPopover>,
-    );
+  const menu = await screen.findByRole("list");
 
-    await user.click(screen.getByRole("button"));
+  const { gridTemplateColumns } = getComputedStyle(menu);
+  expect(gridTemplateColumns).toContain(
+    "[text_column] auto [icon_column] auto",
+  );
+});
 
-    expect(screen.getByRole("button", { name: "example item 1" })).toHaveStyle({
-      justifyContent: "space-between",
-    });
-    expect(screen.getByRole("button", { name: "example item 2" })).toHaveStyle({
-      justifyContent: "space-between",
-    });
+test("a menu item's icons are hidden from assistive technologies", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(
+    <ActionPopover>
+      <ActionPopoverItem
+        icon="favourite"
+        submenu={
+          <ActionPopoverMenu>
+            <ActionPopoverItem>Apple</ActionPopoverItem>
+          </ActionPopoverMenu>
+        }
+      >
+        Fruits
+      </ActionPopoverItem>
+    </ActionPopover>,
+  );
+
+  const menuButton = screen.getByRole("button");
+  await user.click(menuButton);
+
+  const menuItem = await screen.findByRole("button", {
+    name: "Fruits",
   });
 
-  it("renders menu with justify-content space-between when horizontalAlignment is right, submenuPosition is left and that specific menu item has a submenu", async () => {
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  const chevronIcon = within(menuItem).getByTestId("chevron-icon");
+  const itemIcon = within(menuItem).getByTestId("item-icon");
 
-    render(
-      <ActionPopover horizontalAlignment="right" submenuPosition="left">
-        <ActionPopoverItem
-          submenu={
-            <ActionPopoverMenu>
-              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-            </ActionPopoverMenu>
-          }
-        >
-          example item 1
-        </ActionPopoverItem>
-        <ActionPopoverItem>example item 2</ActionPopoverItem>
-        <ActionPopoverItem>example item 3</ActionPopoverItem>
-        <ActionPopoverItem>example item 4</ActionPopoverItem>
-      </ActionPopover>,
-    );
-
-    await user.click(screen.getByRole("button"));
-
-    expect(screen.getByRole("button", { name: "example item 1" })).toHaveStyle({
-      justifyContent: "space-between",
-    });
-    expect(screen.getByRole("button", { name: "example item 2" })).toHaveStyle({
-      justifyContent: "flex-end",
-    });
-  });
+  expect(chevronIcon).toHaveAttribute("aria-hidden", "true");
+  expect(itemIcon).toHaveAttribute("aria-hidden", "true");
 });


### PR DESCRIPTION
### Proposed behaviour

Reduce the amount of internal prop drilling between `ActionPopover` and its subcomponents, by refactoring styling logic to only use CSS where possible.

### Current behaviour

`ActionPopover` and its subcomponents use a combination of JavaScript and CSS code for handling visuals, such as:
  - Controlling the horizontal alignment of each menu item's icons and text
  - Controlling the vertical position of a submenu

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context


### Testing instructions

Comparing `ActionPopover` stories to their production counterparts, verify no regressions have been made to the following:
- Component visuals
- Component behaviour
- Axe scan results
- Screen reader behaviour (test with Safari and macOS VoiceOver, or NVDA and Chrome). 