### PR TITLE
fix(text-editor): character count behaving inconsistently when pasting

### DIFF
--- a/src/components/text-editor/__internal__/plugins/CharacterCounter/character-counter.component.tsx
+++ b/src/components/text-editor/__internal__/plugins/CharacterCounter/character-counter.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $getRoot } from "lexical";
 import {
@@ -20,21 +20,40 @@ const CharacterCounterPlugin = ({
   maxChars,
   namespace,
 }: CharacterCounterPluginProps) => {
-  const [rawContent, setRawContent] = useState<string>("");
+  const [charactersRemaining, setCharactersRemaining] = useState(0);
 
   const [editor] = useLexicalComposerContext();
   useEffect(() => {
-    // The character counter plugin listens for updates to the editor state
-    // independently to ensure updates do not conflict/interrupt other state
-    // changes
-    editor.registerUpdateListener(({ editorState }) => {
-      editorState.read(() => {
-        const newContent = $getRoot().getTextContent();
+    const updateCharCount = () => {
+      editor.getEditorState().read(() => {
+        const root = $getRoot();
+        const paragraphs = root.getChildren();
 
-        setRawContent(newContent);
+        if (
+          paragraphs.length === 1 &&
+          paragraphs[0].getTextContent().length === 0
+        ) {
+          setCharactersRemaining(maxChars);
+        }
+
+        const count = paragraphs.reduce((acc, node, index) => {
+          const textLength = node.getTextContent().length;
+          const isLast = index === paragraphs.length - 1;
+
+          return acc + textLength + (isLast ? 0 : 2);
+        }, 0);
+        setCharactersRemaining(maxChars - count > 0 ? maxChars - count : 0);
+      });
+    };
+
+    updateCharCount();
+
+    return editor.registerUpdateListener(({ editorState }) => {
+      editorState.read(() => {
+        updateCharCount();
       });
     });
-  }, [editor]);
+  }, [editor, maxChars]);
 
   // Get the locale to enable translations
   const locale = useLocale();
@@ -48,14 +67,6 @@ const CharacterCounterPlugin = ({
   );
   const [debouncedValue, setDebouncedValue] = useState<number>(0);
 
-  // Calculate the number of characters remaining
-  const rawCharactersRemaining = useMemo(() => {
-    // Calculate the number of characters remaining
-    const activeCount = maxChars - (rawContent ? rawContent.length : 0);
-    // Return the active count if it is greater than 0, otherwise return 0
-    return activeCount >= 0 ? activeCount : 0;
-  }, [rawContent, maxChars]);
-
   // Use a debounced value to update the remaining character count for screen readers to use
   /* istanbul ignore next */
   const debouncedText = useDebounce((newValue) => {
@@ -63,14 +74,14 @@ const CharacterCounterPlugin = ({
   }, 2000);
 
   useEffect(() => {
-    debouncedText(rawCharactersRemaining);
-  }, [rawCharactersRemaining, debouncedText]);
+    debouncedText(charactersRemaining);
+  }, [charactersRemaining, debouncedText]);
 
   return (
     <>
       <StyledCharacterCounter data-role={`${namespace}-character-limit`}>
         {locale.textEditor.characterCounter(
-          getFormatNumber(rawCharactersRemaining),
+          getFormatNumber(charactersRemaining),
         )}
       </StyledCharacterCounter>
       <VisuallyHiddenCharacterCounter aria-live="polite">

--- a/src/components/text-editor/text-editor.pw.tsx
+++ b/src/components/text-editor/text-editor.pw.tsx
@@ -587,6 +587,52 @@ test.describe("Prop tests", () => {
     });
   });
 
+  test("counts characters correclty after pasting new line characters and interacting with it", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<TextEditorDefaultComponent />);
+
+    const textToPaste = "1\n\n2\n\n3\n\n\n\n4"; // each new line will be counted as two characters
+    const remainingCharactersAfterPasting = "2,980";
+    const textToType = "5";
+    const remainingCharsAfterTyping = "2,979";
+    const textbox = await page.locator("div[role='textbox']");
+
+    await textbox.click();
+
+    await textbox.evaluate((_, text) => {
+      const clipboardData = new DataTransfer();
+      clipboardData.setData("text/plain", text);
+
+      const event = new ClipboardEvent("paste", {
+        clipboardData,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      _.dispatchEvent(event);
+    }, textToPaste);
+
+    const displayedLimitAfterPastingText = await page
+      .locator("div[data-role='pw-rte-character-limit']")
+      .textContent();
+
+    expect(displayedLimitAfterPastingText).toBe(
+      `${remainingCharactersAfterPasting} characters remaining`,
+    );
+
+    await page.keyboard.type(textToType);
+
+    const displayedLimitAfterKeyboardUpdate = await page
+      .locator("div[data-role='pw-rte-character-limit']")
+      .textContent();
+
+    expect(displayedLimitAfterKeyboardUpdate).toBe(
+      `${remainingCharsAfterTyping} characters remaining`,
+    );
+  });
+
   test("should correctly apply margin prop as a number", async ({
     mount,
     page,


### PR DESCRIPTION
fixes: #7380

### Proposed behaviour
To address the issue where Lexical does not consistently preserve empty paragraphs during serialization—especially after content mutations like typing a character—we now track empty lines by explicitly counting paragraph nodes instead of relying on serialized text alone.

https://github.com/user-attachments/assets/c59f443f-5feb-4aaf-b960-729670bca052

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

Currnetly, when users pasted content that included empty lines (e.g., multiple line breaks), Lexical would initially preserve those empty paragraphs in the editor's internal state. However, as soon as a new character was typed (which triggers a content mutation and a tree diff), Lexical would treat those empty paragraphs as insignificant and remove them from the serialized output. As a result, the empty lines would disappear in the serialized data, leading to an inaccurate character count — even though the lines were still visually present in the editor before typing.

https://github.com/user-attachments/assets/92c1ada1-7b7b-4f1f-b5d4-a7b222c15120

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [X] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

1. Go to the Text Editor default storybook page
2. Write some text combined with multiple line breaks and keep track of the remaining characters.
3. Select the text and copy it
4. Delete the text and paste it in the text editor
5. Type an additional character

Expected: the remaining characters count should go down after typing
Actual: the remaining characters count goes up.
