### PR TITLE
fix(menu, multi-action-button, split-button): remove focus first list item on menu-popup open

### DIFF
--- a/src/components/menu/__internal__/submenu/submenu.component.tsx
+++ b/src/components/menu/__internal__/submenu/submenu.component.tsx
@@ -116,7 +116,6 @@ const Submenu = React.forwardRef<HTMLAnchorElement, SubmenuProps>(
     const [applyFocusRadius, setApplyFocusRadius] = useState<boolean>(false);
     const [applyFocusRadiusToLastItem, setApplyFocusRadiusToLastItem] =
       useState<boolean>(false);
-    const focusFirstMenuItemOnOpen = useRef(false);
 
     const numberOfChildren = submenuItemIds.length;
 
@@ -282,28 +281,24 @@ const Submenu = React.forwardRef<HTMLAnchorElement, SubmenuProps>(
           | React.KeyboardEvent<HTMLAnchorElement>
           | React.KeyboardEvent<HTMLButtonElement>,
       ) => {
-        if (!submenuOpen) {
-          if (
-            Events.isEnterKey(event) ||
-            Events.isSpaceKey(event) ||
-            Events.isDownKey(event) ||
-            Events.isUpKey(event)
-          ) {
-            event.preventDefault();
-            openSubmenu();
-            focusFirstMenuItemOnOpen.current = !href;
-          }
+        const isToggleKey =
+          Events.isEnterKey(event) || Events.isSpaceKey(event);
+
+        if ((isToggleKey || Events.isDownKey(event)) && !submenuOpen) {
+          event.preventDefault();
+          openSubmenu();
         }
 
         if (submenuOpen) {
           const index = findCurrentIndex(submenuFocusId);
           let nextIndex = index;
 
-          if (href && !submenuFocusId) {
-            if (Events.isDownKey(event) || Events.isUpKey(event)) {
+          if (!submenuFocusId) {
+            // toggle close when Space/Enter is pressed on the parent item
+            // when parent is a link, allow default behaviour on Enter once submenu is open
+            if ((isToggleKey && !href) || (Events.isSpaceKey(event) && href)) {
               event.preventDefault();
-              setSubmenuFocusId(submenuItemIds[0]);
-              return;
+              closeSubmenu();
             }
           }
 
@@ -407,18 +402,6 @@ const Submenu = React.forwardRef<HTMLAnchorElement, SubmenuProps>(
         }
       }
     }, [children, submenuOpen, submenuRef]);
-
-    useEffect(() => {
-      if (
-        focusFirstMenuItemOnOpen.current &&
-        submenuOpen &&
-        !submenuFocusId &&
-        submenuItemIds.length
-      ) {
-        focusFirstMenuItemOnOpen.current = false;
-        setSubmenuFocusId(submenuItemIds[0]);
-      }
-    }, [submenuOpen, submenuFocusId, submenuItemIds]);
 
     const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
       openSubmenu();

--- a/src/components/menu/menu-item/menu-item.test.tsx
+++ b/src/components/menu/menu-item/menu-item.test.tsx
@@ -720,7 +720,7 @@ describe("when MenuItem has a submenu", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("focuses succeeding submenu item when 'ArrowDown' key is pressed", async () => {
+  it("opens the submenu when the 'ArrowDown' key is pressed, then moves focus to the next submenu items on subsequent presses", async () => {
     const user = userEvent.setup();
     render(
       <Menu>
@@ -732,12 +732,14 @@ describe("when MenuItem has a submenu", () => {
       </Menu>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    act(() => {
-      submenuParentItem.focus();
-    });
+    await user.tab();
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
 
+    expect(submenuParentItem).toHaveFocus();
+    expect(submenuItems[0]).toBeVisible();
+
+    await user.keyboard("{arrowdown}");
     expect(submenuItems[0]).toHaveFocus();
     await user.keyboard("{arrowdown}");
     expect(submenuItems[1]).toHaveFocus();
@@ -747,7 +749,7 @@ describe("when MenuItem has a submenu", () => {
     expect(submenuItems[2]).toHaveFocus();
   });
 
-  it("focuses preceeding submenu item when 'ArrowUp' key is pressed", async () => {
+  it("moves focus to the previous submenu item when 'ArrowUp' key is pressed", async () => {
     const user = userEvent.setup();
     render(
       <Menu>
@@ -759,13 +761,13 @@ describe("when MenuItem has a submenu", () => {
       </Menu>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    act(() => {
-      submenuParentItem.focus();
-    });
-    await user.keyboard("{arrowup}");
+    await user.tab();
+    await user.keyboard("{Enter}");
     const submenuItems = screen.getAllByRole("link");
 
-    expect(submenuItems[0]).toHaveFocus();
+    expect(submenuParentItem).toHaveFocus();
+    expect(submenuItems[0]).toBeVisible();
+
     await user.keyboard("{End}");
     expect(submenuItems[2]).toHaveFocus();
     await user.keyboard("{arrowup}");
@@ -788,14 +790,9 @@ describe("when MenuItem has a submenu", () => {
       </Menu>,
     );
 
-    const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    act(() => {
-      submenuParentItem.focus();
-    });
+    await user.tab();
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
-
-    expect(submenuItems[0]).toHaveFocus();
 
     await user.keyboard("{End}");
 
@@ -814,14 +811,9 @@ describe("when MenuItem has a submenu", () => {
       </Menu>,
     );
 
-    const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    act(() => {
-      submenuParentItem.focus();
-    });
+    await user.tab();
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
-
-    expect(submenuItems[0]).toHaveFocus();
 
     await user.keyboard("{End}");
     await user.keyboard("{Home}");
@@ -841,12 +833,12 @@ describe("when MenuItem has a submenu", () => {
       </Menu>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    act(() => {
-      submenuParentItem.focus();
-    });
+    await user.tab();
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
 
+    expect(submenuParentItem).toHaveFocus();
+    await user.tab();
     expect(submenuItems[0]).toHaveFocus();
     await user.tab();
     expect(submenuItems[1]).toHaveFocus();
@@ -856,7 +848,7 @@ describe("when MenuItem has a submenu", () => {
     expect(submenuItems[2]).not.toHaveFocus();
   });
 
-  it("focuses preceding submenu item when shift tabbing", async () => {
+  it("focuses preceding submenu item when shift tabbing, then focuses on the parent menu item", async () => {
     const user = userEvent.setup();
     render(
       <Menu>
@@ -868,9 +860,7 @@ describe("when MenuItem has a submenu", () => {
       </Menu>,
     );
     const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    act(() => {
-      submenuParentItem.focus();
-    });
+    await user.tab();
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
     await user.keyboard("{End}");
@@ -880,6 +870,8 @@ describe("when MenuItem has a submenu", () => {
     expect(submenuItems[1]).toHaveFocus();
     await user.tab({ shift: true });
     expect(submenuItems[0]).toHaveFocus();
+    await user.tab({ shift: true });
+    expect(submenuParentItem).toHaveFocus();
   });
 
   it("allows focus on the last submenu item to be lost, when tabbing on it", async () => {
@@ -893,10 +885,7 @@ describe("when MenuItem has a submenu", () => {
         </MenuItem>
       </Menu>,
     );
-    const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    act(() => {
-      submenuParentItem.focus();
-    });
+    await user.tab();
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
     await user.keyboard("{End}");
@@ -904,27 +893,6 @@ describe("when MenuItem has a submenu", () => {
     expect(submenuItems[2]).toHaveFocus();
     await user.tab();
     expect(submenuItems[2]).not.toHaveFocus();
-  });
-
-  it("focuses parent menu item when shift tabbing from first submenu item", async () => {
-    const user = userEvent.setup();
-    render(
-      <Menu>
-        <MenuItem submenu="Item One">
-          <MenuItem href="#">Submenu Item One</MenuItem>
-        </MenuItem>
-      </Menu>,
-    );
-    const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    act(() => {
-      submenuParentItem.focus();
-    });
-    await user.keyboard("{arrowdown}");
-    const submenuItems = screen.getAllByRole("link");
-
-    expect(submenuItems[0]).toHaveFocus();
-    await user.tab({ shift: true });
-    expect(submenuParentItem).toHaveFocus();
   });
 
   it("skips any non-focusable submenu items when moving focus cursor with down arrow key", async () => {
@@ -942,6 +910,7 @@ describe("when MenuItem has a submenu", () => {
 
     await user.tab();
     await user.keyboard("{ArrowDown}");
+    await user.tab();
 
     const appleItem = await screen.findByRole("link", { name: "Apple" });
     expect(appleItem).toHaveFocus();
@@ -994,6 +963,7 @@ describe("when MenuItem has a submenu", () => {
 
     await user.tab();
     await user.keyboard("{ArrowDown}");
+    await user.tab();
 
     const appleItem = await screen.findByRole("link", { name: "Apple" });
     expect(appleItem).toHaveFocus();
@@ -1019,6 +989,7 @@ describe("when MenuItem has a submenu", () => {
 
     await user.tab();
     await user.keyboard("{ArrowDown}");
+    await user.tab();
 
     const bananaItem = await screen.findByRole("link", { name: "Banana" });
     expect(bananaItem).toHaveFocus();
@@ -1042,13 +1013,12 @@ describe("when MenuItem has a submenu", () => {
         </MenuItem>
       </Menu>,
     );
-    const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    act(() => {
-      submenuParentItem.focus();
-    });
+
+    await user.tab();
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
 
+    await user.keyboard("{arrowdown}");
     expect(submenuItems[0]).toHaveFocus();
     await user.keyboard("{arrowdown}");
     expect(screen.getByDisplayValue("foo")).toHaveFocus();
@@ -1069,10 +1039,8 @@ describe("when MenuItem has a submenu", () => {
         </MenuItem>
       </Menu>,
     );
-    const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    act(() => {
-      submenuParentItem.focus();
-    });
+
+    await user.tab();
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
     await user.keyboard("{End}");
@@ -1097,13 +1065,12 @@ describe("when MenuItem has a submenu", () => {
         </MenuItem>
       </Menu>,
     );
-    const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    act(() => {
-      submenuParentItem.focus();
-    });
+
+    await user.tab();
     await user.keyboard("{arrowdown}");
     const submenuItems = screen.getAllByRole("link");
 
+    await user.tab();
     expect(submenuItems[0]).toHaveFocus();
     await user.tab();
     expect(screen.getByDisplayValue("foo")).toHaveFocus();
@@ -1123,10 +1090,8 @@ describe("when MenuItem has a submenu", () => {
         </MenuItem>
       </Menu>,
     );
-    const submenuParentItem = screen.getByRole("link", { name: "Item One" });
-    act(() => {
-      submenuParentItem.focus();
-    });
+
+    await user.tab();
     await user.keyboard("{arrowdown}");
     await user.tab();
 
@@ -1146,10 +1111,8 @@ describe("when MenuItem has a submenu", () => {
         </MenuItem>
       </Menu>,
     );
-    const submenuParentItem = screen.getByRole("link", { name: "Item One" });
-    act(() => {
-      submenuParentItem.focus();
-    });
+
+    await user.tab();
     await user.keyboard("{arrowdown}");
     await user.keyboard("{a}");
 
@@ -1195,28 +1158,7 @@ describe("when MenuItem has a submenu", () => {
     expect(submenuItem).toHaveFocus();
   });
 
-  it("should focus the first item when parent has `href` user presses 'arrowup' key twice", async () => {
-    const user = userEvent.setup();
-    render(
-      <Menu>
-        <MenuItem href="#" submenu="Item One">
-          <MenuItem href="#">Submenu Item One</MenuItem>
-          <MenuItem href="#">Submenu Item Two</MenuItem>
-          <MenuItem href="#">Submenu Item Three</MenuItem>
-        </MenuItem>
-      </Menu>,
-    );
-    const submenuParentItem = screen.getByRole("link", { name: "Item One" });
-    await user.click(submenuParentItem);
-    await user.unhover(submenuParentItem);
-    await user.keyboard("{arrowup}");
-    await user.keyboard("{arrowup}");
-    const submenuItem = screen.getByRole("link", { name: "Submenu Item One" });
-
-    expect(submenuItem).toHaveFocus();
-  });
-
-  it("should focus the first item when `submenu` is initially opened via click, closed via mouseout and then 'arrowdown' key pressed", async () => {
+  it("maintains focus on the menu item when `submenu` is initially opened via click, closed via mouseout and then 'arrowdown' key pressed", async () => {
     const user = userEvent.setup();
     render(
       <Menu>
@@ -1227,53 +1169,21 @@ describe("when MenuItem has a submenu", () => {
         </MenuItem>
       </Menu>,
     );
-    const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    await user.click(submenuParentItem);
-    await user.unhover(submenuParentItem);
+
+    const submenuParentItem = screen.getByRole("listitem");
+    const submenuParentButton = screen.getByRole("button", {
+      name: "Item One",
+    });
+
+    await user.click(submenuParentButton);
+    await user.unhover(submenuParentButton);
     await user.keyboard("{arrowdown}");
-    const submenuItem = screen.getByRole("link", { name: "Submenu Item One" });
 
-    expect(submenuItem).toHaveFocus();
-  });
+    const submenu = await within(submenuParentItem).findByRole("list");
+    const menuItem = screen.getByRole("button", { name: "Item One" });
 
-  it("should focus the first item when `submenu` is initially initially opened via click, closed via mouseout and then 'arrowup' key pressed", async () => {
-    const user = userEvent.setup();
-    render(
-      <Menu>
-        <MenuItem submenu="Item One">
-          <MenuItem href="#">Submenu Item One</MenuItem>
-          <MenuItem href="#">Submenu Item Two</MenuItem>
-          <MenuItem href="#">Submenu Item Three</MenuItem>
-        </MenuItem>
-      </Menu>,
-    );
-    const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    await user.click(submenuParentItem);
-    await user.unhover(submenuParentItem);
-    await user.keyboard("{arrowup}");
-    const submenuItem = screen.getByRole("link", { name: "Submenu Item One" });
-
-    expect(submenuItem).toHaveFocus();
-  });
-
-  it("should focus the first item when initially opened via click, closed via mouseout and then 'tab' key pressed", async () => {
-    const user = userEvent.setup();
-    render(
-      <Menu>
-        <MenuItem submenu="Item One">
-          <MenuItem href="#">Submenu Item One</MenuItem>
-          <MenuItem href="#">Submenu Item Two</MenuItem>
-          <MenuItem href="#">Submenu Item Three</MenuItem>
-        </MenuItem>
-      </Menu>,
-    );
-    const submenuParentItem = screen.getByRole("button", { name: "Item One" });
-    await user.click(submenuParentItem);
-    await user.unhover(submenuParentItem);
-    await user.keyboard("{arrowdown}");
-    const submenuItem = screen.getByRole("link", { name: "Submenu Item One" });
-
-    expect(submenuItem).toHaveFocus();
+    expect(submenu).toBeVisible();
+    expect(menuItem).toHaveFocus();
   });
 
   it("focus moves to the first available focusable item, when a submenu opens and the first item isn't focusable", async () => {
@@ -1290,6 +1200,7 @@ describe("when MenuItem has a submenu", () => {
     );
 
     await user.tab();
+    await user.keyboard("{Enter}");
     await user.keyboard("{ArrowDown}");
 
     const bananaItem = await screen.findByRole("link", { name: "Banana" });
@@ -1356,9 +1267,8 @@ describe("when MenuItem has a submenu", () => {
     const parentItem = screen.getByRole("listitem");
     const parentItemButton = within(parentItem).getByRole("button");
 
-    act(() => {
-      parentItemButton.focus();
-    });
+    await user.tab();
+    await user.keyboard("{arrowdown}");
     await user.keyboard("{arrowdown}");
     await user.keyboard("{Escape}");
 
@@ -1381,17 +1291,18 @@ describe("when MenuItem has a submenu", () => {
       </Menu>,
     );
     const parentItem = screen.getByRole("listitem");
-    const parentItemButton = within(parentItem).getByRole("button");
 
-    act(() => {
-      parentItemButton.focus();
-    });
+    await user.tab();
     await user.keyboard("{arrowdown}");
     await user.keyboard("{arrowdown}");
+    await user.keyboard("{arrowdown}");
+
+    expect(screen.getByDisplayValue("foo")).toHaveFocus();
     await user.keyboard("{Enter}");
 
     const submenu = within(parentItem).queryByRole("list");
     expect(submenu).toBeVisible();
+    expect(screen.getByDisplayValue("foo")).toHaveFocus();
   });
 
   it("should close when the user presses 'Enter' and focus is not on input", async () => {
@@ -1407,19 +1318,68 @@ describe("when MenuItem has a submenu", () => {
         </MenuItem>
       </Menu>,
     );
-    const parentItem = screen.getByRole("listitem");
-    const parentItemButton = within(parentItem).getByRole("button");
 
-    act(() => {
-      parentItemButton.focus();
-    });
+    await user.tab();
     await user.keyboard("{arrowdown}");
     await user.keyboard("{Enter}");
 
     await waitFor(() => {
+      const parentItem = screen.getByRole("listitem");
       const submenu = within(parentItem).queryByRole("list");
       expect(submenu).not.toBeInTheDocument();
     });
+  });
+
+  it.each([
+    ["Enter", "{Enter}"],
+    ["Space", " "],
+  ])(
+    "should close when the focus is on a button parent item and '%s' key is pressed",
+    async (_, key) => {
+      const user = userEvent.setup();
+      render(
+        <Menu>
+          <MenuItem submenu="Item One">
+            <MenuItem href="#">Submenu Item One</MenuItem>
+            <MenuItem href="#">Submenu Item Two</MenuItem>
+            <MenuItem href="#">Submenu Item Three</MenuItem>
+          </MenuItem>
+        </Menu>,
+      );
+      const parentItem = screen.getByRole("listitem");
+
+      await user.tab();
+      await user.keyboard(key);
+      const submenu = within(parentItem).queryByRole("list");
+
+      expect(submenu).toBeVisible();
+
+      await user.keyboard(key);
+      expect(submenu).not.toBeInTheDocument();
+    },
+  );
+
+  it("should close when the parent is a link parent item and 'Space' key is pressed", async () => {
+    const user = userEvent.setup();
+    render(
+      <Menu>
+        <MenuItem href="#" submenu="Item One">
+          <MenuItem href="#">Submenu Item One</MenuItem>
+          <MenuItem href="#">Submenu Item Two</MenuItem>
+          <MenuItem href="#">Submenu Item Three</MenuItem>
+        </MenuItem>
+      </Menu>,
+    );
+    const parentItem = screen.getByRole("listitem");
+
+    await user.tab();
+    await user.keyboard(" ");
+    const submenu = within(parentItem).queryByRole("list");
+
+    expect(submenu).toBeVisible();
+
+    await user.keyboard(" ");
+    expect(submenu).not.toBeInTheDocument();
   });
 
   it("should not throw an error when a passed null `children`", () => {
@@ -1448,11 +1408,8 @@ describe("when MenuItem has a submenu", () => {
     );
 
     const parentItem = screen.getByRole("listitem");
-    const parentItemLink = within(parentItem).getByRole("link");
 
-    act(() => {
-      parentItemLink.focus();
-    });
+    await user.tab();
     await user.keyboard("{arrowdown}");
 
     const subitems = within(parentItem).getAllByRole("listitem");

--- a/src/components/menu/menu.pw.tsx
+++ b/src/components/menu/menu.pw.tsx
@@ -112,24 +112,6 @@ test.describe("Prop tests for Menu component", () => {
     await expect(menuItemFour).toHaveCSS("box-shadow", "none");
   });
 
-  test(`should verify a submenu can be navigated using keyboard down arrow after an item was clicked`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<MenuComponent />);
-
-    const subMenu = submenu(page).first();
-    await subMenu.hover();
-    const menuItemThree = innerMenu(page, 2, span).first();
-    await menuItemThree.click();
-    await page.keyboard.press("ArrowDown");
-    const focusedElement1 = page.locator("*:focus");
-    await expect(focusedElement1).toContainText("Item Submenu Three");
-    await page.keyboard.press("ArrowDown");
-    const focusedElement2 = page.locator("*:focus");
-    await expect(focusedElement2).toContainText("Item Submenu Four");
-  });
-
   test(`should verify a submenu can be navigated using keyboard shift + tabbing after an item was clicked`, async ({
     mount,
     page,
@@ -346,7 +328,7 @@ test.describe("Prop tests for Menu component", () => {
     );
   });
 
-  ["Enter", "Space", "ArrowDown", "ArrowUp"].forEach((key) => {
+  ["Enter", "Space", "ArrowDown"].forEach((key) => {
     test(`should verify menu opens using ${key} key when clickToOpen prop is true`, async ({
       mount,
       page,
@@ -372,8 +354,8 @@ test.describe("Prop tests for Menu component", () => {
 
   (
     [
-      ["ArrowDown", 0],
-      ["ArrowUp", 2],
+      ["ArrowDown", 1],
+      ["ArrowUp", 3],
     ] as [string, number][]
   ).forEach(([key, tabs]) => {
     test(`should verify the Search component is focusable by pressing the ${key} key`, async ({
@@ -398,6 +380,7 @@ test.describe("Prop tests for Menu component", () => {
 
     await continuePressingSHIFTTAB(page, 3);
     await page.keyboard.press("Enter");
+    await page.keyboard.press("ArrowDown");
     await page.keyboard.press("ArrowDown");
     await expect(searchDefaultInput(page)).toBeFocused();
   });
@@ -1494,7 +1477,7 @@ test.describe("Event tests for Menu component", () => {
     expect(callbackCount).toBe(1);
   });
 
-  ["Space", "Enter", "ArrowDown", "ArrowUp"].forEach((key) => {
+  ["Space", "Enter", "ArrowDown"].forEach((key) => {
     test(`should call onSubmenuOpen callback when a ${key} keyboard event is triggered`, async ({
       mount,
       page,

--- a/src/components/multi-action-button/components.test-pw.tsx
+++ b/src/components/multi-action-button/components.test-pw.tsx
@@ -63,12 +63,12 @@ export const WithWrapperTwoButtons = (
   props: Partial<MultiActionButtonProps>,
 ) => (
   <Box>
-    <MultiActionButton text="Multi Action Button" {...props}>
+    <MultiActionButton text="Multi Action Button 1" {...props}>
       <ButtonWrapper>Button 1</ButtonWrapper>
       <ButtonWrapper>Button 2</ButtonWrapper>
       <ButtonWrapper>Button 3</ButtonWrapper>
     </MultiActionButton>
-    <MultiActionButton text="Multi Action Button" {...props}>
+    <MultiActionButton text="Multi Action Button 2" {...props}>
       <ButtonWrapper>Button 1</ButtonWrapper>
       <ButtonWrapper>Button 2</ButtonWrapper>
       <ButtonWrapper>Button 3</ButtonWrapper>
@@ -81,12 +81,12 @@ export const MultiActionTwoButtons = (
 ) => {
   return (
     <Box>
-      <MultiActionButton text="Multi Action Button" {...props}>
+      <MultiActionButton text="Multi Action Button 1" {...props}>
         <Button>Example Button</Button>
         <Button>Example Button with long text</Button>
         <Button>Short</Button>
       </MultiActionButton>
-      <MultiActionButton text="Multi Action Button" {...props}>
+      <MultiActionButton text="Multi Action Button 2" {...props}>
         <Button>Example Button</Button>
         <Button>Example Button with long text</Button>
         <Button>Short</Button>

--- a/src/components/multi-action-button/multi-action-button.component.tsx
+++ b/src/components/multi-action-button/multi-action-button.component.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../style/utils";
 import useChildButtons from "../../hooks/__internal__/useChildButtons";
 import FlatTableContext from "../flat-table/__internal__/flat-table.context";
+import guid from "../../__internal__/utils/helpers/guid";
 
 export interface MultiActionButtonProps
   extends WidthProps,
@@ -61,6 +62,7 @@ export const MultiActionButton = forwardRef<
   ) => {
     const buttonRef = useRef<HTMLButtonElement>(null);
     const { isInFlatTable } = useContext(FlatTableContext);
+    const submenuId = useRef(guid());
 
     useImperativeHandle<MultiActionButtonHandle, MultiActionButtonHandle>(
       ref,
@@ -129,7 +131,11 @@ export const MultiActionButton = forwardRef<
           }),
         ]}
       >
-        <StyledButtonChildrenContainer {...wrapperProps} align={align}>
+        <StyledButtonChildrenContainer
+          id={submenuId.current}
+          {...wrapperProps}
+          align={align}
+        >
           <SplitButtonContext.Provider value={contextValue}>
             {React.Children.map(children, (child) => (
               <li>{child}</li>
@@ -152,8 +158,8 @@ export const MultiActionButton = forwardRef<
         {...marginProps}
       >
         <Button
-          aria-haspopup="true"
           aria-expanded={showAdditionalButtons}
+          aria-controls={submenuId.current}
           data-element="toggle-button"
           key="toggle-button"
           {...mainButtonProps}

--- a/src/components/multi-action-button/multi-action-button.component.tsx
+++ b/src/components/multi-action-button/multi-action-button.component.tsx
@@ -66,7 +66,7 @@ export const MultiActionButton = forwardRef<
       ref,
       () => ({
         focusMainButton() {
-          buttonRef.current?.focus();
+          buttonRef.current?.focus({ preventScroll: true });
         },
       }),
       [],
@@ -87,7 +87,12 @@ export const MultiActionButton = forwardRef<
     const handleClick = (
       ev: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>,
     ) => {
-      showButtons();
+      if (showAdditionalButtons) {
+        hideButtons();
+      } else {
+        showButtons();
+      }
+
       handleInsideClick();
       if (onClick) {
         onClick(ev as React.MouseEvent<HTMLButtonElement>);

--- a/src/components/multi-action-button/multi-action-button.pw.tsx
+++ b/src/components/multi-action-button/multi-action-button.pw.tsx
@@ -116,9 +116,11 @@ test.describe("Prop tests", () => {
     }) => {
       await mount(<MultiActionButtonList ml="200px" position={position} />);
 
-      const actionButton = getComponent(page, "multi-action-button");
+      const actionButton = page.getByRole("button", {
+        name: "Multi Action Button",
+      });
       await actionButton.click();
-      const listContainer = getDataElementByValue(page, "additional-buttons");
+      const listContainer = page.getByRole("list");
       await expect(listContainer).toHaveCSS("position", "fixed");
       await assertCssValueIsApproximately(listContainer, "top", 46);
       await assertCssValueIsApproximately(listContainer, "left", value);
@@ -128,7 +130,9 @@ test.describe("Prop tests", () => {
   test(`should render with button disabled`, async ({ mount, page }) => {
     await mount(<MultiActionButtonList disabled />);
 
-    await expect(page.getByRole("button").first()).toBeDisabled();
+    await expect(
+      page.getByRole("button", { name: "Multi Action Button" }),
+    ).toBeDisabled();
   });
 
   test(`should render with specific background colour when hovering`, async ({
@@ -137,9 +141,9 @@ test.describe("Prop tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButton = getComponent(page, "multi-action-button").locator(
-      "button",
-    );
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.hover();
     await expect(actionButton).toHaveCSS("background-color", "rgb(0, 103, 56)");
   });
@@ -150,9 +154,9 @@ test.describe("Prop tests", () => {
   }) => {
     await mount(<MultiActionButtonList width="70%" />);
 
-    const actionButton = getComponent(page, "multi-action-button").locator(
-      "button",
-    );
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.hover();
     await expect(actionButton).toHaveCSS("justify-content", "space-between");
   });
@@ -163,9 +167,9 @@ test.describe("Prop tests", () => {
   }) => {
     await mount(<MultiActionButtonList width="70%" />);
 
-    const actionButton = getComponent(page, "multi-action-button").locator(
-      "button",
-    );
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.hover();
     await assertCssValueIsApproximately(actionButton, "width", 956);
   });
@@ -183,7 +187,9 @@ test.describe("Prop tests", () => {
     }) => {
       await mount(<MultiActionButtonList buttonType={buttonType} />);
 
-      const actionButton = page.getByRole("button");
+      const actionButton = page.getByRole("button", {
+        name: "Multi Action Button",
+      });
       await expect(actionButton).toHaveCSS("background-color", backgroundColor);
       await expect(actionButton).toHaveCSS("color", color);
       await expect(actionButton).toHaveCSS("border-color", borderColor);
@@ -192,32 +198,31 @@ test.describe("Prop tests", () => {
 });
 
 test.describe("Functional tests", () => {
-  test(`should verify that clicking the main button opens the additional buttons and focuses the first button`, async ({
+  test(`should verify that clicking the main button opens the additional buttons`, async ({
     mount,
     page,
   }) => {
     await mount(<MultiActionButtonList />);
 
-    await getComponent(page, "multi-action-button")
-      .first()
-      .locator("button")
-      .click();
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
+    await actionButton.click();
     const additionalButtons = getDataElementByValue(page, "additional-buttons");
 
     await expect(additionalButtons).toBeVisible();
-    await expect(additionalButtons.getByRole("button").first()).toBeFocused();
   });
 
   [...keysToTrigger].forEach((key) => {
-    test(`should verify pressing ${key} key on the main button opens MultiActionButton list and focuses first button`, async ({
+    test(`should verify pressing ${key} key on the main button opens MultiActionButton list`, async ({
       mount,
       page,
     }) => {
       await mount(<MultiActionButtonList />);
 
-      const actionButton = getComponent(page, "multi-action-button").locator(
-        "button",
-      );
+      const actionButton = page.getByRole("button", {
+        name: "Multi Action Button",
+      });
       await actionButton.focus();
       await page.keyboard.press(key);
       const additionalButtons = getDataElementByValue(
@@ -226,7 +231,6 @@ test.describe("Functional tests", () => {
       );
 
       await expect(additionalButtons).toBeVisible();
-      await expect(additionalButtons.getByRole("button").first()).toBeFocused();
     });
   });
 
@@ -257,16 +261,16 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .first()
-      .locator("button");
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    await page.keyboard.press("ArrowUp");
-    await expect(listButton1).toBeFocused();
-    await page.keyboard.press("ArrowUp");
+    await page.keyboard.press("Tab");
+
+    const listButton1 = page.getByRole("button", {
+      name: "Example Button",
+      exact: true,
+    });
     await expect(listButton1).toBeFocused();
     await page.keyboard.press("ArrowUp");
     await expect(listButton1).toBeFocused();
@@ -278,24 +282,24 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .first()
-      .locator("button");
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton2 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(1);
+    const listButton1 = page.getByRole("button", {
+      name: "Example Button",
+      exact: true,
+    });
+    const listButton2 = page.getByRole("button", {
+      name: "Example Button with long text",
+      exact: true,
+    });
 
     await listButton2.focus();
     await page.keyboard.press("Shift+Tab");
     await expect(listButton1).toBeFocused();
     await page.keyboard.press("Shift+Tab");
-    await expect(
-      getComponent(page, "multi-action-button").locator("button"),
-    ).toBeFocused();
+    await expect(actionButton).toBeFocused();
     await expect(listButton1).not.toBeVisible();
     await expect(listButton2).not.toBeVisible();
   });
@@ -306,13 +310,11 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .first()
-      .locator("button");
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const listButton3 = page.getByRole("button", { name: "Short" });
 
     await listButton3.focus();
     await page.keyboard.press("ArrowDown");
@@ -325,29 +327,33 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionTwoButtons />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .first()
-      .locator("button");
-    await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton2 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(1);
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const actionButton1 = page.getByRole("button", {
+      name: "Multi Action Button 1",
+    });
+    await actionButton1.click();
 
+    const listButton1 = page.getByRole("button", {
+      name: "Example Button",
+      exact: true,
+    });
+    const listButton2 = page.getByRole("button", {
+      name: "Example Button with long text",
+      exact: true,
+    });
+    const listButton3 = page.getByRole("button", { name: "Short" });
+
+    await page.keyboard.press("Tab");
     await expect(listButton1).toBeFocused();
     await page.keyboard.press("Tab");
     await expect(listButton2).toBeFocused();
     await page.keyboard.press("Tab");
     await expect(listButton3).toBeFocused();
     await page.keyboard.press("Tab");
-    await expect(
-      getComponent(page, "multi-action-button").nth(1).locator("button"),
-    ).toBeFocused();
+
+    const actionButton2 = page.getByRole("button", {
+      name: "Multi Action Button 2",
+    });
+    await expect(actionButton2).toBeFocused();
     await expect(listButton1).not.toBeVisible();
     await expect(listButton2).not.toBeVisible();
     await expect(listButton3).not.toBeVisible();
@@ -359,16 +365,15 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .first()
-      .locator("button");
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const listButton1 = page.getByRole("button", {
+      name: "Example Button",
+      exact: true,
+    });
+    const listButton3 = page.getByRole("button", { name: "Short" });
 
     await listButton3.focus();
     await page.keyboard.down("Meta");
@@ -383,16 +388,15 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .first()
-      .locator("button");
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const listButton1 = page.getByRole("button", {
+      name: "Example Button",
+      exact: true,
+    });
+    const listButton3 = page.getByRole("button", { name: "Short" });
 
     await listButton3.focus();
     await page.keyboard.down("Control");
@@ -407,16 +411,15 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .first()
-      .locator("button");
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const listButton1 = page.getByRole("button", {
+      name: "Example Button",
+      exact: true,
+    });
+    const listButton3 = page.getByRole("button", { name: "Short" });
 
     await listButton3.focus();
     await page.keyboard.press("Home");
@@ -429,17 +432,17 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .first()
-      .locator("button");
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const listButton1 = page.getByRole("button", {
+      name: "Example Button",
+      exact: true,
+    });
+    const listButton3 = page.getByRole("button", { name: "Short" });
 
+    await page.keyboard.press("Tab");
     await expect(listButton1).toBeFocused();
     await page.keyboard.down("Meta");
     await page.keyboard.press("ArrowDown");
@@ -453,17 +456,17 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .first()
-      .locator("button");
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const listButton1 = page.getByRole("button", {
+      name: "Example Button",
+      exact: true,
+    });
+    const listButton3 = page.getByRole("button", { name: "Short" });
 
+    await page.keyboard.press("Tab");
     await expect(listButton1).toBeFocused();
     await page.keyboard.down("Control");
     await page.keyboard.press("ArrowDown");
@@ -477,17 +480,17 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .first()
-      .locator("button");
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const listButton1 = page.getByRole("button", {
+      name: "Example Button",
+      exact: true,
+    });
+    const listButton3 = page.getByRole("button", { name: "Short" });
 
+    await page.keyboard.press("Tab");
     await expect(listButton1).toBeFocused();
     await page.keyboard.press("End");
     await expect(listButton3).toBeFocused();
@@ -499,17 +502,15 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .first()
-      .locator("button");
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    await expect(getDataElementByValue(page, "additional-buttons")).toHaveCount(
-      1,
-    );
+
+    const additionalButtons = page.getByRole("list");
+    await expect(additionalButtons).toBeVisible();
     await page.keyboard.press("Escape");
-    await expect(getDataElementByValue(page, "additional-buttons")).toHaveCount(
-      0,
-    );
+    await expect(additionalButtons).not.toBeVisible();
   });
 
   test(`should verify that clicking one of the child buttons closes MultiActionButton`, async ({
@@ -518,20 +519,18 @@ test.describe("Functional tests", () => {
   }) => {
     await mount(<MultiActionButtonList />);
 
-    await getComponent(page, "multi-action-button")
-      .first()
-      .locator("button")
-      .click();
-    await expect(getDataElementByValue(page, "additional-buttons")).toHaveCount(
-      1,
-    );
-    await getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0)
-      .click();
-    await expect(getDataElementByValue(page, "additional-buttons")).toHaveCount(
-      0,
-    );
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
+    await actionButton.click();
+
+    const additionalButtons = page.getByRole("list");
+    await expect(additionalButtons).toBeVisible();
+
+    const listButton3 = page.getByRole("button", { name: "Short" });
+    await listButton3.click();
+
+    await expect(additionalButtons).not.toBeVisible();
   });
 });
 
@@ -542,17 +541,13 @@ test.describe("Functional tests with child buttons wrapped in a custom component
   }) => {
     await mount(<WithWrapper />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .locator("button")
-      .first();
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
+    await page.keyboard.press("Tab");
 
-    await page.keyboard.press("ArrowUp");
-    await expect(listButton1).toBeFocused();
-    await page.keyboard.press("ArrowUp");
+    const listButton1 = page.getByRole("button", { name: "Button 1" });
     await expect(listButton1).toBeFocused();
     await page.keyboard.press("ArrowUp");
     await expect(listButton1).toBeFocused();
@@ -564,24 +559,18 @@ test.describe("Functional tests with child buttons wrapped in a custom component
   }) => {
     await mount(<WithWrapper />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .first()
-      .locator("button");
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton2 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(1);
+    const listButton1 = page.getByRole("button", { name: "Button 1" });
+    const listButton2 = page.getByRole("button", { name: "Button 2" });
 
     await listButton2.focus();
     await page.keyboard.press("Shift+Tab");
     await expect(listButton1).toBeFocused();
     await page.keyboard.press("Shift+Tab");
-    await expect(
-      getComponent(page, "multi-action-button").locator("button"),
-    ).toBeFocused();
+    await expect(actionButton).toBeFocused();
     await expect(listButton1).not.toBeVisible();
     await expect(listButton2).not.toBeVisible();
   });
@@ -592,13 +581,11 @@ test.describe("Functional tests with child buttons wrapped in a custom component
   }) => {
     await mount(<WithWrapper />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .locator("button")
-      .first();
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const listButton3 = page.getByRole("button", { name: "Button 3" });
 
     await listButton3.focus();
     await page.keyboard.press("ArrowDown");
@@ -611,29 +598,33 @@ test.describe("Functional tests with child buttons wrapped in a custom component
   }) => {
     await mount(<WithWrapperTwoButtons />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .first()
-      .locator("button");
-    await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton2 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(1);
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const actionButton1 = page.getByRole("button", {
+      name: "Multi Action Button 1",
+    });
+    await actionButton1.click();
 
+    const listButton1 = page.getByRole("button", {
+      name: "Button 1",
+      exact: true,
+    });
+    const listButton2 = page.getByRole("button", {
+      name: "Button 2",
+      exact: true,
+    });
+    const listButton3 = page.getByRole("button", { name: "Button 3" });
+
+    await page.keyboard.press("Tab");
     await expect(listButton1).toBeFocused();
     await page.keyboard.press("Tab");
     await expect(listButton2).toBeFocused();
     await page.keyboard.press("Tab");
     await expect(listButton3).toBeFocused();
     await page.keyboard.press("Tab");
-    await expect(
-      getComponent(page, "multi-action-button").nth(1).locator("button"),
-    ).toBeFocused();
+
+    const actionButton2 = page.getByRole("button", {
+      name: "Multi Action Button 2",
+    });
+    await expect(actionButton2).toBeFocused();
     await expect(listButton1).not.toBeVisible();
     await expect(listButton2).not.toBeVisible();
     await expect(listButton3).not.toBeVisible();
@@ -645,16 +636,12 @@ test.describe("Functional tests with child buttons wrapped in a custom component
   }) => {
     await mount(<WithWrapper />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .locator("button")
-      .first();
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const listButton1 = page.getByRole("button", { name: "Button 1" });
+    const listButton3 = page.getByRole("button", { name: "Button 3" });
 
     await listButton3.focus();
     await page.keyboard.down("Meta");
@@ -669,16 +656,12 @@ test.describe("Functional tests with child buttons wrapped in a custom component
   }) => {
     await mount(<WithWrapper />);
 
-    const actionButtonComp = getComponent(page, "multi-action-button")
-      .locator("button")
-      .first();
-    await actionButtonComp.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
+    await actionButton.click();
+    const listButton1 = page.getByRole("button", { name: "Button 1" });
+    const listButton3 = page.getByRole("button", { name: "Button 3" });
 
     await listButton3.focus();
     await page.keyboard.down("Control");
@@ -693,16 +676,12 @@ test.describe("Functional tests with child buttons wrapped in a custom component
   }) => {
     await mount(<WithWrapper />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .locator("button")
-      .first();
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const listButton1 = page.getByRole("button", { name: "Button 1" });
+    const listButton3 = page.getByRole("button", { name: "Button 3" });
 
     await listButton3.focus();
     await page.keyboard.press("Home");
@@ -715,17 +694,14 @@ test.describe("Functional tests with child buttons wrapped in a custom component
   }) => {
     await mount(<WithWrapper />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .locator("button")
-      .first();
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const listButton1 = page.getByRole("button", { name: "Button 1" });
+    const listButton3 = page.getByRole("button", { name: "Button 3" });
 
+    await page.keyboard.press("Tab");
     await expect(listButton1).toBeFocused();
     await page.keyboard.down("Meta");
     await page.keyboard.press("ArrowDown");
@@ -739,17 +715,14 @@ test.describe("Functional tests with child buttons wrapped in a custom component
   }) => {
     await mount(<WithWrapper />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .locator("button")
-      .first();
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const listButton1 = page.getByRole("button", { name: "Button 1" });
+    const listButton3 = page.getByRole("button", { name: "Button 3" });
 
+    await page.keyboard.press("Tab");
     await expect(listButton1).toBeFocused();
     await page.keyboard.down("Control");
     await page.keyboard.press("ArrowDown");
@@ -763,17 +736,14 @@ test.describe("Functional tests with child buttons wrapped in a custom component
   }) => {
     await mount(<WithWrapper />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .locator("button")
-      .first();
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    const listButton1 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0);
-    const listButton3 = getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(2);
+    const listButton1 = page.getByRole("button", { name: "Button 1" });
+    const listButton3 = page.getByRole("button", { name: "Button 3" });
 
+    await page.keyboard.press("Tab");
     await expect(listButton1).toBeFocused();
     await page.keyboard.press("End");
     await expect(listButton3).toBeFocused();
@@ -785,17 +755,15 @@ test.describe("Functional tests with child buttons wrapped in a custom component
   }) => {
     await mount(<WithWrapper />);
 
-    const actionButton = getComponent(page, "multi-action-button")
-      .locator("button")
-      .first();
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
     await actionButton.click();
-    await expect(getDataElementByValue(page, "additional-buttons")).toHaveCount(
-      1,
-    );
+
+    const additionalButtons = page.getByRole("list");
+    await expect(additionalButtons).toBeVisible();
     await page.keyboard.press("Escape");
-    await expect(getDataElementByValue(page, "additional-buttons")).toHaveCount(
-      0,
-    );
+    await expect(additionalButtons).not.toBeVisible();
   });
 
   test(`should verify that clicking one of the child buttons closes MultiActionButton`, async ({
@@ -804,20 +772,18 @@ test.describe("Functional tests with child buttons wrapped in a custom component
   }) => {
     await mount(<WithWrapper />);
 
-    await getComponent(page, "multi-action-button")
-      .locator("button")
-      .first()
-      .click();
-    await expect(getDataElementByValue(page, "additional-buttons")).toHaveCount(
-      1,
-    );
-    await getDataElementByValue(page, "additional-buttons")
-      .getByRole("button")
-      .nth(0)
-      .click();
-    await expect(getDataElementByValue(page, "additional-buttons")).toHaveCount(
-      0,
-    );
+    const actionButton = page.getByRole("button", {
+      name: "Multi Action Button",
+    });
+    await actionButton.click();
+
+    const additionalButtons = page.getByRole("list");
+    await expect(additionalButtons).toBeVisible();
+
+    const listButton3 = page.getByRole("button", { name: "Button 3" });
+    await listButton3.click();
+
+    await expect(additionalButtons).not.toBeVisible();
   });
 });
 
@@ -828,7 +794,6 @@ test.describe("Accessibility tests", () => {
     await checkAccessibility(page);
   });
 
-  // TODO: test passes even when it shouldn't, see FE-6267
   test(`should pass tests when open`, async ({ mount, page }) => {
     await mount(<MultiActionButtonList />);
 

--- a/src/components/multi-action-button/multi-action-button.style.ts
+++ b/src/components/multi-action-button/multi-action-button.style.ts
@@ -96,10 +96,14 @@ const StyledButtonChildrenContainer = styled.ul.attrs(
       margin-left: 0;
       min-width: 100%;
       text-align: ${align};
-      z-index: ${theme.zIndex.overlay};
 
       & + & {
         margin-top: 3px;
+      }
+
+      &:focus {
+        position: relative;
+        z-index: 1;
       }
     }
   `}

--- a/src/components/multi-action-button/multi-action-button.test.tsx
+++ b/src/components/multi-action-button/multi-action-button.test.tsx
@@ -104,7 +104,7 @@ test("should focus the main button when the focusMainButton on the ref handle is
   expect(screen.getByRole("button", { name: "Main Button" })).toHaveFocus();
 });
 
-test("should open additional buttons when the main button is clicked and focus on the first child", async () => {
+test("should open additional buttons when the main button is clicked", async () => {
   const user = userEvent.setup();
   render(
     <MultiActionButton text="Main Button">
@@ -118,7 +118,23 @@ test("should open additional buttons when the main button is clicked and focus o
   const button = screen.getByRole("button", { name: "First" });
 
   expect(button).toBeVisible();
-  expect(button).toHaveFocus();
+});
+
+test("should close additional buttons when the toggle button is clicked", async () => {
+  const user = userEvent.setup();
+  render(
+    <MultiActionButton text="Main Button">
+      <Button>First</Button>
+    </MultiActionButton>,
+  );
+
+  await user.click(screen.getByRole("button", { name: "Main Button" }));
+  expect(screen.getByRole("button", { name: "First" })).toBeVisible();
+
+  await user.click(screen.getByRole("button", { name: "Main Button" }));
+  expect(
+    screen.queryByRole("button", { name: "First" }),
+  ).not.toBeInTheDocument();
 });
 
 test("should close additional buttons when a child button is clicked", async () => {

--- a/src/components/split-button/split-button-children.style.ts
+++ b/src/components/split-button/split-button-children.style.ts
@@ -58,10 +58,14 @@ const StyledSplitButtonChildrenContainer = styled.ul.attrs(
       margin-left: 0;
       min-width: 100%;
       text-align: ${align};
-      z-index: ${theme.zIndex.overlay};
 
       & + & {
         margin-top: 3px;
+      }
+
+      &:focus {
+        position: relative;
+        z-index: 1;
       }
     }
   `}

--- a/src/components/split-button/split-button.component.tsx
+++ b/src/components/split-button/split-button.component.tsx
@@ -147,7 +147,14 @@ export const SplitButton = forwardRef<SplitButtonHandle, SplitButtonProps>(
     };
 
     const handleToggleClick = () => {
-      showButtons();
+      // ensure button is focused when clicked (Safari)
+      toggleButtonRef.current?.focus({ preventScroll: true });
+
+      if (showAdditionalButtons) {
+        hideButtons();
+      } else {
+        showButtons();
+      }
     };
 
     const toggleButtonProps = {

--- a/src/components/split-button/split-button.component.tsx
+++ b/src/components/split-button/split-button.component.tsx
@@ -91,6 +91,7 @@ export const SplitButton = forwardRef<SplitButtonHandle, SplitButtonProps>(
     const locale = useLocale();
     const theme = useContext(ThemeContext) || baseTheme;
     const buttonLabelId = useRef(guid());
+    const submenuId = useRef(guid());
 
     const mainButtonRef = useRef<HTMLButtonElement>(null);
     const toggleButtonRef = useRef<HTMLButtonElement>(null);
@@ -196,8 +197,8 @@ export const SplitButton = forwardRef<SplitButtonHandle, SplitButtonProps>(
           {text}
         </Button>,
         <StyledSplitButtonToggle
-          aria-haspopup="true"
           aria-expanded={showAdditionalButtons}
+          aria-controls={submenuId.current}
           aria-label={ariaLabel || locale.splitButton.ariaLabel()}
           data-element="toggle-button"
           key="toggle-button"
@@ -236,7 +237,11 @@ export const SplitButton = forwardRef<SplitButtonHandle, SplitButtonProps>(
             }),
           ]}
         >
-          <StyledSplitButtonChildrenContainer {...wrapperProps} align={align}>
+          <StyledSplitButtonChildrenContainer
+            id={submenuId.current}
+            {...wrapperProps}
+            align={align}
+          >
             <SplitButtonContext.Provider value={contextValue}>
               {React.Children.map(children, (child) => (
                 <li>{child}</li>

--- a/src/components/split-button/split-button.pw.tsx
+++ b/src/components/split-button/split-button.pw.tsx
@@ -414,7 +414,6 @@ test.describe("Accessibility tests", () => {
     await checkAccessibility(page);
   });
 
-  // This now passes. I think it's because we've changed the popover to now have `disablePortal` prop as true.
   test(`should pass accessibility tests when open`, async ({ mount, page }) => {
     await mount(<SplitButtonList />);
 

--- a/src/components/split-button/split-button.test.tsx
+++ b/src/components/split-button/split-button.test.tsx
@@ -134,23 +134,6 @@ test("should focus the toggle button when the focusToggleButton on the ref handl
   expect(screen.getByRole("button", { name: "Show more" })).toHaveFocus();
 });
 
-test("focuses first child button when toggle button is clicked", async () => {
-  const user = userEvent.setup();
-  render(
-    <SplitButton text="Main">
-      <Button>Single Button</Button>
-    </SplitButton>,
-  );
-
-  await user.click(screen.getByRole("button", { name: "Show more" }));
-
-  const childButton = await screen.findByRole("button", {
-    name: "Single Button",
-  });
-
-  expect(childButton).toHaveFocus();
-});
-
 test("should render with the correct styles when 'size' is 'small''", async () => {
   const { fontSize, minHeight, paddingLeft, paddingRight } =
     buildSizeConfig("small");
@@ -469,7 +452,7 @@ test("should render the child buttons when a 'Enter' keydown event detected and 
   });
 
   expect(childButton).toBeVisible();
-  expect(childButton).toHaveFocus();
+  expect(toggle).toHaveFocus();
 });
 
 test("should render the child buttons when a ' ' (space) keydown event detected and toggle button is focused", async () => {
@@ -487,7 +470,7 @@ test("should render the child buttons when a ' ' (space) keydown event detected 
   });
 
   expect(childButton).toBeVisible();
-  expect(childButton).toHaveFocus();
+  expect(toggle).toHaveFocus();
 });
 
 test("should render the child buttons when a 'ArrowDown' keydown event detected and toggle button is focused", async () => {
@@ -498,30 +481,15 @@ test("should render the child buttons when a 'ArrowDown' keydown event detected 
     </SplitButton>,
   );
 
-  const toggle = await screen.findByRole("button", { name: "Show more" });
+  const toggle = screen.getByRole("button", { name: "Show more" });
   toggle.focus();
-  expect(toggle).toHaveFocus();
-  await user.keyboard("{arrowdown}");
-  const child = await screen.findByRole("button", { name: "Single Button" });
-  expect(child).toBeVisible();
-  expect(child).toHaveFocus();
-});
+  await user.keyboard("{arrowDown}");
+  const childButton = await screen.findByRole("button", {
+    name: "Single Button",
+  });
 
-test("should render the child buttons when a 'ArrowUp' keydown event detected and toggle button is focused", async () => {
-  const user = userEvent.setup();
-  render(
-    <SplitButton text="Main">
-      <Button>Single Button</Button>
-    </SplitButton>,
-  );
-
-  const toggle = await screen.findByRole("button", { name: "Show more" });
-  toggle.focus();
+  expect(childButton).toBeVisible();
   expect(toggle).toHaveFocus();
-  await user.keyboard("{arrowup}");
-  const child = await screen.findByRole("button", { name: "Single Button" });
-  expect(child).toBeVisible();
-  expect(child).toHaveFocus();
 });
 
 test("should not render the child buttons when a keydown event detected with unrelated key and toggle button is focused", async () => {
@@ -630,6 +598,46 @@ test("should hide the additional buttons when a click event detected outside the
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
 });
 
+test("should hide the additional buttons when the list is open and 'Enter' key is pressed on the toggle button", async () => {
+  const user = userEvent.setup();
+  render(
+    <SplitButton text="Main">
+      <Button>Single Button</Button>
+    </SplitButton>,
+  );
+
+  const toggle = screen.getByRole("button", { name: "Show more" });
+  toggle.focus();
+  await user.keyboard("{Enter}");
+  const childButton = await screen.findByRole("button", {
+    name: "Single Button",
+  });
+
+  expect(childButton).toBeVisible();
+  await user.keyboard("{Enter}");
+  expect(screen.queryByRole("list")).not.toBeInTheDocument();
+});
+
+test("should hide the additional buttons when the list is open and 'Space' key is pressed on the toggle button", async () => {
+  const user = userEvent.setup();
+  render(
+    <SplitButton text="Main">
+      <Button>Single Button</Button>
+    </SplitButton>,
+  );
+
+  const toggle = screen.getByRole("button", { name: "Show more" });
+  toggle.focus();
+  await user.keyboard(" ");
+  const childButton = await screen.findByRole("button", {
+    name: "Single Button",
+  });
+
+  expect(childButton).toBeVisible();
+  await user.keyboard(" ");
+  expect(screen.queryByRole("list")).not.toBeInTheDocument();
+});
+
 test("should hide the additional buttons when a 'Escape' keydown event detected and focus is within component", async () => {
   const user = userEvent.setup();
   render(
@@ -713,6 +721,27 @@ test("should hide the additional buttons when the main button is clicked", async
   expect(childButton).not.toBeInTheDocument();
 });
 
+test("should hide the additional buttons when the list is open the toggle button is clicked", async () => {
+  const user = userEvent.setup();
+  render(
+    <SplitButton text="Main">
+      <Button>Single Button</Button>
+    </SplitButton>,
+  );
+
+  const toggle = screen.getByRole("button", { name: "Show more" });
+  await user.click(toggle);
+  const childButton = await screen.findByRole("button", {
+    name: "Single Button",
+  });
+
+  expect(childButton).toBeVisible();
+
+  await user.click(toggle);
+
+  expect(screen.queryByRole("list")).not.toBeInTheDocument();
+});
+
 test("should support navigating the additional buttons via down arrow key but stop on last button", async () => {
   const user = userEvent.setup();
   render(
@@ -736,6 +765,7 @@ test("should support navigating the additional buttons via down arrow key but st
     name: "Extra Button 3",
   });
 
+  await user.keyboard("{arrowDown}");
   expect(button1).toHaveFocus();
   await user.keyboard("{arrowDown}");
   expect(button2).toHaveFocus();
@@ -767,9 +797,9 @@ test("should support navigating the additional buttons via up arrow key but stop
   const button3 = await screen.findByRole("button", {
     name: "Extra Button 3",
   });
-  await user.keyboard("{arrowDown}");
-  await user.keyboard("{arrowDown}");
 
+  await user.keyboard("{arrowDown}");
+  await user.keyboard("{end}");
   expect(button3).toHaveFocus();
   await user.keyboard("{arrowUp}");
   expect(button2).toHaveFocus();
@@ -799,6 +829,7 @@ test("focuses last child button when End key is pressed", async () => {
     name: "Extra Button 3",
   });
 
+  await user.tab();
   expect(button1).toHaveFocus();
   await user.keyboard("{end}");
   expect(button3).toHaveFocus();
@@ -820,6 +851,7 @@ test("focuses last child button when Control and ArrowDown key are pressed toget
     name: "Extra Button 3",
   });
 
+  await user.tab();
   await user.keyboard("{Control>}{ArrowDown}{/Control}");
 
   expect(button3).toHaveFocus();
@@ -841,6 +873,7 @@ test("focuses last child button when Meta and ArrowDown key are pressed together
     name: "Extra Button 3",
   });
 
+  await user.tab();
   await user.keyboard("{Meta>}{ArrowDown}{/Meta}");
 
   expect(button3).toHaveFocus();
@@ -864,8 +897,8 @@ test("focuses first child button when Home key is pressed", async () => {
   const button3 = await screen.findByRole("button", {
     name: "Extra Button 3",
   });
-  expect(button1).toHaveFocus();
 
+  await user.tab();
   await user.keyboard("{End}");
   expect(button3).toHaveFocus();
 
@@ -887,9 +920,14 @@ test("focuses first child button when Control and ArrowUp key are pressed togeth
   const button1 = await screen.findByRole("button", {
     name: "Extra Button 1",
   });
+  const button3 = await screen.findByRole("button", {
+    name: "Extra Button 3",
+  });
+
+  await user.tab();
   await user.keyboard("{End}");
 
-  expect(screen.getByRole("button", { name: "Extra Button 3" })).toHaveFocus();
+  expect(button3).toHaveFocus();
 
   await user.keyboard("{Control>}{ArrowUp}{/Control}");
 
@@ -910,9 +948,14 @@ test("focuses first child button when Meta and ArrowUp key are pressed together"
   const button1 = await screen.findByRole("button", {
     name: "Extra Button 1",
   });
+  const button3 = await screen.findByRole("button", {
+    name: "Extra Button 3",
+  });
+
+  await user.tab();
   await user.keyboard("{End}");
 
-  expect(screen.getByRole("button", { name: "Extra Button 3" })).toHaveFocus();
+  expect(button3).toHaveFocus();
 
   await user.keyboard("{Meta>}{ArrowUp}{/Meta}");
 
@@ -931,7 +974,7 @@ test("should support navigating the additional buttons via tab key", async () =>
 
   const toggle = screen.getByRole("button", { name: "Show more" });
   toggle.focus();
-  await user.keyboard("{arrowDown}");
+  await user.keyboard("{Enter}");
   const button1 = await screen.findByRole("button", {
     name: "Extra Button 1",
   });
@@ -942,6 +985,7 @@ test("should support navigating the additional buttons via tab key", async () =>
     name: "Extra Button 3",
   });
 
+  await user.tab();
   expect(button1).toHaveFocus();
   await user.tab();
   expect(button2).toHaveFocus();
@@ -961,7 +1005,7 @@ test("should support navigating the additional buttons via shift+tab key, hide t
 
   const toggle = screen.getByRole("button", { name: "Show more" });
   toggle.focus();
-  await user.keyboard("{arrowDown}");
+  await user.keyboard("{Enter}");
   const button1 = await screen.findByRole("button", {
     name: "Extra Button 1",
   });
@@ -972,6 +1016,7 @@ test("should support navigating the additional buttons via shift+tab key, hide t
     name: "Extra Button 3",
   });
 
+  await user.tab();
   expect(button1).toHaveFocus();
   await user.keyboard("{end}");
   expect(button3).toHaveFocus();

--- a/src/hooks/__internal__/useChildButtons/useChildButtons.tsx
+++ b/src/hooks/__internal__/useChildButtons/useChildButtons.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from "react";
+import { useState, useRef, useCallback } from "react";
 import Events from "../../../__internal__/utils/helpers/events";
 import useMenuKeyboardNavigation from "../useMenuKeyboardNavigation";
 
@@ -35,25 +35,24 @@ const useChildButtons = (
     [],
   );
 
-  // focus first child button when opened
-  useEffect(() => {
-    if (showAdditionalButtons) {
-      getButtonChildren()?.[0]?.focus();
-    }
-  }, [showAdditionalButtons, getButtonChildren]);
-
   const handleToggleButtonKeyDown = (
     ev: React.KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>,
   ) => {
-    const isToggleKey =
-      Events.isEnterKey(ev) ||
-      Events.isSpaceKey(ev) ||
-      Events.isDownKey(ev) ||
-      Events.isUpKey(ev);
+    const isToggleKey = Events.isEnterKey(ev) || Events.isSpaceKey(ev);
 
-    if (isToggleKey) {
+    if ((isToggleKey || Events.isDownKey(ev)) && !showAdditionalButtons) {
       ev.preventDefault();
       showButtons();
+    }
+
+    if (Events.isDownKey(ev) && showAdditionalButtons) {
+      ev.preventDefault();
+      getButtonChildren()?.[0]?.focus({ preventScroll: true });
+    }
+
+    if (isToggleKey && showAdditionalButtons) {
+      ev.preventDefault();
+      hideButtons();
     }
   };
 


### PR DESCRIPTION
fix #7264

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

`Menu`, `MultiActionButton` and `SplitButton`: 
- Maintain focus on toggle button/parent item on submenu open. 
- Do not open submenu with ArrowUp.
- Close submenu with Enter/Space on toggle button/parent item.

`MultiActionButton` and `SplitButton`:
- Closes submenu with Enter/Space or click on toggle button.
- Remove `aria-haspopup` and `add aria-controls` to toggle button.
- Focus border is not covered by hover style on menu buttons.

<img width="233" alt="image" src="https://github.com/user-attachments/assets/766ee24f-9dc3-4d1c-a4c7-a7ee522a56f3" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

`Menu`, `MultiActionButton` and `SplitButton`: 
- Focus first menu item on submenu open. 
- Open submenu with ArrowUp.

`MultiActionButton` and `SplitButton`:
- Has `aria-haspopup` on toggle button.
- Focus border is covered by hover style on menu buttons.

<img width="247" alt="image" src="https://github.com/user-attachments/assets/c2d92b60-bab8-4546-8a8d-59114e4a2670" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

All components should:
- Open the submenu with Enter/Space/ArrowDown/Click.
- Close the submenu with Enter/Space/Click.
- Navigate into the menu with Tab/ArrowDown

Exception - in `Menu` when parent item has `href` and a submenu, menu should first open, Space should close and Enter should follow the link (expected default behaviour). See "Submenu Options" story in Menu. 

Screen readers should be able to navigate into the submenu list.