### PR TITLE
test(password): add play functions

### DIFF
--- a/src/components/password/password-interaction.stories.tsx
+++ b/src/components/password/password-interaction.stories.tsx
@@ -1,0 +1,83 @@
+import React, { setValue } from "react";
+
+import { StoryObj } from "@storybook/react";
+import { userEvent, within } from "@storybook/test";
+
+import Password from "./password.component";
+
+import { allowInteractions } from "../../../.storybook/interaction-toggle/reduced-motion";
+import DefaultDecorator from "../../../.storybook/utils/default-decorator";
+
+type Story = StoryObj<typeof Password>;
+
+export default {
+  title: "Password/Interactions",
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
+  },
+};
+
+export const FocusTextbox: Story = {
+  render: () => (
+    <Password label="Password" value="Password" onChange={setValue} mb={2} />
+  ),
+  play: async ({ canvasElement }) => {
+    if (!allowInteractions()) {
+      return;
+    }
+    const canvas = within(canvasElement);
+    const showIcon = canvas.getByLabelText("Password");
+    await userEvent.click(showIcon);
+  },
+  decorators: [
+    (StoryToRender) => (
+      <DefaultDecorator>
+        <StoryToRender />
+      </DefaultDecorator>
+    ),
+  ],
+};
+FocusTextbox.storyName = "Focus Textbox";
+
+export const FocusButton: Story = {
+  render: () => (
+    <Password label="Password" value="Password" onChange={setValue} mb={2} />
+  ),
+  play: async () => {
+    if (!allowInteractions()) {
+      return;
+    }
+    await userEvent.tab();
+    await userEvent.keyboard("{Tab}", { delay: 500 });
+  },
+  decorators: [
+    (StoryToRender) => (
+      <DefaultDecorator>
+        <StoryToRender />
+      </DefaultDecorator>
+    ),
+  ],
+};
+FocusButton.storyName = "Focus Button";
+
+export const ShowPassword: Story = {
+  render: () => (
+    <Password label="Password" value="Password" onChange={setValue} mb={2} />
+  ),
+  play: async ({ canvasElement }) => {
+    if (!allowInteractions()) {
+      return;
+    }
+    const canvas = within(canvasElement);
+    const showIcon = canvas.getByRole("button", { name: "Show password" });
+    await userEvent.click(showIcon);
+  },
+  decorators: [
+    (StoryToRender) => (
+      <DefaultDecorator>
+        <StoryToRender />
+      </DefaultDecorator>
+    ),
+  ],
+};
+ShowPassword.storyName = "Show Password";


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Add Play Functions for `Password`.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

There are currently no Play Functions  for the `Password` component.

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Ensure interactions play as expected without error.