### PR TITLE
[Link] Implement base link component

### DIFF
--- a/.storybook/welcome-page/loves-carbon/loves-carbon.style.js
+++ b/.storybook/welcome-page/loves-carbon/loves-carbon.style.js
@@ -1,7 +1,9 @@
 import styled from "styled-components";
 
 import { StyledComponentHeader } from "../components-demo/component-heading/component-heading.style";
-import { StyledLink } from "../../../src/components/link/link.style";
+import Link from "../../../src/components/link";
+
+const StyledLink = styled(Link)``;
 
 export const Wrapper = styled.div`
   margin: 0 auto;

--- a/src/components/batch-selection/batch-selection.test.tsx
+++ b/src/components/batch-selection/batch-selection.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import BatchSelection from ".";
 import Button from "../button";
@@ -87,19 +88,21 @@ test("`ButtonMinor` children should be automatically disabled via context", () =
   expect(minorButton).toBeDisabled();
 });
 
-test("`Link` children should be automatically disabled via context", () => {
+test("`Link` children should be automatically disabled via context", async () => {
+  const user = userEvent.setup();
+
   render(
     <BatchSelection selectedCount={0} disabled>
       {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-      <Link>Link as an anchor</Link>
+      <Link data-role="link">Link as an anchor</Link>
     </BatchSelection>,
   );
 
   const link = screen.getByTestId("link-anchor");
 
-  expect(link).toHaveStyle("cursor: not-allowed");
+  expect(link).toHaveAttribute("aria-disabled", "true");
 
-  link.focus();
+  await user.tab();
 
   expect(link).not.toHaveFocus();
 });

--- a/src/components/breadcrumbs/breadcrumbs.pw.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.pw.tsx
@@ -57,7 +57,7 @@ test.describe("should render Breadcrumbs component", async () => {
       "background-color",
       "rgb(255, 218, 128)",
     );
-    await expect(crumbAtIndex(page, 0).locator("span").first()).toHaveCSS(
+    await expect(crumbAtIndex(page, 0).locator("button")).toHaveCSS(
       "box-shadow",
       "rgba(0, 0, 0, 0.9) 0px 4px 0px 0px",
     );
@@ -74,7 +74,7 @@ test.describe("should render Breadcrumbs component", async () => {
       "background-color",
       "rgb(255, 218, 128)",
     );
-    await expect(crumbAtIndex(page, 0).locator("span").first()).toHaveCSS(
+    await expect(crumbAtIndex(page, 0).locator("a")).toHaveCSS(
       "box-shadow",
       "rgba(0, 0, 0, 0.9) 0px 4px 0px 0px",
     );
@@ -160,7 +160,7 @@ test.describe("should render Breadcrumbs component", async () => {
       "background-color",
       "rgb(255, 218, 128)",
     );
-    await expect(crumbAtIndex(page, 0).locator("span").first()).toHaveCSS(
+    await expect(crumbAtIndex(page, 0).locator("a")).toHaveCSS(
       "box-shadow",
       "rgba(0, 0, 0, 0.9) 0px 4px 0px 0px",
     );
@@ -222,18 +222,19 @@ test("when Crumb's isCurrent prop is true, Crumb divider should not exist", asyn
   await mount(<DefaultCrumb isCurrent />);
 
   const crumbElement = crumbAtIndex(page, 0);
+
   await expect(crumbElement.locator("a")).toHaveAttribute(
     "aria-current",
     "page",
   );
-  await expect(crumbElement.locator("span").nth(1)).toHaveCSS(
+  await expect(crumbElement.locator("span").nth(0)).toHaveCSS(
     "color",
     "rgba(0, 0, 0, 0.9)",
   );
 });
 
 test.describe("Accessibility tests for Breadcrumbs component", async () => {
-  test("should pass accessibility tests for Breadcrumbs default story", async ({
+  test("should pass accessibility tests for default breadcrumbs", async ({
     mount,
     page,
   }) => {
@@ -241,7 +242,7 @@ test.describe("Accessibility tests for Breadcrumbs component", async () => {
     await checkAccessibility(page);
   });
 
-  test("should pass accessibility tests for Crumb default story", async ({
+  test("should pass accessibility tests for default crumbs", async ({
     mount,
     page,
   }) => {
@@ -249,7 +250,7 @@ test.describe("Accessibility tests for Breadcrumbs component", async () => {
     await checkAccessibility(page);
   });
 
-  test("should pass accessibility tests for Breadcrumbs dark background story", async ({
+  test("should pass accessibility tests for breadcrumbs on a dark background", async ({
     mount,
     page,
   }) => {

--- a/src/components/breadcrumbs/crumb/crumb.component.tsx
+++ b/src/components/breadcrumbs/crumb/crumb.component.tsx
@@ -49,8 +49,6 @@ const Crumb = React.forwardRef<HTMLAnchorElement, CrumbProps>(
 
     const styles = styledCrumb(baseStyles, isDarkBackground, isCurrent);
 
-    console.log({ isCurrent, href, onClick, rest });
-
     return (
       <li>
         <BaseLink

--- a/src/components/breadcrumbs/crumb/crumb.component.tsx
+++ b/src/components/breadcrumbs/crumb/crumb.component.tsx
@@ -1,10 +1,18 @@
 import React from "react";
+
+import { useTheme } from "styled-components";
+
+import { ThemeObject } from "../../../style/themes";
 import { LinkProps } from "../../link";
 import tagComponent, {
   TagProps,
 } from "../../../__internal__/utils/helpers/tags";
-import { StyledCrumb, Divider } from "./crumb.style";
+import { styledCrumb, Divider } from "./crumb.style";
 import { useBreadcrumbsContext } from "../__internal__/breadcrumbs.context";
+
+import addLinkStyles from "../../link/link.style";
+
+import { BaseLink } from "../../link/__internal__/base-link";
 
 export interface CrumbProps
   extends Omit<
@@ -31,14 +39,24 @@ export interface CrumbProps
 const Crumb = React.forwardRef<HTMLAnchorElement, CrumbProps>(
   ({ href, isCurrent, children, onClick, ...rest }: CrumbProps, ref) => {
     const { isDarkBackground } = useBreadcrumbsContext();
+    const theme = useTheme();
+
+    const baseStyles = addLinkStyles({
+      theme: theme as ThemeObject,
+
+      hasContent: !!children,
+    });
+
+    const styles = styledCrumb(baseStyles, isDarkBackground, isCurrent);
+
+    console.log({ isCurrent, href, onClick, rest });
 
     return (
       <li>
-        <StyledCrumb
+        <BaseLink
+          styles={styles}
           ref={ref}
-          isCurrent={isCurrent}
           aria-current={isCurrent ? "page" : undefined}
-          isDarkBackground={isDarkBackground}
           {...rest}
           {...tagComponent("crumb", rest)}
           {...(!isCurrent && {
@@ -47,7 +65,7 @@ const Crumb = React.forwardRef<HTMLAnchorElement, CrumbProps>(
           })}
         >
           {children}
-        </StyledCrumb>
+        </BaseLink>
         {!isCurrent && (
           <Divider
             data-role="crumb-divider"

--- a/src/components/breadcrumbs/crumb/crumb.style.ts
+++ b/src/components/breadcrumbs/crumb/crumb.style.ts
@@ -1,10 +1,4 @@
-import styled, { css } from "styled-components";
-import Link, { LinkProps } from "../../link";
-
-interface StyleCrumbProps extends LinkProps {
-  isCurrent?: boolean;
-  isDarkBackground: boolean;
-}
+import styled, { SimpleInterpolation, css } from "styled-components";
 
 const getCurrentCrumbColor = (isDarkBackground: boolean) => {
   return isDarkBackground
@@ -12,22 +6,49 @@ const getCurrentCrumbColor = (isDarkBackground: boolean) => {
     : "var(--colorsUtilityYin090)";
 };
 
-export const StyledCrumb = styled(Link)<StyleCrumbProps>`
+export const styledCrumb = (
+  baseStyles: SimpleInterpolation,
+  isDarkBackground: boolean,
+  isCurrent?: boolean,
+) => css`
+  ${baseStyles}
+
   font: var(--typographyLinkTextM);
-  ${({ isCurrent, isDarkBackground }) =>
-    isCurrent &&
-    css`
-      a {
+
+  > a {
+    color: ${isDarkBackground
+      ? "var(--colorsActionMajor350)"
+      : "var(--colorsActionMajor500)"};
+  }
+
+  ${!isCurrent &&
+  `
+    a:focus,
+    button:focus {
+      outline: yellow;
+      text-decoration: none;
+      border-bottom-left-radius: var(--borderRadius000);
+      border-bottom-right-radius: var(--borderRadius000);
+      max-width: fit-content;
+      box-shadow: 0 var(--spacing050) 0 0 var(--colorsUtilityYin090);
+      border-bottom-left-radius: var(--borderRadius025);
+      border-bottom-right-radius: var(--borderRadius025);
+    }
+  `}
+
+  ${isCurrent &&
+  `
+    a {
+      color: ${getCurrentCrumbColor(isDarkBackground)};
+      text-decoration: none;
+      font: var(--typographyBreadcrumbCurrentPageM);
+      :hover {
         color: ${getCurrentCrumbColor(isDarkBackground)};
         text-decoration: none;
-        font: var(--typographyBreadcrumbCurrentPageM);
-        :hover {
-          color: ${getCurrentCrumbColor(isDarkBackground)};
-          text-decoration: none;
-          cursor: text;
-        }
+        cursor: text;
       }
-    `}
+    }
+  `}
 `;
 
 interface DividerProps {
@@ -48,4 +69,4 @@ export const Divider = styled.span<DividerProps>`
   }
 `;
 
-export default { StyledCrumb, Divider };
+export default { styledCrumb, Divider };

--- a/src/components/breadcrumbs/crumb/crumb.test.tsx
+++ b/src/components/breadcrumbs/crumb/crumb.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Crumb from "./crumb.component";
 import Logger from "../../../__internal__/utils/logger";
@@ -89,4 +89,29 @@ test("renders with provided data- attributes", () => {
   );
 
   expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
+test("renders `isCurrent` correctly", () => {
+  render(
+    <Breadcrumbs aria-label="Default breadcrumbs">
+      <Crumb href="#" data-role="bc-1">
+        Breadcrumb 1
+      </Crumb>
+      <Crumb href="#" data-role="bc-2">
+        Breadcrumb 2
+      </Crumb>
+      <Crumb href="#" data-role="bc-3">
+        Breadcrumb 3
+      </Crumb>
+      <Crumb href="#" data-role="bc-4" isCurrent>
+        Current Page
+      </Crumb>
+    </Breadcrumbs>,
+  );
+
+  const currentCrumb = screen.getByTestId("bc-4");
+  const anchor = within(currentCrumb).getByTestId("link-anchor");
+
+  expect(currentCrumb).toHaveTextContent("Current Page");
+  expect(anchor).toHaveStyle("text-decoration: none");
 });

--- a/src/components/file-input/__internal__/file-upload-status/file-upload-status.style.tsx
+++ b/src/components/file-input/__internal__/file-upload-status/file-upload-status.style.tsx
@@ -9,7 +9,7 @@ import StyledLoaderBar, {
   StyledLoader,
   InnerBar as LoaderBarInnerBar,
 } from "../../../loader-bar/loader-bar.style";
-import { StyledLink, StyledContent } from "../../../link/link.style";
+import StyledLink from "../../../link/__internal__/base-link/base-link.style";
 
 export const StyledFileLinkContainer = styled.div`
   color: var(--colorsActionMajorYin090);
@@ -29,7 +29,7 @@ export const StyledFileLinkContainer = styled.div`
     text-decoration: none;
   }
 
-  ${StyledContent} {
+  [data-component="link-content"] {
     overflow: hidden;
     text-overflow: ellipsis;
     text-decoration: underline;

--- a/src/components/heading/heading.component.tsx
+++ b/src/components/heading/heading.component.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { MarginProps } from "styled-system";
+import { useTheme } from "styled-components";
 
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import tagComponent, {
@@ -15,10 +16,13 @@ import {
   StyledHeadingTitle,
   StyledDivider,
   StyledHeaderContent,
-  StyledHeadingBackButton,
+  styledHeadingBackButton,
   StyledHeadingPills,
 } from "./heading.style";
 import useLocale from "../../hooks/__internal__/useLocale";
+import { BaseLink } from "../link/__internal__";
+import addLinkStyles from "../link/link.style";
+import { ThemeObject } from "../../style/themes";
 
 export type HeadingType = "h1" | "h2" | "h3" | "h4" | "h5";
 export interface HeadingProps extends MarginProps, TagProps {
@@ -74,6 +78,14 @@ export const Heading = ({
   titleId,
   ...rest
 }: HeadingProps) => {
+  const theme = useTheme();
+
+  const baseStyles = addLinkStyles({
+    theme: theme as ThemeObject,
+
+    hasContent: !!children,
+  });
+
   const getHelp = () => {
     return (
       <StyledHeaderHelp
@@ -92,8 +104,11 @@ export const Heading = ({
     const backButtonProps =
       typeof backLink === "string" ? { href: backLink } : { onClick: backLink };
 
+    const styles = styledHeadingBackButton(baseStyles);
+
     return (
-      <StyledHeadingBackButton
+      <BaseLink
+        styles={styles}
         // this event allows an element to be focusable on click event on IE
         aria-label={l.heading.backLinkAriaLabel()}
         data-element="back"
@@ -102,7 +117,7 @@ export const Heading = ({
         {...backButtonProps}
       >
         <StyledHeadingIcon type="chevron_left" />
-      </StyledHeadingBackButton>
+      </BaseLink>
     );
   };
 

--- a/src/components/heading/heading.style.ts
+++ b/src/components/heading/heading.style.ts
@@ -1,4 +1,4 @@
-import styled, { css } from "styled-components";
+import styled, { css, SimpleInterpolation } from "styled-components";
 import { margin } from "styled-system";
 
 import Icon from "../icon";
@@ -7,7 +7,6 @@ import applyBaseTheme from "../../style/themes/apply-base-theme";
 import Help from "../help";
 import Typography from "../typography";
 import Hr from "../hr";
-import Link from "../link";
 import addFocusStyling from "../../style/utils/add-focus-styling";
 
 const StyledHeading = styled.div.attrs(applyBaseTheme)`
@@ -52,7 +51,9 @@ const StyledHeader = styled.div<StyledHeaderProps>`
   `}
 `;
 
-const StyledHeadingBackButton = styled(Link)`
+export const styledHeadingBackButton = (baseStyles: SimpleInterpolation) => css`
+  ${baseStyles}
+
   margin-right: 5px;
   margin-top: 2px;
   box-shadow: none;
@@ -164,6 +165,5 @@ export {
   StyledHeadingTitle,
   StyledDivider,
   StyledHeaderContent,
-  StyledHeadingBackButton,
   StyledHeadingPills,
 };

--- a/src/components/icon/icon.component.tsx
+++ b/src/components/icon/icon.component.tsx
@@ -58,6 +58,8 @@ export interface IconProps
   inputSize?: "small" | "medium" | "large";
   /** @ignore @private */
   tabIndex?: number;
+  /** @ignore @private */
+  "data-icon-align"?: "left" | "right";
 }
 
 const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
@@ -88,6 +90,7 @@ const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
       tooltipId,
       type,
       role,
+      "data-icon-align": dataIconAlign,
       ...rest
     }: IconProps,
     ref,
@@ -169,6 +172,7 @@ const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
       role,
       tabIndex: computedTabIndex,
       type: iconType,
+      "data-icon-align": dataIconAlign,
       ...filterStyledSystemMarginProps(rest),
     };
 

--- a/src/components/link/__internal__/base-link/base-link-test.stories.tsx
+++ b/src/components/link/__internal__/base-link/base-link-test.stories.tsx
@@ -1,0 +1,116 @@
+import { css } from "styled-components";
+
+import React from "react";
+import BaseLink from "./base-link.component";
+
+export default {
+  title: "Link/Test/BaseLink",
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disableSnapshot: true,
+    },
+  },
+};
+
+export const AsALink = () => {
+  return <BaseLink href="#">This is a link</BaseLink>;
+};
+
+export const AsAButton = () => {
+  return (
+    <BaseLink onClick={() => {}}>
+      This is also a link, but renders as a button
+    </BaseLink>
+  );
+};
+
+const styleConfigs = (destructive = false, disabled = false) => ({
+  primary: css`
+    --bg-color: ${destructive ? "red" : "green"};
+    --border-color: ${destructive ? "blue" : "yellow"};
+
+    background-color: var(--bg-color);
+    border: var(--border-color) 1px solid;
+    width: fit-content;
+    color: white;
+    margin: 4px;
+    padding: 8px;
+    font-weight: 800;
+
+    ${disabled
+      ? `
+        filter: brightness(0.3);
+      `
+      : `
+        &:focus {
+          outline: 2px solid cyan;
+        }
+
+        transition: background-color 0.3s, filter 0.3s;
+
+        &:hover {
+          filter: brightness(0.9);
+        }
+      `}
+  `,
+  secondary: css`
+    --bg-color: transparent;
+    --border-color: ${destructive ? "red" : "green"};
+    --color: ${destructive ? "red" : "green"};
+
+    background-color: var(--bg-color);
+    border: var(--border-color) 1px solid;
+    width: fit-content;
+    color: var(--color);
+    margin: 4px;
+    padding: 8px;
+    font-weight: 800;
+
+    ${disabled
+      ? `
+        filter: brightness(0.3);
+      `
+      : `
+        &:focus {
+          outline: 2px solid cyan;
+        }
+
+        transition: color 0.3s, filter 0.3s;
+
+        &:hover {
+          filter: brightness(0.9);
+        }
+      `}
+  `,
+});
+
+export const PrimaryStyles = () => {
+  const { primary } = styleConfigs();
+  return (
+    <>
+      <BaseLink styles={primary} href="#">
+        Primary Link
+      </BaseLink>
+
+      <BaseLink styles={primary} onClick={() => {}}>
+        Primary Button
+      </BaseLink>
+    </>
+  );
+};
+
+export const SecondaryStyles = () => {
+  const { secondary } = styleConfigs();
+  return (
+    <>
+      <BaseLink styles={secondary} href="#">
+        Secondary Link
+      </BaseLink>
+
+      <BaseLink styles={secondary} onClick={() => {}}>
+        Secondary Button
+      </BaseLink>
+    </>
+  );
+};

--- a/src/components/link/__internal__/base-link/base-link.component.tsx
+++ b/src/components/link/__internal__/base-link/base-link.component.tsx
@@ -1,0 +1,247 @@
+import React, { forwardRef, useCallback, useMemo } from "react";
+import { SimpleInterpolation } from "styled-components";
+
+import StyledBaseLinkWrapper from "./base-link.style";
+
+import Icon, { IconType } from "../../../icon";
+import tagComponent from "../../../../__internal__/utils/helpers/tags/tags";
+
+// BaseLink component is a low-level component that can be used to create links or buttons with consistent styling and behavior.
+export interface BaseLinkProps {
+  /** Aria label for accessibility purposes */
+  ariaLabel?: string;
+  /** Child content to render. */
+  children?: React.ReactNode;
+  /**
+   * @private
+   * @internal
+   * @ignore
+   * Sets className for component. INTERNAL USE ONLY. */
+  className?: string;
+  /**
+   * Data attribute for the component, used for testing and tracking purposes.
+   * @private
+   * @internal
+   * @ignore */
+  "data-component"?: string;
+  /**
+   * Data attribute for the element, used for testing and tracking purposes.
+   * @private
+   * @internal
+   * @ignore */
+  "data-element"?: string;
+  /**
+   * Data attribute for the role, used for testing and tracking purposes.
+   * @private
+   * @internal
+   * @ignore */
+  "data-role"?: string;
+  /** Disables the link. */
+  disabled?: boolean;
+  /** A href for an anchor tag. */
+  href?: string;
+  /** An icon to display next to the link. */
+  icon?: IconType;
+  /** Aligns the icon to the left or right of the link text. */
+  iconAlign?: "left" | "right";
+  /** Function called when focus is lost. */
+  onBlur?: (
+    ev:
+      | React.FocusEvent<HTMLAnchorElement>
+      | React.FocusEvent<HTMLButtonElement>,
+  ) => void;
+  /** Function called when the mouse is clicked. */
+  onClick?: (
+    event:
+      | React.MouseEvent<HTMLAnchorElement>
+      | React.MouseEvent<HTMLButtonElement>
+      | React.KeyboardEvent<HTMLAnchorElement>
+      | React.KeyboardEvent<HTMLButtonElement>,
+  ) => void;
+  /** Function called when focus is received. */
+  onFocus?: (
+    ev:
+      | React.FocusEvent<HTMLAnchorElement>
+      | React.FocusEvent<HTMLButtonElement>,
+  ) => void;
+  /** Function called when a key is pressed. */
+  onKeyDown?: (
+    ev:
+      | React.KeyboardEvent<HTMLAnchorElement>
+      | React.KeyboardEvent<HTMLButtonElement>,
+  ) => void;
+  /** Function called when a mouse down event triggers. */
+  onMouseDown?: (
+    ev:
+      | React.MouseEvent<HTMLAnchorElement>
+      | React.MouseEvent<HTMLButtonElement>,
+  ) => void;
+  /** Value of rel property in <a> tag */
+  rel?: string;
+  /** @ignore @private Internal prop to be set when no aria-label should be specified */
+  removeAriaLabelOnIcon?: boolean;
+  /** Styling to apply to the component */
+  styles?: SimpleInterpolation;
+  /** Target property in which link should open ie: _blank, _self, _parent, _top */
+  target?: string;
+  /** [Legacy] A message to display as a tooltip to the link. */
+  tooltipMessage?: string;
+  /** [Legacy] Positions the tooltip with the link. */
+  tooltipPosition?: "bottom" | "left" | "right" | "top";
+}
+
+const BaseLink = forwardRef<
+  HTMLAnchorElement | HTMLButtonElement,
+  BaseLinkProps
+>(
+  (
+    {
+      ariaLabel,
+      children,
+      className,
+      "data-component": dataComponent = "link",
+      "data-element": dataElement,
+      "data-role": dataRole,
+      disabled,
+      href,
+      icon,
+      iconAlign = "left",
+      onBlur,
+      onClick,
+      onFocus,
+      onKeyDown,
+      onMouseDown,
+      rel,
+      removeAriaLabelOnIcon = false,
+      styles,
+      target,
+      tooltipMessage,
+      tooltipPosition,
+      ...rest
+    }: BaseLinkProps,
+    ref,
+  ) => {
+    /* istanbul ignore next */
+    const setAnchorRef = useCallback(
+      (reference: HTMLAnchorElement | null) => {
+        if (!ref) return;
+        if (typeof ref === "object" && ref !== null)
+          (
+            ref as React.MutableRefObject<
+              HTMLAnchorElement | HTMLButtonElement | null
+            >
+          ).current = reference;
+        if (typeof ref === "function") {
+          ref(reference);
+        }
+      },
+      [ref],
+    );
+
+    /* istanbul ignore next */
+    const setButtonRef = useCallback(
+      (reference: HTMLButtonElement | null) => {
+        if (!ref) return;
+        if (typeof ref === "object" && ref !== null)
+          (
+            ref as React.MutableRefObject<
+              HTMLAnchorElement | HTMLButtonElement | null
+            >
+          ).current = reference;
+        if (typeof ref === "function") {
+          ref(reference);
+        }
+      },
+      [ref],
+    );
+
+    // Extract aria- properties from the rest of the props
+    const ariaProps = useMemo(() => {
+      const restObject = rest as Record<string, unknown>;
+      restObject["aria-disabled"] = disabled;
+
+      return Object.keys(restObject)
+        .filter((key) => key.startsWith("aria"))
+        .reduce((obj: Record<string, unknown>, key: string) => {
+          obj[key] = restObject[key];
+          return obj;
+        }, {});
+    }, [disabled, rest]);
+
+    // Prepare the component props to be passed to the anchor or button element
+    const componentProps = {
+      "aria-label": ariaLabel,
+      ...ariaProps,
+      disabled,
+      href,
+      onBlur,
+      onClick,
+      onFocus,
+      onKeyDown,
+      onMouseDown,
+      rel,
+      target,
+    };
+
+    // Render the component with the icon and children
+    const renderedComponent = useMemo(
+      () => (
+        <>
+          {icon && iconAlign === "left" && (
+            <Icon
+              type={icon}
+              disabled={disabled}
+              ariaLabel={removeAriaLabelOnIcon ? undefined : ariaLabel}
+              tooltipMessage={tooltipMessage}
+              tooltipPosition={tooltipPosition}
+              data-icon-align={iconAlign}
+            />
+          )}
+          {children}
+          {icon && iconAlign === "right" && (
+            <Icon
+              type={icon}
+              disabled={disabled}
+              ariaLabel={removeAriaLabelOnIcon ? undefined : ariaLabel}
+              tooltipMessage={tooltipMessage}
+              tooltipPosition={tooltipPosition}
+              data-icon-align={iconAlign}
+            />
+          )}
+        </>
+      ),
+      [
+        children,
+        icon,
+        iconAlign,
+        disabled,
+        ariaLabel,
+        tooltipMessage,
+        tooltipPosition,
+        removeAriaLabelOnIcon,
+      ],
+    );
+
+    return (
+      <StyledBaseLinkWrapper
+        $styles={styles}
+        className={className}
+        {...tagComponent(dataComponent, rest)}
+        data-element={dataElement}
+        data-role={dataRole}
+      >
+        {onClick && !href ? (
+          <button ref={setButtonRef} type="button" {...componentProps}>
+            {renderedComponent}
+          </button>
+        ) : (
+          <a ref={setAnchorRef} {...componentProps} data-role="link-anchor">
+            {renderedComponent}
+          </a>
+        )}
+      </StyledBaseLinkWrapper>
+    );
+  },
+);
+
+export default BaseLink;

--- a/src/components/link/__internal__/base-link/base-link.style.ts
+++ b/src/components/link/__internal__/base-link/base-link.style.ts
@@ -1,0 +1,11 @@
+import styled, { SimpleInterpolation } from "styled-components";
+
+interface StyledBaseLinkProps {
+  $styles?: SimpleInterpolation;
+}
+
+const StyledBaseLinkWrapper = styled.span<StyledBaseLinkProps>`
+  ${({ $styles }) => $styles};
+`;
+
+export default StyledBaseLinkWrapper;

--- a/src/components/link/__internal__/base-link/base-link.test.tsx
+++ b/src/components/link/__internal__/base-link/base-link.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import BaseLink from "./base-link.component";
+
+test("renders as a link if `href` is provided", () => {
+  render(<BaseLink href="#">This is a link</BaseLink>);
+  const linkElement = screen.getByRole("link");
+  expect(linkElement).toBeInTheDocument();
+  expect(linkElement).toHaveTextContent("This is a link");
+});
+
+test("renders as a button if `onClick` is provided and `href` is not provided", () => {
+  render(
+    <BaseLink onClick={() => {}}>
+      This is also a link, but renders as a button
+    </BaseLink>,
+  );
+  const buttonElement = screen.getByRole("button");
+  expect(buttonElement).toBeInTheDocument();
+  expect(buttonElement).toHaveTextContent(
+    "This is also a link, but renders as a button",
+  );
+});
+
+test("renders with the correct aria attributes", () => {
+  render(
+    <BaseLink
+      href="#"
+      ariaLabel="This is a link with aria-label"
+      aria-describedby="description-id"
+    >
+      Link with aria attributes
+    </BaseLink>,
+  );
+  const linkElement = screen.getByRole("link");
+  expect(linkElement).toHaveAttribute(
+    "aria-label",
+    "This is a link with aria-label",
+  );
+  expect(linkElement).toHaveAttribute("aria-describedby", "description-id");
+});
+
+[true, false].forEach((removeAriaLabelOnIcon) => {
+  test(`renders the icon on the left when "iconAlign" is provided and "removeAriaLabelOnIcon" is ${removeAriaLabelOnIcon}`, () => {
+    render(
+      <BaseLink
+        href="#"
+        icon="info"
+        iconAlign="left"
+        ariaLabel="Link with icon"
+        removeAriaLabelOnIcon={removeAriaLabelOnIcon}
+      >
+        Link with icon
+      </BaseLink>,
+    );
+    const anchorElement = screen.getByRole("link");
+    expect(anchorElement).toBeInTheDocument();
+    const { firstChild, lastChild } = anchorElement;
+
+    expect(firstChild).toHaveAttribute("data-component", "icon");
+    expect(lastChild).toHaveTextContent("Link with icon");
+  });
+});
+
+[true, false].forEach((removeAriaLabelOnIcon) => {
+  test(`renders the icon on the right when "iconAlign" is provided and "removeAriaLabelOnIcon" is ${removeAriaLabelOnIcon}`, () => {
+    render(
+      <BaseLink
+        href="#"
+        icon="info"
+        iconAlign="right"
+        ariaLabel="Link with icon"
+        removeAriaLabelOnIcon={removeAriaLabelOnIcon}
+      >
+        Link with icon
+      </BaseLink>,
+    );
+    const anchorElement = screen.getByRole("link");
+    expect(anchorElement).toBeInTheDocument();
+    const { firstChild, lastChild } = anchorElement;
+
+    expect(firstChild).toHaveTextContent("Link with icon");
+    expect(lastChild).toHaveAttribute("data-component", "icon");
+  });
+});

--- a/src/components/link/__internal__/base-link/index.ts
+++ b/src/components/link/__internal__/base-link/index.ts
@@ -1,0 +1,2 @@
+export { default as BaseLink } from "./base-link.component";
+export type { BaseLinkProps } from "./base-link.component";

--- a/src/components/link/__internal__/index.ts
+++ b/src/components/link/__internal__/index.ts
@@ -1,0 +1,2 @@
+export { default as BaseLink } from "./base-link/base-link.component";
+export type { BaseLinkProps } from "./base-link/base-link.component";

--- a/src/components/link/link-test.stories.tsx
+++ b/src/components/link/link-test.stories.tsx
@@ -138,3 +138,5 @@ export const LinkComponent = (props: LinkProps) => {
     </div>
   );
 };
+
+export const Test = () => <Link icon="basket" iconAlign="right" />;

--- a/src/components/link/link.component.tsx
+++ b/src/components/link/link.component.tsx
@@ -1,13 +1,16 @@
-import React, { useContext, useEffect, useMemo, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
+import { useTheme } from "styled-components";
 
+import addLinkStyle, { StyledLinkProps } from "./link.style";
+import BatchSelectionContext from "../batch-selection/__internal__/batch-selection.context";
 import Icon, { IconType } from "../icon";
 import MenuContext from "../menu/__internal__/menu.context";
-import { StyledLink, StyledContent, StyledLinkProps } from "./link.style";
 import tagComponent, {
   TagProps,
 } from "../../__internal__/utils/helpers/tags/tags";
 import useLocale from "../../hooks/__internal__/useLocale";
-import BatchSelectionContext from "../batch-selection/__internal__/batch-selection.context";
+import type { ThemeObject } from "../../style/themes/theme.types";
+import { BaseLink } from "./__internal__";
 
 export interface LinkProps
   extends StyledLinkProps,
@@ -94,17 +97,6 @@ export const Link = React.forwardRef<
     const { batchSelectionDisabled } = useContext(BatchSelectionContext);
     const isDisabled = disabled || batchSelectionDisabled;
 
-    const setRefs = React.useCallback(
-      (reference: HTMLAnchorElement) => {
-        if (!ref) return;
-        if (typeof ref === "object") ref.current = reference;
-        if (typeof ref === "function") {
-          ref(reference);
-        }
-      },
-      [ref],
-    );
-
     const renderLinkIcon = (currentAlignment = "left") => {
       const hasProperAlignment = icon && iconAlign === currentAlignment;
 
@@ -119,64 +111,23 @@ export const Link = React.forwardRef<
       ) : null;
     };
 
-    const ariaProps = useMemo(() => {
-      const restObject = rest as Record<string, unknown>;
-
-      return Object.keys(restObject)
-        .filter((key) => key.startsWith("aria"))
-        .reduce((obj: Record<string, unknown>, key: string) => {
-          obj[key] = restObject[key];
-          return obj;
-        }, {});
-    }, [rest]);
-
-    const componentProps = {
+    const props = {
       onKeyDown,
       onMouseDown,
       onClick,
       disabled: isDisabled,
       target,
-      ref: setRefs,
+      ref,
       href,
       rel,
       "aria-label": ariaLabel,
-      ...ariaProps,
+      className,
       onFocus: () => setHasFocus(true),
       onBlur: () => setHasFocus(false),
-    };
 
-    const buttonProps = {
-      type: "button",
-    };
-
-    const createLinkBasedOnType = () => {
-      let type = "a";
-
-      if (onClick && !href) {
-        type = "button";
-      }
-
-      return React.createElement(
-        type,
-        type === "button"
-          ? {
-              ...componentProps,
-              ...buttonProps,
-            }
-          : {
-              ...componentProps,
-              "data-role": "link-anchor",
-            },
-        <>
-          {renderLinkIcon()}
-
-          <StyledContent>
-            {isSkipLink ? l.link.skipLinkLabel() : children}
-          </StyledContent>
-
-          {renderLinkIcon("right")}
-        </>,
-      );
+      ...tagComponent("link", rest),
+      ...(isSkipLink && { "data-element": "skip-link" }),
+      ...rest,
     };
 
     useEffect(() => {
@@ -185,22 +136,30 @@ export const Link = React.forwardRef<
       }
     }, [disabled, href, onClick]);
 
+    const theme = useTheme();
+
+    const styles = addLinkStyle({
+      disabled: isDisabled,
+      hasContent: !!children,
+      hasFocus,
+      iconAlign,
+      isDarkBackground,
+      isMenuItem: inMenu,
+      isSkipLink,
+      theme: theme as ThemeObject,
+      variant,
+    });
+
     return (
-      <StyledLink
-        isSkipLink={isSkipLink}
-        disabled={isDisabled}
-        iconAlign={iconAlign}
-        className={className}
-        hasContent={Boolean(children)}
-        variant={variant}
-        isDarkBackground={isDarkBackground}
-        isMenuItem={inMenu}
-        {...tagComponent("link", rest)}
-        {...(isSkipLink && { "data-element": "skip-link" })}
-        hasFocus={hasFocus}
-      >
-        {createLinkBasedOnType()}
-      </StyledLink>
+      <BaseLink {...props} styles={styles}>
+        <>
+          {renderLinkIcon()}
+          <span data-component="link-content">
+            {isSkipLink ? l.link.skipLinkLabel() : children}
+          </span>
+          {renderLinkIcon("right")}
+        </>
+      </BaseLink>
     );
   },
 );

--- a/src/components/link/link.style.ts
+++ b/src/components/link/link.style.ts
@@ -1,9 +1,11 @@
-import styled, { css } from "styled-components";
-import applyBaseTheme from "../../style/themes/apply-base-theme";
+import { css } from "styled-components";
+import baseTheme from "../../style/themes/base";
+import type { ThemeObject } from "../../style/themes/theme.types";
 import StyledIcon from "../icon/icon.style";
 import StyledButton from "../button/button.style";
 
 type Variants = "default" | "negative" | "neutral";
+
 export interface StyledLinkProps {
   /** The disabled state of the link. */
   disabled?: boolean;
@@ -72,173 +74,166 @@ const colorMap: ColorMap = {
   },
 };
 
-const StyledLink = styled.span.attrs(applyBaseTheme)<
-  StyledLinkProps & PrivateStyledLinkProps
->`
-  ${({
-    isSkipLink,
-    theme,
-    iconAlign,
-    hasContent,
-    disabled,
-    variant,
-    isDarkBackground,
-    isMenuItem,
-    hasFocus,
-  }) => {
-    const colorMapKey = isDarkBackground ? "dark" : "light";
-    const { color, hoverColor, disabledColor } = colorMap[colorMapKey](variant);
+export default ({
+  disabled,
+  hasContent,
+  hasFocus,
+  iconAlign,
+  isDarkBackground,
+  isMenuItem,
+  isSkipLink,
+  theme = baseTheme,
+  variant,
+}: StyledLinkProps & PrivateStyledLinkProps & { theme: ThemeObject }) => {
+  const colorMapKey = isDarkBackground ? "dark" : "light";
+  const { color, hoverColor, disabledColor } = colorMap[colorMapKey](variant);
+  const isDisabled = disabled || false;
 
-    return css`
-      ${isSkipLink &&
-      css`
-        a {
-          position: absolute;
-          padding-left: var(--spacing300);
-          padding-right: var(--spacing300);
-          line-height: var(--sizing600);
-          left: -999em;
-          z-index: ${theme.zIndex.aboveAll};
-          border: 3px solid var(--colorsUtilityYin100);
-          box-shadow: var(--boxShadow300);
-          border-radius: var(--spacing000) var(--spacing100) var(--spacing100)
-            var(--spacing000);
-          font-size: var(--fontSizes100);
+  return css`
+    ${isSkipLink &&
+    css`
+      a {
+        position: absolute;
+        padding-left: var(--spacing300);
+        padding-right: var(--spacing300);
+        line-height: var(--sizing600);
+        left: -999em;
+        z-index: ${theme.zIndex.aboveAll};
+        border: 3px solid var(--colorsUtilityYin100);
+        box-shadow: var(--boxShadow300);
+        border-radius: var(--spacing000) var(--spacing100) var(--spacing100)
+          var(--spacing000);
+        font-size: var(--fontSizes100);
+        color: var(--colorsUtilityYin090);
+
+        &:hover {
+          cursor: pointer;
           color: var(--colorsUtilityYin090);
 
-          &:hover {
-            cursor: pointer;
-            color: var(--colorsUtilityYin090);
+          ${StyledIcon} {
+            color: var(--colorsActionMajor600);
+          }
+        }
 
-            ${StyledIcon} {
-              color: var(--colorsActionMajor600);
+        &:focus {
+          background-color: var(--colorsSemanticFocus500);
+          text-decoration: underline var(--colorsUtilityYin100);
+          text-decoration-thickness: 4px;
+          text-underline-offset: 3px;
+          -webkit-text-decoration: underline var(--colorsUtilityYin100);
+          -webkit-text-decoration-thickness: 4px;
+          -webkit-text-underline-offset: 3px;
+        }
+      }
+
+      a:focus {
+        top: var(--spacing100);
+        left: var(--spacing000);
+      }
+    `}
+
+    ${!isSkipLink &&
+    css`
+      > a,
+      > button {
+        font-size: var(--fontSizes100);
+
+        ${!isDisabled &&
+        css`
+          color: ${color};
+          ${StyledIcon} {
+            color: ${color};
+          }
+
+          &:hover {
+            color: ${hoverColor};
+
+            > ${StyledIcon} {
+              color: ${hoverColor};
             }
           }
 
           &:focus {
-            background-color: var(--colorsSemanticFocus500);
-            text-decoration: underline var(--colorsUtilityYin100);
-            text-decoration-thickness: 4px;
-            text-underline-offset: 3px;
-            -webkit-text-decoration: underline var(--colorsUtilityYin100);
-            -webkit-text-decoration-thickness: 4px;
-            -webkit-text-underline-offset: 3px;
+            background-color: var(--colorsSemanticFocus250);
+            border-radius: var(--borderRadius025);
           }
-        }
+        `}
 
-        a:focus {
-          top: var(--spacing100);
-          left: var(--spacing000);
-        }
-      `}
-
-      ${!isSkipLink &&
-      css`
-        > a,
-        > button {
-          font-size: var(--fontSizes100);
-
-          ${!disabled &&
-          css`
-            color: ${color};
-            ${StyledIcon} {
-              color: ${color};
-            }
-
-            &:hover {
-              color: ${hoverColor};
-
-              > ${StyledIcon} {
-                color: ${hoverColor};
-              }
-            }
-
-            &:focus {
-              background-color: var(--colorsSemanticFocus250);
-              border-radius: var(--borderRadius025);
-            }
-          `}
-
-          ${disabled &&
-          css`
+        ${isDisabled &&
+        css`
+          color: ${disabledColor};
+          &:hover,
+          &:focus {
             color: ${disabledColor};
-            &:hover,
-            &:focus {
-              color: ${disabledColor};
-            }
-          `}
-        }
-      `}
+          }
+        `}
+      }
+    `}
 
-      ${!disabled &&
-      css`
-        > a:any-link:hover,
-        > button:hover {
-          cursor: pointer;
-        }
-      `}
+      ${!isDisabled &&
+    css`
+      > a:any-link:hover,
+      > button:hover {
+        cursor: pointer;
+      }
+    `}
 
       > a,
       > button {
-        text-decoration: ${hasContent ? "underline" : "none"};
-        ${isMenuItem && "display: inline-block;"}
+      text-decoration: ${hasContent ? "underline" : "none"};
+      ${isMenuItem && "display: inline-block;"}
 
-        > ${StyledIcon} {
-          display: ${hasContent ? "inline-block" : "inline"};
-          position: relative;
-          vertical-align: middle;
-          ${iconAlign === "left" &&
-          css`
-            margin-right: ${hasContent ? "var(--spacing050)" : 0};
-          `}
-          ${iconAlign === "right" &&
-          css`
-            margin-right: 0;
-            margin-left: ${hasContent ? "var(--spacing100)" : 0};
-          `}
-        }
-
-        &:focus {
-          color: var(--colorsActionMajorYin090);
-          outline: none;
-
-          ${StyledIcon} {
-            color: var(--colorsActionMajorYin090);
-          }
-        }
-
-        ${disabled &&
+      ${StyledIcon} {
+        display: ${hasContent ? "inline-block" : "inline"};
+        position: relative;
+        vertical-align: middle;
+        ${iconAlign === "left" &&
         css`
-          cursor: not-allowed;
+          margin-right: ${hasContent ? "var(--spacing050)" : 0};
+        `}
+        ${iconAlign === "right" &&
+        css`
+          margin-right: 0;
+          margin-left: ${hasContent ? "var(--spacing100)" : 0};
         `}
       }
 
-      ${!isSkipLink &&
-      !disabled &&
-      hasFocus &&
-      css`
-        > a,
-        > button {
-          outline: none;
-          text-decoration: none;
-          border-bottom-left-radius: var(--borderRadius000);
-          border-bottom-right-radius: var(--borderRadius000);
+      &:focus {
+        color: var(--colorsActionMajorYin090);
+        outline: none;
+
+        ${StyledIcon} {
+          color: var(--colorsActionMajorYin090);
         }
-        max-width: fit-content;
-        box-shadow: 0 var(--spacing050) 0 0 var(--colorsUtilityYin090);
-        border-bottom-left-radius: var(--borderRadius025);
-        border-bottom-right-radius: var(--borderRadius025);
-      `}
-
-      > button, ${StyledButton}:not(.search-button) {
-        background-color: transparent;
-        border: none;
-        padding: 0;
       }
-    `;
-  }}
-`;
 
-const StyledContent = styled.span``;
+      ${isDisabled &&
+      css`
+        cursor: not-allowed;
+      `}
+    }
 
-export { StyledLink, StyledContent };
+    ${!isSkipLink &&
+    !isDisabled &&
+    hasFocus &&
+    css`
+      > a,
+      > button {
+        outline: yellow;
+        text-decoration: none;
+        border-bottom-left-radius: var(--borderRadius000);
+        border-bottom-right-radius: var(--borderRadius000);
+      }
+      max-width: fit-content;
+      box-shadow: 0 var(--spacing050) 0 0 var(--colorsUtilityYin090);
+      border-bottom-left-radius: var(--borderRadius025);
+      border-bottom-right-radius: var(--borderRadius025);
+    `}
+
+    > button, ${StyledButton}:not(.search-button) {
+      background-color: transparent;
+      border: none;
+      padding: 0;
+    }
+  `;
+};

--- a/src/components/link/link.test.tsx
+++ b/src/components/link/link.test.tsx
@@ -1,10 +1,11 @@
 /* TODO: FE-6579 To re-enable once button-related props are removed from Link */
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React from "react";
 
 import Link from "./link.component";
+
 import { Menu } from "../menu";
 
 test("should render `Skip to main content` text inside of Link when `isSkipLink` prop is provided", () => {
@@ -572,4 +573,45 @@ test("sets ref to empty after unmount", () => {
   unmount();
 
   expect(mockRef.current).toBe(null);
+});
+
+// Coverage: blur focus styling
+test("the correct focus styling is applied on focus and removed on blur", async () => {
+  const user = userEvent.setup();
+  render(
+    <>
+      <Link href="foo.com" data-role="link" />
+      <button type="button" data-role="button">
+        Button
+      </button>
+    </>,
+  );
+
+  const linkElement = screen.getByTestId("link-anchor");
+
+  await user.tab();
+  expect(linkElement).toHaveFocus();
+
+  await user.tab();
+
+  expect(linkElement).not.toHaveFocus();
+  expect(screen.getByTestId("button")).toHaveFocus();
+});
+
+// coverage: correct styling with no children
+test("has the correct content styling when no children are present", () => {
+  render(<Link href="#" data-role="link" />);
+  const linkElement = screen.getByTestId("link-anchor");
+  expect(linkElement).toHaveStyle("text-decoration: none");
+});
+
+// coverage: correct styling with children
+test("has the correct content styling when children are present", () => {
+  render(
+    <Link href="#" data-role="link">
+      Text
+    </Link>,
+  );
+  const linkElement = screen.getByTestId("link-anchor");
+  expect(linkElement).toHaveStyle("text-decoration: underline");
 });

--- a/src/components/menu/__internal__/submenu/submenu.style.ts
+++ b/src/components/menu/__internal__/submenu/submenu.style.ts
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 import StyledScrollableBlock from "../../../menu/scrollable-block/scrollable-block.style";
 import applyBaseTheme from "../../../../style/themes/apply-base-theme";
-import { StyledLink } from "../../../link/link.style";
+import Link from "../../../link";
 import { StyledMenuItem } from "../../menu.style";
 import StyledBox from "../../../box/box.style";
 import StyledMenuItemWrapper from "../../menu-item/menu-item.style";
@@ -30,6 +30,8 @@ interface StyledSubmenuProps
   applyFocusRadiusStyling: boolean;
   applyFocusRadiusStylingToLastItem: boolean;
 }
+
+const StyledLink = styled(Link)``;
 
 const StyledSubmenuWrapper = styled.div.attrs(
   applyBaseTheme,
@@ -84,9 +86,14 @@ const StyledSubmenu = styled.ul<StyledSubmenuProps>`
       box-shadow: var(--boxShadow100);
       position: absolute;
       top: 100%;
-      background-color: ${variant === "default"
-        ? menuConfigVariants[menuType].submenuItemBackground
-        : menuConfigVariants[menuType].background};
+      &,
+      a,
+      button,
+      ${StyledMenuItem} {
+        background-color: ${variant === "default"
+          ? menuConfigVariants[menuType].submenuItemBackground
+          : menuConfigVariants[menuType].background};
+      }
 
       min-width: ${submenuMinWidth ?? "100%"};
 

--- a/src/components/menu/menu-full-screen/menu-full-screen.style.ts
+++ b/src/components/menu/menu-full-screen/menu-full-screen.style.ts
@@ -7,8 +7,7 @@ import StyledIcon from "../../icon/icon.style";
 import StyledButton from "../../button/button.style";
 import menuConfigVariants from "../menu.config";
 import addFocusStyling from "../../../style/utils/add-focus-styling";
-import { StyledLink } from "../../link/link.style";
-
+import StyledLink from "../../link/__internal__/base-link/base-link.style";
 import type { MenuType } from "../menu.types";
 
 const StyledMenuFullscreen = styled.div.attrs(applyBaseTheme)<{

--- a/src/components/menu/menu-item/menu-item.style.ts
+++ b/src/components/menu/menu-item/menu-item.style.ts
@@ -4,10 +4,10 @@ import { padding, PaddingProps } from "styled-system";
 
 import menuConfigVariants from "../menu.config";
 import Link from "../../link";
+import { BaseLink } from "../../link/__internal__/base-link";
 import StyledButton from "../../button/button.style";
 import StyledIconButton from "../../icon-button/icon-button.style";
 import StyledIcon from "../../icon/icon.style";
-import { StyledContent, StyledLink } from "../../link/link.style";
 import applyBaseTheme from "../../../style/themes/apply-base-theme";
 import addFocusStyling from "../../../style/utils/add-focus-styling";
 
@@ -81,8 +81,10 @@ const parsePadding = (props: Partial<PaddingProps>) => {
   }
 };
 
+const StyledLink = styled(Link)``;
+
 const StyledMenuItemWrapper = styled.a.attrs(applyBaseTheme).attrs({
-  as: Link,
+  as: BaseLink,
 })<StyledMenuItemWrapperProps>`
   ${({
     menuType,
@@ -111,10 +113,12 @@ const StyledMenuItemWrapper = styled.a.attrs(applyBaseTheme).attrs({
     box-shadow: none;
 
     a,
-    button {
+    button:not(.search-button) {
       min-height: 40px;
       height: 100%;
       box-sizing: border-box;
+      border: none;
+      font-size: var(--fontSizes100);
     }
 
     a:focus,
@@ -122,13 +126,35 @@ const StyledMenuItemWrapper = styled.a.attrs(applyBaseTheme).attrs({
       ${addFocusStyling(true)}
     }
 
-    :has([data-element="input"]) ${StyledContent} {
+    > a,
+    > button {
+      [data-icon-align="left"] {
+        display: "inline-block";
+        position: relative;
+        vertical-align: middle;
+        margin-right: var(--spacing050);
+      }
+      [data-icon-align="right"] {
+        display: "inline-block";
+        position: relative;
+        vertical-align: middle;
+        margin-right: 0;
+        margin-left: var(--spacing100);
+      }
+    }
+
+    :has([data-element="input"]) [data-component="link-content"] {
       width: 100%;
     }
 
     ${!overrideColor &&
     css`
-      background-color: ${menuConfigVariants[menuType].background};
+      &,
+      ${StyledLink}, > button,
+      > a {
+        background-color: ${menuConfigVariants[menuType].background};
+        cursor: pointer;
+      }
     `}
 
     ${overrideColor &&
@@ -216,7 +242,7 @@ const StyledMenuItemWrapper = styled.a.attrs(applyBaseTheme).attrs({
         > a:has(${StyledButton}:not(.search-button)) {
           height: 100%;
 
-          ${StyledContent} {
+          [data-component="link-content"] {
             height: inherit;
 
             div {
@@ -309,6 +335,10 @@ const StyledMenuItemWrapper = styled.a.attrs(applyBaseTheme).attrs({
     ${selected &&
     css`
       background-color: ${menuConfigVariants[menuType].selected};
+      a,
+      button {
+        background-color: ${menuConfigVariants[menuType].selected};
+      }
 
       a:focus,
       button:focus {
@@ -325,7 +355,10 @@ const StyledMenuItemWrapper = styled.a.attrs(applyBaseTheme).attrs({
     !inFullscreenView &&
     css`
       &&& {
-        background-color: ${menuConfigVariants[menuType].alternate};
+        a,
+        button {
+          background-color: ${menuConfigVariants[menuType].alternate};
+        }
       }
 
       &&& a:focus,
@@ -393,7 +426,10 @@ const StyledMenuItemWrapper = styled.a.attrs(applyBaseTheme).attrs({
 
       ${selected &&
       css`
-        background-color: ${menuConfigVariants[menuType].submenuSelected};
+        a,
+        button {
+          background-color: ${menuConfigVariants[menuType].submenuSelected};
+        }
 
         a:focus,
         button:focus {

--- a/src/components/menu/menu.style.ts
+++ b/src/components/menu/menu.style.ts
@@ -12,7 +12,8 @@ import {
   StyledVerticalWrapper,
   StyledDivider,
 } from "../vertical-divider/vertical-divider.style";
-import { StyledLink } from "../link/link.style";
+import StyledLink from "../link/__internal__/base-link/base-link.style";
+
 import applyBaseTheme from "../../style/themes/apply-base-theme";
 
 import type { MenuProps } from "./menu.types";
@@ -35,6 +36,7 @@ const StyledMenuWrapper = styled.ul<StyledMenuProps>`
 
   ${layout}
   ${flexbox}
+
 
   ${StyledVerticalWrapper} {
     ${({ menuType }) =>

--- a/src/components/menu/scrollable-block/scrollable-block.style.ts
+++ b/src/components/menu/scrollable-block/scrollable-block.style.ts
@@ -16,7 +16,7 @@ interface StyledScrollableBlockProps {
 const StyledScrollableBlock = styled.li<StyledScrollableBlockProps>`
   ${({ menuType, variant }) => css`
     ${StyledMenuItem} ${StyledLink} {
-      Add comment More actions a,
+      a,
       button {
         background-color: ${variant === "default"
           ? menuConfigVariants[menuType].submenuItemBackground

--- a/src/components/menu/scrollable-block/scrollable-block.style.ts
+++ b/src/components/menu/scrollable-block/scrollable-block.style.ts
@@ -1,10 +1,10 @@
 import styled, { css } from "styled-components";
-import StyledMenuItemWrapper from "../menu-item/menu-item.style";
+
 import menuConfigVariants from "../menu.config";
 import { VariantType } from "../menu-item";
 import StyledBox from "../../box/box.style";
 import { StyledMenuItem } from "../menu.style";
-import { StyledLink } from "../../link/link.style";
+import StyledLink from "../../link/__internal__/base-link/base-link.style";
 
 import type { MenuType } from "../menu.types";
 
@@ -15,11 +15,13 @@ interface StyledScrollableBlockProps {
 
 const StyledScrollableBlock = styled.li<StyledScrollableBlockProps>`
   ${({ menuType, variant }) => css`
-    && ${StyledMenuItemWrapper} {
-      background-color: ${variant === "default"
-        ? menuConfigVariants[menuType].submenuItemBackground
-        : menuConfigVariants[menuType].alternate};
-      padding-right: var(--spacing150);
+    ${StyledMenuItem} ${StyledLink} {
+      Add comment More actions a,
+      button {
+        background-color: ${variant === "default"
+          ? menuConfigVariants[menuType].submenuItemBackground
+          : menuConfigVariants[menuType].alternate};
+      }
     }
 
     ${StyledBox} {

--- a/src/components/pager/__internal__/pager-navigation-link.component.tsx
+++ b/src/components/pager/__internal__/pager-navigation-link.component.tsx
@@ -1,8 +1,12 @@
 import React, { useRef, useEffect, useCallback } from "react";
+import { useTheme } from "styled-components";
 
-import { StyledPagerLink } from "../pager.style";
 import useLocale from "../../../hooks/__internal__/useLocale";
 import { LinkProps } from "../../../components/link";
+import addLinkStyle from "../../link/link.style";
+import pagerLinkStyles from "./pager-navigation-link.style";
+import { BaseLink } from "../../link/__internal__/base-link";
+import { ThemeObject } from "../../../style/themes";
 
 interface PagerNavigationLinkProps {
   /** Type of Pagination link to be allowed for navigation */
@@ -89,21 +93,32 @@ const PagerNavigationLink = ({
   const { text } = navLinkConfig[type];
 
   const hideDisabledButtons = hideDisabledElements && disabled();
+  const theme = useTheme();
+
+  const baseStyles = addLinkStyle({
+    hasContent: true,
+
+    disabled: disabled(),
+
+    theme: theme as ThemeObject,
+  });
+
+  const styles = pagerLinkStyles(!!hideDisabledButtons, baseStyles);
 
   return (
-    <StyledPagerLink
-      hideDisabledButtons={hideDisabledButtons}
+    <BaseLink
+      styles={styles}
       data-element={`pager-link-${type}`}
       disabled={disabled()}
       onClick={
-        // Type assertion due to the fact that StyledPagerLink
+        // Type assertion due to the fact that Link
         // will always return a button element
         handleOnClick as LinkProps["onClick"]
       }
       ref={linkRef}
     >
       {text}
-    </StyledPagerLink>
+    </BaseLink>
   );
 };
 

--- a/src/components/pager/__internal__/pager-navigation-link.style.ts
+++ b/src/components/pager/__internal__/pager-navigation-link.style.ts
@@ -1,0 +1,20 @@
+import { css, SimpleInterpolation } from "styled-components";
+
+export default (hide: boolean, baseStyles: SimpleInterpolation) => css`
+  ${baseStyles}
+
+  ${hide &&
+  `
+
+
+    & {
+
+
+      visibility: hidden;
+
+
+    }
+
+
+  `}
+`;

--- a/src/components/pager/pager.pw.tsx
+++ b/src/components/pager/pager.pw.tsx
@@ -408,8 +408,14 @@ test.describe("Functional tests", () => {
 
     await lastArrow(page).click();
 
-    await expect(nextArrow(page)).toHaveAttribute("disabled", /.*/);
-    await expect(lastArrow(page)).toHaveAttribute("disabled", /.*/);
+    await expect(nextArrow(page).locator("button")).toHaveAttribute(
+      "disabled",
+      "",
+    );
+    await expect(lastArrow(page).locator("button")).toHaveAttribute(
+      "disabled",
+      "",
+    );
   });
 
   test(`should disable firstArrow and previousArrow buttons after clicking on firstArrow button`, async ({
@@ -420,8 +426,14 @@ test.describe("Functional tests", () => {
 
     await firstArrow(page).click();
 
-    await expect(firstArrow(page)).toHaveAttribute("disabled", /.*/);
-    await expect(previousArrow(page)).toHaveAttribute("disabled", /.*/);
+    await expect(firstArrow(page).locator("button")).toHaveAttribute(
+      "disabled",
+      "",
+    );
+    await expect(previousArrow(page).locator("button")).toHaveAttribute(
+      "disabled",
+      "",
+    );
   });
 
   test(`should disable firstArrow and previousArrow buttons after clicking on previousArrow button`, async ({
@@ -432,8 +444,14 @@ test.describe("Functional tests", () => {
 
     await previousArrow(page).click();
 
-    await expect(firstArrow(page)).toHaveAttribute("disabled", /.*/);
-    await expect(previousArrow(page)).toHaveAttribute("disabled", /.*/);
+    await expect(firstArrow(page).locator("button")).toHaveAttribute(
+      "disabled",
+      "",
+    );
+    await expect(previousArrow(page).locator("button")).toHaveAttribute(
+      "disabled",
+      "",
+    );
   });
 
   test(`should disable firstArrow and previousArrow buttons after clicking on nextArrow button`, async ({
@@ -444,8 +462,14 @@ test.describe("Functional tests", () => {
 
     await nextArrow(page).click();
 
-    await expect(nextArrow(page)).toHaveAttribute("disabled", /.*/);
-    await expect(lastArrow(page)).toHaveAttribute("disabled", /.*/);
+    await expect(nextArrow(page).locator("button")).toHaveAttribute(
+      "disabled",
+      "",
+    );
+    await expect(lastArrow(page).locator("button")).toHaveAttribute(
+      "disabled",
+      "",
+    );
   });
 
   [1001, 901, 701, 601, 450].forEach((viewportWidth) => {

--- a/src/components/pager/pager.style.ts
+++ b/src/components/pager/pager.style.ts
@@ -5,7 +5,6 @@ import StyledInputPresentation from "../../__internal__/input/input-presentation
 import StyledFormField from "../../__internal__/form-field/form-field.style";
 import InputIconToggleStyle from "../../__internal__/input-icon-toggle/input-icon-toggle.style";
 import { StyledSelectText } from "../select/__internal__/select-textbox/select-textbox.style";
-import Link from "../link";
 
 const StyledSelectContainer = styled.div`
   height: 26px;
@@ -142,20 +141,6 @@ const StyledPagerNavLabel = styled.label`
   white-space: nowrap;
 `;
 
-interface StyledPagerLinkProps {
-  hideDisabledButtons?: boolean;
-}
-
-const StyledPagerLink = styled(Link)<StyledPagerLinkProps>`
-  ${({ hideDisabledButtons }) =>
-    hideDisabledButtons &&
-    css`
-      & {
-        visibility: hidden;
-      }
-    `}
-`;
-
 const StyledPagerNoSelect = styled.div`
   user-select: none;
   white-space: nowrap;
@@ -183,7 +168,6 @@ export {
   StyledPagerNavigation,
   StyledPagerNavInner,
   StyledPagerNavLabel,
-  StyledPagerLink,
   StyledPagerNoSelect,
   StyledPagerSummary,
   StyledSelectContainer,

--- a/src/components/pod/pod.style.ts
+++ b/src/components/pod/pod.style.ts
@@ -2,7 +2,6 @@ import styled, { css } from "styled-components";
 import { margin, MarginProps } from "styled-system";
 
 import applyBaseTheme from "../../style/themes/apply-base-theme";
-import { StyledContent as StyledLinkContent } from "../link/link.style";
 import IconButton from "../icon-button";
 import StyledIcon from "../icon/icon.style";
 
@@ -237,7 +236,7 @@ const StyledEditAction = styled(IconButton)<StyledEditActionProps>`
         border: none;
         background: var(--colorsActionMajorTransparent);
       `}
-    
+
       ${(isHovered || isFocused) &&
       !internalEditButton &&
       css`
@@ -248,7 +247,7 @@ const StyledEditAction = styled(IconButton)<StyledEditActionProps>`
           color: var(--colorsActionMajorYang100);
         }
       `}
-      
+
       ${isFocused &&
       css`
         outline: 3px solid var(--colorsSemanticFocus500);
@@ -257,7 +256,7 @@ const StyledEditAction = styled(IconButton)<StyledEditActionProps>`
     `};
   }
 
-  ${StyledLinkContent} {
+  [data-component="link-content"] {
     clip: rect(1px, 1px, 1px, 1px);
     position: absolute;
   }
@@ -306,7 +305,7 @@ const StyledDeleteButton = styled(IconButton)<CommonPodButtonProps>`
           color: var(--colorsActionMajorYang100);
         }
       `}
-  
+
       ${isFocused &&
       css`
         outline: 3px solid var(--colorsSemanticFocus500);
@@ -350,7 +349,7 @@ const StyledUndoButton = styled(IconButton)<CommonPodButtonProps>`
         border: none;
         background: var(--colorsActionMajorTransparent);
       `}
-    
+
     ${(isHovered || isFocused) &&
       !internalEditButton &&
       css`
@@ -361,7 +360,7 @@ const StyledUndoButton = styled(IconButton)<CommonPodButtonProps>`
           color: var(--colorsActionMajorYang100);
         }
       `}
-    
+
     ${isFocused &&
       css`
         outline: 3px solid var(--colorsSemanticFocus500);

--- a/src/components/profile/profile.component.tsx
+++ b/src/components/profile/profile.component.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-
+import { useTheme } from "styled-components";
 import { MarginProps } from "styled-system";
 
 import { filterStyledSystemMarginProps } from "../../style/utils";
@@ -13,9 +13,15 @@ import {
   ProfileNameStyle,
   ProfileDetailsStyle,
   ProfileAvatarStyle,
-  ProfileEmailStyle,
+  profileEmailStyle,
   ProfileTextStyle,
 } from "./profile.style";
+
+import addLinkStyle from "../link/link.style";
+
+import { BaseLink } from "../link/__internal__/base-link";
+
+import { ThemeObject } from "../../style/themes";
 
 function acronymize(str?: string) {
   if (!str) return "";
@@ -105,6 +111,15 @@ export const Profile = ({
         " Please use the `name` prop as well as `email` or `text`.",
     );
   }
+  const theme = useTheme();
+
+  const baseStyles = addLinkStyle({
+    hasContent: !!email,
+
+    theme: theme as ThemeObject,
+  });
+
+  const styles = profileEmailStyle(baseStyles, size, darkBackground);
 
   const children = () => {
     if (name)
@@ -114,15 +129,14 @@ export const Profile = ({
             {name}
           </ProfileNameStyle>
           {email && (
-            <ProfileEmailStyle
+            <BaseLink
+              styles={styles}
               href={`mailto: ${email}`}
-              size={size}
               data-role="email-link"
-              darkBackground={darkBackground}
               data-element="email"
             >
               {email}
-            </ProfileEmailStyle>
+            </BaseLink>
           )}
           {text && (
             <ProfileTextStyle size={size} data-element="text">

--- a/src/components/profile/profile.style.ts
+++ b/src/components/profile/profile.style.ts
@@ -1,10 +1,9 @@
-import styled from "styled-components";
+import styled, { SimpleInterpolation, css } from "styled-components";
 import { margin } from "styled-system";
 
 import Portrait from "../portrait";
 import applyBaseTheme from "../../style/themes/apply-base-theme";
 import profileConfigSizes, { ProfileSize } from "./profile.config";
-import Link from "../link";
 import { StyledPortraitContainer } from "../portrait/portrait.style";
 
 interface ProfileSProps {
@@ -18,13 +17,19 @@ const ProfileNameStyle = styled.span<ProfileSProps>`
   font-size: ${({ size = "M" }) => profileConfigSizes[size].nameSize};
 `;
 
-const ProfileEmailStyle = styled(Link)<
-  Pick<ProfileSProps, "size" | "darkBackground">
->`
+const profileEmailStyle = (
+  baseStyles: SimpleInterpolation,
+
+  size?: ProfileSize,
+
+  darkBackground?: boolean,
+) => css`
+  ${baseStyles}
+
   a {
-    font-size: ${({ size = "M" }) => profileConfigSizes[size].emailSize};
-    color: ${({ darkBackground }) =>
-      darkBackground && "var(--colorsActionMajor350)"};
+    ${size && `font-size: ${profileConfigSizes[size].emailSize}`};
+
+    ${darkBackground && "color: var(--colorsActionMajor350)"};
   }
 `;
 
@@ -69,6 +74,6 @@ export {
   ProfileNameStyle,
   ProfileDetailsStyle,
   ProfileAvatarStyle,
-  ProfileEmailStyle,
+  profileEmailStyle,
   ProfileTextStyle,
 };

--- a/src/components/profile/profile.test.tsx
+++ b/src/components/profile/profile.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
 import Profile from "./profile.component";
+import { ProfileSize } from "./profile.config";
 
 testStyledSystemMargin(
   (props) => <Profile data-role="profile" name="John Doe" {...props} />,
@@ -204,4 +205,25 @@ test("renders with custom avatar foreground and background colouring when both `
   expect(avatar).toHaveAttribute("type", "individual");
   expect(portrait).toHaveStyleRule("background-color", "#00FF00");
   expect(portrait).toHaveStyleRule("color", "#FF00FF");
+});
+
+// coverage: email address size styling
+["XS", "S", "M", "ML", "L", "XL", "XXL"].forEach((size) => {
+  test(`renders with email text when 'email' and 'size' prop is of ${size} passed`, () => {
+    const emailAddress = "john.doe@sage.com";
+    render(
+      <Profile
+        name="John Doe"
+        email={emailAddress}
+        size={size as ProfileSize}
+      />,
+    );
+
+    const emailText = screen.getByRole("link", { name: emailAddress });
+    const emailLink = screen.getByTestId("email-link");
+
+    expect(emailText).toBeVisible();
+    expect(emailText).toHaveAttribute("href", `mailto: ${emailAddress}`);
+    expect(emailLink).toHaveAttribute("data-element", "email");
+  });
 });


### PR DESCRIPTION
### Proposed behaviour

Introduce an internal `BaseLink` component for `Link` that handles its core behaviour but applies no styling. `Link` would then render `BaseLink` and apply the styling on top. This allows other components to reuse `Link`'s functionality without inheriting its styles.

### Current behaviour

Currently, multiple Carbon components re-use `Link` and extend its styling, either using styled-components's `styled` function or styled-component's `as` polymorphic prop. This introduces multiple problems:

- Complex styling that's more difficult to maintain;
- Prone to style regressions if changes are made to `Link`.

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required
