### PR TITLE
feat: add support for rendering the validation message under the input or input group

### DIFF
--- a/docs/validations.mdx
+++ b/docs/validations.mdx
@@ -51,6 +51,11 @@ These components can be validated using the same `error` and `warning` props, an
 
 <Canvas of={ValidationsStories.ValidationRedesignWithGroupedInputs} />
 
+#### Validation Message Position
+By default, the validation message will be displayed above the input, however you can set `validationMessagePositionTop` to `false` to display the validation message below the input.
+
+<Canvas of={ValidationsStories.ValidationRedesignMessageBottom} />
+
 **Note:** The new validation redesign pattern **does not** currently support inline labels/legends (with the exception of `Switch`), this means that any related props will not have any effect or may have unexpected behaviour. 
 Component props that are not supported if the opt-in flag is set to true are labelled as [Legacy] in their corresponding prop tables. 
 

--- a/docs/validations.stories.tsx
+++ b/docs/validations.stories.tsx
@@ -160,3 +160,44 @@ export const ValidationRedesignWithGroupedInputs: StoryObj = () => {
 };
 ValidationRedesignWithGroupedInputs.storyName =
   "Validation Redesign with Grouped Inputs";
+
+export const ValidationRedesignMessageBottom: StoryObj = () => {
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      <Form>
+        <RequiredFieldsIndicator mb={2}>
+          Fill in all fields marked with
+        </RequiredFieldsIndicator>
+
+        <Textbox
+          label="Textbox"
+          inputHint="Hint text"
+          value=""
+          required
+          error="Error Message (Fix is required)"
+          validationMessagePositionTop={false}
+        />
+
+        <CheckboxGroup
+          legend="Checkbox Group"
+          legendHelp="Legend help"
+          warning="Warning Message (Fix is optional)"
+          validationMessagePositionTop={false}
+        >
+          <Checkbox
+            id="new-checkbox-1-bottom"
+            value="checkbox1"
+            label="Checkbox Option 1"
+          />
+          <Checkbox
+            id="new-checkbox-2-bottom"
+            value="checkbox2"
+            label="Checkbox Option 2"
+          />
+        </CheckboxGroup>
+      </Form>
+    </CarbonProvider>
+  );
+};
+ValidationRedesignMessageBottom.storyName =
+  "Validation Redesign with Message Below Input";

--- a/src/__internal__/validation-message/validation-message.component.tsx
+++ b/src/__internal__/validation-message/validation-message.component.tsx
@@ -13,6 +13,8 @@ export interface ValidationMessageProps extends TagProps {
   warning?: boolean | string;
   /** Whether this component resides on a dark background */
   isDarkBackground?: boolean;
+  /** Render the validation message above the input */
+  validationMessagePositionTop?: boolean;
 }
 
 const ValidationMessage = ({
@@ -22,6 +24,7 @@ const ValidationMessage = ({
   isDarkBackground,
   "data-element": dataElement,
   "data-role": dataRole = "validation-message",
+  validationMessagePositionTop,
 }: ValidationMessageProps) => {
   const validation = error || warning;
   const isStringValidation = typeof validation === "string";
@@ -35,6 +38,7 @@ const ValidationMessage = ({
         "data-element": dataElement,
         "data-role": dataRole,
       })}
+      validationMessagePositionTop={validationMessagePositionTop}
     >
       {validation}
     </StyledValidationMessage>

--- a/src/__internal__/validation-message/validation-message.style.ts
+++ b/src/__internal__/validation-message/validation-message.style.ts
@@ -3,18 +3,19 @@ import styled, { css } from "styled-components";
 interface StyledValidationMessageProps {
   isWarning?: boolean;
   isDarkBackground?: boolean;
+  validationMessagePositionTop?: boolean;
 }
 
 const StyledValidationMessage = styled.p<StyledValidationMessageProps>`
-  ${({ isWarning, isDarkBackground }) => {
+  ${({ isWarning, isDarkBackground, validationMessagePositionTop }) => {
     const darkBgColour = isDarkBackground
       ? "var(--colorsSemanticNegative450)"
       : "var(--colorsSemanticNegative500)";
     return css`
       color: ${isWarning ? "var(--colorsSemanticCaution600)" : darkBgColour};
       font-weight: ${isWarning ? "normal" : "500"};
-      margin-top: 0px;
-      margin-bottom: 8px;
+      margin: 0px;
+      margin-${validationMessagePositionTop ? "bottom" : "top"}: 8px;
     `;
   }}
 `;

--- a/src/components/checkbox/checkbox-group/checkbox-group.component.tsx
+++ b/src/components/checkbox/checkbox-group/checkbox-group.component.tsx
@@ -57,6 +57,8 @@ export interface CheckboxGroupProps
   tooltipPosition?: "top" | "bottom" | "left" | "right";
   /** When true, Checkboxes are inline */
   inline?: boolean;
+  /** Render the ValidationMessage above the Checkbox inputs when validationRedesignOptIn flag is set */
+  validationMessagePositionTop?: boolean;
 }
 
 let deprecateOptionalWarnTriggered = false;
@@ -77,6 +79,7 @@ export const CheckboxGroup = ({
   tooltipPosition,
   inline,
   id,
+  validationMessagePositionTop = true,
   ...rest
 }: CheckboxGroupProps) => {
   if (!deprecateOptionalWarnTriggered && isOptional) {
@@ -98,9 +101,11 @@ export const CheckboxGroup = ({
     info,
   });
 
-  const combinedAriaDescribedBy = [ariaDescribedBy, inputHintId]
-    .filter(Boolean)
-    .join(" ");
+  const describedByArray =
+    validationRedesignOptIn && validationMessagePositionTop
+      ? [ariaDescribedBy, inputHintId]
+      : [inputHintId, ariaDescribedBy];
+  const combinedAriaDescribedBy = describedByArray.filter(Boolean).join(" ");
 
   return (
     <>
@@ -127,13 +132,18 @@ export const CheckboxGroup = ({
             </HintText>
           )}
           <Box position="relative">
-            <ValidationMessage
-              error={error}
-              warning={warning}
-              validationId={validationId}
-            />
-            {(error || warning) && (
-              <ErrorBorder warning={!!(!error && warning)} inline={inline} />
+            {validationMessagePositionTop && (
+              <>
+                <ValidationMessage
+                  error={error}
+                  warning={warning}
+                  validationId={validationId}
+                  validationMessagePositionTop={validationMessagePositionTop}
+                />
+                {(error || warning) && (
+                  <ErrorBorder warning={!!(!error && warning)} />
+                )}
+              </>
             )}
             <StyledCheckboxGroup
               data-component="checkbox-group"
@@ -149,6 +159,19 @@ export const CheckboxGroup = ({
                 {children}
               </CheckboxGroupContext.Provider>
             </StyledCheckboxGroup>
+            {!validationMessagePositionTop && (
+              <>
+                <ValidationMessage
+                  error={error}
+                  warning={warning}
+                  validationId={validationId}
+                  validationMessagePositionTop={validationMessagePositionTop}
+                />
+                {(error || warning) && (
+                  <ErrorBorder warning={!!(!error && warning)} />
+                )}
+              </>
+            )}
           </Box>
         </Fieldset>
       ) : (

--- a/src/components/checkbox/checkbox-group/checkbox-group.style.ts
+++ b/src/components/checkbox/checkbox-group/checkbox-group.style.ts
@@ -50,8 +50,13 @@ const StyledCheckboxGroup = styled.div<{
     inline &&
     css`
       flex-direction: row;
-      ${CheckboxStyle}:not(:first-of-type) {
-        margin-left: 32px;
+
+      ${CheckboxStyle} {
+        margin: 0;
+
+        :not(:first-of-type) {
+          margin-left: 32px;
+        }
       }
     `}
 `;

--- a/src/components/checkbox/checkbox-group/checkbox-group.test.tsx
+++ b/src/components/checkbox/checkbox-group/checkbox-group.test.tsx
@@ -194,6 +194,46 @@ describe("when the `validationRedesignOptIn` flag is true", () => {
     expect(fieldset).toHaveAccessibleDescription("warning message");
   });
 
+  it("should describe the group with the error and legendHelp text when the validationMessagePositionTop is false", () => {
+    render(
+      <CarbonProvider validationRedesignOptIn>
+        <CheckboxGroup
+          legend="legend"
+          error="error message"
+          legendHelp="Legend Help"
+          validationMessagePositionTop={false}
+        >
+          <Checkbox value="1" label="label" onChange={() => {}} />
+        </CheckboxGroup>
+      </CarbonProvider>,
+    );
+
+    const fieldset = screen.getByRole("group", { name: "legend" });
+
+    expect(screen.getByText("error message")).toBeVisible();
+    expect(fieldset).toHaveAccessibleDescription("Legend Help error message");
+  });
+
+  it("should describe the group with the warning and lengendHelp text when the validationMessagePositionTop is false", () => {
+    render(
+      <CarbonProvider validationRedesignOptIn>
+        <CheckboxGroup
+          legend="legend"
+          warning="warning message"
+          legendHelp="Legend Help"
+          validationMessagePositionTop={false}
+        >
+          <Checkbox value="1" label="label" onChange={() => {}} />
+        </CheckboxGroup>
+      </CarbonProvider>,
+    );
+
+    const fieldset = screen.getByRole("group", { name: "legend" });
+
+    expect(screen.getByText("warning message")).toBeVisible();
+    expect(fieldset).toHaveAccessibleDescription("Legend Help warning message");
+  });
+
   it("should render with combined validation and legendHelp messages as the fieldset's accessible description", () => {
     render(
       <CarbonProvider validationRedesignOptIn>

--- a/src/components/checkbox/checkbox-test.stories.tsx
+++ b/src/components/checkbox/checkbox-test.stories.tsx
@@ -155,6 +155,28 @@ export const NewValidation = () => {
         <Checkbox label="Checkbox 1" />
         <Checkbox label="Checkbox 2" />
       </CheckboxGroup>
+      <CheckboxGroup
+        validationMessagePositionTop={false}
+        mt={2}
+        error="Error message (Fix is required)"
+        legend="Label"
+        legendHelp="Hint Text"
+        required
+      >
+        <Checkbox label="Checkbox 1" />
+        <Checkbox label="Checkbox 2" />
+      </CheckboxGroup>
+      <CheckboxGroup
+        validationMessagePositionTop={false}
+        mt={2}
+        warning="Warning message (Fix is optional)"
+        legend="Label"
+        legendHelp="Hint text"
+        required
+      >
+        <Checkbox label="Checkbox 1" />
+        <Checkbox label="Checkbox 2" />
+      </CheckboxGroup>
     </CarbonProvider>
   );
 };
@@ -180,6 +202,32 @@ export const NewValidationInline = () => {
       </CheckboxGroup>
       <CheckboxGroup
         mt={2}
+        warning="Warning message (Fix is optional)"
+        legend="Label"
+        legendHelp="Hint text"
+        required
+        inline
+      >
+        <Checkbox label="Checkbox 1" />
+        <Checkbox label="Checkbox 2" />
+        <Checkbox label="Checkbox 3" />
+      </CheckboxGroup>
+      <CheckboxGroup
+        mt={2}
+        validationMessagePositionTop={false}
+        error="Error message (Fix is required)"
+        legend="Label"
+        legendHelp="Hint Text"
+        required
+        inline
+      >
+        <Checkbox label="Checkbox 1" />
+        <Checkbox label="Checkbox 2" />
+        <Checkbox label="Checkbox 3" />
+      </CheckboxGroup>
+      <CheckboxGroup
+        mt={2}
+        validationMessagePositionTop={false}
         warning="Warning message (Fix is optional)"
         legend="Label"
         legendHelp="Hint text"

--- a/src/components/date-range/__internal__/date-range.context.ts
+++ b/src/components/date-range/__internal__/date-range.context.ts
@@ -15,6 +15,7 @@ interface DateInputRefMap {
 export interface DateRangeContextProps {
   inputRefMap?: Partial<Record<InputName, DateInputRefMap>>;
   setInputRefMap?: (value: SetInputRefMapValue) => void;
+  validationMessagePositionTop?: boolean;
 }
 
 export default React.createContext<DateRangeContextProps>({});

--- a/src/components/date-range/date-range-test.stories.tsx
+++ b/src/components/date-range/date-range-test.stories.tsx
@@ -251,6 +251,32 @@ export const NewValidation = () => {
         endWarning="End Warning with long text"
         onChange={handleChange}
         value={state}
+        mb={2}
+        startDateProps={{ inputHint: "Start Date Hint" }}
+        endDateProps={{ inputHint: "End Date Hint" }}
+      />
+      <DateRange
+        validationMessagePositionTop={false}
+        startLabel="Start"
+        endLabel="End"
+        startError="Start Error with long text"
+        endError="End Error"
+        onChange={handleChange}
+        value={state}
+        mb={2}
+        startDateProps={{ inputHint: "Start Date Hint" }}
+        endDateProps={{ inputHint: "End Date Hint" }}
+      />
+      <DateRange
+        validationMessagePositionTop={false}
+        startLabel="Start"
+        endLabel="End"
+        startWarning="Start Warning"
+        endWarning="End Warning with long text"
+        onChange={handleChange}
+        value={state}
+        startDateProps={{ inputHint: "Start Date Hint" }}
+        endDateProps={{ inputHint: "End Date Hint" }}
       />
     </CarbonProvider>
   );

--- a/src/components/date-range/date-range.component.tsx
+++ b/src/components/date-range/date-range.component.tsx
@@ -130,6 +130,8 @@ export interface DateRangeProps
   datePickerEndAriaLabel?: string;
   /** Prop to specify the aria-labelledby attribute of the end date picker */
   datePickerEndAriaLabelledBy?: string;
+  /** Render the ValidationMessage above the Date inputs when validationRedesignOptIn flag is set */
+  validationMessagePositionTop?: boolean;
 }
 
 let deprecateOptionalWarnTriggered = false;
@@ -154,6 +156,7 @@ export const DateRange = ({
   datePickerStartAriaLabelledBy,
   datePickerEndAriaLabel,
   datePickerEndAriaLabelledBy,
+  validationMessagePositionTop = true,
   ...rest
 }: DateRangeProps) => {
   if (!deprecateOptionalWarnTriggered && isOptional) {
@@ -389,9 +392,14 @@ export const DateRange = ({
       {...tagComponent("date-range", rest)}
       labelsInline={labelsInlineWithNewValidation}
       {...filterStyledSystemMarginProps(rest)}
+      validationMessagePositionTop={validationMessagePositionTop}
     >
       <DateRangeContext.Provider
-        value={{ inputRefMap, setInputRefMap: updateInputMap }}
+        value={{
+          inputRefMap,
+          setInputRefMap: updateInputMap,
+          validationMessagePositionTop,
+        }}
       >
         <DateInput
           my={0} // prevents any form spacing being applied

--- a/src/components/date-range/date-range.style.ts
+++ b/src/components/date-range/date-range.style.ts
@@ -8,8 +8,14 @@ import applyBaseTheme from "../../style/themes/apply-base-theme";
 export interface StyledDateRangeProps {
   /** [Legacy] Display labels inline */
   labelsInline?: boolean;
+  /** Render the ValidationMessage above the inputs when validationRedesignOptIn flag is set */
+  validationMessagePositionTop?: boolean;
 }
 const StyledDateRange = styled.div.attrs(applyBaseTheme)<StyledDateRangeProps>`
+  ${({ validationMessagePositionTop }) => `
+    display: flex;
+    align-items: ${validationMessagePositionTop ? "flex-end" : "flex-start"};
+  `}
   margin-bottom: var(--fieldSpacing);
   ${margin}
 

--- a/src/components/date-range/date-range.test.tsx
+++ b/src/components/date-range/date-range.test.tsx
@@ -1143,6 +1143,30 @@ test("should not display the error message for both inputs when booleans are pas
   expect(within(end).queryByText("end error")).not.toBeInTheDocument();
 });
 
+// for coverage
+test("should display the error message below both inputs when strings are passed to the error props, `validationRedesignOptIn` is true and `validationMessagePositionTop` is false", () => {
+  render(
+    <CarbonProvider validationRedesignOptIn>
+      <DateRange
+        validationMessagePositionTop={false}
+        startLabel="start"
+        onChange={() => {}}
+        endLabel="end"
+        value={["10/10/2016", "11/11/2016"]}
+        startError="start error"
+        endError="end error"
+        startDateProps={{ "data-role": "start" }}
+        endDateProps={{ "data-role": "end" }}
+      />
+    </CarbonProvider>,
+  );
+  const start = screen.getByTestId("start");
+  const end = screen.getByTestId("end");
+
+  expect(within(start).getByText("start error")).toBeVisible();
+  expect(within(end).getByText("end error")).toBeVisible();
+});
+
 test("should display the warning message for both inputs when strings are passed to the warning props and `validationRedesignOptIn` is set", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
@@ -1185,6 +1209,30 @@ test("should not display the warning message for both inputs when booleans are p
 
   expect(within(start).queryByText("start warning")).not.toBeInTheDocument();
   expect(within(end).queryByText("end warning")).not.toBeInTheDocument();
+});
+
+// for coverage
+test("should display the warning message below both inputs when strings are passed to the error props, `validationRedesignOptIn` is true and `validationMessagePositionTop` is false", () => {
+  render(
+    <CarbonProvider validationRedesignOptIn>
+      <DateRange
+        validationMessagePositionTop={false}
+        startLabel="start"
+        onChange={() => {}}
+        endLabel="end"
+        value={["10/10/2016", "11/11/2016"]}
+        startWarning="start warning"
+        endWarning="end warning"
+        startDateProps={{ "data-role": "start" }}
+        endDateProps={{ "data-role": "end" }}
+      />
+    </CarbonProvider>,
+  );
+  const start = screen.getByTestId("start");
+  const end = screen.getByTestId("end");
+
+  expect(within(start).getByText("start warning")).toBeVisible();
+  expect(within(end).getByText("end warning")).toBeVisible();
 });
 
 test("should have the expected styling when the `labelsInline` prop is set", () => {

--- a/src/components/date/date-test.stories.tsx
+++ b/src/components/date/date-test.stories.tsx
@@ -198,6 +198,25 @@ export const NewValidation = () => {
         warning="Warning Message"
         value={state}
         onChange={setValue}
+        mb={2}
+      />
+      <DateInput
+        validationMessagePositionTop={false}
+        label="Date"
+        name="date-input"
+        inputHint="Input hint"
+        error="Error Message"
+        value={state}
+        onChange={setValue}
+        mb={2}
+      />
+      <DateInput
+        validationMessagePositionTop={false}
+        label="Date"
+        name="date-input"
+        warning="Warning Message"
+        value={state}
+        onChange={setValue}
       />
     </CarbonProvider>
   );

--- a/src/components/date/date.component.tsx
+++ b/src/components/date/date.component.tsx
@@ -149,6 +149,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       dateFormatOverride: dateFormatOverrideProp,
       datePickerAriaLabel,
       datePickerAriaLabelledBy,
+      validationMessagePositionTop = true,
       ...rest
     }: DateInputProps,
     ref,
@@ -169,7 +170,11 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
         ),
       [dateFnsLocale, dateFormatOverride, dateFormatOverrideProp],
     );
-    const { inputRefMap, setInputRefMap } = useContext(DateRangeContext);
+    const {
+      inputRefMap,
+      setInputRefMap,
+      validationMessagePositionTop: validationMessagePositionTopContext,
+    } = useContext(DateRangeContext);
     const [open, setOpen] = useState(false);
     const [selectedDays, setSelectedDays] = useState(() => {
       const isValidDate = isValidLocaleDate(value, dateFnsLocale());
@@ -183,6 +188,8 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
     });
     const isInitialValue = useRef(true);
     const pickerTabGuardId = useRef(guid());
+    const showValidationMessageOnTop =
+      validationMessagePositionTopContext ?? validationMessagePositionTop;
 
     const computeInvalidRawValue = (inputValue: string) =>
       allowEmptyValue && !inputValue.length ? inputValue : null;
@@ -503,6 +510,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
           labelWidth={labelWidth}
           maxWidth={maxWidth}
           m={0}
+          validationMessagePositionTop={showValidationMessageOnTop}
         />
         <DatePicker
           disablePortal={disablePortal}

--- a/src/components/decimal/decimal-test.stories.tsx
+++ b/src/components/decimal/decimal-test.stories.tsx
@@ -227,6 +227,22 @@ export const NewValidation = () => {
         warning="Warning Message"
         value={state}
         onChange={setValue}
+        mb={2}
+      />
+      <Decimal
+        validationMessagePositionTop={false}
+        label="Decimal"
+        error="Error Message"
+        value={state}
+        onChange={setValue}
+        mb={2}
+      />
+      <Decimal
+        validationMessagePositionTop={false}
+        label="Decimal"
+        warning="Warning Message"
+        value={state}
+        onChange={setValue}
       />
     </CarbonProvider>
   );

--- a/src/components/file-input/file-input-test.stories.tsx
+++ b/src/components/file-input/file-input-test.stories.tsx
@@ -113,6 +113,14 @@ export const Validation = () => {
         error
         onChange={() => {}}
       />
+      <FileInput
+        validationMessagePositionTop={false}
+        m={4}
+        label="error as string"
+        inputHint="Hint text (optional)"
+        error="error message"
+        onChange={() => {}}
+      />
     </>
   );
 };

--- a/src/components/file-input/file-input.component.tsx
+++ b/src/components/file-input/file-input.component.tsx
@@ -62,6 +62,8 @@ export interface FileInputProps
    * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
    */
   isOptional?: boolean;
+  /** Render the ValidationMessage above the FileInput */
+  validationMessagePositionTop?: boolean;
 }
 
 let deprecateOptionalWarnTriggered = false;
@@ -88,6 +90,7 @@ export const FileInput = React.forwardRef(
       required,
       isOptional,
       uploadStatus = [],
+      validationMessagePositionTop = true,
       ...rest
     }: FileInputProps,
     ref: React.ForwardedRef<HTMLInputElement>,
@@ -194,8 +197,17 @@ export const FileInput = React.forwardRef(
       <>
         {inputHint && <HintText>{inputHint}</HintText>}
         <Box position="relative">
-          <ValidationMessage error={error} validationId={validationId} />
-          {error && <ErrorBorder warning={false} />}
+          {validationMessagePositionTop && (
+            <>
+              <ValidationMessage
+                error={error}
+                validationId={validationId}
+                validationMessagePositionTop={validationMessagePositionTop}
+                data-role="validation-message-top"
+              />
+              {error && <ErrorBorder warning={false} />}
+            </>
+          )}
           <StyledHiddenFileInput
             {...(required && { required })}
             accept={accept}
@@ -223,6 +235,17 @@ export const FileInput = React.forwardRef(
             </ButtonMinor>
             <Typography m={0}>{mainText}</Typography>
           </StyledFileInputPresentation>
+          {!validationMessagePositionTop && (
+            <>
+              <ValidationMessage
+                error={error}
+                validationId={validationId}
+                validationMessagePositionTop={validationMessagePositionTop}
+                data-role="validation-message-bottom"
+              />
+              {error && <ErrorBorder warning={false} />}
+            </>
+          )}
         </Box>
       </>
     );

--- a/src/components/file-input/file-input.test.tsx
+++ b/src/components/file-input/file-input.test.tsx
@@ -123,6 +123,20 @@ describe("rendering with no file uploaded", () => {
     expect(screen.getByText("error text")).toBeVisible();
   });
 
+  it("renders the error message element under the input area when error prop is passed as a string and validationMessagePositionTop is false", () => {
+    render(
+      <FileInput
+        error="error text"
+        validationMessagePositionTop={false}
+        onChange={() => {}}
+      />,
+    );
+
+    const errorMessage = screen.getByTestId("validation-message-bottom");
+
+    expect(errorMessage).toBeVisible();
+  });
+
   it("accepts a name prop and passes it to the underlying input", () => {
     render(
       <FileInput label="file input" name="input-name" onChange={() => {}} />,

--- a/src/components/grouped-character/grouped-character-test.stories.tsx
+++ b/src/components/grouped-character/grouped-character-test.stories.tsx
@@ -181,6 +181,27 @@ export const NewValidation = () => {
         groups={[2, 2, 3]}
         separator="-"
         warning="Warning Message"
+        mb={2}
+      />
+      <GroupedCharacter
+        validationMessagePositionTop={false}
+        label="GroupedCharacter"
+        inputHint="Hint text (optional)."
+        value={state}
+        onChange={setValue}
+        groups={[2, 2, 3]}
+        separator="-"
+        error="Error Message"
+        mb={2}
+      />
+      <GroupedCharacter
+        validationMessagePositionTop={false}
+        label="GroupedCharacter"
+        value={state}
+        onChange={setValue}
+        groups={[2, 2, 3]}
+        separator="-"
+        warning="Warning Message"
       />
     </CarbonProvider>
   );

--- a/src/components/number/number-test.stories.tsx
+++ b/src/components/number/number-test.stories.tsx
@@ -114,6 +114,21 @@ export const NewValidation = () => {
         mb={2}
       />
       <Number label="Number" value="123456" warning="Warning Message" mb={2} />
+      <Number
+        validationMessagePositionTop={false}
+        label="Number"
+        value="123456"
+        error="Error Message"
+        inputHint="Hint text"
+        mb={2}
+      />
+      <Number
+        validationMessagePositionTop={false}
+        label="Number"
+        value="123456"
+        warning="Warning Message"
+        mb={2}
+      />
     </CarbonProvider>
   );
 };

--- a/src/components/numeral-date/numeral-date-test.stories.tsx
+++ b/src/components/numeral-date/numeral-date-test.stories.tsx
@@ -142,9 +142,29 @@ export const NewValidations = (args: NumeralDateProps) => {
         label="Numeral date"
         error="Error Message"
         labelHelp="Hint text"
+        mb={2}
         {...args}
       />
-      <NumeralDate label="Numeral date" warning="Warning Message" {...args} />
+      <NumeralDate
+        label="Numeral date"
+        warning="Warning Message"
+        mb={2}
+        {...args}
+      />
+      <NumeralDate
+        validationMessagePositionTop={false}
+        label="Numeral date"
+        error="Error Message"
+        labelHelp="Hint text"
+        mb={2}
+        {...args}
+      />
+      <NumeralDate
+        validationMessagePositionTop={false}
+        label="Numeral date"
+        warning="Warning Message"
+        {...args}
+      />
     </CarbonProvider>
   );
 };

--- a/src/components/numeral-date/numeral-date.component.tsx
+++ b/src/components/numeral-date/numeral-date.component.tsx
@@ -141,6 +141,8 @@ export interface NumeralDateProps
    * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
    */
   isOptional?: boolean;
+  /** Render the ValidationMessage above the NumeralDate inputs when validationRedesignOptIn flag is set */
+  validationMessagePositionTop?: boolean;
 }
 
 export type ValidDateFormat = (typeof ALLOWED_DATE_FORMATS)[number];
@@ -262,6 +264,7 @@ export const NumeralDate = forwardRef<NumeralDateHandle, NumeralDateProps>(
       dayRef,
       monthRef,
       yearRef,
+      validationMessagePositionTop = true,
       ...rest
     },
     ref,
@@ -442,9 +445,11 @@ export const NumeralDate = forwardRef<NumeralDateHandle, NumeralDateProps>(
         fieldHelp,
       });
 
-    const combinedAriaDescribedBy = [ariaDescribedBy, inputHintId.current]
-      .filter(Boolean)
-      .join(" ");
+    const describedByArray =
+      validationRedesignOptIn && validationMessagePositionTop
+        ? [ariaDescribedBy, inputHintId.current]
+        : [inputHintId.current, ariaDescribedBy];
+    const combinedAriaDescribedBy = describedByArray.filter(Boolean).join(" ");
 
     const renderInputs = () => {
       return (
@@ -575,17 +580,31 @@ export const NumeralDate = forwardRef<NumeralDateHandle, NumeralDateProps>(
         )}
 
         <Box position="relative" mt={labelHelp ? 0 : 1}>
-          {(internalError || internalWarning) && (
-            <>
-              <ValidationMessage
-                error={internalError}
-                warning={internalWarning}
-                validationId={validationId}
-              />
-              <ErrorBorder warning={!!(!internalError && internalWarning)} />
-            </>
-          )}
+          {validationMessagePositionTop &&
+            (internalError || internalWarning) && (
+              <>
+                <ValidationMessage
+                  error={internalError}
+                  warning={internalWarning}
+                  validationId={validationId}
+                  validationMessagePositionTop={validationMessagePositionTop}
+                />
+                <ErrorBorder warning={!!(!internalError && internalWarning)} />
+              </>
+            )}
           {renderInputs()}
+          {!validationMessagePositionTop &&
+            (internalError || internalWarning) && (
+              <>
+                <ValidationMessage
+                  error={internalError}
+                  warning={internalWarning}
+                  validationId={validationId}
+                  validationMessagePositionTop={validationMessagePositionTop}
+                />
+                <ErrorBorder warning={!!(!internalError && internalWarning)} />
+              </>
+            )}
         </Box>
       </StyledFieldset>
     );

--- a/src/components/numeral-date/numeral-date.test.tsx
+++ b/src/components/numeral-date/numeral-date.test.tsx
@@ -2184,6 +2184,26 @@ test.each(["error", "warning"])(
   },
 );
 
+test.each(["error", "warning"])(
+  "should render with expected accessible description when '%s' and 'labelHelp' props are passed, 'validationRedesignOptIn' is true and validationMessagePositionTop is false",
+  (validation) => {
+    render(
+      <CarbonProvider validationRedesignOptIn>
+        <NumeralDate
+          value={{ dd: "", mm: "", yyyy: "" }}
+          onChange={() => {}}
+          labelHelp="labelHelp"
+          validationMessagePositionTop={false}
+          {...{ [validation]: "Message" }}
+        />
+      </CarbonProvider>,
+    );
+
+    const fieldset = screen.getByRole("group");
+    expect(fieldset).toHaveAccessibleDescription("labelHelp Message");
+  },
+);
+
 test("should focus the first textbox when the component is programmatically focused when the date format is dd/mm/yyyy", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
   const MockComponent = () => {

--- a/src/components/password/password-test.stories.tsx
+++ b/src/components/password/password-test.stories.tsx
@@ -205,6 +205,23 @@ export const NewValidation = () => {
         warning="Warning Message"
         value={state}
         onChange={setValue}
+        mb={2}
+      />
+      <Password
+        validationMessagePositionTop={false}
+        label="Password"
+        error="Error Message"
+        inputHint="Hint text (optional)."
+        value={state}
+        onChange={setValue}
+        mb={2}
+      />
+      <Password
+        validationMessagePositionTop={false}
+        label="Password"
+        warning="Warning Message"
+        value={state}
+        onChange={setValue}
       />
     </CarbonProvider>
   );

--- a/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
+++ b/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
@@ -72,6 +72,8 @@ export interface RadioButtonGroupProps
   value?: string;
   /** [Legacy] Overrides the default tooltip position */
   tooltipPosition?: "top" | "bottom" | "left" | "right";
+  /** Render the ValidationMessage above the RadioButton inputs when validationRedesignOptIn flag is set */
+  validationMessagePositionTop?: boolean;
 }
 
 let deprecateOptionalWarnTriggered = false;
@@ -99,6 +101,7 @@ export const RadioButtonGroup = ({
   required,
   isOptional,
   tooltipPosition,
+  validationMessagePositionTop = true,
   ...rest
 }: RadioButtonGroupProps) => {
   if (!deprecateOptionalWarnTriggered && isOptional) {
@@ -147,9 +150,12 @@ export const RadioButtonGroup = ({
     info,
   });
 
-  const combinedAriaDescribedBy = [ariaDescribedBy, inputHintId]
-    .filter(Boolean)
-    .join(" ");
+  const describedByArray =
+    validationRedesignOptIn && validationMessagePositionTop
+      ? [ariaDescribedBy, inputHintId]
+      : [inputHintId, ariaDescribedBy];
+
+  const combinedAriaDescribedBy = describedByArray.filter(Boolean).join(" ");
 
   return (
     <>
@@ -176,17 +182,21 @@ export const RadioButtonGroup = ({
             </HintText>
           )}
           <Box position="relative">
-            <ValidationMessage
-              error={error}
-              warning={warning}
-              validationId={validationId}
-            />
-            {(error || warning) && (
-              <ErrorBorder
-                data-role="radio-error-border"
-                inline={inline}
-                warning={!!(!error && warning)}
-              />
+            {validationMessagePositionTop && (
+              <>
+                <ValidationMessage
+                  error={error}
+                  warning={warning}
+                  validationId={validationId}
+                  validationMessagePositionTop={validationMessagePositionTop}
+                />
+                {(error || warning) && (
+                  <ErrorBorder
+                    data-role="radio-error-border"
+                    warning={!!(!error && warning)}
+                  />
+                )}
+              </>
             )}
             <RadioButtonGroupStyle
               data-component="radio-button-group"
@@ -215,6 +225,22 @@ export const RadioButtonGroup = ({
                 })}
               </RadioButtonMapper>
             </RadioButtonGroupStyle>
+            {!validationMessagePositionTop && (
+              <>
+                <ValidationMessage
+                  error={error}
+                  warning={warning}
+                  validationId={validationId}
+                  validationMessagePositionTop={validationMessagePositionTop}
+                />
+                {(error || warning) && (
+                  <ErrorBorder
+                    data-role="radio-error-border"
+                    warning={!!(!error && warning)}
+                  />
+                )}
+              </>
+            )}
           </Box>
         </Fieldset>
       ) : (

--- a/src/components/radio-button/radio-button-group/radio-button-group.test.tsx
+++ b/src/components/radio-button/radio-button-group/radio-button-group.test.tsx
@@ -306,7 +306,7 @@ describe("when `validationRedesignOptIn` flag is true", () => {
     expect(hintText).toHaveStyleRule("font-size", "14px");
   });
 
-  it("renders ErrorBorder with expected styles when `inline` is true", () => {
+  it("renders with expected styles when `inline` is true", () => {
     render(
       <CarbonProvider validationRedesignOptIn>
         <RadioButtonGroup
@@ -320,10 +320,10 @@ describe("when `validationRedesignOptIn` flag is true", () => {
       </CarbonProvider>,
     );
 
-    const errorBorder = screen.getByTestId("radio-error-border");
+    const radioButtons = screen.getByRole("radiogroup");
 
-    expect(errorBorder).toHaveStyle({
-      bottom: "10px",
+    expect(radioButtons).toHaveStyle({
+      flexDirection: "row",
     });
   });
 
@@ -344,5 +344,53 @@ describe("when `validationRedesignOptIn` flag is true", () => {
 
     expect(screen.getAllByRole("radio")).toHaveLength(2);
     expect(screen.getByText("foo")).toBeVisible();
+  });
+
+  it("renders with provided `error` message and `labelHelp` describing the group when `validationMessagePositionTop` is false", () => {
+    render(
+      <CarbonProvider validationRedesignOptIn>
+        <RadioButtonGroup
+          name="group"
+          legend="legend"
+          legendHelp="Legend help text"
+          error="Error message"
+          onChange={() => {}}
+          validationMessagePositionTop={false}
+        >
+          <RadioButton value="radio1" label="Radio Button 1" />
+        </RadioButtonGroup>
+      </CarbonProvider>,
+    );
+
+    const fieldset = screen.getByRole("group", { name: "legend" });
+
+    expect(screen.getByText("Error message")).toBeVisible();
+    expect(fieldset).toHaveAccessibleDescription(
+      "Legend help text Error message",
+    );
+  });
+
+  it("renders with provided `warning` message and `labelHelp` describing the group when `validationMessagePositionTop` is false", () => {
+    render(
+      <CarbonProvider validationRedesignOptIn>
+        <RadioButtonGroup
+          name="group"
+          legend="legend"
+          legendHelp="Legend help text"
+          warning="Warning message"
+          onChange={() => {}}
+          validationMessagePositionTop={false}
+        >
+          <RadioButton value="radio1" label="Radio Button 1" />
+        </RadioButtonGroup>
+      </CarbonProvider>,
+    );
+
+    const fieldset = screen.getByRole("group", { name: "legend" });
+
+    expect(screen.getByText("Warning message")).toBeVisible();
+    expect(fieldset).toHaveAccessibleDescription(
+      "Legend help text Warning message",
+    );
   });
 });

--- a/src/components/radio-button/radio-button-test.stories.tsx
+++ b/src/components/radio-button/radio-button-test.stories.tsx
@@ -192,7 +192,7 @@ export const NewValidation = ({ ...props }: Partial<RadioButtonGroupProps>) => {
   return (
     <CarbonProvider validationRedesignOptIn>
       <RadioButtonGroup
-        name="radio-button-group"
+        name="radio-button-group-error"
         error="Error Message"
         mb={2}
         {...props}
@@ -207,7 +207,39 @@ export const NewValidation = ({ ...props }: Partial<RadioButtonGroupProps>) => {
         />
       </RadioButtonGroup>
       <RadioButtonGroup
-        name="radio-button-group"
+        name="radio-button-group-warning"
+        warning="Warning Message"
+        mb={2}
+        {...props}
+      >
+        <RadioButton id="radio-1" value="radio1" label="Yes" />
+        <RadioButton id="radio-2" value="radio2" label="No" />
+        <RadioButton
+          id="radio-3"
+          value="radio3"
+          label="Maybe"
+          fieldHelp="fieldHelp text"
+        />
+      </RadioButtonGroup>
+      <RadioButtonGroup
+        validationMessagePositionTop={false}
+        name="radio-button-group-error-bottom"
+        error="Error Message"
+        mb={2}
+        {...props}
+      >
+        <RadioButton id="radio-1" value="radio1" label="Yes" />
+        <RadioButton id="radio-2" value="radio2" label="No" />
+        <RadioButton
+          id="radio-3"
+          value="radio3"
+          label="Maybe"
+          fieldHelp="fieldHelp text"
+        />
+      </RadioButtonGroup>
+      <RadioButtonGroup
+        validationMessagePositionTop={false}
+        name="radio-button-group-warning-bottom"
         warning="Warning Message"
         {...props}
       >
@@ -233,6 +265,73 @@ NewValidation.args = {
   inline: false,
 };
 NewValidation.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};
+
+export const NewValidationInline = ({
+  ...props
+}: Partial<RadioButtonGroupProps>) => {
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      <RadioButtonGroup
+        name="radio-button-group-error"
+        error="Error Message"
+        inline
+        mb={2}
+        {...props}
+      >
+        <RadioButton id="radio-1" value="radio1" label="Yes" />
+        <RadioButton id="radio-2" value="radio2" label="No" />
+        <RadioButton id="radio-3" value="radio3" label="Maybe" />
+      </RadioButtonGroup>
+      <RadioButtonGroup
+        name="radio-button-group-warning"
+        warning="Warning Message"
+        inline
+        mb={2}
+        {...props}
+      >
+        <RadioButton id="radio-1" value="radio1" label="Yes" />
+        <RadioButton id="radio-2" value="radio2" label="No" />
+        <RadioButton id="radio-3" value="radio3" label="Maybe" />
+      </RadioButtonGroup>
+      <RadioButtonGroup
+        validationMessagePositionTop={false}
+        name="radio-button-group-error-bottom"
+        error="Error Message"
+        inline
+        mb={2}
+        {...props}
+      >
+        <RadioButton id="radio-1" value="radio1" label="Yes" />
+        <RadioButton id="radio-2" value="radio2" label="No" />
+        <RadioButton id="radio-3" value="radio3" label="Maybe" />
+      </RadioButtonGroup>
+      <RadioButtonGroup
+        validationMessagePositionTop={false}
+        name="radio-button-group-warning-bottom"
+        warning="Warning Message"
+        inline
+        mb={2}
+        {...props}
+      >
+        <RadioButton id="radio-1" value="radio1" label="Yes" />
+        <RadioButton id="radio-2" value="radio2" label="No" />
+        <RadioButton id="radio-3" value="radio3" label="Maybe" />
+      </RadioButtonGroup>
+    </CarbonProvider>
+  );
+};
+NewValidationInline.args = {
+  id: "new-validation",
+  legend: "Radio group legend",
+  legendHelp: "Legend help text",
+  legendAlign: "left",
+  required: true,
+  isOptional: false,
+};
+NewValidationInline.parameters = {
   chromatic: { disableSnapshot: false },
   themeProvider: { chromatic: { theme: "sage" } },
 };

--- a/src/components/radio-button/radio-button.pw.tsx
+++ b/src/components/radio-button/radio-button.pw.tsx
@@ -626,11 +626,11 @@ test.describe("Testing RadioButtonGroup component", () => {
   }) => {
     await mount(<RadioButtonGroupComponent inline />);
     const firstRadiobuttonElement = radiobutton(page, 0);
-    await expect(firstRadiobuttonElement).toHaveCSS("margin-bottom", "12px");
+    await expect(firstRadiobuttonElement).toHaveCSS("margin-bottom", "0px");
     await expect(firstRadiobuttonElement).toHaveCSS("margin-left", "0px");
 
     const secondRadiobuttonElement = radiobutton(page, 1);
-    await expect(secondRadiobuttonElement).toHaveCSS("margin-bottom", "12px");
+    await expect(secondRadiobuttonElement).toHaveCSS("margin-bottom", "0px");
     await expect(secondRadiobuttonElement).toHaveCSS("margin-left", "32px");
 
     const thirdRadiobuttonElement = radiobutton(page, 2);

--- a/src/components/radio-button/radio-button.style.ts
+++ b/src/components/radio-button/radio-button.style.ts
@@ -109,6 +109,7 @@ const RadioButtonStyle = styled(CheckboxStyle).attrs(applyBaseTheme)<
 
     ${inline &&
     `
+      margin: 0;
       &:not(:first-of-type) {
         margin-left: 32px;
       }

--- a/src/components/select/filterable-select/filterable-select-test.stories.tsx
+++ b/src/components/select/filterable-select/filterable-select-test.stories.tsx
@@ -248,6 +248,30 @@ export const NewValidation = () => {
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </FilterableSelect>
+      <FilterableSelect
+        validationMessagePositionTop={false}
+        name="filterable"
+        id="filterable"
+        label="Filterable Select"
+        error="Error Message"
+        mb={2}
+      >
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+      </FilterableSelect>
+      <FilterableSelect
+        validationMessagePositionTop={false}
+        name="filterable"
+        id="filterable"
+        label="Filterable Select"
+        warning="Warning Message"
+        mb={2}
+      >
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+      </FilterableSelect>
     </CarbonProvider>
   );
 };

--- a/src/components/select/multi-select/multi-select-test.stories.tsx
+++ b/src/components/select/multi-select/multi-select-test.stories.tsx
@@ -209,6 +209,7 @@ export const NewValidation = () => {
         id="multi"
         label="MultiSelect"
         error="Error Message"
+        mb={2}
       >
         <Option value="1" text="One" />
         <Option value="2" text="Two" />
@@ -219,6 +220,31 @@ export const NewValidation = () => {
         id="multi"
         label="MultiSelect"
         warning="Warning Message"
+        mb={2}
+      >
+        <Option value="1" text="One" />
+        <Option value="2" text="Two" />
+        <Option value="3" text="Three" />
+      </MultiSelect>
+      <MultiSelect
+        validationMessagePositionTop={false}
+        name="multi"
+        id="multi"
+        label="MultiSelect"
+        error="Error Message"
+        mb={2}
+      >
+        <Option value="1" text="One" />
+        <Option value="2" text="Two" />
+        <Option value="3" text="Three" />
+      </MultiSelect>
+      <MultiSelect
+        validationMessagePositionTop={false}
+        name="multi"
+        id="multi"
+        label="MultiSelect"
+        warning="Warning Message"
+        mb={2}
       >
         <Option value="1" text="One" />
         <Option value="2" text="Two" />

--- a/src/components/select/simple-select/simple-select-test.stories.tsx
+++ b/src/components/select/simple-select/simple-select-test.stories.tsx
@@ -227,6 +227,31 @@ export const NewValidation = () => {
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </Select>
+      <Select
+        validationMessagePositionTop={false}
+        name="simple"
+        id="simple"
+        label="Simple Select"
+        error="Error message"
+        inputHint="Hint text"
+        mb={2}
+      >
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+      </Select>
+      <Select
+        validationMessagePositionTop={false}
+        name="simple"
+        id="simple"
+        label="Simple Select"
+        warning="Warning message"
+        mb={2}
+      >
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+      </Select>
     </CarbonProvider>
   );
 };

--- a/src/components/switch/switch-test.stories.tsx
+++ b/src/components/switch/switch-test.stories.tsx
@@ -133,6 +133,18 @@ export const NewValidation = ({ ...args }: Partial<SwitchProps>) => {
     <CarbonProvider validationRedesignOptIn>
       <Switch error="Error Message (Fix is required)" mb={2} {...args} />
       <Switch warning="Warning Message (Fix is optional)" mb={2} {...args} />
+      <Switch
+        validationMessagePositionTop={false}
+        error="Error Message (Fix is required)"
+        mb={2}
+        {...args}
+      />
+      <Switch
+        validationMessagePositionTop={false}
+        warning="Warning Message (Fix is optional)"
+        mb={2}
+        {...args}
+      />
     </CarbonProvider>
   );
 };
@@ -187,6 +199,22 @@ export const NewValidationInline = ({ ...args }: Partial<SwitchProps>) => {
         warning="Warning Message (Fix is optional)"
         labelInline
         fieldHelp="fieldHelp"
+        mb={2}
+        {...args}
+      />
+      <Switch
+        labelHelp="Hint text"
+        error="Error Message (Fix is required)"
+        labelInline
+        validationMessagePositionTop={false}
+        my={2}
+        {...args}
+      />
+      <Switch
+        warning="Warning Message (Fix is optional)"
+        labelInline
+        fieldHelp="fieldHelp"
+        validationMessagePositionTop={false}
         mb={2}
         {...args}
       />

--- a/src/components/switch/switch.component.tsx
+++ b/src/components/switch/switch.component.tsx
@@ -40,6 +40,8 @@ export interface SwitchProps
   helpAriaLabel?: string;
   /** Whether this component resides on a dark background */
   isDarkBackground?: boolean;
+  /** Render the ValidationMessage above the Switch input when validationRedesignOptIn flag is set */
+  validationMessagePositionTop?: boolean;
 }
 
 let deprecateUncontrolledWarnTriggered = false;
@@ -77,6 +79,7 @@ export const Switch = React.forwardRef(
       "data-role": dataRole,
       helpAriaLabel,
       isDarkBackground = false,
+      validationMessagePositionTop = true,
       ...rest
     }: SwitchProps,
     ref: React.ForwardedRef<HTMLInputElement>,
@@ -312,19 +315,25 @@ export const Switch = React.forwardRef(
               id="input-wrapper"
               data-role="input-wrapper"
             >
-              <ValidationMessage
-                error={error}
-                warning={warning}
-                validationId={validationMessageId.current}
-                isDarkBackground={isDarkBackground}
-              />
-              {applyValidation && (
-                <ErrorBorder
-                  data-role="error-border"
-                  warning={!!(!error && warning)}
-                  reverse={!reverse}
-                  isDarkBackground={isDarkBackground}
-                />
+              {validationMessagePositionTop && (
+                <>
+                  <ValidationMessage
+                    error={error}
+                    warning={warning}
+                    validationId={validationMessageId.current}
+                    isDarkBackground={isDarkBackground}
+                    validationMessagePositionTop={validationMessagePositionTop}
+                    data-role="validation-message-top"
+                  />
+                  {applyValidation && (
+                    <ErrorBorder
+                      data-role="error-border"
+                      warning={!!(!error && warning)}
+                      reverse={!reverse}
+                      isDarkBackground={isDarkBackground}
+                    />
+                  )}
+                </>
               )}
               <CheckableInput
                 ariaLabelledBy={`${label && labelId.current}`}
@@ -334,6 +343,26 @@ export const Switch = React.forwardRef(
               >
                 <SwitchSlider {...switchSliderPropsForNewValidation} />
               </CheckableInput>
+              {!validationMessagePositionTop && (
+                <>
+                  <ValidationMessage
+                    error={error}
+                    warning={warning}
+                    validationId={validationMessageId.current}
+                    isDarkBackground={isDarkBackground}
+                    validationMessagePositionTop={validationMessagePositionTop}
+                    data-role="validation-message-bottom"
+                  />
+                  {applyValidation && (
+                    <ErrorBorder
+                      data-role="error-border"
+                      warning={!!(!error && warning)}
+                      reverse={!reverse}
+                      isDarkBackground={isDarkBackground}
+                    />
+                  )}
+                </>
+              )}
             </Box>
           </Box>
         </StyledSwitch>

--- a/src/components/switch/switch.test.tsx
+++ b/src/components/switch/switch.test.tsx
@@ -285,6 +285,25 @@ test("the `info` prop should not throw an error if `loading` is true", () => {
   }).not.toThrow();
 });
 
+test.each(["error", "warning"])(
+  "should render the validation message under the input when %s passed as string and validationMessagePositionTop is false",
+  (validationType) => {
+    render(
+      <CarbonProvider validationRedesignOptIn>
+        <Switch
+          label="label"
+          validationMessagePositionTop={false}
+          {...{ [validationType]: "This is a validation message" }}
+        />
+      </CarbonProvider>,
+    );
+
+    const validationMessage = screen.getByTestId("validation-message-bottom");
+
+    expect(validationMessage).toBeVisible();
+  },
+);
+
 test("`helpAriaLabel` prop should set the aria-label on the Help component", () => {
   render(<Switch label="foo" labelHelp="fooHelp" helpAriaLabel="text" />);
 
@@ -600,7 +619,7 @@ test("renders with the correct error colour when `isDarkBackground` is false", (
     </CarbonProvider>,
   );
 
-  expect(screen.getByTestId("validation-message")).toHaveStyleRule(
+  expect(screen.getByTestId("validation-message-top")).toHaveStyleRule(
     "color: var(--colorsSemanticNegative500)",
   );
 });
@@ -618,7 +637,7 @@ test("renders with the correct error colour when `isDarkBackground` is true", ()
     </CarbonProvider>,
   );
 
-  expect(screen.getByTestId("validation-message")).toHaveStyleRule(
+  expect(screen.getByTestId("validation-message-top")).toHaveStyleRule(
     "color: var(--colorsSemanticNegative450)",
   );
 });

--- a/src/components/text-editor/__internal__/plugins/ContentEditor/content-editor.component.tsx
+++ b/src/components/text-editor/__internal__/plugins/ContentEditor/content-editor.component.tsx
@@ -24,6 +24,8 @@ export interface ContentEditorProps {
   error?: boolean;
   /** Editor has a warning */
   warning?: boolean;
+  /** Render the ValidationMessage above the Editor */
+  validationMessagePositionTop?: boolean;
 }
 
 const ContentEditor = forwardRef<HTMLDivElement, ContentEditorProps>(
@@ -37,6 +39,7 @@ const ContentEditor = forwardRef<HTMLDivElement, ContentEditorProps>(
       required,
       error,
       warning,
+      validationMessagePositionTop,
     },
     ref,
   ) => {
@@ -45,7 +48,10 @@ const ContentEditor = forwardRef<HTMLDivElement, ContentEditorProps>(
     const validationMessageId =
       error || warning ? `${namespace}-validation-message` : "";
     const inputHintId = inputHint ? `${namespace}-input-hint` : "";
-    const ariaDescribedBy = `${validationMessageId} ${inputHintId}`.trim();
+    const describedByString = validationMessagePositionTop
+      ? `${validationMessageId} ${inputHintId}`
+      : `${inputHintId} ${validationMessageId}`;
+    const ariaDescribedBy = describedByString.trim();
 
     return (
       <StyledContentEditable

--- a/src/components/text-editor/text-editor-test.stories.tsx
+++ b/src/components/text-editor/text-editor-test.stories.tsx
@@ -27,7 +27,7 @@ export const NewValidation: Story = () => {
   return (
     <>
       <TextEditor
-        namespace="storybook-witherror"
+        namespace="storybook-error-top"
         labelText="Text Editor"
         inputHint="Hint text"
         error="error"
@@ -35,7 +35,24 @@ export const NewValidation: Story = () => {
         mb={2}
       />
       <TextEditor
-        namespace="storybook-withwarning"
+        namespace="storybook-warning-top"
+        labelText="Text Editor"
+        warning="warning"
+        characterLimit={100}
+        mb={2}
+      />
+      <TextEditor
+        validationMessagePositionTop={false}
+        namespace="storybook-error-bottom"
+        labelText="Text Editor"
+        inputHint="Hint text"
+        error="error"
+        characterLimit={100}
+        mb={2}
+      />
+      <TextEditor
+        validationMessagePositionTop={false}
+        namespace="storybook-warning-bottom"
         labelText="Text Editor"
         warning="warning"
         characterLimit={100}

--- a/src/components/text-editor/text-editor.component.tsx
+++ b/src/components/text-editor/text-editor.component.tsx
@@ -116,6 +116,8 @@ export interface TextEditorProps extends MarginProps, TagProps {
    * This prop is optional and supports a single plugin, multiple plugins (via fragments or arrays), or `null`.
    */
   customPlugins?: React.ReactNode;
+  /** Render the ValidationMessage above the TextEditor */
+  validationMessagePositionTop?: boolean;
 }
 
 let deprecateOptionalWarnTriggered = false;
@@ -145,6 +147,7 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
       warning,
       value,
       customPlugins,
+      validationMessagePositionTop = true,
       ...rest
     },
     ref,
@@ -310,14 +313,19 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
           <LexicalComposer initialConfig={initialConfig}>
             <EditorRefPlugin editorRef={editorRef} />
             <StyledWrapper data-role={`${namespace}-wrapper`}>
-              <ValidationMessage
-                error={error}
-                warning={warningMessage}
-                validationId={`${namespace}-validation-message`}
-                data-role={`${namespace}-validation-message`}
-              />
-              {(error || warningMessage) && (
-                <ErrorBorder warning={!!(!error && warningMessage)} />
+              {validationMessagePositionTop && (
+                <>
+                  <ValidationMessage
+                    error={error}
+                    warning={warningMessage}
+                    validationId={`${namespace}-validation-message`}
+                    data-role={`${namespace}-validation-message`}
+                    validationMessagePositionTop={validationMessagePositionTop}
+                  />
+                  {(error || warningMessage) && (
+                    <ErrorBorder warning={!!(!error && warningMessage)} />
+                  )}
+                </>
               )}
               <StyledEditorToolbarWrapper
                 data-role={`${namespace}-editor-toolbar-wrapper`}
@@ -351,6 +359,9 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
                         required={required}
                         error={!!error}
                         warning={!!warning || !!characterLimitWarning}
+                        validationMessagePositionTop={
+                          validationMessagePositionTop
+                        }
                       />
                     }
                     placeholder={
@@ -376,6 +387,20 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
                 )}
                 <LinkMonitorPlugin />
               </StyledEditorToolbarWrapper>
+              {!validationMessagePositionTop && (
+                <>
+                  <ValidationMessage
+                    error={error}
+                    warning={warningMessage}
+                    validationId={`${namespace}-validation-message`}
+                    data-role={`${namespace}-validation-message`}
+                    validationMessagePositionTop={validationMessagePositionTop}
+                  />
+                  {(error || warningMessage) && (
+                    <ErrorBorder warning={!!(!error && warningMessage)} />
+                  )}
+                </>
+              )}
 
               {characterLimit > 0 && !readOnly && (
                 <CharacterCounterPlugin

--- a/src/components/text-editor/text-editor.test.tsx
+++ b/src/components/text-editor/text-editor.test.tsx
@@ -342,6 +342,41 @@ test("validation renders correctly when error prop is provided", () => {
   expect(editor).not.toBeValid();
 });
 
+test("validation renders correctly when error prop is provided and validationMessagePositionTop is false", () => {
+  render(
+    <TextEditor
+      error="This is an error"
+      labelText="Example"
+      inputHint="Hint"
+      validationMessagePositionTop={false}
+    />,
+  );
+
+  const editor = screen.getByRole("textbox", { name: "Example" });
+  const errorMessage = screen.getByText("This is an error");
+
+  expect(errorMessage).toBeVisible();
+  expect(editor).toHaveAccessibleDescription("Hint This is an error");
+  expect(editor).not.toBeValid();
+});
+
+test("validation renders correctly when warning prop is provided and validationMessagePositionTop is false", () => {
+  render(
+    <TextEditor
+      warning="This is an warning"
+      labelText="Example"
+      inputHint="Hint"
+      validationMessagePositionTop={false}
+    />,
+  );
+
+  const editor = screen.getByRole("textbox", { name: "Example" });
+  const warningMessage = screen.getByText("This is an warning");
+
+  expect(warningMessage).toBeVisible();
+  expect(editor).toHaveAccessibleDescription("Hint This is an warning");
+});
+
 test("validation renders correctly when warning prop is provided", () => {
   // render the TextEditor component with an error
   render(<TextEditor warning="This is a warning" labelText="Example" />);

--- a/src/components/textarea/textarea-test.stories.tsx
+++ b/src/components/textarea/textarea-test.stories.tsx
@@ -203,7 +203,18 @@ export const NewValidation = () => {
   return (
     <CarbonProvider validationRedesignOptIn>
       <Textarea label="Textarea" error="Error Message" mb={2} />
-      <Textarea label="Textarea" warning="Warning Message" />
+      <Textarea label="Textarea" warning="Warning Message" mb={2} />
+      <Textarea
+        validationMessagePositionTop={false}
+        label="Textarea"
+        error="Error Message"
+        mb={2}
+      />
+      <Textarea
+        validationMessagePositionTop={false}
+        label="Textarea"
+        warning="Warning Message"
+      />
     </CarbonProvider>
   );
 };

--- a/src/components/textarea/textarea.component.tsx
+++ b/src/components/textarea/textarea.component.tsx
@@ -131,6 +131,8 @@ export interface TextareaProps
   hideBorders?: boolean;
   /** Specify the minimum height. This property is only applied if rows is not set. */
   minHeight?: number;
+  /** Render the ValidationMessage above the Textarea when validationRedesignOptIn flag is set */
+  validationMessagePositionTop?: boolean;
 }
 
 let deprecatedAriaDescribedByWarnTriggered = false;
@@ -183,6 +185,7 @@ export const Textarea = React.forwardRef(
       required,
       isOptional,
       minHeight = DEFAULT_MIN_HEIGHT,
+      validationMessagePositionTop = true,
       ...rest
     }: TextareaProps,
     ref: React.ForwardedRef<HTMLTextAreaElement>,
@@ -355,9 +358,12 @@ export const Textarea = React.forwardRef(
     const hintId = useRef(guid());
     const inputHintId = inputHint ? hintId.current : undefined;
 
+    const describedByArray =
+      validationRedesignOptIn && validationMessagePositionTop
+        ? [ariaDescribedBy, inputHintId]
+        : [inputHintId, ariaDescribedBy];
     const combinedAriaDescribedBy = [
-      ariaDescribedBy,
-      inputHintId,
+      ...describedByArray,
       visuallyHiddenHintId,
       ariaDescribedByProp || ariaDescribedByPropDeprecated,
     ]
@@ -465,15 +471,37 @@ export const Textarea = React.forwardRef(
               )}
               {validationRedesignOptIn ? (
                 <Box position="relative">
-                  <ValidationMessage
-                    error={error}
-                    validationId={validationId}
-                    warning={warning}
-                  />
-                  {(error || warning) && (
-                    <ErrorBorder warning={!!(!error && warning)} />
+                  {validationMessagePositionTop && (
+                    <>
+                      <ValidationMessage
+                        error={error}
+                        validationId={validationId}
+                        warning={warning}
+                        validationMessagePositionTop={
+                          validationMessagePositionTop
+                        }
+                      />
+                      {(error || warning) && (
+                        <ErrorBorder warning={!!(!error && warning)} />
+                      )}
+                    </>
                   )}
                   {input}
+                  {!validationMessagePositionTop && (
+                    <>
+                      <ValidationMessage
+                        error={error}
+                        validationId={validationId}
+                        warning={warning}
+                        validationMessagePositionTop={
+                          validationMessagePositionTop
+                        }
+                      />
+                      {(error || warning) && (
+                        <ErrorBorder warning={!!(!error && warning)} />
+                      )}
+                    </>
+                  )}
                 </Box>
               ) : (
                 input

--- a/src/components/textarea/textarea.test.tsx
+++ b/src/components/textarea/textarea.test.tsx
@@ -655,11 +655,32 @@ describe("when rendered with new validations", () => {
     (validationType) => {
       render(
         <CarbonProvider validationRedesignOptIn>
-          <Textarea {...{ [validationType]: "bar" }} />
+          <Textarea inputHint="Hint" {...{ [validationType]: "Validation" }} />
         </CarbonProvider>,
       );
 
-      expect(screen.getByRole("textbox")).toHaveAccessibleDescription("bar");
+      expect(screen.getByRole("textbox")).toHaveAccessibleDescription(
+        "Validation Hint",
+      );
+    },
+  );
+
+  it.each(["error", "warning"])(
+    "the validation text is assigned as the accessible description for textarea element when validationMessagePositionTop is false",
+    (validationType) => {
+      render(
+        <CarbonProvider validationRedesignOptIn>
+          <Textarea
+            inputHint="Hint"
+            {...{ [validationType]: "Validation" }}
+            validationMessagePositionTop={false}
+          />
+        </CarbonProvider>,
+      );
+
+      expect(screen.getByRole("textbox")).toHaveAccessibleDescription(
+        "Hint Validation",
+      );
     },
   );
 

--- a/src/components/textbox/textbox-test.stories.tsx
+++ b/src/components/textbox/textbox-test.stories.tsx
@@ -72,6 +72,16 @@ export const NewValidation = () => {
     <CarbonProvider validationRedesignOptIn>
       <Textbox label="Textbox" error="Error Message" />
       <Textbox label="Textbox" warning="Warning Message" />
+      <Textbox
+        validationMessagePositionTop={false}
+        label="Textbox"
+        error="Error Message"
+      />
+      <Textbox
+        validationMessagePositionTop={false}
+        label="Textbox"
+        warning="Warning Message"
+      />
     </CarbonProvider>
   );
 };

--- a/src/components/textbox/textbox.component.tsx
+++ b/src/components/textbox/textbox.component.tsx
@@ -129,6 +129,8 @@ export interface CommonTextboxProps
   tooltipId?: string;
   /** @private @internal @ignore */
   "data-component"?: string;
+  /** Render the ValidationMessage above the Textbox input when validationRedesignOptIn flag is set */
+  validationMessagePositionTop?: boolean;
 }
 
 export interface TextboxProps extends CommonTextboxProps {
@@ -200,6 +202,7 @@ export const Textbox = React.forwardRef(
       characterLimit,
       helpAriaLabel,
       tooltipId,
+      validationMessagePositionTop = true,
       ...props
     }: TextboxProps,
     ref: React.ForwardedRef<HTMLInputElement>,
@@ -270,9 +273,12 @@ export const Textbox = React.forwardRef(
     const hintId = useRef(guid());
     const inputHintId = inputHint ? hintId.current : undefined;
 
+    const describedByArray =
+      validationRedesignOptIn && validationMessagePositionTop
+        ? [ariaDescribedBy, inputHintId]
+        : [inputHintId, ariaDescribedBy];
     const combinedAriaDescribedBy = [
-      ariaDescribedBy,
-      inputHintId,
+      ...describedByArray,
       visuallyHiddenHintId,
       ariaDescribedByProp || ariaDescribedByDeprecated,
     ]
@@ -401,15 +407,37 @@ export const Textbox = React.forwardRef(
             )}
             {validationRedesignOptIn ? (
               <Box position="relative">
-                <ValidationMessage
-                  error={error}
-                  validationId={validationId}
-                  warning={warning}
-                />
-                {!disableErrorBorder && (error || warning) && (
-                  <ErrorBorder warning={!!(!error && warning)} />
+                {validationMessagePositionTop && (
+                  <>
+                    <ValidationMessage
+                      error={error}
+                      validationId={validationId}
+                      warning={warning}
+                      validationMessagePositionTop={
+                        validationMessagePositionTop
+                      }
+                    />
+                    {!disableErrorBorder && (error || warning) && (
+                      <ErrorBorder warning={!!(!error && warning)} />
+                    )}
+                  </>
                 )}
                 {input}
+                {!validationMessagePositionTop && (
+                  <>
+                    <ValidationMessage
+                      error={error}
+                      validationId={validationId}
+                      warning={warning}
+                      validationMessagePositionTop={
+                        validationMessagePositionTop
+                      }
+                    />
+                    {!disableErrorBorder && (error || warning) && (
+                      <ErrorBorder warning={!!(!error && warning)} />
+                    )}
+                  </>
+                )}
               </Box>
             ) : (
               input

--- a/src/components/textbox/textbox.style.ts
+++ b/src/components/textbox/textbox.style.ts
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 
 const ErrorBorder = styled.span`
-  ${({ warning, inline }: { warning: boolean; inline?: boolean }) => css`
+  ${({ warning }: { warning: boolean }) => css`
     position: absolute;
     z-index: 6;
     width: 2px;
@@ -9,7 +9,7 @@ const ErrorBorder = styled.span`
       ? "var(--colorsSemanticCaution500)"
       : "var(--colorsSemanticNegative500)"};
     left: -12px;
-    bottom: ${inline ? "10px" : "0px"};
+    bottom: 0px;
     top: 0px;
   `}
 `;

--- a/src/components/textbox/textbox.test.tsx
+++ b/src/components/textbox/textbox.test.tsx
@@ -571,6 +571,62 @@ test.each(validationTypes)(
   },
 );
 
+test("describes the input with the inputHint and error message when validationMessagePositionTop is true", () => {
+  render(
+    <CarbonProvider validationRedesignOptIn>
+      <Textbox inputHint="input hint" error="validation message" />
+    </CarbonProvider>,
+  );
+
+  expect(screen.getByRole("textbox")).toHaveAccessibleDescription(
+    "validation message input hint",
+  );
+});
+
+test("describes the input with the inputHint and warning when validationMessagePositionTop is true", () => {
+  render(
+    <CarbonProvider validationRedesignOptIn>
+      <Textbox inputHint="input hint" warning="validation message" />
+    </CarbonProvider>,
+  );
+
+  expect(screen.getByRole("textbox")).toHaveAccessibleDescription(
+    "validation message input hint",
+  );
+});
+
+test("describes the input with the inputHint and error message when validationMessagePositionTop is false", () => {
+  render(
+    <CarbonProvider validationRedesignOptIn>
+      <Textbox
+        inputHint="input hint"
+        error="validation message"
+        validationMessagePositionTop={false}
+      />
+    </CarbonProvider>,
+  );
+
+  expect(screen.getByRole("textbox")).toHaveAccessibleDescription(
+    "input hint validation message",
+  );
+});
+
+test("describes the input with the inputHint and warning when validationMessagePositionTop is false", () => {
+  render(
+    <CarbonProvider validationRedesignOptIn>
+      <Textbox
+        inputHint="input hint"
+        warning="validation message"
+        validationMessagePositionTop={false}
+      />
+    </CarbonProvider>,
+  );
+
+  expect(screen.getByRole("textbox")).toHaveAccessibleDescription(
+    "input hint validation message",
+  );
+});
+
 test("renders validation tooltip with provided 'tooltipId' prop", async () => {
   render(<Textbox label="bar" error="baz" tooltipId="foo" />);
 

--- a/src/components/time/time-test.stories.tsx
+++ b/src/components/time/time-test.stories.tsx
@@ -88,6 +88,60 @@ export const Validation: Story = () => {
         minutesInputProps={{
           warning: "Minutes value must be in  AM/PM format.",
         }}
+        mb={1}
+      />
+      <Time
+        validationMessagePositionTop={false}
+        value={valueInvalidHours}
+        onChange={() => {}}
+        label="Time - with error on hours"
+        hoursInputProps={{ error: "Hours value must be in AM/PM format." }}
+        mb={1}
+      />
+      <Time
+        validationMessagePositionTop={false}
+        value={valueInvalidMinutes}
+        onChange={() => {}}
+        label="Time - with error on minutes"
+        minutesInputProps={{ error: "Minutes value must be in  AM/PM format." }}
+        mb={1}
+      />
+      <Time
+        validationMessagePositionTop={false}
+        value={valueInvalidBoth}
+        onChange={() => {}}
+        label="Time - with error on both"
+        hoursInputProps={{ error: "Hours value must be in AM/PM format." }}
+        minutesInputProps={{ error: "Minutes value must be in  AM/PM format." }}
+        mb={2}
+      />
+      <Time
+        validationMessagePositionTop={false}
+        value={valueInvalidHours}
+        onChange={() => {}}
+        label="Time - with warning on hours"
+        hoursInputProps={{ warning: "Hours value must be in AM/PM format." }}
+        mb={1}
+      />
+      <Time
+        validationMessagePositionTop={false}
+        value={valueInvalidMinutes}
+        onChange={() => {}}
+        label="Time - with warning on minutes"
+        minutesInputProps={{
+          warning: "Minutes value must be in  AM/PM format.",
+        }}
+        mb={1}
+      />
+      <Time
+        validationMessagePositionTop={false}
+        value={valueInvalidBoth}
+        onChange={() => {}}
+        label="Time - with warning on both"
+        hoursInputProps={{ warning: "Hours value must be in AM/PM format." }}
+        minutesInputProps={{
+          warning: "Minutes value must be in  AM/PM format.",
+        }}
       />
     </Box>
   );

--- a/src/components/time/time.component.tsx
+++ b/src/components/time/time.component.tsx
@@ -97,6 +97,8 @@ export interface TimeProps extends TagProps, MarginProps {
   readOnly?: boolean;
   /** Set custom data- attributes on the toggle elements */
   toggleProps?: ToggleDataProps;
+  /** Render the ValidationMessage above the Time inputs */
+  validationMessagePositionTop?: boolean;
 }
 
 export type TimeHandle = {
@@ -127,6 +129,7 @@ const Time = React.forwardRef<TimeHandle, TimeProps>(
       disabled,
       readOnly,
       toggleProps = {},
+      validationMessagePositionTop = true,
       ...rest
     },
     ref,
@@ -241,9 +244,10 @@ const Time = React.forwardRef<TimeHandle, TimeProps>(
       warning,
     });
 
-    const combinedAriaDescribedBy = [ariaDescribedBy, inputHintId.current]
-      .filter(Boolean)
-      .join(" ");
+    const describedByArray = validationMessagePositionTop
+      ? [ariaDescribedBy, inputHintId.current]
+      : [inputHintId.current, ariaDescribedBy];
+    const combinedAriaDescribedBy = describedByArray.filter(Boolean).join(" ");
 
     useImperativeHandle<TimeHandle, TimeHandle>(
       ref,
@@ -350,13 +354,18 @@ const Time = React.forwardRef<TimeHandle, TimeProps>(
           </HintText>
         )}
         <Box position="relative" mt={inputHint ? 0 : 1}>
-          <ValidationMessage
-            validationId={validationId}
-            error={error}
-            warning={warning}
-          />
-          {hasValidationFailure && (
-            <ErrorBorder warning={!!(!error && warning)} />
+          {validationMessagePositionTop && (
+            <>
+              <ValidationMessage
+                validationId={validationId}
+                error={error}
+                warning={warning}
+                validationMessagePositionTop={validationMessagePositionTop}
+              />
+              {hasValidationFailure && (
+                <ErrorBorder warning={!!(!error && warning)} />
+              )}
+            </>
           )}
           <Box display="flex">
             <div>
@@ -440,6 +449,19 @@ const Time = React.forwardRef<TimeHandle, TimeProps>(
               </Box>
             )}
           </Box>
+          {!validationMessagePositionTop && (
+            <>
+              <ValidationMessage
+                error={error}
+                validationId={validationId}
+                warning={warning}
+                validationMessagePositionTop={validationMessagePositionTop}
+              />
+              {hasValidationFailure && (
+                <ErrorBorder warning={!!(!error && warning)} />
+              )}
+            </>
+          )}
         </Box>
       </Fieldset>
     );

--- a/src/components/time/time.test.tsx
+++ b/src/components/time/time.test.tsx
@@ -1262,13 +1262,46 @@ test("should apply the correct aria-describedby attribute to fieldset when input
     <Time
       value={{ hours: "", minutes: "" }}
       onChange={() => {}}
-      inputHint="hint"
+      inputHint="Hint"
+      hoursInputProps={{ error: "Validation" }}
     />,
   );
 
   const fieldset = screen.getByRole("group");
 
-  expect(fieldset).toHaveAccessibleDescription("hint");
+  expect(fieldset).toHaveAccessibleDescription("Hrs. Hint");
+});
+
+test("should apply the correct aria-describedby attribute to fieldset when inputHint is provided and validationMessagePositionTop is false", () => {
+  render(
+    <Time
+      value={{ hours: "", minutes: "" }}
+      onChange={() => {}}
+      inputHint="Hint"
+      hoursInputProps={{ error: "Validation" }}
+      validationMessagePositionTop={false}
+    />,
+  );
+
+  const fieldset = screen.getByRole("group");
+
+  expect(fieldset).toHaveAccessibleDescription("Hint Hrs.");
+});
+
+test("should apply the correct aria-describedby attribute to fieldset when inputHint is provided with a warning and validationMessagePositionTop is false", () => {
+  render(
+    <Time
+      value={{ hours: "", minutes: "" }}
+      onChange={() => {}}
+      inputHint="Hint"
+      hoursInputProps={{ warning: "Validation" }}
+      validationMessagePositionTop={false}
+    />,
+  );
+
+  const fieldset = screen.getByRole("group");
+
+  expect(fieldset).toHaveAccessibleDescription("Hint Hrs.");
 });
 
 test("should not apply the aria-describedby attribute to fieldset when inputHint is not provided", () => {


### PR DESCRIPTION

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Adds `validationMessagePositionTop` prop to input and input group components. Prop defaults to true so that all messages are still rendered above for now unless consumers explicitly set it to below. This will only have an affect when the `validationRedesignOptIn` flag is set.

When rendered below voiceover should read `label -> input hint -> input text -> validation`, if it is above it should be like it is in master

<img width="410" alt="image" src="https://github.com/user-attachments/assets/e95fab53-864c-4643-a291-ea8e187920d9" />

<img width="214" alt="image" src="https://github.com/user-attachments/assets/8881c06e-94c7-42e7-ae7a-fb118c6a98fb" />

<img width="1118" alt="image" src="https://github.com/user-attachments/assets/942f026f-96c2-4d83-92d2-893eae982201" />

<img width="502" alt="image" src="https://github.com/user-attachments/assets/20517249-f15f-43b2-9335-4fed665f42a8" />


### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
No support for rendering the validation message below the inputs/input groups

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Unit tests added or updated if required
- [x] Storybook added or updated if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
