### PR TITLE
feat(responsive-vertical-menu): allows custom aria-label for menu launcher

### DIFF
--- a/src/components/vertical-menu/index.ts
+++ b/src/components/vertical-menu/index.ts
@@ -12,6 +12,7 @@ export type { VerticalMenuTriggerProps } from "./vertical-menu-trigger/vertical-
 
 export {
   ResponsiveVerticalMenu,
+  ResponsiveVerticalMenuDivider,
   ResponsiveVerticalMenuItem,
   ResponsiveVerticalMenuProvider,
 } from "./responsive-vertical-menu";

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-test.stories.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-test.stories.tsx
@@ -161,6 +161,57 @@ export const Default = (props: Partial<ResponsiveVerticalMenuProps>) => {
 };
 Default.storyName = "Default";
 
+export const WithoutGlobalHeader = (
+  props: Partial<ResponsiveVerticalMenuProps>,
+) => {
+  return (
+    <ResponsiveVerticalMenuProvider>
+      <ResponsiveVerticalMenu {...props}>
+        <ResponsiveVerticalMenuItem icon="home" id="home" label="Home" />
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem
+          customIcon={<CustomAccountingIcon />}
+          id="accounting"
+          label="Accounting"
+        >
+          <ResponsiveVerticalMenuItem id="summary" label="Summary" />
+          <ResponsiveVerticalMenuItem
+            id="sales-invoices"
+            label="Sales Invoices"
+          >
+            <ResponsiveVerticalMenuItem
+              id="quotes-and-estimates"
+              label="Quotes & Estimates"
+              href="#"
+            />
+            <ResponsiveVerticalMenuItem
+              id="new-sales-invoice"
+              label="New Sales Invoice"
+              href="#"
+            />
+            <ResponsiveVerticalMenuItem
+              id="sales-summary"
+              label="Sales Summary"
+              href="#"
+            />
+          </ResponsiveVerticalMenuItem>
+          <ResponsiveVerticalMenuItem id="contacts" label="Contacts">
+            <ResponsiveVerticalMenuItem
+              id="nested-menu-item-1"
+              label="Nested Menu Item 1"
+            />
+          </ResponsiveVerticalMenuItem>
+          <ResponsiveVerticalMenuItem
+            id="products-and-services"
+            label="Products & Services"
+          />
+        </ResponsiveVerticalMenuItem>
+      </ResponsiveVerticalMenu>
+    </ResponsiveVerticalMenuProvider>
+  );
+};
+WithoutGlobalHeader.storyName = "Without Global Header";
+
 export const WithFullIcons = (props: Partial<ResponsiveVerticalMenuProps>) => {
   return (
     <GlobalHeader>

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
@@ -16,8 +16,8 @@ import {
 } from "./responsive-vertical-menu.style";
 
 import Box from "../../box";
-
 import Modal from "../../modal";
+
 import useIsAboveBreakpoint from "../../../hooks/__internal__/useIsAboveBreakpoint";
 import useMediaQuery from "../../../hooks/useMediaQuery";
 
@@ -26,6 +26,7 @@ import tagComponent, {
 } from "../../../__internal__/utils/helpers/tags";
 import { DepthProvider } from "./__internal__/depth.context";
 import { MenuFocusProvider } from "./__internal__/focus.context";
+import useLocale from "../../../hooks/__internal__/useLocale";
 
 export interface ResponsiveVerticalMenuProps extends TagProps {
   /** The content of the menu */
@@ -45,6 +46,7 @@ const BaseMenu = ({
   width,
   ...rest
 }: ResponsiveVerticalMenuProps) => {
+  const locale = useLocale();
   const {
     activeMenuItem,
     buttonRef,
@@ -164,6 +166,9 @@ const BaseMenu = ({
     <div ref={containerRef}>
       <StyledButton
         active={active}
+        aria-controls="responsive-vertical-menu-primary"
+        aria-expanded={active}
+        aria-label={locale.verticalMenu.ariaLabels?.responsiveMenuLauncher()}
         buttonType="tertiary"
         data-component="responsive-vertical-menu-launcher"
         data-role="responsive-vertical-menu-launcher"
@@ -183,7 +188,7 @@ const BaseMenu = ({
               p={1}
             >
               <StyledCloseButton
-                aria-label="close-menu"
+                aria-label={locale.verticalMenu.ariaLabels?.responsiveMenuCloseButton()}
                 data-component="responsive-vertical-menu-close"
                 data-role="responsive-vertical-menu-close"
                 iconType="close"

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.mdx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.mdx
@@ -1,4 +1,5 @@
 import { Meta, ArgTypes, Canvas } from "@storybook/blocks";
+import TranslationKeysTable from "../../../../.storybook/utils/translation-keys-table";
 
 import * as ResponsiveVerticalMenuStories from "./responsive-vertical-menu.stories";
 import * as ResponsiveVerticalMenuDividerStories from "./responsive-vertical-menu-divider/responsive-vertical-menu-divider.stories";
@@ -213,3 +214,20 @@ You can pass any valid `ReactNode` to the `label` prop of the `ResponsiveVertica
 ### ResponsiveVerticalMenuItem
 
 <ArgTypes of={ResponsiveVerticalMenuItemStories} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object
+to the [i18nProvider](../?path=/docs/documentation-i18n--docs).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "verticalMenu.ariaLabels.responsiveMenuLauncher",
+      description:
+        "An accessible label for the launcher of the `ResponsiveVerticalMenu`.",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
+/>

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.test.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.test.tsx
@@ -12,6 +12,7 @@ import {
 import useIsAboveBreakpoint from "../../../hooks/__internal__/useIsAboveBreakpoint";
 import useMediaQuery from "../../../hooks/useMediaQuery";
 import guid from "../../../__internal__/utils/helpers/guid";
+import I18nProvider from "../../../components/i18n-provider";
 
 jest.mock("../../../hooks/__internal__/useIsAboveBreakpoint");
 jest.mock("../../../hooks/useMediaQuery");
@@ -1303,4 +1304,61 @@ test("nested menu items are correctly justified when icons are present", async (
 
   const nestedMenu = screen.getByTestId("menu-item-2-nested-menu-wrapper");
   expect(nestedMenu).toHaveStyleRule("justify-content", "flex-end");
+});
+
+test("correct aria-label values are set", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  mockUseIsAboveBreakpoint.mockReturnValue(false);
+
+  render(
+    <I18nProvider
+      locale={{
+        locale: () => "en-GB",
+        verticalMenu: {
+          ariaLabels: {
+            responsiveMenuLauncher: () => "Test menu launcher",
+            responsiveMenuCloseButton: () => "Test product menu close button",
+          },
+        },
+      }}
+    >
+      <ResponsiveVerticalMenuProvider>
+        <ResponsiveVerticalMenu>
+          <ResponsiveVerticalMenuItem
+            data-role="menu-item-1"
+            icon="home"
+            id="menu-item-1"
+            label="Menu Item 1"
+            href="https://example.com"
+          >
+            <ResponsiveVerticalMenuItem
+              data-role="menu-item-2"
+              icon="business"
+              id="menu-item-2"
+              label="Menu Item 2"
+            >
+              <ResponsiveVerticalMenuItem
+                data-role="menu-item-3"
+                icon="analysis"
+                id="menu-item-3"
+                label="Menu Item 3"
+              />
+            </ResponsiveVerticalMenuItem>
+          </ResponsiveVerticalMenuItem>
+        </ResponsiveVerticalMenu>
+      </ResponsiveVerticalMenuProvider>
+    </I18nProvider>,
+  );
+
+  const launcherButton = screen.getByTestId(
+    "responsive-vertical-menu-launcher",
+  );
+  expect(launcherButton).toHaveAttribute("aria-label", "Test menu launcher");
+  await user.click(launcherButton);
+
+  const closeButton = screen.getByTestId("responsive-vertical-menu-close");
+  expect(closeButton).toHaveAttribute(
+    "aria-label",
+    "Test product menu close button",
+  );
 });

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -249,6 +249,12 @@ const enGB: Locale = {
     neutral: () => "Information",
     notification: () => "Notification",
   },
+  verticalMenu: {
+    ariaLabels: {
+      responsiveMenuLauncher: () => "Product menu",
+      responsiveMenuCloseButton: () => "Close product menu",
+    },
+  },
   verticalMenuFullScreen: {
     ariaLabels: {
       close: () => "Close",

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -211,6 +211,12 @@ interface Locale {
     neutral: () => string;
     notification: () => string;
   };
+  verticalMenu: {
+    ariaLabels: {
+      responsiveMenuLauncher: () => string;
+      responsiveMenuCloseButton: () => string;
+    };
+  };
   verticalMenuFullScreen: {
     ariaLabels: {
       close: () => string;


### PR DESCRIPTION
### Proposed behaviour

- `ResponsiveVerticalMenu` now allows an additional prop to set the value of `aria-label`;
- The `ResponsiveVerticalMenuDivider` is now exported correctly

### Current behaviour

- The launcher button for the `ResponsiveVerticalMenu` is announced via the name of the icon used, with no additional context;
- The `ResponsiveVerticalMenuDivider` isn't exported for use

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Use the `Without Global Header` test story to verify that `Main menu` is announced when focus is gained and a screen reader is active