### PR TITLE
feat(menu-item): add programmatic focus support

### DIFF
--- a/src/components/menu/index.ts
+++ b/src/components/menu/index.ts
@@ -1,7 +1,11 @@
 export { default as Menu } from "./menu.component";
 export type { MenuProps } from "./menu.types";
 export { default as MenuItem } from "./menu-item";
-export type { MenuWithIcon, MenuWithChildren } from "./menu-item";
+export type {
+  MenuWithIcon,
+  MenuWithChildren,
+  MenuItemHandle,
+} from "./menu-item";
 export { default as MenuDivider } from "./menu-divider";
 export type { MenuDividerProps } from "./menu-divider";
 export { default as MenuSegmentTitle } from "./menu-segment-title";

--- a/src/components/menu/menu-item/index.ts
+++ b/src/components/menu/menu-item/index.ts
@@ -3,4 +3,5 @@ export type {
   MenuWithChildren,
   MenuWithIcon,
   VariantType,
+  MenuItemHandle,
 } from "./menu-item.component";

--- a/src/components/menu/menu-item/menu-item.test.tsx
+++ b/src/components/menu/menu-item/menu-item.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { createRef } from "react";
 import {
   act,
   fireEvent,
@@ -9,7 +9,7 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { Menu, MenuItem, MenuSegmentTitle } from "..";
+import { Menu, MenuItem, MenuItemHandle, MenuSegmentTitle } from "..";
 import {
   StrictMenuContextType,
   StrictMenuProvider,
@@ -1205,6 +1205,72 @@ describe("when MenuItem has a submenu", () => {
 
     const bananaItem = await screen.findByRole("link", { name: "Banana" });
     expect(bananaItem).toHaveFocus();
+  });
+
+  it("should focus an interactive MenuItem when the focus method on the ref handle is invoked", async () => {
+    const menuItemHandle = createRef<MenuItemHandle>();
+    render(
+      <Menu>
+        <MenuItem href="#" ref={menuItemHandle}>
+          Apple
+        </MenuItem>
+        <MenuItem href="#">Banana</MenuItem>
+        <MenuItem href="#">Cherry</MenuItem>
+        <MenuItem href="#">Dates</MenuItem>
+      </Menu>,
+    );
+
+    act(() => {
+      menuItemHandle.current?.focus();
+    });
+
+    const appleItem = await screen.findByRole("link", { name: "Apple" });
+    expect(appleItem).toHaveFocus();
+  });
+
+  it("does not focus an non-interactive MenuItem when the focus method on the ref handle is invoked", () => {
+    const menuItemHandle = createRef<MenuItemHandle>();
+    render(
+      <Menu>
+        <MenuItem ref={menuItemHandle}>Apple</MenuItem>
+        <MenuItem href="#">Banana</MenuItem>
+        <MenuItem href="#">Cherry</MenuItem>
+        <MenuItem href="#">Dates</MenuItem>
+      </Menu>,
+    );
+
+    act(() => {
+      menuItemHandle.current?.focus();
+    });
+
+    const appleItem = screen.getByText("Apple");
+    expect(appleItem).not.toHaveFocus();
+  });
+
+  it("should focus an interactive Submenu when the focus method on the ref handle is invoked", async () => {
+    const user = userEvent.setup();
+    const menuItemHandle = createRef<MenuItemHandle>();
+    render(
+      <Menu>
+        <MenuItem submenu="Fruit">
+          <MenuItem ref={menuItemHandle} href="#">
+            Apple
+          </MenuItem>
+          <MenuItem href="#">Banana</MenuItem>
+          <MenuItem href="#">Cherry</MenuItem>
+          <MenuItem href="#">Dates</MenuItem>
+        </MenuItem>
+      </Menu>,
+    );
+    await user.tab();
+    await user.keyboard("{Enter}");
+
+    act(() => {
+      menuItemHandle.current?.focus();
+    });
+
+    const appleItem = await screen.findByRole("link", { name: "Apple" });
+    expect(appleItem).toHaveFocus();
   });
 
   it("should not open the `submenu` when initially opened via click, closed via mouseout and then non-related key pressed", async () => {

--- a/src/components/menu/menu.mdx
+++ b/src/components/menu/menu.mdx
@@ -51,6 +51,19 @@ import {
 
 > **Note**: To ensure a `MenuItem` is interactive, it should either have an `href`, `onClick` or `submenu` prop, or contain another focusable Carbon component like Button. Without one of these, the item will not be keyboard-focusable or interactive, affecting accessibility for keyboard and screen reader users.
 
+### Focusing MenuItem's Programmatically
+
+```javascript
+import { MenuItemHandle } from "carbon-react/lib/components/menu";
+```
+
+The `MenuItemHandle` type provides an imperative handle for programmatic control over `MenuItem`. 
+Using a `ref`, you can access its `focus()` method to set focus on the `MenuItem` as needed.
+
+> **Note**: The `focus()` method will only work on interactive elements. 
+
+<Canvas of={MenuStories.ProgrammaticFocus} />
+
 ### Selected
 
 <Canvas of={MenuStories.SelectedStory} />

--- a/src/components/menu/menu.stories.tsx
+++ b/src/components/menu/menu.stories.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import { allModes } from "../../../.storybook/modes";
 import generateStyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import isChromatic from "../../../.storybook/isChromatic";
 
+import Button from "../button";
 import Box from "../box";
 import useMediaQuery from "../../hooks/useMediaQuery";
 import Search, { SearchEvent } from "../search";
@@ -13,6 +14,7 @@ import Portrait from "../portrait";
 import {
   Menu,
   MenuItem,
+  MenuItemHandle,
   MenuDivider,
   MenuSegmentTitle,
   ScrollableBlock,
@@ -102,6 +104,45 @@ export const DefaultStory: MenuStory = () => {
   );
 };
 DefaultStory.storyName = "Default";
+
+export const ProgrammaticFocus: MenuStory = () => {
+  const menuItemHandle = useRef<MenuItemHandle>(null);
+
+  return (
+    <Box mb={150}>
+      <Box>
+        <Button mb={2} onClick={() => menuItemHandle.current?.focus()}>
+          Click to focus Menu Item One
+        </Button>
+        <Menu>
+          <MenuItem ref={menuItemHandle} icon="settings" href="#">
+            Menu Item One
+          </MenuItem>
+          <MenuItem icon="settings" onClick={() => {}}>
+            Menu Item Two
+          </MenuItem>
+          <MenuItem submenu="Menu Item Three">
+            <MenuItem href="#">Item Submenu One</MenuItem>
+            <MenuItem href="#">Item Submenu Two</MenuItem>
+            <MenuDivider />
+            <MenuItem icon="entry" href="#">
+              Item Submenu Three
+            </MenuItem>
+            <MenuItem icon="settings" href="#">
+              Item Submenu Four
+            </MenuItem>
+          </MenuItem>
+          <MenuItem submenu="Menu Item Four" onClick={() => {}}>
+            <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
+            <MenuItem href="#">Item Submenu Two</MenuItem>
+          </MenuItem>
+        </Menu>
+      </Box>
+    </Box>
+  );
+};
+ProgrammaticFocus.storyName = "Programmatic Focus";
+ProgrammaticFocus.parameters = { chromatic: { disableSnapshot: true } };
 
 export const SelectedStory: MenuStory = () => {
   return (


### PR DESCRIPTION
fix #7450

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

`MenuItem` now supports a `forwardRef`, to enable programmatic focus via a `useImperativeHandle`. 

`MenuItem` now exports a handle type that can be used for programmatic focus via this handle.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, `MenuItem` cannot be focused programmatically 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
