### PR TITLE
fix(menu-item): increase specificity for links that don't contain buttons - FE-7456

### DIFF
--- a/src/components/menu/menu-item/menu-item.style.ts
+++ b/src/components/menu/menu-item/menu-item.style.ts
@@ -220,33 +220,33 @@ const StyledMenuItemWrapper = styled.a.attrs(applyBaseTheme).attrs({
 
     ${hasFocusableChild &&
     css`
-      ${!inFullscreenView &&
-      css`
-        > a:not(:has(button)) {
-          padding: 11px 16px;
-        }
+      &&
+        ${!inFullscreenView &&
+        css`
+          && > a:not(:has(button)) {
+            padding: 11px 16px;
+          }
 
-        > a:has(${StyledButton}:not(.search-button)) {
-          height: 100%;
+          > a:has(${StyledButton}:not(.search-button)) {
+            height: 100%;
 
-          ${StyledContent} {
-            height: inherit;
-
-            div {
+            ${StyledContent} {
               height: inherit;
+
+              div {
+                height: inherit;
+              }
+            }
+
+            ${StyledButton} {
+              min-height: 40px;
+              padding: 10px 0px;
+              box-sizing: border-box;
+              height: 100%;
             }
           }
-
-          ${StyledButton} {
-            min-height: 40px;
-            padding: 10px 0px;
-            box-sizing: border-box;
-            height: 100%;
-          }
-        }
-      `}
-
-      ${StyledIconButton} {
+        `}
+        ${StyledIconButton} {
         > span {
           display: inline-flex;
           margin-right: 0;

--- a/src/components/menu/menu-test.stories.tsx
+++ b/src/components/menu/menu-test.stories.tsx
@@ -18,6 +18,8 @@ import GlobalHeader from "../global-header";
 import Icon from "../icon";
 
 import type { MenuType } from "./menu.types";
+import NavigationBar from "../navigation-bar";
+import Pill from "../pill";
 
 const defaultOpenState = isChromatic();
 
@@ -483,3 +485,30 @@ MenuFullScreenWithMaxWidth.decorators = [
     </>
   ),
 ];
+
+export const NavBarMenuWithPill: StoryFullScreen = () => {
+  return (
+    <NavigationBar navigationType="white" orientation="top">
+      <Menu menuType="white">
+        <MenuItem href="#">Menu Item One</MenuItem>
+        <MenuItem onClick={() => {}}>Menu Item Button</MenuItem>
+        <MenuItem onClick={() => {}}>
+          incomplete
+          <Pill pillRole="status" colorVariant="warning" fill ml={1} size="M">
+            2
+          </Pill>
+        </MenuItem>
+
+        <MenuItem submenu="Menu Item Four" onClick={() => {}}>
+          <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+        </MenuItem>
+      </Menu>
+    </NavigationBar>
+  );
+};
+NavBarMenuWithPill.storyName = "Menu in a Navigation Bar with Pill ";
+NavBarMenuWithPill.parameters = {
+  themeProvider: { chromatic: { theme: "sage" } },
+  chromatic: { disableSnapshot: false },
+};


### PR DESCRIPTION
We have had an issue reported where the CSS seems to be loading in an incorrect order. The solution to this is to increase the specificity of the CSS we need applying.

fixes #7497

### Proposed behaviour

Increase specificity of `padding: 11px 16px` styling code so that it is consistently applied.

### Current behaviour

We have had a case where `padding: 11px 16px` styling has been overriden with `padding: 0px` causing a visual issue.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

This issue is very difficult to recreate as it relies on the browser loading the CSS in an order where `padding: 0px` takes precedence. 

### Testing instructions

There should be no visual regressions to menu-item styling. 
