### PR TITLE
fix(use-modal-aria): rework useModalAria hook to improve cleanup and fix stale effects

### DIFF
--- a/src/components/adaptive-sidebar/adaptive-sidebar-test.stories.tsx
+++ b/src/components/adaptive-sidebar/adaptive-sidebar-test.stories.tsx
@@ -266,7 +266,6 @@ export const ExampleImplementation: StoryObj = () => {
       >
         <Box
           p={2}
-          borderRadius="borderRadius200"
           m={2}
           backgroundColor="var(--colorsUtilityMajor025)"
           color="var(--colorsUtilityYin090)"


### PR DESCRIPTION
### Proposed behaviour

Rework the hook to improve the clean-up process and fix stale effects. Might fix some things, might not 🤷 

### Current behaviour

An edge-case scenario seems to exist whereby the `inert` attribute added dynamically via the `useModalAria` hook doesn't get removed correctly, or at all.

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Do modal things with components and make sure everything continues to work as normal