### PR TITLE
refactor: replace polished with custom utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "invariant": "^2.2.4",
         "lexical": "^0.21.0",
         "lodash": "^4.17.21",
-        "polished": "^4.2.2",
         "prop-types": "^15.8.1",
         "react-day-picker": "~9.3.2",
         "react-dnd": "^16.0.1",
@@ -25191,6 +25190,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/polished/-/polished-4.3.1.tgz",
       "integrity": "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.8"

--- a/package.json
+++ b/package.json
@@ -207,7 +207,6 @@
     "invariant": "^2.2.4",
     "lexical": "^0.21.0",
     "lodash": "^4.17.21",
-    "polished": "^4.2.2",
     "prop-types": "^15.8.1",
     "react-day-picker": "~9.3.2",
     "react-dnd": "^16.0.1",

--- a/src/components/icon/icon-test.stories.tsx
+++ b/src/components/icon/icon-test.stories.tsx
@@ -11,7 +11,7 @@ import Icon from ".";
 
 export default {
   title: "Icon/Test",
-  includeStories: ["Default", "All"],
+  component: Icon,
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -19,50 +19,15 @@ export default {
     },
   },
   argTypes: {
-    type: {
-      options: ICONS,
-      control: {
-        type: "select",
-      },
-    },
     tooltipMessage: {
       control: {
         type: "text",
-      },
-    },
-    tooltipPosition: {
-      options: ICON_TOOLTIP_POSITIONS,
-      control: {
-        type: "select",
       },
     },
     tooltipFlipOverrides: {
       options: [undefined, ...ICON_TOOLTIP_POSITIONS],
       control: {
         type: "select",
-      },
-    },
-    fontSize: {
-      options: ICON_FONT_SIZES,
-      control: {
-        type: "select",
-      },
-    },
-    bgSize: {
-      options: ICON_SIZES,
-      control: {
-        type: "select",
-      },
-    },
-    bgShape: {
-      options: ICON_SHAPES,
-      control: {
-        type: "select",
-      },
-    },
-    bg: {
-      control: {
-        type: "text",
       },
     },
   },

--- a/src/components/icon/icon.style.ts
+++ b/src/components/icon/icon.style.ts
@@ -1,14 +1,11 @@
 import styled, { css } from "styled-components";
 
-import { shade } from "polished";
-
 import { margin } from "styled-system";
 
 import applyBaseTheme from "../../style/themes/apply-base-theme";
 import { ThemeObject } from "../../style/themes/theme.types";
 import addFocusStyling from "../../style/utils/add-focus-styling";
 import styledColor from "../../style/utils/color";
-import getColorValue from "../../style/utils/get-color-value";
 import { getNavigator, getWindow } from "../../__internal__/dom/globals";
 import browserTypeCheck, {
   isSafari,
@@ -102,33 +99,24 @@ const StyledIcon = styled.span.attrs(applyBaseTheme)<
     hasTooltip,
   }) => {
     let finalColor = "var(--colorsYin090)";
-    let finalHoverColor = "var(--colorsYin090)";
     let bgColor = "transparent";
-    let bgHoverColor = "transparent";
 
     const win = getWindow();
     const nav = getNavigator();
     const adjustedBgSize = adjustIconBgSize(fontSize, bgSize);
 
-    try {
-      if (disabled) {
-        finalColor = "var(--colorsYin030)";
-        finalHoverColor = "var(--colorsYin030)";
-      } else if (color) {
-        const { color: renderedColor } = styledColor({ color, theme });
-        finalColor = renderedColor;
-        finalHoverColor = shade(0.2, getColorValue(renderedColor));
-      }
-
-      if (bg) {
-        const { backgroundColor } = styledColor({ bg, theme });
-        bgColor = backgroundColor;
-        bgHoverColor = shade(0.2, getColorValue(backgroundColor));
-      }
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.error(e);
+    if (disabled) {
+      finalColor = "var(--colorsYin030)";
+    } else if (color) {
+      const { color: renderedColor } = styledColor({ color, theme });
+      finalColor = renderedColor;
     }
+
+    if (bg) {
+      const { backgroundColor } = styledColor({ bg, theme });
+      bgColor = backgroundColor;
+    }
+
     return css`
       position: relative;
       color: ${finalColor};
@@ -143,9 +131,8 @@ const StyledIcon = styled.span.attrs(applyBaseTheme)<
 
       ${isInteractive &&
       css`
-        &:hover {
-          color: ${finalHoverColor};
-          background-color: ${bgHoverColor};
+        &:not(:focus):hover {
+          filter: brightness(0.9);
         }
       `}
 

--- a/src/components/icon/icon.test.tsx
+++ b/src/components/icon/icon.test.tsx
@@ -151,40 +151,6 @@ test("logs a warning when the `fontSize` props value is larger than the `bgSize`
   loggerSpy.mockRestore();
 });
 
-test("catches and logs a thrown error when the `color` prop is passed a value that cannot be parsed", () => {
-  const consoleErrorSpy = jest
-    .spyOn(console, "error")
-    .mockImplementation(() => {});
-
-  render(<Icon type="home" color="invalid-color" />);
-
-  expect(consoleErrorSpy).toHaveBeenCalledWith(
-    expect.objectContaining({
-      message: expect.stringContaining(
-        "Couldn't parse the color string. Please provide the color as a string in hex, rgb, rgba, hsl or hsla notation.",
-      ),
-    }),
-  );
-  consoleErrorSpy.mockRestore();
-});
-
-test("catches and logs a thrown error when the `bg` prop is passed a value that cannot be parsed", () => {
-  const consoleErrorSpy = jest
-    .spyOn(console, "error")
-    .mockImplementation(() => {});
-
-  render(<Icon type="home" bg="invalid-color" />);
-
-  expect(consoleErrorSpy).toHaveBeenCalledWith(
-    expect.objectContaining({
-      message: expect.stringContaining(
-        "Couldn't parse the color string. Please provide the color as a string in hex, rgb, rgba, hsl or hsla notation.",
-      ),
-    }),
-  );
-  consoleErrorSpy.mockRestore();
-});
-
 /* styling test for coverage */
 test.each(["circle", "rounded-rect", "square"] as BackgroundShape[])(
   "renders with the correct border radius on the icon background when the `bgShape` is %s",

--- a/src/components/pill/pill-test.stories.tsx
+++ b/src/components/pill/pill-test.stories.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
-import Pill, { PillProps } from "./pill.component";
+import Pill from "./pill.component";
 import Box from "../box";
 
 export default {
   title: "Pill/Test",
+  component: Pill,
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -12,27 +13,9 @@ export default {
     },
   },
   argTypes: {
-    pillRole: {
-      options: ["tag", "status"],
+    onDelete: {
       control: {
-        type: "select",
-      },
-    },
-    size: {
-      options: ["S", "M", "L", "XL"],
-      control: {
-        type: "select",
-      },
-    },
-    colorVariant: {
-      options: ["neutral", "negative", "positive", "warning", "information"],
-      control: {
-        type: "select",
-      },
-    },
-    borderColor: {
-      control: {
-        type: "text",
+        type: "boolean",
       },
     },
   },
@@ -50,12 +33,17 @@ export const Default = ({ children, onDelete, ...args }: PillStoryArgs) => {
     </Pill>
   );
 };
-
-export const PillComponent = ({
-  children = "noop",
-  ...args
-}: Partial<PillProps>) => {
-  return <Pill {...args}>{children}</Pill>;
+Default.story = {
+  name: "default",
+  args: {
+    children: "Pill",
+    borderColor: undefined,
+    fill: false,
+    onDelete: false,
+    size: "M",
+    pillRole: "tag",
+    colorVariant: "neutral",
+  },
 };
 
 export const StatusDarkBackground = ({
@@ -74,23 +62,6 @@ export const StatusDarkBackground = ({
       </Pill>
     </Box>
   );
-};
-
-Default.story = {
-  name: "default",
-  args: {
-    ml: 0,
-    mr: 0,
-    mt: 0,
-    mb: 0,
-    children: "Pill",
-    borderColor: undefined,
-    fill: false,
-    onDelete: false,
-    size: "M",
-    pillRole: "tag",
-    colorVariant: "neutral",
-  },
 };
 
 StatusDarkBackground.story = {

--- a/src/components/pill/pill.mdx
+++ b/src/components/pill/pill.mdx
@@ -37,25 +37,23 @@ import Pill from "carbon-react/lib/components/pill";
 
 ### Wrapped
 
-By default the text within a Pill will not wrap. You can override this behavior by setting the `wrapText`
+By default the text within a Pill will not wrap, however you can override this behavior by setting the `wrapText`
 and `maxWidth` props. It is also possible to hyphenate the words but you may need to define where to place
 the hyphens using `&shy;` if they are not automatically added: this is because the rules for adding them are
-language-specific and support for every `lang` attrribute is not universal.
+language-specific and support for every `lang` attribute is not universal.
 
 <Canvas of={PillStories.Wrapped} />
 
 ### With remove button
 
-When a callback in the onDelete prop is provided, a remove button will be rendered
-and click on it will trigger that callback.
+When a callback in the `onDelete` prop is provided, a remove button will be rendered and clicking on it will trigger that callback.
 
 <Canvas of={PillStories.WithRemoveButton} />
 
 ### With custom remove button aria-label
 
 By default the aria-label of the remove button will be set to "remove pill".
-That attribute could be customized to increase accessibility by providing unique button descriptions
-in the `ariaLabelOfRemoveButton` prop.
+That attribute can be customized by passing a string to the `ariaLabelOfRemoveButton` prop.
 
 <Canvas of={PillStories.WithCustomRemoveButtonAriaLabel} />
 
@@ -73,15 +71,17 @@ Applied by the user, and indicate something in common. Change the theme to see t
 
 ### Custom colors
 
-It's possible to change the color of the Pill by using the `borderColor` prop. It will override `colorVariant` value.
-See [Colors](../?path=/docs/documentation-colors--docs) for more information.
+You can pass a custom color to Pill by using the `borderColor` prop, which will be set as the background color if `fill` is true. 
+This prop will take precedence over the `colorVariant` value.
+See our [Colors](../?path=/docs/documentation-colors--docs) documentation for more information.
 
 <Canvas of={PillStories.CustomColors} />
 
 ### Dark background
 
 Color variants for dark theme, to apply these set `isDarkBackground` to `true`.
-Note: `"neutralWhite"` can only be used on dark backgrounds with `fill` also set to true.
+
+**Note:** `"neutralWhite"` can only be used on dark backgrounds with `fill` also set to true.
 
 <Canvas of={PillStories.DarkBackground} />
 

--- a/src/components/pill/pill.pw.tsx
+++ b/src/components/pill/pill.pw.tsx
@@ -27,12 +27,6 @@ const neutralWhite = "rgb(255, 255, 255)";
 const tag = "rgb(0, 126, 69)";
 const status = "rgb(51, 91, 112)";
 const transparent = "rgba(0, 0, 0, 0)";
-const colorsSemanticCaution500 = "rgb(239, 103, 0)";
-const blackOpacity65 = "rgba(0, 0, 0, 0.65)";
-const brilliantGreenShade20 = "rgb(0, 176, 0)";
-const red = "rgb(255, 0, 0)";
-const hexBlue = "#123456";
-const green = "rgb(0, 123, 10)";
 const small = "S";
 const medium = "M";
 const large = "L";
@@ -207,17 +201,14 @@ test.describe("should render Pill component with props", () => {
     });
   });
 
-  (
-    [
-      [colorsSemanticCaution500, "rgb(239, 103, 0)"],
-      [blackOpacity65, "rgba(0, 0, 0, 0.65)"],
-      [brilliantGreenShade20, "rgb(0, 176, 0)"],
-      [red, "rgb(255, 0, 0)"],
-      [green, "rgb(0, 123, 10)"],
-      [hexBlue, "rgb(18, 52, 86)"],
-    ] as const
-  ).forEach(([color, output]) => {
-    test(`should render borderColor prop set as ${output}`, async ({
+  [
+    ["--colorsSemanticCaution500", "rgb(239, 103, 0)"],
+    ["var(--colorsActionMajor500)", "rgb(0, 126, 69)"],
+    ["brilliantGreenShade20", "rgb(0, 176, 0)"],
+    ["red", "rgb(255, 0, 0)"],
+    ["#2525c2", "rgb(37, 37, 194)"],
+  ].forEach(([color, output]) => {
+    test(`should render borderColor prop set as ${color}`, async ({
       mount,
       page,
     }) => {
@@ -502,16 +493,15 @@ test.describe("should check for Accessibility tests", () => {
     });
   });
 
-  (
-    [
-      colorsSemanticCaution500,
-      blackOpacity65,
-      brilliantGreenShade20,
-      red,
-      hexBlue,
-      green,
-    ] as const
-  ).forEach((color) => {
+  [
+    "--colorsSemanticCaution500",
+    "var(--colorsActionMajor500)",
+    "brilliantGreenShade20",
+    "red",
+    "#0000ff",
+    "rgb(125, 70, 120)",
+    "hsl(120, 100%, 50%)",
+  ].forEach((color) => {
     test(`should render borderColor set as ${color} for accessibility`, async ({
       mount,
       page,

--- a/src/components/pill/pill.stories.tsx
+++ b/src/components/pill/pill.stories.tsx
@@ -603,20 +603,6 @@ export const CustomColors: Story = () => {
         </Pill>
       </Box>
       <Box mb={1}>
-        <Pill borderColor="blackOpacity65" mr={1}>
-          tag
-        </Pill>
-        <Pill borderColor="blackOpacity65" fill mr={1}>
-          tag
-        </Pill>
-        <Pill borderColor="blackOpacity65" onDelete={noop} mr={1}>
-          tag
-        </Pill>
-        <Pill borderColor="blackOpacity65" onDelete={noop} fill>
-          tag
-        </Pill>
-      </Box>
-      <Box mb={1}>
         <Pill borderColor="brilliantGreenShade20" mr={1}>
           tag
         </Pill>
@@ -658,7 +644,7 @@ export const CustomColors: Story = () => {
           tag
         </Pill>
       </Box>
-      <Box>
+      <Box mb={1}>
         <Pill borderColor="rgb(0, 123, 10)" mr={1}>
           tag
         </Pill>
@@ -669,6 +655,20 @@ export const CustomColors: Story = () => {
           tag
         </Pill>
         <Pill borderColor="rgb(0, 123, 10)" onDelete={noop} fill>
+          tag
+        </Pill>
+      </Box>
+      <Box mb={1}>
+        <Pill borderColor="hsl(317, 40%, 64%)" mr={1}>
+          tag
+        </Pill>
+        <Pill borderColor="hsl(317, 40%, 64%)" fill mr={1}>
+          tag
+        </Pill>
+        <Pill borderColor="hsl(317, 40%, 64%)" onDelete={noop} mr={1}>
+          tag
+        </Pill>
+        <Pill borderColor="hsl(317, 40%, 64%)" onDelete={noop} fill>
           tag
         </Pill>
       </Box>

--- a/src/components/pill/pill.style.ts
+++ b/src/components/pill/pill.style.ts
@@ -1,5 +1,4 @@
 import styled, { css } from "styled-components";
-import { shade, meetsContrastGuidelines } from "polished";
 import { margin, MarginProps } from "styled-system";
 
 import styleConfig from "./pill.style.config";
@@ -9,6 +8,8 @@ import StyledIcon from "../icon/icon.style";
 import StyledIconButton from "../icon-button/icon-button.style";
 import { toColor } from "../../style/utils/color";
 import getColorValue from "../../style/utils/get-color-value";
+import getHexValue from "../../style/utils/get-hex-value";
+import getAccessibleForegroundColor from "../../style/utils/get-accessible-foreground-color";
 
 export interface StyledPillProps extends MarginProps {
   /** Override color variant, provide any color from palette or any valid css color value. */
@@ -52,34 +53,28 @@ const StyledPill = styled.span.attrs(applyBaseTheme)<AllStyledPillProps>`
     theme,
   }) => {
     const isStatus = pillRole === "status";
-    let pillColor;
-    let buttonFocusColor;
-    let contentColor;
+    let pillColor: string;
+    let buttonFocusColor: string | undefined;
+    let contentColor: string;
 
-    try {
-      if (borderColor) {
-        pillColor = toColor(theme, borderColor);
-        buttonFocusColor = shade(0.2, getColorValue(pillColor));
-        contentColor = meetsContrastGuidelines(
-          getColorValue(pillColor),
-          theme.compatibility.colorsUtilityYin090,
-        ).AAA
-          ? "var(--colorsUtilityYin090)"
-          : "var(--colorsUtilityYang100)";
-      } else {
-        const { status, tag } = styleConfig(isDarkBackground);
-        const { varietyColor, buttonFocus, content } = isStatus
-          ? status[colorVariant]
-          : tag.primary;
-        pillColor = varietyColor;
-        buttonFocusColor = buttonFocus;
-        contentColor = content;
-      }
-    } catch (e) {
-      // eslint-disable-next-line no-console
-      console.error(
-        `Error: [Pill] - Could not parse the string '${borderColor}', please provide the color as a string in hex, rgb, rgba, hsl or hsla notation.`,
+    if (borderColor) {
+      pillColor = toColor(theme, borderColor);
+
+      // get token value in rgb
+      const colorVal = getColorValue(pillColor);
+      contentColor = getAccessibleForegroundColor(
+        getHexValue(colorVal),
+        false,
+        true,
       );
+    } else {
+      const { status, tag } = styleConfig(isDarkBackground);
+      const { varietyColor, buttonFocus, content } = isStatus
+        ? status[colorVariant]
+        : tag.primary;
+      pillColor = varietyColor;
+      buttonFocusColor = buttonFocus;
+      contentColor = content;
     }
 
     return css`
@@ -168,7 +163,6 @@ const StyledPill = styled.span.attrs(applyBaseTheme)<AllStyledPillProps>`
           line-height: 16px;
 
           &:focus {
-            background-color: ${buttonFocusColor};
             border-radius: var(--borderRadius000) var(--borderRadius025)
               var(--borderRadius025) var(--borderRadius000);
             ::-moz-focus-inner {
@@ -178,17 +172,44 @@ const StyledPill = styled.span.attrs(applyBaseTheme)<AllStyledPillProps>`
             ${StyledIcon} {
               color: ${contentColor};
             }
+
+            ${borderColor
+              ? css`
+                  &::before {
+                    border-radius: var(--borderRadius000) var(--borderRadius025)
+                      var(--borderRadius025) var(--borderRadius000);
+                  }
+                `
+              : css`
+                  background-color: ${buttonFocusColor};
+                `}
           }
 
           &:hover {
             background-color: ${buttonFocusColor};
-            color: ${contentColor};
             cursor: pointer;
 
             ${StyledIcon} {
               color: ${contentColor};
             }
           }
+
+          ${borderColor &&
+          css`
+            &:hover,
+            &:focus {
+              &::before {
+                content: "";
+                position: absolute;
+                left: 0;
+                top: 0;
+                width: 100%;
+                height: 100%;
+                background-color: ${pillColor};
+                filter: brightness(0.9);
+              }
+            }
+          `}
 
           ${StyledIcon} {
             height: unset;

--- a/src/components/pill/pill.test.tsx
+++ b/src/components/pill/pill.test.tsx
@@ -119,7 +119,7 @@ test("should throw an error when an invalid value is passed to borderColor", () 
   render(<Pill borderColor="invalidColour">Test Pill</Pill>);
 
   expect(consoleSpy).toHaveBeenCalledWith(
-    "Error: [Pill] - Could not parse the string 'invalidColour', please provide the color as a string in hex, rgb, rgba, hsl or hsla notation.",
+    'Could not parse "invalidColour", please provide a valid hex, rgb, rgba, hsl, hsla or named color.',
   );
   expect(consoleSpy).toHaveBeenCalledTimes(1);
 

--- a/src/components/portrait/__internal__/get-colors.test.ts
+++ b/src/components/portrait/__internal__/get-colors.test.ts
@@ -1,4 +1,4 @@
-import getColoursForPortrait from "./utils";
+import getColoursForPortrait from "./get-colors";
 
 test("returns the default string if no arguments are passed", () => {
   const result = getColoursForPortrait(undefined);
@@ -66,7 +66,9 @@ test("returns a string with the custom background color if the `backgroundColor`
 describe("Contrast ratio tests", () => {
   it("uses a white foreground colour if the white contrast ratio meets the minimum contrast threshold and is higher than the black contrast ratio", () => {
     const result = getColoursForPortrait("#0000FF");
-    expect(result).toBe("background-color: #0000FF; color: #FFFFFF;");
+    expect(result).toBe(
+      "background-color: #0000FF; color: var(--colorsUtilityYang100);",
+    );
   });
 
   it("uses a black foreground colour if the  black contrast ratio meets the minimum contrast threshold", () => {
@@ -79,7 +81,9 @@ describe("Contrast ratio tests", () => {
 
 test("returns a string with the custom background color and light text if the `backgroundColor` argument is set to a colour with poor contrast ratios (higher white contrast)", () => {
   const result = getColoursForPortrait("#0000FF");
-  expect(result).toBe("background-color: #0000FF; color: #FFFFFF;");
+  expect(result).toBe(
+    "background-color: #0000FF; color: var(--colorsUtilityYang100);",
+  );
 });
 
 test("returns a string with the custom colors if the `backgroundColor` and `foregroundColor` arguments are provided and all others are false", () => {

--- a/src/components/portrait/__internal__/get-colors.ts
+++ b/src/components/portrait/__internal__/get-colors.ts
@@ -1,0 +1,39 @@
+import getAccessibleForegroundColor from "../../../style/utils/get-accessible-foreground-color";
+
+const getColoursForPortrait = (
+  // The custom background colour, if any
+  backgroundColour: string | undefined,
+  // Whether the portrait is on a dark background
+  darkBackground = false,
+  // Whether the text is large
+  largeText = false,
+  /**
+   * Whether to use strict contrast (i.e., WCAG AAA). If this is false, it uses WCAG AA contrast
+   * ratios (4.5:1 for normal text, 3:1 for large text). If true, it uses 7:1 for normal text and
+   * 4.5:1 for large text.
+   */
+  strict = false,
+  // The custom foreground colour, if any
+  foregroundColor: string | undefined = undefined,
+): string => {
+  let fgColor = "var(--colorsUtilityYin090)";
+  let bgColor = "var(--colorsUtilityReadOnly400)";
+
+  if (darkBackground && !backgroundColour && !foregroundColor) {
+    bgColor = "var(--colorsUtilityYin090)";
+    fgColor = "var(--colorsUtilityReadOnly600)";
+  }
+
+  if (backgroundColour) {
+    bgColor = backgroundColour;
+    fgColor = getAccessibleForegroundColor(backgroundColour, largeText, strict);
+  }
+
+  if (foregroundColor) {
+    fgColor = foregroundColor;
+  }
+
+  return `background-color: ${bgColor}; color: ${fgColor};`;
+};
+
+export default getColoursForPortrait;

--- a/src/components/portrait/portrait.style.tsx
+++ b/src/components/portrait/portrait.style.tsx
@@ -11,7 +11,7 @@ import applyBaseTheme from "../../style/themes/apply-base-theme";
 import { PortraitSizes, PortraitShapes } from "./portrait.component";
 import { PORTRAIT_SIZE_PARAMS } from "./portrait.config";
 
-import getColoursForPortrait from "./__internal__/utils";
+import getColoursForPortrait from "./__internal__/get-colors";
 
 type StyledPortraitProps = {
   backgroundColor?: string;

--- a/src/components/portrait/portrait.test.tsx
+++ b/src/components/portrait/portrait.test.tsx
@@ -151,7 +151,7 @@ describe("custom background colours", () => {
 
     const container = screen.getByTestId("portrait");
     expect(container).toHaveStyle("background-color: #000000");
-    expect(container).toHaveStyleRule("color", "#FFFFFF");
+    expect(container).toHaveStyleRule("color", "var(--colorsUtilityYang100)");
   });
 
   it("renders with the correct colours when a light colour is provided", () => {

--- a/src/style/utils/get-accessible-foreground-color.test.ts
+++ b/src/style/utils/get-accessible-foreground-color.test.ts
@@ -1,0 +1,49 @@
+import getAccessibleForegroundColor from "./get-accessible-foreground-color";
+
+test("returns white color token when white contrast is highest, `largeText` is true and `strict` is true", () => {
+  const color = getAccessibleForegroundColor("#0000FF", true, true);
+
+  expect(color).toBe("var(--colorsUtilityYang100)");
+});
+
+test("returns white color token when white contrast is highest, `largeText` is true and `strict` is false", () => {
+  const color = getAccessibleForegroundColor("#0000FF", true, false);
+
+  expect(color).toBe("var(--colorsUtilityYang100)");
+});
+
+test("returns white color token when white contrast is highest, `largeText` is false and `strict` is true", () => {
+  const color = getAccessibleForegroundColor("#0000FF", false, true);
+
+  expect(color).toBe("var(--colorsUtilityYang100)");
+});
+
+test("returns white color token when white contrast is highest, `largeText` is false and `strict` is false", () => {
+  const color = getAccessibleForegroundColor("#0000FF", false, false);
+
+  expect(color).toBe("var(--colorsUtilityYang100)");
+});
+
+test("returns black color token when black contrast is highest, `largeText` is true and `strict` is true", () => {
+  const color = getAccessibleForegroundColor("#FF0000", true, true);
+
+  expect(color).toBe("var(--colorsUtilityYin090)");
+});
+
+test("returns black color token when black contrast is highest, `largeText` is true and `strict` is false", () => {
+  const color = getAccessibleForegroundColor("#FF0000", true, false);
+
+  expect(color).toBe("var(--colorsUtilityYin090)");
+});
+
+test("returns black color token when black contrast is highest, `largeText` is false and `strict` is true", () => {
+  const color = getAccessibleForegroundColor("#FF0000", false, true);
+
+  expect(color).toBe("var(--colorsUtilityYin090)");
+});
+
+test("returns black color token when black contrast is highest, `largeText` is false and `strict` is false", () => {
+  const color = getAccessibleForegroundColor("#FF0000", false, false);
+
+  expect(color).toBe("var(--colorsUtilityYin090)");
+});

--- a/src/style/utils/get-accessible-foreground-color.ts
+++ b/src/style/utils/get-accessible-foreground-color.ts
@@ -27,6 +27,13 @@ const calculateLuminance = (hexColor: string): number => {
   return luminance;
 };
 
+/**
+ * Get the accessible foreground color based on the background color and text size.
+ * Returns either white or black based on the contrast ratio.
+ * @param backgroundColor the background color in hex format
+ * @param largeText whether the text is large
+ * @param strict whether to use strict contrast (i.e. WCAG AA or AAA)
+ */
 function getAccessibleForegroundColor(
   backgroundColor: string,
   largeText: boolean,
@@ -43,12 +50,10 @@ function getAccessibleForegroundColor(
   const nonStrictThreshold = largeText ? 3.0 : 4.5;
   const minContrast = strict ? strictThreshold : nonStrictThreshold;
 
-  /* istanbul ignore else */
   if (whiteContrast >= minContrast && whiteContrast > blackContrast) {
-    return "#FFFFFF";
+    return "var(--colorsUtilityYang100)";
   }
 
-  /* istanbul ignore else */
   if (blackContrast >= minContrast) {
     return "var(--colorsUtilityYin090)";
   }
@@ -59,44 +64,8 @@ function getAccessibleForegroundColor(
   // is highly unlikely.
   /* istanbul ignore next */
   return whiteContrast > blackContrast
-    ? "#FFFFFF"
+    ? "var(--colorsUtilityYang100)"
     : "var(--colorsUtilityYin090)";
 }
 
-const getColoursForPortrait = (
-  // The custom background colour, if any
-  backgroundColour: string | undefined,
-  // Whether the portrait is on a dark background
-  darkBackground = false,
-  // Whether the text is large
-  largeText = false,
-  /**
-   * Whether to use strict contrast (i.e., WCAG AAA). If this is false, it uses WCAG AA contrast
-   * ratios (4.5:1 for normal text, 3:1 for large text). If true, it uses 7:1 for normal text and
-   * 4.5:1 for large text.
-   */
-  strict = false,
-  // The custom foreground colour, if any
-  foregroundColor: string | undefined = undefined,
-): string => {
-  let fgColor = "var(--colorsUtilityYin090)";
-  let bgColor = "var(--colorsUtilityReadOnly400)";
-
-  if (darkBackground && !backgroundColour && !foregroundColor) {
-    bgColor = "var(--colorsUtilityYin090)";
-    fgColor = "var(--colorsUtilityReadOnly600)";
-  }
-
-  if (backgroundColour) {
-    bgColor = backgroundColour;
-    fgColor = getAccessibleForegroundColor(backgroundColour, largeText, strict);
-  }
-
-  if (foregroundColor) {
-    fgColor = foregroundColor;
-  }
-
-  return `background-color: ${bgColor}; color: ${fgColor};`;
-};
-
-export default getColoursForPortrait;
+export default getAccessibleForegroundColor;

--- a/src/style/utils/get-hex-value.test.ts
+++ b/src/style/utils/get-hex-value.test.ts
@@ -1,0 +1,76 @@
+import getHexValue from "./get-hex-value";
+
+test("converts 3-digit hex to 6-digit hex", () => {
+  expect(getHexValue("#abc")).toBe("#aabbcc");
+});
+
+test("converts 4-digit hex to 8-digit hex", () => {
+  expect(getHexValue("#abcd")).toBe("#aabbccdd");
+});
+
+test("returns 6-digit hex", () => {
+  expect(getHexValue("#123456")).toBe("#123456");
+});
+
+test("converts rgb to hex", () => {
+  expect(getHexValue("rgb(255, 0, 128)")).toBe("#ff0080");
+});
+
+test("converts rgba to hex", () => {
+  expect(getHexValue("rgba(255, 0, 128, 0.5)")).toBe("#ff008080");
+});
+
+test("returns #000000 when invalid rgb is passed", () => {
+  expect(getHexValue("rgb()")).toBe("#000000");
+});
+
+test("converts hsl to hex", () => {
+  expect(getHexValue("hsl(0, 100%, 50%)")).toBe("#ff0000");
+});
+
+test("converts hsl with hue < 120 to hex", () => {
+  expect(getHexValue("hsl(100, 100%, 50%)")).toBe("#55ff00");
+});
+
+test("converts hsl with hue < 180 to hex", () => {
+  expect(getHexValue("hsl(150, 100%, 50%)")).toBe("#00ff80");
+});
+
+test("converts hsl with hue < 240 to hex", () => {
+  expect(getHexValue("hsl(210, 100%, 50%)")).toBe("#0080ff");
+});
+
+test("converts hsl with hue < 300 to hex", () => {
+  expect(getHexValue("hsl(270, 100%, 50%)")).toBe("#8000ff");
+});
+
+test("converts hsl with hue < 360 to hex", () => {
+  expect(getHexValue("hsl(330, 100%, 50%)")).toBe("#ff0080");
+});
+
+test("converts hsl with negative hue to hex", () => {
+  expect(getHexValue("hsl(-120, 100%, 50%)")).toBe("#0000ff");
+});
+
+test("converts hsla to hex", () => {
+  expect(getHexValue("hsla(100, 100%, 50%, 0.5)")).toBe("#55ff0080");
+});
+
+test("returns #000000 when invalid hsl is passed", () => {
+  expect(getHexValue("hsl()")).toBe("#000000");
+});
+
+test("converts named color to hex", () => {
+  expect(getHexValue("palegoldenrod")).toBe("#eee8aa");
+});
+
+test("throws error when an invalid color is passed", () => {
+  const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+  expect(getHexValue("notacolor")).toBe("#000000");
+  expect(spy).toHaveBeenCalledWith(
+    'Could not parse "notacolor", please provide a valid hex, rgb, rgba, hsl, hsla or named color.',
+  );
+
+  spy.mockRestore();
+});

--- a/src/style/utils/get-hex-value.ts
+++ b/src/style/utils/get-hex-value.ts
@@ -1,0 +1,299 @@
+import Logger from "../../__internal__/utils/logger";
+
+function normaliseHex(hex: string): string {
+  const h = hex.replace("#", "");
+
+  // Convert 3-digit to 6-digit
+  if (h.length === 3) {
+    return `#${h[0]}${h[0]}${h[1]}${h[1]}${h[2]}${h[2]}`;
+  }
+
+  // Convert 4-digit to 8-digit
+  if (h.length === 4) {
+    return `#${h[0]}${h[0]}${h[1]}${h[1]}${h[2]}${h[2]}${h[3]}${h[3]}`;
+  }
+
+  return `#${h}`;
+}
+
+function rgbToHex(rgb: string): string {
+  const values = rgb.match(/\d+(\.\d+)?%?/g);
+
+  if (!values) {
+    return "#000000";
+  }
+
+  const r = parseInt(values[0], 10);
+  const g = parseInt(values[1], 10);
+  const b = parseInt(values[2], 10);
+  const a = values.length > 3 ? parseFloat(values[3]) : 1;
+
+  let hex = `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+
+  if (a !== 1) {
+    const alpha = Math.round(a * 255)
+      .toString(16)
+      .padStart(2, "0");
+    hex += alpha;
+  }
+
+  return hex;
+}
+
+function hslToRgb(
+  h: number,
+  s: number,
+  l: number,
+): { r: number; g: number; b: number } {
+  // Normalise hue to be between 0 and 360
+  let hue = h % 360;
+  if (hue < 0) {
+    hue += 360;
+  }
+
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+
+  let r, g, b;
+
+  switch (Math.floor(hue / 60)) {
+    case 0:
+      [r, g, b] = [c, x, 0];
+      break;
+    case 1:
+      [r, g, b] = [x, c, 0];
+      break;
+    case 2:
+      [r, g, b] = [0, c, x];
+      break;
+    case 3:
+      [r, g, b] = [0, x, c];
+      break;
+    case 4:
+      [r, g, b] = [x, 0, c];
+      break;
+    default:
+      [r, g, b] = [c, 0, x];
+      break;
+  }
+
+  return {
+    r: Math.round((r + m) * 255),
+    g: Math.round((g + m) * 255),
+    b: Math.round((b + m) * 255),
+  };
+}
+
+function hslToHex(hsl: string): string {
+  const values = hsl.match(/-?\d+(\.\d+)?%?/g);
+
+  if (!values) {
+    return "#000000";
+  }
+
+  const h = parseFloat(values[0]);
+  const s = parseFloat(values[1]) / 100;
+  const l = parseFloat(values[2]) / 100;
+  const a = values.length > 3 ? parseFloat(values[3]) : 1;
+
+  const { r, g, b } = hslToRgb(h, s, l);
+
+  let hex = `#${Math.round(r).toString(16).padStart(2, "0")}${Math.round(g).toString(16).padStart(2, "0")}${Math.round(b).toString(16).padStart(2, "0")}`;
+
+  if (a !== 1) {
+    const alpha = Math.round(a * 255)
+      .toString(16)
+      .padStart(2, "0");
+    hex += alpha;
+  }
+
+  return hex;
+}
+
+const COLOR_NAMES: Record<string, string> = {
+  aliceblue: "#f0f8ff",
+  antiquewhite: "#faebd7",
+  aqua: "#00ffff",
+  aquamarine: "#7fffd4",
+  azure: "#f0ffff",
+  beige: "#f5f5dc",
+  bisque: "#ffe4c4",
+  black: "#000000",
+  blanchedalmond: "#ffebcd",
+  blue: "#0000ff",
+  blueviolet: "#8a2be2",
+  brown: "#a52a2a",
+  burlywood: "#deb887",
+  cadetblue: "#5f9ea0",
+  chartreuse: "#7fff00",
+  chocolate: "#d2691e",
+  coral: "#ff7f50",
+  cornflowerblue: "#6495ed",
+  cornsilk: "#fff8dc",
+  crimson: "#dc143c",
+  cyan: "#00ffff",
+  darkblue: "#00008b",
+  darkcyan: "#008b8b",
+  darkgoldenrod: "#b8860b",
+  darkgray: "#a9a9a9",
+  darkgreen: "#006400",
+  darkgrey: "#a9a9a9",
+  darkkhaki: "#bdb76b",
+  darkmagenta: "#8b008b",
+  darkolivegreen: "#556b2f",
+  darkorange: "#ff8c00",
+  darkorchid: "#9932cc",
+  darkred: "#8b0000",
+  darksalmon: "#e9967a",
+  darkseagreen: "#8fbc8f",
+  darkslateblue: "#483d8b",
+  darkslategray: "#2f4f4f",
+  darkslategrey: "#2f4f4f",
+  darkturquoise: "#00ced1",
+  darkviolet: "#9400d3",
+  deeppink: "#ff1493",
+  deepskyblue: "#00bfff",
+  dimgray: "#696969",
+  dimgrey: "#696969",
+  dodgerblue: "#1e90ff",
+  firebrick: "#b22222",
+  floralwhite: "#fffaf0",
+  forestgreen: "#228b22",
+  fuchsia: "#ff00ff",
+  gainsboro: "#dcdcdc",
+  ghostwhite: "#f8f8ff",
+  gold: "#ffd700",
+  goldenrod: "#daa520",
+  gray: "#808080",
+  green: "#008000",
+  greenyellow: "#adff2f",
+  grey: "#808080",
+  honeydew: "#f0fff0",
+  hotpink: "#ff69b4",
+  indianred: "#cd5c5c",
+  indigo: "#4b0082",
+  ivory: "#fffff0",
+  khaki: "#f0e68c",
+  lavender: "#e6e6fa",
+  lavenderblush: "#fff0f5",
+  lawngreen: "#7cfc00",
+  lemonchiffon: "#fffacd",
+  lightblue: "#add8e6",
+  lightcoral: "#f08080",
+  lightcyan: "#e0ffff",
+  lightgoldenrodyellow: "#fafad2",
+  lightgray: "#d3d3d3",
+  lightgreen: "#90ee90",
+  lightgrey: "#d3d3d3",
+  lightpink: "#ffb6c1",
+  lightsalmon: "#ffa07a",
+  lightseagreen: "#20b2aa",
+  lightskyblue: "#87cefa",
+  lightslategray: "#778899",
+  lightslategrey: "#778899",
+  lightsteelblue: "#b0c4de",
+  lightyellow: "#ffffe0",
+  lime: "#00ff00",
+  limegreen: "#32cd32",
+  linen: "#faf0e6",
+  magenta: "#ff00ff",
+  maroon: "#800000",
+  mediumaquamarine: "#66cdaa",
+  mediumblue: "#0000cd",
+  mediumorchid: "#ba55d3",
+  mediumpurple: "#9370db",
+  mediumseagreen: "#3cb371",
+  mediumslateblue: "#7b68ee",
+  mediumspringgreen: "#00fa9a",
+  mediumturquoise: "#48d1cc",
+  mediumvioletred: "#c71585",
+  midnightblue: "#191970",
+  mintcream: "#f5fffa",
+  mistyrose: "#ffe4e1",
+  moccasin: "#ffe4b5",
+  navajowhite: "#ffdead",
+  navy: "#000080",
+  oldlace: "#fdf5e6",
+  olive: "#808000",
+  olivedrab: "#6b8e23",
+  orange: "#ffa500",
+  orangered: "#ff4500",
+  orchid: "#da70d6",
+  palegoldenrod: "#eee8aa",
+  palegreen: "#98fb98",
+  paleturquoise: "#afeeee",
+  palevioletred: "#db7093",
+  papayawhip: "#ffefd5",
+  peachpuff: "#ffdab9",
+  peru: "#cd853f",
+  pink: "#ffc0cb",
+  plum: "#dda0dd",
+  powderblue: "#b0e0e6",
+  purple: "#800080",
+  rebeccapurple: "#663399",
+  red: "#ff0000",
+  rosybrown: "#bc8f8f",
+  royalblue: "#4169e1",
+  saddlebrown: "#8b4513",
+  salmon: "#fa8072",
+  sandybrown: "#f4a460",
+  seagreen: "#2e8b57",
+  seashell: "#fff5ee",
+  sienna: "#a0522d",
+  silver: "#c0c0c0",
+  skyblue: "#87ceeb",
+  slateblue: "#6a5acd",
+  slategray: "#708090",
+  slategrey: "#708090",
+  snow: "#fffafa",
+  springgreen: "#00ff7f",
+  steelblue: "#4682b4",
+  tan: "#d2b48c",
+  teal: "#008080",
+  thistle: "#d8bfd8",
+  tomato: "#ff6347",
+  turquoise: "#40e0d0",
+  violet: "#ee82ee",
+  wheat: "#f5deb3",
+  white: "#ffffff",
+  whitesmoke: "#f5f5f5",
+  yellow: "#ffff00",
+  yellowgreen: "#9acd32",
+};
+
+function namedColorToHex(name: string): string | null {
+  return COLOR_NAMES[name] || null;
+}
+
+/**
+ * Converts CSS color string to a hex value.
+ * @param color - CSS color string (hex, rgb, rgba, hsl, hsla, or named color).
+ */
+function getHexValue(color: string): string {
+  const c = color.trim().toLowerCase();
+
+  if (c.startsWith("#")) {
+    return normaliseHex(c);
+  }
+
+  if (c.startsWith("rgb")) {
+    return rgbToHex(c);
+  }
+
+  if (c.startsWith("hsl")) {
+    return hslToHex(c);
+  }
+
+  const namedHex = namedColorToHex(c);
+  if (namedHex) {
+    return namedHex;
+  }
+
+  Logger.error(
+    `Could not parse "${color}", please provide a valid hex, rgb, rgba, hsl, hsla or named color.`,
+  );
+  return "#000000";
+}
+
+export default getHexValue;


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- Remove `polished` dependency. 
- Replace `shade` with CSS. 
- Replace `meetsConstrastGuidelines` with our own custom utils. 
- When using custom colours on Pill, text colour should pass colour contrast checks

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- Icon and Pill components use `shade` from polished to determine colours on hover when a custom one is provided. 
- Pill uses `meetsContrastGuidelines` from polished to determine the text and close icon colour when a custom `borderColor` is provided. 
- Some content (text) colours calculated by polished cause colour contrast fails:

<img width="700" alt="image" src="https://github.com/user-attachments/assets/ab783d1b-5b33-4268-b821-cfc45a4e6b4f" />
<img width="700" alt="image" src="https://github.com/user-attachments/assets/79f30cd8-ecc7-4aa6-84de-1700c785b42e" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
