### PR TITLE
fix(note): render title semantically with h3 when passed as text

### DIFF
--- a/playwright/components/note/index.ts
+++ b/playwright/components/note/index.ts
@@ -11,7 +11,7 @@ const noteComponent = (page: Page) => {
   return page.locator(NOTE_COMPONENT);
 };
 const noteHeader = (page: Page) => {
-  return page.locator(NOTE_COMPONENT).locator("h2");
+  return page.locator(NOTE_COMPONENT).locator("h3");
 };
 const noteContent = (page: Page) => {
   return page.locator(DATA_CONTENTS);

--- a/src/components/note/note.component.tsx
+++ b/src/components/note/note.component.tsx
@@ -96,7 +96,7 @@ export const Note = ({
                   fontSize="16px"
                   lineHeight="21px"
                   paddingBottom="16px"
-                  variant="h2"
+                  variant="h3"
                 >
                   {title}
                 </Typography>

--- a/src/components/note/note.test.tsx
+++ b/src/components/note/note.test.tsx
@@ -31,7 +31,7 @@ test("renders a Typography component with h2 `variant` and `title` as its child 
     <Note createdDate="23 May 2020, 12:08 PM" noteContent="" title="Title" />,
   );
 
-  const titleElement = screen.getByRole("heading", { level: 2 });
+  const titleElement = screen.getByRole("heading", { level: 3 });
 
   expect(titleElement).toHaveTextContent("Title");
   expect(titleElement).toHaveAttribute("data-role", "note-title");


### PR DESCRIPTION
### Proposed behaviour
title prop in Note component renders using Typography with `variant="h3"`
<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

Styling for H3 for a title prop is being overwritten in a Note component within `with title` story.

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
