### PR TITLE
fix(responsive-vertical-menu): ensure items are rendered within an unordered list

### DIFF
--- a/src/components/vertical-menu/responsive-vertical-menu/components.test-pw.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/components.test-pw.tsx
@@ -5,6 +5,7 @@ import {
   ResponsiveVerticalMenuItem,
   ResponsiveVerticalMenuProps,
   ResponsiveVerticalMenuProvider,
+  ResponsiveVerticalMenuDivider,
 } from ".";
 
 import Box from "../../box";
@@ -35,6 +36,7 @@ export const ResponsiveVerticalMenuDefaultComponent = (
               label="Secondary Menu Item"
             />
           </ResponsiveVerticalMenuItem>
+          <ResponsiveVerticalMenuDivider />
           <ResponsiveVerticalMenuItem
             icon="home"
             id="primary-menu-no-children"

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-divider/responsive-vertical-menu-divider.component.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-divider/responsive-vertical-menu-divider.component.tsx
@@ -24,6 +24,7 @@ export const ResponsiveVerticalMenuDivider = (
       data-role="responsive-vertical-menu-divider"
       depth={depth}
       responsive={responsiveMode}
+      aria-hidden="true"
     >
       <StyledHr {...filterStyledSystemMarginProps(props)} />
     </StyledResponsiveVerticalMenuDivider>

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-item/responsive-vertical-menu-item.component.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-item/responsive-vertical-menu-item.component.tsx
@@ -18,6 +18,7 @@ import {
   StyledNestedMenuWrapper,
   StyledResponsiveMenuAction,
   StyledResponsiveMenuItem,
+  StyledResponsiveMenuListItem,
 } from "./responsive-vertical-menu-item.style";
 import { IncreaseDepth, useDepth } from "../__internal__/depth.context";
 import { useMenuFocus } from "../__internal__/focus.context";
@@ -289,7 +290,7 @@ const BaseItem = forwardRef<HTMLElement, BaseItemProps>(
     };
 
     return (
-      <>
+      <StyledResponsiveMenuListItem>
         {hasChildren ? (
           <>
             <StyledResponsiveMenuItem
@@ -392,7 +393,7 @@ const BaseItem = forwardRef<HTMLElement, BaseItemProps>(
             />
           </StyledResponsiveMenuAction>
         )}
-      </>
+      </StyledResponsiveMenuListItem>
     );
   },
 );

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-item/responsive-vertical-menu-item.style.ts
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-item/responsive-vertical-menu-item.style.ts
@@ -46,7 +46,6 @@ const commonAttributes = css`
   min-height: var(--sizing500);
   padding: 0 var(--spacing200);
   width: 100%;
-  max-width: 340px;
 
   ${margin}
   ${padding}
@@ -102,7 +101,6 @@ export const StyledNestedMenuWrapper = styled.div<{
   display: flex;
   justify-content: ${({ hasIcon, responsive }) =>
     hasIcon && responsive ? "flex-end" : "flex-start"};
-  padding: 0 16px;
   width: 100%;
 
   ${({ depth, responsive }) =>
@@ -113,27 +111,36 @@ export const StyledNestedMenuWrapper = styled.div<{
     `}
 `;
 
-export const StyledNestedMenu = styled.div<{
+export const StyledNestedMenu = styled.ul<{
   depth: number;
   hasIcon?: boolean;
   responsive?: boolean;
 }>`
-  ${({ depth, hasIcon }) => css`
+  padding: 0;
+
+  ${({ depth, hasIcon, responsive }) => css`
     width: ${depth < 2 && !hasIcon ? "100%" : "88%"};
-  `}
+    margin-left: var(--spacing400);
 
-  > a {
-    ${({ depth }) => css`
-      font-weight: var(--fontWeights500);
-
-      ${depth === 1 &&
-      css`
-        font-weight: var(--fontWeights400);
-        margin-left: var(--spacing200);
-        margin-right: var(--spacing200);
-      `};
+    ${responsive &&
+    css`
+      margin-left: ${hasIcon || depth === 1 ? "var(--spacing200)" : "0"};
     `}
-  }
+
+    li > a {
+      font-weight: ${depth === 1
+        ? "var(--fontWeights400)"
+        : "var(--fontWeights500)"};
+    }
+  `}
+`;
+
+export const StyledResponsiveMenuListItem = styled.li`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  max-width: 340px;
 `;
 
 export const StyledResponsiveMenuItem = styled.button<StyledResponsiveMenuItemProps>`

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
@@ -81,9 +81,7 @@ const BaseMenu = ({
         document.querySelector("[id='responsive-vertical-menu-primary']");
       /* istanbul ignore else */
       if (menuContainer) {
-        setResponsiveWidth(
-          `${menuContainer.getBoundingClientRect().width - 16}px`,
-        );
+        setResponsiveWidth(`${menuContainer.getBoundingClientRect().width}px`);
       }
     }
 
@@ -279,6 +277,7 @@ const BaseMenu = ({
         <Modal open={active}>
           <Box position="fixed" top={0} width={responsiveWidth}>
             <Box
+              boxSizing="border-box"
               display="flex"
               justifyContent="flex-end"
               width="100%"

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
@@ -63,7 +63,7 @@ const BaseMenu = ({
   const [left, setLeft] = useState("auto");
   const [responsiveWidth, setResponsiveWidth] = useState("100%");
   const [top, setTop] = useState("auto");
-  const subMenuRef = useRef<HTMLDivElement>(null);
+  const subMenuRef = useRef<HTMLUListElement>(null);
   const reduceMotion = !useMediaQuery(
     "screen and (prefers-reduced-motion: no-preference)",
   );

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.context.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.context.tsx
@@ -23,7 +23,7 @@ export interface MenuContextType {
   activeMenuItem: ResponsiveVerticalMenuButtonItem | null;
   buttonRef: RefObject<HTMLButtonElement>;
   containerRef: RefObject<HTMLDivElement>;
-  menuRef: RefObject<HTMLDivElement>;
+  menuRef: RefObject<HTMLUListElement>;
   reducedMotion?: boolean;
   responsiveMode?: boolean;
   setActiveMenuItem: (item: ResponsiveVerticalMenuButtonItem | null) => void;
@@ -56,7 +56,7 @@ export const ResponsiveVerticalMenuProvider = ({
   const buttonRef = useRef<HTMLButtonElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const menuRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLUListElement>(null);
   const [responsiveMode, setResponsiveMode] = useState<boolean>(false);
   const [reducedMotion, setReducedMotion] = useState<boolean>(false);
 

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.style.ts
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.style.ts
@@ -57,7 +57,9 @@ export const StyledGlobalVerticalMenuWrapper = styled.div`
   width: fit-content;
 `;
 
-export const StyledResponsiveMenu = styled.div<StyledResponsiveMenuProps>`
+export const StyledResponsiveMenu = styled.ul<StyledResponsiveMenuProps>`
+  margin: 0;
+  padding: 0;
   align-items: center;
   background-color: var(--colorsUtilityYin100);
   box-sizing: border-box;


### PR DESCRIPTION
fix #7374

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
- `ResponsiveVerticalMenu` is announced as lists of items when using screen readers. 

- `ResponsiveVerticalMenuItem`s extend the correct length and are aligned on the right when in responsive mode. 
<img width="350" alt="image" src="https://github.com/user-attachments/assets/21d9464e-ccce-4ea9-8426-ce108e5c9177" />

- When `box-sizing: border-box;` style is applied to `ResponsiveVerticalMenu` through a universal selector, the header containing the close button in responsive mode matches the width of the menu:
![image](https://github.com/user-attachments/assets/de86dc1e-7f25-4064-a286-20c6ab2f8804)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
- `ResponsiveVerticalMenu` is not announced as lists of items when using a screen reader. 

- `ResponsiveVerticalMenuItem`s in a tertiary submenu extended beyond adjacent items in responsive mode.
<img width="350" alt="image" src="https://github.com/user-attachments/assets/8465b2dd-c6ef-4b52-b062-bef2458ead97" />

- When `box-sizing: border-box;` style is applied to `ResponsiveVerticalMenu` through a universal selector, the header containing the close button in responsive mode no longer matches the width of the menu:
![image](https://github.com/user-attachments/assets/a90f7f6a-3f9d-42b6-a089-b9a129d9d24f)


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

- Using a screen reader, each submenu should be announced as a list with the correct number of items within it. 
- Menu dividers should be hidden from the accessibility tree and not be announced.
- Check for any accessibility issues on axe. 
- To check visual bug, open any story with a tertiary submenu and reduce screen size to enter responsive mode and hover or focus on a tertiary menu item. 

