### PR TITLE
feat(link): add subtle variant & underline prop

### DIFF
--- a/src/components/link/link-test.stories.tsx
+++ b/src/components/link/link-test.stories.tsx
@@ -7,7 +7,11 @@ import Box from "../box";
 
 export default {
   title: "Link/Test",
-  includeStories: ["DefaultStory", "FlexContainer"],
+  includeStories: [
+    "DefaultStory",
+    "FlexContainer",
+    "HoverUnderlineAndWhiteVariant",
+  ],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -124,6 +128,30 @@ export const FlexContainer = () => {
 };
 
 FlexContainer.parameters = { chromatic: { disableSnapshot: false } };
+
+export const HoverUnderlineAndWhiteVariant = () => {
+  const link = (
+    <Link href="#foo" variant="subtle" isDarkBackground underline="hover">
+      Link with underline on hover and subtle variant.
+    </Link>
+  );
+  return (
+    <div
+      style={{
+        margin: "64px",
+        backgroundColor: "#000000",
+        width: "fit-content",
+        padding: "8px",
+      }}
+    >
+      {link}
+    </div>
+  );
+};
+
+HoverUnderlineAndWhiteVariant.parameters = {
+  chromatic: { disableSnapshot: false },
+};
 
 export const LinkComponent = (props: LinkProps) => {
   return (

--- a/src/components/link/link.component.tsx
+++ b/src/components/link/link.component.tsx
@@ -73,6 +73,7 @@ export const Link = React.forwardRef<
       iconAlign = "left",
       isSkipLink,
       disabled = false,
+      underline = "always",
       ariaLabel,
       rel,
       tooltipMessage,
@@ -187,6 +188,7 @@ export const Link = React.forwardRef<
       <StyledLink
         isSkipLink={isSkipLink}
         disabled={isDisabled}
+        underline={underline}
         iconAlign={iconAlign}
         className={className}
         hasContent={Boolean(children)}

--- a/src/components/link/link.mdx
+++ b/src/components/link/link.mdx
@@ -109,7 +109,7 @@ perform client-side routing, but still provide the `href` to render an HTML link
 
 ### variants
 
-Setting the `variant` prop to either `negative` or `neutral` enables overriding of the `default` styling of the `Link` component.
+Setting the `variant` prop to either `negative`, `neutral` or `subtle` enables overriding of the `default` styling of the `Link` component.
 
 <Canvas of={LinkStories.Variants} />
 

--- a/src/components/link/link.mdx
+++ b/src/components/link/link.mdx
@@ -53,6 +53,18 @@ Setting the `disabled` prop to true disables the link.
 
 <Canvas of={LinkStories.WithDisabled} />
 
+### Underline
+
+Setting the `underline` prop to `"hover"` will render the link with no underline by default, but will add an underline when the link is hovered over.
+
+<Canvas of={LinkStories.WithUnderlineOnlyOnHover} />
+
+Setting the `underline` prop to `"never"` removes the underline from the link.
+
+<Canvas of={LinkStories.WithNoUnderline} />
+
+**Please note**: Without the underline, context must be provided to the user to indicate that the text is a link.
+
 ### Icon
 
 The `icon` prop allows you to render an icon.

--- a/src/components/link/link.pw.tsx
+++ b/src/components/link/link.pw.tsx
@@ -64,6 +64,105 @@ test.describe("check props for Link component", () => {
     await expect(linkElement).toHaveCSS("cursor", "not-allowed");
   });
 
+  test("when `underline` prop is 'always' and component is not hovered, it should apply text-decoration underline", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <LinkComponent underline="always" href="#">
+        Test Content
+      </LinkComponent>,
+    );
+    const linkElement = linkChildren(page);
+    await expect(linkElement).toHaveCSS(
+      "text-decoration",
+      "underline solid rgb(0, 126, 69)",
+    );
+  });
+
+  test("when `underline` prop is 'always' and component is hovered over, it should maintain text-decoration underline", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <LinkComponent underline="always" href="#">
+        Test Content
+      </LinkComponent>,
+    );
+    const linkElement = linkChildren(page);
+    await linkElement.hover();
+    await expect(linkElement).toHaveCSS(
+      "text-decoration",
+      "underline solid rgb(0, 103, 56)",
+    );
+  });
+
+  test("when `underline` prop is 'hover' and component is not hovered over, it should apply no text-decoration", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <LinkComponent underline="hover" href="#">
+        Test Content
+      </LinkComponent>,
+    );
+    const linkElement = linkChildren(page);
+    await expect(linkElement).toHaveCSS(
+      "text-decoration",
+      "none solid rgb(0, 126, 69)",
+    );
+  });
+
+  test("when `underline` prop is 'hover' and component is hovered over, it should apply the text-decoration underline", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <LinkComponent underline="hover" href="#">
+        Test Content
+      </LinkComponent>,
+    );
+    const linkElement = linkChildren(page);
+    await linkElement.hover();
+    await expect(linkElement).toHaveCSS(
+      "text-decoration",
+      "underline solid rgb(0, 103, 56)",
+    );
+  });
+
+  test("when `underline` prop is 'never' and component is not hovered over, it should apply no text-decoration", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <LinkComponent underline="never" href="#">
+        Test Content
+      </LinkComponent>,
+    );
+    const linkElement = linkChildren(page);
+    await expect(linkElement).toHaveCSS(
+      "text-decoration",
+      "none solid rgb(0, 126, 69)",
+    );
+  });
+
+  test("when `underline` prop is 'never' and component is hovered over, it should maintain no text-decoration", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <LinkComponent underline="never" href="#">
+        Test Content
+      </LinkComponent>,
+    );
+    const linkElement = linkChildren(page);
+    await linkElement.hover();
+    await expect(linkElement).toHaveCSS(
+      "text-decoration",
+      "none solid rgb(0, 103, 56)",
+    );
+  });
+
   test("should render with icon prop", async ({ mount, page }) => {
     await mount(<LinkComponent icon="add" />);
 

--- a/src/components/link/link.pw.tsx
+++ b/src/components/link/link.pw.tsx
@@ -340,6 +340,27 @@ test.describe("check props for Link component", () => {
 
   (
     [
+      ["default", "rgb(77, 167, 126)"],
+      ["negative", "rgb(219, 115, 128)"],
+      ["neutral", "rgb(230, 235, 237)"],
+      ["subtle", "rgb(255, 255, 255)"],
+    ] as [LinkProps["variant"], string][]
+  ).forEach(([variant, defaultColor]) => {
+    test(`should render with variant prop set to ${variant} and isDarkBackground`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <LinkComponentWithDarkBackground variant={variant} isDarkBackground />,
+      );
+
+      const linkElement = linkChildren(page);
+      await expect(linkElement).toHaveCSS("color", defaultColor);
+    });
+  });
+
+  (
+    [
       ["default", "rgb(0, 103, 56)"],
       ["negative", "rgb(162, 44, 59)"],
       ["neutral", "rgb(0, 103, 56)"],
@@ -362,13 +383,16 @@ test.describe("check props for Link component", () => {
       ["default", "rgb(25, 142, 89)"],
       ["negative", "rgb(208, 75, 92)"],
       ["neutral", "rgb(25, 142, 89)"],
+      ["subtle", "rgb(255, 255, 255)"],
     ] as [LinkProps["variant"], string][]
   ).forEach(([variant, hoverColor]) => {
     test(`should render with correct hover state with isDarkBackground prop set with ${variant} variant`, async ({
       mount,
       page,
     }) => {
-      await mount(<LinkComponent variant={variant} isDarkBackground />);
+      await mount(
+        <LinkComponentWithDarkBackground variant={variant} isDarkBackground />,
+      );
 
       const linkElement = linkChildren(page);
       await linkElement.hover();
@@ -554,6 +578,24 @@ test.describe("should check accessibility for Link component", () => {
         page,
       }) => {
         await mount(<LinkComponent variant={variant} />);
+
+        await checkAccessibility(page);
+      });
+    },
+  );
+
+  (["default", "negative", "neutral"] as LinkProps["variant"][]).forEach(
+    (variant) => {
+      test(`should pass accessibility tests with variant prop set to ${variant} and isDarkBackground`, async ({
+        mount,
+        page,
+      }) => {
+        await mount(
+          <LinkComponentWithDarkBackground
+            variant={variant}
+            isDarkBackground
+          />,
+        );
 
         await checkAccessibility(page);
       });

--- a/src/components/link/link.stories.tsx
+++ b/src/components/link/link.stories.tsx
@@ -240,6 +240,30 @@ export const OnADarkBackground: Story = () => {
         </React.Fragment>
       ))}
       <br />
+      <Link
+        href="https://carbon.sage.com"
+        target="_blank"
+        rel="noreferrer noopener"
+        isDarkBackground
+        variant="subtle"
+      >
+        This is a link
+      </Link>
+      {(["left", "right"] as const).map((align) => (
+        <React.Fragment key={`${align}-subtle-variant`}>
+          <br />
+          <Link
+            icon="settings"
+            isDarkBackground
+            variant="subtle"
+            iconAlign={align}
+            href="#foo"
+          >
+            This is a link
+          </Link>
+        </React.Fragment>
+      ))}
+      <br />
       <Link isDarkBackground disabled>
         This is a link
       </Link>

--- a/src/components/link/link.stories.tsx
+++ b/src/components/link/link.stories.tsx
@@ -33,6 +33,25 @@ export const WithDisabled = () => {
 };
 WithDisabled.storyName = "With Disabled";
 
+export const WithUnderlineOnlyOnHover = () => {
+  return (
+    <Link underline="hover" href="#foo">
+      This is an anchor link with an underline applied on hover
+    </Link>
+  );
+};
+WithUnderlineOnlyOnHover.storyName = "With Underline Only On Hover";
+WithUnderlineOnlyOnHover.parameters = { chromatic: { disableSnapshot: true } };
+
+export const WithNoUnderline = () => {
+  return (
+    <Link underline="never" href="#foo">
+      This is an anchor link with no underline
+    </Link>
+  );
+};
+WithNoUnderline.storyName = "Without Underline";
+
 export const WithIcon: Story = () => {
   return (
     <Link icon="settings" href="#foo">

--- a/src/components/link/link.style.ts
+++ b/src/components/link/link.style.ts
@@ -3,7 +3,7 @@ import applyBaseTheme from "../../style/themes/apply-base-theme";
 import StyledIcon from "../icon/icon.style";
 import StyledButton from "../button/button.style";
 
-type Variants = "default" | "negative" | "neutral";
+type Variants = "default" | "negative" | "neutral" | "subtle";
 export interface StyledLinkProps {
   /** The disabled state of the link. */
   disabled?: boolean;
@@ -64,6 +64,9 @@ const colorMap: ColorMap = {
       hoverColor = "var(--colorsSemanticNegative450)";
     } else if (variant === "neutral") {
       color = "var(--colorsActionMinor100)";
+    } else if (variant === "subtle") {
+      color = "var(--colorsUtilityYang100)";
+      hoverColor = "var(--colorsUtilityYang100)";
     }
 
     return {

--- a/src/components/link/link.style.ts
+++ b/src/components/link/link.style.ts
@@ -7,6 +7,8 @@ type Variants = "default" | "negative" | "neutral";
 export interface StyledLinkProps {
   /** The disabled state of the link. */
   disabled?: boolean;
+  /** Specifies when the link underline should be displayed. */
+  underline?: "always" | "hover" | "never";
   /** Which side of the link to the render the link. */
   iconAlign?: "left" | "right";
   /** Allows to create skip link */
@@ -81,6 +83,7 @@ const StyledLink = styled.span.attrs(applyBaseTheme)<
     iconAlign,
     hasContent,
     disabled,
+    underline,
     variant,
     isDarkBackground,
     isMenuItem,
@@ -180,7 +183,19 @@ const StyledLink = styled.span.attrs(applyBaseTheme)<
 
       > a,
       > button {
-        text-decoration: ${hasContent ? "underline" : "none"};
+        text-decoration: ${hasContent && underline === "always"
+          ? "underline"
+          : "none"};
+
+        :hover {
+          text-decoration: ${
+            /* istanbul ignore next - having issues testing CSS :hover pseudo-states in jsdom */
+            hasContent && (underline === "hover" || underline === "always")
+              ? "underline"
+              : "none"
+          };
+        }
+
         ${isMenuItem && "display: inline-block;"}
 
         > ${StyledIcon} {

--- a/src/components/link/link.test.tsx
+++ b/src/components/link/link.test.tsx
@@ -568,6 +568,69 @@ describe("isDarkBackground", () => {
     });
     expect(iconElement).toHaveStyle("color: var(--colorsActionMajorYin090)");
   });
+
+  it("matches the styling when `variant` is set to subtle", () => {
+    render(
+      <Link
+        href="foo.com"
+        isDarkBackground
+        icon="home"
+        variant="subtle"
+        data-role="link"
+      />,
+    );
+
+    const linkElement = screen.getByTestId("link");
+    const iconElement = screen.getByTestId("icon");
+
+    expect(linkElement).toHaveStyle(`color: var(--colorsUtilityYang100)`);
+    expect(iconElement).toHaveStyle(`color: var(--colorsUtilityYang100)`);
+  });
+
+  it("matches the styling when `variant` is set to subtle and is hovered over", async () => {
+    const user = userEvent.setup();
+    render(
+      <Link
+        href="foo.com"
+        isDarkBackground
+        icon="home"
+        variant="subtle"
+        data-role="link"
+      />,
+    );
+
+    const linkElement = screen.getByTestId("link");
+    const iconElement = screen.getByTestId("icon");
+
+    await user.hover(linkElement);
+
+    expect(linkElement).toHaveStyle(`color: var(--colorsUtilityYang100)`);
+    expect(iconElement).toHaveStyle(`color: var(--colorsUtilityYang100)`);
+  });
+
+  it("matches the styling when `variant` is set to subtle and is focused", async () => {
+    const user = userEvent.setup();
+    render(
+      <Link
+        href="foo.com"
+        isDarkBackground
+        icon="home"
+        variant="subtle"
+        data-role="link"
+      />,
+    );
+
+    const linkElement = screen.getByTestId("link");
+    const iconElement = screen.getByTestId("icon");
+
+    await user.tab();
+
+    expect(linkElement).toHaveStyle({
+      color: "var(--colorsActionMajorYin090)",
+      backgroundColor: "var(--colorsSemanticFocus250)",
+    });
+    expect(iconElement).toHaveStyle("color: var(--colorsActionMajorYin090)");
+  });
 });
 
 // Test is just for coverage

--- a/src/components/link/link.test.tsx
+++ b/src/components/link/link.test.tsx
@@ -241,6 +241,52 @@ test("renders with custom data tags", () => {
   expect(screen.getByTestId("foo")).toHaveAttribute("data-element", "bar");
 });
 
+describe("when using the underline prop", () => {
+  it("should display an underline for all states when the prop is `always`", () => {
+    render(
+      <Link href="foo.com" underline="always">
+        Test Content
+      </Link>,
+    );
+    const linkElement = screen.getByRole("link");
+    expect(linkElement).toHaveStyle("text-decoration: underline");
+  });
+
+  it("should maintain an underline on hover when the prop is `always`", async () => {
+    const user = userEvent.setup();
+    render(
+      <Link href="foo.com" underline="always">
+        Test Content
+      </Link>,
+    );
+    const linkElement = screen.getByRole("link");
+    await user.hover(linkElement);
+    expect(linkElement).toHaveStyle("text-decoration: underline");
+  });
+
+  it("should not display an underline for all states when the prop is `never`", () => {
+    render(
+      <Link href="foo.com" underline="never">
+        Test Content
+      </Link>,
+    );
+    const linkElement = screen.getByRole("link");
+    expect(linkElement).toHaveStyle("text-decoration: none");
+  });
+
+  it("should not display an underline on hover when the prop is `never`", async () => {
+    const user = userEvent.setup();
+    render(
+      <Link href="foo.com" underline="never">
+        Test Content
+      </Link>,
+    );
+    const linkElement = screen.getByRole("link");
+    await user.hover(linkElement);
+    expect(linkElement).toHaveStyle("text-decoration: none");
+  });
+});
+
 // Test is just for coverage
 test("neutral `variant` has the expected styling when `isDarkBackground` is false", () => {
   render(


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Adds the subtle variant to `Link`, also adds the `underline` prop, which when set to `"false"` removes `text-decoration: underline` from the component.

<img width="135" height="75" alt="Screenshot 2025-07-30 at 12 53 15" src="https://github.com/user-attachments/assets/43edd06f-0afe-4bf3-a9fb-5681afa40d01" />

<img width="310" height="85" alt="Screenshot 2025-07-30 at 12 53 02" src="https://github.com/user-attachments/assets/70be66ee-64d4-4ce0-b2e7-d90745772afe" />

<img width="337" height="93" alt="Screenshot 2025-07-30 at 12 53 22" src="https://github.com/user-attachments/assets/52338608-b3e3-479f-b7b2-268d2debbf91" />


A test story has also been added to create a baseline for the use of both props when used simultaneously.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

N/A

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
