### PR TITLE
chore(eslint): remove legacy config rule for vscode extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,9 +11,6 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-  "eslint.options": {
-    "extensions": [".js", ".jsx", ".md", ".mdx", ".ts", ".tsx"]
-  },
   "eslint.validate": [
     "markdown",
     "mdx",


### PR DESCRIPTION
### Proposed behaviour

- Remove legacy config rule in the repo settings for the ESLint VSCode extension

### Current behaviour

- A legacy config rule, which appears to be removed in ESLint v9, is causing the ESLint VSCode extension to fail each time it runs over files:
  ```
  [Error - 10:17:49] An unexpected error occurred:
  [Error - 10:17:49] Error: Invalid Options:
  - Unknown options: extensions
  - 'extensions' has been removed.
  ```

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
