### PR TITLE
chore: move types to top of exports in package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -262,9 +262,9 @@
   },
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./esm/index.js",
-      "require": "./lib/index.js",
-      "types": "./lib/index.d.ts"
+      "require": "./lib/index.js"
     },
     "./lib/style/*": "./lib/style/*",
     "./esm/style/*": "./esm/style/*"


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Moves `types` above `import` and `require` as it is checked first when resolving the `exports` property of a package.json

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Warning in console when running local storybook as `types` is defined after `require` and `import` so will never be checked

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide


#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
