### PR TITLE
chore: remove CustomRefObject type and replace with RefObject

### DIFF
--- a/src/__internal__/focus-trap/focus-trap-utils.ts
+++ b/src/__internal__/focus-trap/focus-trap-utils.ts
@@ -1,6 +1,4 @@
-type CustomRefObject<T> = {
-  current?: T | null;
-};
+import { RefObject } from "react";
 
 const defaultFocusableSelectors =
   'button:not([disabled]), [href], input:not([type="hidden"]):not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]';
@@ -125,11 +123,11 @@ const getNextElement = (
 
 const onTabGuardFocus =
   (
-    trapWrappers: CustomRefObject<HTMLElement>[],
+    trapWrappers: RefObject<HTMLElement>[],
     focusableSelectors: string | undefined,
     position: "top" | "bottom",
   ) =>
-  (guardWrapperRef: CustomRefObject<HTMLElement>) =>
+  (guardWrapperRef: RefObject<HTMLElement>) =>
   () => {
     const isTop = position === "top";
     const currentIndex = trapWrappers.indexOf(guardWrapperRef);

--- a/src/__internal__/focus-trap/focus-trap.component.tsx
+++ b/src/__internal__/focus-trap/focus-trap.component.tsx
@@ -5,6 +5,7 @@ import React, {
   useMemo,
   useRef,
   useState,
+  RefObject,
 } from "react";
 
 import {
@@ -22,16 +23,11 @@ import TopModalContext from "../../components/carbon-provider/__internal__/top-m
 export const TAB_GUARD_TOP = "tab-guard-top";
 export const TAB_GUARD_BOTTOM = "tab-guard-bottom";
 
-// TODO investigate why React.RefObject<T> produces a failed prop type when current = null
-export type CustomRefObject<T> = {
-  current?: T | null;
-};
-
 export interface FocusTrapProps {
   children: React.ReactNode;
   autoFocus?: boolean;
   /** provide a custom first element to focus */
-  focusFirstElement?: CustomRefObject<HTMLElement> | HTMLElement | null;
+  focusFirstElement?: RefObject<HTMLElement> | HTMLElement | null;
   /** a custom callback that will override the default focus trap behaviour */
   bespokeTrap?: (
     ev: KeyboardEvent,
@@ -41,11 +37,11 @@ export interface FocusTrapProps {
   /** optional selector to identify the focusable elements, if not provided a default selector is used */
   focusableSelectors?: string;
   /** a ref to the container wrapping the focusable elements */
-  wrapperRef: CustomRefObject<HTMLElement>;
+  wrapperRef: RefObject<HTMLElement>;
   /* whether the modal (etc.) component that the focus trap is inside is open or not */
   isOpen?: boolean;
   /** an optional array of refs to containers whose content should also be reachable from the FocusTrap */
-  additionalWrapperRefs?: CustomRefObject<HTMLElement>[];
+  additionalWrapperRefs?: RefObject<HTMLElement>[];
 }
 
 const FocusTrap = ({

--- a/src/__internal__/focus-trap/index.ts
+++ b/src/__internal__/focus-trap/index.ts
@@ -1,2 +1,2 @@
 export { default } from "./focus-trap.component";
-export type { CustomRefObject, FocusTrapProps } from "./focus-trap.component";
+export type { FocusTrapProps } from "./focus-trap.component";

--- a/src/__internal__/popover/popover.component.tsx
+++ b/src/__internal__/popover/popover.component.tsx
@@ -1,4 +1,10 @@
-import React, { MutableRefObject, useContext, useEffect, useRef } from "react";
+import React, {
+  MutableRefObject,
+  useContext,
+  useEffect,
+  useRef,
+  RefObject,
+} from "react";
 import ReactDOM from "react-dom";
 import { flip, Placement, Middleware } from "@floating-ui/dom";
 
@@ -8,10 +14,6 @@ import CarbonScopedTokensProvider from "../../style/design-tokens/carbon-scoped-
 import ModalContext, {
   ModalContextProps,
 } from "../../components/modal/__internal__/modal.context";
-
-type CustomRefObject<T> = {
-  current?: T | null;
-};
 
 export interface PopoverProps {
   /**
@@ -38,7 +40,7 @@ export interface PopoverProps {
   /**
    * Reference element, children will be positioned in relation to this element - should be a ref shaped object.
    */
-  reference: CustomRefObject<HTMLElement>;
+  reference: RefObject<HTMLElement>;
   /**
    * Determines if the popover is currently open/visible or not. Defaults to true.
    */

--- a/src/components/date/__internal__/date-picker/date-picker.component.tsx
+++ b/src/components/date/__internal__/date-picker/date-picker.component.tsx
@@ -8,6 +8,7 @@ import React, {
   useRef,
   useState,
   useContext,
+  RefObject,
 } from "react";
 import {
   DayPicker,
@@ -27,10 +28,6 @@ import FlatTableContext from "../../../flat-table/__internal__/flat-table.contex
 
 import StyledDayPicker from "./day-picker.style";
 
-type CustomRefObject<T> = {
-  current?: T | null;
-};
-
 export interface PickerProps
   extends Omit<DayPickerProps, "mode" | "modifiers"> {
   modifiers?: Partial<Modifiers>;
@@ -49,7 +46,7 @@ export interface DatePickerProps {
    * */
   pickerProps?: PickerProps;
   /** Element that the DatePicker will be displayed under */
-  inputElement: CustomRefObject<HTMLElement>;
+  inputElement: RefObject<HTMLElement>;
   /** Currently selected date */
   selectedDays?: Date | undefined;
   /** Callback to handle mousedown event on picker container */

--- a/src/components/dialog-full-screen/dialog-full-screen.component.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.component.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useRef, RefObject } from "react";
 
 import createGuid from "../../__internal__/utils/helpers/guid";
 import Modal, { ModalProps } from "../modal";
@@ -6,7 +6,7 @@ import Heading from "../heading";
 import FullScreenHeading from "../../__internal__/full-screen-heading";
 import StyledDialogFullScreen from "./dialog-full-screen.style";
 import StyledContent from "./content.style";
-import FocusTrap, { CustomRefObject } from "../../__internal__/focus-trap";
+import FocusTrap from "../../__internal__/focus-trap";
 import IconButton from "../icon-button";
 import Icon from "../icon";
 import useLocale from "../../hooks/__internal__/useLocale";
@@ -38,7 +38,7 @@ export interface DialogFullScreenProps
   /** remove padding from content */
   disableContentPadding?: boolean;
   /** Optional reference to an element meant to be focused on open */
-  focusFirstElement?: CustomRefObject<HTMLElement> | HTMLElement | null;
+  focusFirstElement?: RefObject<HTMLElement> | HTMLElement | null;
   /**
    * Function to replace focus trap
    * @ignore
@@ -66,7 +66,7 @@ export interface DialogFullScreenProps
   /** The ARIA role to be applied to the DialogFullscreen container */
   role?: string;
   /** an optional array of refs to containers whose content should also be reachable by tabbing from the dialog */
-  focusableContainers?: CustomRefObject<HTMLElement>[];
+  focusableContainers?: RefObject<HTMLElement>[];
   /** Optional selector to identify the focusable elements, if not provided a default selector is used */
   focusableSelectors?: string;
   /** A custom close event handler */

--- a/src/components/dialog/dialog.component.tsx
+++ b/src/components/dialog/dialog.component.tsx
@@ -1,4 +1,9 @@
-import React, { useRef, useImperativeHandle, forwardRef } from "react";
+import React, {
+  useRef,
+  useImperativeHandle,
+  forwardRef,
+  RefObject,
+} from "react";
 
 import createGuid from "../../__internal__/utils/helpers/guid";
 import Modal, { ModalProps } from "../modal";
@@ -13,7 +18,7 @@ import {
 } from "./dialog.style";
 import { DialogSizes } from "./dialog.config";
 
-import FocusTrap, { CustomRefObject } from "../../__internal__/focus-trap";
+import FocusTrap from "../../__internal__/focus-trap";
 import IconButton from "../icon-button";
 import Icon from "../icon";
 import useLocale from "../../hooks/__internal__/useLocale";
@@ -64,7 +69,7 @@ export interface DialogProps extends ModalProps, TagProps {
     lastElement?: HTMLElement,
   ) => void;
   /** Optional reference to an element meant to be focused on open */
-  focusFirstElement?: CustomRefObject<HTMLElement> | HTMLElement | null;
+  focusFirstElement?: RefObject<HTMLElement> | HTMLElement | null;
   /** Optional selector to identify the focusable elements, if not provided a default selector is used */
   focusableSelectors?: string;
   /** Allows developers to specify a specific height for the dialog. */
@@ -97,7 +102,7 @@ export interface DialogProps extends ModalProps, TagProps {
   /** Change the background color of the content to grey */
   greyBackground?: boolean;
   /** an optional array of refs to containers whose content should also be reachable by tabbing from the dialog */
-  focusableContainers?: CustomRefObject<HTMLElement>[];
+  focusableContainers?: RefObject<HTMLElement>[];
   /** @private @internal @ignore */
   "data-component"?: string;
 }

--- a/src/components/sidebar/sidebar.component.tsx
+++ b/src/components/sidebar/sidebar.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from "react";
+import React, { useCallback, useRef, RefObject } from "react";
 import { PaddingProps, WidthProps } from "styled-system";
 
 import Modal, { ModalProps } from "../modal";
@@ -13,11 +13,6 @@ import { filterStyledSystemPaddingProps } from "../../style/utils";
 import { TagProps } from "../../__internal__/utils/helpers/tags/tags";
 import useModalAria from "../../hooks/__internal__/useModalAria/useModalAria";
 import SidebarContext from "./__internal__/sidebar.context";
-
-// TODO FE-5408 will investigate why React.RefObject<T> produces a failed prop type when current = null
-type CustomRefObject<T> = {
-  current?: T | null;
-};
 
 export interface SidebarProps
   extends PaddingProps,
@@ -82,7 +77,7 @@ export interface SidebarProps
     | "large"
     | "extra-large";
   /** an optional array of refs to containers whose content should also be reachable by tabbing from the sidebar */
-  focusableContainers?: CustomRefObject<HTMLElement>[];
+  focusableContainers?: RefObject<HTMLElement>[];
   /** Optional selector to identify the focusable elements, if not provided a default selector is used */
   focusableSelectors?: string;
   /** Padding to be set on the Sidebar header */

--- a/src/hooks/__internal__/useFloating/useFloating.ts
+++ b/src/hooks/__internal__/useFloating/useFloating.ts
@@ -1,4 +1,4 @@
-import { useRef, useLayoutEffect } from "react";
+import { useRef, useLayoutEffect, RefObject } from "react";
 
 import {
   computePosition,
@@ -8,13 +8,9 @@ import {
   Placement,
 } from "@floating-ui/dom";
 
-type CustomRefObject<T> = {
-  current?: T | null;
-};
-
 export interface UseFloatingProps {
   isOpen?: boolean;
-  reference: CustomRefObject<HTMLElement | null>;
+  reference: RefObject<HTMLElement | null>;
   floating: React.RefObject<HTMLElement | null>;
   strategy?: Strategy;
   middleware?: Middleware[];


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Removes the instances of CustomRefObject now that we no longer convert the types into prop types

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
We type props as CustomRefObject due to a issue in the previously used package that generated prop types for our components

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required
