### PR TITLE
fix(responsive-vertical-menu): ensure secondary menu is a child of primary

### DIFF
--- a/src/components/vertical-menu/responsive-vertical-menu/__internal__/focus.context.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/__internal__/focus.context.tsx
@@ -24,9 +24,7 @@ interface MenuFocusContextType {
     parentId?: string;
   }>;
   focusItem: (id: string) => void;
-  moveFocus: (
-    direction: "next" | "prev" | "parent" | "firstChild" | "lastChild",
-  ) => void;
+  moveFocus: (direction: "next" | "prev" | "parent" | "lastChild") => void;
   registerMenuItem: (
     id: string,
     ref: RefObject<HTMLElement>,
@@ -151,7 +149,7 @@ export const MenuFocusProvider = ({ children }: { children: ReactNode }) => {
   // and then finds the next item based on the direction.
   // It also handles expanding/collapsing items as needed.
   const moveFocus = useCallback(
-    (direction: "next" | "prev" | "parent" | "firstChild" | "lastChild") => {
+    (direction: "next" | "prev" | "parent" | "lastChild") => {
       /* istanbul ignore if */
       if (!focusedItemId) return;
 
@@ -172,19 +170,6 @@ export const MenuFocusProvider = ({ children }: { children: ReactNode }) => {
           /* istanbul ignore else */
           if (currentItem.parentId) {
             focusItem(currentItem.parentId);
-          }
-          break;
-
-        // Move focus to the first child
-        // If the current item has children and is not already expanded,
-        // expand it and focus on the first child
-        case "firstChild":
-          /* istanbul ignore else */
-          if (currentItem.childIds.length > 0) {
-            if (!expandedItems.includes(focusedItemId)) {
-              expandItem(focusedItemId, true);
-            }
-            focusItem(currentItem.childIds[0]);
           }
           break;
 

--- a/src/components/vertical-menu/responsive-vertical-menu/components.test-pw.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/components.test-pw.tsx
@@ -4,7 +4,6 @@ import {
   ResponsiveVerticalMenu,
   ResponsiveVerticalMenuItem,
   ResponsiveVerticalMenuProps,
-  ResponsiveVerticalMenuProvider,
   ResponsiveVerticalMenuDivider,
 } from ".";
 
@@ -15,35 +14,33 @@ export const ResponsiveVerticalMenuDefaultComponent = (
 ) => {
   return (
     <Box height="100vh">
-      <ResponsiveVerticalMenuProvider>
-        <ResponsiveVerticalMenu height="100%" {...props}>
+      <ResponsiveVerticalMenu height="100%" {...props}>
+        <ResponsiveVerticalMenuItem
+          icon="home"
+          id="primary-menu"
+          label="Primary Menu With Children"
+        >
           <ResponsiveVerticalMenuItem
-            icon="home"
-            id="primary-menu"
-            label="Primary Menu With Children"
+            id="secondary-menu"
+            label="Secondary Menu With Children"
           >
             <ResponsiveVerticalMenuItem
-              id="secondary-menu"
-              label="Secondary Menu With Children"
-            >
-              <ResponsiveVerticalMenuItem
-                id="tertiary-menu"
-                label="Tertiary Menu"
-              />
-            </ResponsiveVerticalMenuItem>
-            <ResponsiveVerticalMenuItem
-              id="secondary-menu-no-children"
-              label="Secondary Menu Item"
+              id="tertiary-menu"
+              label="Tertiary Menu"
             />
           </ResponsiveVerticalMenuItem>
-          <ResponsiveVerticalMenuDivider />
           <ResponsiveVerticalMenuItem
-            icon="home"
-            id="primary-menu-no-children"
-            label="Primary Menu Item"
+            id="secondary-menu-no-children"
+            label="Secondary Menu Item"
           />
-        </ResponsiveVerticalMenu>
-      </ResponsiveVerticalMenuProvider>
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem
+          icon="home"
+          id="primary-menu-no-children"
+          label="Primary Menu Item"
+        />
+      </ResponsiveVerticalMenu>
     </Box>
   );
 };
@@ -104,58 +101,101 @@ export const ResponsiveVerticalMenuIconMixture = (
 
   return (
     <Box height="100vh">
-      <ResponsiveVerticalMenuProvider>
-        <ResponsiveVerticalMenu height="100%" {...props}>
+      <ResponsiveVerticalMenu height="100%" {...props}>
+        <ResponsiveVerticalMenuItem
+          icon="home"
+          id="primary-menu-item-with-icon"
+          label="Primary Icon"
+        />
+        <ResponsiveVerticalMenuItem
+          id="primary-menu-item-with-no-icon"
+          label="Primary No Icon"
+        />
+        <ResponsiveVerticalMenuItem
+          customIcon={<CustomAccountingIcon />}
+          id="primary-menu-item-with-custom-icon"
+          label="Primary Custom Icon"
+        />
+        <ResponsiveVerticalMenuItem
+          id="secondary-menu-toggle"
+          label="Secondary Menu Toggle"
+        >
           <ResponsiveVerticalMenuItem
-            icon="home"
-            id="primary-menu-item-with-icon"
-            label="Primary Icon"
+            id="secondary-menu-item-with-icon"
+            label="Secondary Icon"
           />
           <ResponsiveVerticalMenuItem
-            id="primary-menu-item-with-no-icon"
-            label="Primary No Icon"
+            id="secondary-menu-item-with-no-icon"
+            label="Secondary No Icon"
           />
           <ResponsiveVerticalMenuItem
-            customIcon={<CustomAccountingIcon />}
-            id="primary-menu-item-with-custom-icon"
-            label="Primary Custom Icon"
+            id="secondary-menu-item-with-custom-icon"
+            label="Secondary Custom Icon"
           />
           <ResponsiveVerticalMenuItem
-            id="secondary-menu-toggle"
-            label="Secondary Menu Toggle"
+            id="tertiary-menu-toggle"
+            label="Tertiary Menu Toggle"
           >
             <ResponsiveVerticalMenuItem
-              id="secondary-menu-item-with-icon"
-              label="Secondary Icon"
+              id="tertiary-menu-item-with-icon"
+              label="Tertiary Icon"
             />
             <ResponsiveVerticalMenuItem
-              id="secondary-menu-item-with-no-icon"
-              label="Secondary No Icon"
+              id="tertiary-menu-item-with-no-icon"
+              label="Tertiary No Icon"
             />
             <ResponsiveVerticalMenuItem
-              id="secondary-menu-item-with-custom-icon"
-              label="Secondary Custom Icon"
+              id="tertiary-menu-item-with-custom-icon"
+              label="Tertiary Custom Icon"
             />
+          </ResponsiveVerticalMenuItem>
+        </ResponsiveVerticalMenuItem>
+      </ResponsiveVerticalMenu>
+    </Box>
+  );
+};
+
+export const WithDifferentDepthsAsLastItem = () => {
+  return (
+    <Box height="100vh">
+      <ResponsiveVerticalMenu>
+        <ResponsiveVerticalMenuItem id="with-level-2" label="With Level 2">
+          <ResponsiveVerticalMenuItem
+            href="#"
+            id="level-2-as-last-item"
+            label="Level 2 As Last Item"
+          />
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuItem id="with-level-3" label="With Level 3">
+          <ResponsiveVerticalMenuItem
+            id="level-2-parent-1"
+            label="Level 2 Parent"
+          >
             <ResponsiveVerticalMenuItem
-              id="tertiary-menu-toggle"
-              label="Tertiary Menu Toggle"
+              href="#"
+              id="level-3-as-last-item"
+              label="Level 3 As Last Item"
+            />
+          </ResponsiveVerticalMenuItem>
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuItem id="with-level-4" label="With Level 4">
+          <ResponsiveVerticalMenuItem
+            id="level-2-parent-2"
+            label="Level 2 Parent"
+          >
+            <ResponsiveVerticalMenuItem
+              id="level-3-parent"
+              label="Level 3 Parent"
             >
               <ResponsiveVerticalMenuItem
-                id="tertiary-menu-item-with-icon"
-                label="Tertiary Icon"
-              />
-              <ResponsiveVerticalMenuItem
-                id="tertiary-menu-item-with-no-icon"
-                label="Tertiary No Icon"
-              />
-              <ResponsiveVerticalMenuItem
-                id="tertiary-menu-item-with-custom-icon"
-                label="Tertiary Custom Icon"
+                href="#"
+                id="level-4-as-last-item"
+                label="Level 4 As Last Item"
               />
             </ResponsiveVerticalMenuItem>
           </ResponsiveVerticalMenuItem>
-        </ResponsiveVerticalMenu>
-      </ResponsiveVerticalMenuProvider>
+        </ResponsiveVerticalMenuItem>
+      </ResponsiveVerticalMenu>
     </Box>
   );
 };

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-interaction.stories.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-interaction.stories.tsx
@@ -7,7 +7,6 @@ import {
   ResponsiveVerticalMenu,
   ResponsiveVerticalMenuDivider,
   ResponsiveVerticalMenuItem,
-  ResponsiveVerticalMenuProvider,
 } from ".";
 import GlobalHeader from "../../global-header";
 
@@ -82,54 +81,52 @@ const CustomAccountingIcon = () => (
 const DefaultResponsiveVerticalMenu = () => (
   <>
     <GlobalHeader>
-      <ResponsiveVerticalMenuProvider>
-        <ResponsiveVerticalMenu height="100%">
+      <ResponsiveVerticalMenu height="100%">
+        <ResponsiveVerticalMenuItem
+          customIcon={<CustomAccountingIcon />}
+          id="primary-menu"
+          label="Primary Menu With Children"
+        >
           <ResponsiveVerticalMenuItem
-            customIcon={<CustomAccountingIcon />}
-            id="primary-menu"
-            label="Primary Menu With Children"
+            id="secondary-menu"
+            label="Secondary Menu With Children"
           >
             <ResponsiveVerticalMenuItem
-              id="secondary-menu"
-              label="Secondary Menu With Children"
-            >
-              <ResponsiveVerticalMenuItem
-                id="tertiary-menu"
-                label="Tertiary Menu"
-              />
-            </ResponsiveVerticalMenuItem>
-            <ResponsiveVerticalMenuItem
-              id="secondary-menu-no-children"
-              label="Secondary Menu Item"
+              id="tertiary-menu"
+              label="Tertiary Menu"
             />
           </ResponsiveVerticalMenuItem>
-          <ResponsiveVerticalMenuDivider />
           <ResponsiveVerticalMenuItem
-            id="primary-menu-no-icon"
-            label="Primary Menu Item Without Icon"
-          >
-            <ResponsiveVerticalMenuItem
-              id="secondary-menu-no-icon"
-              label="Secondary Menu With Children"
-            >
-              <ResponsiveVerticalMenuItem
-                id="tertiary-menu-no-icon"
-                label="Tertiary Menu"
-              />
-            </ResponsiveVerticalMenuItem>
-            <ResponsiveVerticalMenuItem
-              id="secondary-menu-no-icon-2"
-              label="Secondary Menu Item"
-            />
-          </ResponsiveVerticalMenuItem>
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem
-            icon="home"
-            id="primary-menu-icon"
-            label="Primary Menu Item With Icon"
+            id="secondary-menu-no-children"
+            label="Secondary Menu Item"
           />
-        </ResponsiveVerticalMenu>
-      </ResponsiveVerticalMenuProvider>
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem
+          id="primary-menu-no-icon"
+          label="Primary Menu Item Without Icon"
+        >
+          <ResponsiveVerticalMenuItem
+            id="secondary-menu-no-icon"
+            label="Secondary Menu With Children"
+          >
+            <ResponsiveVerticalMenuItem
+              id="tertiary-menu-no-icon"
+              label="Tertiary Menu"
+            />
+          </ResponsiveVerticalMenuItem>
+          <ResponsiveVerticalMenuItem
+            id="secondary-menu-no-icon-2"
+            label="Secondary Menu Item"
+          />
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem
+          icon="home"
+          id="primary-menu-icon"
+          label="Primary Menu Item With Icon"
+        />
+      </ResponsiveVerticalMenu>
     </GlobalHeader>
   </>
 );

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-test.stories.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-test.stories.tsx
@@ -5,7 +5,6 @@ import {
   ResponsiveVerticalMenuDivider,
   ResponsiveVerticalMenuItem,
   ResponsiveVerticalMenuProps,
-  ResponsiveVerticalMenuProvider,
 } from ".";
 
 import Box from "../../box";
@@ -78,95 +77,6 @@ const CustomAccountingIcon = () => (
 export const Default = (props: Partial<ResponsiveVerticalMenuProps>) => {
   return (
     <GlobalHeader>
-      <ResponsiveVerticalMenuProvider>
-        <ResponsiveVerticalMenu {...props}>
-          <ResponsiveVerticalMenuItem icon="home" id="home" label="Home" />
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem
-            customIcon={<CustomAccountingIcon />}
-            id="accounting"
-            label="Accounting"
-          >
-            <ResponsiveVerticalMenuItem id="summary" label="Summary" />
-            <ResponsiveVerticalMenuItem
-              id="sales-invoices"
-              label="Sales Invoices"
-            >
-              <ResponsiveVerticalMenuItem
-                id="quotes-and-estimates"
-                label="Quotes & Estimates"
-                href="#"
-              />
-              <ResponsiveVerticalMenuItem
-                id="new-sales-invoice"
-                label="New Sales Invoice"
-                href="#"
-              />
-              <ResponsiveVerticalMenuItem
-                id="sales-summary"
-                label="Sales Summary"
-                href="#"
-              />
-            </ResponsiveVerticalMenuItem>
-            <ResponsiveVerticalMenuItem id="contacts" label="Contacts">
-              <ResponsiveVerticalMenuItem
-                id="nested-menu-item-1"
-                label="Nested Menu Item 1"
-              />
-            </ResponsiveVerticalMenuItem>
-            <ResponsiveVerticalMenuItem
-              id="products-and-services"
-              label="Products & Services"
-            />
-          </ResponsiveVerticalMenuItem>
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem id="payroll" label="Payroll">
-            <ResponsiveVerticalMenuItem id="payroll-summary" label="Summary" />
-            <ResponsiveVerticalMenuItem id="payroll-sales" label="Sales" />
-          </ResponsiveVerticalMenuItem>
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem id="profile" label="Profile">
-            <ResponsiveVerticalMenuItem
-              id="profile-my-profile"
-              label="My Profile"
-            />
-            <ResponsiveVerticalMenuItem id="profile-logout" label="Log out" />
-          </ResponsiveVerticalMenuItem>
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem
-            id="manage-business-account"
-            label="Manage Business Account"
-          />
-          <ResponsiveVerticalMenuItem id="manage-users" label="Manage Users" />
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem id="help" label="Help">
-            <ResponsiveVerticalMenuItem
-              id="help-centre"
-              label={
-                <Box display="flex" width="100%" alignItems="center" gap={1}>
-                  <span>Help Centre</span>
-                  <Icon type="link" />
-                </Box>
-              }
-            />
-            <ResponsiveVerticalMenuItem id="help-chat" label="Chat" />
-            <ResponsiveVerticalMenuItem
-              id="help-feedback"
-              label="Give feedback"
-            />
-          </ResponsiveVerticalMenuItem>
-        </ResponsiveVerticalMenu>
-      </ResponsiveVerticalMenuProvider>
-    </GlobalHeader>
-  );
-};
-Default.storyName = "Default";
-
-export const WithoutGlobalHeader = (
-  props: Partial<ResponsiveVerticalMenuProps>,
-) => {
-  return (
-    <ResponsiveVerticalMenuProvider>
       <ResponsiveVerticalMenu {...props}>
         <ResponsiveVerticalMenuItem icon="home" id="home" label="Home" />
         <ResponsiveVerticalMenuDivider />
@@ -207,8 +117,90 @@ export const WithoutGlobalHeader = (
             label="Products & Services"
           />
         </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem id="payroll" label="Payroll">
+          <ResponsiveVerticalMenuItem id="payroll-summary" label="Summary" />
+          <ResponsiveVerticalMenuItem id="payroll-sales" label="Sales" />
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem id="profile" label="Profile">
+          <ResponsiveVerticalMenuItem
+            id="profile-my-profile"
+            label="My Profile"
+          />
+          <ResponsiveVerticalMenuItem id="profile-logout" label="Log out" />
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem
+          id="manage-business-account"
+          label="Manage Business Account"
+        />
+        <ResponsiveVerticalMenuItem id="manage-users" label="Manage Users" />
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem id="help" label="Help">
+          <ResponsiveVerticalMenuItem
+            id="help-centre"
+            label={
+              <Box display="flex" width="100%" alignItems="center" gap={1}>
+                <span>Help Centre</span>
+                <Icon type="link" />
+              </Box>
+            }
+          />
+          <ResponsiveVerticalMenuItem id="help-chat" label="Chat" />
+          <ResponsiveVerticalMenuItem
+            id="help-feedback"
+            label="Give feedback"
+          />
+        </ResponsiveVerticalMenuItem>
       </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>
+    </GlobalHeader>
+  );
+};
+Default.storyName = "Default";
+
+export const WithoutGlobalHeader = (
+  props: Partial<ResponsiveVerticalMenuProps>,
+) => {
+  return (
+    <ResponsiveVerticalMenu {...props}>
+      <ResponsiveVerticalMenuItem icon="home" id="home" label="Home" />
+      <ResponsiveVerticalMenuDivider />
+      <ResponsiveVerticalMenuItem
+        customIcon={<CustomAccountingIcon />}
+        id="accounting"
+        label="Accounting"
+      >
+        <ResponsiveVerticalMenuItem id="summary" label="Summary" />
+        <ResponsiveVerticalMenuItem id="sales-invoices" label="Sales Invoices">
+          <ResponsiveVerticalMenuItem
+            id="quotes-and-estimates"
+            label="Quotes & Estimates"
+            href="#"
+          />
+          <ResponsiveVerticalMenuItem
+            id="new-sales-invoice"
+            label="New Sales Invoice"
+            href="#"
+          />
+          <ResponsiveVerticalMenuItem
+            id="sales-summary"
+            label="Sales Summary"
+            href="#"
+          />
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuItem id="contacts" label="Contacts">
+          <ResponsiveVerticalMenuItem
+            id="nested-menu-item-1"
+            label="Nested Menu Item 1"
+          />
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuItem
+          id="products-and-services"
+          label="Products & Services"
+        />
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>
   );
 };
 WithoutGlobalHeader.storyName = "Without Global Header";
@@ -216,57 +208,55 @@ WithoutGlobalHeader.storyName = "Without Global Header";
 export const WithFullIcons = (props: Partial<ResponsiveVerticalMenuProps>) => {
   return (
     <GlobalHeader>
-      <ResponsiveVerticalMenuProvider>
-        <ResponsiveVerticalMenu {...props}>
-          <ResponsiveVerticalMenuItem icon="home" id="home" label="Home" />
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem
-            customIcon={<CustomAccountingIcon />}
-            id="accounting"
-            label="Accounting"
-          />
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem
-            id="payroll"
-            label="Payroll"
-            icon="business"
-          >
-            <ResponsiveVerticalMenuItem id="payroll-summary" label="Summary" />
-            <ResponsiveVerticalMenuItem id="payroll-sales" label="Sales" />
-          </ResponsiveVerticalMenuItem>
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem
-            icon="home"
-            id="primary-menu"
-            label={
-              <Box display="flex" width="100%" alignItems="center" gap={1}>
-                <span>Primary Menu Item</span>
-                <Icon type="link" />
-              </Box>
-            }
-          >
-            <ResponsiveVerticalMenuItem id="sales" label="Sales" />
-          </ResponsiveVerticalMenuItem>
-          <ResponsiveVerticalMenuItem
-            icon="question"
-            id="loading-menu"
-            label="Loading"
-          >
-            <Box
-              display="flex"
-              width="100%"
-              alignItems="center"
-              gap={1}
-              flexDirection="column"
-              justifyContent="center"
-              color="white"
-            >
-              <Loader />
-              <span>Loading, please wait...</span>
+      <ResponsiveVerticalMenu {...props}>
+        <ResponsiveVerticalMenuItem icon="home" id="home" label="Home" />
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem
+          customIcon={<CustomAccountingIcon />}
+          id="accounting"
+          label="Accounting"
+        />
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem
+          id="payroll"
+          label="Payroll"
+          icon="business"
+        >
+          <ResponsiveVerticalMenuItem id="payroll-summary" label="Summary" />
+          <ResponsiveVerticalMenuItem id="payroll-sales" label="Sales" />
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem
+          icon="home"
+          id="primary-menu"
+          label={
+            <Box display="flex" width="100%" alignItems="center" gap={1}>
+              <span>Primary Menu Item</span>
+              <Icon type="link" />
             </Box>
-          </ResponsiveVerticalMenuItem>
-        </ResponsiveVerticalMenu>
-      </ResponsiveVerticalMenuProvider>
+          }
+        >
+          <ResponsiveVerticalMenuItem id="sales" label="Sales" />
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuItem
+          icon="question"
+          id="loading-menu"
+          label="Loading"
+        >
+          <Box
+            display="flex"
+            width="100%"
+            alignItems="center"
+            gap={1}
+            flexDirection="column"
+            justifyContent="center"
+            color="white"
+          >
+            <Loader />
+            <span>Loading, please wait...</span>
+          </Box>
+        </ResponsiveVerticalMenuItem>
+      </ResponsiveVerticalMenu>
     </GlobalHeader>
   );
 };
@@ -275,44 +265,42 @@ WithFullIcons.storyName = "Full Icons";
 export const NoIcons = (props: Partial<ResponsiveVerticalMenuProps>) => {
   return (
     <GlobalHeader>
-      <ResponsiveVerticalMenuProvider>
-        <ResponsiveVerticalMenu {...props}>
-          <ResponsiveVerticalMenuItem id="home" label="Home" />
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem id="accounting" label="Accounting" />
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem id="payroll" label="Payroll">
-            <ResponsiveVerticalMenuItem id="payroll-summary" label="Summary" />
-            <ResponsiveVerticalMenuItem id="payroll-sales" label="Sales" />
-          </ResponsiveVerticalMenuItem>
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem
-            id="primary-menu"
-            label={
-              <Box display="flex" width="100%" alignItems="center" gap={1}>
-                <span>Primary Menu Item</span>
-                <Icon type="link" />
-              </Box>
-            }
-          >
-            <ResponsiveVerticalMenuItem id="sales" label="Sales" />
-          </ResponsiveVerticalMenuItem>
-          <ResponsiveVerticalMenuItem id="loading-menu" label="Loading">
-            <Box
-              display="flex"
-              width="100%"
-              alignItems="center"
-              gap={1}
-              flexDirection="column"
-              justifyContent="center"
-              color="white"
-            >
-              <Loader />
-              <span>Loading, please wait...</span>
+      <ResponsiveVerticalMenu {...props}>
+        <ResponsiveVerticalMenuItem id="home" label="Home" />
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem id="accounting" label="Accounting" />
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem id="payroll" label="Payroll">
+          <ResponsiveVerticalMenuItem id="payroll-summary" label="Summary" />
+          <ResponsiveVerticalMenuItem id="payroll-sales" label="Sales" />
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem
+          id="primary-menu"
+          label={
+            <Box display="flex" width="100%" alignItems="center" gap={1}>
+              <span>Primary Menu Item</span>
+              <Icon type="link" />
             </Box>
-          </ResponsiveVerticalMenuItem>
-        </ResponsiveVerticalMenu>
-      </ResponsiveVerticalMenuProvider>
+          }
+        >
+          <ResponsiveVerticalMenuItem id="sales" label="Sales" />
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuItem id="loading-menu" label="Loading">
+          <Box
+            display="flex"
+            width="100%"
+            alignItems="center"
+            gap={1}
+            flexDirection="column"
+            justifyContent="center"
+            color="white"
+          >
+            <Loader />
+            <span>Loading, please wait...</span>
+          </Box>
+        </ResponsiveVerticalMenuItem>
+      </ResponsiveVerticalMenu>
     </GlobalHeader>
   );
 };
@@ -321,54 +309,52 @@ NoIcons.storyName = "No Icons";
 export const MixedIcons = (props: Partial<ResponsiveVerticalMenuProps>) => {
   return (
     <GlobalHeader>
-      <ResponsiveVerticalMenuProvider>
-        <ResponsiveVerticalMenu {...props}>
-          <ResponsiveVerticalMenuItem icon="home" id="home" label="Home" />
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem id="accounting" label="Accounting" />
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem
-            id="payroll"
-            label="Payroll"
-            icon="business"
-          >
-            <ResponsiveVerticalMenuItem id="payroll-summary" label="Summary" />
-            <ResponsiveVerticalMenuItem id="payroll-sales" label="Sales" />
-          </ResponsiveVerticalMenuItem>
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem
-            id="primary-menu"
-            label={
-              <Box
-                display="flex"
-                width="100%"
-                alignItems="center"
-                gap={1}
-                color="white"
-              >
-                <span>Primary Menu Item</span>
-                <Icon type="link" />
-              </Box>
-            }
-          >
-            <ResponsiveVerticalMenuItem id="sales" label="Sales" />
-          </ResponsiveVerticalMenuItem>
-          <ResponsiveVerticalMenuItem id="loading-menu" label="Loading">
+      <ResponsiveVerticalMenu {...props}>
+        <ResponsiveVerticalMenuItem icon="home" id="home" label="Home" />
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem id="accounting" label="Accounting" />
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem
+          id="payroll"
+          label="Payroll"
+          icon="business"
+        >
+          <ResponsiveVerticalMenuItem id="payroll-summary" label="Summary" />
+          <ResponsiveVerticalMenuItem id="payroll-sales" label="Sales" />
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem
+          id="primary-menu"
+          label={
             <Box
               display="flex"
               width="100%"
               alignItems="center"
               gap={1}
-              flexDirection="column"
-              justifyContent="center"
               color="white"
             >
-              <Loader />
-              <span>Loading, please wait...</span>
+              <span>Primary Menu Item</span>
+              <Icon type="link" />
             </Box>
-          </ResponsiveVerticalMenuItem>
-        </ResponsiveVerticalMenu>
-      </ResponsiveVerticalMenuProvider>
+          }
+        >
+          <ResponsiveVerticalMenuItem id="sales" label="Sales" />
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuItem id="loading-menu" label="Loading">
+          <Box
+            display="flex"
+            width="100%"
+            alignItems="center"
+            gap={1}
+            flexDirection="column"
+            justifyContent="center"
+            color="white"
+          >
+            <Loader />
+            <span>Loading, please wait...</span>
+          </Box>
+        </ResponsiveVerticalMenuItem>
+      </ResponsiveVerticalMenu>
     </GlobalHeader>
   );
 };
@@ -421,41 +407,39 @@ const TestMenu = ({ data }: { data: MenuItem[] }) => {
   const products = postData.length === 0 ? data : postData;
 
   return (
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu height="100%">
-        <>
+    <ResponsiveVerticalMenu height="100%">
+      <>
+        <ResponsiveVerticalMenuItem
+          label="Home"
+          id="home"
+          icon="home"
+          href="#"
+        />
+        {products.map((p) => (
           <ResponsiveVerticalMenuItem
-            label="Home"
-            id="home"
-            icon="home"
-            href="#"
-          />
-          {products.map((p) => (
-            <ResponsiveVerticalMenuItem
-              key={p.productName}
-              id={p.productName}
-              label={p.productName}
-            >
-              {p?.menuItems?.map((s) => (
-                <ResponsiveVerticalMenuItem
-                  key={s.productName}
-                  id={s.productName}
-                  label={s.productName}
-                >
-                  {s?.menuItems?.map((t) => (
-                    <ResponsiveVerticalMenuItem
-                      key={t.productName}
-                      id={t.productName}
-                      label={t.productName}
-                    />
-                  ))}
-                </ResponsiveVerticalMenuItem>
-              ))}
-            </ResponsiveVerticalMenuItem>
-          ))}
-        </>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>
+            key={p.productName}
+            id={p.productName}
+            label={p.productName}
+          >
+            {p?.menuItems?.map((s) => (
+              <ResponsiveVerticalMenuItem
+                key={s.productName}
+                id={s.productName}
+                label={s.productName}
+              >
+                {s?.menuItems?.map((t) => (
+                  <ResponsiveVerticalMenuItem
+                    key={t.productName}
+                    id={t.productName}
+                    label={t.productName}
+                  />
+                ))}
+              </ResponsiveVerticalMenuItem>
+            ))}
+          </ResponsiveVerticalMenuItem>
+        ))}
+      </>
+    </ResponsiveVerticalMenu>
   );
 };
 
@@ -477,34 +461,32 @@ export const WithExternalLinkStyles = () => {
     <>
       <style>{styles}</style>
       <GlobalHeader>
-        <ResponsiveVerticalMenuProvider>
-          <ResponsiveVerticalMenu height="100%">
+        <ResponsiveVerticalMenu height="100%">
+          <ResponsiveVerticalMenuItem
+            icon="home"
+            id="primary-menu"
+            label="Primary Menu With Children"
+          >
             <ResponsiveVerticalMenuItem
-              icon="home"
-              id="primary-menu"
-              label="Primary Menu With Children"
+              id="secondary-menu"
+              label="Secondary Menu With Children"
             >
               <ResponsiveVerticalMenuItem
-                id="secondary-menu"
-                label="Secondary Menu With Children"
-              >
-                <ResponsiveVerticalMenuItem
-                  id="tertiary-menu"
-                  label="Tertiary Menu"
-                />
-              </ResponsiveVerticalMenuItem>
-              <ResponsiveVerticalMenuItem
-                id="secondary-menu-no-children"
-                label="Secondary Menu Item"
+                id="tertiary-menu"
+                label="Tertiary Menu"
               />
             </ResponsiveVerticalMenuItem>
             <ResponsiveVerticalMenuItem
-              icon="home"
-              id="primary-menu-no-children"
-              label="Primary Menu Item"
+              id="secondary-menu-no-children"
+              label="Secondary Menu Item"
             />
-          </ResponsiveVerticalMenu>
-        </ResponsiveVerticalMenuProvider>
+          </ResponsiveVerticalMenuItem>
+          <ResponsiveVerticalMenuItem
+            icon="home"
+            id="primary-menu-no-children"
+            label="Primary Menu Item"
+          />
+        </ResponsiveVerticalMenu>
       </GlobalHeader>
     </>
   );
@@ -517,33 +499,31 @@ export const CustomLinkAction = (
   return (
     <>
       <GlobalHeader>
-        <ResponsiveVerticalMenuProvider>
-          <ResponsiveVerticalMenu {...props}>
+        <ResponsiveVerticalMenu {...props}>
+          <ResponsiveVerticalMenuItem
+            icon="home"
+            id="home"
+            label="Home"
+            onClick={() => setToggled(true)}
+          />
+          <ResponsiveVerticalMenuDivider />
+          <ResponsiveVerticalMenuItem id="help" label="Help">
             <ResponsiveVerticalMenuItem
-              icon="home"
-              id="home"
-              label="Home"
-              onClick={() => setToggled(true)}
+              id="help-centre"
+              label={
+                <Box display="flex" width="100%" alignItems="center" gap={1}>
+                  <span>Help Centre</span>
+                  <Icon type="link" />
+                </Box>
+              }
             />
-            <ResponsiveVerticalMenuDivider />
-            <ResponsiveVerticalMenuItem id="help" label="Help">
-              <ResponsiveVerticalMenuItem
-                id="help-centre"
-                label={
-                  <Box display="flex" width="100%" alignItems="center" gap={1}>
-                    <span>Help Centre</span>
-                    <Icon type="link" />
-                  </Box>
-                }
-              />
-              <ResponsiveVerticalMenuItem id="help-chat" label="Chat" />
-              <ResponsiveVerticalMenuItem
-                id="help-feedback"
-                label="Give feedback"
-              />
-            </ResponsiveVerticalMenuItem>
-          </ResponsiveVerticalMenu>
-        </ResponsiveVerticalMenuProvider>
+            <ResponsiveVerticalMenuItem id="help-chat" label="Chat" />
+            <ResponsiveVerticalMenuItem
+              id="help-feedback"
+              label="Give feedback"
+            />
+          </ResponsiveVerticalMenuItem>
+        </ResponsiveVerticalMenu>
       </GlobalHeader>
       <Typography my={3}>
         HOME action fired: {toggled ? "Yes" : "No"}
@@ -555,62 +535,105 @@ export const CustomLinkAction = (
 export const FourLevels = (props: Partial<ResponsiveVerticalMenuProps>) => {
   return (
     <GlobalHeader>
-      <ResponsiveVerticalMenuProvider>
-        <ResponsiveVerticalMenu {...props}>
-          <ResponsiveVerticalMenuItem icon="home" id="home" label="Home" />
-          <ResponsiveVerticalMenuDivider />
+      <ResponsiveVerticalMenu {...props}>
+        <ResponsiveVerticalMenuItem icon="home" id="home" label="Home" />
+        <ResponsiveVerticalMenuDivider />
+        <ResponsiveVerticalMenuItem
+          customIcon={<CustomAccountingIcon />}
+          id="level-1"
+          label="Level 1"
+        >
           <ResponsiveVerticalMenuItem
-            customIcon={<CustomAccountingIcon />}
-            id="level-1"
-            label="Level 1"
+            id="level-2-item-1"
+            label="Level 2 Item 1"
+          />
+          <ResponsiveVerticalMenuItem
+            id="level-2-item-2"
+            label="Level 2 Item 2"
           >
             <ResponsiveVerticalMenuItem
-              id="level-2-item-1"
-              label="Level 2 Item 1"
+              id="level-3-item-1"
+              label="Level 3 Item 1"
+              href="#"
+            >
+              <ResponsiveVerticalMenuItem
+                id="level-4-item-1"
+                label="Level 4 Item 1"
+                href="#"
+              />
+            </ResponsiveVerticalMenuItem>
+            <ResponsiveVerticalMenuItem
+              id="level-3-item-2"
+              label="Level 3 Item 2"
+              href="#"
             />
             <ResponsiveVerticalMenuItem
-              id="level-2-item-2"
-              label="Level 2 Item 2"
-            >
-              <ResponsiveVerticalMenuItem
-                id="level-3-item-1"
-                label="Level 3 Item 1"
-                href="#"
-              >
-                <ResponsiveVerticalMenuItem
-                  id="level-4-item-1"
-                  label="Level 4 Item 1"
-                  href="#"
-                />
-              </ResponsiveVerticalMenuItem>
-              <ResponsiveVerticalMenuItem
-                id="level-3-item-2"
-                label="Level 3 Item 2"
-                href="#"
-              />
-              <ResponsiveVerticalMenuItem
-                id="level-3-item-3"
-                label="Level 3 Item 3"
-                href="#"
-              />
-            </ResponsiveVerticalMenuItem>
-            <ResponsiveVerticalMenuItem
-              id="level-2-item-3"
-              label="Level 2 Item 3"
-            >
-              <ResponsiveVerticalMenuItem
-                id="level-3-item-4"
-                label="Level 3 Item 4"
-              />
-            </ResponsiveVerticalMenuItem>
-            <ResponsiveVerticalMenuItem
-              id="level-2-item-4"
-              label="Level 2 Item 4"
+              id="level-3-item-3"
+              label="Level 3 Item 3"
+              href="#"
             />
           </ResponsiveVerticalMenuItem>
-        </ResponsiveVerticalMenu>
-      </ResponsiveVerticalMenuProvider>
+          <ResponsiveVerticalMenuItem
+            id="level-2-item-3"
+            label="Level 2 Item 3"
+          >
+            <ResponsiveVerticalMenuItem
+              id="level-3-item-4"
+              label="Level 3 Item 4"
+            />
+          </ResponsiveVerticalMenuItem>
+          <ResponsiveVerticalMenuItem
+            id="level-2-item-4"
+            label="Level 2 Item 4"
+          />
+        </ResponsiveVerticalMenuItem>
+      </ResponsiveVerticalMenu>
     </GlobalHeader>
   );
 };
 FourLevels.storyName = "4th Level Menu Items";
+
+export const WithDifferentDepthsAsLastItem = () => {
+  return (
+    <GlobalHeader>
+      <ResponsiveVerticalMenu>
+        <ResponsiveVerticalMenuItem id="with-level-2" label="With Level 2">
+          <ResponsiveVerticalMenuItem
+            href="#"
+            id="level-2-as-last-item"
+            label="Level 2 As Last Item"
+          />
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuItem id="with-level-3" label="With Level 3">
+          <ResponsiveVerticalMenuItem
+            id="level-2-parent-1"
+            label="Level 2 Parent"
+          >
+            <ResponsiveVerticalMenuItem
+              href="#"
+              id="level-3-as-last-item"
+              label="Level 3 As Last Item"
+            />
+          </ResponsiveVerticalMenuItem>
+        </ResponsiveVerticalMenuItem>
+        <ResponsiveVerticalMenuItem id="with-level-4" label="With Level 4">
+          <ResponsiveVerticalMenuItem
+            id="level-2-parent-2"
+            label="Level 2 Parent"
+          >
+            <ResponsiveVerticalMenuItem
+              id="level-3-parent"
+              label="Level 3 Parent"
+            >
+              <ResponsiveVerticalMenuItem
+                href="#"
+                id="level-4-as-last-item"
+                label="Level 4 As Last Item"
+              />
+            </ResponsiveVerticalMenuItem>
+          </ResponsiveVerticalMenuItem>
+        </ResponsiveVerticalMenuItem>
+      </ResponsiveVerticalMenu>
+    </GlobalHeader>
+  );
+};

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
@@ -7,7 +7,10 @@ import React, {
   useState,
 } from "react";
 
-import { useResponsiveVerticalMenu } from "./responsive-vertical-menu.context";
+import {
+  useResponsiveVerticalMenu,
+  ResponsiveVerticalMenuProvider,
+} from "./responsive-vertical-menu.context";
 import {
   StyledButton,
   StyledCloseButton,
@@ -57,18 +60,18 @@ const BaseMenu = ({
     containerRef,
     menuRef,
     responsiveMode,
+    top,
     setActive,
     setActiveMenuItem,
     setReducedMotion,
     setResponsiveMode,
+    setLeft,
+    setTop,
   } = useResponsiveVerticalMenu();
 
   const [childItemCount, setChildItemCount] = useState(0);
   const largeScreen = useIsAboveBreakpoint(responsiveBreakpoint);
-  const [left, setLeft] = useState("auto");
   const [responsiveWidth, setResponsiveWidth] = useState("100%");
-  const [top, setTop] = useState("auto");
-  const subMenuRef = useRef<HTMLUListElement>(null);
   const reduceMotion = !useMediaQuery(
     "screen and (prefers-reduced-motion: no-preference)",
   );
@@ -342,25 +345,6 @@ const BaseMenu = ({
               >
                 {children}
               </StyledResponsiveMenu>
-
-              {activeMenuItem ? (
-                <StyledResponsiveMenu
-                  data-component="responsive-vertical-menu-secondary"
-                  data-role="responsive-vertical-menu-secondary"
-                  height={height || "100%"}
-                  id="responsive-vertical-menu-secondary"
-                  left={left}
-                  menu="secondary"
-                  reduceMotion={reduceMotion}
-                  ref={subMenuRef}
-                  responsive={false}
-                  tabIndex={-1}
-                  top={top}
-                  width={width}
-                >
-                  {activeMenuItem.children}
-                </StyledResponsiveMenu>
-              ) : null}
             </>
           )}
         </StyledGlobalVerticalMenuWrapper>
@@ -371,12 +355,18 @@ const BaseMenu = ({
 
 export const ResponsiveVerticalMenu = ({
   children,
+  width,
+  height,
   ...props
 }: ResponsiveVerticalMenuProps) => {
   return (
     <DepthProvider>
       <MenuFocusProvider>
-        <BaseMenu {...props}>{children}</BaseMenu>
+        <ResponsiveVerticalMenuProvider width={width} height={height}>
+          <BaseMenu width={width} height={height} {...props}>
+            {children}
+          </BaseMenu>
+        </ResponsiveVerticalMenuProvider>
       </MenuFocusProvider>
     </DepthProvider>
   );

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.context.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.context.tsx
@@ -10,6 +10,7 @@ import React, {
 } from "react";
 
 import { IconType } from "../../icon/icon-type";
+import Logger from "../../../__internal__/utils/logger";
 
 export interface ResponsiveVerticalMenuButtonItem {
   children?: ReactNode;
@@ -29,10 +30,16 @@ export interface MenuContextType {
   menuRef: RefObject<HTMLUListElement>;
   reducedMotion?: boolean;
   responsiveMode?: boolean;
+  left: string;
+  top: string;
+  width?: string;
+  height?: string;
   setActive: Dispatch<SetStateAction<boolean>>; // This allows both value and function
   setActiveMenuItem: (item: ResponsiveVerticalMenuButtonItem | null) => void;
   setReducedMotion?: (reducedMotion: boolean) => void;
   setResponsiveMode?: (responsiveMode: boolean) => void;
+  setLeft: (left: string) => void;
+  setTop: (top: string) => void;
 }
 
 export const ResponsiveVerticalMenuContext =
@@ -50,11 +57,29 @@ export const useResponsiveVerticalMenu = () => {
 
 export interface ResponsiveVerticalMenuProviderProps {
   children: ReactNode;
+  /** @private @internal @ignore */
+  width?: string;
+  /** @private @internal @ignore */
+  height?: string;
 }
+
+let deprecatedWarning = false;
 
 export const ResponsiveVerticalMenuProvider = ({
   children,
+  width,
+  height,
 }: ResponsiveVerticalMenuProviderProps) => {
+  const externalContext = useContext(ResponsiveVerticalMenuContext);
+  const hasExternalContext = externalContext !== null;
+
+  if (!deprecatedWarning && hasExternalContext) {
+    deprecatedWarning = true;
+    Logger.deprecate(
+      "`ResponsiveVerticalMenuProvider` is deprecated and no longer needed for `ResponsiveVerticalMenu`. You can use `ResponsiveVerticalMenu` directly without wrapping it in a provider.",
+    );
+  }
+
   const [active, setActive] = useState<boolean>(false);
   const [activeMenuItem, setActiveMenuItem] =
     useState<ResponsiveVerticalMenuButtonItem | null>(null);
@@ -64,6 +89,9 @@ export const ResponsiveVerticalMenuProvider = ({
   const menuRef = useRef<HTMLUListElement>(null);
   const [responsiveMode, setResponsiveMode] = useState<boolean>(false);
   const [reducedMotion, setReducedMotion] = useState<boolean>(false);
+
+  const [left, setLeft] = useState("auto");
+  const [top, setTop] = useState("auto");
 
   return (
     <ResponsiveVerticalMenuContext.Provider
@@ -75,10 +103,16 @@ export const ResponsiveVerticalMenuProvider = ({
         menuRef,
         reducedMotion,
         responsiveMode,
+        left,
+        top,
+        width,
+        height,
         setActive,
         setActiveMenuItem,
         setReducedMotion,
         setResponsiveMode,
+        setLeft,
+        setTop,
       }}
     >
       {children}

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.mdx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.mdx
@@ -21,30 +21,20 @@ A vertical menu that is responsive to the screen size. It can be used as a menu 
 
 ## Quick Start
 
-To use `ResponsiveVerticalMenu`, you need to import the `ResponsiveVerticalMenu` and `ResponsiveVerticalMenuItem` components. These
-should be wrapped in the `ResponsiveVerticalMenuProvider` component, which should also be imported.
+To use `ResponsiveVerticalMenu`, you need to import the `ResponsiveVerticalMenu` and `ResponsiveVerticalMenuItem` components. 
 
 ```javascript
 import {
   ResponsiveVerticalMenu,
   ResponsiveVerticalMenuDivider,
   ResponsiveVerticalMenuItem,
-  ResponsiveVerticalMenuProvider,
 } from "carbon-react/lib/components/vertical-menu";
 ```
 
 ## Usage
 
-In order to render a `ResponsiveVerticalMenu`, you need to wrap it in a `ResponsiveVerticalMenuProvider` component. This component provides the context for the menu and its items.
-
 Two modes are available for the `ResponsiveVerticalMenu`: default and responsive. The default mode is used when the screen size is large enough to accommodate two columns; the
 responsive mode is used when the screen size is small enough to require a single column (see the [Responsive](#responsive) example below).
-
-```javascript
-  <ResponsiveVerticalMenuProvider>
-    <ResponsiveVerticalMenu height="100%" />
-  </ResponsiveVerticalMenuProvider>
-```
 
 You can then add `ResponsiveVerticalMenuItem` components as children of the `ResponsiveVerticalMenu` component. Each item must have at the very least an individual `id` and `label` prop.
 The `icon` and `customIcon` props are optional; if you wish to render a [Carbon icon](../?path=/story/icon--list-of-icons), use the `icon` property. Custom icons, such as `SVG` graphics,

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.pw.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.pw.tsx
@@ -5,6 +5,7 @@ import { test, expect } from "../../../../playwright/helpers/base-test";
 import {
   ResponsiveVerticalMenuDefaultComponent,
   ResponsiveVerticalMenuIconMixture,
+  WithDifferentDepthsAsLastItem,
 } from "./components.test-pw";
 
 import {
@@ -18,7 +19,6 @@ import {
   responsiveVerticalMenuNthPrimaryItem,
   responsiveVerticalMenuNthSecondaryItem,
   responsiveVerticalMenuSecondary,
-  // responsiveVerticalMenuSecondary,
 } from "../../../../playwright/components/vertical-menu/responsive-vertical-menu";
 
 test.describe("functional tests", () => {
@@ -192,6 +192,176 @@ test.describe("functional tests", () => {
     await expect(clientOffsetTertiaryCustomIconMenuItem).toBeLessThanOrEqual(
       441,
     );
+  });
+});
+
+test.describe("keyboard navigation tests", () => {
+  test("should loop back to primary menu item when Tab is pressed on last secondary menu item", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<WithDifferentDepthsAsLastItem />);
+
+    await responsiveVerticalMenuLauncher(page).click();
+
+    const primaryMenuItem = page.getByRole("button", { name: "With Level 2" });
+    await page.keyboard.press("Tab");
+    await expect(primaryMenuItem).toBeFocused();
+    await page.keyboard.press("Enter");
+
+    const secondaryMenuItem = page.getByRole("link", {
+      name: "Level 2 As Last Item",
+    });
+    await expect(secondaryMenuItem).toBeVisible();
+    await page.keyboard.press("Tab");
+    await expect(secondaryMenuItem).toBeFocused();
+    await page.keyboard.press("Tab");
+    await expect(primaryMenuItem).toBeFocused();
+  });
+
+  test("should loop back to primary menu item when Tab is pressed on last tertiary menu item", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<WithDifferentDepthsAsLastItem />);
+
+    await responsiveVerticalMenuLauncher(page).click();
+
+    const primaryMenuItem = page.getByRole("button", { name: "With Level 3" });
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    await expect(primaryMenuItem).toBeFocused();
+    await page.keyboard.press("Enter");
+
+    await page.keyboard.press("Tab"); // go to secondary menu
+    await page.keyboard.press("Enter"); // open secondary menu
+
+    const tertiaryMenuItem = page.getByRole("link", {
+      name: "Level 3 As Last Item",
+    });
+    await expect(tertiaryMenuItem).toBeVisible();
+    await page.keyboard.press("Tab");
+    await expect(tertiaryMenuItem).toBeFocused();
+    await page.keyboard.press("Tab");
+    await expect(primaryMenuItem).toBeFocused();
+  });
+
+  test("should loop back to primary menu item when Tab is pressed on last level 4 item", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<WithDifferentDepthsAsLastItem />);
+
+    await responsiveVerticalMenuLauncher(page).click();
+
+    const primaryMenuItem = page.getByRole("button", { name: "With Level 4" });
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    await page.keyboard.press("Tab");
+    await expect(primaryMenuItem).toBeFocused();
+    await page.keyboard.press("Enter");
+
+    await page.keyboard.press("Tab"); // go to secondary menu
+    await page.keyboard.press("Enter"); // open secondary menu
+    await page.keyboard.press("Tab"); // go to tertiary menu
+
+    const quaternaryMenuItem = page.getByRole("link", {
+      name: "Level 4 As Last Item",
+    });
+    await expect(quaternaryMenuItem).toBeVisible();
+    await page.keyboard.press("Tab");
+    await expect(quaternaryMenuItem).toBeFocused();
+    await page.keyboard.press("Tab");
+
+    // TODO: FE-7448
+    // await expect(primaryMenuItem).toBeFocused();
+  });
+
+  test("should go to last secondary menu item when Shift+Tab is pressed on the primary menu", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<WithDifferentDepthsAsLastItem />);
+
+    await responsiveVerticalMenuLauncher(page).click();
+
+    const primaryMenuItem = page.getByRole("button", { name: "With Level 2" });
+    await page.keyboard.press("Tab");
+    await expect(primaryMenuItem).toBeFocused();
+    await page.keyboard.press("Enter");
+
+    const secondaryMenuItem = page.getByRole("link", {
+      name: "Level 2 As Last Item",
+    });
+    await expect(secondaryMenuItem).toBeVisible();
+    await page.keyboard.press("Shift+Tab");
+    await expect(secondaryMenuItem).toBeFocused();
+    await page.keyboard.press("Shift+Tab");
+    await expect(primaryMenuItem).toBeFocused();
+  });
+
+  test("should go to last tertiary menu item when Shift+Tab is pressed on the secondary menu", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<WithDifferentDepthsAsLastItem />);
+
+    await responsiveVerticalMenuLauncher(page).click();
+
+    const primaryMenuItem = page.getByRole("button", { name: "With Level 3" });
+    await primaryMenuItem.click(); // open primary menu
+    const secondaryMenuItem = page.getByRole("button", {
+      name: "Level 2 Parent",
+    });
+    await secondaryMenuItem.click(); // open secondary menu
+    const tertiaryMenuItem = page.getByRole("link", {
+      name: "Level 3 As Last Item",
+    });
+    await expect(tertiaryMenuItem).toBeVisible();
+
+    await primaryMenuItem.focus();
+
+    await page.keyboard.press("Shift+Tab");
+    await expect(tertiaryMenuItem).toBeFocused();
+    await page.keyboard.press("Shift+Tab");
+    await expect(secondaryMenuItem).toBeFocused();
+    await page.keyboard.press("Shift+Tab");
+    await expect(primaryMenuItem).toBeFocused();
+  });
+
+  // TODO: FE-7448
+  test.skip("should go to last level 4 item when Shift+Tab is pressed on the tertiary menu", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<WithDifferentDepthsAsLastItem />);
+
+    await responsiveVerticalMenuLauncher(page).click();
+
+    const primaryMenuItem = page.getByRole("button", { name: "With Level 4" });
+    await primaryMenuItem.click(); // open primary menu
+    const secondaryMenuItem = page.getByRole("button", {
+      name: "Level 2 Parent",
+    });
+    await secondaryMenuItem.click(); // open secondary menu
+    const tertiaryMenuItem = page.getByRole("button", {
+      name: "Level 3 Parent",
+    });
+    const quaternaryMenuItem = page.getByRole("link", {
+      name: "Level 4 As Last Item",
+    });
+    await expect(quaternaryMenuItem).toBeVisible();
+
+    await primaryMenuItem.focus();
+
+    await page.keyboard.press("Shift+Tab");
+    await expect(quaternaryMenuItem).toBeFocused();
+    await page.keyboard.press("Shift+Tab");
+    await expect(tertiaryMenuItem).toBeFocused();
+    await page.keyboard.press("Shift+Tab");
+    await expect(secondaryMenuItem).toBeFocused();
+    await page.keyboard.press("Shift+Tab");
+    await expect(primaryMenuItem).toBeFocused();
   });
 });
 

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.stories.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.stories.tsx
@@ -8,7 +8,6 @@ import {
   ResponsiveVerticalMenu,
   ResponsiveVerticalMenuDivider,
   ResponsiveVerticalMenuItem,
-  ResponsiveVerticalMenuProvider,
 } from ".";
 import Box from "../../box";
 import Icon from "../../icon";
@@ -48,34 +47,32 @@ export const Default: Story = () => {
   return (
     <>
       <GlobalHeader>
-        <ResponsiveVerticalMenuProvider>
-          <ResponsiveVerticalMenu height="100%">
+        <ResponsiveVerticalMenu height="100%">
+          <ResponsiveVerticalMenuItem
+            icon="home"
+            id="primary-menu"
+            label="Primary Menu With Children"
+          >
             <ResponsiveVerticalMenuItem
-              icon="home"
-              id="primary-menu"
-              label="Primary Menu With Children"
+              id="secondary-menu"
+              label="Secondary Menu With Children"
             >
               <ResponsiveVerticalMenuItem
-                id="secondary-menu"
-                label="Secondary Menu With Children"
-              >
-                <ResponsiveVerticalMenuItem
-                  id="tertiary-menu"
-                  label="Tertiary Menu"
-                />
-              </ResponsiveVerticalMenuItem>
-              <ResponsiveVerticalMenuItem
-                id="secondary-menu-no-children"
-                label="Secondary Menu Item"
+                id="tertiary-menu"
+                label="Tertiary Menu"
               />
             </ResponsiveVerticalMenuItem>
             <ResponsiveVerticalMenuItem
-              icon="home"
-              id="primary-menu-no-children"
-              label="Primary Menu Item"
+              id="secondary-menu-no-children"
+              label="Secondary Menu Item"
             />
-          </ResponsiveVerticalMenu>
-        </ResponsiveVerticalMenuProvider>
+          </ResponsiveVerticalMenuItem>
+          <ResponsiveVerticalMenuItem
+            icon="home"
+            id="primary-menu-no-children"
+            label="Primary Menu Item"
+          />
+        </ResponsiveVerticalMenu>
       </GlobalHeader>
       <Box m="50px">This text will be hidden by the menu when opened</Box>
     </>
@@ -87,44 +84,42 @@ export const WithDivider: Story = () => {
   return (
     <>
       <GlobalHeader>
-        <ResponsiveVerticalMenuProvider>
-          <ResponsiveVerticalMenu height="100%">
-            <ResponsiveVerticalMenuItem
-              icon="home"
-              id="primary-menu-item-1"
-              label="Primary Menu Item 1"
-            />
+        <ResponsiveVerticalMenu height="100%">
+          <ResponsiveVerticalMenuItem
+            icon="home"
+            id="primary-menu-item-1"
+            label="Primary Menu Item 1"
+          />
 
+          <ResponsiveVerticalMenuItem
+            icon="home"
+            id="primary-menu-item-2"
+            label="Primary Menu Item 2"
+          />
+          <ResponsiveVerticalMenuDivider />
+          <ResponsiveVerticalMenuItem
+            icon="business"
+            id="primary-menu-with-children"
+            label="Primary Menu With Children"
+          >
             <ResponsiveVerticalMenuItem
-              icon="home"
-              id="primary-menu-item-2"
-              label="Primary Menu Item 2"
+              id="secondary-menu-item-1"
+              label="Secondary Menu Item 1"
             />
             <ResponsiveVerticalMenuDivider />
             <ResponsiveVerticalMenuItem
-              icon="business"
-              id="primary-menu-with-children"
-              label="Primary Menu With Children"
-            >
-              <ResponsiveVerticalMenuItem
-                id="secondary-menu-item-1"
-                label="Secondary Menu Item 1"
-              />
-              <ResponsiveVerticalMenuDivider />
-              <ResponsiveVerticalMenuItem
-                id="secondary-menu-item-2"
-                label="Secondary Menu Item 2"
-              />
-            </ResponsiveVerticalMenuItem>
-            <ResponsiveVerticalMenuDivider m={4} />
-
-            <ResponsiveVerticalMenuItem
-              icon="business"
-              id="primary-menu-item-3"
-              label="Primary Menu Item 3"
+              id="secondary-menu-item-2"
+              label="Secondary Menu Item 2"
             />
-          </ResponsiveVerticalMenu>
-        </ResponsiveVerticalMenuProvider>
+          </ResponsiveVerticalMenuItem>
+          <ResponsiveVerticalMenuDivider m={4} />
+
+          <ResponsiveVerticalMenuItem
+            icon="business"
+            id="primary-menu-item-3"
+            label="Primary Menu Item 3"
+          />
+        </ResponsiveVerticalMenu>
       </GlobalHeader>
       <Box m="50px">This text will be hidden by the menu when opened</Box>
     </>
@@ -136,25 +131,23 @@ export const CustomHeight: Story = () => {
   return (
     <>
       <GlobalHeader>
-        <ResponsiveVerticalMenuProvider>
-          <ResponsiveVerticalMenu height="500px">
+        <ResponsiveVerticalMenu height="500px">
+          <ResponsiveVerticalMenuItem
+            icon="home"
+            id="primary-menu"
+            label="Primary Menu With Children"
+          >
             <ResponsiveVerticalMenuItem
-              icon="home"
-              id="primary-menu"
-              label="Primary Menu With Children"
+              id="secondary-menu"
+              label="Secondary Menu With Children"
             >
               <ResponsiveVerticalMenuItem
-                id="secondary-menu"
-                label="Secondary Menu With Children"
-              >
-                <ResponsiveVerticalMenuItem
-                  id="tertiary-menu"
-                  label="Tertiary Menu"
-                />
-              </ResponsiveVerticalMenuItem>
+                id="tertiary-menu"
+                label="Tertiary Menu"
+              />
             </ResponsiveVerticalMenuItem>
-          </ResponsiveVerticalMenu>
-        </ResponsiveVerticalMenuProvider>
+          </ResponsiveVerticalMenuItem>
+        </ResponsiveVerticalMenu>
       </GlobalHeader>
       <Box m="50px">This text will be hidden by the menu when opened</Box>
     </>
@@ -166,28 +159,26 @@ export const CustomWidth: Story = () => {
   return (
     <>
       <GlobalHeader>
-        <ResponsiveVerticalMenuProvider>
-          <ResponsiveVerticalMenu width="200px">
+        <ResponsiveVerticalMenu width="200px">
+          <ResponsiveVerticalMenuItem
+            icon="home"
+            id="primary-menu"
+            label="Primary Menu"
+            py={1}
+          >
             <ResponsiveVerticalMenuItem
-              icon="home"
-              id="primary-menu"
-              label="Primary Menu"
+              id="secondary-menu"
+              label="Secondary Menu"
               py={1}
             >
               <ResponsiveVerticalMenuItem
-                id="secondary-menu"
-                label="Secondary Menu"
+                id="tertiary-menu"
+                label="Tertiary Menu"
                 py={1}
-              >
-                <ResponsiveVerticalMenuItem
-                  id="tertiary-menu"
-                  label="Tertiary Menu"
-                  py={1}
-                />
-              </ResponsiveVerticalMenuItem>
+              />
             </ResponsiveVerticalMenuItem>
-          </ResponsiveVerticalMenu>
-        </ResponsiveVerticalMenuProvider>
+          </ResponsiveVerticalMenuItem>
+        </ResponsiveVerticalMenu>
       </GlobalHeader>
       <Box m="50px">This text will be hidden by the menu when opened</Box>
     </>
@@ -199,25 +190,23 @@ export const Responsive: Story = () => {
   return (
     <>
       <GlobalHeader>
-        <ResponsiveVerticalMenuProvider>
-          <ResponsiveVerticalMenu responsiveBreakpoint={900}>
+        <ResponsiveVerticalMenu responsiveBreakpoint={900}>
+          <ResponsiveVerticalMenuItem
+            icon="home"
+            id="primary-menu"
+            label="Primary Menu With Children"
+          >
             <ResponsiveVerticalMenuItem
-              icon="home"
-              id="primary-menu"
-              label="Primary Menu With Children"
+              id="secondary-menu"
+              label="Secondary Menu With Children"
             >
               <ResponsiveVerticalMenuItem
-                id="secondary-menu"
-                label="Secondary Menu With Children"
-              >
-                <ResponsiveVerticalMenuItem
-                  id="tertiary-menu"
-                  label="Tertiary Menu"
-                />
-              </ResponsiveVerticalMenuItem>
+                id="tertiary-menu"
+                label="Tertiary Menu"
+              />
             </ResponsiveVerticalMenuItem>
-          </ResponsiveVerticalMenu>
-        </ResponsiveVerticalMenuProvider>
+          </ResponsiveVerticalMenuItem>
+        </ResponsiveVerticalMenu>
       </GlobalHeader>
       <Box m="50px">This text will be hidden by the menu when opened</Box>
     </>
@@ -280,25 +269,23 @@ export const CustomIcon: Story = () => {
   return (
     <>
       <GlobalHeader>
-        <ResponsiveVerticalMenuProvider>
-          <ResponsiveVerticalMenu responsiveBreakpoint={900}>
+        <ResponsiveVerticalMenu responsiveBreakpoint={900}>
+          <ResponsiveVerticalMenuItem
+            customIcon={<CustomSVG />}
+            id="primary-menu"
+            label="Primary Menu With Children"
+          >
             <ResponsiveVerticalMenuItem
-              customIcon={<CustomSVG />}
-              id="primary-menu"
-              label="Primary Menu With Children"
+              id="secondary-menu"
+              label="Secondary Menu With Children"
             >
               <ResponsiveVerticalMenuItem
-                id="secondary-menu"
-                label="Secondary Menu With Children"
-              >
-                <ResponsiveVerticalMenuItem
-                  id="tertiary-menu"
-                  label="Tertiary Menu"
-                />
-              </ResponsiveVerticalMenuItem>
+                id="tertiary-menu"
+                label="Tertiary Menu"
+              />
             </ResponsiveVerticalMenuItem>
-          </ResponsiveVerticalMenu>
-        </ResponsiveVerticalMenuProvider>
+          </ResponsiveVerticalMenuItem>
+        </ResponsiveVerticalMenu>
       </GlobalHeader>
       <Box m="50px">This text will be hidden by the menu when opened</Box>
     </>
@@ -315,18 +302,16 @@ export const ItemWithOnClickHandler: Story = () => {
   return (
     <>
       <GlobalHeader>
-        <ResponsiveVerticalMenuProvider>
-          <ResponsiveVerticalMenu height="100%">
-            <ResponsiveVerticalMenuItem
-              icon="home"
-              id="toggle-click-handler"
-              label="Toggle Click Handler"
-              onClick={handleClick}
-              target="_blank"
-              rel="noopener noreferrer"
-            />
-          </ResponsiveVerticalMenu>
-        </ResponsiveVerticalMenuProvider>
+        <ResponsiveVerticalMenu height="100%">
+          <ResponsiveVerticalMenuItem
+            icon="home"
+            id="toggle-click-handler"
+            label="Toggle Click Handler"
+            onClick={handleClick}
+            target="_blank"
+            rel="noopener noreferrer"
+          />
+        </ResponsiveVerticalMenu>
       </GlobalHeader>
       <Box m="50px">This text will be hidden by the menu when opened</Box>
     </>
@@ -341,20 +326,18 @@ export const ItemWithCustomLabel: Story = () => {
   return (
     <>
       <GlobalHeader>
-        <ResponsiveVerticalMenuProvider>
-          <ResponsiveVerticalMenu height="100%">
-            <ResponsiveVerticalMenuItem
-              icon="home"
-              id="primary-menu"
-              label={
-                <Box display="flex" width="100%" alignItems="center" gap={1}>
-                  <span>Primary Menu Item</span>
-                  <Icon type="link" />
-                </Box>
-              }
-            />
-          </ResponsiveVerticalMenu>
-        </ResponsiveVerticalMenuProvider>
+        <ResponsiveVerticalMenu height="100%">
+          <ResponsiveVerticalMenuItem
+            icon="home"
+            id="primary-menu"
+            label={
+              <Box display="flex" width="100%" alignItems="center" gap={1}>
+                <span>Primary Menu Item</span>
+                <Icon type="link" />
+              </Box>
+            }
+          />
+        </ResponsiveVerticalMenu>
       </GlobalHeader>
       <Box m="50px">This text will be hidden by the menu when opened</Box>
     </>

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.test.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.test.tsx
@@ -18,6 +18,7 @@ import useIsAboveBreakpoint from "../../../hooks/__internal__/useIsAboveBreakpoi
 import useMediaQuery from "../../../hooks/useMediaQuery";
 import guid from "../../../__internal__/utils/helpers/guid";
 import I18nProvider from "../../../components/i18n-provider";
+import Logger from "../../../__internal__/utils/logger";
 
 jest.mock("../../../hooks/__internal__/useIsAboveBreakpoint");
 jest.mock("../../../hooks/useMediaQuery");
@@ -98,13 +99,11 @@ test("renders correctly", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
-        <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
-        <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+      <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
+      <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -117,11 +116,11 @@ test("renders correctly", async () => {
   expect(screen.getByText("Menu Item 3")).toBeInTheDocument();
 });
 
-test("throws if not wrapped in provider", async () => {
+test("throws if children are not wrapped in the provider", async () => {
   const consoleSpy = jest.spyOn(console, "error").mockImplementation();
 
   expect(() => {
-    render(<ResponsiveVerticalMenu />);
+    render(<ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />);
   }).toThrow(
     "useResponsiveVerticalMenu must be used within a ResponsiveVerticalMenuProvider",
   );
@@ -129,20 +128,42 @@ test("throws if not wrapped in provider", async () => {
   consoleSpy.mockRestore();
 });
 
-test("items without children are rendered as anchor links", async () => {
-  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+test("logs deprecation warning if context provider is used", () => {
+  jest.spyOn(Logger, "error").mockImplementation(() => {});
+  const loggerDeprecateSpy = jest
+    .spyOn(Logger, "deprecate")
+    .mockImplementation(() => {});
 
   render(
     <ResponsiveVerticalMenuProvider>
       <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-          href="https://example.com"
-        />
+        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+        <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
+        <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
       </ResponsiveVerticalMenu>
     </ResponsiveVerticalMenuProvider>,
+  );
+
+  expect(loggerDeprecateSpy).toHaveBeenCalledTimes(1);
+  expect(loggerDeprecateSpy).toHaveBeenCalledWith(
+    expect.stringContaining(
+      "`ResponsiveVerticalMenuProvider` is deprecated and no longer needed for `ResponsiveVerticalMenu`. You can use `ResponsiveVerticalMenu` directly without wrapping it in a provider.",
+    ),
+  );
+});
+
+test("items without children are rendered as anchor links", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+        href="https://example.com"
+      />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -159,21 +180,19 @@ test("items with children are rendered as buttons", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+      >
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-        >
-          <ResponsiveVerticalMenuItem
-            data-role="menu-item-2"
-            id="menu-item-2"
-            label="Menu Item 2"
-          />
-        </ResponsiveVerticalMenuItem>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+          data-role="menu-item-2"
+          id="menu-item-2"
+          label="Menu Item 2"
+        />
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -191,21 +210,19 @@ test("top-level items with children are expanded and collapsed on click", async 
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+      >
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-        >
-          <ResponsiveVerticalMenuItem
-            data-role="menu-item-2"
-            id="menu-item-2"
-            label="Menu Item 2"
-          />
-        </ResponsiveVerticalMenuItem>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+          data-role="menu-item-2"
+          id="menu-item-2"
+          label="Menu Item 2"
+        />
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
   );
 
   expect(screen.queryByText("Menu Item 2")).not.toBeInTheDocument();
@@ -233,21 +250,19 @@ test("top-level items with children are expanded and collapsed on click", async 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     render(
-      <ResponsiveVerticalMenuProvider>
-        <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenu>
+        <ResponsiveVerticalMenuItem
+          data-role="menu-item-1"
+          id="menu-item-1"
+          label="Menu Item 1"
+        >
           <ResponsiveVerticalMenuItem
-            data-role="menu-item-1"
-            id="menu-item-1"
-            label="Menu Item 1"
-          >
-            <ResponsiveVerticalMenuItem
-              data-role="menu-item-2"
-              id="menu-item-2"
-              label="Menu Item 2"
-            />
-          </ResponsiveVerticalMenuItem>
-        </ResponsiveVerticalMenu>
-      </ResponsiveVerticalMenuProvider>,
+            data-role="menu-item-2"
+            id="menu-item-2"
+            label="Menu Item 2"
+          />
+        </ResponsiveVerticalMenuItem>
+      </ResponsiveVerticalMenu>,
     );
 
     expect(screen.queryByText("Menu Item 2")).not.toBeInTheDocument();
@@ -277,27 +292,25 @@ test("secondary-level items with children are expanded and collapsed on click", 
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+      >
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
+          data-role="menu-item-2"
+          id="menu-item-2"
+          label="Menu Item 2"
         >
           <ResponsiveVerticalMenuItem
-            data-role="menu-item-2"
-            id="menu-item-2"
-            label="Menu Item 2"
-          >
-            <ResponsiveVerticalMenuItem
-              data-role="menu-item-3"
-              id="menu-item-3"
-              label="Menu Item 3"
-            />
-          </ResponsiveVerticalMenuItem>
+            data-role="menu-item-3"
+            id="menu-item-3"
+            label="Menu Item 3"
+          />
         </ResponsiveVerticalMenuItem>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
   );
 
   expect(screen.queryByText("Menu Item 3")).not.toBeInTheDocument();
@@ -327,27 +340,25 @@ test("secondary-level items with children are expanded and collapsed on click", 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     render(
-      <ResponsiveVerticalMenuProvider>
-        <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenu>
+        <ResponsiveVerticalMenuItem
+          data-role="menu-item-1"
+          id="menu-item-1"
+          label="Menu Item 1"
+        >
           <ResponsiveVerticalMenuItem
-            data-role="menu-item-1"
-            id="menu-item-1"
-            label="Menu Item 1"
+            data-role="menu-item-2"
+            id="menu-item-2"
+            label="Menu Item 2"
           >
             <ResponsiveVerticalMenuItem
-              data-role="menu-item-2"
-              id="menu-item-2"
-              label="Menu Item 2"
-            >
-              <ResponsiveVerticalMenuItem
-                data-role="menu-item-3"
-                id="menu-item-3"
-                label="Menu Item 3"
-              />
-            </ResponsiveVerticalMenuItem>
+              data-role="menu-item-3"
+              id="menu-item-3"
+              label="Menu Item 3"
+            />
           </ResponsiveVerticalMenuItem>
-        </ResponsiveVerticalMenu>
-      </ResponsiveVerticalMenuProvider>,
+        </ResponsiveVerticalMenuItem>
+      </ResponsiveVerticalMenu>,
     );
 
     expect(screen.queryByText("Menu Item 3")).not.toBeInTheDocument();
@@ -379,16 +390,14 @@ test("items render with a Carbon icon", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem
-          icon="home"
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-        />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        icon="home"
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+      />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -404,16 +413,14 @@ test("items render with a custom icon", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem
-          customIcon={<CustomSVG />}
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-        />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        customIcon={<CustomSVG />}
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+      />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -428,17 +435,15 @@ test("items render with a custom icon", async () => {
 test("items render with a custom icon if both customIcon and icon are provided", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem
-          customIcon={<CustomSVG />}
-          data-role="menu-item-1"
-          icon="home"
-          id="menu-item-1"
-          label="Menu Item 1"
-        />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        customIcon={<CustomSVG />}
+        data-role="menu-item-1"
+        icon="home"
+        id="menu-item-1"
+        label="Menu Item 1"
+      />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -457,11 +462,9 @@ test("closes menu when Escape key is pressed", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -479,15 +482,13 @@ test("closes menu when Escape key is pressed", async () => {
 test("closes menu when focus is lost", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-        />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+      />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -515,11 +516,9 @@ test("closes menu when the user clicks outside of the menu", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -539,11 +538,9 @@ test("does not close the menu when the user clicks outside of the menu but respo
   mockUseIsAboveBreakpoint.mockReturnValue(false);
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+    </ResponsiveVerticalMenu>,
   );
   const launcherButton = screen.getByTestId(
     "responsive-vertical-menu-launcher",
@@ -562,11 +559,9 @@ test("closes menu when the user clicks the close button in responsive mode", asy
   mockUseIsAboveBreakpoint.mockReturnValue(false);
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -591,33 +586,31 @@ test("has the correct styling when interacting", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+      >
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
+          data-role="menu-item-2"
+          id="menu-item-2"
+          label="Menu Item 2"
         >
           <ResponsiveVerticalMenuItem
-            data-role="menu-item-2"
-            id="menu-item-2"
-            label="Menu Item 2"
-          >
-            <ResponsiveVerticalMenuItem
-              data-role="menu-item-3"
-              id="menu-item-3"
-              label="Menu Item 3"
-              icon="home"
-            />
-          </ResponsiveVerticalMenuItem>
+            data-role="menu-item-3"
+            id="menu-item-3"
+            label="Menu Item 3"
+            icon="home"
+          />
         </ResponsiveVerticalMenuItem>
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-4"
-          id="menu-item-4"
-          label="Menu Item 4"
-        />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+      </ResponsiveVerticalMenuItem>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-4"
+        id="menu-item-4"
+        label="Menu Item 4"
+      />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -661,32 +654,30 @@ test("has the correct styling when interacting and responsive", async () => {
   mockUseIsAboveBreakpoint.mockReturnValue(false);
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+      >
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
+          data-role="menu-item-2"
+          id="menu-item-2"
+          label="Menu Item 2"
         >
           <ResponsiveVerticalMenuItem
-            data-role="menu-item-2"
-            id="menu-item-2"
-            label="Menu Item 2"
-          >
-            <ResponsiveVerticalMenuItem
-              data-role="menu-item-3"
-              id="menu-item-3"
-              label="Menu Item 3"
-            />
-          </ResponsiveVerticalMenuItem>
-          <ResponsiveVerticalMenuItem
-            data-role="menu-item-4"
-            id="menu-item-4"
-            label="Menu Item 4"
+            data-role="menu-item-3"
+            id="menu-item-3"
+            label="Menu Item 3"
           />
         </ResponsiveVerticalMenuItem>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+        <ResponsiveVerticalMenuItem
+          data-role="menu-item-4"
+          id="menu-item-4"
+          label="Menu Item 4"
+        />
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -723,27 +714,25 @@ test("respects reduced motion and has the correct styling when interacting", asy
   mockUseMediaQuery.mockReturnValue(false);
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+      >
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
+          data-role="menu-item-2"
+          id="menu-item-2"
+          label="Menu Item 2"
         >
           <ResponsiveVerticalMenuItem
-            data-role="menu-item-2"
-            id="menu-item-2"
-            label="Menu Item 2"
-          >
-            <ResponsiveVerticalMenuItem
-              data-role="menu-item-3"
-              id="menu-item-3"
-              label="Menu Item 3"
-            />
-          </ResponsiveVerticalMenuItem>
+            data-role="menu-item-3"
+            id="menu-item-3"
+            label="Menu Item 3"
+          />
         </ResponsiveVerticalMenuItem>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -783,31 +772,29 @@ test("allows for full keyboard navigation of primary menus", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
   mockUseIsAboveBreakpoint.mockReturnValue(true);
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+      >
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-        >
-          <ResponsiveVerticalMenuItem
-            data-role="menu-item-4"
-            id="menu-item-4"
-            label="Menu Item 4"
-          />
-        </ResponsiveVerticalMenuItem>
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-2"
-          id="menu-item-2"
-          label="Menu Item 2"
+          data-role="menu-item-4"
+          id="menu-item-4"
+          label="Menu Item 4"
         />
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-3"
-          id="menu-item-3"
-          label="Menu Item 3"
-        />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+      </ResponsiveVerticalMenuItem>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-2"
+        id="menu-item-2"
+        label="Menu Item 2"
+      />
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-3"
+        id="menu-item-3"
+        label="Menu Item 3"
+      />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -845,32 +832,30 @@ test("allows for full keyboard navigation of secondary menus", async () => {
   mockUseIsAboveBreakpoint.mockReturnValue(true);
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+      >
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-        >
-          <ResponsiveVerticalMenuItem
-            data-role="menu-item-4"
-            id="menu-item-4"
-            label="Menu Item 4"
-          />
-        </ResponsiveVerticalMenuItem>
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-2"
-          id="menu-item-2"
-          label="Menu Item 2"
+          data-role="menu-item-4"
+          id="menu-item-4"
+          label="Menu Item 4"
         />
+      </ResponsiveVerticalMenuItem>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-2"
+        id="menu-item-2"
+        label="Menu Item 2"
+      />
 
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-3"
-          id="menu-item-3"
-          label="Menu Item 3"
-        />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-3"
+        id="menu-item-3"
+        label="Menu Item 3"
+      />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -905,38 +890,36 @@ test("allows for full keyboard navigation of tertiary menus", async () => {
   mockUseIsAboveBreakpoint.mockReturnValue(true);
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+      >
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
+          data-role="menu-item-4"
+          id="menu-item-4"
+          label="Menu Item 4"
         >
           <ResponsiveVerticalMenuItem
-            data-role="menu-item-4"
-            id="menu-item-4"
-            label="Menu Item 4"
-          >
-            <ResponsiveVerticalMenuItem
-              data-role="menu-item-5"
-              id="menu-item-5"
-              label="Menu Item 5"
-            />
-          </ResponsiveVerticalMenuItem>
+            data-role="menu-item-5"
+            id="menu-item-5"
+            label="Menu Item 5"
+          />
         </ResponsiveVerticalMenuItem>
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-2"
-          id="menu-item-2"
-          label="Menu Item 2"
-        />
+      </ResponsiveVerticalMenuItem>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-2"
+        id="menu-item-2"
+        label="Menu Item 2"
+      />
 
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-3"
-          id="menu-item-3"
-          label="Menu Item 3"
-        />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-3"
+        id="menu-item-3"
+        label="Menu Item 3"
+      />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -973,31 +956,62 @@ test("allows for full keyboard navigation of tertiary menus", async () => {
   expect(menuItem).toHaveFocus();
 });
 
+test("focuses the primary menu item when Tab is pressed and the last item is a tertiary menu item with a closed submenu", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  render(
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem id="primary-item" label="Primary Item">
+        <ResponsiveVerticalMenuItem id="secondary-item" label="Secondary Item">
+          <ResponsiveVerticalMenuItem id="tertiary-item" label="Tertiary Item">
+            <ResponsiveVerticalMenuItem
+              id="level-4-item"
+              label="Level 4 Item"
+            />
+          </ResponsiveVerticalMenuItem>
+        </ResponsiveVerticalMenuItem>
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
+  );
+
+  await user.click(screen.getByRole("button"));
+  const primaryItem = screen.getByRole("button", { name: "Primary Item" });
+  await user.click(primaryItem);
+  const secondaryItem = screen.getByRole("button", { name: "Secondary Item" });
+  await user.click(secondaryItem);
+  const tertiaryItem = screen.getByRole("button", { name: "Tertiary Item" });
+  await user.click(tertiaryItem); // closes the tertiary menu
+
+  await user.tab();
+  expect(primaryItem).toHaveFocus();
+  await user.tab();
+  expect(secondaryItem).toHaveFocus();
+  await user.tab();
+  expect(tertiaryItem).toHaveFocus();
+});
+
 test(`anchor links are correctly rendered`, async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+        href="https://example.com"
+      />
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-2"
+        id="menu-item-2"
+        label="Menu Item 2"
+      >
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-          href="https://example.com"
+          data-role="menu-item-3"
+          id="menu-item-3"
+          label="Menu Item 3"
         />
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-2"
-          id="menu-item-2"
-          label="Menu Item 2"
-        >
-          <ResponsiveVerticalMenuItem
-            data-role="menu-item-3"
-            id="menu-item-3"
-            label="Menu Item 3"
-          />
-        </ResponsiveVerticalMenuItem>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1015,13 +1029,11 @@ test("generates IDs for menu items if omitted", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem label="Menu Item 1" />
-        <ResponsiveVerticalMenuItem id="actual-id-1" label="Menu Item 2" />
-        <ResponsiveVerticalMenuItem id="actual-id-2" label="Menu Item 3" />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem label="Menu Item 1" />
+      <ResponsiveVerticalMenuItem id="actual-id-1" label="Menu Item 2" />
+      <ResponsiveVerticalMenuItem id="actual-id-2" label="Menu Item 3" />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1044,28 +1056,26 @@ test("generates IDs for menu items if omitted", async () => {
 test("renders dividers correctly at depth 0", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+        href="https://example.com"
+      />
+      <ResponsiveVerticalMenuDivider />
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-2"
+        id="menu-item-2"
+        label="Menu Item 2"
+      >
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-          href="https://example.com"
+          data-role="menu-item-3"
+          id="menu-item-3"
+          label="Menu Item 3"
         />
-        <ResponsiveVerticalMenuDivider />
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-2"
-          id="menu-item-2"
-          label="Menu Item 2"
-        >
-          <ResponsiveVerticalMenuItem
-            data-role="menu-item-3"
-            id="menu-item-3"
-            label="Menu Item 3"
-          />
-        </ResponsiveVerticalMenuItem>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1083,33 +1093,31 @@ test("renders dividers correctly when responsive", async () => {
   mockUseIsAboveBreakpoint.mockReturnValue(false);
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+        href="https://example.com"
+      />
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-2"
+        id="menu-item-2"
+        label="Menu Item 2"
+      >
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-          href="https://example.com"
+          data-role="menu-item-3"
+          id="menu-item-3"
+          label="Menu Item 3"
         />
+        <ResponsiveVerticalMenuDivider />
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-2"
-          id="menu-item-2"
-          label="Menu Item 2"
-        >
-          <ResponsiveVerticalMenuItem
-            data-role="menu-item-3"
-            id="menu-item-3"
-            label="Menu Item 3"
-          />
-          <ResponsiveVerticalMenuDivider />
-          <ResponsiveVerticalMenuItem
-            data-role="menu-item-4"
-            id="menu-item-4"
-            label="Menu Item 4"
-          />
-        </ResponsiveVerticalMenuItem>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+          data-role="menu-item-4"
+          id="menu-item-4"
+          label="Menu Item 4"
+        />
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1130,16 +1138,14 @@ test("should allow an onClick handler to be passed to items", async () => {
   const onClick = jest.fn();
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-          onClick={onClick}
-        />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+        onClick={onClick}
+      />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1158,18 +1164,16 @@ test("items without children correctly pass `target` and `rel` props to the unde
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-          href="https://example.com"
-          target="_blank"
-          rel="noopener noreferrer"
-        />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+        href="https://example.com"
+        target="_blank"
+        rel="noopener noreferrer"
+      />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1187,23 +1191,21 @@ test("items with children do not pass `target` and `rel` props to the underlying
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <ResponsiveVerticalMenuItem
-            data-role="menu-item-2"
-            id="menu-item-2"
-            label="Menu Item 2"
-          />
-        </ResponsiveVerticalMenuItem>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+          data-role="menu-item-2"
+          id="menu-item-2"
+          label="Menu Item 2"
+        />
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1222,28 +1224,26 @@ test("nested menu items are correctly justified when icons are not present", asy
   mockUseIsAboveBreakpoint.mockReturnValue(false);
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        id="menu-item-1"
+        label="Menu Item 1"
+        href="https://example.com"
+      >
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          id="menu-item-1"
-          label="Menu Item 1"
-          href="https://example.com"
+          data-role="menu-item-2"
+          id="menu-item-2"
+          label="Menu Item 2"
         >
           <ResponsiveVerticalMenuItem
-            data-role="menu-item-2"
-            id="menu-item-2"
-            label="Menu Item 2"
-          >
-            <ResponsiveVerticalMenuItem
-              data-role="menu-item-3"
-              id="menu-item-3"
-              label="Menu Item 3"
-            />
-          </ResponsiveVerticalMenuItem>
+            data-role="menu-item-3"
+            id="menu-item-3"
+            label="Menu Item 3"
+          />
         </ResponsiveVerticalMenuItem>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1266,31 +1266,29 @@ test("nested menu items are correctly justified when icons are present", async (
   mockUseIsAboveBreakpoint.mockReturnValue(false);
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        icon="home"
+        id="menu-item-1"
+        label="Menu Item 1"
+        href="https://example.com"
+      >
         <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          icon="home"
-          id="menu-item-1"
-          label="Menu Item 1"
-          href="https://example.com"
+          data-role="menu-item-2"
+          icon="business"
+          id="menu-item-2"
+          label="Menu Item 2"
         >
           <ResponsiveVerticalMenuItem
-            data-role="menu-item-2"
-            icon="business"
-            id="menu-item-2"
-            label="Menu Item 2"
-          >
-            <ResponsiveVerticalMenuItem
-              data-role="menu-item-3"
-              icon="analysis"
-              id="menu-item-3"
-              label="Menu Item 3"
-            />
-          </ResponsiveVerticalMenuItem>
+            data-role="menu-item-3"
+            icon="analysis"
+            id="menu-item-3"
+            label="Menu Item 3"
+          />
         </ResponsiveVerticalMenuItem>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1324,31 +1322,29 @@ test("correct aria-label values are set", async () => {
         },
       }}
     >
-      <ResponsiveVerticalMenuProvider>
-        <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenu>
+        <ResponsiveVerticalMenuItem
+          data-role="menu-item-1"
+          icon="home"
+          id="menu-item-1"
+          label="Menu Item 1"
+          href="https://example.com"
+        >
           <ResponsiveVerticalMenuItem
-            data-role="menu-item-1"
-            icon="home"
-            id="menu-item-1"
-            label="Menu Item 1"
-            href="https://example.com"
+            data-role="menu-item-2"
+            icon="business"
+            id="menu-item-2"
+            label="Menu Item 2"
           >
             <ResponsiveVerticalMenuItem
-              data-role="menu-item-2"
-              icon="business"
-              id="menu-item-2"
-              label="Menu Item 2"
-            >
-              <ResponsiveVerticalMenuItem
-                data-role="menu-item-3"
-                icon="analysis"
-                id="menu-item-3"
-                label="Menu Item 3"
-              />
-            </ResponsiveVerticalMenuItem>
+              data-role="menu-item-3"
+              icon="analysis"
+              id="menu-item-3"
+              label="Menu Item 3"
+            />
           </ResponsiveVerticalMenuItem>
-        </ResponsiveVerticalMenu>
-      </ResponsiveVerticalMenuProvider>
+        </ResponsiveVerticalMenuItem>
+      </ResponsiveVerticalMenu>
     </I18nProvider>,
   );
 
@@ -1371,18 +1367,16 @@ test("children populated by empty map", async () => {
   mockUseIsAboveBreakpoint.mockReturnValue(false);
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          icon="home"
-          id="menu-item-1"
-          label="Menu Item 1"
-        >
-          {[].map((item) => item)}
-        </ResponsiveVerticalMenuItem>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        icon="home"
+        id="menu-item-1"
+        label="Menu Item 1"
+      >
+        {[].map((item) => item)}
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1400,18 +1394,16 @@ test("children populated by map of non-React elements", async () => {
   mockUseIsAboveBreakpoint.mockReturnValue(false);
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem
-          data-role="menu-item-1"
-          icon="home"
-          id="menu-item-1"
-          label="Menu Item 1"
-        >
-          {["a", "b", "c"].map((item) => item)}
-        </ResponsiveVerticalMenuItem>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        data-role="menu-item-1"
+        icon="home"
+        id="menu-item-1"
+        label="Menu Item 1"
+      >
+        {["a", "b", "c"].map((item) => item)}
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1429,13 +1421,11 @@ test("adds and removes resize event listener on mount/unmount", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   const { unmount } = render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
-        <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
-        <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+      <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
+      <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1460,13 +1450,11 @@ test("sets and clears resize timeout on window resize", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
-        <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
-        <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+      <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
+      <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1488,13 +1476,11 @@ test("clears previous timeout on rapid resizes", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
-        <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
-        <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+      <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
+      <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1516,13 +1502,11 @@ test("clears timeout on unmount if it exists", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   const { unmount } = render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
-        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
-        <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
-        <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+      <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
+      <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1543,11 +1527,9 @@ test("clears timeout on unmount if it exists", async () => {
 test("renders menu with provided data tags", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu data-role="test-role" data-element="test-element">
-        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu data-role="test-role" data-element="test-element">
+      <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByRole("button", { name: "Product menu" });
@@ -1559,16 +1541,14 @@ test("renders menu with provided data tags", async () => {
 
 test("renders with provided menu launcher data tags", async () => {
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu
-        launcherButtonDataProps={{
-          "data-role": "test-launcher-role",
-          "data-element": "test-launcher-element",
-        }}
-      >
-        <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+    <ResponsiveVerticalMenu
+      launcherButtonDataProps={{
+        "data-role": "test-launcher-role",
+        "data-element": "test-launcher-element",
+      }}
+    >
+      <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByRole("button", { name: "Product menu" });
@@ -1583,33 +1563,31 @@ test("applies the correct styling at depth level 4", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        id="menu-item-1"
+        label="Menu Item 1"
+        data-role="menu-item-1"
+      >
         <ResponsiveVerticalMenuItem
-          id="menu-item-1"
-          label="Menu Item 1"
-          data-role="menu-item-1"
+          id="menu-item-2"
+          label="Menu Item 2"
+          data-role="menu-item-2"
         >
           <ResponsiveVerticalMenuItem
-            id="menu-item-2"
-            label="Menu Item 2"
-            data-role="menu-item-2"
+            id="menu-item-3"
+            label="Menu Item 3"
+            data-role="menu-item-3"
           >
             <ResponsiveVerticalMenuItem
-              id="menu-item-3"
-              label="Menu Item 3"
-              data-role="menu-item-3"
-            >
-              <ResponsiveVerticalMenuItem
-                id="menu-item-4"
-                data-role="menu-item-4"
-                label="Menu Item 4"
-              />
-            </ResponsiveVerticalMenuItem>
+              id="menu-item-4"
+              data-role="menu-item-4"
+              label="Menu Item 4"
+            />
           </ResponsiveVerticalMenuItem>
         </ResponsiveVerticalMenuItem>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(
@@ -1641,33 +1619,31 @@ test("applies the correct styling at depth level 4 when responsive", async () =>
   mockUseIsAboveBreakpoint.mockReturnValue(false);
 
   render(
-    <ResponsiveVerticalMenuProvider>
-      <ResponsiveVerticalMenu>
+    <ResponsiveVerticalMenu>
+      <ResponsiveVerticalMenuItem
+        id="menu-item-1"
+        label="Menu Item 1"
+        data-role="menu-item-1"
+      >
         <ResponsiveVerticalMenuItem
-          id="menu-item-1"
-          label="Menu Item 1"
-          data-role="menu-item-1"
+          id="menu-item-2"
+          label="Menu Item 2"
+          data-role="menu-item-2"
         >
           <ResponsiveVerticalMenuItem
-            id="menu-item-2"
-            label="Menu Item 2"
-            data-role="menu-item-2"
+            id="menu-item-3"
+            label="Menu Item 3"
+            data-role="menu-item-3"
           >
             <ResponsiveVerticalMenuItem
-              id="menu-item-3"
-              label="Menu Item 3"
-              data-role="menu-item-3"
-            >
-              <ResponsiveVerticalMenuItem
-                id="menu-item-4"
-                data-role="menu-item-4"
-                label="Menu Item 4"
-              />
-            </ResponsiveVerticalMenuItem>
+              id="menu-item-4"
+              data-role="menu-item-4"
+              label="Menu Item 4"
+            />
           </ResponsiveVerticalMenuItem>
         </ResponsiveVerticalMenuItem>
-      </ResponsiveVerticalMenu>
-    </ResponsiveVerticalMenuProvider>,
+      </ResponsiveVerticalMenuItem>
+    </ResponsiveVerticalMenu>,
   );
 
   const launcherButton = screen.getByTestId(


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- Moves secondary menu element to be a child of the primary menu instead of a sibling to ensure correct screen reader behaviour. 

https://github.com/user-attachments/assets/16964dbf-a351-4551-890d-3b684526f109

- Children of last tertiary item in secondary menu are accessible via Tab.

https://github.com/user-attachments/assets/119d70fb-7a27-40c4-bff3-f24f88652dea

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

- Secondary menu element is a sibling of the primary menu, meaning screen readers will navigate through all of the items within the primary menu before moving onto the secondary.

https://github.com/user-attachments/assets/6bc6434d-91a9-4210-8335-fb0264610cf2

- Children of last tertiary item in secondary menu are not accessible via Tab.


https://github.com/user-attachments/assets/6ab6924e-6859-46b9-a062-45dcaf28f3fe


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

Additional ticket (FE-7448) has been raised to fix other keyboard nav issues regarding level 4 menu items, playwright tests have been written for these but skipped.

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

See [demo](https://stackblitz.com/edit/parsium-carbon-starter-avlyhfm7?file=src%2FApp.tsx) for Tabbing issue, see `WithDifferentDepthAsLastItem` test story for fix.

