### PR TITLE
fix(dialog-full-screen): ensure title does not overlap with close button

### DIFF
--- a/src/__internal__/full-screen-heading/full-screen-heading.component.tsx
+++ b/src/__internal__/full-screen-heading/full-screen-heading.component.tsx
@@ -13,11 +13,12 @@ const FullScreenHeading = React.forwardRef<
   HTMLDivElement,
   FullScreenHeadingProps
 >((props: FullScreenHeadingProps, ref) => {
-  const { children, hasContent } = props;
+  const { children, hasContent, hasCloseButton } = props;
 
   return (
     <StyledFullScreenHeading
       hasContent={hasContent}
+      hasCloseButton={hasCloseButton}
       {...tagComponent("full-screen-heading", props)}
       ref={ref}
     >

--- a/src/__internal__/full-screen-heading/full-screen-heading.style.ts
+++ b/src/__internal__/full-screen-heading/full-screen-heading.style.ts
@@ -6,6 +6,7 @@ import {
 
 export interface StyledFullScreenHeadingProps {
   hasContent?: boolean;
+  hasCloseButton?: boolean;
 }
 
 export const StyledHeaderContainer = styled.div`
@@ -35,6 +36,15 @@ const StyledFullScreenHeading = styled.div<StyledFullScreenHeadingProps>`
   @media screen and (min-width: 1260px) {
     padding: 0 40px;
   }
+
+  ${({ hasCloseButton }) =>
+    hasCloseButton &&
+    css`
+      & {
+        // prevent the close button from overlapping the title
+        padding-right: 64px;
+      }
+    `}
 
   ${StyledHeading} {
     width: auto;

--- a/src/components/dialog-full-screen/dialog-full-screen-test.stories.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen-test.stories.tsx
@@ -246,3 +246,26 @@ export const WithWrappedStickyForm: StoryType = {
   },
   parameters: { chromatic: { disableSnapshot: true } },
 };
+
+export const WithLongTitle: StoryType = {
+  render: (args) => {
+    const { children, ...rest } = args;
+    return <DialogFullScreen {...rest}>{children}</DialogFullScreen>;
+  },
+  args: {
+    children:
+      "Lorem, ipsum dolor sit amet consectetur adipisicing elit. Alias labore nostrum quo deserunt repellendus accusamus facilis voluptatem? Dicta illo esse non! Corrupti suscipit reprehenderit ea nesciunt delectus. Non voluptate expedita, repellendus ea vitae dolor nobis aperiam ullam unde ducimus aliquam quidem veniam necessitatibus, suscipit eaque exercitationem aut corrupti, qui ipsa.",
+    open: true,
+    title:
+      "Really long title for Dialog Full Screen that should wrap in small screens",
+    subtitle: "Subtitle",
+    showCloseIcon: true,
+    onCancel: () => {},
+  },
+};
+
+WithLongTitle.storyName = "With Long Title";
+WithLongTitle.parameters = {
+  chromatic: { disableSnapshot: false, viewports: [500] },
+  themeProvider: { chromatic: { theme: "sage" } },
+};

--- a/src/components/dialog-full-screen/dialog-full-screen.component.tsx
+++ b/src/components/dialog-full-screen/dialog-full-screen.component.tsx
@@ -159,7 +159,11 @@ export const DialogFullScreen = ({
   };
 
   const dialogTitle = () => (
-    <FullScreenHeading hasContent={!!title} ref={headingRef}>
+    <FullScreenHeading
+      hasContent={!!title}
+      hasCloseButton={showCloseIcon}
+      ref={headingRef}
+    >
       {typeof title === "string" ? (
         <Heading
           data-element="dialog-title"


### PR DESCRIPTION
fix #7434

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Add extra padding-right to `DialogFullScreen` title to prevent it from overlapping the close button. 

<img width="447" height="288" alt="image" src="https://github.com/user-attachments/assets/1d6b3cf2-bfda-4053-af62-89bfcfcd06e2" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

In `DialogFullScreen`, long titles overlap with the close button due to it having absolute positioning. 

<img width="524" height="322" alt="image" src="https://github.com/user-attachments/assets/c80200fc-1162-4674-8351-6f13dceb2e06" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
