### PR TITLE
fix(textbox): test stories load to error

### DIFF
--- a/src/components/date/components.test-pw.tsx
+++ b/src/components/date/components.test-pw.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import DateInput, { DateChangeEvent, DateInputProps } from "./date.component";
-import { CommonTextboxArgs } from "../textbox/textbox-test.stories";
+import { CommonTextboxArgs } from "../textbox/utils";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 import Dialog from "../dialog";
 

--- a/src/components/decimal/decimal-test.stories.tsx
+++ b/src/components/decimal/decimal-test.stories.tsx
@@ -8,7 +8,7 @@ import {
   commonTextboxArgTypes,
   getCommonTextboxArgs,
   getCommonTextboxArgsWithSpecialCharacters,
-} from "../textbox/textbox-test.stories";
+} from "../textbox/utils";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 
 export default {

--- a/src/components/grouped-character/grouped-character-test.stories.tsx
+++ b/src/components/grouped-character/grouped-character-test.stories.tsx
@@ -5,7 +5,7 @@ import {
   getCommonTextboxArgs,
   getCommonTextboxArgsWithSpecialCharacters,
   CommonTextboxArgs,
-} from "../textbox/textbox-test.stories";
+} from "../textbox/utils";
 import GroupedCharacter, { CustomEvent } from "./grouped-character.component";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 

--- a/src/components/number/number-test.stories.tsx
+++ b/src/components/number/number-test.stories.tsx
@@ -8,7 +8,7 @@ import {
   commonTextboxArgTypes,
   getCommonTextboxArgs,
   getCommonTextboxArgsWithSpecialCharacters,
-} from "../textbox/textbox-test.stories";
+} from "../textbox/utils";
 
 export default {
   title: "Number Input/Test",

--- a/src/components/textbox/textbox-test.stories.tsx
+++ b/src/components/textbox/textbox-test.stories.tsx
@@ -3,110 +3,12 @@ import { action } from "@storybook/addon-actions";
 import Textbox, { TextboxProps } from ".";
 import Box from "../box";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
-import { ICONS } from "../icon/icon-config";
-
-export const getCommonTextboxArgs = (
-  isNewValidation = false,
-  autoFocusDefault = false,
-  disabledDefault = false,
-) => {
-  return {
-    disabled: disabledDefault,
-    readOnly: disabledDefault,
-    autoFocus: autoFocusDefault,
-    prefix: "",
-    label: isNewValidation ? "Label - new validation" : "Label",
-    labelHelp: "",
-    placeholder: "",
-    adaptiveLabelBreakpoint: undefined,
-    ...(!isNewValidation && {
-      fieldHelp: "",
-      labelInline: false,
-      labelWidth: 30,
-      inputWidth: 70,
-      labelAlign: undefined,
-      tooltipId: "",
-    }),
-    size: "medium",
-    inputIcon: undefined,
-    required: false,
-    characterLimit: undefined,
-    error: "",
-    warning: "",
-  };
-};
-
-export interface CommonTextboxArgs {
-  prefix: string;
-  fieldHelp: string;
-  label: string;
-  labelHelp: string;
-  placeholder: string;
-}
-
-export const getCommonTextboxArgsWithSpecialCharacters = (
-  args: CommonTextboxArgs,
-) => {
-  const { prefix, fieldHelp, label, labelHelp, placeholder } = args;
-  return {
-    ...args,
-    prefix,
-    fieldHelp,
-    label,
-    labelHelp,
-    helpAriaLabel: labelHelp,
-    placeholder,
-  };
-};
-
-export const commonTextboxArgTypes = (isNewValidation?: boolean) => ({
-  size: {
-    options: ["small", "medium", "large"],
-    control: {
-      type: "select",
-    },
-  },
-  inputIcon: {
-    options: ["", ...ICONS],
-    control: {
-      type: "select",
-    },
-  },
-  labelAlign: {
-    options: ["left", "right"],
-    control: {
-      type: "select",
-    },
-  },
-  ...(!isNewValidation && {
-    labelWidth: {
-      control: {
-        type: "range",
-        min: 0,
-        max: 100,
-        step: 1,
-      },
-    },
-    inputWidth: {
-      control: {
-        type: "range",
-        min: 0,
-        max: 100,
-        step: 1,
-      },
-    },
-    tooltipId: {
-      control: {
-        type: "text",
-      },
-    },
-  }),
-  adaptiveLabelBreakpoint: {
-    control: {
-      type: "number",
-    },
-  },
-});
+import {
+  CommonTextboxArgs,
+  commonTextboxArgTypes,
+  getCommonTextboxArgs,
+  getCommonTextboxArgsWithSpecialCharacters,
+} from "./utils";
 
 export default {
   title: "Textbox/Test",

--- a/src/components/textbox/utils.ts
+++ b/src/components/textbox/utils.ts
@@ -1,0 +1,104 @@
+import { ICONS } from "../icon/icon-config";
+
+export interface CommonTextboxArgs {
+  prefix: string;
+  fieldHelp: string;
+  label: string;
+  labelHelp: string;
+  placeholder: string;
+}
+
+export const getCommonTextboxArgs = (
+  isNewValidation = false,
+  autoFocusDefault = false,
+  disabledDefault = false,
+) => {
+  return {
+    disabled: disabledDefault,
+    readOnly: disabledDefault,
+    autoFocus: autoFocusDefault,
+    prefix: "",
+    label: isNewValidation ? "Label - new validation" : "Label",
+    labelHelp: "",
+    placeholder: "",
+    adaptiveLabelBreakpoint: undefined,
+    ...(!isNewValidation && {
+      fieldHelp: "",
+      labelInline: false,
+      labelWidth: 30,
+      inputWidth: 70,
+      labelAlign: undefined,
+      tooltipId: "",
+    }),
+    size: "medium",
+    inputIcon: undefined,
+    required: false,
+    characterLimit: undefined,
+    error: "",
+    warning: "",
+  };
+};
+
+export const getCommonTextboxArgsWithSpecialCharacters = (
+  args: CommonTextboxArgs,
+) => {
+  const { prefix, fieldHelp, label, labelHelp, placeholder } = args;
+  return {
+    ...args,
+    prefix,
+    fieldHelp,
+    label,
+    labelHelp,
+    helpAriaLabel: labelHelp,
+    placeholder,
+  };
+};
+
+export const commonTextboxArgTypes = (isNewValidation?: boolean) => ({
+  size: {
+    options: ["small", "medium", "large"],
+    control: {
+      type: "select",
+    },
+  },
+  inputIcon: {
+    options: ["", ...ICONS],
+    control: {
+      type: "select",
+    },
+  },
+  labelAlign: {
+    options: ["left", "right"],
+    control: {
+      type: "select",
+    },
+  },
+  ...(!isNewValidation && {
+    labelWidth: {
+      control: {
+        type: "range",
+        min: 0,
+        max: 100,
+        step: 1,
+      },
+    },
+    inputWidth: {
+      control: {
+        type: "range",
+        min: 0,
+        max: 100,
+        step: 1,
+      },
+    },
+    tooltipId: {
+      control: {
+        type: "text",
+      },
+    },
+  }),
+  adaptiveLabelBreakpoint: {
+    control: {
+      type: "number",
+    },
+  },
+});


### PR DESCRIPTION
### Proposed behaviour

The `textbox-test.stories.tsx` file was exporting three helper functions that were incorrectly interpreted as stories and added to the Textbox test stories. However, attempting to load them caused errors. To fix this, the functions were moved to a separate utils file, and the exports were updated accordingly.

![textbox-after](https://github.com/user-attachments/assets/efe1f546-7340-4266-9287-f69e0cdbdb1a)

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

Three helper functions exports are incorrectly interpreted as stories and added to the Textbox test stories.

![textbox-before](https://github.com/user-attachments/assets/d34e490a-1e38-4f02-8075-e7f68ad1ef04)

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [X] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

1. Load the Textbox test stories
2. The stories for the helper functions should no longer be present.

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
