### PR TITLE
feat(badge): align with beta DS

### DIFF
--- a/src/components/badge/badge-test.stories.tsx
+++ b/src/components/badge/badge-test.stories.tsx
@@ -1,66 +1,70 @@
 import React from "react";
-import { action } from "@storybook/addon-actions";
-import Badge from ".";
+import { Meta, StoryObj } from "@storybook/react";
+import Badge, { BadgeProps } from ".";
 import Box from "../box";
 import Button from "../button";
 import MultiActionButton from "../multi-action-button";
 import SplitButton from "../split-button";
+import { Menu, MenuItem } from "../menu";
+import Icon from "../icon";
+import Portrait from "../portrait";
+import { Tabs, Tab } from "../tabs";
+import Typography from "../typography";
 
-export default {
+const meta: Meta<typeof Badge> = {
   title: "Badge/Test",
+  component: Badge,
   parameters: {
     info: { disable: true },
     chromatic: {
       disableSnapshot: true,
     },
   },
+  argTypes: {
+    counter: {
+      control: {
+        type: "text",
+      },
+    },
+  },
 };
-interface BadgeStoryProps {
-  counter?: string | number;
+
+export default meta;
+type Story = StoryObj<typeof Badge>;
+
+interface BadgeTestProps extends BadgeProps {
+  counterAsString?: string;
+  counterAsNumber?: number;
 }
 
-export const DefaultStory = ({ counter, ...args }: BadgeStoryProps) => {
-  const handleClick = () => {
-    action("click")();
-  };
+export const Default = ({
+  counterAsString,
+  counterAsNumber,
+  ...args
+}: BadgeTestProps) => {
   return (
-    <div style={{ margin: "40px" }}>
-      <Badge onClick={handleClick} counter={counter} {...args}>
-        <Button mr={0} buttonType="tertiary">
-          Filter
-        </Button>
-      </Badge>
-    </div>
-  );
-};
-DefaultStory.storyName = "default";
-DefaultStory.args = { counter: 1, color: "--colorsActionMajor500" };
-
-export const DisplayOnlyStory = ({ counter, ...args }: BadgeStoryProps) => {
-  return (
-    <Box margin="40px">
-      <Badge counter={counter} {...args}>
-        <Button mr={0} buttonType="tertiary">
-          Filter
-        </Button>
-      </Badge>
+    <Box p={3} backgroundColor="--colorsUtilityMajor025">
+      <Badge mr={2} counter={counterAsString} {...args} />
+      <Badge counter={counterAsNumber} {...args} />
     </Box>
   );
 };
-DisplayOnlyStory.storyName = "display only";
-DisplayOnlyStory.args = { counter: 1, color: "--colorsActionMajor500" };
+Default.args = {
+  counterAsString: "99+",
+  counterAsNumber: 99,
+};
 
-export const WithOtherButtons = () => {
+export const WithOtherButtons: Story = ({ ...args }) => {
   return (
     <>
-      <Badge counter={2} onClick={() => {}}>
+      <Badge {...args}>
         <MultiActionButton text="Multi action">
           <Button onClick={() => {}}>Action</Button>
           <Button onClick={() => {}}>Action</Button>
         </MultiActionButton>
       </Badge>
 
-      <Badge counter={2} onClick={() => {}}>
+      <Badge {...args}>
         <SplitButton text="Split button">
           <Button href="#">Button 1</Button>
           <Button>Button 2</Button>
@@ -70,6 +74,87 @@ export const WithOtherButtons = () => {
     </>
   );
 };
+WithOtherButtons.args = { counter: 2 };
 WithOtherButtons.parameters = {
+  themeProvider: { chromatic: { theme: "sage" } },
+  chromatic: { disableSnapshot: false },
+};
+
+export const SizesWithChildren: Story = ({ ...args }) => {
+  return (
+    <Box m={2} display="flex" gap={2}>
+      <Badge id="badge-small" size="small" {...args}>
+        <Button buttonType="secondary" aria-describedby="badge-small">
+          Filter
+        </Button>
+      </Badge>
+      <Badge id="badge-medium" size="medium" {...args}>
+        <Button buttonType="secondary" aria-describedby="badge-medium">
+          Filter
+        </Button>
+      </Badge>
+      <Badge id="badge-large" size="large" {...args}>
+        <Button buttonType="secondary" aria-describedby="badge-large">
+          Filter
+        </Button>
+      </Badge>
+    </Box>
+  );
+};
+SizesWithChildren.storyName = "Sizes with Children";
+SizesWithChildren.args = { counter: 99 };
+
+export const InMenu = ({ ...args }) => {
+  return (
+    <Menu menuType="black">
+      <MenuItem onClick={() => {}}>
+        MenuItem
+        <Badge ml={1} counter={2} {...args} />
+      </MenuItem>
+      <MenuItem ariaLabel="Notifications" onClick={() => {}}>
+        <Badge size="small" inverse counter={6} {...args}>
+          <Icon type="alert" />
+        </Badge>
+      </MenuItem>
+      <MenuItem onClick={() => {}}>
+        <Box display="flex" alignItems="center" gap="8px">
+          <Badge size="small" inverse counter={6} {...args}>
+            <Portrait size="XS" initials="JS" />
+          </Badge>
+          <Typography m={0} fontWeight="500" fontSize="14px" color="white">
+            John Smith
+          </Typography>
+        </Box>
+      </MenuItem>
+    </Menu>
+  );
+};
+InMenu.parameters = {
+  themeProvider: { chromatic: { theme: "sage" } },
+  chromatic: { disableSnapshot: false },
+};
+
+export const InTabs = ({ ...args }) => {
+  return (
+    <Tabs>
+      <Tab
+        tabId="tab-1"
+        title="Tab 1"
+        siblings={<Badge mb="2px" counter={55} {...args} />}
+      >
+        Content
+      </Tab>
+      <Tab
+        tabId="tab-2"
+        title="Tab 2"
+        siblings={<Badge mb="2px" counter={555} {...args} />}
+      >
+        Content
+      </Tab>
+    </Tabs>
+  );
+};
+InTabs.parameters = {
+  themeProvider: { chromatic: { theme: "sage" } },
   chromatic: { disableSnapshot: false },
 };

--- a/src/components/badge/badge.mdx
+++ b/src/components/badge/badge.mdx
@@ -9,14 +9,12 @@ import * as BadgeStories from "./badge.stories";
 
 <a
   target="_blank"
-  href="https://zeroheight.com/2ccf2b601/p/112938-badge/b/97debf"
+  href="https://zeroheight.com/35ee2cc26/v/latest/p/8249bb-badge"
   style={{ color: "#007E45", fontWeight: "bold", textDecoration: "underline" }}
   rel="noreferrer"
 >
   Product Design System component
 </a>
-
-Compact visual indicators that help things in common stand out.
 
 ## Contents
 
@@ -26,7 +24,7 @@ Compact visual indicators that help things in common stand out.
 
 ## Quick Start
 
-To use Badge component you need to import `Badge` and use another component as a child.
+To use Badge component, import `Badge` and use as a standalone component or wrap it around another component to position it relatively.
 
 ```javascript
 import Badge from "carbon-react/lib/components/badge";
@@ -34,30 +32,50 @@ import Badge from "carbon-react/lib/components/badge";
 
 ## Examples
 
-### Default Badge
+### Default
+
+To render a `Badge`, pass the `counter` prop with a number or string value.
+
+If the value is a number greater than `999`, it will be displayed as `999+`.
+If the value is a string, the displayed value will be limited to 4 characters, therefore please ensure to format the string accordingly.
+
+If the `counter` prop is not provided or its value is `0`, the `Badge` will not render.
 
 <Canvas of={BadgeStories.Default} />
 
-### Badge with counter > 99
+### With Children
 
-If the `counter` value greater than 2 digits, the displayed value will be truncated to "99".
+To position a `Badge` relative to another component, for example a `Button`, you can pass it as a child of `Badge`.
 
-<Canvas of={BadgeStories.WithThreeDigits} />
+Please make sure you associate the `Badge` to the component it relates to, this can be done by setting the `Badge`'s `id` to the child component's `aria-describedby`.
 
-### Badge with counter 0
+<Canvas of={BadgeStories.WithChildren} />
 
-If the `counter` value is `0`, the badge will not be displayed.
+### Sizes
 
-<Canvas of={BadgeStories.WithCounterZero} />
+You can use the `size` prop to change the size of the `Badge` to "small", "medium" (default), or "large".
 
-### Display Only
+The "small" size will not visually display the `counter` value, however the prop will still be needed for the badge to render.
 
-By not providing an `onClick` prop, the badge will be rendered as a display-only element. 
-To ensure they are accessible to screen readers, you can pass the `Badge`'s `id` to the `aria-describedby` prop of the element that it is describing.
+<Canvas of={BadgeStories.Sizes} />
 
-<Canvas of={BadgeStories.DisplayOnly} />
+### Subtle Variant
 
-### Custom Color
+By default, the `Badge` is rendered as the "typical" variant, however you can use the `variant` prop to change the appearance to "subtle".
+
+<Canvas of={BadgeStories.SubtleVariant} />
+
+### Inverse
+
+You can use the `inverse` prop to render the `Badge` with the inverse color scheme.
+
+<Canvas of={BadgeStories.Inverse} />
+
+### (Deprecated) Badge with onClick
+
+<Canvas of={BadgeStories.WithOnClick} />
+
+### (Deprecated) Custom Color
 
 You can use the `color` prop to override the default color of the component.
 

--- a/src/components/badge/badge.stories.tsx
+++ b/src/components/badge/badge.stories.tsx
@@ -4,98 +4,177 @@ import { Meta, StoryObj } from "@storybook/react";
 import Badge from ".";
 import Button from "../button";
 import Box from "../box";
+import Icon from "../icon";
 
 const meta: Meta<typeof Badge> = {
   title: "Badge",
   component: Badge,
+  argTypes: {
+    counter: {
+      control: {
+        type: "text",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Box
+        p={3}
+        display="flex"
+        justifyContent="center"
+        gap={2}
+        backgroundColor="--colorsUtilityMajor025"
+      >
+        <Story />
+      </Box>
+    ),
+  ],
 };
 
 export default meta;
 type Story = StoryObj<typeof Badge>;
 
-export const Default: Story = () => {
-  const counter = 9;
+export const Default: Story = ({ ...args }) => {
   return (
-    <Box margin="40px">
-      <Badge
-        counter={counter}
-        onClick={() => {}}
-        aria-label={`Remove ${counter} filters.`}
-      >
-        <Button mr={0} buttonType="tertiary">
-          Filter
-        </Button>
-      </Badge>
-    </Box>
+    <>
+      <Badge id="badge-default-1" counter={9} {...args} />
+      <Badge id="badge-default-2" counter={99} {...args} />
+      <Badge id="badge-default-3" counter="99+" {...args} />
+      <Badge id="badge-default-4" counter="999+" {...args} />
+    </>
   );
 };
 Default.storyName = "Default";
 
-export const WithThreeDigits: Story = () => {
-  const counter = 130;
+export const WithChildren: Story = ({ ...args }) => {
   return (
-    <Box margin="40px">
-      <Badge
-        counter={counter}
-        onClick={() => {}}
-        aria-label={`Remove ${counter} filters.`}
-      >
-        <Button mr={0} buttonType="tertiary">
-          Filter
-        </Button>
-      </Badge>
-    </Box>
+    <Badge id="badge-button" counter={99} {...args}>
+      <Button buttonType="secondary" aria-describedby="badge-button">
+        Filter
+      </Button>
+    </Badge>
   );
 };
-WithThreeDigits.storyName = "With Three Digits";
+WithChildren.storyName = "With Children";
 
-export const WithCounterZero: Story = () => {
-  const counter = 0;
+export const Sizes: Story = ({ ...args }) => {
   return (
-    <Box margin="40px">
-      <Badge
-        counter={counter}
-        onClick={() => {}}
-        aria-label={`Remove ${counter} filters.`}
-      >
-        <Button mr={0} buttonType="tertiary">
-          Filter
-        </Button>
+    <>
+      <Badge id="badge-small" counter={99} size="small" {...args}>
+        <Icon type="alert" color="black" />
       </Badge>
-    </Box>
+      <Badge id="badge-medium" counter={99} size="medium" {...args} />
+      <Badge id="badge-large" counter={99} size="large" {...args} />
+    </>
   );
 };
-WithCounterZero.storyName = "With Counter Zero";
+Sizes.storyName = "Sizes";
 
-export const DisplayOnly: Story = () => {
+export const SubtleVariant: Story = ({ ...args }) => {
+  return (
+    <>
+      <Badge id="badge-subtle-small" counter={99} size="small" {...args}>
+        <Icon type="alert" color="black" />
+      </Badge>
+      <Badge id="badge-subtle-medium" counter={99} size="medium" {...args} />
+      <Badge id="badge-subtle-large" counter={99} size="large" {...args} />
+    </>
+  );
+};
+SubtleVariant.storyName = "Subtle Variant";
+SubtleVariant.args = {
+  variant: "subtle",
+};
+
+export const Inverse: Story = ({ ...args }) => {
+  return (
+    <>
+      <Badge id="badge-inverse-small" counter={99} size="small" {...args}>
+        <Icon type="alert" color="white" />
+      </Badge>
+      <Badge id="badge-inverse-medium" counter={99} size="medium" {...args} />
+      <Badge id="badge-inverse-large" counter={99} size="large" {...args} />
+
+      <Badge
+        id="badge-icon"
+        counter={99}
+        size="small"
+        variant="subtle"
+        {...args}
+      >
+        <Icon type="alert" color="white" />
+      </Badge>
+      <Badge
+        id="badge-subtle-inverse-medium"
+        counter={99}
+        size="medium"
+        variant="subtle"
+        {...args}
+      />
+      <Badge
+        id="badge-subtle-inverse-large"
+        counter={99}
+        size="large"
+        variant="subtle"
+        {...args}
+      />
+    </>
+  );
+};
+Inverse.storyName = "Inverse";
+Inverse.args = {
+  inverse: true,
+};
+Inverse.decorators = [
+  (Story) => (
+    <Box p={3} display="flex" gap={2} backgroundColor="--colorsUtilityYin090">
+      <Story />
+    </Box>
+  ),
+];
+
+export const WithOnClick: Story = ({ ...args }) => {
   const counter = 9;
   return (
-    <Box margin="40px">
-      <Badge counter={counter} id="badge-1">
-        <Button mr={0} buttonType="tertiary" aria-describedby="badge-1">
-          Filter
-        </Button>
-      </Badge>
-    </Box>
+    <Badge
+      id="badge-onclick"
+      counter={counter}
+      onClick={() => {}}
+      aria-label={`Remove ${counter} filters.`}
+      {...args}
+    >
+      <Button aria-describedby="badge-onclick" buttonType="secondary">
+        Filter
+      </Button>
+    </Badge>
   );
 };
-DisplayOnly.storyName = "Display Only";
+WithOnClick.storyName = "With OnClick";
+WithOnClick.parameters = {
+  chromatic: {
+    disableSnapshot: true,
+  },
+};
 
-export const CustomColor: Story = () => {
+export const CustomColor: Story = ({ ...args }) => {
   const counter = 9;
   return (
-    <Box margin="40px">
-      <Badge
-        counter={counter}
-        onClick={() => {}}
-        aria-label={`Remove ${counter} filters.`}
-        color="--colorsSemanticNegative500"
+    <Badge
+      id="badge-custom-color"
+      counter={counter}
+      onClick={() => {}}
+      aria-label={`Remove ${counter} filters.`}
+      color="--colorsSemanticNegative500"
+      {...args}
+    >
+      <Button
+        aria-describedby="badge-custom-color"
+        buttonType="secondary"
+        destructive
       >
-        <Button mr={0} buttonType="tertiary" destructive>
-          Filter
-        </Button>
-      </Badge>
-    </Box>
+        Filter
+      </Button>
+    </Badge>
   );
 };
 CustomColor.storyName = "Custom Color";

--- a/src/components/badge/badge.style.ts
+++ b/src/components/badge/badge.style.ts
@@ -1,107 +1,164 @@
 import styled, { css } from "styled-components";
+import { margin } from "styled-system";
 import StyledIcon from "../icon/icon.style";
 import Button from "../button";
-import Icon from "../icon";
 import applyBaseTheme from "../../style/themes/apply-base-theme";
 import { toColor } from "../../style/utils/color";
 
-const commonStyles = `
-  overflow: hidden;
-  border-radius: var(--borderRadiusCircle);
-  position: absolute;
-  top: -14px;
-  right: -4px;
-  padding: 0;
-  margin-right: 0;
-  background: var(--colorsActionMajorYang100);
-`;
+// size of badge + 2px border
+const getSize = (size?: string) => {
+  switch (size) {
+    case "small":
+      return css`
+        width: 12px;
+        height: 12px;
+      `;
+    case "large":
+      return css`
+        min-width: 28px;
+        height: 28px;
+        padding: 0px 4px 1px;
+      `;
+    // medium
+    default:
+      return css`
+        min-width: 24px;
+        height: 24px;
+        padding: 0px 2px 1px;
+      `;
+  }
+};
+
+// TODO: replace with design tokens
+const getVariantColor = (variant?: string, inverse?: boolean) => {
+  switch (variant) {
+    case "subtle":
+      return `
+        ${inverse ? "#007ED9" : "#0060A7"};
+      `;
+    // typical
+    default:
+      return `
+        ${inverse ? "#E13E53" : "#CD384B"};
+      `;
+  }
+};
+
+const getPosition = (size?: string) => {
+  switch (size) {
+    case "small":
+      return css`
+        top: -3px;
+        right: -2px;
+      `;
+    case "large":
+      return css`
+        top: -14px;
+        right: -8px;
+      `;
+    // medium
+    default:
+      return css`
+        top: -12px;
+        right: -8px;
+      `;
+  }
+};
 
 const StyledBadgeWrapper = styled.div`
+  ${margin}
   position: relative;
   display: inline-block;
 `;
 
 const StyledCounter = styled.div`
   font-weight: 500;
-  font-size: 12px;
-  margin-top: -1px;
+  font-size: 13px;
+  line-height: 150%;
 `;
 
 interface StyledBadgeProps {
-  color: string;
-  isFocused?: boolean;
-  isHovered?: boolean;
+  customColor?: string;
+  size?: "small" | "medium" | "large";
+  variant?: "typical" | "subtle";
+  inverse?: boolean;
+  hasChildren?: boolean;
 }
 
 const StyledBadge = styled.span.attrs(applyBaseTheme).attrs(({ onClick }) => ({
   as: onClick ? Button : undefined,
 }))<StyledBadgeProps>`
-  ${commonStyles}
-  cursor: default;
-  align-items: center;
+  ${margin}
+  box-sizing: border-box;
   display: inline-flex;
+  align-items: center;
   justify-content: center;
-  width: 22px;
-  min-height: 22px;
-  border: solid 2px transparent;
-  z-index: 2;
+  overflow: hidden;
+  border-radius: 999px;
+  border: solid 2px;
 
-  ${({ color, theme }) => css`
-    border-color: ${toColor(theme, color)};
-    color: ${toColor(theme, color)};
-  `};
+  ${({
+    size,
+    variant,
+    inverse,
+    hasChildren,
+    customColor,
+    theme,
+    onClick,
+  }) => css`
+    ${getSize(size)};
+    background-color: ${getVariantColor(variant, inverse)};
 
-  ::-moz-focus-inner {
-    border: none;
-  }
+    border-color: ${inverse
+      ? "var(--colorsUtilityYin100)"
+      : "var(--colorsUtilityYang100)"};
+    color: ${inverse
+      ? "var(--colorsUtilityYin100)"
+      : "var(--colorsUtilityYang100)"};
 
-  ${({ onClick, color, theme, isFocused, isHovered }) => css`
+    ${hasChildren &&
+    css`
+      position: absolute;
+      z-index: 2;
+      ${getPosition(size)};
+    `}
+
     ${onClick &&
-    `
-      ${commonStyles}
-      width: 26px;
-      min-height: 26px;
-      text-align: center;
+    css`
+      min-height: 0;
+      :hover,
+      :focus {
+        padding: 0;
+        border-color: ${getVariantColor(variant, inverse)};
+        background-color: ${getVariantColor(variant, inverse)};
 
-      ::-moz-focus-inner {
-        border: none;
-      }
-
-      border-color: ${toColor(theme, color)};
-      color: ${toColor(theme, color)};
-
-      ${
-        (isFocused || isHovered) &&
-        `
-        && {
-          background: ${toColor(theme, color)};
-          border: none;
-          ${StyledCounter} {
-            display: none;
-          }
-
-          ${StyledIcon} {
-            display: block;
-            width: auto;
-            height: auto;
-            margin-right: 0;
-
-            :before {
-              font-size: 20px;
-              color: var(--colorsActionMajorYang100);
-            }
-          }
+        ${StyledIcon} {
+          margin: 0;
+          color: ${inverse
+            ? "var(--colorsUtilityYin100)"
+            : "var(--colorsUtilityYang100)"};
         }
-      `
       }
-      }
+    `}
+
+    ${customColor &&
+    css`
+      background-color: var(--colorsUtilityYang100);
+      border-color: ${toColor(theme, customColor)};
+      color: ${toColor(theme, customColor)};
+
+      ${onClick &&
+      // tested in playwright, RTL cannot test pseudo-classes
+      /* istanbul ignore next */
+      css`
+        :hover,
+        :focus {
+          background-color: ${toColor(theme, customColor)};
+          border-color: ${toColor(theme, customColor)};
+        }
+      `}
     `}
   `}
 `;
 
-const StyledCrossIcon = styled(Icon)`
-  margin: 0;
-  display: none;
-`;
-
-export { StyledBadge, StyledBadgeWrapper, StyledCrossIcon, StyledCounter };
+export { StyledBadge, StyledBadgeWrapper, StyledCounter };

--- a/src/components/badge/badge.test.tsx
+++ b/src/components/badge/badge.test.tsx
@@ -2,159 +2,306 @@ import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Badge from "./badge.component";
+import Logger from "../../__internal__/utils/logger";
 
-const renderComponent = (props = {}) =>
+jest.mock("../../__internal__/utils/logger");
+
+test("should log a deprecation warning for onClick prop", () => {
+  const loggerSpy = jest.spyOn(Logger, "deprecate");
+  render(<Badge onClick={() => {}} />);
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The `onClick` prop in `Badge` is deprecated and will soon be removed.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
+  loggerSpy.mockClear();
+});
+
+test("should log a deprecation warning for aria-label prop", () => {
+  const loggerSpy = jest.spyOn(Logger, "deprecate");
+  render(<Badge aria-label="Test label" />);
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The `aria-label` prop in `Badge` is deprecated and will soon be removed.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
+  loggerSpy.mockClear();
+});
+
+test("should log a deprecation warning for color prop", () => {
+  const loggerSpy = jest.spyOn(Logger, "deprecate");
+  render(<Badge color="red" />);
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The `color` prop in `Badge` is deprecated and will soon be removed.",
+  );
+  expect(loggerSpy).toHaveBeenCalledTimes(1);
+
+  loggerSpy.mockRestore();
+  loggerSpy.mockClear();
+});
+
+test("should render badge with children", () => {
   render(
-    <Badge data-role="badge" {...props}>
-      Foo
+    <Badge counter={5}>
+      <span>Test Badge</span>
     </Badge>,
   );
 
-describe("Badge", () => {
-  it("should render number when counter is between 1 and 99", () => {
-    renderComponent({ counter: 50 });
+  expect(screen.getByText("Test Badge")).toBeVisible();
+  expect(screen.getByText("5")).toBeVisible();
+});
 
-    expect(screen.getByText("50")).toBeVisible();
+test("should render counter as a number", () => {
+  render(<Badge counter={50} />);
+
+  expect(screen.getByText("50")).toBeVisible();
+});
+
+test("should render counter as a string", () => {
+  render(<Badge counter="99+" />);
+
+  expect(screen.getByText("99+")).toBeVisible();
+});
+
+test("should render `999+` when counter is a number higher than 999", () => {
+  render(<Badge counter={1000} />);
+
+  expect(screen.getByText("999+")).toBeVisible();
+});
+
+test("should trim the counter when it is a string longer than 4 characters", () => {
+  render(<Badge counter="12345" />);
+
+  expect(screen.getByText("1234")).toBeVisible();
+});
+
+test("should not render badge when counter is not set", () => {
+  render(<Badge data-role="badge" />);
+
+  expect(screen.queryByTestId("badge")).not.toBeInTheDocument();
+});
+
+test("should not render badge when counter is `0` as a number", () => {
+  render(<Badge data-role="badge" counter={0} />);
+
+  expect(screen.queryByTestId("badge")).not.toBeInTheDocument();
+});
+
+test("should not render badge when counter is a decimal number", () => {
+  render(<Badge data-role="badge" counter={3.14} />);
+
+  expect(screen.queryByTestId("badge")).not.toBeInTheDocument();
+});
+
+test("should not render badge when counter is an empty string", () => {
+  render(<Badge data-role="badge" counter="" />);
+
+  expect(screen.queryByTestId("badge")).not.toBeInTheDocument();
+});
+
+test("should not render counter if size is small", () => {
+  render(<Badge data-role="badge" counter={9} size="small" />);
+
+  expect(screen.queryByText("9")).not.toBeInTheDocument();
+  expect(screen.queryByTestId("badge")).toBeVisible();
+});
+
+test("should render with provided id", () => {
+  render(<Badge data-role="badge" counter={9} id="custom-id" />);
+
+  const badge = screen.getByTestId("badge");
+  expect(badge).toHaveAttribute("id", "custom-id");
+});
+
+test("should not render as a button if onClick is not set", () => {
+  render(<Badge counter={9} />);
+
+  expect(screen.getByText("9")).toBeVisible();
+  expect(screen.queryByRole("button")).not.toBeInTheDocument();
+});
+
+test("should render as a button when onClick is set", () => {
+  render(<Badge counter={9} onClick={() => {}} />);
+
+  expect(screen.getByText("9")).toBeVisible();
+  expect(screen.getByRole("button")).toBeVisible();
+});
+
+test("should not render as a button when onClick is set and size is small", () => {
+  render(
+    <Badge data-role="badge" counter={9} onClick={() => {}} size="small" />,
+  );
+
+  expect(screen.getByTestId("badge")).toBeVisible();
+  expect(screen.queryByRole("button")).not.toBeInTheDocument();
+});
+
+test("calls onClick callback when badge is clicked", async () => {
+  const onClick = jest.fn();
+  const user = userEvent.setup();
+
+  render(<Badge counter={9} onClick={onClick} />);
+
+  const badgeButton = screen.getByRole("button");
+  await user.click(badgeButton);
+
+  expect(onClick).toHaveBeenCalledTimes(1);
+});
+
+// coverage
+test("should render cross icon when onClick is set and badge is focused", async () => {
+  render(<Badge counter={9} onClick={() => {}} />);
+
+  const badgeButton = screen.getByRole("button");
+  let badgeCounter = screen.getByText("9");
+
+  expect(badgeCounter).toBeVisible();
+
+  act(() => {
+    badgeButton.focus();
   });
 
-  it("should render number `99` when counter is higher than 99", () => {
-    renderComponent({ counter: 101 });
+  const crossIcon = await screen.findByTestId("badge-cross-icon");
+  expect(crossIcon).toBeVisible();
+  expect(badgeCounter).not.toBeInTheDocument();
 
-    expect(screen.getByText("99")).toBeVisible();
+  act(() => {
+    badgeButton.blur();
   });
 
-  it("should not render badge when counter is `0`", () => {
-    renderComponent({ counter: 0, onClick: () => {} });
+  badgeCounter = await screen.findByText("9");
+  expect(crossIcon).not.toBeInTheDocument();
+  expect(badgeCounter).toBeVisible();
+});
 
-    expect(screen.queryByText("0")).not.toBeInTheDocument();
+// coverage
+test("should render cross icon when onClick is set and badge is hovered", async () => {
+  const user = userEvent.setup();
+  render(<Badge counter={9} onClick={() => {}} inverse />);
+
+  const badgeButton = screen.getByRole("button");
+  let badgeCounter = screen.getByText("9");
+
+  expect(badgeCounter).toBeVisible();
+
+  await user.hover(badgeButton);
+
+  const crossIcon = await screen.findByTestId("badge-cross-icon");
+  expect(crossIcon).toBeVisible();
+  expect(badgeCounter).not.toBeInTheDocument();
+
+  await user.unhover(badgeButton);
+
+  badgeCounter = await screen.findByText("9");
+  expect(crossIcon).not.toBeInTheDocument();
+  expect(badgeCounter).toBeVisible();
+});
+
+test("should have the relevant aria-label when aria-label is specified", () => {
+  render(<Badge counter={9} onClick={() => {}} aria-label="Remove filters" />);
+
+  const badgeButton = screen.getByRole("button");
+  expect(badgeButton).toHaveAccessibleName("Remove filters");
+});
+
+test("should render with provided data- attributes", () => {
+  render(<Badge counter={9} data-element="bar" data-role="baz" />);
+
+  expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
+// coverage
+test("should render with correct style when color prop is specified", () => {
+  render(
+    <Badge data-role="badge" counter={9} color="--colorsSemanticNegative500" />,
+  );
+
+  const badge = screen.getByTestId("badge");
+
+  expect(badge).toHaveStyleRule(
+    "border-color",
+    "var(--colorsSemanticNegative500)",
+  );
+  expect(badge).toHaveStyleRule("color", "var(--colorsSemanticNegative500)");
+});
+
+// coverage
+test("should render with correct style when variant is typical", () => {
+  render(<Badge data-role="badge" counter={9} variant="typical" />);
+
+  const badge = screen.getByTestId("badge");
+
+  expect(badge).toHaveStyle({ backgroundColor: "#CD384B" });
+});
+
+// coverage
+test("should render with correct style when variant is subtle", () => {
+  render(<Badge data-role="badge" counter={9} variant="subtle" />);
+
+  const badge = screen.getByTestId("badge");
+
+  expect(badge).toHaveStyle({ backgroundColor: "#0060A7" });
+});
+
+// coverage
+test("should render with correct style when variant is typical and inverse prop is true", () => {
+  render(<Badge data-role="badge" counter={9} inverse variant="typical" />);
+
+  const badge = screen.getByTestId("badge");
+
+  expect(badge).toHaveStyle({ backgroundColor: "#E13E53" });
+  expect(badge).toHaveStyleRule("border-color", "var(--colorsUtilityYin100)");
+  expect(badge).toHaveStyleRule("color", "var(--colorsUtilityYin100)");
+});
+
+// coverage
+test("should render with correct style when variant is subtle and inverse prop is true", () => {
+  render(<Badge data-role="badge" counter={9} inverse variant="subtle" />);
+
+  const badge = screen.getByTestId("badge");
+
+  expect(badge).toHaveStyle({ backgroundColor: "#007ED9" });
+  expect(badge).toHaveStyleRule("border-color", "var(--colorsUtilityYin100)");
+  expect(badge).toHaveStyleRule("color", "var(--colorsUtilityYin100)");
+});
+
+// coverage
+test("should render with correct style size is small and badge has children", () => {
+  render(
+    <Badge data-role="badge" counter={9} size="small">
+      Test
+    </Badge>,
+  );
+
+  const badge = screen.getByTestId("badge");
+
+  expect(badge).toHaveStyle({
+    width: "12px",
+    height: "12px",
+    top: "-3px",
+    right: "-2px",
   });
+});
 
-  it("should not render badge when counter is not set", () => {
-    renderComponent({ onClick: () => {} });
+// coverage
+test("should render with correct style size is large and badge has children", () => {
+  render(
+    <Badge data-role="badge" counter={9} size="large">
+      Test
+    </Badge>,
+  );
 
-    expect(screen.queryByRole("button")).not.toBeInTheDocument();
-  });
+  const badge = screen.getByTestId("badge");
 
-  it("should render as a button element when onClick is set", () => {
-    renderComponent({ counter: 9, onClick: () => {} });
-
-    expect(screen.getByText("9")).toBeVisible();
-    expect(screen.getByRole("button")).toBeVisible();
-  });
-
-  it("should hide the counter text when the badge is focused and displays it when blurred", () => {
-    renderComponent({ counter: 9, onClick: () => {} });
-
-    const badgeButton = screen.getByRole("button");
-    const badgeText = screen.getByText("9");
-
-    act(() => {
-      badgeButton.focus();
-    });
-
-    expect(badgeText).not.toBeVisible();
-
-    act(() => {
-      badgeButton.blur();
-    });
-
-    expect(badgeText).toBeVisible();
-  });
-
-  it("should hide the counter text when the badge is hovered and displays it when unhovered", async () => {
-    const user = userEvent.setup();
-
-    renderComponent({ counter: 9, onClick: () => {} });
-
-    const badgeButton = screen.getByRole("button");
-    const badgeText = screen.getByText("9");
-
-    await user.hover(badgeButton);
-
-    expect(badgeText).not.toBeVisible();
-
-    await user.unhover(badgeButton);
-
-    expect(badgeText).toBeVisible();
-  });
-
-  it("should not render as a button if onClick is not set", () => {
-    renderComponent({ counter: 9 });
-
-    expect(screen.getByText("9")).toBeVisible();
-    expect(screen.queryByRole("button")).not.toBeInTheDocument();
-  });
-
-  it("should have the relevant aria-label when aria-label is specified", () => {
-    renderComponent({
-      counter: 9,
-      onClick: () => {},
-      "aria-label": "Generic aria message",
-    });
-
-    const badgeButton = screen.getByRole("button");
-    expect(badgeButton).toHaveAccessibleName("Generic aria message");
-  });
-
-  it("should render with provided data- attributes", () => {
-    renderComponent({ counter: 9, "data-element": "bar", "data-role": "baz" });
-
-    expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
-  });
-
-  it("calls onClick callback when badge is clicked", async () => {
-    const onClick = jest.fn();
-    const user = userEvent.setup();
-
-    renderComponent({ counter: 5, onClick });
-
-    const badgeButton = screen.getByRole("button");
-    await user.click(badgeButton);
-
-    expect(onClick).toHaveBeenCalledTimes(1);
-  });
-
-  it("should render with provided id", () => {
-    renderComponent({ counter: 9, id: "custom-id" });
-
-    const badge = screen.getByTestId("badge");
-    expect(badge).toHaveAttribute("id", "custom-id");
-  });
-
-  it("should apply the correct cursor style when onClick is not specified", () => {
-    renderComponent({ counter: 9 });
-
-    const badge = screen.getByTestId("badge");
-    expect(badge).toHaveStyle({ cursor: "default" });
-  });
-
-  it("should apply correct border radius for counter", () => {
-    renderComponent({ counter: 9 });
-
-    const badge = screen.getByTestId("badge");
-    expect(badge).toHaveStyleRule("border-radius", "var(--borderRadiusCircle)");
-  });
-
-  it("should render badge with default style when color prop is not specified", () => {
-    renderComponent({ counter: 9 });
-
-    const badge = screen.getByTestId("badge");
-    expect(badge).toHaveStyleRule(
-      "border-color",
-      "var(--colorsActionMajor500)",
-    );
-    expect(badge).toHaveStyleRule("color", "var(--colorsActionMajor500)");
-  });
-
-  it("should render badge with correct style when color prop is specified", () => {
-    renderComponent({ counter: 9, color: "--colorsSemanticNegative500" });
-
-    const badge = screen.getByTestId("badge");
-
-    expect(badge).toHaveStyleRule(
-      "border-color",
-      "var(--colorsSemanticNegative500)",
-    );
-    expect(badge).toHaveStyleRule("color", "var(--colorsSemanticNegative500)");
+  expect(badge).toHaveStyle({
+    minWidth: "28px",
+    height: "28px",
+    top: "-14px",
+    right: "-8px",
   });
 });

--- a/src/components/badge/components.test-pw.tsx
+++ b/src/components/badge/components.test-pw.tsx
@@ -3,16 +3,30 @@ import Badge, { BadgeProps } from "./badge.component";
 import Box from "../box";
 import Button from "../button";
 
-const BadgeComponent = (props: Partial<BadgeProps>) => {
+export const BadgeComponent = (props: Partial<BadgeProps>) => {
   return (
-    <Box margin="40px">
-      <Badge {...props}>
-        <Button mr={0} buttonType="tertiary">
+    <Box m={2}>
+      <Badge {...props} />
+    </Box>
+  );
+};
+
+export const BadgeOnDarkBackground = (props: Partial<BadgeProps>) => {
+  return (
+    <Box m={2} backgroundColor="--colorsUtilityYin090">
+      <Badge {...props} />
+    </Box>
+  );
+};
+
+export const BadgeWithChildren = (props: Partial<BadgeProps>) => {
+  return (
+    <Box m={2}>
+      <Badge id="badge" {...props}>
+        <Button mr={0} buttonType="secondary" aria-describedby="badge">
           Filter
         </Button>
       </Badge>
     </Box>
   );
 };
-
-export default BadgeComponent;

--- a/src/components/tabs/__internal__/tab-title/tab-title.component.tsx
+++ b/src/components/tabs/__internal__/tab-title/tab-title.component.tsx
@@ -159,16 +159,7 @@ const TabTitle = React.forwardRef(
 
       const titleSiblings = (
         <StyledLayoutWrapper titlePosition={titlePosition} key="title-siblings">
-          {React.Children.toArray(siblings).map((child) => {
-            // istanbul ignore next
-            if (!React.isValidElement(child)) {
-              return child;
-            }
-            return React.cloneElement(child, {
-              ...child.props,
-              onClick: handleClick,
-            });
-          })}
+          {siblings}
         </StyledLayoutWrapper>
       );
 


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Align `Badge` component with the new beta DS:
- Deprecate `onClick`, `aria-label` and `color` props. 
- Make `children` optional to render `Badge` as a standalone component.
- Allow `counter` prop to accept number or string values - numbers greater than `1000` will display as `999+`, strings longer than 4 characters will be trimmed (e.g. `12345` will display `1234`). 
- Add `size` prop which accepts "small", "medium" and "large".
- Add `variant` prop which accepts "typical" and "subtle" variants. 
- Add `inverse` prop to apply inverse styles to badge. 

<img width="225" alt="image" src="https://github.com/user-attachments/assets/de23bf6f-d3c8-43fe-93d0-307224a18905" />

<img width="175" alt="image" src="https://github.com/user-attachments/assets/3547bbe3-e50c-4652-94bb-1065c1ce8946" />

<img width="175" alt="image" src="https://github.com/user-attachments/assets/e9894e9e-5c69-4d21-9a00-d24ba581063b" />

<img width="175" alt="image" src="https://github.com/user-attachments/assets/6e55d522-4b57-41a8-b9a8-8eb78e62e2fe" />

<img width="300" alt="image" src="https://github.com/user-attachments/assets/516e28cb-9bd3-4bc5-9f4e-45f5ea44f9ae" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

`Badge` component is not in line with the new beta DS.

<img width="150" alt="image" src="https://github.com/user-attachments/assets/a92b90d0-c451-479f-82d3-369960b8a76c" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

All stories should support controls for testing purposes - "Default" test story has controls to set `counterAsString` and `counterAsNumber`.

- Counter should not be displayed in small size. 
- If number or string equivalent to 0 is passed to `counter`, `Badge` will not render.
- Deprecated onClick behaviour should still be supported with new variants and inverse styles. 