### PR TITLE
fix(version-picker): ensure version-picker has its own addon/tool_id for Storybook registry

### DIFF
--- a/.storybook/interaction-toggle/constants.ts
+++ b/.storybook/interaction-toggle/constants.ts
@@ -1,0 +1,2 @@
+export const INTERACTION_TOGGLE_ADDON_ID = "storybook/interaction-toggle";
+export const INTERACTION_TOGGLE_TOOL_ID = `${INTERACTION_TOGGLE_ADDON_ID}/interaction-toggle`;

--- a/.storybook/interaction-toggle/reduced-motion.tsx
+++ b/.storybook/interaction-toggle/reduced-motion.tsx
@@ -2,9 +2,8 @@ import React, { useCallback, useEffect, useState } from "react";
 
 import { IconButton } from "@storybook/components";
 import { CheckIcon, CrossIcon } from "@storybook/icons";
+import { INTERACTION_TOGGLE_TOOL_ID } from "./constants";
 
-export const ADDON_ID = "toggle-interaction";
-export const TOOL_ID = `${ADDON_ID}/tool`;
 export const STORAGE_KEY = "storybook:reducedMotion";
 
 export const allowInteractions = () => {
@@ -36,7 +35,7 @@ export const InteractionToggle = () => {
 
   return (
     <IconButton
-      key={TOOL_ID}
+      key={INTERACTION_TOGGLE_TOOL_ID}
       aria-label={`Turn interactions ${disableInteractions ? "on" : "off"}`}
       onClick={toggleInteractions}
       active={disableInteractions}

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -1,7 +1,11 @@
 import { addons, types } from "@storybook/manager-api";
 import sageTheme from "./sage-docs-theme";
-import { InteractionToggle } from "./reduced-motion";
 import { ADDON_ID, TOOL_ID } from "./version-picker/constants";
+import {
+  INTERACTION_TOGGLE_ADDON_ID,
+  INTERACTION_TOGGLE_TOOL_ID,
+} from "./interaction-toggle/constants";
+import { InteractionToggle } from "./interaction-toggle/reduced-motion";
 import { VersionPicker } from "./version-picker";
 import { API_PreparedIndexEntry, API_StatusObject } from "@storybook/types";
 
@@ -18,8 +22,8 @@ if (useVersionPicker) {
   });
 }
 
-addons.register(ADDON_ID, () => {
-  addons.add(TOOL_ID, {
+addons.register(INTERACTION_TOGGLE_ADDON_ID, () => {
+  addons.add(INTERACTION_TOGGLE_TOOL_ID, {
     type: types.TOOL,
     title: "Interaction toggle",
     match: ({ viewMode, tabId }) => viewMode === "story" && !tabId,

--- a/src/components/accordion/accordion-interaction.stories.tsx
+++ b/src/components/accordion/accordion-interaction.stories.tsx
@@ -7,7 +7,7 @@ import { Accordion, AccordionGroup } from ".";
 import Box from "../box";
 import Textbox from "../textbox";
 
-import { allowInteractions } from "../../../.storybook/reduced-motion";
+import { allowInteractions } from "../../../.storybook/interaction-toggle/reduced-motion";
 import DefaultDecorator from "../../../.storybook/utils/default-decorator";
 import userInteractionPause from "../../../.storybook/utils/user-interaction-pause";
 

--- a/src/components/action-popover/action-popover-interaction.stories.tsx
+++ b/src/components/action-popover/action-popover-interaction.stories.tsx
@@ -11,7 +11,7 @@ import {
 
 import Box from "../box";
 
-import { allowInteractions } from "../../../.storybook/reduced-motion";
+import { allowInteractions } from "../../../.storybook/interaction-toggle/reduced-motion";
 import DefaultDecorator from "../../../.storybook/utils/default-decorator";
 import userInteractionPause from "../../../.storybook/utils/user-interaction-pause";
 

--- a/src/components/adaptive-sidebar/adaptive-sidebar-interaction.stories.tsx
+++ b/src/components/adaptive-sidebar/adaptive-sidebar-interaction.stories.tsx
@@ -13,7 +13,7 @@ import Textbox from "../textbox";
 
 import Typography from "../typography";
 
-import { allowInteractions } from "../../../.storybook/reduced-motion";
+import { allowInteractions } from "../../../.storybook/interaction-toggle/reduced-motion";
 import DefaultDecorator from "../../../.storybook/utils/default-decorator";
 import userInteractionPause from "../../../.storybook/utils/user-interaction-pause";
 

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-interaction.stories.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-interaction.stories.tsx
@@ -11,7 +11,7 @@ import {
 } from ".";
 import GlobalHeader from "../../global-header";
 
-import { allowInteractions } from "../../../../.storybook/reduced-motion";
+import { allowInteractions } from "../../../../.storybook/interaction-toggle/reduced-motion";
 import DefaultDecorator from "../../../../.storybook/utils/default-decorator";
 import userInteractionPause from "../../../../.storybook/utils/user-interaction-pause";
 

--- a/src/components/vertical-menu/vertical-menu-interaction.stories.tsx
+++ b/src/components/vertical-menu/vertical-menu-interaction.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from ".";
 import Pill from "../pill";
 
-import { allowInteractions } from "../../../.storybook/reduced-motion";
+import { allowInteractions } from "../../../.storybook/interaction-toggle/reduced-motion";
 import DefaultDecorator from "../../../.storybook/utils/default-decorator";
 import userInteractionPause from "../../../.storybook/utils/user-interaction-pause";
 


### PR DESCRIPTION
### Proposed behaviour

- Set the interaction toggle addon to have it's own addon and tool_id[s]
- Move the addon functionality into a subfolder of Storybook so that it's better contained

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

Currently the interaction toggle addon is overriding the version picker addon in the Storybook manager

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Storybook added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
