### PR TITLE
fix(button, button-minor): fixes a scrolling bug in Chrome when clicking buttons

### DIFF
--- a/src/components/button/button-test.stories.tsx
+++ b/src/components/button/button-test.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import { action } from "@storybook/addon-actions";
 import { Meta, StoryObj } from "@storybook/react";
 import { userEvent, waitFor, within, expect } from "@storybook/test";
@@ -12,6 +12,9 @@ import {
   BUTTON_VARIANTS,
 } from "./button.config";
 import { ButtonIconPosition, ButtonTypes } from "./button.component";
+import { Tile, TileContent } from "../tile";
+import Hr from "../hr";
+import Typography from "../typography";
 
 export default {
   title: "Button/Test",
@@ -1272,3 +1275,113 @@ ButtonHover.parameters = {
     hover: true,
   },
 };
+
+const Tiles = () => {
+  const defaultButtonRef = useRef<HTMLButtonElement>(null);
+  const handleClick = () => {
+    defaultButtonRef.current?.focus();
+  };
+
+  return (
+    <Tile orientation="vertical" p={0} width="288px">
+      <TileContent>
+        <Box display="flex" flexDirection="column" height="100%">
+          <Box
+            display="flex"
+            flexDirection="column"
+            flexGrow={1}
+            gap={2}
+            justifyContent="space-between"
+            p={2}
+          >
+            <button
+              className="htmlButton"
+              type="button"
+              ref={defaultButtonRef}
+              onClick={handleClick}
+            >
+              Default button
+            </button>
+            <Button onClick={() => {}} fullWidth>
+              Carbon Button
+            </Button>
+          </Box>
+        </Box>
+      </TileContent>
+    </Tile>
+  );
+};
+
+const Groups = () => {
+  return (
+    <Box display="flex" flexDirection="column" maxWidth="900px">
+      <Box>
+        <Hr my={3} />
+      </Box>
+      <Typography variant="h3">Some Title</Typography>
+      <Typography variant="p">Some Description</Typography>
+      <Box gap={2} my={2}>
+        <Box display="flex" flexDirection="row" flexWrap="wrap" gap={2} my={2}>
+          <Tiles />
+          <Tiles />
+          <Tiles />
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+export const ButtonFocusNoScroll: Story = {
+  render: () => (
+    <>
+      <p>
+        This story can be used to check that the focus indicator styling doesn't
+        cause the page to scroll when a button is clicked. It can also be used
+        to check that FE-7404 has not regressed.
+      </p>
+      <div style={{ display: "flex" }}>
+        <div
+          style={{
+            display: "flex",
+            height: "calc(100vh - 40px)",
+          }}
+        >
+          <div style={{ overflowY: "auto" }}>
+            <Box ml={7} mr={5} mb={2}>
+              <Box display="flex" alignItems="flex-start">
+                <Box
+                  flexDirection="column"
+                  display="flex"
+                  alignItems="flex-start"
+                  flexGrow={1}
+                  flexWrap="wrap"
+                  mr={5}
+                >
+                  <Box {...{ width: "100%" }} mb={4}>
+                    <Groups />
+                    <Groups />
+                    <Groups />
+                    <Groups />
+                    <Groups />
+                    <Groups />
+                    <Box>
+                      <Hr my={3} />
+                    </Box>
+                  </Box>
+                </Box>
+              </Box>
+            </Box>
+          </div>
+        </div>
+      </div>
+    </>
+  ),
+  decorators: [
+    (StoryToRender) => (
+      <div style={{ height: "100vh", width: "100vw" }}>
+        <StoryToRender />
+      </div>
+    ),
+  ],
+};
+ButtonFocusNoScroll.storyName = "Button Focuses Without Scrolling";

--- a/src/style/utils/add-focus-styling.ts
+++ b/src/style/utils/add-focus-styling.ts
@@ -8,7 +8,6 @@ export default (inset = false) => {
   }
 
   return `
-    -webkit-appearance: none;
     -webkit-box-shadow: ${focusStyling};
     box-shadow: ${focusStyling};
 


### PR DESCRIPTION
Clicking buttons adds the focus border, which causes Chrome to recalculate element positions and scroll the window. This does not occur in other browsers. This has been fixed by removing the use of "webkit-appreance" in the focus styling.

fix #7412

### Proposed behaviour

Investigations showed that the cause of this was the `webkit-appearance` property in the focus styling CSS definition. Removing this aligns Chrome with the other browsers.

### Current behaviour

When clicking buttons, the page jumps/scrolls, mostly to where you would expect it to if you were using tab keyboard and selected the element in that fashion. This only occurs in Chrome; all other browsers are unaffected.

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

A Storybook test story has been added to cover this: `Button Focuses Without Scrolling`. To replicate the issue:
- Open said story; 
- Scroll the page until a Carbon button is on-screen that was initially off-screen (e.g. one of the final buttons);
- Click the button and ensure that the button remains on screen and in focus.
