### PR TITLE
[Adaptive Sidebar] Implement show/hide functionality

### DIFF
--- a/src/components/adaptive-sidebar/adaptive-sidebar-test.stories.tsx
+++ b/src/components/adaptive-sidebar/adaptive-sidebar-test.stories.tsx
@@ -488,25 +488,27 @@ export const WithDropdown: StoryObj = () => {
           <Option text="Yellow" value="11" />
         </Select>
       </Box>
-      <AdaptiveSidebar open width="50%">
-        <Typography variant="h1">Sidebar content</Typography>
-        <Select
-          name="simple-2"
-          id="simple-2"
-          label="open to test that the input and dropdowns show when the adaptive sidebar is open & triggered"
-        >
-          <Option text="Amber" value="1" />
-          <Option text="Black" value="2" />
-          <Option text="Blue" value="3" />
-          <Option text="Brown" value="4" />
-          <Option text="Green" value="5" />
-          <Option text="Orange" value="6" />
-          <Option text="Pink" value="7" />
-          <Option text="Purple" value="8" />
-          <Option text="Red" value="9" />
-          <Option text="White" value="10" />
-          <Option text="Yellow" value="11" />
-        </Select>
+      <AdaptiveSidebar open width="50%" p={2}>
+        <Box px={2}>
+          <Typography variant="h1">Sidebar content</Typography>
+          <Select
+            name="simple-2"
+            id="simple-2"
+            label="open to test that the input and dropdowns show when the adaptive sidebar is open & triggered"
+          >
+            <Option text="Amber" value="1" />
+            <Option text="Black" value="2" />
+            <Option text="Blue" value="3" />
+            <Option text="Brown" value="4" />
+            <Option text="Green" value="5" />
+            <Option text="Orange" value="6" />
+            <Option text="Pink" value="7" />
+            <Option text="Purple" value="8" />
+            <Option text="Red" value="9" />
+            <Option text="White" value="10" />
+            <Option text="Yellow" value="11" />
+          </Select>
+        </Box>
       </AdaptiveSidebar>
     </Box>
   );

--- a/src/components/adaptive-sidebar/adaptive-sidebar.component.tsx
+++ b/src/components/adaptive-sidebar/adaptive-sidebar.component.tsx
@@ -30,6 +30,8 @@ export interface AdaptiveSidebarProps
   children?: React.ReactNode;
   /** The height of the sidebar, relative to the wrapping component */
   height?: string;
+  /** Whether the sidebar is hidden from view. In this state, the adaptive sidebar will continue to receive updates, etc. but will not be visible to users */
+  hidden?: boolean;
   /** Whether the sidebar is open or closed */
   open: boolean;
   /** Whether to render the sidebar as a modal component instead of as an inline sidebar */
@@ -44,6 +46,7 @@ export const AdaptiveSidebar = ({
   borderColor = "none",
   children,
   height = "100%",
+  hidden = false,
   open,
   renderAsModal = false,
   width = "320px",
@@ -67,18 +70,33 @@ export const AdaptiveSidebar = ({
     }
   }, [open]);
 
+  // Remove inert attribute from elements when sidebar is hidden
+  /* istanbul ignore next */
+  useEffect(() => {
+    if (!hidden || !open) return;
+
+    const inertElements = document.querySelectorAll("[inert]");
+
+    inertElements.forEach((element) => {
+      element.removeAttribute("inert");
+    });
+  }, [hidden, open]);
+
   if (renderAsModal || !largeScreen) {
     return (
       <StyledSidebar
-        className="adaptive-sidebar-modal-view"
         backgroundColor={backgroundColor}
+        className="adaptive-sidebar-modal-view"
+        data-role={"adaptive-sidebar-modal-view"}
+        enableBackgroundUI={open && hidden}
+        hidden={hidden}
         open={open}
         p={0}
         ref={adaptiveSidebarRef}
       >
         <Box
-          height="100%"
           data-role="adaptive-sidebar-content-wrapper"
+          height="100%"
           {...colours}
         >
           {children}
@@ -94,6 +112,7 @@ export const AdaptiveSidebar = ({
       data-element="adaptive-sidebar"
       data-role="adaptive-sidebar"
       height={height}
+      hidden={hidden}
       ref={adaptiveSidebarRef}
       role="region"
       tabIndex={-1}

--- a/src/components/adaptive-sidebar/adaptive-sidebar.mdx
+++ b/src/components/adaptive-sidebar/adaptive-sidebar.mdx
@@ -50,7 +50,6 @@ click in the nav bar, and positions itself accordingly. This example is best vie
 
 <Canvas of={AdaptiveSidebarStories.Complex} />
 
-
 ### With Custom Width
 
 The width of the `AdaptiveSidebar` component can be customised by passing a `width` prop. The width can be set to a specific value, or omitted to use the
@@ -95,6 +94,15 @@ By default, no separator is rendered between the main content and the sidebar. I
 a `borderColor` prop. The following example demonstrates the use of a custom border color.
 
 <Canvas of={AdaptiveSidebarStories.WithCustomBorderColor} />
+
+### Hidden
+
+By using the `hidden` prop, the `AdaptiveSidebar` component can be hidden from view. This is useful for cases where the sidebar should not be displayed, but
+the component should still be rendered in the DOM. The following example demonstrates the use of the `hidden` prop. The sidebar is closed by default, and can
+be opened by clicking the "Open" button in the main content. The sidebar can be closed by clicking the "Close" button within the sidebar itself, or hidden by
+clicking the "Hide" button in the sidebar itself. The sidebar can be revealed again by clicking the "Show" button in the main content.
+
+<Canvas of={AdaptiveSidebarStories.Hidden} />
 
 ## Props
 

--- a/src/components/adaptive-sidebar/adaptive-sidebar.stories.tsx
+++ b/src/components/adaptive-sidebar/adaptive-sidebar.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { allModes } from "../../../.storybook/modes";
 import isChromatic from "../../../.storybook/isChromatic";
 import generateStyledSystemProps from "../../../.storybook/utils/styled-system-props";
@@ -13,6 +13,7 @@ import Typography from "../typography";
 import Button from "../button";
 import Hr from "../hr";
 import { Menu, MenuItem } from "../menu";
+import SplitButton from "../split-button";
 
 const styledSystemProps = generateStyledSystemProps({
   margin: true,
@@ -531,3 +532,98 @@ export const WithCustomBorderColor: Story = () => {
   );
 };
 WithCustomBorderColor.storyName = "With Custom Border Color";
+
+export const Hidden: Story = () => {
+  const [adaptiveSidebarOpen, setAdaptiveSidebarOpen] =
+    useState(defaultOpenState);
+  const [adaptiveSidebarHidden, setAdaptiveSidebarHidden] = useState(false);
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let handle: ReturnType<typeof setInterval>;
+    if (adaptiveSidebarOpen || adaptiveSidebarHidden) {
+      handle = setInterval(() => {
+        setCount((prevCount) => prevCount + 1);
+      }, 1000);
+    }
+
+    return () => clearTimeout(handle);
+  }, [adaptiveSidebarOpen, adaptiveSidebarHidden]);
+
+  const buttonText = useMemo(() => {
+    if (adaptiveSidebarHidden) {
+      return "Show";
+    } else if (adaptiveSidebarOpen) {
+      return "Close";
+    } else {
+      return "Open";
+    }
+  }, [adaptiveSidebarHidden, adaptiveSidebarOpen]);
+
+  return (
+    <Box display="flex" flexDirection="row">
+      <Box>
+        <Button
+          onClick={() => {
+            if (adaptiveSidebarHidden) {
+              setAdaptiveSidebarHidden(false);
+              return;
+            }
+            if (adaptiveSidebarOpen) {
+              setCount(0);
+              setAdaptiveSidebarOpen(false);
+              return;
+            }
+            setAdaptiveSidebarOpen(true);
+          }}
+          mb={2}
+        >
+          {buttonText}
+        </Button>
+        <Typography variant="p">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi at odio
+          ultricies, luctus dolor at, fringilla elit. Nulla non nunc eu sapien
+          tempus porta. Nullam sodales nisi ut orci efficitur, nec ullamcorper
+          nunc pulvinar. Integer eleifend a augue ac accumsan. Fusce ultrices
+          auctor aliquam. Sed eu metus sit amet est tempor ullamcorper. Praesent
+          eu elit eget lacus fermentum porta at ut dui.
+        </Typography>
+      </Box>
+      <AdaptiveSidebar
+        hidden={adaptiveSidebarHidden}
+        open={adaptiveSidebarOpen}
+        width="300px"
+      >
+        <Box
+          display="flex"
+          flexDirection="row"
+          justifyContent="space-between"
+          p={1}
+        >
+          <Typography variant="h3">Content</Typography>
+          <SplitButton
+            text="Hide"
+            onClick={() => setAdaptiveSidebarHidden(true)}
+          >
+            <Button
+              onClick={() => {
+                setCount(0);
+                setAdaptiveSidebarOpen(false);
+              }}
+            >
+              Close
+            </Button>
+          </SplitButton>
+        </Box>
+        <Hr my={0} mx={0} />
+        <Box display="flex" flexDirection="column" p={1}>
+          <Typography>
+            This counter will update every second when the sidebar is open or
+            hidden: {count}
+          </Typography>
+        </Box>
+      </AdaptiveSidebar>
+    </Box>
+  );
+};
+Hidden.storyName = "Hidden";

--- a/src/components/adaptive-sidebar/adaptive-sidebar.style.ts
+++ b/src/components/adaptive-sidebar/adaptive-sidebar.style.ts
@@ -19,11 +19,15 @@ type StyledAdaptiveSidebarProps = Pick<
   };
 
 const StyledAdaptiveSidebar = styled(Box)<StyledAdaptiveSidebarProps>`
-  ${({ backgroundColor, borderColor, height, width }) => css`
+  ${({ backgroundColor, borderColor, height, hidden, width }) => css`
     ${getColors(backgroundColor)}
     ${borderColor &&
     css`
       border-left: 1px solid var(${borderColor});
+    `}
+    ${hidden &&
+    css`
+      display: none;
     `}
     max-height: ${height};
     max-width: ${width};
@@ -37,9 +41,16 @@ const StyledAdaptiveSidebar = styled(Box)<StyledAdaptiveSidebarProps>`
 
 interface StyledSidebarProps extends SidebarProps {
   backgroundColor: "app" | "black" | "white";
+  hidden?: boolean;
 }
 
 const StyledSidebar = styled(Sidebar)<StyledSidebarProps>`
+  ${({ hidden }) => css`
+    ${hidden &&
+    css`
+      display: none;
+    `}
+  `}
   ${({ backgroundColor }) => css`
     div[data-element="sidebar-content"] {
       ${getColors(backgroundColor)}

--- a/src/components/box/box.component.tsx
+++ b/src/components/box/box.component.tsx
@@ -72,6 +72,8 @@ export interface BoxProps
   bg?: string;
   /** Set the backgroundColor attribute of the Box component */
   backgroundColor?: string;
+  /** Whether the component is hidden from view. In this state, the component will not be visible to users but will remain in the HTML document */
+  hidden?: boolean;
   /** Set the opacity attribute of the Box component */
   opacity?: string | number;
   /** Set the container to be hidden from screen readers */
@@ -106,6 +108,7 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
       opacity,
       height,
       width,
+      hidden,
       "aria-hidden": ariaHidden,
       ...rest
     }: BoxProps,
@@ -151,6 +154,7 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
         boxShadow={boxShadow}
         borderRadius={borderRadius}
         aria-hidden={ariaHidden}
+        hidden={hidden}
         {...tagComponent(dataComponent, rest)}
         {...filterStyledSystemMarginProps(rest)}
         {...filterStyledSystemPaddingProps(rest)}

--- a/src/components/box/box.style.ts
+++ b/src/components/box/box.style.ts
@@ -42,7 +42,7 @@ const StyledBox = styled.div.attrs(applyBaseTheme)<
   ${({ borderRadius = "borderRadius000" }) => css`
     border-radius: var(--${borderRadius});
   `}
-  
+
   ${({ cssProps, bg, backgroundColor, ...rest }) =>
     styledColor({ color: cssProps?.color, bg, backgroundColor, ...rest })}
 
@@ -55,7 +55,7 @@ const StyledBox = styled.div.attrs(applyBaseTheme)<
     css`
       overflow-wrap: ${overflowWrap};
     `}
-  
+
   ${({ cssProps, size }) =>
     cssProps?.height &&
     !size &&
@@ -120,6 +120,10 @@ const StyledBox = styled.div.attrs(applyBaseTheme)<
     css`
       box-shadow: var(--${boxShadow});
     `}
+
+  ${({ display, hidden }) => css`
+    display: ${hidden ? "none" : display};
+  `}
 `;
 
 export default StyledBox;

--- a/src/components/box/box.test.tsx
+++ b/src/components/box/box.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/tabindex-no-positive */
 import React from "react";
 import { getGapValue } from "style/utils/box-gap";
 import { render, screen } from "@testing-library/react";
@@ -66,6 +65,22 @@ test("sets the styling for 'column-gap' when it is passed in as a prop", () => {
   const box = screen.getByTestId("box");
   const columnGap = getGapValue("20px");
   expect(box).toHaveStyle(`column-gap: ${columnGap}`);
+});
+
+test("overrides the styling for 'display' when `hidden` is passed in as a prop", () => {
+  render(<Box display="flex" data-role="box" hidden />);
+
+  const box = screen.getByTestId("box");
+  expect(box).toHaveStyle(`display: none`);
+});
+
+[false, undefined].forEach((hidden) => {
+  test(`uses the provided styling for 'display' when 'hidden' is omitted as a prop via value, "${hidden}"`, () => {
+    render(<Box display="flex" data-role="box" hidden={hidden} />);
+
+    const box = screen.getByTestId("box");
+    expect(box).toHaveStyle(`display: flex`);
+  });
 });
 
 it("applies the boxShadow styling correctly when a design token is passed in", () => {


### PR DESCRIPTION
### Proposed behaviour

Add a property to indicate a third "state" to the `AdaptiveSidebar` that allows it to be hidden. This would visually remove it from the screen but not destroy the underlying elements, attached scripts, etc.

### Current behaviour

Currently, `AdaptiveSidebar` can only be open or closed, which is not fit for purpose when it is used to store and display e.g. agent chat or complex forms.

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

Accessibility and DS have approved this approach and have no concerns as to the suggested implementation.

### Testing instructions

A story has been added to the `AdaptiveSidebar` documentation to demonstrate the new `hidden` property: `Hidden`
