### PR TITLE
fix(responsive-vertical-menu): fix auto-close issue in Chrome

### DIFF
--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.pw.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.pw.tsx
@@ -265,3 +265,18 @@ test.describe("accessibility tests", () => {
     await checkAccessibility(page);
   });
 });
+
+test.describe("focus tests", () => {
+  test(`closes menu when focus is lost`, async ({ mount, page }) => {
+    await mount(<ResponsiveVerticalMenuDefaultComponent />);
+
+    await expect(responsiveVerticalMenuLauncher(page)).toBeVisible();
+    await responsiveVerticalMenuLauncher(page).click();
+
+    await page.keyboard.press("Tab", { delay: 100 });
+    await page.keyboard.press("Tab", { delay: 100 });
+    await page.keyboard.press("Tab", { delay: 100 });
+
+    await expect(page.locator("[id='primary-menu']")).not.toBeVisible();
+  });
+});

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.test.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import React, { act } from "react";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import {
@@ -472,41 +472,6 @@ test("closes menu when Escape key is pressed", async () => {
   expect(screen.queryByText("Menu Item 1")).not.toBeInTheDocument();
 });
 
-test("closes menu when focus is lost", async () => {
-  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-  render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-        />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
-  );
-
-  const launcherButton = screen.getByTestId(
-    "responsive-vertical-menu-launcher",
-  );
-  await user.click(launcherButton);
-
-  const menuItem = screen.getByTestId("menu-item-1");
-  expect(menuItem).toBeInTheDocument();
-
-  await user.tab();
-  expect(launcherButton).not.toHaveFocus();
-  expect(menuItem).toHaveFocus();
-
-  await user.tab();
-  expect(menuItem).not.toHaveFocus();
-
-  await waitFor(() => {
-    expect(screen.queryByText("Menu Item 1")).not.toBeInTheDocument();
-  });
-});
-
 test("closes menu when the user clicks outside of the menu", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -829,13 +794,6 @@ test("allows for full keyboard navigation of primary menus", async () => {
   const menuItem3 = screen.getByTestId("menu-item-3");
   expect(menuItem2).not.toHaveFocus();
   expect(menuItem3).toHaveFocus();
-
-  await user.tab();
-  expect(menuItem3).not.toHaveFocus();
-
-  await waitFor(() => {
-    expect(menuItem).not.toBeInTheDocument();
-  });
 });
 
 test("allows for full keyboard navigation of secondary menus", async () => {


### PR DESCRIPTION
### Proposed behaviour

Ensure that the blur function handles the situation correctly when the `focusout` handler is called in Chrome (Firefox and Safari behaviour is unaffected). This is down to how restrictive Chrome is when handling DOM updates.

### Current behaviour

When programmatically closing the responsive menu as a result of child menu updates (e.g. via API calls), Chrome closes the entire menu as opposed to just updating in place

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Across all browsers, and using the `Responsive Vertical Menu > Test > Delayed Menu Items` story, open all menus and await the re-load. Ensure that the secondary-level menu closes when this happens but the main menu stays open.