### PR TITLE
feat(date): deprecate disablePortal and set default value to true

### DIFF
--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
         testIdAttribute: "data-role",
         viewport: { width: 1366, height: 768 },
+        trace: "on-first-retry",
       },
     },
   ],

--- a/src/components/date-range/date-range.stories.tsx
+++ b/src/components/date-range/date-range.stories.tsx
@@ -6,6 +6,7 @@ import generateStyledSystemProps from "../../../.storybook/utils/styled-system-p
 import I18nProvider from "../i18n-provider";
 
 import DateRange, { DateRangeChangeEvent } from "./date-range.component";
+import Box from "../box";
 
 const styledSystemProps = generateStyledSystemProps({
   margin: true,
@@ -17,6 +18,11 @@ const meta: Meta<typeof DateRange> = {
   argTypes: {
     ...styledSystemProps,
   },
+  decorators: (StoryToRender) => (
+    <Box minHeight="460px" p={4}>
+      <StoryToRender />
+    </Box>
+  ),
 };
 
 export default meta;

--- a/src/components/date/__internal__/date-picker/date-picker.component.tsx
+++ b/src/components/date/__internal__/date-picker/date-picker.component.tsx
@@ -24,6 +24,7 @@ import { getDisabledDays } from "../utils";
 import { defaultFocusableSelectors } from "../../../../__internal__/focus-trap/focus-trap-utils";
 import Events from "../../../../__internal__/utils/helpers/events";
 import FlatTableContext from "../../../flat-table/__internal__/flat-table.context";
+import Logger from "../../../../__internal__/utils/logger";
 
 import StyledDayPicker from "./day-picker.style";
 
@@ -37,7 +38,10 @@ export interface PickerProps
 }
 
 export interface DatePickerProps {
-  /** Boolean to toggle where DatePicker is rendered in relation to the Date Input */
+  /**
+   * [Legacy] Boolean to toggle where DatePicker is rendered in relation to the Date Input
+   * @deprecated
+   */
   disablePortal?: boolean;
   /** Minimum possible date YYYY-MM-DD */
   minDate?: string;
@@ -78,13 +82,14 @@ const popoverMiddleware = [
 ];
 
 const Nav = Navbar;
+let deprecateDisablePortalWarnTriggered = false;
 
 export const DatePicker = ({
   inputElement,
   minDate,
   maxDate,
   selectedDays,
-  disablePortal,
+  disablePortal = true,
   onDayClick,
   pickerMouseDown,
   pickerProps,
@@ -95,6 +100,13 @@ export const DatePicker = ({
   ariaLabel: datePickerAriaLabel,
   ariaLabelledBy: datePickerAriaLabelledBy,
 }: DatePickerProps) => {
+  if (!deprecateDisablePortalWarnTriggered && !!disablePortal) {
+    deprecateDisablePortalWarnTriggered = true;
+    Logger.deprecate(
+      "`disablePortal` is deprecated in DateInput and DateRange, and support will soon be removed.",
+    );
+  }
+
   const [focusedMonth, setFocusedMonth] = useState<Date | undefined>(
     selectedDays || new Date(),
   );

--- a/src/components/date/__internal__/date-picker/date-picker.test.tsx
+++ b/src/components/date/__internal__/date-picker/date-picker.test.tsx
@@ -13,6 +13,7 @@ import { frCA as frCALocale } from "date-fns/locale/fr-CA";
 import { zhCN as zhCNLocale } from "date-fns/locale/zh-CN";
 import type { Locale } from "react-day-picker";
 
+import Logger from "../../../../__internal__/utils/logger";
 import I18nProvider from "../../../i18n-provider";
 import DatePicker, { DatePickerProps } from "./date-picker.component";
 
@@ -46,6 +47,26 @@ const getWeekdayTranslations = (
     ?.day(((index + startDay) % 7) as Day, { width: "abbreviated" })
     .substring(0, substringLimit);
 };
+
+test("logs a deprecation warning when disablePortal is used", async () => {
+  const loggerSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
+
+  render(
+    <>
+      <DatePickerWithInput setOpen={() => {}} open disablePortal />
+      <DatePickerWithInput setOpen={() => {}} open disablePortal />
+    </>,
+  );
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "`disablePortal` is deprecated in DateInput and DateRange, and support will soon be removed.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
+});
 
 test("should not render the date picker when `open` is false", () => {
   render(<DatePickerWithInput setOpen={() => {}} />);

--- a/src/components/date/date.component.tsx
+++ b/src/components/date/date.component.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-lonely-if */
 import React, {
   useContext,
   useEffect,
@@ -124,7 +125,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       "data-element": dataElement,
       "data-role": dataRole,
       disabled,
-      disablePortal = false,
+      disablePortal = true,
       helpAriaLabel,
       labelInline,
       minDate,
@@ -346,13 +347,16 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
         if (Events.isShiftKey(ev)) {
           setOpen(false);
           onPickerClose?.();
-        } else if (!disablePortal) {
-          ev.preventDefault();
-          (
-            document?.querySelector(
-              `[id="${pickerTabGuardId.current}"]`,
-            ) as HTMLElement
-          )?.focus();
+        } else {
+          /* istanbul ignore if */
+          if (!disablePortal) {
+            ev.preventDefault();
+            (
+              document?.querySelector(
+                `[id="${pickerTabGuardId.current}"]`,
+              ) as HTMLElement
+            )?.focus();
+          }
         }
         alreadyFocused.current = false;
       }

--- a/src/components/date/date.stories.tsx
+++ b/src/components/date/date.stories.tsx
@@ -20,6 +20,11 @@ const meta: Meta<typeof DateInput> = {
   argTypes: {
     ...styledSystemProps,
   },
+  decorators: (StoryToRender) => (
+    <Box minHeight="460px" p={4}>
+      <StoryToRender />
+    </Box>
+  ),
 };
 
 export default meta;

--- a/src/components/date/date.test.tsx
+++ b/src/components/date/date.test.tsx
@@ -665,7 +665,14 @@ test("should render the picker as a descendant of the main presentation element 
 
 test("should not render the picker as a descendant of the main presentation element when `disablePortal` is false", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-  render(<DateInput label="label" onChange={() => {}} value="" />);
+  render(
+    <DateInput
+      disablePortal={false}
+      label="label"
+      onChange={() => {}}
+      value=""
+    />,
+  );
   const input = screen.getByRole("textbox");
   await user.click(input);
 


### PR DESCRIPTION
Portals interfere with tab ordering when using DateRange. Disabling portals by default resolves the issue.

BREAKING CHANGE: Previously, disablePortal was false, meaning date picker popovers appeared outside of the natural DOM ordering. Whilst visually fine, keyboard control was impacted when using the DateRange component. All date components have now been updated to render inline unless disablePortal is explicitly set to false.

resolves #7386

### Proposed behaviour

Set the Date Picker component (shared between `DateInput` and `DateRange`) to disable portal usage by default.

### Current behaviour

Keyboard users cannot interact with the End Date calendar of the DateRange component correctly

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

- `disablePortal` now carries a deprecation warning.
- The stories have been updated with a specific height - now that portals aren't being used by default, the examples wouldn't render the pickers outside of the box correctly.

### Testing instructions

Test that keyboard behaviour in DateRange works such that all elements of each calendar are reachable.
