### PR TITLE
refactor(heading): replace onMouseDown with onClick

### DIFF
--- a/src/components/heading/heading.component.tsx
+++ b/src/components/heading/heading.component.tsx
@@ -94,11 +94,10 @@ export const Heading = ({
 
     return (
       <StyledHeadingBackButton
-        // this event allows an element to be focusable on click event on IE
         aria-label={l.heading.backLinkAriaLabel()}
         data-element="back"
         data-role="heading-back-button"
-        onMouseDown={(e) => e.currentTarget.focus({ preventScroll: true })}
+        onClick={(e) => e.currentTarget.focus({ preventScroll: true })}
         {...backButtonProps}
       >
         <StyledHeadingIcon type="chevron_left" />


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

an IE specific onMouseDown implementation has been removed and replaced with onClick, IE has been officially discontinued and its replacement Edge is now chromium-based, meaning this adaption can be safely removed

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

an IE specific onMouseDown implementation is being used

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Ensure the back button still works as intended across browsers in the `Heading` component
