### PR TITLE
fix(popover-container): aria hidden elements must not be focusable

### DIFF
--- a/src/components/popover-container/popover-container.component.tsx
+++ b/src/components/popover-container/popover-container.component.tsx
@@ -419,7 +419,6 @@ export const PopoverContainer = forwardRef<
             data-element="tab-guard-top"
             // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
             tabIndex={0}
-            aria-hidden
             onFocus={(ev) => handleFocusGuard("prev", ev)}
           />
           {popover()}
@@ -427,7 +426,6 @@ export const PopoverContainer = forwardRef<
             data-element="tab-guard-bottom"
             // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
             tabIndex={0}
-            aria-hidden
             onFocus={(ev) => handleFocusGuard("next", ev)}
           />
         </>


### PR DESCRIPTION
fixes: #7350

### Proposed behaviour
Removed the `aria-hidden` from the tab guards to prevent any accessibility violations.

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour
Currently `tabindex="0"` makes the element focusable and included in the tab order while `aria-hidden="true"` indicates to assistive technologies (like screen readers) that the element should be ignored. This can lead to confusing keyboard navigation  and accessibility violations.

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

1. Open the popover container storybook page
2. Inspect the container
3. The tab-guard-top and tab-guard-bottom elements should not have the `aria-hidden` attribute.

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
