### PR TITLE
fix(action-popover): submenu stays open when another submenu is clicked

### DIFF
--- a/src/components/action-popover/__internal__/action-popover.context.ts
+++ b/src/components/action-popover/__internal__/action-popover.context.ts
@@ -8,6 +8,8 @@ type ActionPopoverContextType = {
   focusButton: () => void;
   horizontalAlignment: Alignment;
   submenuPosition: Alignment;
+  selectedSubmenuRef: HTMLUListElement | null;
+  setSelectedSubmenuRef: (ref: HTMLUListElement | null) => void;
 };
 
 const ActionPopoverContext = createContext<ActionPopoverContextType | null>(

--- a/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
+++ b/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
@@ -99,8 +99,13 @@ export const ActionPopoverItem = ({
     "ActionPopoverItem only accepts submenu of type `ActionPopoverMenu`",
   );
 
-  const { setOpenPopover, focusButton, submenuPosition } =
-    useActionPopoverContext();
+  const {
+    setOpenPopover,
+    focusButton,
+    submenuPosition,
+    selectedSubmenuRef,
+    setSelectedSubmenuRef,
+  } = useActionPopoverContext();
   const isHref = !!href;
   const [containerPosition, setContainerPosition] = useState<
     ContainerPosition | undefined
@@ -131,6 +136,12 @@ export const ActionPopoverItem = ({
     submenuPosition,
     currentSubmenuPosition,
   ]);
+
+  useEffect(() => {
+    if (!disabled && submenuRef.current) {
+      setOpen(selectedSubmenuRef === submenuRef.current);
+    }
+  }, [disabled, selectedSubmenuRef]);
 
   useEffect(() => {
     const getContainerPosition = () => {
@@ -214,6 +225,7 @@ export const ActionPopoverItem = ({
           if (currentSubmenuPosition === "left") {
             // LEFT: open if has submenu and left aligned otherwise close submenu
             if (Events.isLeftKey(e) || Events.isEnterKey(e)) {
+              setSelectedSubmenuRef(submenuRef.current);
               setOpen(true);
               setFocusIndex(0);
               e.stopPropagation();
@@ -248,12 +260,21 @@ export const ActionPopoverItem = ({
         e.stopPropagation();
       }
     },
-    [disabled, download, isHref, onClick, submenu, currentSubmenuPosition],
+    [
+      disabled,
+      submenu,
+      currentSubmenuPosition,
+      setSelectedSubmenuRef,
+      isHref,
+      download,
+      onClick,
+    ],
   );
 
   const itemSubmenuProps = {
     ...(!disabled && {
       onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
+        setSelectedSubmenuRef(submenuRef.current);
         setOpen(true);
         ref.current?.focus();
         e.preventDefault();
@@ -273,6 +294,7 @@ export const ActionPopoverItem = ({
         setFocusIndex(-1);
         mouseEnterTimer.current = setTimeout(() => {
           setOpen(true);
+          setSelectedSubmenuRef(submenuRef.current);
         }, INTERVAL);
         e.stopPropagation();
       },

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -114,6 +114,9 @@ export const ActionPopover = forwardRef<
     const menu = useRef<HTMLUListElement>(null);
     const { isInFlatTable } = useContext(FlatTableContext);
 
+    const [selectedSubmenuRef, setSelectedSubmenuRef] =
+      useState<HTMLUListElement | null>(null);
+
     const hasProperChildren = useMemo(() => {
       const incorrectChild = React.Children.toArray(children).find(
         (child: React.ReactNode) => {
@@ -334,6 +337,8 @@ export const ActionPopover = forwardRef<
             focusButton,
             submenuPosition,
             horizontalAlignment,
+            selectedSubmenuRef,
+            setSelectedSubmenuRef,
           }}
         >
           {isOpen && (

--- a/src/components/action-popover/action-popover.pw.tsx
+++ b/src/components/action-popover/action-popover.pw.tsx
@@ -57,10 +57,79 @@ import {
   ActionPopoverNestedInDialog,
   LongMenuExample,
   ActionPopoverWithSomeSubmenusAndNoIcons,
+  ActionPopoverWithDifferentSubmenus,
 } from "../../../src/components/action-popover/components.test-pw";
 
 const keyToTrigger = ["Enter", " ", "End", "ArrowDown", "ArrowUp"] as const;
 const subMenuOption = ["Sub Menu 1", "Sub Menu 2", "Sub Menu 3"] as const;
+
+test("should close opened submenu by keyboard event when another submenu is opened by click event", async ({
+  mount,
+  page,
+}) => {
+  await mount(<ActionPopoverWithDifferentSubmenus />);
+
+  const openButton = page.getByRole("button");
+  await openButton.click();
+
+  const businessItem = page
+    .getByRole("listitem")
+    .filter({ hasText: "Business" });
+
+  const businessSubmenuItem = businessItem
+    .getByRole("listitem")
+    .filter({ hasText: "Business Sub Menu Item" });
+
+  await businessItem.press("Enter");
+
+  await expect(businessSubmenuItem).toBeVisible();
+
+  const emailItem = page.getByRole("listitem").filter({ hasText: "Email" });
+
+  const emailSubmenuItem = emailItem
+    .getByRole("listitem")
+    .filter({ hasText: "Email Sub Menu Item" });
+
+  await emailItem.click();
+
+  await expect(emailSubmenuItem).toBeVisible();
+
+  await expect(businessSubmenuItem).not.toBeVisible();
+});
+
+test("should close opened submenu by keyboard event when another submenu is opened by hover event", async ({
+  mount,
+  page,
+}) => {
+  await mount(<ActionPopoverWithDifferentSubmenus />);
+
+  const openButton = page.getByRole("button");
+  await openButton.click();
+
+  const businessItem = page
+    .getByRole("listitem")
+    .filter({ hasText: "Business" });
+
+  const businessSubmenuItem = businessItem
+    .getByRole("listitem")
+    .filter({ hasText: "Business Sub Menu Item" });
+
+  await businessItem.press("Enter");
+
+  await expect(businessSubmenuItem).toBeVisible();
+
+  const emailItem = page.getByRole("listitem").filter({ hasText: "Email" });
+
+  const emailSubmenuItem = emailItem
+    .getByRole("listitem")
+    .filter({ hasText: "Email Sub Menu Item" });
+
+  await emailItem.hover();
+
+  await expect(emailSubmenuItem).toBeVisible();
+
+  await expect(businessSubmenuItem).not.toBeVisible();
+});
 
 test.describe("check functionality for ActionPopover component", () => {
   test("should render component", async ({ mount, page }) => {

--- a/src/components/action-popover/components.test-pw.tsx
+++ b/src/components/action-popover/components.test-pw.tsx
@@ -323,6 +323,37 @@ export const ActionPopoverWithIconsAndNoSubmenus = ({ ...props }) => (
   </ActionPopover>
 );
 
+export const ActionPopoverWithDifferentSubmenus = ({ ...props }) => {
+  const businessSubmenu = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem onClick={() => {}}>
+        Business Sub Menu Item
+      </ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+  const emailSubmenu = (
+    <ActionPopoverMenu>
+      <ActionPopoverItem onClick={() => {}}>
+        Email Sub Menu Item
+      </ActionPopoverItem>
+    </ActionPopoverMenu>
+  );
+  return (
+    <ActionPopover {...props}>
+      <ActionPopoverItem
+        icon="graph"
+        onClick={() => {}}
+        submenu={businessSubmenu}
+      >
+        Business
+      </ActionPopoverItem>
+      <ActionPopoverItem icon="email" onClick={() => {}} submenu={emailSubmenu}>
+        Email
+      </ActionPopoverItem>
+    </ActionPopover>
+  );
+};
+
 export const ActionPopoverWithSubmenusAndIcons = ({ ...props }) => {
   const submenu = (
     <ActionPopoverMenu>


### PR DESCRIPTION
### Proposed behaviour

We are now maintaining the selected submenu in the action popover context. On state update, we compare the current value and automatically close any submenus that don't match, ensuring only one submenu remains open at a time regardless if it was opened by click event or keyboard event.

https://github.com/user-attachments/assets/8bd5a306-567f-43a9-86c1-26700281147a

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

Currently if a submenu is opened by keyboard event, and you open a new submenu by mouse event, the first submenu is not closed.

https://github.com/user-attachments/assets/90ae0580-57f4-49c6-aa60-aabec2283f20

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [X] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

1. Go to the default action popover storybook
2. Open the first action popover using the keyboard
3. Use the keyboard to navigate to the first submenu and open it
4. Hover the second submenu with the mouse
5. Click the second submenu to open it

Actual : the first submenu does not close
Expected: the first submenu should close after clicking the second submenu

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
