### PR TITLE
docs(link): fix profile and radio button doc link

### DIFF
--- a/src/components/profile/profile.mdx
+++ b/src/components/profile/profile.mdx
@@ -15,7 +15,7 @@ import * as ProfileStories from "./profile.stories";
   Product Design System component
 </a>
 
-- Display information alongside a [Portrait](/components/portrait) component.
+- Display information alongside a [Portrait](../?path=/docs/portrait--docs) component.
 - Useful to represent a person, user, or organisation.
 - Use initials rather than an avatar if you prefer.
 

--- a/src/components/radio-button/radio-button.mdx
+++ b/src/components/radio-button/radio-button.mdx
@@ -39,9 +39,9 @@ import {
 
 ## Related Components
 
-- Choosing one option from a very long list? [Try Select](/docs/select--default-story "Try Select").
-- Choosing more than one option? [Try Checkbox](/docs/checkbox--default-story "Try Checkbox").
-- Choosing one option from a highly visible small range? [Try Button Toggle](/story/button-toggle--default "Try Button Toggle").
+- Choosing one option from a very long list? [Try Select](../?path=/docs/select--docs).
+- Choosing more than one option? [Try Checkbox](../?path=/docs/checkbox--docs).
+- Choosing one option from a highly visible small range? [Try Button Toggle](../?path=/docs/button-toggle--docs).
 
 ## Examples
 


### PR DESCRIPTION
### Proposed behaviour

In Radio Button links to related components (Select, Checkbox and Button Toggle) link to the correct location.
In Profile docs Portrait link opens to the correct location.

### Current behaviour

In Radio Button links to related components (Select, Checkbox and Button Toggle) do not point to the correct location.
In Profile docs Portrait does not link to the correct location.

### Checklist

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

In Radio Button Docs, ensure links to Select, Checkbox and Button Toggle navigate to the expected location.
In Profile docs, ensure link to Portrait works as expected.

