### PR TITLE
test(dialog): add play functions

### DIFF
--- a/src/components/dialog/dialog.interactions.stories.tsx
+++ b/src/components/dialog/dialog.interactions.stories.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import { StoryObj } from "@storybook/react";
+import { userEvent, within, expect, waitFor } from "@storybook/test";
+import Dialog from ".";
+import Button from "../button";
+import { allowInteractions } from "../../../.storybook/interaction-toggle/reduced-motion";
+
+type Story = StoryObj<typeof Dialog>;
+
+export default {
+  title: "Dialog/Interactions",
+  component: Dialog,
+  parameters: {
+    layout: "padded",
+    chromatic: { disableSnapshot: true },
+  },
+  decorators: [],
+};
+
+export const FocusManagement: Story = {
+  render: function FocusManagementRender() {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)} data-role="open-dialog-btn">
+          Open Dialog
+        </Button>
+        <Dialog
+          open={isOpen}
+          title="Title"
+          subtitle="Subtitle"
+          onCancel={() => setIsOpen(false)}
+          showCloseIcon
+        >
+          <p>Content</p>
+        </Dialog>
+      </>
+    );
+  },
+
+  play: async ({ canvasElement }) => {
+    if (!allowInteractions()) return;
+    const canvas = within(canvasElement);
+    const portal = within(canvasElement.ownerDocument.body);
+
+    const openButton = canvas.getByRole("button", { name: /open dialog/i });
+
+    openButton.focus();
+    await waitFor(() => expect(openButton).toHaveFocus());
+
+    await userEvent.click(openButton);
+
+    const closeButton = await portal.findByRole("button", { name: /close/i });
+    await waitFor(() => expect(closeButton).toBeVisible());
+
+    await userEvent.tab();
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    closeButton.focus();
+  },
+};
+
+FocusManagement.storyName = "Focus Management";
+FocusManagement.parameters = {
+  themeProvider: {
+    chromatic: { theme: "sage" },
+  },
+};


### PR DESCRIPTION
### Proposed behaviour
Adding play functions to the Dialog component.
<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour
There are no play functions in this component currently. 
<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
