### PR TITLE
fix(loader-spinner): update style tests that assert tokens values to use toHaveStyleRule

### DIFF
--- a/src/components/loader-spinner/loader-spinner.test.tsx
+++ b/src/components/loader-spinner/loader-spinner.test.tsx
@@ -180,9 +180,10 @@ describe("when custom props are passed", () => {
     render(<LoaderSpinner size="extra-small" />);
     const visibleLabelElement = screen.getByTestId("visible-label");
 
-    expect(visibleLabelElement).toHaveStyle({
-      marginLeft: "var(--spacing100)",
-    });
+    expect(visibleLabelElement).toHaveStyleRule(
+      "margin-left",
+      "var(--spacing100)",
+    );
   });
 
   it.each(["small", "medium", "large", "extra-large"] as LoaderSpinnerSizes[])(
@@ -230,10 +231,12 @@ describe("when custom props are passed", () => {
     "when the 'variant' prop is passed as '%s' the correct outer arc stroke (color) is rendered",
     (variant) => {
       render(<LoaderSpinner variant={variant} />);
-      const outerArcSvgElement = screen.getByTestId("outer-arc");
+      const outerArcWrapper = screen.getByRole("presentation");
 
-      expect(outerArcSvgElement).toHaveStyle(
-        `stroke: ${outerArcStrokeValues[variant]}`,
+      expect(outerArcWrapper).toHaveStyleRule(
+        "stroke",
+        `${outerArcStrokeValues[variant]}`,
+        { modifier: 'circle[data-role="outer-arc"]' },
       );
     },
   );
@@ -255,9 +258,11 @@ describe("when custom props are passed", () => {
     "when the 'variant' prop is passed as `%s` the correct inner arc stroke (color) is rendered",
     (variants, strokeValues) => {
       render(<LoaderSpinner variant={variants} />);
-      const innerArcSvgElement = screen.getByTestId("inner-arc");
+      const innerArcWrapper = screen.getByRole("presentation");
 
-      expect(innerArcSvgElement).toHaveStyle(`stroke: ${strokeValues}`);
+      expect(innerArcWrapper).toHaveStyleRule("stroke", `${strokeValues}`, {
+        modifier: 'circle[data-role="inner-arc"]',
+      });
     },
   );
 
@@ -277,9 +282,13 @@ describe("when custom props are passed", () => {
       "renders correct stroke for variant='%s'",
       (variant) => {
         render(<LoaderSpinner variant={variant} />);
-        const innerArc = screen.getByTestId("inner-arc");
+        const innerArcWrapper = screen.getByRole("presentation");
 
-        expect(innerArc).toHaveStyle(`stroke: ${isWheelStrokeColors[variant]}`);
+        expect(innerArcWrapper).toHaveStyleRule(
+          "stroke",
+          `${isWheelStrokeColors[variant]}`,
+          { modifier: 'circle[data-role="inner-arc"]' },
+        );
       },
     );
   });


### PR DESCRIPTION
### Proposed behaviour
When CSS rules target child elements through parent selectors, using `toHaveStyleRule` directly on the child element won't work because the CSS rule is defined on the parent, not the child. Instead, we can test the parent element and use the `modifier` option in `toHaveStyleRule` to specify the nested selector that targets the child element.

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour
Current tests for asserting tokens use `toHaveStyle`.
<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
