### PR TITLE
docs(date): adjust date interaction stories to prevent failings

### DIFF
--- a/src/components/date/date-interaction.stories.tsx
+++ b/src/components/date/date-interaction.stories.tsx
@@ -74,7 +74,7 @@ export const DateTyping: Story = {
     const canvas = within(canvasElement);
     const input = canvas.getByRole("textbox");
     await userEvent.click(input);
-    await userEvent.keyboard("05/12/2025");
+    await userEvent.keyboard("05/12/2024");
     const calendarIcon = canvas.getByTestId("icon");
     await userEvent.click(calendarIcon);
   },
@@ -93,10 +93,10 @@ export const MinMaxDate: Story = {
     <DateInput
       label="Date"
       name="date-input"
-      value="17/07/2025"
+      value="17/07/2024"
       onChange={() => {}}
-      minDate="2025-07-14"
-      maxDate="2025-07-20"
+      minDate="2024-07-14"
+      maxDate="2024-07-20"
     />
   ),
   play: async ({ canvasElement }) => {
@@ -124,17 +124,17 @@ export const DisabledDate: Story = {
       <DateInput
         label="Date"
         name="date-input"
-        value="10/07/2025"
+        value="10/07/2024"
         onChange={() => {}}
         pickerProps={{
           disabled: [
             isWeekend,
             {
-              from: new Date(2025, 6, 15),
-              to: new Date(2025, 6, 18),
+              from: new Date(2024, 6, 15),
+              to: new Date(2024, 6, 18),
             },
-            { before: new Date(2025, 6, 3) },
-            { after: new Date(2025, 6, 29) },
+            { before: new Date(2024, 6, 3) },
+            { after: new Date(2024, 6, 29) },
           ],
         }}
       />
@@ -175,7 +175,7 @@ export const WeekStartDay: Story = {
       >
         <DateInput
           label="`en-US` locale - First week day: Sunday"
-          value="17/07/2025"
+          value="17/07/2024"
           onChange={() => {}}
           data-role="enUsDate"
         />
@@ -194,7 +194,7 @@ export const WeekStartDay: Story = {
       >
         <DateInput
           label="`de-DE` locale - first week day: Monday"
-          value="17/07/2025"
+          value="17/07/2024"
           onChange={() => {}}
           data-role="deDate"
         />


### PR DESCRIPTION
The date input is relative, so it can change visually if e.g. today is in the current month, which impacts the snapshots

### Proposed behaviour

Set all date interaction values to use a date in the past to ensure nothing visually changes

### Current behaviour

Chromatic snapshots change if the current date is highlighted within the active month shown in the calendar.

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required
