### PR TITLE
fix(responsive-vertical-menu): fix issue that stopped off-screen menu items from scrolling into view

### DIFF
--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.style.ts
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.style.ts
@@ -84,6 +84,10 @@ export const StyledResponsiveMenu = styled.div<StyledResponsiveMenuProps>`
       ? "2px solid var(--colorsGray850)"
       : "1px solid var(--colorsGray850)"};
 
+  & > :last-child {
+    margin-bottom: 40px;
+  }
+
   ${({ childOpen }) =>
     childOpen &&
     css`
@@ -95,13 +99,5 @@ export const StyledResponsiveMenu = styled.div<StyledResponsiveMenuProps>`
     css`
       left: ${left};
       min-height: ${height};
-    `}
-
-    ${({ responsive }) =>
-    !responsive &&
-    css`
-      & > :last-child {
-        margin-bottom: 40px;
-      }
     `}
 `;


### PR DESCRIPTION
### Proposed behaviour

Ensure that both responsive and non-responsive view modes applied the bottom margin to the final item to ensure that scrolling can always occur and that all items are reachable

### Current behaviour

It is not possible in responsive mode to scroll beyond the final item in a responsive vertical menu, which can lead to the last item being beyond the reach of users

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Use the `Test > Default` story under `Vertical Menu > Responsive` and use the browser's device emulator to a small device e.g. an iPhone SE 2nd Gen (or a device running at a resolution of 375x667). Open the menu and ensure that the `Give feedback` menu item is always able to be viewed when scrolling occurs.