### PR TITLE
fix(responsive-vertical-menu): fixes how screen readers announce the menu

### DIFF
--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-item/responsive-vertical-menu-item.component.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-item/responsive-vertical-menu-item.component.tsx
@@ -300,13 +300,24 @@ const BaseItem = forwardRef<HTMLElement, BaseItemProps>(
       setActive(false);
     };
 
+    const ariaControls = (): string | undefined => {
+      if (responsiveMode) {
+        return depth === 0 ? undefined : `${id}-nested-menu-wrapper`;
+      }
+
+      return `responsive-vertical-menu-secondary`;
+    };
+
     return (
       <StyledResponsiveMenuListItem>
         {hasChildren ? (
           <>
             <StyledResponsiveMenuItem
               active={isActive}
-              aria-expanded={isActive || expanded}
+              aria-expanded={
+                responsiveMode && depth === 0 ? undefined : isActive || expanded
+              }
+              aria-controls={isActive || expanded ? ariaControls() : undefined}
               data-component={`responsive-vertical-menu-item-${id}`}
               data-depth={depth}
               data-role={`responsive-vertical-menu-item-${id}`}
@@ -354,6 +365,7 @@ const BaseItem = forwardRef<HTMLElement, BaseItemProps>(
                 data-role={`${id}-nested-menu-wrapper`}
                 depth={depth}
                 hasIcon={!!icon || !!customIcon}
+                id={`${id}-nested-menu-wrapper`}
                 responsive={responsiveMode}
               >
                 <StyledNestedMenu

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
@@ -277,14 +277,12 @@ const BaseMenu = ({
     if (responsiveMode) {
       return {
         "aria-expanded": undefined,
-        "aria-haspopup": "dialog" as const,
         "aria-controls": "responsive-vertical-menu-dialog",
         "aria-label": locale.verticalMenu.ariaLabels?.responsiveMenuLauncher(),
       };
     }
     return {
       "aria-expanded": active,
-      "aria-haspopup": "menu" as const,
       "aria-controls": "responsive-vertical-menu-primary",
       "aria-label": locale.verticalMenu.ariaLabels?.responsiveMenuLauncher(),
     };


### PR DESCRIPTION
### Proposed behaviour

- Adjust menu items to only report their expansion status if not responsive **and** at depth level of 0;
- Remove `aria-haspopup` entirely, as it adds no real value given the menu semantics.

### Current behaviour

- In responsive mode, the top-level menu headings still retain their `expanded` mark-up despite no longer being expandable/collapsible
- `aria-haspopup` conveys that the responsive menu is an actual menu, whereas it is a menu in name only (functionally it's more akin to `nav`)

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Using Safari and VO:
- Open a responsive menu story with nested items and switch to responsive mode;
- Tab onto the launcher button and ensure it is announced as such (i.e. as a button, not a dialogue, web popup, etc.);
- Using the keyboard, navigate focus to the top-level item and ensure that it is not flagged as `expanded`.