### PR TITLE
feat(popover-container): various design updates

### DIFF
--- a/src/components/box/box.component.tsx
+++ b/src/components/box/box.component.tsx
@@ -24,10 +24,13 @@ export type BoxSizing = "content-box" | "border-box";
 
 type DesignTokensType = keyof typeof DesignTokens;
 type BoxShadowsType = Extract<DesignTokensType, `boxShadow${string}`>;
-export type BorderRadiusType = Extract<
-  DesignTokensType,
-  `borderRadius${string}`
->;
+type BorderRadiusToken = Extract<DesignTokensType, `borderRadius${string}`>;
+
+export type BorderRadiusType =
+  | BorderRadiusToken
+  | `${BorderRadiusToken} ${BorderRadiusToken}`
+  | `${BorderRadiusToken} ${BorderRadiusToken} ${BorderRadiusToken}`
+  | `${BorderRadiusToken} ${BorderRadiusToken} ${BorderRadiusToken} ${BorderRadiusToken}`;
 
 export interface BoxProps
   extends FlexboxProps,
@@ -152,7 +155,7 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
         bg={bg}
         backgroundColor={backgroundColor}
         boxShadow={boxShadow}
-        borderRadius={borderRadius}
+        $borderRadius={borderRadius}
         aria-hidden={ariaHidden}
         hidden={hidden}
         {...tagComponent(dataComponent, rest)}

--- a/src/components/box/box.style.ts
+++ b/src/components/box/box.style.ts
@@ -24,13 +24,14 @@ const calculatePosition = (props: Omit<PositionProps, "zIndex">) => {
 };
 
 const StyledBox = styled.div.attrs(applyBaseTheme)<
-  BoxProps & {
+  Omit<BoxProps, "borderRadius"> & {
     cssProps?: {
       color?: string;
       opacity?: string;
       height?: string;
       width?: string;
     };
+    $borderRadius?: BoxProps["borderRadius"];
   }
 >`
   ${space}
@@ -39,9 +40,14 @@ const StyledBox = styled.div.attrs(applyBaseTheme)<
   ${grid}
   ${calculatePosition}
 
-  ${({ borderRadius = "borderRadius000" }) => css`
-    border-radius: var(--${borderRadius});
-  `}
+${({ $borderRadius = "borderRadius000" }) => {
+    const radiusValues = $borderRadius.split(" ");
+    return css`
+      border-radius: ${radiusValues
+        .map((radius) => `var(--${radius})`)
+        .join(" ")};
+    `;
+  }}
 
   ${({ cssProps, bg, backgroundColor, ...rest }) =>
     styledColor({ color: cssProps?.color, bg, backgroundColor, ...rest })}

--- a/src/components/box/box.test.tsx
+++ b/src/components/box/box.test.tsx
@@ -90,6 +90,21 @@ it("applies the boxShadow styling correctly when a design token is passed in", (
   expect(box).toHaveStyle(`box-shadow: var(--boxShadow100)`);
 });
 
+test("sets the correct border radius when `borderRadius` is passed with multiple border radius values", () => {
+  render(
+    <Box
+      borderRadius="borderRadius200 borderRadius200 borderRadius100 borderRadius100"
+      data-role="box"
+    />,
+  );
+
+  const box = screen.getByTestId("box");
+  expect(box).toHaveStyle({
+    borderRadius:
+      "var(--borderRadius200) var(--borderRadius200) var(--borderRadius100) var(--borderRadius100)",
+  });
+});
+
 it("applies the correct styling from the cssProps", () => {
   render(
     <Box

--- a/src/components/hr/hr.component.tsx
+++ b/src/components/hr/hr.component.tsx
@@ -13,6 +13,8 @@ export interface HrProps extends MarginProps, TagProps {
   adaptiveMxBreakpoint?: number;
   /** Set the height of the component. Accepts one of "small", "medium", or "large" */
   height?: "small" | "medium" | "large";
+  /** Set the color variant of the horizontal rule. Use "typical" for standard styling or "inverse" for use in darker backgrounds */
+  type?: "typical" | "inverse";
 }
 
 export const Hr = ({
@@ -20,6 +22,7 @@ export const Hr = ({
   ml,
   mr,
   "aria-hidden": ariaHidden,
+  type = "typical",
   height = "small",
   ...rest
 }: HrProps): JSX.Element => {
@@ -35,6 +38,7 @@ export const Hr = ({
     <StyledHr
       aria-hidden={ariaHidden}
       height={height}
+      $type={type}
       ml={marginLeft}
       mr={marginRight}
       mt={rest.mt || 3}

--- a/src/components/hr/hr.mdx
+++ b/src/components/hr/hr.mdx
@@ -42,6 +42,12 @@ The `height` prop sets the height of the hr. Accepts `"small"`, `"medium"` and `
 
 <Canvas of={HrStories.DifferentHeights} />
 
+### With inverse type
+
+The `type` prop can be set to `"inverse"` for darker backgrounds, it applies a white background color to the horizontal rule at 30% opacity.
+
+<Canvas of={HrStories.InverseType} />
+
 ### Inside a form
 
 <Canvas of={HrStories.InsideForm} />

--- a/src/components/hr/hr.stories.tsx
+++ b/src/components/hr/hr.stories.tsx
@@ -51,6 +51,22 @@ export const DifferentHeights: Story = () => {
 };
 DifferentHeights.storyName = "Different Heights";
 
+export const InverseType: Story = () => {
+  const heights = ["small", "medium", "large"] as const;
+  return (
+    <>
+      <Box backgroundColor="var(--colorsActionMajor500)">
+        {heights.map((height) => (
+          <Box key={height} mb={3}>
+            <Hr type="inverse" height={height} />
+          </Box>
+        ))}
+      </Box>
+    </>
+  );
+};
+InverseType.storyName = "Inverse Type";
+
 export const InsideForm: Story = () => {
   return (
     <Form

--- a/src/components/hr/hr.style.ts
+++ b/src/components/hr/hr.style.ts
@@ -9,13 +9,18 @@ const heightMap = {
 };
 
 const StyledHr = styled.hr.attrs(applyBaseTheme)<
-  MarginProps & { height: "small" | "medium" | "large" }
+  MarginProps & { height: "small" | "medium" | "large" } & {
+    $type?: "typical" | "inverse";
+  }
 >`
   ${margin}
   width: 100%;
   border: 0;
   height: ${({ height }) => heightMap[height]}px;
-  background: var(--colorsUtilityMajor100);
+  background-color: ${({ $type }) =>
+    $type === "typical"
+      ? "var(--colorsUtilityMajor100)"
+      : "var(--colorsActionMajorYang030)"};
 `;
 
 export default StyledHr;

--- a/src/components/hr/hr.test.tsx
+++ b/src/components/hr/hr.test.tsx
@@ -41,6 +41,13 @@ test("should render with a large height", () => {
   expect(hr).toHaveStyle("height: 3px");
 });
 
+test("should render with the correct background-color when the type prop is inverse", () => {
+  render(<Hr type="inverse" />);
+  const hr = screen.getByRole("separator");
+
+  expect(hr).toHaveStyle("background-color: var(--colorsActionMajorYang030)");
+});
+
 test("should apply the expected margin top", () => {
   render(<Hr mt={7} />);
   const hr = screen.getByRole("separator");

--- a/src/components/link/link.style.ts
+++ b/src/components/link/link.style.ts
@@ -246,6 +246,11 @@ const StyledLink = styled.span.attrs(applyBaseTheme)<
         box-shadow: 0 var(--spacing050) 0 0 var(--colorsUtilityYin090);
         border-bottom-left-radius: var(--borderRadius025);
         border-bottom-right-radius: var(--borderRadius025);
+
+        &:has([data-popover-container-button="true"]) {
+          border-bottom-left-radius: var(--borderRadius000);
+          border-bottom-right-radius: var(--borderRadius000);
+        }
       `}
 
       > button, ${StyledButton}:not(.search-button) {

--- a/src/components/menu/menu-item/menu-item.style.ts
+++ b/src/components/menu/menu-item/menu-item.style.ts
@@ -129,6 +129,10 @@ const StyledMenuItemWrapper = styled.a.attrs(applyBaseTheme).attrs({
     ${!overrideColor &&
     css`
       background-color: ${menuConfigVariants[menuType].background};
+
+      &:has([data-popover-container-button="true"]) {
+        background-color: var(--colorsActionMajor500);
+      }
     `}
 
     ${overrideColor &&
@@ -162,6 +166,15 @@ const StyledMenuItemWrapper = styled.a.attrs(applyBaseTheme).attrs({
           color: ${menuConfigVariants[menuType].color};
           z-index: 1;
           position: relative;
+        }
+      }
+
+      &:has([data-popover-container-button="true"]) {
+        && {
+          a:focus,
+          button:focus {
+            background-color: var(--colorsActionMajor500);
+          }
         }
       }
 
@@ -265,7 +278,6 @@ const StyledMenuItemWrapper = styled.a.attrs(applyBaseTheme).attrs({
             }
           `}
     `}
-
     button,
     ${StyledLink} button,
     a,

--- a/src/components/popover-container/popover-container-test.stories.tsx
+++ b/src/components/popover-container/popover-container-test.stories.tsx
@@ -238,6 +238,67 @@ export const InsideMenuWithOpenButton = () => {
   );
 };
 
+export const InsideMenuWithPrimaryOpenButton = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <Menu menuType="black">
+      <MenuItem href="#">Menu Item One</MenuItem>
+      <MenuItem onClick={() => {}} submenu="Menu Item Two">
+        <MenuItem href="#">Submenu Item One</MenuItem>
+        <MenuItem href="#">Submenu Item Two</MenuItem>
+      </MenuItem>
+      <MenuItem submenu="Search">
+        <MenuSegmentTitle text="My Title" variant="alternate">
+          <MenuItem>
+            <Search
+              key="business-search"
+              defaultValue=""
+              variant="dark"
+              placeholder="Search all businesses"
+              searchWidth="100%"
+            />
+          </MenuItem>
+          <MenuItem href="#">Submenu Item Two</MenuItem>
+        </MenuSegmentTitle>
+      </MenuItem>
+      <MenuItem>
+        <PopoverContainer
+          disableAnimation
+          containerAriaLabel="notifications"
+          closeButtonAriaLabel="closeContainerAriaLabel"
+          position="left"
+          shouldCoverButton
+          onOpen={() => setOpen(true)}
+          onClose={() => setOpen(false)}
+          open={open}
+          renderOpenComponent={({
+            ref,
+            onClick,
+            "data-popover-container-button": dataPopoverContainerButton,
+          }) => (
+            <Box data-role="gblnav-notificationui-bell">
+              <Button
+                aria-label="Notifications"
+                ref={ref}
+                onClick={onClick}
+                data-popover-container-button={dataPopoverContainerButton}
+              >
+                <Box alignItems="center" display="flex" px={2}>
+                  <Icon type="alert" />
+                  notifications
+                </Box>
+              </Button>
+            </Box>
+          )}
+        >
+          Content
+        </PopoverContainer>
+      </MenuItem>
+      <MenuItem href="#">Menu Item Six</MenuItem>
+    </Menu>
+  );
+};
+
 export const WithFullWidthButton = () => {
   return (
     <PopoverContainer

--- a/src/components/popover-container/popover-container-test.stories.tsx
+++ b/src/components/popover-container/popover-container-test.stories.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import useMediaQuery from "../../hooks/useMediaQuery";
 import Button from "../button";
 import Box from "../box";
 import PopoverContainer, {
@@ -24,10 +25,12 @@ import {
 } from "../flat-table";
 import Dialog from "../dialog";
 import Form from "../form";
+import Link from "../link";
+import Hr from "../hr";
 import DateRange, { DateRangeChangeEvent } from "../date-range";
 import DateInput, { DateChangeEvent } from "../date";
 import GlobalHeader from "../global-header";
-
+import carbonLogo from "../../../logo/carbon-logo.png";
 import isChromatic from "../../../.storybook/isChromatic";
 
 export default {
@@ -296,6 +299,156 @@ export const InsideMenuWithPrimaryOpenButton = () => {
       </MenuItem>
       <MenuItem href="#">Menu Item Six</MenuItem>
     </Menu>
+  );
+};
+
+export const InsideMenuWithPrimaryOpenButtonResponsive = () => {
+  const Logo = () => <img height={28} src={carbonLogo} alt="Carbon logo" />;
+  const [open, setOpen] = useState(false);
+  const isMid = useMediaQuery("(max-width: 1075px)");
+  const isSmall = useMediaQuery("(max-width: 512px)");
+
+  const PopoverLink = ({ text }: { text: string }) => (
+    <Link href="#" variant="subtle" isDarkBackground underline="hover">
+      {text}
+    </Link>
+  );
+
+  return (
+    <GlobalHeader logo={Logo()}>
+      <Menu menuType="black" flex="1">
+        <MenuItem flex="1" submenu="Product Switcher">
+          <MenuItem href="#">Product A</MenuItem>
+        </MenuItem>
+        <MenuItem href="#" flex="0 0 auto">
+          <PopoverContainer
+            containerAriaLabel="Create"
+            closeButtonAriaLabel="Close Create Popover"
+            position={isSmall || !isMid ? "center" : "right"}
+            offset={0}
+            p={0}
+            borderRadius="borderRadius000 borderRadius000 borderRadius200 borderRadius200"
+            onOpen={() => setOpen(true)}
+            onClose={() => setOpen(false)}
+            open={open}
+            renderOpenComponent={({
+              ref,
+              onClick,
+              "data-popover-container-button": dataPopoverContainerButton,
+            }) => (
+              <Button
+                aria-label="Create"
+                ref={ref}
+                onClick={onClick}
+                data-popover-container-button={dataPopoverContainerButton}
+              >
+                <Box alignItems="center" display="flex" px={2}>
+                  <Icon type="plus" />
+                  Create
+                </Box>
+              </Button>
+            )}
+            renderCloseComponent={({ ref, onClick }) => (
+              <Box position="absolute" right="15px" top="15px">
+                <IconButton
+                  aria-label="Close Create Popover"
+                  ref={ref}
+                  onClick={onClick}
+                >
+                  <Icon color="var(--colorsActionMajorYang100)" type="close" />
+                </IconButton>
+              </Box>
+            )}
+          >
+            <Box
+              display="flex"
+              flexDirection={!isMid ? "row" : "column"}
+              gap={!isMid ? "64px" : "24px"}
+              padding="24px 32px"
+              borderRadius="borderRadius000 borderRadius000 borderRadius200 borderRadius200"
+              backgroundColor="var(--colorsActionMajor500)"
+              boxSizing="border-box"
+              marginLeft="0"
+              maxHeight="410px"
+              overflowY="auto"
+              {...(isSmall && { width: "100vw" })}
+            >
+              <Box
+                display="flex"
+                flexDirection="column"
+                boxSizing="border-box"
+                margin="0"
+                padding="0"
+              >
+                <Typography variant="segment-subheader" color="white" m={0}>
+                  Lorem Ipsum
+                </Typography>
+                <Hr type="inverse" mt={1} mb={2} />
+                <Box display="flex" flexDirection="row" gap="32px">
+                  <Box display="flex" flexDirection="column" gap="8px">
+                    <PopoverLink text="Lorem ipsum dolor" />
+                    <PopoverLink text="Sit amet consectetur" />
+                    <PopoverLink text="Adipiscing elit sed" />
+                    <PopoverLink text="Do eiusmod tempor" />
+                    <PopoverLink text="Incididunt ut labore" />
+                    <PopoverLink text="Et dolore magna" />
+                  </Box>
+                  <Box display="flex" flexDirection="column" gap="8px">
+                    <PopoverLink text="Aliqua ut enim" />
+                    <PopoverLink text="Ad minim veniam" />
+                    <PopoverLink text="Quis nostrud exercitation" />
+                    <PopoverLink text="Ullamco laboris nisi" />
+                    <PopoverLink text="Ut aliquip ex" />
+                    <PopoverLink text="Ea commodo consequat" />
+                  </Box>
+                </Box>
+              </Box>
+              <Box
+                display="flex"
+                flexDirection="column"
+                boxSizing="border-box"
+                margin="0"
+                padding="0"
+              >
+                <Typography variant="segment-subheader" color="white" m={0}>
+                  Dolor Sit Amet
+                </Typography>
+                <Hr type="inverse" mt={1} mb={2} />
+                <Box display="flex" flexDirection="row" gap="32px">
+                  <Box display="flex" flexDirection="column" gap="8px">
+                    <PopoverLink text="Duis aute irure" />
+                    <PopoverLink text="Dolor in reprehenderit" />
+                    <PopoverLink text="In voluptate velit" />
+                    <PopoverLink text="Esse cillum dolore" />
+                    <PopoverLink text="Eu fugiat nulla" />
+                  </Box>
+                  <Box display="flex" flexDirection="column" gap="8px">
+                    <PopoverLink text="Pariatur excepteur sint" />
+                    <PopoverLink text="Occaecat cupidatat non" />
+                    <PopoverLink text="Proident sunt in" />
+                    <PopoverLink text="Culpa qui officia" />
+                    <PopoverLink text="Deserunt mollit anim" />
+                  </Box>
+                </Box>
+              </Box>
+            </Box>
+          </PopoverContainer>
+        </MenuItem>
+        <MenuItem href="#" flex="0 0 auto" icon="person">
+          User name
+        </MenuItem>
+        <MenuItem href="#" flex="0 0 auto" icon="person">
+          User name
+        </MenuItem>
+        <MenuItem flex="0 0 auto" submenu="Selected role">
+          <MenuItem href="#">Administrator</MenuItem>
+        </MenuItem>
+        <MenuItem ariaLabel="search" icon="search" href="#" />
+        <MenuItem ariaLabel="alert" icon="alert" href="#" />
+        <MenuItem ariaLabel="settings" icon="settings" href="#" />
+        <MenuItem ariaLabel="logout" icon="logout" href="#" />
+      </Menu>
+    </GlobalHeader>
   );
 };
 

--- a/src/components/popover-container/popover-container.component.tsx
+++ b/src/components/popover-container/popover-container.component.tsx
@@ -394,12 +394,14 @@ export const PopoverContainer = forwardRef<
         {...filterStyledSystemPaddingProps(rest)}
       >
         <PopoverContainerHeaderStyle>
-          <PopoverContainerTitleStyle
-            id={popoverContainerId}
-            data-element="popover-container-title"
-          >
-            {title}
-          </PopoverContainerTitleStyle>
+          {title && (
+            <PopoverContainerTitleStyle
+              id={popoverContainerId}
+              data-element="popover-container-title"
+            >
+              {title}
+            </PopoverContainerTitleStyle>
+          )}
           {renderCloseComponent(renderCloseComponentProps)}
         </PopoverContainerHeaderStyle>
         {children}

--- a/src/components/popover-container/popover-container.component.tsx
+++ b/src/components/popover-container/popover-container.component.tsx
@@ -130,6 +130,8 @@ export interface PopoverContainerProps extends PaddingProps, TagProps {
   children?: React.ReactNode;
   /** Sets rendering position of dialog */
   position?: Position;
+  /** The popover offset from the reference element */
+  offset?: number;
   /** Sets the popover container dialog header name */
   title?: string;
   /** Sets the border radius of the popover container */
@@ -170,20 +172,24 @@ export type PopoverContainerHandle = {
   focusButton: () => void;
 } | null;
 
-function usePopoverMiddleware(shouldCoverButton: boolean, isCentered: boolean) {
+function usePopoverMiddleware(
+  shouldCoverButton: boolean,
+  isCentered: boolean,
+  popoverOffset: number,
+) {
   return useMemo(
     () => [
       offset(
         shouldCoverButton
           ? ({ rects }) => ({ mainAxis: -rects.reference.height })
-          : 6,
+          : popoverOffset,
       ),
       flip({
         fallbackStrategy: "initialPlacement",
       }),
       ...(isCentered ? [shift()] : []),
     ],
-    [shouldCoverButton, isCentered],
+    [shouldCoverButton, isCentered, popoverOffset],
   );
 }
 
@@ -197,6 +203,7 @@ export const PopoverContainer = forwardRef<
       title,
       borderRadius,
       position = "right",
+      offset = 6,
       open,
       onOpen,
       onClose,
@@ -235,6 +242,7 @@ export const PopoverContainer = forwardRef<
     const popoverMiddleware = usePopoverMiddleware(
       shouldCoverButton,
       position === "center",
+      offset,
     );
     const { isInFlatTable } = useContext(FlatTableContext);
 
@@ -405,6 +413,7 @@ export const PopoverContainer = forwardRef<
         aria-describedby={ariaDescribedBy}
         p="16px 24px"
         $borderRadius={borderRadius}
+        $popoverOffset={offset}
         ref={popoverContentNodeRef}
         tabIndex={-1}
         disableAnimation={disableAnimation || reduceMotion}

--- a/src/components/popover-container/popover-container.component.tsx
+++ b/src/components/popover-container/popover-container.component.tsx
@@ -50,6 +50,7 @@ export interface RenderOpenProps {
   id?: string;
   "aria-expanded": boolean;
   "aria-haspopup": "dialog";
+  "data-popover-container-button"?: string;
 }
 
 export const renderOpen = ({
@@ -373,6 +374,7 @@ export const PopoverContainer = forwardRef<
       ref: openButtonRef,
       "aria-label": openButtonAriaLabel || title,
       id: isOpen ? undefined : popoverContainerId,
+      "data-popover-container-button": "true",
     };
 
     const renderCloseComponentProps = {

--- a/src/components/popover-container/popover-container.component.tsx
+++ b/src/components/popover-container/popover-container.component.tsx
@@ -33,6 +33,7 @@ import useFocusPortalContent from "../../hooks/__internal__/useFocusPortalConten
 import tagComponent, {
   TagProps,
 } from "../../__internal__/utils/helpers/tags/tags";
+import { BoxProps } from "../box";
 import { defaultFocusableSelectors } from "../../__internal__/focus-trap/focus-trap-utils";
 import FlatTableContext from "../flat-table/__internal__/flat-table.context";
 import { useGlobalHeader } from "../global-header/__internal__/global-header.context";
@@ -131,6 +132,8 @@ export interface PopoverContainerProps extends PaddingProps, TagProps {
   position?: Position;
   /** Sets the popover container dialog header name */
   title?: string;
+  /** Sets the border radius of the popover container */
+  borderRadius?: BoxProps["borderRadius"];
   /** Callback fires when close icon clicked */
   onClose?: (
     ev:
@@ -192,6 +195,7 @@ export const PopoverContainer = forwardRef<
     {
       children,
       title,
+      borderRadius,
       position = "right",
       open,
       onOpen,
@@ -400,6 +404,7 @@ export const PopoverContainer = forwardRef<
         aria-label={containerAriaLabel}
         aria-describedby={ariaDescribedBy}
         p="16px 24px"
+        $borderRadius={borderRadius}
         ref={popoverContentNodeRef}
         tabIndex={-1}
         disableAnimation={disableAnimation || reduceMotion}

--- a/src/components/popover-container/popover-container.mdx
+++ b/src/components/popover-container/popover-container.mdx
@@ -50,6 +50,12 @@ The center position automatically calculates the optimal placement to keep the p
 
 <Canvas of={PopoverContainerStories.CenterPosition} />
 
+### Border Radius
+
+Use the `borderRadius` prop to customise the corner rounding of the `PopoverContainer`.
+
+<Canvas of={PopoverContainerStories.BorderRadius} />
+
 ### Cover Button
 
 Use the `shouldCoverButton` prop to hide the open button when the `PopoverContainer` is open.

--- a/src/components/popover-container/popover-container.mdx
+++ b/src/components/popover-container/popover-container.mdx
@@ -41,7 +41,14 @@ of the screen.
 
 **Please note you should supply an `onClose` when controlling the `open` state in order for the `PopoverContainer` to close when clicking outside of the wrapper element**
 
-<Canvas of={PopoverContainerStories.Position} />
+<Canvas of={PopoverContainerStories.RightPosition} />
+
+### Center Aligned
+
+Use `position="center"` to center the `PopoverContainer` below the trigger element. This positioning is ideal when your trigger element is centrally located and you want the popover to appear directly underneath it, maintaining visual alignment.
+The center position automatically calculates the optimal placement to keep the popover centered relative to its trigger, while ensuring it stays within the viewport boundaries.
+
+<Canvas of={PopoverContainerStories.CenterPosition} />
 
 ### Cover Button
 

--- a/src/components/popover-container/popover-container.mdx
+++ b/src/components/popover-container/popover-container.mdx
@@ -56,6 +56,12 @@ Use the `borderRadius` prop to customise the corner rounding of the `PopoverCont
 
 <Canvas of={PopoverContainerStories.BorderRadius} />
 
+### Offset
+
+Use the `offset` prop to control the distance between the `PopoverContainer` and its trigger element. 
+
+<Canvas of={PopoverContainerStories.Offset} />
+
 ### Cover Button
 
 Use the `shouldCoverButton` prop to hide the open button when the `PopoverContainer` is open.

--- a/src/components/popover-container/popover-container.stories.tsx
+++ b/src/components/popover-container/popover-container.stories.tsx
@@ -144,6 +144,26 @@ export const BorderRadius: Story = () => {
 };
 BorderRadius.storyName = "Border Radius";
 
+export const Offset: Story = () => {
+  const [open, setOpen] = useState(defaultOpenState);
+  const onOpen = () => setOpen(true);
+  const onClose = () => setOpen(false);
+  return (
+    <Box height={100}>
+      <PopoverContainer
+        title="Offset"
+        offset={0}
+        open={open}
+        onClose={onClose}
+        onOpen={onOpen}
+      >
+        Contents
+      </PopoverContainer>
+    </Box>
+  );
+};
+Offset.storyName = "Offset";
+
 export const CoverButton: Story = () => {
   const [open, setOpen] = useState(defaultOpenState);
   const onOpen = () => setOpen(true);

--- a/src/components/popover-container/popover-container.stories.tsx
+++ b/src/components/popover-container/popover-container.stories.tsx
@@ -124,6 +124,26 @@ export const CenterPosition: Story = () => {
 };
 CenterPosition.storyName = "Center Position";
 
+export const BorderRadius: Story = () => {
+  const [open, setOpen] = useState(defaultOpenState);
+  const onOpen = () => setOpen(true);
+  const onClose = () => setOpen(false);
+  return (
+    <Box height={100}>
+      <PopoverContainer
+        title="Border Radius"
+        borderRadius="borderRadius000 borderRadius000 borderRadius200 borderRadius200"
+        open={open}
+        onClose={onClose}
+        onOpen={onOpen}
+      >
+        Contents
+      </PopoverContainer>
+    </Box>
+  );
+};
+BorderRadius.storyName = "Border Radius";
+
 export const CoverButton: Story = () => {
   const [open, setOpen] = useState(defaultOpenState);
   const onOpen = () => setOpen(true);

--- a/src/components/popover-container/popover-container.stories.tsx
+++ b/src/components/popover-container/popover-container.stories.tsx
@@ -84,7 +84,7 @@ export const Title: Story = () => {
 };
 Title.storyName = "Title";
 
-export const Position: Story = () => {
+export const RightPosition: Story = () => {
   const [open, setOpen] = useState(defaultOpenState);
   const onOpen = () => setOpen(true);
   const onClose = () => setOpen(false);
@@ -102,7 +102,27 @@ export const Position: Story = () => {
     </div>
   );
 };
-Position.storyName = "Position";
+RightPosition.storyName = "Right Position";
+
+export const CenterPosition: Story = () => {
+  const [open, setOpen] = useState(defaultOpenState);
+  const onOpen = () => setOpen(true);
+  const onClose = () => setOpen(false);
+  return (
+    <Box height={150} display="flex" justifyContent="center">
+      <PopoverContainer
+        title="Center Aligned"
+        position="center"
+        open={open}
+        onClose={onClose}
+        onOpen={onOpen}
+      >
+        Contents
+      </PopoverContainer>
+    </Box>
+  );
+};
+CenterPosition.storyName = "Center Position";
 
 export const CoverButton: Story = () => {
   const [open, setOpen] = useState(defaultOpenState);

--- a/src/components/popover-container/popover-container.style.ts
+++ b/src/components/popover-container/popover-container.style.ts
@@ -51,6 +51,7 @@ type PopoverContainerContentStyleProps = {
   disableAnimation?: boolean;
   zIndex?: number;
   $borderRadius?: BoxProps["borderRadius"];
+  $popoverOffset?: number;
 };
 
 const PopoverContainerContentStyle = styled.div.attrs(
@@ -72,7 +73,7 @@ const PopoverContainerContentStyle = styled.div.attrs(
   position: absolute;
   z-index: ${({ zIndex }) => zIndex};
 
-  ${({ disableAnimation }) =>
+  ${({ disableAnimation, $popoverOffset }) =>
     disableAnimation
       ? css`
           opacity: 1;
@@ -81,7 +82,12 @@ const PopoverContainerContentStyle = styled.div.attrs(
       : css`
           &.enter {
             opacity: 0;
-            transform: translateY(-8px);
+            transform: translateY(
+              ${
+                /* istanbul ignore next */
+                $popoverOffset ? -8 : 0
+              }px
+            );
           }
 
           &.enter-done {

--- a/src/components/popover-container/popover-container.style.ts
+++ b/src/components/popover-container/popover-container.style.ts
@@ -26,11 +26,23 @@ const PopoverContainerWrapperStyle = styled.div<PopoverContainerWrapperProps>`
     `}
 `;
 
+const PopoverContainerTitleStyle = styled.div`
+  font-size: 16px;
+  font-weight: 500;
+`;
+
 const PopoverContainerHeaderStyle = styled.div`
   display: flex;
-  justify-content: space-between;
-  margin-bottom: 8px;
   max-width: 280px;
+
+  &:has(${PopoverContainerTitleStyle}) {
+    margin-bottom: 8px;
+    justify-content: space-between;
+  }
+
+  &:not(:has(${PopoverContainerTitleStyle})) {
+    justify-content: end;
+  }
 `;
 
 type PopoverContainerContentStyleProps = {
@@ -128,11 +140,6 @@ const PopoverContainerCloseIcon = styled(IconButton)<AdditionalIconButtonProps>`
   ${StyledIcon} {
     color: var(--colorsActionMinor500);
   }
-`;
-
-const PopoverContainerTitleStyle = styled.div`
-  font-size: 16px;
-  font-weight: 500;
 `;
 
 export {

--- a/src/components/popover-container/popover-container.style.ts
+++ b/src/components/popover-container/popover-container.style.ts
@@ -10,6 +10,7 @@ import {
   StyledFormContent,
   StyledFormFooter,
 } from "../form/form.style";
+import { BoxProps } from "../box";
 
 type PopoverContainerWrapperProps = {
   hasFullWidth?: boolean;
@@ -49,6 +50,7 @@ type PopoverContainerContentStyleProps = {
   animationState?: TransitionStatus;
   disableAnimation?: boolean;
   zIndex?: number;
+  $borderRadius?: BoxProps["borderRadius"];
 };
 
 const PopoverContainerContentStyle = styled.div.attrs(
@@ -57,7 +59,14 @@ const PopoverContainerContentStyle = styled.div.attrs(
   ${padding}
 
   background: var(--colorsUtilityYang100);
-  border-radius: var(--borderRadius100);
+  ${({ $borderRadius = "borderRadius100" }) => {
+    const radiusValues = $borderRadius.split(" ").filter(Boolean);
+    return css`
+      border-radius: ${radiusValues
+        .map((radius) => `var(--${radius.trim()})`)
+        .join(" ")};
+    `;
+  }}
   box-shadow: var(--boxShadow100);
   min-width: 300px;
   position: absolute;

--- a/src/components/popover-container/popover-container.test.tsx
+++ b/src/components/popover-container/popover-container.test.tsx
@@ -167,6 +167,42 @@ test("popup title has correct data tag", () => {
   );
 });
 
+test("popover renders with the correct default border radius", () => {
+  render(<PopoverContainer open>Ta da!</PopoverContainer>);
+
+  expect(screen.getByRole("dialog")).toHaveStyle({
+    borderRadius: "var(--borderRadius100)",
+  });
+});
+
+test("popover renders with the correct border radius when `borderRadius` is passed", () => {
+  render(
+    <PopoverContainer borderRadius="borderRadius200" open>
+      Ta da!
+    </PopoverContainer>,
+  );
+
+  expect(screen.getByRole("dialog")).toHaveStyle({
+    borderRadius: "var(--borderRadius200)",
+  });
+});
+
+test("popover renders with the correct border radius when `borderRadius` is passed with mutple border radius values", () => {
+  render(
+    <PopoverContainer
+      borderRadius="borderRadius200 borderRadius200 borderRadius100 borderRadius100"
+      open
+    >
+      Ta da!
+    </PopoverContainer>,
+  );
+
+  expect(screen.getByRole("dialog")).toHaveStyle({
+    borderRadius:
+      "var(--borderRadius200) var(--borderRadius200) var(--borderRadius100) var(--borderRadius100)",
+  });
+});
+
 describe("close button", () => {
   it("renders close button in popup when onClose prop is passed", () => {
     render(

--- a/src/components/popover-container/popover-container.test.tsx
+++ b/src/components/popover-container/popover-container.test.tsx
@@ -293,6 +293,7 @@ test("popup allows outside focus when shouldCoverButton prop is false", async ()
 test.each([
   ["left", "bottom-end"],
   ["right", "bottom-start"],
+  ["center", "bottom"],
 ] as const)(
   "computes popup positioning correctly when position prop is '%s'",
   async (position, placement) => {


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Adds the `type` prop with a `"inverse"` option to `Hr`

<img width="973" height="109" alt="Screenshot 2025-08-08 at 15 58 31" src="https://github.com/user-attachments/assets/bf64e644-1ff2-45c4-b19e-82449cc4f7ac" />

Adds the center positon to `PopoverContainer`

<img width="470" height="169" alt="Screenshot 2025-08-08 at 15 58 05" src="https://github.com/user-attachments/assets/6161b2fc-bdf7-4db5-a5c7-17e10b0f1d4b" />

Adds the `borderRadius` prop to `PopoverContainer`

<img width="416" height="158" alt="Screenshot 2025-08-12 at 10 11 48" src="https://github.com/user-attachments/assets/8b3abbd9-e080-45c8-9c59-0b2ce54847a4" />

Adds the `offset` prop to `PopoverContainer`

<img width="399" height="153" alt="Screenshot 2025-08-12 at 10 12 03" src="https://github.com/user-attachments/assets/730e3cd4-d909-44f1-a264-e3eec381b694" />

Adds the `data-popover-container-button` to `renderOpenComponent`'s to prop interface

<img width="653" height="69" alt="Screenshot 2025-08-12 at 10 12 30" src="https://github.com/user-attachments/assets/f28c2e07-c45e-403a-9928-598919af97cb" />

Adds multiple border radius value support to `Box`

Adds conditional rendering for the `title` prop on `PopoverContainer`

adds a test story for the primary open button responsive example

<img width="828" height="362" alt="Screenshot 2025-08-12 at 10 12 57" src="https://github.com/user-attachments/assets/25194eba-fa3d-43b3-b818-515e33e230a3" />


<img width="497" height="544" alt="Screenshot 2025-08-12 at 10 13 07" src="https://github.com/user-attachments/assets/c80df8f2-68a6-4482-bdd1-f40d18490470" />

<img width="492" height="577" alt="Screenshot 2025-08-12 at 10 13 25" src="https://github.com/user-attachments/assets/b1205df4-a3a2-49e1-a63a-6690aeea6ccc" />


### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

No `type` prop on `Hr`
No ability to center the `PopoverContainer`
No ability to set a border radius on `PopoverContainer`
No ability to add an offset to `PopoverContainer`
An empty title container is rendered even when `title` is not passed
Only one border radius value can be used on `Box`
`data-popover-container-button` is not currently present on the renderOpenComponent's prop interface


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Each prop added can be tested in isolation on each relevant components' story book docs. The full implementation can be seen on the new test story that has been added.
