### PR TITLE
docs(link): add subtle to variant examples - FE-7453

### DIFF
--- a/src/components/link/link.stories.tsx
+++ b/src/components/link/link.stories.tsx
@@ -141,26 +141,42 @@ WithOnClick.parameters = { chromatic: { disableSnapshot: true } };
 
 export const Variants: Story = () => {
   return (
-    <>
+    <Box width="max-content" display="flex" flexDirection="column" gap="32px">
       <Link
         href="https://carbon.sage.com"
         target="_blank"
         rel="noreferrer noopener"
         variant="negative"
       >
-        This is a link
+        This is a negative link
       </Link>
-      <br />
-      <br />
       <Link
         href="https://carbon.sage.com"
         target="_blank"
         rel="noreferrer noopener"
         variant="neutral"
       >
-        This is a link
+        This is a neutral link
       </Link>
-    </>
+      <Box
+        backgroundColor="#000000"
+        width="max-content"
+        padding="20px 10px"
+        display="flex"
+        flexDirection="column"
+        alignItems="center"
+      >
+        <Link
+          href="https://carbon.sage.com"
+          target="_blank"
+          rel="noreferrer noopener"
+          variant="subtle"
+          isDarkBackground
+        >
+          This is a subtle link
+        </Link>
+      </Box>
+    </Box>
   );
 };
 Variants.storyName = "Variants";

--- a/src/components/link/link.stories.tsx
+++ b/src/components/link/link.stories.tsx
@@ -190,6 +190,7 @@ export const OnADarkBackground: Story = () => {
       display="flex"
       flexDirection="column"
       alignItems="center"
+      gap="16px"
     >
       <Link
         href="https://carbon.sage.com"
@@ -201,13 +202,11 @@ export const OnADarkBackground: Story = () => {
       </Link>
       {(["left", "right"] as const).map((align) => (
         <React.Fragment key={`${align}-default-variant`}>
-          <br />
           <Link icon="settings" isDarkBackground iconAlign={align} href="#foo">
             This is a link
           </Link>
         </React.Fragment>
       ))}
-      <br />
       <Link
         href="https://carbon.sage.com"
         target="_blank"
@@ -219,7 +218,6 @@ export const OnADarkBackground: Story = () => {
       </Link>
       {(["left", "right"] as const).map((align) => (
         <React.Fragment key={`${align}-negative-variant`}>
-          <br />
           <Link
             icon="settings"
             isDarkBackground
@@ -231,7 +229,6 @@ export const OnADarkBackground: Story = () => {
           </Link>
         </React.Fragment>
       ))}
-      <br />
       <Link
         href="https://carbon.sage.com"
         target="_blank"
@@ -243,7 +240,6 @@ export const OnADarkBackground: Story = () => {
       </Link>
       {(["left", "right"] as const).map((align) => (
         <React.Fragment key={`${align}-neutral-variant`}>
-          <br />
           <Link
             icon="settings"
             isDarkBackground
@@ -255,7 +251,6 @@ export const OnADarkBackground: Story = () => {
           </Link>
         </React.Fragment>
       ))}
-      <br />
       <Link
         href="https://carbon.sage.com"
         target="_blank"
@@ -267,7 +262,6 @@ export const OnADarkBackground: Story = () => {
       </Link>
       {(["left", "right"] as const).map((align) => (
         <React.Fragment key={`${align}-subtle-variant`}>
-          <br />
           <Link
             icon="settings"
             isDarkBackground
@@ -279,7 +273,6 @@ export const OnADarkBackground: Story = () => {
           </Link>
         </React.Fragment>
       ))}
-      <br />
       <Link isDarkBackground disabled>
         This is a link
       </Link>


### PR DESCRIPTION
This piece of work adds a `subtle` variant example to variants docs of the Link component

fixes #7489

### Proposed behaviour

- Adds a `subtle` example of Link to the `Variants` part of the documentations.
- Fix an issue in Firefox where the `br` tags aren't applied, causing no space between the examples.

### Current behaviour

- A `subtle` variant example is only included in the `Dark Background` part of the docs.
- Firefox has an issue where the `br` tags aren't applied, causing no space between the examples/

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in provided StackBlitz sandbox/Storybook
- [x] Add new Playwright test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- An additional example should be displayed in the `Variants` examples. This is example should be the `subtle` variant and it should be appear against a dark background. 
- There should be no other regressions relating to the Link documentation and no new AXE accessibility violations. 
- Ensure that the updated Chromatic snapshot matches the expected changes that have been made to the documentation. (**Additional info on 05/09/25** - The snapshots will have updated because the `br` tag had a height of 17px and I have changed the css gap value to be a multiplier of 8 to match our wider use of the spacing multiplier.)
