### PR TITLE
fix(pager): increase width to prevent text truncation

### DIFF
--- a/src/components/pager/pager.style.ts
+++ b/src/components/pager/pager.style.ts
@@ -9,7 +9,7 @@ import Link from "../link";
 
 const StyledSelectContainer = styled.div`
   height: 26px;
-  width: 55px;
+  width: 64px;
   margin-left: 8px;
   margin-right: 8px;
   ${StyledInputPresentation} {
@@ -65,7 +65,7 @@ const StyledPagerSizeOptions = styled.div`
   grid-area: 1 / 1 / 1 / 1;
 
   ${StyledInputPresentation} {
-    width: 55px;
+    width: 64px;
     height: 26px;
     min-height: 26px;
     min-width: 10px;


### PR DESCRIPTION
fixes #7421 

### Proposed behaviour

Increase the width of the `Pager` to prevent truncation

### Current behaviour

When displaying larger numbers of items, the text within `Pager` is truncated

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

- Test at default (100%) zoom in all browsers. 
- Using the `Hiding Pager Elements` storybook story, select 100 items from the page size dropdown. 
- Ensure that no truncation occurs.