### PR TITLE
fix(responsive-vertial-menu): menu closes when shrinking the size

### DIFF
--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
@@ -130,6 +130,32 @@ const BaseMenu = ({
     };
   }, [active, measureDimensions, menu, responsiveMode]);
 
+  const isResizingRef = useRef(false);
+  const resizeTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const handleResize = () => {
+      isResizingRef.current = true;
+
+      if (resizeTimeoutRef.current !== null) {
+        clearTimeout(resizeTimeoutRef.current);
+      }
+
+      resizeTimeoutRef.current = window.setTimeout(() => {
+        isResizingRef.current = false;
+      }, 100);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      if (resizeTimeoutRef.current !== null) {
+        clearTimeout(resizeTimeoutRef.current);
+      }
+    };
+  }, []);
+
   useEffect(() => {
     const handleBlur = ({ relatedTarget, target }: FocusEvent) => {
       /* istanbul ignore if */
@@ -145,7 +171,7 @@ const BaseMenu = ({
         /* istanbul ignore if */
         if (relatedTarget === null && target !== buttonRef.current) {
           setTimeout(() => {
-            if (!activeMenuItem) {
+            if (!activeMenuItem && !isResizingRef.current) {
               setActive(false);
             }
           }, 10);
@@ -176,6 +202,7 @@ const BaseMenu = ({
   }, [
     active,
     activeMenuItem,
+    buttonRef,
     containerRef,
     handleOutsideClick,
     responsiveMode,

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.test.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.test.tsx
@@ -1424,3 +1424,120 @@ test("children populated by map of non-React elements", async () => {
   const menuItem = screen.getByTestId("menu-item-1");
   expect(menuItem).toBeInTheDocument();
 });
+
+test("adds and removes resize event listener on mount/unmount", async () => {
+  const addEventListenerSpy = jest.spyOn(window, "addEventListener");
+  const removeEventListenerSpy = jest.spyOn(window, "removeEventListener");
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  const { unmount } = render(
+    <ResponsiveVerticalMenuProvider>
+      <ResponsiveVerticalMenu>
+        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+        <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
+        <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
+      </ResponsiveVerticalMenu>
+    </ResponsiveVerticalMenuProvider>,
+  );
+
+  const launcherButton = screen.getByTestId(
+    "responsive-vertical-menu-launcher",
+  );
+  await user.click(launcherButton);
+
+  expect(addEventListenerSpy).toHaveBeenCalledWith(
+    "resize",
+    expect.any(Function),
+  );
+  unmount();
+  expect(removeEventListenerSpy).toHaveBeenCalledWith(
+    "resize",
+    expect.any(Function),
+  );
+});
+
+test("sets and clears resize timeout on window resize", async () => {
+  const setTimeoutSpy = jest.spyOn(window, "setTimeout");
+  const clearTimeoutSpy = jest.spyOn(window, "clearTimeout");
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(
+    <ResponsiveVerticalMenuProvider>
+      <ResponsiveVerticalMenu>
+        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+        <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
+        <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
+      </ResponsiveVerticalMenu>
+    </ResponsiveVerticalMenuProvider>,
+  );
+
+  const launcherButton = screen.getByTestId(
+    "responsive-vertical-menu-launcher",
+  );
+  await user.click(launcherButton);
+
+  // Fire first resize event
+  window.dispatchEvent(new Event("resize"));
+  // Should have set a timeout
+  expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 100);
+  // Fast-forward time to simulate debounce completion
+  jest.advanceTimersByTime(100);
+  expect(clearTimeoutSpy).not.toHaveBeenCalled(); // no clear yet on first call
+});
+
+test("clears previous timeout on rapid resizes", async () => {
+  const clearTimeoutSpy = jest.spyOn(window, "clearTimeout");
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(
+    <ResponsiveVerticalMenuProvider>
+      <ResponsiveVerticalMenu>
+        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+        <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
+        <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
+      </ResponsiveVerticalMenu>
+    </ResponsiveVerticalMenuProvider>,
+  );
+
+  const launcherButton = screen.getByTestId(
+    "responsive-vertical-menu-launcher",
+  );
+
+  await user.click(launcherButton);
+  // First resize
+  window.dispatchEvent(new Event("resize"));
+  // Second resize
+  window.dispatchEvent(new Event("resize"));
+
+  expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+});
+
+test("clears timeout on unmount if it exists", async () => {
+  const setTimeoutSpy = jest.spyOn(window, "setTimeout");
+  const clearTimeoutSpy = jest.spyOn(window, "clearTimeout");
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  const { unmount } = render(
+    <ResponsiveVerticalMenuProvider>
+      <ResponsiveVerticalMenu>
+        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+        <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
+        <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
+      </ResponsiveVerticalMenu>
+    </ResponsiveVerticalMenuProvider>,
+  );
+
+  const launcherButton = screen.getByTestId(
+    "responsive-vertical-menu-launcher",
+  );
+
+  await user.click(launcherButton);
+
+  window.dispatchEvent(new Event("resize"));
+
+  expect(setTimeoutSpy).toHaveBeenCalled();
+
+  unmount();
+
+  expect(clearTimeoutSpy).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
### Proposed behaviour

If the menu loses focus during a resize event, the `handleBlur` handler is prevented from closing the menu. This should only be prevented during a resize because the menu should close when losing focus during keyboard navigation.

To achieve this, a new resize event listener has been added. We track whether a resize is in progress by setting a flag (`isResizingRef`) to true in the resize event handler, and resetting it to false using a debounced `setTimeout` after `100ms` of no resize activity. This allows us to detect when the user is actively resizing the window.

In the `handleBlur` logic, we check this flag. If a blur occurs while `isResizingRef` is `true`, we skip closing the menu. This prevents unwanted closures caused by temporary focus shifts during layout reflows or DOM changes triggered by resizing.

This logic ensures the menu remains open during intentional layout changes (like a resize), but still closes appropriately during user-driven navigation events like pressing Tab or clicking outside the menu.


https://github.com/user-attachments/assets/7c4f5902-4407-4258-8cd2-25112dd07b1a


https://github.com/user-attachments/assets/b948fe4b-2094-4933-a2bd-ef54434054cc


<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

During a window resize, conditional rendering causes  the menu to temporarily unmount and remount. As a result, the `document.activeElement` resets to the `<body>`. This triggers the `handleBlur` event handler, which interprets the loss of focus as the user navigating away from the menu and closes it.

This behavior is unintentional: the menu closes not because the user actively moved focus, but because the layout shift during the resize disrupted focus handling.

https://github.com/user-attachments/assets/4e0ca713-de30-4ca6-bb71-640247a4cfa1

https://github.com/user-attachments/assets/582e3efc-d9d7-445a-b192-8f11274e28c0

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Steps:
1. Go to the Storybook page for the component.
2. Open the menu.
3. Resize the browser window to a width greater than 700px — this should render the menu in its default (non-modal) mode.
4. Select an option from the menu.
5. Now, resize the window down to less than 700px — this should switch the menu to responsive mode (rendered inside a modal).

Expected Result:
The menu should remain open and visible after the window is resized into responsive mode.
