### PR TITLE
fix(switch): ensure inline hint text takes full width of label container

### DIFF
--- a/src/components/switch/switch-test.stories.tsx
+++ b/src/components/switch/switch-test.stories.tsx
@@ -1,11 +1,14 @@
 import React, { useState, useEffect } from "react";
+import { Meta, StoryObj } from "@storybook/react";
+
 import I18nProvider from "../i18n-provider/i18n-provider.component";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 import Switch, { SwitchProps } from "./switch.component";
 import Box from "../box/box.component";
 
-export default {
+const meta: Meta<typeof Switch> = {
   title: "Switch/Test",
+  component: Switch,
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -13,47 +16,31 @@ export default {
     },
   },
   argTypes: {
-    inputWidth: {
-      control: {
-        type: "range",
-        min: 0,
-        max: 100,
-        step: 1,
-      },
+    label: {
+      control: { type: "text" },
     },
-    labelWidth: {
-      control: {
-        type: "range",
-        min: 0,
-        max: 100,
-        step: 1,
-      },
+    labelHelp: {
+      control: { type: "text" },
     },
-    labelSpacing: {
-      options: [1, 2],
-      control: {
-        type: "select",
-      },
-    },
-    size: {
-      options: ["small", "large"],
-      control: {
-        type: "select",
-      },
+    fieldHelp: {
+      control: { type: "text" },
     },
     error: {
-      control: {
-        type: "text",
-      },
+      control: { type: "text" },
+    },
+    warning: {
+      control: { type: "text" },
+    },
+    info: {
+      control: { type: "text" },
     },
   },
 };
 
-export const Default = ({
-  fieldHelp,
-  label,
-  ...args
-}: Partial<SwitchProps>) => {
+export default meta;
+type Story = StoryObj<typeof Switch>;
+
+export const Default: Story = ({ ...args }: Partial<SwitchProps>) => {
   const [isChecked, setIsChecked] = useState(false);
   const handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
     const { checked } = ev.target;
@@ -64,8 +51,6 @@ export const Default = ({
       onChange={handleChange}
       name="switch-default"
       checked={isChecked}
-      fieldHelp={fieldHelp}
-      label={label}
       {...args}
     />
   );
@@ -74,24 +59,12 @@ export const Default = ({
 Default.storyName = "Default";
 Default.args = {
   fieldHelp: "This text provides help for the input.",
-  fieldHelpInline: false,
   label: "Switch on this component?",
   labelHelp: "Switch off and on this component.",
   helpAriaLabel: "Switch off and on this component.",
-  labelInline: false,
-  loading: false,
-  inputWidth: 0,
-  labelWidth: 0,
-  labelSpacing: 1,
-  reverse: true,
-  value: "test-value",
-  disabled: false,
-  size: "small",
-  required: false,
-  isOptional: false,
 };
 
-export const Validation = ({ ...args }: Partial<SwitchProps>) => {
+export const Validation: Story = ({ ...args }: Partial<SwitchProps>) => {
   return (
     <>
       <Switch error="Error Message" mb={2} {...args} />
@@ -111,24 +84,13 @@ export const Validation = ({ ...args }: Partial<SwitchProps>) => {
 Validation.storyName = "Validation";
 Validation.args = {
   label: "Label",
-  labelHelp: "",
-  loading: false,
-  inputWidth: 0,
-  labelWidth: 0,
-  labelSpacing: 1,
-  reverse: true,
-  value: "test-value",
-  disabled: false,
-  size: "small",
-  required: false,
-  isOptional: false,
 };
 Validation.parameters = {
-  chromatic: { disableSnapshot: true },
+  chromatic: { disableSnapshot: false },
   themeProvider: { chromatic: { theme: "sage" } },
 };
 
-export const NewValidation = ({ ...args }: Partial<SwitchProps>) => {
+export const NewValidation: Story = ({ ...args }: Partial<SwitchProps>) => {
   return (
     <CarbonProvider validationRedesignOptIn>
       <Switch error="Error Message (Fix is required)" mb={2} {...args} />
@@ -153,90 +115,72 @@ NewValidation.storyName = "New Validation";
 NewValidation.args = {
   label: "Label",
   labelHelp: "Hint text",
-  loading: false,
-  inputWidth: 0,
-  labelWidth: 0,
-  labelSpacing: 1,
-  reverse: true,
-  value: "test-value",
-  disabled: false,
-  size: "small",
-  required: false,
-  isOptional: false,
 };
 NewValidation.parameters = {
-  chromatic: { disableSnapshot: true },
+  chromatic: { disableSnapshot: false },
   themeProvider: { chromatic: { theme: "sage" } },
 };
 
-export const NewValidationInline = ({ ...args }: Partial<SwitchProps>) => {
+export const NewValidationInline: Story = ({
+  ...args
+}: Partial<SwitchProps>) => {
   return (
     <CarbonProvider validationRedesignOptIn>
-      <Switch labelInline mb={2} {...args} />
-      <Switch labelInline labelHelp="Hint text" mb={2} {...args} />
-      <Switch
-        labelInline
-        labelHelp="Hint text"
-        fieldHelp="fieldHelp"
-        {...args}
-      />
-      <Switch
-        label="Example switch"
-        labelInline
-        labelHelp="Really long hint text that should wrap to the next line if it gets too long"
-        fieldHelp="Field help"
-        mt={2}
-      />
-
-      <Switch
-        labelHelp="Hint text"
-        error="Error Message (Fix is required)"
-        labelInline
-        my={2}
-        {...args}
-      />
-      <Switch
-        warning="Warning Message (Fix is optional)"
-        labelInline
-        fieldHelp="fieldHelp"
-        mb={2}
-        {...args}
-      />
-      <Switch
-        labelHelp="Hint text"
-        error="Error Message (Fix is required)"
-        labelInline
-        validationMessagePositionTop={false}
-        my={2}
-        {...args}
-      />
-      <Switch
-        warning="Warning Message (Fix is optional)"
-        labelInline
-        fieldHelp="fieldHelp"
-        validationMessagePositionTop={false}
-        mb={2}
-        {...args}
-      />
+      <Box maxWidth="400px" backgroundColor="#f5f5f5" p={2}>
+        <Switch {...args} />
+        <Switch labelHelp="Hint text" mt={2} {...args} />
+        <Switch labelHelp="Hint text" fieldHelp="fieldHelp" mt={2} {...args} />
+        <Switch
+          labelHelp="Really long hint text that should wrap to the next line if it gets too long because labelWidth is set to 50%"
+          fieldHelp="fieldHelp"
+          labelWidth={50}
+          mt={2}
+          {...args}
+        />
+        <Switch
+          labelHelp="Hint text"
+          error="Error Message (Fix is required)"
+          mt={2}
+          {...args}
+        />
+        <Switch
+          warning="Warning Message (Fix is optional)"
+          fieldHelp="fieldHelp"
+          my={2}
+          {...args}
+        />
+        <Switch
+          labelHelp="Hint text"
+          error="Error Message (Fix is required)"
+          validationMessagePositionTop={false}
+          mt={2}
+          {...args}
+        />
+        <Switch
+          warning="Warning Message (Fix is optional)"
+          fieldHelp="fieldHelp"
+          validationMessagePositionTop={false}
+          my={2}
+          {...args}
+        />
+        <Switch
+          reverse={false}
+          labelHelp="Hint text"
+          error="Error Message (Fix is required)"
+          mt={2}
+          {...args}
+        />
+      </Box>
     </CarbonProvider>
   );
 };
 NewValidationInline.storyName = "New Validation Inline";
 NewValidationInline.args = {
   label: "Label",
-  loading: false,
-  inputWidth: 0,
-  labelWidth: 0,
-  labelSpacing: 1,
-  reverse: true,
-  value: "test-value",
-  disabled: false,
-  size: "small",
-  required: false,
-  isOptional: false,
+  labelInline: true,
 };
 NewValidationInline.parameters = {
-  chromatic: { disableSnapshot: true },
+  chromatic: { disableSnapshot: false },
   themeProvider: { chromatic: { theme: "sage" } },
 };
 
@@ -397,11 +341,6 @@ export const WithLoading = () => {
   );
 };
 WithLoading.storyName = "With Loading";
-WithLoading.parameters = {
-  chromatic: {
-    disableSnapshot: true,
-  },
-};
 
 export const LabelHelpAndFieldHelp = () => {
   return (

--- a/src/components/switch/switch.component.tsx
+++ b/src/components/switch/switch.component.tsx
@@ -26,7 +26,7 @@ export interface SwitchProps
   adaptiveLabelBreakpoint?: number;
   /** Set the default value of the Switch if component is meant to be used as uncontrolled */
   defaultChecked?: boolean;
-  /** [Legacy] When true label is inline */
+  /** When true label is inline */
   labelInline?: boolean;
   /** Triggers loading animation */
   loading?: boolean;
@@ -42,6 +42,8 @@ export interface SwitchProps
   isDarkBackground?: boolean;
   /** Render the ValidationMessage above the Switch input when validationRedesignOptIn flag is set */
   validationMessagePositionTop?: boolean;
+  /** Label width, as a percentage, when labelInline is true */
+  labelWidth?: number;
 }
 
 let deprecateUncontrolledWarnTriggered = false;
@@ -67,8 +69,9 @@ export const Switch = React.forwardRef(
       labelInline = false,
       labelSpacing,
       labelHelp,
+      labelWidth,
       fieldHelpInline,
-      size,
+      size = "small",
       name,
       adaptiveLabelBreakpoint,
       tooltipPosition,
@@ -164,6 +167,7 @@ export const Switch = React.forwardRef(
       checked: isControlled ? checked : checkedInternal,
       label,
       labelHelp,
+      labelWidth,
       fieldHelpInline,
       labelInline: shouldLabelBeInline,
       labelSpacing,
@@ -195,6 +199,8 @@ export const Switch = React.forwardRef(
       labelInline: shouldLabelBeInline,
       isDarkBackground,
       size,
+      reverse: !reverse,
+      validationRedesignOptIn,
       ...marginProps,
     };
 
@@ -271,12 +277,15 @@ export const Switch = React.forwardRef(
           <Box
             data-role="field-reverse-wrapper"
             display="flex"
-            flexWrap="wrap"
             alignItems={error || warning ? "flex-start" : undefined}
             flexDirection={!reverse ? reverseDirection : direction}
             width={labelInline ? "100%" : "auto"}
           >
-            <Box data-role="label-wrapper" alignSelf={labelWrapperAlignSelf}>
+            <Box
+              data-role="label-wrapper"
+              alignSelf={labelWrapperAlignSelf}
+              {...(labelWidth && { width: `${labelWidth}%` })}
+            >
               <Label
                 isDarkBackground={isDarkBackground}
                 labelId={labelId.current}
@@ -288,19 +297,13 @@ export const Switch = React.forwardRef(
               </Label>
 
               {labelHelp && (
-                <Box
-                  data-role="hint-text-wrapper"
-                  mb={labelInline ? 0 : 1}
-                  mr={reverse ? 0 : 1}
-                  ml={reverse ? 0 : 1}
-                >
+                <Box data-role="hint-text-wrapper" mb={labelInline ? 0 : 1}>
                   <HintText
                     data-role="hint-text"
                     fontWeight="400"
                     id={inputHintId.current}
                     isDarkBackground={isDarkBackground}
                     marginTop="8px"
-                    maxWidth="160px"
                   >
                     {labelHelp}
                   </HintText>

--- a/src/components/switch/switch.style.ts
+++ b/src/components/switch/switch.style.ts
@@ -22,6 +22,7 @@ interface StyledSwitchProps
     "fieldHelpInline" | "labelInline" | "reverse" | "size"
   > {
   theme: ThemeObject;
+  validationRedesignOptIn?: boolean;
 }
 
 export const ErrorBorder = styled.span`
@@ -53,11 +54,16 @@ export const ErrorBorder = styled.span`
 `;
 
 const StyledSwitch = styled.div.attrs(applyBaseTheme)`
-  ${({ fieldHelpInline, labelInline, reverse, size }: StyledSwitchProps) => css`
+  ${({
+    fieldHelpInline,
+    labelInline,
+    reverse,
+    size,
+    validationRedesignOptIn,
+  }: StyledSwitchProps) => css`
     margin-bottom: var(--fieldSpacing);
     ${margin}
     ${FieldLineStyle} {
-      display: flex;
       flex-flow: ${labelInline ? "row wrap" : "column wrap"};
 
       ${!labelInline &&
@@ -141,7 +147,11 @@ const StyledSwitch = styled.div.attrs(applyBaseTheme)`
       }
 
       ${FieldLineStyle} {
-        display: flex;
+        ${reverse &&
+        validationRedesignOptIn &&
+        css`
+          justify-content: flex-end;
+        `}
       }
 
       ${StyledLabelContainer} {

--- a/src/components/switch/switch.test.tsx
+++ b/src/components/switch/switch.test.tsx
@@ -690,6 +690,17 @@ test("when `labelInline` is true and `reverse` is true no margin right is applie
   expect(inputWrapper).toHaveStyleRule("margin-right: var(--spacing000)");
 });
 
+test("when `labelInline` is true, the provided `labelWidth` is applied to the label-wrapper", () => {
+  render(
+    <CarbonProvider validationRedesignOptIn>
+      <Switch label="label" labelInline labelWidth={50} />
+    </CarbonProvider>,
+  );
+
+  const labelWrapper = screen.getByTestId("label-wrapper");
+  expect(labelWrapper).toHaveStyle("width: 50%");
+});
+
 test("when component is uncontrolled and loading, it doesn't change internal state and the provided onChange is not called", async () => {
   const user = userEvent.setup({ delay: null });
   const onChangeMock = jest.fn();


### PR DESCRIPTION
fix #7411

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

`labelHelp` (hint text) has no width restrictions
<img width="395" height="116" alt="image" src="https://github.com/user-attachments/assets/dfceb71a-3178-4e73-85a8-90f349d061e0" />

`labelWidth` can be used to set label and hint text width when `labelInline` is true:
<img width="297" height="124" alt="image" src="https://github.com/user-attachments/assets/1afb0344-76da-4490-acb4-cfc50bf0c367" />

When `reverse` is false, input is aligned to the right and label and hint text are aligned
<img width="293" height="68" alt="image" src="https://github.com/user-attachments/assets/2adf5df0-b6b8-4d80-85c3-236284bc3a80" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

`labelHelp` (hint text) has max-width of "160px" that cannot be changed
<img width="319" height="134" alt="image" src="https://github.com/user-attachments/assets/68e6bc85-77ec-4686-9e99-f290ea857b7f" />
<img width="530" height="70" alt="image" src="https://github.com/user-attachments/assets/ddcc36df-e1ed-46d4-8d81-da32c28f0535" />

When `reverse` is false, input does not align to the right and label and hint text are not aligned
<img width="302" height="68" alt="image" src="https://github.com/user-attachments/assets/2ab921fc-f6df-4e87-a9db-53d7ce3baae2" />
 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Controls have been added to `Validation` and `New Validation` test stories, container with limited width has been added to `New Validation Inline` to demonstrate text wrapping. Snapshots for these stories have been enabled.

- Check no width restrictions are set on label or hintText when label is not inline.
- When label is inline, no width should be applied by default.
- `labelWidth` prop should apply to both label and hintText, meaning both should wrap if they overflow
- `reverse` set to false should align switch to the right and hintText and label should align vertically
