### PR TITLE
feat(pill): add translation support to pill

### DIFF
--- a/docs/i18n.mdx
+++ b/docs/i18n.mdx
@@ -230,6 +230,7 @@ export const PolishPlural = (
 | numeralDate           | [Table](?path=/docs/numeral-date--docs#translation-keys)            |
 | pager                 | [Table](?path=/docs/pager--docs#translation-keys)                   |
 | password              | [Table](?path=/docs/password--docs#translation-keys)                |
+| pill                  | [Table](?path=/docs/pill--docs#translation-keys)                |
 | progressTracker       | [Table](?path=/docs/progress-tracker--docs#translation-keys)        |
 | pod                   | [Table](?path=/docs/pod--docs#translation-keys)                     |
 | search                | [Table](?path=/docs/search--docs#translation-keys)                  |

--- a/src/components/pill/pill-test.stories.tsx
+++ b/src/components/pill/pill-test.stories.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
-import Pill from "./pill.component";
+import Pill, { PillProps } from "./pill.component";
 import Box from "../box";
+import { MultiSelect, Option } from "../select";
 
 export default {
   title: "Pill/Test",
@@ -88,4 +89,59 @@ StatusDarkBackground.story = {
     pillRole: "status",
     colorVariant: "neutral",
   },
+};
+
+export const WithCustomAriaLabels = ({ ...args }: PillProps) => {
+  const noop = () => action("delete");
+
+  const [selectedPills, setSelectedPills] = useState(["1", "4"]);
+  const handleActivityChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedPills(event.target.value as unknown as string[]);
+  };
+
+  return (
+    <>
+      <Pill onDelete={noop} {...args}>
+        Localised
+      </Pill>
+      <Pill
+        ariaLabelOfRemoveButton="Remove the pill with a custom ARIA label value"
+        onDelete={noop}
+        {...args}
+      >
+        This should not be read out
+      </Pill>
+
+      <Pill ariaLabelOfRemoveButton="remove pill" onDelete={noop} {...args}>
+        Prop passed but with default value
+      </Pill>
+      <br />
+      <br />
+      <MultiSelect
+        name="multi-select-with-pills"
+        value={selectedPills}
+        onChange={handleActivityChange}
+        onOpen={action("onOpen")}
+        onClick={action("onClick")}
+        onFilterChange={action("onFilterChange")}
+        onFocus={action("onFocus")}
+        onBlur={action("onBlur")}
+        onKeyDown={action("onKeyDown")}
+        openOnFocus
+        label="Multi-Select with Pills"
+        placeholder=" "
+      >
+        <Option value="1" text="One" />
+        <Option value="2" text="Two" />
+        <Option value="3" text="Three" />
+        <Option value="4" text="Four" />
+        <Option value="5" text="Five" />
+        <Option value="6" text="Six" />
+        <Option value="7" text="Seven" />
+        <Option value="8" text="Eight" />
+        <Option value="9" text="Nine" />
+        <Option value="10" text="Ten" />
+      </MultiSelect>
+    </>
+  );
 };

--- a/src/components/pill/pill.component.tsx
+++ b/src/components/pill/pill.component.tsx
@@ -6,6 +6,7 @@ import tagComponent, {
 } from "../../__internal__/utils/helpers/tags/tags";
 import Logger from "../../__internal__/utils/logger";
 import IconButton from "../icon-button";
+import useLocale from "../../hooks/__internal__/useLocale";
 
 export interface PillProps extends StyledPillProps, TagProps {
   /** The content to display inside of the pill.  */
@@ -52,9 +53,11 @@ export const Pill = ({
   onDelete,
   pillRole = "tag",
   size = "M",
-  ariaLabelOfRemoveButton = "remove pill",
+  ariaLabelOfRemoveButton,
   ...rest
 }: PillProps) => {
+  const locale = useLocale();
+
   if (
     !neutralWhiteWarnTriggered &&
     !isDarkBackground &&
@@ -89,7 +92,7 @@ export const Pill = ({
         <IconButton
           onClick={onDelete}
           data-element="close"
-          aria-label={ariaLabelOfRemoveButton}
+          aria-label={ariaLabelOfRemoveButton || locale.pill.remove(children)}
         >
           <Icon type="cross" />
         </IconButton>

--- a/src/components/pill/pill.mdx
+++ b/src/components/pill/pill.mdx
@@ -1,4 +1,5 @@
 import { Meta, ArgTypes, Canvas } from "@storybook/blocks";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 
 import * as PillStories from "./pill.stories";
 
@@ -22,6 +23,7 @@ Compact visual indicators that help things in common stand out.
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Props](#props)
+- [Translation keys](#translation-keys)
 
 ## Quick Start
 
@@ -52,8 +54,8 @@ When a callback in the `onDelete` prop is provided, a remove button will be rend
 
 ### With custom remove button aria-label
 
-By default the aria-label of the remove button will be set to "remove pill".
-That attribute can be customized by passing a string to the `ariaLabelOfRemoveButton` prop.
+By default, the remove button's `aria-label` is handled via the `pill.remove` [translation keys](#translation-keys) using the pill's label as an argument.
+To override this, provide a custom string via the `ariaLabelOfRemoveButton` prop.
 
 <Canvas of={PillStories.WithCustomRemoveButtonAriaLabel} />
 
@@ -71,7 +73,7 @@ Applied by the user, and indicate something in common. Change the theme to see t
 
 ### Custom colors
 
-You can pass a custom color to Pill by using the `borderColor` prop, which will be set as the background color if `fill` is true. 
+You can pass a custom color to Pill by using the `borderColor` prop, which will be set as the background color if `fill` is true.
 This prop will take precedence over the `colorVariant` value.
 See our [Colors](../?path=/docs/documentation-colors--docs) documentation for more information.
 
@@ -90,3 +92,20 @@ Color variants for dark theme, to apply these set `isDarkBackground` to `true`.
 ### Pill
 
 <ArgTypes of={PillStories} />
+
+## Translation keys
+
+The following keys are available to override the translations for this component by passing in a custom locale object to the
+[i18nProvider](../?path=/docs/documentation-i18n--docs).
+
+<TranslationKeysTable
+  translationData={[
+    {
+      name: "pill.remove",
+      description:
+        "The text to be read out by screen readers when the pill's remove button is focused. The label of the pill will be passed as an argument.",
+      type: "func",
+      returnType: "string",
+    },
+  ]}
+/>

--- a/src/components/pill/pill.test.tsx
+++ b/src/components/pill/pill.test.tsx
@@ -27,7 +27,9 @@ test("should render remove button when onDelete is set and call onDelete when th
   const onDelete = jest.fn();
   render(<Pill onDelete={onDelete}>Test Pill</Pill>);
 
-  const removeButton = screen.getByRole("button", { name: "remove pill" });
+  const removeButton = screen.getByRole("button", {
+    name: "Remove Test Pill pill",
+  });
   expect(removeButton).toBeVisible();
 
   await user.click(removeButton);

--- a/src/components/select/multi-select/multi-select.test.tsx
+++ b/src/components/select/multi-select/multi-select.test.tsx
@@ -154,7 +154,7 @@ describe("when value prop is provided", () => {
 
     const amberPill = screen.getByTitle("amber");
     expect(
-      within(amberPill).getByRole("button", { name: "remove pill" }),
+      within(amberPill).getByRole("button", { name: "Remove amber pill" }),
     ).toBeVisible();
   });
 

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -158,6 +158,9 @@ const enGB: Locale = {
       "Your password has been shown. Focus on the password input to have it read to you, if it is safe to do so.",
     ariaLiveHiddenMessage: () => "Your password is currently hidden.",
   },
+  pill: {
+    remove: (label: string) => `Remove ${label} pill`,
+  },
   progressTracker: {
     of: () => "of",
   },

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -125,6 +125,9 @@ interface Locale {
     ariaLiveShownMessage: () => string;
     ariaLiveHiddenMessage: () => string;
   };
+  pill: {
+    remove: (label: string) => string;
+  };
   progressTracker: {
     of: () => string;
   };


### PR DESCRIPTION
fixes #7514

### Proposed behaviour

Adds a translation entry to the locale files to allow customised aria-label messages. This is now applied by default; unless the user provides a value via `ariaLabelOfRemoveButton`, this translation entry will be used (defaults to `Remove XYZ pill` where "XYZ" is the value as displayed in the Pill)

### Current behaviour

The remove pill button fails WCAG 1.3.1 due to it not announcing the value of the pill it removes, which can be confusing to screen reader users when there are multiple pills on-screen

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

A new story has been added into Pill's testing stories to demonstrate Pills with divergent aria labels, which can be used for testing
