### PR TITLE
feat(responsive-vertical-menu): fix stale menu bug when child items change

### DIFF
--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-item/responsive-vertical-menu-item.component.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-item/responsive-vertical-menu-item.component.tsx
@@ -413,8 +413,10 @@ export const ResponsiveVerticalMenuItem = ({
 
   // Register the menu item with the focus context
   useEffect(() => {
-    registerMenuItem(uniqueId.current, itemRef, parentId);
-  }, [id, registerMenuItem, parentId]);
+    const currentId = uniqueId.current;
+
+    registerMenuItem(currentId, itemRef, parentId);
+  }, [parentId, registerMenuItem]);
 
   return (
     <BaseItem

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-test.stories.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-test.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 
 import {
   ResponsiveVerticalMenu,
@@ -372,3 +372,94 @@ export const MixedIcons = (props: Partial<ResponsiveVerticalMenuProps>) => {
   );
 };
 MixedIcons.storyName = "Mixed Icons";
+
+type MenuItem = {
+  productName: string;
+  menuItems?: MenuItem[];
+};
+
+const useGetData = () => {
+  const [data] = useState<MenuItem[]>([
+    {
+      productName: "foo",
+      menuItems: [{ productName: "bar" }, { productName: "baz" }],
+    },
+  ]);
+  return data;
+};
+
+const usePostData = () => {
+  const [postData, setPostData] = useState<MenuItem[]>([]);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setPostData([
+        {
+          productName: "accounting",
+          menuItems: [
+            {
+              productName: "payroll",
+              menuItems: [{ productName: "payroll-summary" }],
+            },
+            { productName: "hr" },
+            { productName: "clientmanage" },
+          ],
+        },
+      ]);
+    }, 5000);
+    return () => {
+      clearTimeout(handle);
+    };
+  }, []);
+  return postData;
+};
+
+const TestMenu = ({ data }: { data: MenuItem[] }) => {
+  const postData = usePostData();
+
+  const products = postData.length === 0 ? data : postData;
+
+  return (
+    <ResponsiveVerticalMenuProvider>
+      <ResponsiveVerticalMenu height="100%">
+        <>
+          <ResponsiveVerticalMenuItem
+            label="Home"
+            id="home"
+            icon="home"
+            href="#"
+          />
+          {products.map((p) => (
+            <ResponsiveVerticalMenuItem
+              key={p.productName}
+              id={p.productName}
+              label={p.productName}
+            >
+              {p?.menuItems?.map((s) => (
+                <ResponsiveVerticalMenuItem
+                  key={s.productName}
+                  id={s.productName}
+                  label={s.productName}
+                >
+                  {s?.menuItems?.map((t) => (
+                    <ResponsiveVerticalMenuItem
+                      key={t.productName}
+                      id={t.productName}
+                      label={t.productName}
+                    />
+                  ))}
+                </ResponsiveVerticalMenuItem>
+              ))}
+            </ResponsiveVerticalMenuItem>
+          ))}
+        </>
+      </ResponsiveVerticalMenu>
+    </ResponsiveVerticalMenuProvider>
+  );
+};
+
+export const DelayedMenuItems = () => {
+  const data = useGetData();
+  return <TestMenu data={data} />;
+};
+DelayedMenuItems.storyName = "Delayed Menu Items";

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
@@ -58,6 +58,7 @@ const BaseMenu = ({
     setResponsiveMode,
   } = useResponsiveVerticalMenu();
   const [active, setActive] = useState(false);
+  const [childItemCount, setChildItemCount] = useState(0);
   const largeScreen = useIsAboveBreakpoint(responsiveBreakpoint);
   const [left, setLeft] = useState("auto");
   const [responsiveWidth, setResponsiveWidth] = useState("100%");
@@ -161,6 +162,53 @@ const BaseMenu = ({
     setReducedMotion?.(reduceMotion);
     setResponsiveMode?.(!largeScreen);
   }, [largeScreen, reduceMotion, setReducedMotion, setResponsiveMode]);
+
+  const countChildren = useCallback((currentChildren: React.ReactNode) => {
+    // If there are no children, return 0
+    if (!currentChildren) {
+      return 0;
+    }
+
+    // If the content of children is a single React element, count it and check its children
+    if (React.isValidElement(currentChildren)) {
+      const nodeChildren: number = countChildren(
+        currentChildren.props.children,
+      );
+      return 1 + nodeChildren;
+    }
+
+    // If the content of children is an array of React elements, iterate through them
+    const childrenAsArray = React.Children.toArray(currentChildren);
+
+    /* istanbul ignore else */
+    if (childrenAsArray.length) {
+      const reducedChildren: number = childrenAsArray.reduce(
+        (acc: number, child: React.ReactNode) => {
+          /* istanbul ignore else */
+          if (React.isValidElement(child)) {
+            const total = acc + 1;
+            const childrenCount = countChildren(child.props.children);
+            return total + childrenCount;
+          }
+          return acc;
+        },
+        0,
+      );
+
+      return reducedChildren;
+    }
+    return 0;
+  }, []);
+
+  useEffect(() => {
+    const previousChildCount = childItemCount;
+    const newChildCount = countChildren(children);
+
+    if (previousChildCount !== newChildCount) {
+      setChildItemCount(newChildCount);
+      setActiveMenuItem(null);
+    }
+  }, [childItemCount, children, countChildren, setActiveMenuItem]);
 
   return (
     <div ref={containerRef}>

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.test.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.test.tsx
@@ -1362,3 +1362,61 @@ test("correct aria-label values are set", async () => {
     "Test product menu close button",
   );
 });
+
+// coverage: children is an empty array
+test("children populated by empty map", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  mockUseIsAboveBreakpoint.mockReturnValue(false);
+
+  render(
+    <ResponsiveVerticalMenuProvider>
+      <ResponsiveVerticalMenu>
+        <ResponsiveVerticalMenuItem
+          data-role="menu-item-1"
+          icon="home"
+          id="menu-item-1"
+          label="Menu Item 1"
+        >
+          {[].map((item) => item)}
+        </ResponsiveVerticalMenuItem>
+      </ResponsiveVerticalMenu>
+    </ResponsiveVerticalMenuProvider>,
+  );
+
+  const launcherButton = screen.getByTestId(
+    "responsive-vertical-menu-launcher",
+  );
+  await user.click(launcherButton);
+
+  const menuItem = screen.getByTestId("menu-item-1");
+  expect(menuItem).toBeInTheDocument();
+});
+
+// coverage: children is a list of non-React elements
+test("children populated by map of non-React elements", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  mockUseIsAboveBreakpoint.mockReturnValue(false);
+
+  render(
+    <ResponsiveVerticalMenuProvider>
+      <ResponsiveVerticalMenu>
+        <ResponsiveVerticalMenuItem
+          data-role="menu-item-1"
+          icon="home"
+          id="menu-item-1"
+          label="Menu Item 1"
+        >
+          {["a", "b", "c"].map((item) => item)}
+        </ResponsiveVerticalMenuItem>
+      </ResponsiveVerticalMenu>
+    </ResponsiveVerticalMenuProvider>,
+  );
+
+  const launcherButton = screen.getByTestId(
+    "responsive-vertical-menu-launcher",
+  );
+  await user.click(launcherButton);
+
+  const menuItem = screen.getByTestId("menu-item-1");
+  expect(menuItem).toBeInTheDocument();
+});


### PR DESCRIPTION
### Proposed behaviour

Add a simple watcher that clears the active menu when the total number of children changes, which removes and hides any obsolete data

### Current behaviour

Menu items loaded with possible delay can display with stale or invalid values

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

View the story under `VerticalMenu > Responsive > Test > Delayed Menu Items`. Upon loading, immediately open the menu and then the available sub-menu. After 5 seconds, the menu should update and close. Clicking the newly-replaced menu item should show different options correctly.