### PR TITLE
refactor(button): remove use of default props in style file

### DIFF
--- a/src/components/button/button.style.ts
+++ b/src/components/button/button.style.ts
@@ -76,7 +76,10 @@ type StyledButtonProps = SpaceProps &
     buttonType: Required<ButtonProps>["buttonType"];
   };
 
-const StyledButton = styled.button<StyledButtonProps>`
+const StyledButton = styled.button.attrs(({ theme }) => ({
+  // istanbul ignore next
+  theme: theme || BaseTheme,
+}))<StyledButtonProps>`
   ${space}
   ${({ disabled, noWrap }) => css`
     align-items: center;
@@ -147,8 +150,5 @@ export const StyledButtonMainText = styled.span`
   display: flex;
   align-items: center;
 `;
-StyledButton.defaultProps = {
-  theme: BaseTheme,
-};
 
 export default StyledButton;


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
