### PR TITLE
fix(icon): address react 18.3.0 warning regarding spreading keys

### DIFF
--- a/src/components/icon/icon.component.tsx
+++ b/src/components/icon/icon.component.tsx
@@ -165,7 +165,6 @@ const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
       hasTooltip,
       id,
       isInteractive,
-      key: "icon",
       ref,
       role,
       tabIndex: computedTabIndex,


### PR DESCRIPTION
### Proposed behaviour

Remove React key that is no longer needed

### Current behaviour

`Icon` currently causes React v18.3.0 to log the following warning:
```
Warning: A props object containing a "key" prop is being spread into JSX
```

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
