### PR TITLE
Remove uncontrolled input support

### DIFF
--- a/.storybook/welcome-page/components-demo/demo/demo.component.jsx
+++ b/.storybook/welcome-page/components-demo/demo/demo.component.jsx
@@ -18,6 +18,7 @@ import {
 } from "./demo.style";
 
 const Demo = () => {
+  const [decimalValue, setDecimalValue] = useState("0.01");
   const [numberValue, setNumberValue] = useState("0");
   const [dateValue, setDateValue] = useState(["01/01/2020", "14/02/2020"]);
   const handleDateChange = ({ target }) => {
@@ -78,7 +79,11 @@ const Demo = () => {
                 />
               </StyledComponentWrapper>
               <StyledComponentWrapper styling={{ width: "30%", padding: "1%" }}>
-                <Decimal aria-label="An example decimal input component" />
+                <Decimal
+                  aria-label="An example decimal input component"
+                  value={decimalValue}
+                  onChange={(e) => setDecimalValue(e.target.value.rawValue)}
+                />
               </StyledComponentWrapper>
             </StyledDemoRow>
             <StyledDemoRow styling={{ display: "flex" }}>

--- a/src/__internal__/input/input.component.tsx
+++ b/src/__internal__/input/input.component.tsx
@@ -14,7 +14,7 @@ export type EnterKeyHintTypes =
   | "send";
 
 export interface CommonInputProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> {
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type" | "value"> {
   /* The default value alignment on the input */
   align?: "right" | "left";
   /**
@@ -54,6 +54,8 @@ export interface CommonInputProps
   required?: boolean;
   /** Id of the validation icon */
   validationIconId?: string;
+  /** The value of the input */
+  value: string | readonly string[] | number | undefined;
 }
 
 export interface InputProps extends CommonInputProps {

--- a/src/components/decimal/components.test-pw.tsx
+++ b/src/components/decimal/components.test-pw.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 
 import Decimal, { DecimalProps, CustomEvent } from ".";
+import Box from "../box/box.component";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 
 export const DefaultStory = (
@@ -128,7 +129,8 @@ export const Validations = (
           />
           <Decimal
             label="Decimal - readOnly"
-            value="0.01"
+            value={state[validationType]}
+            onChange={handleChange(validationType)}
             readOnly
             {...{ [validationType]: args.message }}
             mb={2}
@@ -162,7 +164,7 @@ export const ValidationsRedesign = () => {
     <CarbonProvider validationRedesignOptIn>
       {(["error", "warning"] as const).map((validationType) =>
         (["small", "medium", "large"] as const).map((size) => (
-          <div style={{ width: "296px" }} key={`${size}-${validationType}`}>
+          <Box width="296px" key={`${size}-${validationType}`}>
             <Decimal
               label={`${size} - ${validationType}`}
               value={state[validationType]}
@@ -173,13 +175,14 @@ export const ValidationsRedesign = () => {
             />
             <Decimal
               label={`readOnly - ${size} - ${validationType}`}
-              value="0.01"
+              value={state[validationType]}
+              onChange={handleChange(validationType)}
               size={size}
               readOnly
               {...{ [validationType]: "Message" }}
               m={4}
             />
-          </div>
+          </Box>
         )),
       )}
     </CarbonProvider>

--- a/src/components/decimal/decimal-test.stories.tsx
+++ b/src/components/decimal/decimal-test.stories.tsx
@@ -66,26 +66,6 @@ export const DecimalStory = (args: CommonTextboxArgs) => {
 DecimalStory.storyName = "Default";
 DecimalStory.args = commonArgs;
 
-export const UncontrolledDecimalStory = (args: CommonTextboxArgs) => {
-  const handleChange = (ev: CustomEvent) => {
-    action("onChange")(ev.target.value);
-  };
-
-  const handleBlur = (event: CustomEvent) => {
-    action("onBlur")(event.target.value);
-  };
-  return (
-    <Decimal
-      defaultValue="0.03"
-      onChange={handleChange}
-      onBlur={handleBlur}
-      {...getCommonTextboxArgsWithSpecialCharacters(args)}
-    />
-  );
-};
-UncontrolledDecimalStory.storyName = "Uncontrolled Default";
-UncontrolledDecimalStory.args = commonArgs;
-
 type Locale = {
   options: string[];
   control: { type: string };

--- a/src/components/decimal/decimal.component.tsx
+++ b/src/components/decimal/decimal.component.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-  useContext,
-} from "react";
+import React, { useState, useEffect, useCallback, useContext } from "react";
 import invariant from "invariant";
 
 import Textbox, { CommonTextboxProps } from "../textbox";
@@ -30,14 +24,12 @@ export interface DecimalProps
   align?: "left" | "right";
   /** Allow an empty value instead of defaulting to 0.00 */
   allowEmptyValue?: boolean;
-  /** The default value of the input if it's meant to be used as an uncontrolled component */
-  defaultValue?: string;
   /** The input id */
   id?: string;
   /** The width of the input as a percentage */
   inputWidth?: number;
-  /** Handler for change event if input is meant to be used as a controlled component */
-  onChange?: (ev: CustomEvent) => void;
+  /** Handler for change event */
+  onChange: (ev: CustomEvent) => void;
   /** Handler for blur event */
   onBlur?: (ev: CustomEvent) => void;
   /** The input name */
@@ -62,19 +54,16 @@ export interface DecimalProps
     | 15;
   /** If true, the component will be read-only */
   readOnly?: boolean;
-  /** The value of the input if it's used as a controlled component */
-  value?: string;
+  /** The value of the input */
+  value: string;
   /** The locale string - default en */
   locale?: string;
 }
-
-let deprecateUncontrolledWarnTriggered = false;
 
 export const Decimal = React.forwardRef(
   (
     {
       align = "right",
-      defaultValue,
       precision = 2,
       inputWidth,
       readOnly,
@@ -173,6 +162,8 @@ export const Decimal = React.forwardRef(
     const prevPrecisionValue = usePrevious(precision);
 
     useEffect(() => {
+      // Skipped coverage test - see notes in test file
+      /* istanbul ignore if */
       if (prevPrecisionValue && prevPrecisionValue !== precision) {
         Logger.error(
           "Decimal `precision` prop has changed value. Changing the Decimal `precision` prop has no effect.",
@@ -230,7 +221,7 @@ export const Decimal = React.forwardRef(
       [getSeparator, removeDelimiters],
     );
 
-    const decimalValue = getSafeValueProp(defaultValue || value || emptyValue);
+    const decimalValue = getSafeValueProp(value || emptyValue);
     const [stateValue, setStateValue] = useState(
       isNaN(toStandardDecimal(decimalValue))
         ? decimalValue
@@ -253,6 +244,7 @@ export const Decimal = React.forwardRef(
     const handleOnChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
       const { value: val } = ev.target;
       setStateValue(val);
+      /* istanbul ignore else */
       if (onChange) onChange(createEvent(val));
     };
 
@@ -277,35 +269,18 @@ export const Decimal = React.forwardRef(
     };
 
     const isControlled = value !== undefined;
-    const prevControlledRef = useRef<boolean | null>();
-
-    useEffect(() => {
-      const message =
-        "Input elements should not switch from uncontrolled to controlled (or vice versa). " +
-        "Decide between using a controlled or uncontrolled input element for the lifetime of the component";
-
-      invariant(prevControlledRef.current !== isControlled, message);
-
-      prevControlledRef.current = isControlled;
-
-      return () => {
-        prevControlledRef.current = null;
-      };
-    }, [isControlled]);
 
     const prevValue = usePrevious(value);
 
     useEffect(() => {
       const standardDecimalValue = toStandardDecimal(stateValue);
 
-      if (isControlled) {
-        const valueProp = getSafeValueProp(value);
-        if (standardDecimalValue !== valueProp) {
-          if (valueProp === "" && prevValue === "") {
-            setStateValue(formatValue(emptyValue));
-          } else {
-            setStateValue(formatValue(valueProp));
-          }
+      const valueProp = getSafeValueProp(value);
+      if (standardDecimalValue !== valueProp) {
+        if (valueProp === "" && prevValue === "") {
+          setStateValue(formatValue(emptyValue));
+        } else {
+          setStateValue(formatValue(valueProp));
         }
       }
     }, [
@@ -318,13 +293,6 @@ export const Decimal = React.forwardRef(
       toStandardDecimal,
       value,
     ]);
-
-    if (!deprecateUncontrolledWarnTriggered && !isControlled) {
-      deprecateUncontrolledWarnTriggered = true;
-      Logger.deprecate(
-        "Uncontrolled behaviour in `Decimal` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-      );
-    }
 
     return (
       <>

--- a/src/components/decimal/decimal.pw.tsx
+++ b/src/components/decimal/decimal.pw.tsx
@@ -104,7 +104,7 @@ test.describe("check props for Decimal component", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal precision={precision} />);
+      await mount(<DefaultStory precision={precision} />);
 
       const commonDataElementInputPreviewElement =
         commonDataElementInputPreview(page);
@@ -139,7 +139,7 @@ test.describe("check props for Decimal component", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal locale={locale} precision={3} />);
+      await mount(<DefaultStory locale={locale} precision={3} />);
 
       const commonDataElementInputPreviewElement =
         commonDataElementInputPreview(page);
@@ -157,7 +157,7 @@ test.describe("check props for Decimal component", () => {
   });
 
   test("should render Decimal with readOnly prop", async ({ mount, page }) => {
-    await mount(<Decimal readOnly />);
+    await mount(<DefaultStory readOnly />);
 
     const inputValue = "test";
     const commonDataElementInputPreviewElement =
@@ -176,7 +176,7 @@ test.describe("check props for Decimal component", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal maxWidth={maxWidth} />);
+      await mount(<DefaultStory maxWidth={maxWidth} />);
 
       const textboxParent = await textbox(page).evaluateHandle(
         (element: Element) => {
@@ -195,7 +195,7 @@ test.describe("check props for Decimal component", () => {
     mount,
     page,
   }) => {
-    await mount(<Decimal maxWidth="" />);
+    await mount(<DefaultStory maxWidth="" />);
 
     const textboxParent = await textbox(page).evaluateHandle(
       (element: Element) => {
@@ -217,7 +217,7 @@ test.describe("check Decimal input", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal fieldHelp={specificValue} />);
+      await mount(<DefaultStory fieldHelp={specificValue} />);
 
       const fieldHelpPreviewElement = fieldHelpPreview(page);
       await expect(fieldHelpPreviewElement).toHaveText(specificValue);
@@ -229,7 +229,7 @@ test.describe("check Decimal input", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal label={specificValue} />);
+      await mount(<DefaultStory label={specificValue} />);
 
       const getDataElementByValueElementLabel = getDataElementByValue(
         page,
@@ -244,7 +244,7 @@ test.describe("check Decimal input", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal label="Label" labelHelp={specificValue} />);
+      await mount(<DefaultStory label="Label" labelHelp={specificValue} />);
 
       const getDataElementByValueElementQuestion = getDataElementByValue(
         page,
@@ -261,7 +261,7 @@ test.describe("check Decimal input", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal prefix={prefix} />);
+      await mount(<DefaultStory prefix={prefix} />);
 
       const textboxPrefixElement = textboxPrefix(page);
       await expect(textboxPrefixElement).toHaveText(prefix);
@@ -275,7 +275,7 @@ test.describe("check Decimal input", () => {
     mount,
     page,
   }) => {
-    await mount(<Decimal prefix="foo" />);
+    await mount(<DefaultStory prefix="foo" />);
 
     const textboxInput = textbox(page);
     await expect(textboxInput).toHaveCSS("flex-direction", "row");
@@ -286,7 +286,7 @@ test.describe("check Decimal input", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal />);
+      await mount(<DefaultStory />);
 
       const commonDataElementInputPreviewElement =
         commonDataElementInputPreview(page);
@@ -307,7 +307,7 @@ test.describe("check Decimal input", () => {
     mount,
     page,
   }) => {
-    await mount(<Decimal />);
+    await mount(<DefaultStory />);
 
     const commonDataElementInputPreviewElement =
       commonDataElementInputPreview(page);
@@ -342,7 +342,7 @@ test.describe("allowEmptyValue", () => {
       page,
     }) => {
       await mount(
-        <Decimal
+        <DefaultStory
           precision={precisionValue}
           locale={localeValue}
           allowEmptyValue={false}
@@ -382,7 +382,7 @@ test.describe("allowEmptyValue", () => {
       page,
     }) => {
       await mount(
-        <Decimal
+        <DefaultStory
           precision={precisionValue}
           locale={localeValue}
           allowEmptyValue
@@ -415,17 +415,15 @@ test.describe("check events for Decimal component", () => {
       mount,
       page,
     }) => {
-      let callbackCount = 0;
-      const callback: DecimalProps["onChange"] = () => {
-        callbackCount += 1;
-      };
-      await mount(<Decimal precision={2} onChange={callback} />);
+      await mount(<DefaultStory precision={2} />);
 
       const commonDataElementInputPreviewElement =
         commonDataElementInputPreview(page);
+
       await commonDataElementInputPreviewElement.fill(rawValueTest);
-      expect(callbackCount).toBe(1);
+
       await commonDataElementInputPreviewElement.blur();
+
       await expect(commonDataElementInputPreviewElement).toHaveAttribute(
         "value",
         formattedValueTest,
@@ -441,7 +439,7 @@ test.describe("check events for Decimal component", () => {
     const callback: DecimalProps["onBlur"] = () => {
       callbackCount += 1;
     };
-    await mount(<Decimal onBlur={callback} />);
+    await mount(<DefaultStory onBlur={callback} />);
 
     const inputValue = "123";
     const commonDataElementInputPreviewElement =
@@ -604,7 +602,7 @@ test("should have the expected border radius styling", async ({
   mount,
   page,
 }) => {
-  await mount(<Decimal />);
+  await mount(<DefaultStory />);
 
   const getElementElementInput = getElement(page, "input");
   await expect(getElementElementInput).toHaveCSS("border-radius", "4px");

--- a/src/components/decimal/decimal.test.tsx
+++ b/src/components/decimal/decimal.test.tsx
@@ -14,7 +14,7 @@ const ControlledDecimal = ({
   onChange,
   startingValue,
   ...rest
-}: Partial<DecimalProps> & { startingValue?: string }) => {
+}: Partial<DecimalProps> & { startingValue: string }) => {
   const [value, setValue] = useState(startingValue);
   const handleChange = (e: CustomEvent) => {
     setValue(e.target.value.rawValue);
@@ -25,1365 +25,238 @@ const ControlledDecimal = ({
 };
 
 testStyledSystemMargin(
-  (props) => <Decimal data-role="decimal" {...props} />,
+  (props) => (
+    <Decimal
+      data-role="decimal"
+      value="0.01"
+      onChange={() => jest.fn()}
+      {...props}
+    />
+  ),
   () => screen.getByTestId("decimal"),
   { modifier: "&&&" },
 );
 
-describe("when the component is uncontrolled", () => {
-  it("displays a deprecation warning for uncontrolled", () => {
-    const loggerSpy = jest.spyOn(Logger, "deprecate");
-    render(<Decimal defaultValue="0.01" />);
-
-    expect(loggerSpy).toHaveBeenCalledWith(
-      "Uncontrolled behaviour in `Decimal` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-    );
-    expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-    loggerSpy.mockRestore();
-  });
-
-  it("has a default value of 0.00 when no defaultValue prop is provided", () => {
-    render(<Decimal />);
-    expect(screen.getByRole("textbox")).toHaveValue("0.00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.00");
-  });
-
-  it("has a default value specified by the defaultValue prop", () => {
-    render(<Decimal defaultValue="12345.67" />);
-    expect(screen.getByRole("textbox")).toHaveValue("12,345.67");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("12345.67");
-  });
-
-  it("has a default value specified by the defaultValue prop when the value is negative", () => {
-    render(<Decimal defaultValue="-1234.56" />);
-    expect(screen.getByRole("textbox")).toHaveValue("-1,234.56");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("-1234.56");
-  });
-
-  it("removes unnecessary separators on blur", async () => {
-    const user = userEvent.setup();
-    render(<Decimal />);
-    const decimalInput = screen.getByRole("textbox");
-
-    await user.type(decimalInput, "1,1");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("11.00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("11.00");
-  });
-
-  it("fixes incorrectly placed separators on blur", async () => {
-    const user = userEvent.setup();
-    render(<Decimal />);
-    const decimalInput = screen.getByRole("textbox");
-
-    await user.type(decimalInput, "1,2,34576.00");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("1,234,576.00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1234576.00");
-  });
-
-  it("does not change the value on blur when it contains numbers, letters and too many separators", async () => {
-    const user = userEvent.setup();
-    render(<Decimal />);
-    const decimalInput = screen.getByRole("textbox");
-
-    await user.type(decimalInput, "123a,123a,123a");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("123a,123a,123a");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("123a,123a,123a");
-  });
-
-  it("does not change the value on blur when it contains numbers, letters and too many separators, and ends with a separator", async () => {
-    const user = userEvent.setup();
-    render(<Decimal />);
-    const decimalInput = screen.getByRole("textbox");
-
-    await user.type(decimalInput, "123a,123a,123a,");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("123a,123a,123a,");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("123a,123a,123a,");
-  });
-
-  it("does not revert to the defaultValue on blur when allowEmptyValue is not set and the user enters just a negative sign", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="-1234.56" />);
-    const decimalInput = screen.getByRole("textbox");
-
-    await user.type(decimalInput, "-");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("-");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("-");
-  });
-
-  it("does not revert to an empty value on blur when allowEmptyValue is set and the user enters just a negative sign", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="-1234.56" allowEmptyValue />);
-    const decimalInput = screen.getByRole("textbox");
-
-    await user.type(decimalInput, "-");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("-");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("-");
-  });
-
-  it("fires a console error if precision is changed", () => {
-    const loggerSpy = jest.spyOn(Logger, "error").mockImplementation(() => {});
-
-    const { rerender } = render(<Decimal defaultValue="12345" precision={2} />);
-
-    rerender(<Decimal precision={1} />);
-    expect(loggerSpy).toHaveBeenCalledWith(
-      "Decimal `precision` prop has changed value. Changing the Decimal `precision` prop has no effect.",
-    );
-    loggerSpy.mockRestore();
-  });
-
-  it("supports having a precision of 0", () => {
-    render(<Decimal defaultValue="12345.65" precision={0} />);
-    expect(screen.getByRole("textbox")).toHaveValue("12,345.65");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("12345.65");
-  });
-
-  it("does not round the default value if it has more precision than the `precision` prop", () => {
-    render(<Decimal defaultValue="12345.655" precision={2} />);
-    expect(screen.getByRole("textbox")).toHaveValue("12,345.655");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("12345.655");
-  });
-
-  it("supports having a bigger precision than the default of 2", () => {
-    render(<Decimal defaultValue="12345.654" precision={3} />);
-    expect(screen.getByRole("textbox")).toHaveValue("12,345.654");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("12345.654");
-  });
-
-  it.each<[DecimalProps["precision"], string]>([
-    [0, "150"],
-    [1, "130.4"],
-    [2, "136.42"],
-    [3, "150.456"],
-    [4, "130.5776"],
-    [5, "136.42345"],
-    [6, "150.234543"],
-    [7, "130.4234435"],
-    [8, "136.87556431"],
-    [9, "150.192837564"],
-    [10, "130.1988745670"],
-    [11, "136.10029938475"],
-    [12, "136.129034895673"],
-    [13, "150.1290238945785"],
-    [14, "130.10299288377462"],
-    [15, "136.896647588492756"],
-  ])(
-    "formats the default value correctly when the precision is (%s)",
-    (precisionValue, decimalValue) => {
-      render(
-        <Decimal defaultValue={decimalValue} precision={precisionValue} />,
-      );
-      expect(screen.getByRole("textbox")).toHaveValue(decimalValue);
-      expect(screen.getByTestId("hidden-input")).toHaveValue(decimalValue);
-    },
-  );
-
-  it("pads the value with 0s if the precision is greater than the number of decimal places", () => {
-    render(<Decimal defaultValue="12345" precision={3} />);
-    expect(screen.getByRole("textbox")).toHaveValue("12,345.000");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("12345.000");
-  });
-
-  it("calls onChange when the user enters a value", async () => {
-    const onChange = jest.fn();
-    const user = userEvent.setup();
-
-    render(<Decimal onChange={onChange} />);
-
-    await user.type(screen.getByRole("textbox"), "12345.56");
-
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: {
-          value: {
-            formattedValue: "12,345.56",
-            rawValue: "12345.56",
-          },
-        },
-      }),
-    );
-  });
-
-  it("calls onBlur when the field loses focus", async () => {
-    const onBlur = jest.fn();
-    const user = userEvent.setup();
-
-    render(<Decimal onBlur={onBlur} />);
-
-    await user.type(screen.getByRole("textbox"), "12345.56");
-    await user.tab();
-
-    expect(onBlur).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: {
-          value: {
-            formattedValue: "12,345.56",
-            rawValue: "12345.56",
-          },
-        },
-      }),
-    );
-  });
-
-  it.each([
-    "1a",
-    "1b",
-    "1c",
-    "1d",
-    "1e",
-    "1f",
-    "1g",
-    "1h",
-    "1i",
-    "1j",
-    "1k",
-    "1l",
-    "1m",
-    "1n",
-    "1o",
-    "1p",
-    "1q",
-    "1r",
-    "1s",
-    "1t",
-    "1u",
-    "1v",
-    "1w",
-    "1x",
-    "1y",
-    "1z",
-    "1A",
-    "1B",
-    "1C",
-    "1D",
-    "1E",
-    "1F",
-    "1G",
-    "1H",
-    "1I",
-    "1J",
-    "1K",
-    "1L",
-    "1M",
-    "1N",
-    "1O",
-    "1P",
-    "1Q",
-    "1R",
-    "1S",
-    "1T",
-    "1U",
-    "1V",
-    "1W",
-    "1X",
-    "1Y",
-    "1Z",
-    "1!",
-    '1"',
-    "1£",
-    "1$",
-    "1%",
-    "1^",
-    "1&",
-    "1*",
-    "1(",
-    "1)",
-    "1_",
-    "1+",
-    "1`",
-    "1¬",
-    "1\\",
-    "1|",
-    "1[",
-    "1{",
-    "1]",
-    "1}",
-    "1:",
-    "1;",
-    "1@",
-    "1'",
-    "1~",
-    "1#",
-    "1<",
-    "1>",
-    "1?",
-    "1/",
-    "a1",
-    "b1",
-    "c1",
-    "d1",
-    "e1",
-    "f1",
-    "g1",
-    "h1",
-    "i1",
-    "j1",
-    "k1",
-    "l1",
-    "m1",
-    "n1",
-    "o1",
-    "p1",
-    "q1",
-    "r1",
-    "s1",
-    "t1",
-    "u1",
-    "v1",
-    "w1",
-    "x1",
-    "y1",
-    "z1",
-    "A1",
-    "B1",
-    "C1",
-    "D1",
-    "E1",
-    "F1",
-    "G1",
-    "H1",
-    "I1",
-    "J1",
-    "K1",
-    "L1",
-    "M1",
-    "N1",
-    "O1",
-    "P1",
-    "Q1",
-    "R1",
-    "S1",
-    "T1",
-    "U1",
-    "V1",
-    "W1",
-    "X1",
-    "Y1",
-    "Z1",
-    "!1",
-    '"1',
-    "£1",
-    "$1",
-    "%1",
-    "^1",
-    "&1",
-    "*1",
-    "(1",
-    ")1",
-    "_1",
-    "`1",
-    "¬1",
-    "\\1",
-    "|1",
-    "[1",
-    "{1",
-    "]1",
-    "}1",
-    ":1",
-    ";1",
-    "@1",
-    "'1",
-    "~1",
-    "#1",
-    "<1",
-    ">1",
-    "?1",
-    "/1",
-    "11111a",
-    "a111111",
-    "1111a1111",
-  ])(
-    "allows the user to paste `%s` and calls onChange with the pasted value",
-    async (pastedText) => {
-      const onChange = jest.fn();
-      const user = userEvent.setup();
-      render(<Decimal onChange={onChange} />);
-
-      act(() => {
-        screen.getByRole("textbox").focus();
-      });
-      (screen.getByRole("textbox") as HTMLInputElement).select();
-      await user.paste(pastedText);
-
-      expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          target: {
-            value: {
-              formattedValue: pastedText,
-              rawValue: pastedText,
-            },
-          },
-        }),
-      );
-    },
-  );
-
-  it.each([
-    [1, "0-.00"],
-    [2, "0.-00"],
-    [3, "0.0-0"],
-  ])(
-    "allows the user to type the negative symbol within the number at index %s",
-    async (insertionIndex, result) => {
-      const user = userEvent.setup();
-      render(<Decimal defaultValue="0.00" />);
-
-      const decimalInput = screen.getByRole("textbox");
-
-      await user.type(decimalInput, "-", {
-        initialSelectionStart: insertionIndex,
-      });
-
-      expect(decimalInput).toHaveValue(result);
-      expect(screen.getByTestId("hidden-input")).toHaveValue(result);
-    },
-  );
-
-  // insertions at start and end have to be handled separately from the cases above, as setting the
-  // initialSelectionStart to 0 or 4 (the default input length) seems to result in the entire value
-  // being selected. So we explicitly use arrow-key manipulation to handle these cases correctly.
-  it("allows the user to type a negative symbol at the start of the number", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="0.00" />);
-
-    const decimalInput = screen.getByRole("textbox");
-
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{ArrowLeft}");
-    await user.keyboard("-");
-
-    expect(decimalInput).toHaveValue("-0.00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("-0.00");
-  });
-
-  it("allows the user to type a negative symbol at the end of the number", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="0.00" />);
-
-    const decimalInput = screen.getByRole("textbox");
-
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{ArrowRight}");
-    await user.keyboard("-");
-
-    expect(decimalInput).toHaveValue("0.00-");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.00-");
-  });
-
-  it.each([
-    [1, 1, ",234.56", ",234.56"],
-    [2, 2, "1234.56", "1234.56"],
-    [3, 3, "1,34.56", "134.56"],
-    [4, 4, "1,24.56", "124.56"],
-    [5, 5, "1,23.56", "123.56"],
-    [6, 6, "1,23456", "123456"],
-    [7, 7, "1,234.6", "1234.6"],
-    [0, 1, ",234.56", ",234.56"],
-    [0, 2, "234.56", "234.56"],
-    [0, 3, "34.56", "34.56"],
-    [0, 4, "4.56", "4.56"],
-    [0, 5, ".56", ".56"],
-    [0, 6, "56", "56"],
-    [0, 7, "6", "6"],
-    [0, 8, "", ""],
-    [1, 2, "1234.56", "1234.56"],
-    [1, 3, "134.56", "134.56"],
-    [1, 4, "14.56", "14.56"],
-    [1, 5, "1.56", "1.56"],
-    [1, 6, "156", "156"],
-    [1, 7, "16", "16"],
-    [1, 8, "1", "1"],
-    [2, 3, "1,34.56", "134.56"],
-    [2, 4, "1,4.56", "14.56"],
-    [2, 5, "1,.56", "1,.56"],
-    [2, 6, "1,56", "156"],
-    [2, 7, "1,6", "16"],
-    [2, 8, "1,", "1,"],
-    [3, 4, "1,24.56", "124.56"],
-    [3, 5, "1,2.56", "12.56"],
-    [3, 6, "1,256", "1256"],
-    [3, 7, "1,26", "126"],
-    [3, 8, "1,2", "12"],
-    [4, 5, "1,23.56", "123.56"],
-    [4, 6, "1,2356", "12356"],
-    [4, 7, "1,236", "1236"],
-    [4, 8, "1,23", "123"],
-    [5, 6, "1,23456", "123456"],
-    [5, 7, "1,2346", "12346"],
-    [5, 8, "1,234", "1234"],
-    [6, 7, "1,234.6", "1234.6"],
-    [6, 8, "1,234.", "1,234."],
-    [7, 8, "1,234.5", "1234.5"],
-  ])(
-    "allows deletion of content using the backspace key for a selection starting at index %s and ending at index %s",
-    async (selectionStart, selectionEnd, rawValue, sanitisedValue) => {
-      const user = userEvent.setup();
-      render(<Decimal defaultValue="1234.56" />);
-
-      const decimalInput = screen.getByRole("textbox") as HTMLInputElement;
-      act(() => {
-        decimalInput.focus();
-      });
-      decimalInput.setSelectionRange(selectionStart, selectionEnd);
-      await user.keyboard("{Backspace}");
-
-      expect(decimalInput).toHaveValue(rawValue);
-      expect(screen.getByTestId("hidden-input")).toHaveValue(sanitisedValue);
-    },
-  );
-
-  // as above, a simple cursor placement (no selection) at the start or end need special handling
-  it("doesn't delete anything when backspace is pressed with the cursor at the start of the input", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="1234.56" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{ArrowLeft}");
-    await user.keyboard("{Backspace}");
-
-    expect(decimalInput).toHaveValue("1,234.56");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1234.56");
-  });
-
-  it("allows deletion of the final character using the backspace key with the cursor at the end of the input", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="1234.56" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{ArrowRight}");
-    await user.keyboard("{Backspace}");
-
-    expect(decimalInput).toHaveValue("1,234.5");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1234.5");
-  });
-
-  it.each([
-    [1, 1, "1234.56", "1234.56"],
-    [2, 2, "1,34.56", "134.56"],
-    [3, 3, "1,24.56", "124.56"],
-    [4, 4, "1,23.56", "123.56"],
-    [5, 5, "1,23456", "123456"],
-    [6, 6, "1,234.6", "1234.6"],
-    [7, 7, "1,234.5", "1234.5"],
-    [0, 1, ",234.56", ",234.56"],
-    [0, 2, "234.56", "234.56"],
-    [0, 3, "34.56", "34.56"],
-    [0, 4, "4.56", "4.56"],
-    [0, 5, ".56", ".56"],
-    [0, 6, "56", "56"],
-    [0, 7, "6", "6"],
-    [0, 8, "", ""],
-    [1, 2, "1234.56", "1234.56"],
-    [1, 3, "134.56", "134.56"],
-    [1, 4, "14.56", "14.56"],
-    [1, 5, "1.56", "1.56"],
-    [1, 6, "156", "156"],
-    [1, 7, "16", "16"],
-    [1, 8, "1", "1"],
-    [2, 3, "1,34.56", "134.56"],
-    [2, 4, "1,4.56", "14.56"],
-    [2, 5, "1,.56", "1,.56"],
-    [2, 6, "1,56", "156"],
-    [2, 7, "1,6", "16"],
-    [2, 8, "1,", "1,"],
-    [3, 4, "1,24.56", "124.56"],
-    [3, 5, "1,2.56", "12.56"],
-    [3, 6, "1,256", "1256"],
-    [3, 7, "1,26", "126"],
-    [3, 8, "1,2", "12"],
-    [4, 5, "1,23.56", "123.56"],
-    [4, 6, "1,2356", "12356"],
-    [4, 7, "1,236", "1236"],
-    [4, 8, "1,23", "123"],
-    [5, 6, "1,23456", "123456"],
-    [5, 7, "1,2346", "12346"],
-    [5, 8, "1,234", "1234"],
-    [6, 7, "1,234.6", "1234.6"],
-    [6, 8, "1,234.", "1,234."],
-    [7, 8, "1,234.5", "1234.5"],
-  ])(
-    "allows deletion of content using the delete key for a selection starting at index %s and ending at index %s",
-    async (selectionStart, selectionEnd, rawValue, sanitisedValue) => {
-      const user = userEvent.setup();
-      render(<Decimal defaultValue="1234.56" />);
-
-      const decimalInput = screen.getByRole("textbox") as HTMLInputElement;
-      act(() => {
-        decimalInput.focus();
-      });
-      decimalInput.setSelectionRange(selectionStart, selectionEnd);
-      await user.keyboard("{Delete}");
-
-      expect(decimalInput).toHaveValue(rawValue);
-      expect(screen.getByTestId("hidden-input")).toHaveValue(sanitisedValue);
-    },
-  );
-
-  // as above, a simple cursor placement (no selection) at the start or end need special handling
-  it("deletes the first character when delete is pressed with the cursor at the start of the input", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="1234.56" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{ArrowLeft}");
-    await user.keyboard("{Delete}");
-
-    expect(decimalInput).toHaveValue(",234.56");
-    expect(screen.getByTestId("hidden-input")).toHaveValue(",234.56");
-  });
-
-  it("doesn't delete anything when delete is pressed with the cursor at the end of the input", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="1234.56" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{ArrowRight}");
-    await user.keyboard("{Delete}");
-
-    expect(decimalInput).toHaveValue("1,234.56");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1234.56");
-  });
-
-  it.each([",", ".", "£", "$", "%", "@", "!", "*", "#"])(
-    "should not format multiple `%s` characters",
-    async (char) => {
-      const user = userEvent.setup();
-      render(<Decimal />);
-
-      const input = char.repeat(4);
-      await user.type(screen.getByRole("textbox"), input);
-      await user.tab();
-
-      expect(screen.getByRole("textbox")).toHaveValue(input);
-      expect(screen.getByTestId("hidden-input")).toHaveValue(input);
-    },
-  );
-
-  it("calls the onKeyDown callback when a key is pressed", async () => {
-    const user = userEvent.setup();
-    const onKeyDown = jest.fn();
-    render(<Decimal defaultValue="0.00" onKeyDown={onKeyDown} />);
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{ArrowRight}");
-    await user.keyboard("1");
-
-    expect(onKeyDown).toHaveBeenCalledWith(
-      expect.objectContaining({ key: "1" }),
-    );
-  });
-
-  it("has the correct data tag", () => {
-    render(
-      <Decimal data-role="test-data-role" data-element="test-data-element" />,
-    );
-    expect(screen.getByTestId("test-data-role")).toHaveAttribute(
-      "data-component",
-      "decimal",
-    );
-    expect(screen.getByTestId("test-data-role")).toHaveAttribute(
-      "data-element",
-      "test-data-element",
-    );
-  });
-
-  it("adds the expected HTML attributes to the hidden input", async () => {
-    const user = userEvent.setup();
-    render(<Decimal name="example" />);
-
-    await user.type(screen.getByRole("textbox"), "1.23");
-
-    const hiddenInput = screen.getByTestId("hidden-input");
-    expect(hiddenInput).toHaveAttribute("data-component", "hidden-input");
-    expect(hiddenInput).toHaveAttribute("type", "hidden");
-    expect(hiddenInput).toHaveValue("1.23");
-    expect(hiddenInput).toHaveAttribute("name", "example");
-  });
-
-  it("does not fire onChange when the input blurs with no change in value", async () => {
-    const user = userEvent.setup();
-    const onChange = jest.fn();
-    render(<Decimal allowEmptyValue onChange={onChange} />);
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.tab();
-
-    expect(onChange).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    ["1,1,1,1,1.1", "11,111.10", "11111.1"],
-    ["1,1,1222,12,1.1", "111,222,121.10", "111222121.1"],
-    ["1,,1,,1", "1,,1,,1", "1,,1,,1"],
-  ])(
-    "formats %s to %s and rawValue %s when the `en` locale is set",
-    async (input, formatted, rawValue) => {
-      const user = userEvent.setup();
-      const onBlur = jest.fn();
-      render(<Decimal locale="en" onBlur={onBlur} />);
-
-      await user.type(screen.getByRole("textbox"), input);
-      await user.tab();
-
-      expect(screen.getByRole("textbox")).toHaveValue(formatted);
-      expect(onBlur).toHaveBeenCalledWith(
-        expect.objectContaining({
-          target: {
-            value: {
-              formattedValue: formatted,
-              rawValue,
-            },
-          },
-        }),
-      );
-    },
-  );
-
-  it.each([
-    ["1000.23", "1000,23"],
-    ["10000.00", "10.000,00"],
-    ["10000.23", "10.000,23"],
-    ["100000.00", "100.000,00"],
-    ["1000000.00", "1.000.000,00"],
-  ])(
-    "formats %s to %s when provided as the defaultValue prop and the `es-ES` locale is set",
-    async (input, formatted) => {
-      render(<Decimal locale="es-ES" defaultValue={input} />);
-
-      expect(screen.getByRole("textbox")).toHaveValue(formatted);
-      expect(screen.getByTestId("hidden-input")).toHaveValue(input);
-    },
-  );
-
-  it.each([
-    ["1.1.1.1.1.1,1", "111.111,10", "111111.1"],
-    ["2.123", "2123,00", "2123"],
-    ["21.21.111.1,013", "21.211.111,013", "21211111.013"],
-    ["2.,12.,1", "2.,12.,1", "2.,12.,1"],
-    ["100", "100,00", "100"],
-    ["1000", "1000,00", "1000"],
-    ["1000,23", "1000,23", "1000.23"],
-    ["10000", "10.000,00", "10000"],
-    ["10000,23", "10.000,23", "10000.23"],
-    ["100000", "100.000,00", "100000"],
-    ["1000000", "1.000.000,00", "1000000"],
-  ])(
-    "formats %s to %s and rawValue %s when the `es-ES` locale is set",
-    async (input, formatted, rawValue) => {
-      const user = userEvent.setup();
-      const onBlur = jest.fn();
-      render(<Decimal locale="es-ES" onBlur={onBlur} />);
-
-      await user.type(screen.getByRole("textbox"), input);
-      await user.tab();
-
-      expect(screen.getByRole("textbox")).toHaveValue(formatted);
-      expect(onBlur).toHaveBeenCalledWith(
-        expect.objectContaining({
-          target: {
-            value: {
-              formattedValue: formatted,
-              rawValue,
-            },
-          },
-        }),
-      );
-    },
-  );
-
-  it("formats an empty value correctly when precision is 0, allowEmptyValue is false, and the `es-ES` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={0}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="es-ES"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0");
-  });
-
-  it("formats an empty value correctly when precision is 1, allowEmptyValue is false, and the `es-ES` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={1}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="es-ES"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0,0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.0");
-  });
-
-  it.each([
-    ["1000.23", "1000,23"],
-    ["10000.00", "10\xa0000,00"],
-    ["10000.23", "10\xa0000,23"],
-    ["100000.00", "100\xa0000,00"],
-    ["1000000.00", "1\xa0000\xa0000,00"],
-  ])(
-    "formats %s to %s when provided as the defaultValue prop and the `pt-PT` locale is set",
-    async (input, formatted) => {
-      render(<Decimal locale="pt-PT" defaultValue={input} />);
-
-      expect(screen.getByRole("textbox")).toHaveValue(formatted);
-      expect(screen.getByTestId("hidden-input")).toHaveValue(input);
-    },
-  );
-
-  it.each([
-    ["1111,2", "1111,20", "1111.2"],
-    ["100", "100,00", "100"],
-    ["1000", "1000,00", "1000"],
-    ["1000.23", "1000,23", "1000.23"],
-    ["10000", "10\xa0000,00", "10000"],
-    ["10000.23", "10\xa0000,23", "10000.23"],
-    ["100000", "100\xa0000,00", "100000"],
-    ["1000000", "1\xa0000\xa0000,00", "1000000"],
-  ])(
-    "formats %s to %s and rawValue %s when the `pt-PT` locale is set",
-    async (input, formatted, rawValue) => {
-      const user = userEvent.setup();
-      const onBlur = jest.fn();
-      render(<Decimal locale="pt-PT" onBlur={onBlur} />);
-
-      await user.type(screen.getByRole("textbox"), input);
-      await user.tab();
-
-      expect(screen.getByRole("textbox")).toHaveValue(formatted);
-      expect(onBlur).toHaveBeenCalledWith(
-        expect.objectContaining({
-          target: {
-            value: {
-              formattedValue: formatted,
-              rawValue,
-            },
-          },
-        }),
-      );
-    },
-  );
-
-  it("correctly handles a value that has white-spaces when the `pt-PT` locale is set", async () => {
-    const user = userEvent.setup();
-    render(<Decimal locale="pt-PT" />);
-
-    await user.type(screen.getByRole("textbox"), "10 000,00");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("10\xa0000,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("10000.00");
-  });
-
-  it("correctly handles a value that has white-spaces in the wrong place when the `pt-PT` locale is set", async () => {
-    const user = userEvent.setup();
-    render(<Decimal locale="pt-PT" />);
-
-    await user.type(screen.getByRole("textbox"), "1 0000,00");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("10\xa0000,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("10000.00");
-  });
-
-  it("correctly handles a value that has multiple white-spaces when the `pt-PT` locale is set", async () => {
-    const user = userEvent.setup();
-    render(<Decimal locale="pt-PT" />);
-
-    await user.type(screen.getByRole("textbox"), "1  0000,00");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("1  0000,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1  0000,00");
-  });
-
-  it("correctly handles a value that has multiple groups with white-spaces when the `pt-PT` locale is set", async () => {
-    const user = userEvent.setup();
-    render(<Decimal locale="pt-PT" />);
-
-    await user.type(screen.getByRole("textbox"), "1 0000 000,00");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("10\xa0000\xa0000,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("10000000.00");
-  });
-
-  it("formats an empty value correctly when precision is 0, allowEmptyValue is false, and the `pt-PT` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={0}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="pt-PT"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0");
-  });
-
-  it("formats an empty value correctly when precision is 1, allowEmptyValue is false, and the `pt-PT` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={1}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="pt-PT"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0,0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.0");
-  });
-
-  it("formats %s to %s and rawValue %s when the `fr` locale is set", async () => {
-    const user = userEvent.setup();
-    const onBlur = jest.fn();
-    render(<Decimal locale="fr" onBlur={onBlur} />);
-
-    await user.type(screen.getByRole("textbox"), "11111,25");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("11 111,25");
-    expect(onBlur).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: {
-          value: {
-            formattedValue: "11 111,25",
-            rawValue: "11111.25",
-          },
-        },
-      }),
-    );
-  });
-
-  it("formats an empty value correctly when precision is 0, allowEmptyValue is false, and the `fr` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={0}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="fr"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0");
-  });
-
-  it("formats an empty value correctly when precision is 1, allowEmptyValue is false, and the `fr` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={1}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="fr"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0,0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.0");
-  });
-
-  it("has a defaultValue of 0,00 when the `it` locale is set", () => {
-    render(<Decimal locale="it" />);
-
-    expect(screen.getByRole("textbox")).toHaveValue("0,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.00");
-  });
-
-  it("formats the defaultValue prop correctly when the `it` locale is set", () => {
-    render(<Decimal defaultValue="12345.67" locale="it" />);
-
-    expect(screen.getByRole("textbox")).toHaveValue("12.345,67");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("12345.67");
-  });
-
-  it("formats a user-entered value correctly when the `it` locale is set", async () => {
-    const user = userEvent.setup();
-    render(<Decimal locale="it" />);
-
-    await user.type(screen.getByRole("textbox"), "1234576");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("1.234.576,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1234576.00");
-  });
-
-  it("formats a value correctly when it has an extra separator and the `it` locale is set", async () => {
-    const user = userEvent.setup();
-    render(<Decimal locale="it" />);
-
-    await user.type(screen.getByRole("textbox"), "1.2.34576,00");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("1.234.576,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1234576.00");
-  });
-
-  it("fixes incorrectly placed delimiters when the `it` locale is set", async () => {
-    const user = userEvent.setup();
-    render(<Decimal locale="it" />);
-
-    await user.type(screen.getByRole("textbox"), "1.1");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("11,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("11.00");
-  });
-
-  it("renders a negative value with correct formatting when the `it` locale is set", () => {
-    render(<Decimal defaultValue="-1234.56" locale="it" />);
-
-    const formatter = new Intl.NumberFormat("it", { minimumFractionDigits: 2 });
-    const formatted = formatter.format(-1234.56);
-
-    expect(screen.getByRole("textbox")).toHaveValue(formatted);
-    expect(screen.getByTestId("hidden-input")).toHaveValue("-1234.56");
-  });
-
-  it("formats an empty value correctly when precision is 0, allowEmptyValue is false and the `it` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={0}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="it"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0");
-  });
-
-  it("formats an empty value correctly when precision is 1, allowEmptyValue is false, and the `it` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={1}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="it"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0,0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.0");
-  });
+it.each([
+  ["123", "123.00"],
+  ["456", "456.00"],
+  ["", ""],
+])("renders the value prop %s in the input", (rawValue, formattedValue) => {
+  render(<Decimal value={rawValue} onChange={jest.fn} />);
+
+  expect(screen.getByRole("textbox")).toHaveValue(formattedValue);
+  expect(screen.getByTestId("hidden-input")).toHaveValue(formattedValue);
 });
 
-describe("when the component is controlled", () => {
-  it.each([
-    ["123", "123.00"],
-    ["456", "456.00"],
-    ["", ""],
-  ])("renders the value prop %s in the input", (rawValue, formattedValue) => {
-    render(<Decimal value={rawValue} />);
+it("does not fire onChange when the input blurs with no change in value", async () => {
+  const user = userEvent.setup();
+  const onChange = jest.fn();
+  render(<Decimal value="123" onChange={onChange} />);
 
-    expect(screen.getByRole("textbox")).toHaveValue(formattedValue);
-    expect(screen.getByTestId("hidden-input")).toHaveValue(formattedValue);
+  act(() => {
+    screen.getByRole("textbox").focus();
   });
+  await user.tab();
 
-  it("does not fire onChange when the input blurs with no change in value", async () => {
-    const user = userEvent.setup();
-    const onChange = jest.fn();
-    render(<Decimal value="123" onChange={onChange} />);
+  expect(onChange).not.toHaveBeenCalled();
+});
 
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.tab();
+it("does not revert to the default value on blur when the user enters just a negative sign", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="123" />);
+  const decimalInput = screen.getByRole("textbox");
 
-    expect(onChange).not.toHaveBeenCalled();
+  await user.type(decimalInput, "-");
+  await user.tab();
+
+  expect(decimalInput).toHaveValue("-");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("-");
+});
+
+it("formats the default value correctly on blur when precision is 0 and allowEmptyValue is false", async () => {
+  const user = userEvent.setup();
+  render(
+    <ControlledDecimal
+      precision={0}
+      startingValue=""
+      allowEmptyValue={false}
+    />,
+  );
+
+  act(() => {
+    screen.getByRole("textbox").focus();
   });
+  await user.tab();
 
-  it("does not revert to the default value on blur when the user enters just a negative sign", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="123" />);
-    const decimalInput = screen.getByRole("textbox");
+  expect(screen.getByRole("textbox")).toHaveValue("0");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("0");
+});
 
-    await user.type(decimalInput, "-");
-    await user.tab();
+it("formats the default value correctly on blur when precision is 1 and allowEmptyValue is false", async () => {
+  const user = userEvent.setup();
+  render(
+    <ControlledDecimal
+      precision={1}
+      startingValue=""
+      allowEmptyValue={false}
+    />,
+  );
 
-    expect(decimalInput).toHaveValue("-");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("-");
+  act(() => {
+    screen.getByRole("textbox").focus();
   });
+  await user.tab();
 
-  it("formats the default value correctly on blur when precision is 0 and allowEmptyValue is false", async () => {
-    const user = userEvent.setup();
-    render(
-      <ControlledDecimal
-        precision={0}
-        startingValue=""
-        allowEmptyValue={false}
-      />,
-    );
+  expect(screen.getByRole("textbox")).toHaveValue("0.0");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("0.0");
+});
 
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.tab();
+it("does not revert to the empty value when allowEmptyValue is true and the user enters just a negative sign", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="" allowEmptyValue />);
+  const decimalInput = screen.getByRole("textbox");
 
-    expect(screen.getByRole("textbox")).toHaveValue("0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0");
+  await user.type(decimalInput, "-");
+  await user.tab();
+
+  expect(decimalInput).toHaveValue("-");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("-");
+});
+
+it("does not format a value that is not a number", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="" />);
+
+  const decimalInput = screen.getByRole("textbox");
+  await user.type(decimalInput, "FooBar");
+  expect(decimalInput).toHaveValue("FooBar");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("FooBar");
+});
+
+it("does not format a value that is white-space only", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="" />);
+
+  const decimalInput = screen.getByRole("textbox");
+  await user.type(decimalInput, "     ");
+  expect(decimalInput).toHaveValue("     ");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("     ");
+});
+
+it("does not format a value that is delimiters only", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="" />);
+
+  const decimalInput = screen.getByRole("textbox");
+  await user.type(decimalInput, ",,,");
+  expect(decimalInput).toHaveValue(",,,");
+  expect(screen.getByTestId("hidden-input")).toHaveValue(",,,");
+});
+
+it("does not format a value that is special characters and delimiters only", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="" />);
+
+  const decimalInput = screen.getByRole("textbox");
+  await user.type(decimalInput, "^^&^%%$,,,,");
+  expect(decimalInput).toHaveValue("^^&^%%$,,,,");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("^^&^%%$,,,,");
+});
+
+it("does not format a value that has numbers and has too many delimiters", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="" />);
+
+  const decimalInput = screen.getByRole("textbox");
+  await user.type(decimalInput, "10,.10,.11,.6");
+  expect(decimalInput).toHaveValue("10,.10,.11,.6");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("10,.10,.11,.6");
+});
+
+it("handles a value that is numbers, delimiters and special characters only", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="" />);
+
+  const decimalInput = screen.getByRole("textbox");
+  await user.type(decimalInput, "1,234$");
+  expect(decimalInput).toHaveValue("1,234$");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("1,234$");
+});
+
+it("handles an empty value on blur when allowEmptyValue is true", async () => {
+  const onBlur = jest.fn();
+  const user = userEvent.setup();
+  render(
+    <ControlledDecimal startingValue="1" onBlur={onBlur} allowEmptyValue />,
+  );
+
+  const decimalInput = screen.getByRole("textbox");
+  act(() => {
+    decimalInput.focus();
   });
+  await user.keyboard("{Backspace}");
+  await user.tab();
 
-  it("formats the default value correctly on blur when precision is 1 and allowEmptyValue is false", async () => {
-    const user = userEvent.setup();
-    render(
-      <ControlledDecimal
-        precision={1}
-        startingValue=""
-        allowEmptyValue={false}
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0.0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.0");
-  });
-
-  it("does not revert to the empty value when allowEmptyValue is true and the user enters just a negative sign", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="" allowEmptyValue />);
-    const decimalInput = screen.getByRole("textbox");
-
-    await user.type(decimalInput, "-");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("-");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("-");
-  });
-
-  it("does not format a value that is not a number", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    await user.type(decimalInput, "FooBar");
-    expect(decimalInput).toHaveValue("FooBar");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("FooBar");
-  });
-
-  it("does not format a value that is white-space only", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    await user.type(decimalInput, "     ");
-    expect(decimalInput).toHaveValue("     ");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("     ");
-  });
-
-  it("does not format a value that is delimiters only", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    await user.type(decimalInput, ",,,");
-    expect(decimalInput).toHaveValue(",,,");
-    expect(screen.getByTestId("hidden-input")).toHaveValue(",,,");
-  });
-
-  it("does not format a value that is special characters and delimiters only", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    await user.type(decimalInput, "^^&^%%$,,,,");
-    expect(decimalInput).toHaveValue("^^&^%%$,,,,");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("^^&^%%$,,,,");
-  });
-
-  it("does not format a value that has numbers and has too many delimiters", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    await user.type(decimalInput, "10,.10,.11,.6");
-    expect(decimalInput).toHaveValue("10,.10,.11,.6");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("10,.10,.11,.6");
-  });
-
-  it("handles a value that is numbers, delimiters and special characters only", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    await user.type(decimalInput, "1,234$");
-    expect(decimalInput).toHaveValue("1,234$");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1,234$");
-  });
-
-  it("handles an empty value on blur when allowEmptyValue is true", async () => {
-    const onBlur = jest.fn();
-    const user = userEvent.setup();
-    render(
-      <ControlledDecimal startingValue="1" onBlur={onBlur} allowEmptyValue />,
-    );
-
-    const decimalInput = screen.getByRole("textbox");
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{Backspace}");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("");
-    expect(onBlur).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: {
-          value: {
-            formattedValue: "",
-            rawValue: "",
-          },
+  expect(decimalInput).toHaveValue("");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("");
+  expect(onBlur).toHaveBeenCalledWith(
+    expect.objectContaining({
+      target: {
+        value: {
+          formattedValue: "",
+          rawValue: "",
         },
-      }),
-    );
+      },
+    }),
+  );
+});
+
+it("handles an empty value on blur when allowEmptyValue is false", async () => {
+  const onBlur = jest.fn();
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="1" onBlur={onBlur} />);
+
+  const decimalInput = screen.getByRole("textbox");
+  act(() => {
+    decimalInput.focus();
   });
+  await user.keyboard("{Backspace}");
+  await user.tab();
 
-  it("handles an empty value on blur when allowEmptyValue is false", async () => {
-    const onBlur = jest.fn();
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="1" onBlur={onBlur} />);
-
-    const decimalInput = screen.getByRole("textbox");
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{Backspace}");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("0.00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.00");
-    expect(onBlur).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: {
-          value: {
-            formattedValue: "0.00",
-            rawValue: "0.00",
-          },
+  expect(decimalInput).toHaveValue("0.00");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("0.00");
+  expect(onBlur).toHaveBeenCalledWith(
+    expect.objectContaining({
+      target: {
+        value: {
+          formattedValue: "0.00",
+          rawValue: "0.00",
         },
-      }),
-    );
-  });
+      },
+    }),
+  );
 });
 
 describe("refs", () => {
   it("accepts ref as a ref object", () => {
     const ref = { current: null };
-    render(<Decimal ref={ref} />);
+    render(<Decimal ref={ref} onChange={jest.fn} value="0.01" />);
 
     expect(ref.current).toBe(screen.getByRole("textbox"));
   });
 
   it("accepts ref as a ref callback", () => {
     const ref = jest.fn();
-    render(<Decimal ref={ref} />);
+    render(<Decimal ref={ref} onChange={jest.fn} value="0.01" />);
 
     expect(ref).toHaveBeenCalledWith(screen.getByRole("textbox"));
   });
 
   it("sets ref to empty after unmount", () => {
     const ref = { current: null };
-    const { unmount } = render(<Decimal ref={ref} />);
+    const { unmount } = render(
+      <Decimal ref={ref} onChange={jest.fn} value="0.01" />,
+    );
 
     unmount();
 
@@ -1399,7 +272,7 @@ test("when wrapped in an I18nProvider, the appropriate locale is used, and the f
         locale: () => "fr-FR",
       }}
     >
-      <Decimal />
+      <Decimal onChange={jest.fn} value="0.00" />
     </I18nProvider>,
   );
   expect(screen.getByRole("textbox")).toHaveValue("0,00");
@@ -1410,7 +283,7 @@ test("when wrapped in an I18nProvider, the appropriate locale is used, and the f
         locale: () => "en-GB",
       }}
     >
-      <Decimal />
+      <Decimal onChange={jest.fn} value="0.00" />
     </I18nProvider>,
   );
   act(() => {
@@ -1421,7 +294,7 @@ test("when wrapped in an I18nProvider, the appropriate locale is used, and the f
 });
 
 test("the `id` prop is passed to the input element", () => {
-  render(<Decimal id="decimalId" />);
+  render(<Decimal id="decimalId" onChange={jest.fn} value="0.01" />);
 
   expect(screen.getByRole("textbox")).toHaveAttribute("id", "decimalId");
 });
@@ -1431,20 +304,20 @@ test("no error message is triggered if the `precision` prop is not specified", (
     .spyOn(global.console, "error")
     .mockImplementation(() => {});
 
-  render(<Decimal defaultValue="12345.654" />);
+  render(<Decimal value="12345.654" onChange={jest.fn} />);
   expect(consoleSpy).not.toHaveBeenCalled();
 
   consoleSpy.mockRestore();
 });
 
 test("the `required` prop is passed to the visible input", () => {
-  render(<Decimal label="required" required />);
+  render(<Decimal label="required" required onChange={jest.fn} value="0.01" />);
 
   expect(screen.getByRole("textbox")).toBeRequired();
 });
 
 test("the `required` prop is not passed to the hidden input", () => {
-  render(<Decimal label="required" required />);
+  render(<Decimal label="required" required onChange={jest.fn} value="0.01" />);
 
   expect(screen.getByTestId("hidden-input")).not.toBeRequired();
 });
@@ -1467,4 +340,20 @@ test("component should render without invariant firing in strict mode", () => {
   );
 
   consoleErrorSpy.mockRestore();
+});
+
+// Skipped coverage test - Logger.error not being called in this test despite the precision prop changing
+// and the useEffect being hit (line 164 of decimal.component.tsx).
+test.skip("logs an error when precision changes", () => {
+  const loggerSpy = jest.spyOn(Logger, "error");
+
+  const { rerender } = render(
+    <Decimal onChange={jest.fn} value="0.01" precision={2} />,
+  );
+
+  rerender(<Decimal onChange={jest.fn} value="0.01" precision={4} />);
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "Decimal `precision` prop has changed value. Changing the Decimal `precision` prop has no effect.",
+  );
 });

--- a/src/components/number/components.test-pw.tsx
+++ b/src/components/number/components.test-pw.tsx
@@ -24,6 +24,10 @@ export const Default = (props: Partial<NumberProps>) => {
 
 export const Sizes = () => {
   const sizes: NumberProps["size"][] = ["small", "medium", "large"];
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
 
   return (
     <>
@@ -31,7 +35,8 @@ export const Sizes = () => {
         <Number
           key={`Number - ${size}`}
           label={`Number - ${size}`}
-          value="123456"
+          value={state}
+          onChange={setValue}
           size={size}
           mb={2}
         />
@@ -40,22 +45,49 @@ export const Sizes = () => {
   );
 };
 
-export const Disabled = () => <Number label="Number" value="123456" disabled />;
+export const Disabled = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
 
-export const ReadOnly = () => <Number label="Number" value="123456" readOnly />;
+  return <Number label="Number" value={state} onChange={setValue} disabled />;
+};
 
-export const AutoFocus = () => (
-  <Number label="Number" value="123456" autoFocus />
-);
+export const ReadOnly = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Number label="Number" value={state} onChange={setValue} readOnly />;
+};
+
+export const AutoFocus = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Number label="Number" value={state} onChange={setValue} autoFocus />;
+};
 AutoFocus.parameters = { chromatic: { disableSnapshot: true } };
 
-export const WithLabelInline = () => (
-  <Number label="Number" value="123456" labelInline />
-);
+export const WithLabelInline = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number label="Number" value={state} onChange={setValue} labelInline />
+  );
+};
 WithLabelInline.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithLabelAlign = () => {
   const alignments: NumberProps["align"][] = ["right", "left"];
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
 
   return (
     <>
@@ -63,7 +95,8 @@ export const WithLabelAlign = () => {
         <Number
           label="Number"
           labelInline
-          value="123456"
+          value={state}
+          onChange={setValue}
           inputWidth={50}
           key={alignment}
           labelAlign={alignment}
@@ -73,31 +106,73 @@ export const WithLabelAlign = () => {
   );
 };
 
-export const WithCustomLabelWidthAndInputWidth = () => (
-  <Number
-    label="Number"
-    value="123456"
-    labelInline
-    labelWidth={50}
-    inputWidth={50}
-  />
-);
+export const WithCustomLabelWidthAndInputWidth = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number
+      label="Number"
+      value={state}
+      onChange={setValue}
+      labelInline
+      labelWidth={50}
+      inputWidth={50}
+    />
+  );
+};
 
-export const WithCustomMaxWidth = () => (
-  <Number label="Number" value="123456" maxWidth="50%" />
-);
+export const WithCustomMaxWidth = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number label="Number" value={state} onChange={setValue} maxWidth="50%" />
+  );
+};
 
-export const WithFieldHelp = () => (
-  <Number label="Number" value="123456" fieldHelp="Help" />
-);
+export const WithFieldHelp = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number label="Number" value={state} onChange={setValue} fieldHelp="Help" />
+  );
+};
 
-export const WithInputHint = () => (
-  <Number label="Number" value="123456" inputHint="Hint text (optional)." />
-);
+export const WithInputHint = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number
+      label="Number"
+      value={state}
+      onChange={setValue}
+      inputHint="Hint text (optional)."
+    />
+  );
+};
 
-export const WithLabelHelp = () => (
-  <Number label="Number" value="123456" labelHelp="Help" helpAriaLabel="Help" />
-);
+export const WithLabelHelp = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number
+      label="Number"
+      value={state}
+      onChange={setValue}
+      labelHelp="Help"
+      helpAriaLabel="Help"
+    />
+  );
+};
 
 export const WithPositionedChildren = () => {
   const [state, setState] = useState("123456");

--- a/src/components/number/number-test.stories.tsx
+++ b/src/components/number/number-test.stories.tsx
@@ -63,37 +63,77 @@ Default.args = {
 };
 
 export const Validation = () => {
+  const [state, setState] = useState("123456");
   return (
     <>
-      <Number label="Number" value="123456" error="Error Message" mb={2} />
-      <Number label="Number" value="123456" warning="Warning Message" mb={2} />
-      <Number label="Number" value="123456" info="Info Message" mb={2} />
+      <Number
+        label="Number"
+        value={state}
+        error="Error Message"
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
+      <Number
+        label="Number"
+        value={state}
+        warning="Warning Message"
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
+      <Number
+        label="Number"
+        value={state}
+        info="Info Message"
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
 
       <Number
         label="Number"
-        value="123456"
+        value={state}
         error="Error Message"
         validationOnLabel
         mb={2}
+        onChange={(e) => setState(e.target.value)}
       />
       <Number
         label="Number"
-        value="123456"
+        value={state}
         warning="Warning Message"
         validationOnLabel
         mb={2}
+        onChange={(e) => setState(e.target.value)}
       />
       <Number
         label="Number"
-        value="123456"
+        value={state}
         info="Info Message"
         validationOnLabel
         mb={2}
+        onChange={(e) => setState(e.target.value)}
       />
 
-      <Number label="Number" value="123456" error mb={2} />
-      <Number label="Number" value="123456" warning mb={2} />
-      <Number label="Number" value="123456" info mb={2} />
+      <Number
+        label="Number"
+        value={state}
+        error
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
+      <Number
+        label="Number"
+        value={state}
+        warning
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
+      <Number
+        label="Number"
+        value={state}
+        info
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
     </>
   );
 };
@@ -104,30 +144,40 @@ Validation.parameters = {
 };
 
 export const NewValidation = () => {
+  const [state, setState] = useState("123456");
   return (
     <CarbonProvider validationRedesignOptIn>
       <Number
         label="Number"
-        value="123456"
+        value={state}
         error="Error Message"
         inputHint="Hint text"
         mb={2}
-      />
-      <Number label="Number" value="123456" warning="Warning Message" mb={2} />
-      <Number
-        validationMessagePositionTop={false}
-        label="Number"
-        value="123456"
-        error="Error Message"
-        inputHint="Hint text"
-        mb={2}
+        onChange={(e) => setState(e.target.value)}
       />
       <Number
-        validationMessagePositionTop={false}
         label="Number"
         value="123456"
         warning="Warning Message"
         mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
+      <Number
+        validationMessagePositionTop={false}
+        label="Number"
+        value={state}
+        error="Error Message"
+        inputHint="Hint text"
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
+      <Number
+        validationMessagePositionTop={false}
+        label="Number"
+        value={state}
+        warning="Warning Message"
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
       />
     </CarbonProvider>
   );
@@ -139,7 +189,15 @@ NewValidation.parameters = {
 };
 
 export const AutoFocus = () => {
-  return <Number label="Number" value="123456" autoFocus />;
+  const [state, setState] = useState("123456");
+  return (
+    <Number
+      label="Number"
+      value={state}
+      autoFocus
+      onChange={(e) => setState(e.target.value)}
+    />
+  );
 };
 AutoFocus.storyName = "Auto Focus";
 AutoFocus.parameters = {

--- a/src/components/number/number.component.tsx
+++ b/src/components/number/number.component.tsx
@@ -1,6 +1,5 @@
 import React, { useRef } from "react";
 import Textbox, { TextboxProps } from "../textbox";
-import Logger from "../../__internal__/utils/logger";
 import {
   ALIGN_DEFAULT,
   LABEL_VALIDATION_DEFAULT,
@@ -9,11 +8,9 @@ import {
 } from "../textbox/textbox.component";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 
-let deprecateUncontrolledWarnTriggered = false;
-
 export interface NumberProps extends Omit<TextboxProps, "value"> {
   /** Value passed to the input */
-  value?: string;
+  value: string;
 }
 
 function isValidNumber(value: string) {
@@ -40,15 +37,8 @@ export const Number = React.forwardRef(
     const selectionStart = useRef<null | number>(null);
     const selectionEnd = useRef<null | number>(null);
 
-    if (!deprecateUncontrolledWarnTriggered && !onChange) {
-      deprecateUncontrolledWarnTriggered = true;
-      Logger.deprecate(
-        "Uncontrolled behaviour in `Number` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-      );
-    }
-
     const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      if (isValidNumber(event.target.value) && onChange) {
+      if (isValidNumber(event.target.value)) {
         onChange(event);
       } else {
         event.target.value = value || "";

--- a/src/components/number/number.stories.tsx
+++ b/src/components/number/number.stories.tsx
@@ -32,6 +32,10 @@ Default.storyName = "Default";
 
 export const Sizes: Story = () => {
   const sizes: NumberProps["size"][] = ["small", "medium", "large"];
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
 
   return (
     <>
@@ -39,7 +43,8 @@ export const Sizes: Story = () => {
         <Number
           key={`Number - ${size}`}
           label={`Number - ${size}`}
-          value="123456"
+          value={state}
+          onChange={setValue}
           size={size}
           mb={2}
         />
@@ -50,23 +55,41 @@ export const Sizes: Story = () => {
 Sizes.storyName = "Sizes";
 
 export const Disabled: Story = () => {
-  return <Number label="Number" value="123456" disabled />;
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Number label="Number" value={state} onChange={setValue} disabled />;
 };
 Disabled.storyName = "Disabled";
 
 export const ReadOnly: Story = () => {
-  return <Number label="Number" value="123456" readOnly />;
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Number label="Number" value={state} onChange={setValue} readOnly />;
 };
 ReadOnly.storyName = "Read Only";
 
 export const WithLabelInline: Story = () => {
-  return <Number label="Number" value="123456" labelInline />;
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number label="Number" value={state} onChange={setValue} labelInline />
+  );
 };
 WithLabelInline.storyName = "With Label Inline";
 WithLabelInline.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithLabelAlign: Story = () => {
   const alignments: NumberProps["align"][] = ["right", "left"];
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
 
   return (
     <>
@@ -74,7 +97,8 @@ export const WithLabelAlign: Story = () => {
         <Number
           label="Number"
           labelInline
-          value="123456"
+          value={state}
+          onChange={setValue}
           inputWidth={50}
           key={alignment}
           labelAlign={alignment}
@@ -86,25 +110,53 @@ export const WithLabelAlign: Story = () => {
 WithLabelAlign.storyName = "With Label Align";
 
 export const WithCustomMaxWidth: Story = () => {
-  return <Number label="Number" value="123456" maxWidth="50%" />;
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number label="Number" value={state} onChange={setValue} maxWidth="50%" />
+  );
 };
 WithCustomMaxWidth.storyName = "With Custom Max Width";
 
 export const WithFieldHelp: Story = () => {
-  return <Number label="Number" value="123456" fieldHelp="Help" />;
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number label="Number" value={state} onChange={setValue} fieldHelp="Help" />
+  );
 };
 WithFieldHelp.storyName = "With Field Help";
 
-export const WithInputHint: Story = () => (
-  <Number label="Number" value="123456" inputHint="Hint text (optional)." />
-);
-WithInputHint.storyName = "With Input Hint";
-
-export const WithLabelHelp: Story = () => {
+export const WithInputHint: Story = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
   return (
     <Number
       label="Number"
-      value="123456"
+      value={state}
+      onChange={setValue}
+      inputHint="Hint text (optional)."
+    />
+  );
+};
+WithInputHint.storyName = "With Input Hint";
+
+export const WithLabelHelp: Story = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number
+      label="Number"
+      value={state}
+      onChange={setValue}
       labelHelp="Help"
       helpAriaLabel="Help"
     />
@@ -113,11 +165,19 @@ export const WithLabelHelp: Story = () => {
 WithLabelHelp.storyName = "With Label Help";
 
 export const Required: Story = () => {
-  return <Number label="Number" value="123456" required />;
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Number label="Number" value={state} onChange={setValue} required />;
 };
 Required.storyName = "Required";
 
 export const IsOptional: Story = () => {
-  return <Number label="Number" value="123456" isOptional />;
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Number label="Number" value={state} onChange={setValue} isOptional />;
 };
 IsOptional.storyName = "IsOptional";

--- a/src/components/number/number.test.tsx
+++ b/src/components/number/number.test.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Number from ".";
-import Logger from "../../__internal__/utils/logger";
 
 jest.mock("../../__internal__/utils/logger");
 
@@ -15,13 +14,13 @@ const ControlledNumber = () => {
 };
 
 test("renders a textbox with provided label", () => {
-  render(<Number label="foo" />);
+  render(<Number label="foo" value="" onChange={jest.fn} />);
 
   expect(screen.getByRole("textbox", { name: "foo" })).toBeVisible();
 });
 
 test("renders a textbox with provided value", () => {
-  render(<Number value="123" />);
+  render(<Number value="123" onChange={jest.fn} />);
 
   expect(screen.getByRole("textbox")).toHaveValue("123");
 });
@@ -29,7 +28,7 @@ test("renders a textbox with provided value", () => {
 test("calls onChange when valid characters are provided", async () => {
   const user = userEvent.setup();
   const onChange = jest.fn();
-  render(<Number onChange={onChange} />);
+  render(<Number onChange={onChange} value="" />);
 
   await user.type(screen.getByRole("textbox"), "123");
 
@@ -39,7 +38,7 @@ test("calls onChange when valid characters are provided", async () => {
 test("does not call onChange when invalid characters are provided", async () => {
   const user = userEvent.setup();
   const onChange = jest.fn();
-  render(<Number onChange={onChange} />);
+  render(<Number onChange={onChange} value="" />);
 
   await user.tab();
   await user.keyboard("abc");
@@ -50,7 +49,7 @@ test("does not call onChange when invalid characters are provided", async () => 
 test("calls onKeyDown when a key is pressed", async () => {
   const user = userEvent.setup();
   const onKeyDown = jest.fn();
-  render(<Number onKeyDown={onKeyDown} />);
+  render(<Number onKeyDown={onKeyDown} onChange={jest.fn} value="" />);
 
   await user.tab();
   await user.keyboard("1");
@@ -101,47 +100,47 @@ test("maintains the user's cursor position when an invalid character is provided
   expect(textbox.selectionEnd).toBe(0);
 });
 
-test("logs a deprecation warning when uncontrolled", () => {
-  const loggerSpy = jest.spyOn(Logger, "deprecate");
-  render(<Number />);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "Uncontrolled behaviour in `Number` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
-});
-
 test("renders a required textbox when `required` prop is true", () => {
-  render(<Number required />);
+  render(<Number required onChange={jest.fn} value="" />);
 
   expect(screen.getByRole("textbox")).toBeRequired();
 });
 
 test("renders a disabled textbox when `disabled` prop is true", () => {
-  render(<Number disabled />);
+  render(<Number disabled onChange={jest.fn} value="" />);
 
   expect(screen.getByRole("textbox")).toBeDisabled();
 });
 
 test("renders with `ref` when passed as an object", () => {
   const ref = { current: null };
-  render(<Number ref={ref}>foo</Number>);
+  render(
+    <Number ref={ref} onChange={jest.fn} value="">
+      foo
+    </Number>,
+  );
 
   expect(ref.current).toBe(screen.getByRole("textbox"));
 });
 
 test("renders with `ref` when passed as a callback", () => {
   const ref = jest.fn();
-  render(<Number ref={ref}>foo</Number>);
+  render(
+    <Number ref={ref} onChange={jest.fn} value="">
+      foo
+    </Number>,
+  );
 
   expect(ref).toHaveBeenCalledWith(screen.getByRole("textbox"));
 });
 
 test("sets `ref` to empty after unmount", () => {
   const ref = { current: null };
-  const { unmount } = render(<Number ref={ref}>foo</Number>);
+  const { unmount } = render(
+    <Number ref={ref} onChange={jest.fn} value="">
+      foo
+    </Number>,
+  );
 
   expect(ref.current).toBe(screen.getByRole("textbox"));
 

--- a/src/components/textbox/components.test-pw.tsx
+++ b/src/components/textbox/components.test-pw.tsx
@@ -352,7 +352,7 @@ export const TextboxNewDesignsValidation = () => {
       <CarbonProvider validationRedesignOptIn>
         {(["error", "warning"] as const).map((validationType) =>
           SIZES.map((size) => (
-            <div style={{ width: "296px" }} key={`${validationType}-${size}`}>
+            <Box width="296px" key={`${validationType}-${size}`}>
               <Textbox
                 m={4}
                 label={`${size} - ${validationType}`}
@@ -372,7 +372,7 @@ export const TextboxNewDesignsValidation = () => {
                 readOnly
                 {...{ [validationType]: "Message" }}
               />
-            </div>
+            </Box>
           )),
         )}
       </CarbonProvider>

--- a/src/components/textbox/components.test-pw.tsx
+++ b/src/components/textbox/components.test-pw.tsx
@@ -19,6 +19,10 @@ export const TextboxComponent = (props: Partial<TextboxProps>) => {
 
 export const TextboxComponentRef = () => {
   const ref = useRef<HTMLInputElement | null>(null);
+  const [state, setState] = useState("");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
 
   return (
     <Box margin="0 25px">
@@ -29,7 +33,7 @@ export const TextboxComponentRef = () => {
       >
         Focus Textbox
       </Button>
-      <Textbox ref={ref} />
+      <Textbox ref={ref} value={state} onChange={setValue} />
     </Box>
   );
 };
@@ -65,117 +69,284 @@ export const TextboxComponentWithPositionedChildren = () => {
 };
 
 export const TextboxValidationsAsAStringWithTooltipDefault = () => {
+  const [errorState, setErrorState] = useState("Textbox");
+  const [warningState, setWarningState] = useState("Textbox");
+  const [infoState, setInfoState] = useState("Textbox");
+  const setValue = (
+    { target }: React.ChangeEvent<HTMLInputElement>,
+    size: string,
+  ) => {
+    if (size === "error") setErrorState(target.value);
+    else if (size === "warning") setWarningState(target.value);
+    else if (size === "info") setInfoState(target.value);
+  };
+
   return (
     <Box>
-      {VALIDATIONS.map((validationType) => (
-        <div key={`${validationType}-string-label`}>
-          <Textbox
-            label="Textbox"
-            value="Textbox"
-            validationOnLabel
-            {...{ [validationType]: "Message" }}
-            mb={2}
-            tooltipPosition="bottom"
-          />
-        </div>
-      ))}
+      <div key={`error-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={errorState}
+          onChange={(e) => setValue(e, "error")}
+          validationOnLabel
+          error="Message"
+          mb={2}
+          tooltipPosition="bottom"
+        />
+      </div>
+      <div key={`warning-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={warningState}
+          onChange={(e) => setValue(e, "warning")}
+          validationOnLabel
+          warning="Message"
+          mb={2}
+          tooltipPosition="bottom"
+        />
+      </div>
+      <div key={`info-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={infoState}
+          onChange={(e) => setValue(e, "info")}
+          validationOnLabel
+          info="Message"
+          mb={2}
+          tooltipPosition="bottom"
+        />
+      </div>
     </Box>
   );
 };
 
 export const TextboxValidationsAsABoolean = () => {
+  const [errorState, setErrorState] = useState("Textbox");
+  const [warningState, setWarningState] = useState("Textbox");
+  const [infoState, setInfoState] = useState("Textbox");
+  const setValue = (
+    { target }: React.ChangeEvent<HTMLInputElement>,
+    size: string,
+  ) => {
+    if (size === "error") setErrorState(target.value);
+    else if (size === "warning") setWarningState(target.value);
+    else if (size === "info") setInfoState(target.value);
+  };
+
   return (
     <Box>
-      {VALIDATIONS.map((validationType) => (
-        <div key={`${validationType}-boolean-component`}>
-          <Textbox
-            label="Textbox"
-            value="Textbox"
-            {...{ [validationType]: true }}
-            mb={2}
-          />
-          <Textbox
-            label="Textbox - readOnly"
-            value="Textbox"
-            readOnly
-            {...{ [validationType]: true }}
-            mb={2}
-          />
-        </div>
-      ))}
+      <div key={`error-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={errorState}
+          onChange={(e) => setValue(e, "error")}
+          error
+          mb={2}
+        />
+      </div>
+      <div key={`warning-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={warningState}
+          onChange={(e) => setValue(e, "warning")}
+          warning
+          mb={2}
+        />
+      </div>
+      <div key={`info-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={infoState}
+          onChange={(e) => setValue(e, "info")}
+          info
+          mb={2}
+        />
+      </div>
     </Box>
   );
 };
 
 export const TextboxValidationsAsAString = () => {
+  const [errorState, setErrorState] = useState("Textbox");
+  const [warningState, setWarningState] = useState("Textbox");
+  const [infoState, setInfoState] = useState("Textbox");
+  const setValue = (
+    { target }: React.ChangeEvent<HTMLInputElement>,
+    size: string,
+  ) => {
+    if (size === "error") setErrorState(target.value);
+    else if (size === "warning") setWarningState(target.value);
+    else if (size === "info") setInfoState(target.value);
+  };
+
   return (
     <Box>
-      {VALIDATIONS.map((validationType) => (
-        <div key={`${validationType}-string-component`}>
-          <Textbox
-            label="Textbox"
-            value="Textbox"
-            {...{ [validationType]: "Message" }}
-            mb={2}
-          />
-          <Textbox
-            label="Textbox - readOnly"
-            value="Textbox"
-            readOnly
-            {...{ [validationType]: "Message" }}
-            mb={2}
-          />
-        </div>
-      ))}
+      <div key={`error-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={errorState}
+          onChange={(e) => setValue(e, "error")}
+          error
+          mb={2}
+        />
+      </div>
+      <div key={`warning-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={warningState}
+          onChange={(e) => setValue(e, "warning")}
+          warning
+          mb={2}
+        />
+      </div>
+      <div key={`info-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={infoState}
+          onChange={(e) => setValue(e, "info")}
+          info
+          mb={2}
+        />
+      </div>
     </Box>
   );
 };
 
 export const TextboxValidationsAsAStringWithTooltipCustom = () => {
+  const [errorState, setErrorState] = useState("Textbox");
+  const [warningState, setWarningState] = useState("Textbox");
+  const [infoState, setInfoState] = useState("Textbox");
+  const setValue = (
+    { target }: React.ChangeEvent<HTMLInputElement>,
+    size: string,
+  ) => {
+    if (size === "error") setErrorState(target.value);
+    else if (size === "warning") setWarningState(target.value);
+    else if (size === "info") setInfoState(target.value);
+  };
+
   return (
     <Box>
-      {VALIDATIONS.map((validationType) => (
-        <div key={`${validationType}-string-component`}>
-          <Textbox
-            label="Textbox"
-            value="Textbox"
-            {...{ [validationType]: "Message" }}
-            mb={2}
-            tooltipPosition="bottom"
-          />
-        </div>
-      ))}
+      <div key={`error-string-component`}>
+        <Textbox
+          label="Textbox"
+          error="Message"
+          value={errorState}
+          onChange={(e) => setValue(e, "error")}
+          mb={2}
+          tooltipPosition="bottom"
+        />
+      </div>
+
+      <div key={`warning-string-component`}>
+        <Textbox
+          label="Textbox"
+          warning="Message"
+          value={warningState}
+          onChange={(e) => setValue(e, "error")}
+          mb={2}
+          tooltipPosition="bottom"
+        />
+      </div>
+
+      <div key={`info-string-component`}>
+        <Textbox
+          label="Textbox"
+          info="Message"
+          value={infoState}
+          onChange={(e) => setValue(e, "info")}
+          mb={2}
+          tooltipPosition="bottom"
+        />
+      </div>
     </Box>
   );
 };
 
 export const TextboxValidationsAsAStringDisplayedOnLabel = () => {
+  const [errorState, setErrorState] = useState("Textbox");
+  const [warningState, setWarningState] = useState("Textbox");
+  const [infoState, setInfoState] = useState("Textbox");
+  const setValue = (
+    { target }: React.ChangeEvent<HTMLInputElement>,
+    size: string,
+  ) => {
+    if (size === "error") setErrorState(target.value);
+    else if (size === "warning") setWarningState(target.value);
+    else if (size === "info") setInfoState(target.value);
+  };
+
   return (
     <Box>
-      {VALIDATIONS.map((validationType) => (
-        <div key={`${validationType}-string-label`}>
-          <Textbox
-            label="Textbox"
-            value="Textbox"
-            validationOnLabel
-            {...{ [validationType]: "Message" }}
-            mb={2}
-          />
-          <Textbox
-            label="Textbox - readOnly"
-            value="Textbox"
-            validationOnLabel
-            readOnly
-            {...{ [validationType]: "Message" }}
-            mb={2}
-          />
-        </div>
-      ))}
+      <div key={`error-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={errorState}
+          onChange={(e) => setValue(e, "error")}
+          validationOnLabel
+          error="Message"
+          mb={2}
+        />
+        <Textbox
+          label="Textbox - readOnly"
+          value={errorState}
+          onChange={(e) => setValue(e, "error")}
+          validationOnLabel
+          readOnly
+          error="Message"
+          mb={2}
+        />
+      </div>
+
+      <div key={`warning-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={warningState}
+          onChange={(e) => setValue(e, "warning")}
+          validationOnLabel
+          warning="Message"
+          mb={2}
+        />
+        <Textbox
+          label="Textbox - readOnly"
+          value={warningState}
+          onChange={(e) => setValue(e, "warning")}
+          validationOnLabel
+          readOnly
+          warning="Message"
+          mb={2}
+        />
+      </div>
+
+      <div key={`info-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={infoState}
+          onChange={(e) => setValue(e, "info")}
+          validationOnLabel
+          info="Message"
+          mb={2}
+        />
+        <Textbox
+          label="Textbox - readOnly"
+          value={infoState}
+          onChange={(e) => setValue(e, "info")}
+          validationOnLabel
+          readOnly
+          info="Message"
+          mb={2}
+        />
+      </div>
     </Box>
   );
 };
 
 export const TextboxNewDesignsValidation = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
   return (
     <Box>
       <CarbonProvider validationRedesignOptIn>
@@ -185,7 +356,8 @@ export const TextboxNewDesignsValidation = () => {
               <Textbox
                 m={4}
                 label={`${size} - ${validationType}`}
-                defaultValue="Textbox"
+                value={state}
+                onChange={setValue}
                 labelHelp="Hint text (optional)"
                 size={size}
                 {...{ [validationType]: "Message" }}
@@ -193,7 +365,8 @@ export const TextboxNewDesignsValidation = () => {
               <Textbox
                 m={4}
                 label={`readOnly - ${size} - ${validationType}`}
-                defaultValue="Textbox"
+                value={state}
+                onChange={setValue}
                 size={size}
                 labelHelp="Hint text (optional)"
                 readOnly

--- a/src/components/textbox/textbox-test.stories.tsx
+++ b/src/components/textbox/textbox-test.stories.tsx
@@ -45,19 +45,57 @@ Default.argTypes = commonTextboxArgTypes();
 Default.args = getCommonTextboxArgs();
 
 export const Validation = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
   return (
     <>
-      <Textbox label="Textbox" error="Error Message" />
-      <Textbox label="Textbox" warning="Warning Message" />
-      <Textbox label="Textbox" info="Info Message" />
+      <Textbox
+        label="Textbox"
+        error="Error Message"
+        value={state}
+        onChange={setValue}
+      />
+      <Textbox
+        label="Textbox"
+        warning="Warning Message"
+        value={state}
+        onChange={setValue}
+      />
+      <Textbox
+        label="Textbox"
+        info="Info Message"
+        value={state}
+        onChange={setValue}
+      />
 
-      <Textbox label="Textbox" error="Error Message" validationOnLabel />
-      <Textbox label="Textbox" warning="Warning Message" validationOnLabel />
-      <Textbox label="Textbox" info="Info Message" validationOnLabel />
+      <Textbox
+        label="Textbox"
+        error="Error Message"
+        validationOnLabel
+        value={state}
+        onChange={setValue}
+      />
+      <Textbox
+        label="Textbox"
+        warning="Warning Message"
+        validationOnLabel
+        value={state}
+        onChange={setValue}
+      />
+      <Textbox
+        label="Textbox"
+        info="Info Message"
+        validationOnLabel
+        value={state}
+        onChange={setValue}
+      />
 
-      <Textbox label="Textbox" error />
-      <Textbox label="Textbox" warning />
-      <Textbox label="Textbox" info />
+      <Textbox label="Textbox" error value={state} onChange={setValue} />
+      <Textbox label="Textbox" warning value={state} onChange={setValue} />
+      <Textbox label="Textbox" info value={state} onChange={setValue} />
     </>
   );
 };
@@ -68,19 +106,37 @@ Validation.parameters = {
 };
 
 export const NewValidation = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
   return (
     <CarbonProvider validationRedesignOptIn>
-      <Textbox label="Textbox" error="Error Message" />
-      <Textbox label="Textbox" warning="Warning Message" />
+      <Textbox
+        label="Textbox"
+        error="Error Message"
+        value={state}
+        onChange={setValue}
+      />
+      <Textbox
+        label="Textbox"
+        warning="Warning Message"
+        value={state}
+        onChange={setValue}
+      />
       <Textbox
         validationMessagePositionTop={false}
         label="Textbox"
         error="Error Message"
+        value={state}
+        onChange={setValue}
       />
       <Textbox
         validationMessagePositionTop={false}
         label="Textbox"
         warning="Warning Message"
+        value={state}
+        onChange={setValue}
       />
     </CarbonProvider>
   );
@@ -92,13 +148,18 @@ NewValidation.parameters = {
 };
 
 export const PrefixWithSizes = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
   return (
     <>
       {["small", "medium", "large"].map((size) => (
         <Textbox
           key={`Textbox - ${size}`}
           label={`Textbox - ${size}`}
-          defaultValue="Textbox"
+          value={state}
+          onChange={setValue}
           prefix="prefix"
           size={size as TextboxProps["size"]}
           mb={2}
@@ -120,6 +181,10 @@ export const LabelAndHintTextAlign = () => {
     { inline: true, align: "right", error: "Error message" },
     { inline: true, align: "right", error: undefined },
   ];
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
   return (
     <Box>
       <h1>Old Validation</h1>
@@ -127,7 +192,8 @@ export const LabelAndHintTextAlign = () => {
         {variants.map(({ inline, align, error: e }) => (
           <Textbox
             label={`${inline ? "Inline" : "Stacked"} - ${align}${e ? " with Error" : ""}`}
-            value="Textbox"
+            value={state}
+            onChange={setValue}
             inputWidth={50}
             key={`${inline ? "inline" : "stacked"}-${align}-old-${e ? "error" : "no-error"}`}
             labelAlign={align as TextboxProps["labelAlign"]}
@@ -144,7 +210,8 @@ export const LabelAndHintTextAlign = () => {
           {variants.map(({ inline, align, error: e }) => (
             <Textbox
               label={`${inline ? "Inline" : "Stacked"} - ${align}${e ? " with Error" : ""}`}
-              value="Textbox"
+              value={state}
+              onChange={setValue}
               inputWidth={50}
               key={`${inline ? "inline" : "stacked"}-${align}-new-${e ? "error" : "no-error"}`}
               labelAlign={align as TextboxProps["labelAlign"]}
@@ -165,9 +232,13 @@ LabelAndHintTextAlign.parameters = {
 };
 
 export const AutoFocus = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
   return (
     <Box>
-      <Textbox label="Textbox" value="Textbox" autoFocus />
+      <Textbox label="Textbox" value={state} onChange={setValue} autoFocus />
     </Box>
   );
 };

--- a/src/components/textbox/textbox.component.tsx
+++ b/src/components/textbox/textbox.component.tsx
@@ -95,7 +95,7 @@ export interface CommonTextboxProps
   /** [Legacy] Label width as a percentage when label is inline. */
   labelWidth?: number;
   /** Specify a callback triggered on change */
-  onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   /** Deferred callback to be called after the onChange event */
   onChangeDeferred?: () => void;
   /** Specify a callback triggered on click */
@@ -133,7 +133,7 @@ export interface CommonTextboxProps
   validationMessagePositionTop?: boolean;
 }
 
-export interface TextboxProps extends CommonTextboxProps {
+export interface TextboxProps extends Omit<CommonTextboxProps, "defaultValue"> {
   /** Content to be rendered next to the input */
   children?: React.ReactNode;
   /** Container for DatePicker or SelectList components */
@@ -144,7 +144,6 @@ export interface TextboxProps extends CommonTextboxProps {
 
 let deprecatedAriaDescribedByWarnTriggered = false;
 let deprecateOptionalWarnTriggered = false;
-let deprecateUncontrolledWarnTriggered = false;
 
 export const Textbox = React.forwardRef(
   (
@@ -244,13 +243,6 @@ export const Textbox = React.forwardRef(
     const { disableErrorBorder } = useContext(NumeralDateContext);
     const computeLabelPropValues = <T,>(prop: T): undefined | T =>
       validationRedesignOptIn ? undefined : prop;
-
-    if (!deprecateUncontrolledWarnTriggered && !onChange) {
-      deprecateUncontrolledWarnTriggered = true;
-      Logger.deprecate(
-        "Uncontrolled behaviour in `Textbox` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-      );
-    }
 
     if (!deprecatedAriaDescribedByWarnTriggered && ariaDescribedByDeprecated) {
       deprecatedAriaDescribedByWarnTriggered = true;

--- a/src/components/textbox/textbox.stories.tsx
+++ b/src/components/textbox/textbox.stories.tsx
@@ -22,10 +22,8 @@ const meta: Meta<typeof Textbox> = {
 export default meta;
 type Story = StoryObj<typeof Textbox>;
 
-const SIZES = ["small", "medium", "large"] as const;
-
 export const Default: Story = () => {
-  const [state, setState] = useState("Textbox");
+  const [state, setState] = useState("");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
   };
@@ -102,17 +100,45 @@ export const Prefix: Story = () => {
 Prefix.storyName = "Prefix";
 
 export const Sizes: Story = () => {
+  const [smallState, setSmallState] = useState("Textbox");
+  const [mediumState, setMediumState] = useState("Textbox");
+  const [largeState, setLargeState] = useState("Textbox");
+  const setValue = (
+    { target }: React.ChangeEvent<HTMLInputElement>,
+    size: string,
+  ) => {
+    if (size === "small") setSmallState(target.value);
+    else if (size === "medium") setMediumState(target.value);
+    else if (size === "large") setLargeState(target.value);
+  };
   return (
     <Box>
-      {SIZES.map((size) => (
-        <Textbox
-          key={`Textbox - ${size}`}
-          label={`Textbox - ${size}`}
-          defaultValue="Textbox"
-          size={size}
-          mb={2}
-        />
-      ))}
+      <Textbox
+        key={`Textbox - Small`}
+        label={`Textbox - Small`}
+        value={smallState}
+        size={"small"}
+        mb={2}
+        onChange={(e) => setValue(e, "small")}
+      />
+
+      <Textbox
+        key={`Textbox - Medium`}
+        label={`Textbox - Medium`}
+        value={mediumState}
+        size={"medium"}
+        mb={2}
+        onChange={(e) => setValue(e, "medium")}
+      />
+
+      <Textbox
+        key={`Textbox - Large`}
+        label={`Textbox - Large`}
+        value={largeState}
+        size={"large"}
+        mb={2}
+        onChange={(e) => setValue(e, "large")}
+      />
     </Box>
   );
 };
@@ -128,26 +154,46 @@ export const Margins: Story = () => {
 Margins.storyName = "Margins";
 
 export const Disabled: Story = () => {
-  return <Textbox label="Textbox" value="Textbox" disabled />;
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Textbox label="Textbox" disabled value={state} onChange={setValue} />;
 };
 Disabled.storyName = "Disabled";
 
 export const ReadOnly: Story = () => {
-  return <Textbox label="Textbox" value="Textbox" readOnly />;
+  const [state, setState] = useState("");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Textbox label="Textbox" readOnly value={state} onChange={setValue} />;
 };
 ReadOnly.storyName = "Read Only";
 
 export const WithLabelInline: Story = () => {
-  return <Textbox label="Textbox" value="Textbox" labelInline />;
+  const [state, setState] = useState("");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Textbox label="Textbox" labelInline value={state} onChange={setValue} />
+  );
 };
 WithLabelInline.storyName = "With Label Inline";
 WithLabelInline.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithCustomLabelWidthAndInputWidth: Story = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
   return (
     <Textbox
       label="Textbox"
-      value="Textbox"
+      value={state}
+      onChange={setValue}
       labelInline
       labelWidth={50}
       inputWidth={50}
@@ -158,20 +204,45 @@ WithCustomLabelWidthAndInputWidth.storyName =
   "With Custom Label Width And Input Width";
 
 export const WithCustomMaxWidth: Story = () => {
-  return <Textbox label="Textbox" value="Textbox" maxWidth="50%" />;
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Textbox label="Textbox" value={state} onChange={setValue} maxWidth="50%" />
+  );
 };
 WithCustomMaxWidth.storyName = "With Custom Max Width";
 
 export const WithFieldHelp: Story = () => {
-  return <Textbox label="Textbox" value="Textbox" fieldHelp="Help" />;
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Textbox
+      label="Textbox"
+      value={state}
+      onChange={setValue}
+      fieldHelp="Help"
+    />
+  );
 };
 WithFieldHelp.storyName = "With Field Help";
 
 export const WithInputHint: Story = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
   return (
     <Textbox
       label="Textbox"
-      value="Textbox"
+      value={state}
+      onChange={setValue}
       inputHint="Hint text (optional)."
     />
   );
@@ -179,10 +250,15 @@ export const WithInputHint: Story = () => {
 WithInputHint.storyName = "With Input Hint";
 
 export const WithLabelHelp: Story = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
   return (
     <Textbox
       label="Textbox"
-      value="Textbox"
+      value={state}
+      onChange={setValue}
       labelHelp="Help"
       helpAriaLabel="Help"
     />
@@ -191,22 +267,37 @@ export const WithLabelHelp: Story = () => {
 WithLabelHelp.storyName = "With Label Help";
 
 export const Required: Story = () => {
-  return <Textbox label="Textbox" value="Textbox" required />;
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Textbox label="Textbox" value={state} onChange={setValue} required />;
 };
 Required.storyName = "Required";
 
 export const IsOptional: Story = () => {
-  return <Textbox label="Textbox" value="Textbox" isOptional />;
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Textbox label="Textbox" value={state} onChange={setValue} isOptional />
+  );
 };
 IsOptional.storyName = "IsOptional";
 
 export const LabelAlign: Story = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
   return (
     <Box>
       {(["right", "left"] as const).map((alignment) => (
         <Textbox
           label="Textbox"
-          value="Textbox"
+          value={state}
+          onChange={setValue}
           labelInline
           inputWidth={50}
           key={alignment}

--- a/src/components/textbox/textbox.test.tsx
+++ b/src/components/textbox/textbox.test.tsx
@@ -35,18 +35,8 @@ afterAll(() => {
   loggerSpy.mockClear();
 });
 
-test("should display deprecation warning once when rendered as uncontrolled", () => {
-  render(<Textbox name="my-textbox" defaultValue="test" />);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "Uncontrolled behaviour in `Textbox` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-  );
-
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-});
-
 test("should display deprecation warning once for `ariaDescribedby`", () => {
-  render(<Textbox onChange={() => {}} ariaDescribedBy="test" />);
+  render(<Textbox value="foo" onChange={() => {}} ariaDescribedBy="test" />);
 
   expect(loggerSpy).toHaveBeenCalledWith(
     "The `ariaDescribedBy` prop in `Textbox` is deprecated and will soon be removed, please use `aria-describedby` instead.",
@@ -58,8 +48,8 @@ test("should display deprecation warning once for `ariaDescribedby`", () => {
 test("should display deprecation warning once for optional prop", () => {
   render(
     <>
-      <Textbox onChange={() => {}} isOptional />
-      <Textbox onChange={() => {}} isOptional />
+      <Textbox value="foo" onChange={() => {}} isOptional />
+      <Textbox value="foo" onChange={() => {}} isOptional />
     </>,
   );
 
@@ -73,7 +63,14 @@ test("should display deprecation warning once for optional prop", () => {
 });
 
 testStyledSystemMargin(
-  (props) => <Textbox data-role="textbox-wrapper" {...props} />,
+  (props) => (
+    <Textbox
+      data-role="textbox-wrapper"
+      value="foo"
+      onChange={() => {}}
+      {...props}
+    />
+  ),
   () => screen.getByTestId("textbox-wrapper"),
   { modifier: "&&&" },
 );
@@ -82,7 +79,13 @@ describe(`when the characterLimit prop is passed`, () => {
   it.each([2, 3, 4])("renders a character counter", (characterLimit) => {
     const valueString = "foo";
     const limitMinusValue = characterLimit - valueString.length >= 0;
-    render(<Textbox value={valueString} characterLimit={characterLimit} />);
+    render(
+      <Textbox
+        value={valueString}
+        onChange={() => {}}
+        characterLimit={characterLimit}
+      />,
+    );
     const underCharacters =
       characterLimit - valueString.length === 1 ? "character" : "characters";
     const overCharacters =
@@ -103,7 +106,7 @@ describe(`when the characterLimit prop is passed`, () => {
   });
 
   it("should render a visually hidden hint with id generated via guid", () => {
-    render(<Textbox value="foo" characterLimit={73} />);
+    render(<Textbox value="foo" onChange={() => {}} characterLimit={73} />);
     expect(
       screen.getByText("You can enter up to 73 characters", {
         selector: '[data-element="visually-hidden-hint"]',
@@ -112,7 +115,7 @@ describe(`when the characterLimit prop is passed`, () => {
   });
 
   it("should reference the visually hidden hint id in the input's aria-describedby", () => {
-    render(<Textbox value="foo" characterLimit={73} />);
+    render(<Textbox value="foo" onChange={() => {}} characterLimit={73} />);
     expect(screen.getByRole("textbox")).toHaveAttribute(
       "aria-describedby",
       mockedGuid,
@@ -120,7 +123,9 @@ describe(`when the characterLimit prop is passed`, () => {
   });
 
   it("renders a counter with an over limit warning", () => {
-    render(<Textbox value="test string" characterLimit={10} />);
+    render(
+      <Textbox value="test string" onChange={() => {}} characterLimit={10} />,
+    );
 
     expect(
       screen.getByText("1 character too many", {
@@ -132,21 +137,23 @@ describe(`when the characterLimit prop is passed`, () => {
 
 test("accepts ref as a ref object", () => {
   const ref = { current: null };
-  render(<Textbox ref={ref} />);
+  render(<Textbox value="foo" onChange={() => {}} ref={ref} />);
 
   expect(ref.current).toBe(screen.getByRole("textbox"));
 });
 
 test("accepts ref as a ref callback", () => {
   const ref = jest.fn();
-  render(<Textbox ref={ref} />);
+  render(<Textbox value="foo" onChange={() => {}} ref={ref} />);
 
   expect(ref).toHaveBeenCalledWith(screen.getByRole("textbox"));
 });
 
 test("sets ref to empty after unmount", () => {
   const ref = { current: null };
-  const { unmount } = render(<Textbox ref={ref} />);
+  const { unmount } = render(
+    <Textbox value="foo" onChange={() => {}} ref={ref} />,
+  );
 
   unmount();
 
@@ -169,7 +176,7 @@ test.each([
 ] as const)(
   "styles the input appropriately when an icon is present inside",
   (props: Partial<TextboxProps>) => {
-    render(<Textbox value="test string" {...props} />);
+    render(<Textbox value="test string" onChange={() => {}} {...props} />);
     expect(screen.getByRole("presentation")).toHaveStyleRule(
       "padding-right",
       "0",
@@ -186,6 +193,7 @@ test("supports a separate onClick handler passing for the icon", async () => {
   render(
     <Textbox
       value="foobar"
+      onChange={() => {}}
       inputIcon="search"
       onClick={onClick}
       iconOnClick={iconOnClick}
@@ -209,7 +217,9 @@ test.each([
 ] as EnterKeyHintTypes[])(
   "'enterKeyHint' is correctly passed to the input when prop value is %s",
   (keyHints) => {
-    render(<Textbox value="foobar" enterKeyHint={keyHints} />);
+    render(
+      <Textbox value="foobar" onChange={() => {}} enterKeyHint={keyHints} />,
+    );
 
     expect(screen.getByRole("textbox")).toHaveAttribute(
       "enterkeyhint",
@@ -228,6 +238,7 @@ test.each(["disabled", "readOnly"])(
     render(
       <Textbox
         value="foobar"
+        onChange={() => {}}
         inputIcon="search"
         onClick={onClick}
         iconOnClick={iconOnClick}
@@ -252,6 +263,7 @@ test.each(["disabled", "readOnly"])(
     render(
       <Textbox
         value="foobar"
+        onChange={() => {}}
         inputIcon="search"
         onMouseDown={onMouseDown}
         iconOnMouseDown={iconOnMouseDown}
@@ -275,6 +287,7 @@ test.each(["disabled", "readOnly"])(
     render(
       <Textbox
         value="foobar"
+        onChange={() => {}}
         inputIcon="search"
         onClick={onClick}
         disabled={propName === "disabled"}
@@ -297,6 +310,7 @@ test.each(["disabled", "readOnly"])(
     render(
       <Textbox
         value="foobar"
+        onChange={() => {}}
         inputIcon="search"
         onMouseDown={onMouseDown}
         disabled={propName === "disabled"}
@@ -313,7 +327,14 @@ test.each(["disabled", "readOnly"])(
 test.each(validationTypes)(
   "when %s prop passed as string render proper validation icon by the input",
   (type) => {
-    render(<Textbox label="Label" {...{ [type]: "Message" }} />);
+    render(
+      <Textbox
+        label="Label"
+        value="foo"
+        onChange={() => {}}
+        {...{ [type]: "Message" }}
+      />,
+    );
     const inputPresentationContainer = screen.getByRole("presentation");
     const validationIcon = screen.getByTestId(`icon-${type}`);
     expect(inputPresentationContainer).toContainElement(validationIcon);
@@ -325,7 +346,13 @@ test.each(validationTypes)(
   as true render proper validation icon on the label`,
   (type) => {
     render(
-      <Textbox label="Label" {...{ [type]: "Message" }} validationOnLabel />,
+      <Textbox
+        label="Label"
+        value="foo"
+        onChange={() => {}}
+        {...{ [type]: "Message" }}
+        validationOnLabel
+      />,
     );
     const labelContainer = screen.getByTestId("label-container");
     const validationIcon = screen.getByTestId(`icon-${type}`);
@@ -348,6 +375,8 @@ test.each([
     render(
       <Textbox
         label="Label"
+        value="foo"
+        onChange={() => {}}
         error="Message"
         validationOnLabel={onLabel}
         tooltipPosition={tooltipPosition}
@@ -365,7 +394,7 @@ test.each([
 describe("when the prefix prop is set", () => {
   it("renders a StyledPrefix with this prop value", () => {
     const prefixValue = "bar";
-    render(<Textbox value="foo" prefix={prefixValue} />);
+    render(<Textbox value="foo" onChange={() => {}} prefix={prefixValue} />);
     expect(screen.getByText(prefixValue)).toHaveAttribute(
       "data-element",
       "textbox-prefix",
@@ -374,7 +403,14 @@ describe("when the prefix prop is set", () => {
 
   it("renders with 'flex-direction' as 'row' when the align prop is 'right'", () => {
     const prefixValue = "bar";
-    render(<Textbox value="foo" prefix={prefixValue} align="right" />);
+    render(
+      <Textbox
+        value="foo"
+        onChange={() => {}}
+        prefix={prefixValue}
+        align="right"
+      />,
+    );
     expect(screen.getByRole("presentation")).toHaveStyle({
       flexDirection: "row",
     });
@@ -382,12 +418,12 @@ describe("when the prefix prop is set", () => {
 });
 
 test("the required prop is passed to the input", () => {
-  render(<Textbox value="foo" label="Required" required />);
+  render(<Textbox value="foo" onChange={() => {}} label="Required" required />);
   expect(screen.getByRole("textbox")).toBeRequired();
 });
 
 test("when the required prop is set, the label includes the 'required' asterisk", () => {
-  render(<Textbox value="foo" label="Required" required />);
+  render(<Textbox value="foo" onChange={() => {}} label="Required" required />);
   expect(screen.getByText("Required")).toHaveStyleRule("content", '"*"', {
     modifier: "::after",
   });
@@ -395,7 +431,13 @@ test("when the required prop is set, the label includes the 'required' asterisk"
 
 test("renders the positionChildren prop before the input", () => {
   const Component = () => <div>positionedChildren content</div>;
-  render(<Textbox positionedChildren={<Component />} />);
+  render(
+    <Textbox
+      value="foo"
+      onChange={() => {}}
+      positionedChildren={<Component />}
+    />,
+  );
   const positionChildren = screen.getByText("positionedChildren content");
   const input = screen.getByRole("textbox");
   expect(positionChildren.compareDocumentPosition(input)).toEqual(
@@ -408,6 +450,7 @@ test("passes the helpAriaLabel prop down to the help component", () => {
   render(
     <Textbox
       value=""
+      onChange={() => {}}
       label="label"
       labelHelp="some help"
       helpAriaLabel={text}
@@ -421,7 +464,7 @@ test("sets the accessible label to the provided aria-labelledby", () => {
   const Component = () => (
     <>
       <p id="test">label</p>
-      <Textbox aria-labelledby="test" />
+      <Textbox aria-labelledby="test" value="foo" onChange={() => {}} />
     </>
   );
   render(<Component />);
@@ -433,7 +476,12 @@ test("appends the provided `aria-describedby` to the accessible description", ()
   const Component = () => (
     <>
       <p id="test">description</p>
-      <Textbox inputHint="hint text" aria-describedby="test" />
+      <Textbox
+        inputHint="hint text"
+        aria-describedby="test"
+        value="foo"
+        onChange={() => {}}
+      />
     </>
   );
   render(<Component />);
@@ -447,7 +495,12 @@ test("appends the provided `ariaDescribedBy` to the accessible description", () 
   const Component = () => (
     <>
       <p id="test">description</p>
-      <Textbox inputHint="hint text" ariaDescribedBy="test" />
+      <Textbox
+        inputHint="hint text"
+        ariaDescribedBy="test"
+        value="foo"
+        onChange={() => {}}
+      />
     </>
   );
   render(<Component />);
@@ -460,7 +513,15 @@ test("appends the provided `ariaDescribedBy` to the accessible description", () 
 test.each(validationTypes)(
   'when id is present, %s prop is set as a string and the input is focused, the id of the validation tooltip is added to "aria-describedby" in the input',
   async (validationType) => {
-    render(<Textbox label="bar" id="foo" {...{ [validationType]: "test" }} />);
+    render(
+      <Textbox
+        label="bar"
+        id="foo"
+        {...{ [validationType]: "test" }}
+        value="foo"
+        onChange={() => {}}
+      />,
+    );
     const input = screen.getByRole("textbox");
     act(() => {
       input.focus();
@@ -477,7 +538,14 @@ test.each(validationTypes)(
 test.each(validationTypes)(
   "when id is not present, %s prop is set as a string and the input is focused, the id of the validation tooltip is added to 'aria-describedby' in the input",
   async (validationType) => {
-    render(<Textbox label="bar" {...{ [validationType]: "test" }} />);
+    render(
+      <Textbox
+        label="bar"
+        value="foo"
+        onChange={() => {}}
+        {...{ [validationType]: "test" }}
+      />,
+    );
     const input = screen.getByRole("textbox");
     act(() => {
       input.focus();
@@ -495,7 +563,15 @@ test.each(validationTypes)(
 );
 
 test("when id and fieldHelp are both present, the id of the field help is added to 'aria-describedby' in the input", () => {
-  render(<Textbox id="foo" label="bar" fieldHelp="baz" />);
+  render(
+    <Textbox
+      id="foo"
+      label="bar"
+      fieldHelp="baz"
+      value="foo"
+      onChange={() => {}}
+    />,
+  );
 
   expect(screen.getByText("baz")).toHaveAttribute("id", "foo-field-help");
   expect(screen.getByRole("textbox")).toHaveAttribute(
@@ -505,7 +581,9 @@ test("when id and fieldHelp are both present, the id of the field help is added 
 });
 
 test("when fieldHelp is present and id is not present, the id of the field help is added to 'aria-describedby' in the input", () => {
-  render(<Textbox label="bar" fieldHelp="baz" />);
+  render(
+    <Textbox label="bar" fieldHelp="baz" value="foo" onChange={() => {}} />,
+  );
 
   expect(screen.getByText("baz")).toHaveAttribute(
     "id",
@@ -523,6 +601,8 @@ test.each(validationTypes)(
     render(
       <Textbox
         label="bar"
+        value="foo"
+        onChange={() => {}}
         id="foo"
         fieldHelp="baz"
         {...{ [validationType]: "test" }}
@@ -549,7 +629,13 @@ test.each(validationTypes)(
   'when id is not present, %s prop is set as a string, fieldHelp is present and the input is focused, the ids of both the validation tooltip are added to "aria-describedby" in the input',
   async (validationType) => {
     render(
-      <Textbox label="bar" fieldHelp="baz" {...{ [validationType]: "test" }} />,
+      <Textbox
+        label="bar"
+        value="foo"
+        onChange={() => {}}
+        fieldHelp="baz"
+        {...{ [validationType]: "test" }}
+      />,
     );
     const input = screen.getByRole("textbox");
     act(() => {
@@ -574,7 +660,12 @@ test.each(validationTypes)(
 test("describes the input with the inputHint and error message when validationMessagePositionTop is true", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Textbox inputHint="input hint" error="validation message" />
+      <Textbox
+        inputHint="input hint"
+        value="foo"
+        onChange={() => {}}
+        error="validation message"
+      />
     </CarbonProvider>,
   );
 
@@ -586,7 +677,12 @@ test("describes the input with the inputHint and error message when validationMe
 test("describes the input with the inputHint and warning when validationMessagePositionTop is true", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Textbox inputHint="input hint" warning="validation message" />
+      <Textbox
+        inputHint="input hint"
+        value="foo"
+        onChange={() => {}}
+        warning="validation message"
+      />
     </CarbonProvider>,
   );
 
@@ -600,6 +696,8 @@ test("describes the input with the inputHint and error message when validationMe
     <CarbonProvider validationRedesignOptIn>
       <Textbox
         inputHint="input hint"
+        value="foo"
+        onChange={() => {}}
         error="validation message"
         validationMessagePositionTop={false}
       />
@@ -615,6 +713,8 @@ test("describes the input with the inputHint and warning when validationMessageP
   render(
     <CarbonProvider validationRedesignOptIn>
       <Textbox
+        value="foo"
+        onChange={() => {}}
         inputHint="input hint"
         warning="validation message"
         validationMessagePositionTop={false}
@@ -628,7 +728,15 @@ test("describes the input with the inputHint and warning when validationMessageP
 });
 
 test("renders validation tooltip with provided 'tooltipId' prop", async () => {
-  render(<Textbox label="bar" error="baz" tooltipId="foo" />);
+  render(
+    <Textbox
+      label="bar"
+      error="baz"
+      value="foo"
+      onChange={() => {}}
+      tooltipId="foo"
+    />,
+  );
 
   const input = screen.getByRole("textbox");
   act(() => {
@@ -641,12 +749,12 @@ test("renders validation tooltip with provided 'tooltipId' prop", async () => {
 
 describe("when inputHint prop is present", () => {
   it("renders the hint", () => {
-    render(<Textbox value="test string" inputHint="foo" />);
+    render(<Textbox value="test string" onChange={() => {}} inputHint="foo" />);
     expect(screen.getByText("foo")).toBeInTheDocument();
   });
 
   it("assigns the input hint a guid as id and references it in the aria-describedby of the input", () => {
-    render(<Textbox value="test string" inputHint="bar" />);
+    render(<Textbox value="test string" onChange={() => {}} inputHint="bar" />);
     expect(screen.getByText("bar")).toHaveAttribute("id", mockedGuid);
     expect(screen.getByRole("textbox")).toHaveAttribute(
       "aria-describedby",
@@ -657,7 +765,13 @@ describe("when inputHint prop is present", () => {
   it("uses the inputHint prop instead of labelHelp when both are passed", () => {
     render(
       <CarbonProvider validationRedesignOptIn>
-        <Textbox labelHelp="labelHelp" inputHint="inputHint" error="foo" />
+        <Textbox
+          labelHelp="labelHelp"
+          inputHint="inputHint"
+          error="foo"
+          value="foo"
+          onChange={() => {}}
+        />
       </CarbonProvider>,
     );
     expect(screen.getByText("inputHint")).toBeInTheDocument();
@@ -675,7 +789,12 @@ describe("when rendered with new validations", () => {
 
   it('adds the id of the validation text to "aria-describedby" in the input', () => {
     const mockId = "foo";
-    renderWithNewValidations({ id: mockId, error: "bar" });
+    renderWithNewValidations({
+      id: mockId,
+      error: "bar",
+      value: "foo",
+      onChange: jest.fn(),
+    });
 
     expect(screen.getByText("bar")).toHaveAttribute(
       "id",
@@ -695,6 +814,8 @@ describe("when rendered with new validations", () => {
       labelWidth: 100,
       labelSpacing: 1,
       reverse: true,
+      value: "foo",
+      onChange: jest.fn(),
     });
     const labelContainer = screen.getByTestId("label-container");
     expect(labelContainer).toHaveStyle({ width: undefined });
@@ -704,7 +825,11 @@ describe("when rendered with new validations", () => {
   });
 
   it("renders the hint text with the correct styling when the labelHelp prop is passed", () => {
-    renderWithNewValidations({ labelHelp: "help" });
+    renderWithNewValidations({
+      labelHelp: "help",
+      value: "foo",
+      onChange: jest.fn(),
+    });
     const hintText = screen.getByText("help");
     expect(hintText).toBeInTheDocument();
     expect(hintText).toHaveStyleRule("color", "var(--colorsUtilityYin055)");
@@ -715,7 +840,7 @@ describe("when rendered with new validations", () => {
 });
 
 test("renders with the expected border radius styling", () => {
-  render(<Textbox />);
+  render(<Textbox value="foo" onChange={() => {}} />);
   expect(screen.getByRole("textbox")).toHaveStyleRule(
     "border-radius",
     "var(--borderRadius050)",


### PR DESCRIPTION
### Proposed behaviour

Remove support for uncontrolled usage from the following components:

- [ ] Textbox
- [ ] Decimal
- [ ] Number
- [ ] SimpleSelect
- [ ] Filterable Select
- [ ] MultiSelect
- [ ] GroupedCharacter
- [ ] NumeralDate
- [ ] Search
- [ ] Checkbox
- [ ] RadioButton
- [ ] Switch
- [ ] SimpleColorPicker
- [ ] AdvancedColorPicker
- [ ] ButtonToggle
- [ ] Password

### Current behaviour

Our input-based components support uncontrolled usage

### Checklist

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required
