### PR TITLE
fix(adaptive-sidebar): ensure all elements are indexed behind the component when rendered as a modal

### DIFF
--- a/src/__internal__/input/input-presentation.test.tsx
+++ b/src/__internal__/input/input-presentation.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import InputPresentation from "./input-presentation.component";
 import Input from "./input.component";
 import { InputContext, InputGroupContext } from "../input-behaviour";
+import StyledSelect from "../../components/select/select.style";
 
 test("renders presentational div and presentation container elements", () => {
   render(<InputPresentation>Children</InputPresentation>);
@@ -106,8 +107,27 @@ test("triggers a passed function via the `onMouseLeave` prop from the input cont
   expect(onMouseLeaveMock).toHaveBeenCalled();
 });
 
-/* Styling test for coverage */
+test("applies the correct z-index values when inside an open select", () => {
+  render(
+    <StyledSelect isOpen>
+      <InputPresentation>
+        <Input />
+      </InputPresentation>
+      ,
+    </StyledSelect>,
+  );
 
+  const inputPresentation = screen.getByRole("presentation");
+  const backdropIndex =
+    getComputedStyle(inputPresentation).getPropertyValue("z-index");
+
+  // non-default value
+  expect(backdropIndex).toContain("--adaptiveSidebarModalBackdrop");
+  // default value
+  expect(backdropIndex).toContain("9999");
+});
+
+/* Styling test for coverage */
 test.each(["left", "right"])(
   "when `hasIcon` is true and the `align` prop is %s, the corresponding padding attribute is 0",
   (alignValue) => {

--- a/src/__internal__/popover/popover.style.ts
+++ b/src/__internal__/popover/popover.style.ts
@@ -7,7 +7,12 @@ export const StyledBackdrop = styled.div.attrs(applyBaseTheme)`
   position: fixed;
   right: 0;
   top: 0;
-  z-index: ${({ theme }) => theme.zIndex.popover};
+  /* If behind an adaptive sidebar, use the backdrop z-index value, if not default to original z-index value */
+  z-index: var(
+    --adaptiveSidebarModalBackdrop,
+    ${({ theme }) => theme.zIndex.popover}
+  );
+
   background: transparent;
 `;
 

--- a/src/__internal__/popover/popover.test.tsx
+++ b/src/__internal__/popover/popover.test.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Popover, { PopoverProps } from "./popover.component";
-import { baseTheme } from "../../style/themes";
 import Dialog from "../../components/dialog";
 
 const PopoverWithButton = (
@@ -144,15 +143,22 @@ test("renders popup within a transparent backdrop to prevent scrolling outside t
   );
 
   const backdrop = screen.getByTestId("popup-backdrop");
+
   expect(backdrop).toHaveStyle({
     background: "transparent",
-    zIndex: baseTheme.zIndex.popover,
     position: "fixed",
     top: 0,
     right: 0,
     bottom: 0,
     left: 0,
   });
+
+  const backdropIndex = getComputedStyle(backdrop).getPropertyValue("z-index");
+
+  // non-default value
+  expect(backdropIndex).toContain("--adaptiveSidebarModalBackdrop");
+  // default value
+  expect(backdropIndex).toContain("6000");
 });
 
 test("does not render a backdrop when disableBackgroundUI is false", () => {

--- a/src/components/adaptive-sidebar/adaptive-sidebar-test.stories.tsx
+++ b/src/components/adaptive-sidebar/adaptive-sidebar-test.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useLayoutEffect, useState } from "react";
 
 import { StoryObj } from "@storybook/react/*";
 import AdaptiveSidebar from ".";
@@ -451,6 +451,77 @@ ExampleImplementation.decorators = [
 
 ExampleImplementation.parameters = {
   chromatic: { disableSnapshot: false, viewports: [1200, 900] },
+  layout: "fullscreen",
+  themeProvider: {
+    chromatic: { theme: "sage" },
+  },
+};
+
+export const WithDropdown: StoryObj = () => {
+  // This is to ensure the select dropdown opens when the page loads
+  const selectRef = React.useRef<HTMLInputElement>(null);
+  useLayoutEffect(() => {
+    selectRef.current?.focus();
+  }, []);
+
+  return (
+    <Box margin="var(--spacing200)" display="flex" flexDirection="row">
+      <Box width="50%" display="flex" flexDirection="column">
+        <Typography variant="h1">Page content</Typography>
+        <Select
+          ref={selectRef}
+          openOnFocus
+          name="simple"
+          id="simple"
+          label="open dropdown and decrease screen size until sidebar changes to modal"
+        >
+          <Option text="Amber" value="1" />
+          <Option text="Black" value="2" />
+          <Option text="Blue" value="3" />
+          <Option text="Brown" value="4" />
+          <Option text="Green" value="5" />
+          <Option text="Orange" value="6" />
+          <Option text="Pink" value="7" />
+          <Option text="Purple" value="8" />
+          <Option text="Red" value="9" />
+          <Option text="White" value="10" />
+          <Option text="Yellow" value="11" />
+        </Select>
+      </Box>
+      <AdaptiveSidebar open width="50%">
+        <Typography variant="h1">Sidebar content</Typography>
+        <Select
+          name="simple-2"
+          id="simple-2"
+          label="open to test that the input and dropdowns show when the adaptive sidebar is open & triggered"
+        >
+          <Option text="Amber" value="1" />
+          <Option text="Black" value="2" />
+          <Option text="Blue" value="3" />
+          <Option text="Brown" value="4" />
+          <Option text="Green" value="5" />
+          <Option text="Orange" value="6" />
+          <Option text="Pink" value="7" />
+          <Option text="Purple" value="8" />
+          <Option text="Red" value="9" />
+          <Option text="White" value="10" />
+          <Option text="Yellow" value="11" />
+        </Select>
+      </AdaptiveSidebar>
+    </Box>
+  );
+};
+
+WithDropdown.decorators = [
+  (Story) => (
+    <Box height="100vh" width="100vw">
+      <Story />
+    </Box>
+  ),
+];
+
+WithDropdown.parameters = {
+  chromatic: { disableSnapshot: false, viewports: [767, 900] },
   layout: "fullscreen",
   themeProvider: {
     chromatic: { theme: "sage" },

--- a/src/components/adaptive-sidebar/adaptive-sidebar.component.tsx
+++ b/src/components/adaptive-sidebar/adaptive-sidebar.component.tsx
@@ -70,6 +70,7 @@ export const AdaptiveSidebar = ({
   if (renderAsModal || !largeScreen) {
     return (
       <StyledSidebar
+        className="adaptive-sidebar-modal-view"
         backgroundColor={backgroundColor}
         open={open}
         p={0}

--- a/src/components/flat-table/flat-table.test.tsx
+++ b/src/components/flat-table/flat-table.test.tsx
@@ -18,7 +18,6 @@ import DrawerSidebarContext from "../drawer/__internal__/drawer-sidebar.context"
 import { StyledFlatTableCell } from "./flat-table-cell/flat-table-cell.style";
 import StyledFlatTableRow from "./flat-table-row/flat-table-row.style";
 import Pager from "../pager/pager.component";
-import { baseTheme } from "../../style/themes";
 import DateInput from "../date/date.component";
 
 import {
@@ -1553,13 +1552,19 @@ test("when an ActionPopover is opened inside the FlatTable, it will have the bac
 
   expect(backdrop).toHaveStyle({
     background: "transparent",
-    zIndex: baseTheme.zIndex.popover,
     position: "fixed",
     top: 0,
     right: 0,
     bottom: 0,
     left: 0,
   });
+
+  const backdropIndex = getComputedStyle(backdrop).getPropertyValue("z-index");
+
+  // non-default value
+  expect(backdropIndex).toContain("--adaptiveSidebarModalBackdrop");
+  // default value
+  expect(backdropIndex).toContain("6000");
 
   await user.click(document.body);
 

--- a/src/components/select/select.style.ts
+++ b/src/components/select/select.style.ts
@@ -44,7 +44,8 @@ const StyledSelect = styled.div.attrs(applyBaseTheme)<StyledSelectProps>`
 
       ${isOpen &&
       css`
-        z-index: ${theme.zIndex.aboveAll};
+        /* If behind an adaptive sidebar, use the backdrop z-index value, if not default to original z-index value */
+        z-index: var(--adaptiveSidebarModalBackdrop, ${theme.zIndex.aboveAll});
       `}
 
       ${disabled &&

--- a/src/style/global-style.ts
+++ b/src/style/global-style.ts
@@ -3,6 +3,7 @@ import {
   TAB_GUARD_TOP,
   TAB_GUARD_BOTTOM,
 } from "../__internal__/focus-trap/focus-trap.component";
+import { baseTheme } from "./themes";
 
 const GlobalStyle = createGlobalStyle`
   body {
@@ -28,6 +29,11 @@ const GlobalStyle = createGlobalStyle`
 
   [data-element=${TAB_GUARD_TOP}], [data-element=${TAB_GUARD_BOTTOM}] {
     position: fixed;
+  }
+
+  body:has(.adaptive-sidebar-modal-view) {
+  --adaptiveSidebarModalBackdrop: ${baseTheme.zIndex.overlay};
+  
   }
 `;
 


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Adds a global style variable which ensures all popover based components and the select input have a lower z-index than the adaptive sidebar

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, when the adaptive sidebar hits the set breakpoint, any popover based components and the select input have a higher z-index, which causes them to still be visible, even when the adaptive sidebar covers them

<img width="483" alt="Screenshot 2025-06-18 at 17 08 00" src="https://github.com/user-attachments/assets/df888d96-efe9-43a8-a927-08e7b65237da" />


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

In the `WithDropdown` test story, a chromatic test has been added to catch the fixed regression.

Also, a select has also been added inside the adaptive sidebar to verify that the z-index of the fixed components is not adversely affected when rendered inside the adaptive sidebar
