### PR TITLE
chore: add exports property to package.json to support npm link from root of project

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,5 +259,14 @@
       ],
       "@semantic-release/github"
     ]
+  },
+  "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./lib/index.js",
+      "types": "./lib/index.d.ts"
+    },
+    "./lib/style/*": "./lib/style/*",
+    "./esm/style/*": "./esm/style/*"
   }
 }


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
adds `exports` to `package.json` file to allow `npm link` to work from root of carbon

`types` just points to lib ones for now, it's the same file as in `esm`, future work will move this to a shared location to remove duplication

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
currently npm link only works when called within the `esm` directory as `lib` has it's own `package.json` to support the module aliasing is consumers use `import`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
- add a `foo` prop to `ButtonProps` or some other interface in Carbon
- create a project in stackblitz and export it so you can run locally
- `npm install` to install node_modules to the consuming project
- in carbon repo root create the symlink -> `npm link`
- in the consuming project, point the carbon dep at the symlink -> `npm link carbon-react`
- import the component you updated and confirm you can pas `foo` prop
- do your happy dance when it works
