### PR TITLE
feat(password): add de-DE, es-ES, fr-CA and fr-FR show/hide related translations

### DIFF
--- a/src/locales/de-de.ts
+++ b/src/locales/de-de.ts
@@ -148,6 +148,10 @@ const deDE: Partial<Locale> = {
     ofY: (count) => `von ${count}`,
   },
   password: {
+    buttonLabelHide: () => "Ausblenden",
+    buttonLabelShow: () => "Anzeigen",
+    ariaLabelHide: () => "Passwort ausblenden",
+    ariaLabelShow: () => "Passwort anzeigen",
     ariaLiveShownMessage: () =>
       "Ihr Passwort wurde angezeigt. Bewegen Sie den Cursor über das Passwort, um es sich vorlesen zu lassen, wenn dies sicher ist.",
     ariaLiveHiddenMessage: () => "Ihr Passwort ist derzeit ausgeblendet.",

--- a/src/locales/es-es.ts
+++ b/src/locales/es-es.ts
@@ -155,6 +155,10 @@ const esES: Partial<Locale> = {
     ofY: (count) => `de ${count}`,
   },
   password: {
+    buttonLabelHide: () => "Ocultar",
+    buttonLabelShow: () => "Mostrar",
+    ariaLabelHide: () => "Ocultar contraseña",
+    ariaLabelShow: () => "Mostrar contraseña",
     ariaLiveShownMessage: () =>
       "Tu contraseña se muestra en pantalla. Si estás en un entorno seguro, coloca el cursor sobre ella para que se te lea en voz alta.",
     ariaLiveHiddenMessage: () => "La contraseña está oculta.",

--- a/src/locales/fr-ca.ts
+++ b/src/locales/fr-ca.ts
@@ -157,6 +157,10 @@ const frCA: Partial<Locale> = {
     ofY: (count) => `de ${count}`,
   },
   password: {
+    buttonLabelHide: () => "Masquer",
+    buttonLabelShow: () => "Afficher",
+    ariaLabelHide: () => "Masquer le mot de passe",
+    ariaLabelShow: () => "Afficher le mot de passe",
     ariaLiveShownMessage: () =>
       "Votre mot de passe a été affiché. Si vous pouvez le faire en toute sécurité, focalisez sur la zone de saisie du mot de passe pour qu’il vous soit lu.",
     ariaLiveHiddenMessage: () => "Votre mot de passe est actuellement masqué.",

--- a/src/locales/fr-fr.ts
+++ b/src/locales/fr-fr.ts
@@ -157,6 +157,10 @@ const frFR: Partial<Locale> = {
     ofY: (count) => `de ${count}`,
   },
   password: {
+    buttonLabelHide: () => "Masquer",
+    buttonLabelShow: () => "Afficher",
+    ariaLabelHide: () => "Masquer le mot de passe",
+    ariaLabelShow: () => "Afficher le mot de passe",
     ariaLiveShownMessage: () =>
       "Votre mot de passe s'affiche. Assurez-vous d'être dans un environnement sûr puis survolez la zone avec votre souris et vous pourrez écouter le mot de passe.",
     ariaLiveHiddenMessage: () => "Votre mot de passe est actuellement caché.",


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

adds `de-DE`, `es-ES`, `fr-CA` and `fr-FR` show/hide related translations

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, there is no support for `de-DE`, `es-ES`, `fr-CA` and `fr-FR` show/hide related translations

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
