### PR TITLE
test(date-range): change date to avoid incorrect snapshot change

### DIFF
--- a/src/components/date-range/date-range-interactions.stories.tsx
+++ b/src/components/date-range/date-range-interactions.stories.tsx
@@ -304,6 +304,7 @@ export const TypingSyncDateRange: Story = {
   ),
   play: async ({ canvasElement }) => {
     if (!allowInteractions()) return;
+
     const canvas = within(canvasElement);
 
     const [startIcon] = canvas.getAllByTestId("icon");
@@ -312,11 +313,11 @@ export const TypingSyncDateRange: Story = {
 
     const startInput = canvas.getByRole("textbox", { name: /start date/i });
     await userEvent.clear(startInput);
-    await userEvent.keyboard("10/09/2025");
+    await userEvent.type(startInput, "05/05/2022");
     await userInteractionPause(300);
 
     const caption = canvas.getByRole("status");
-    expect(caption).toHaveTextContent(/September 2025/i);
+    expect(caption).toHaveTextContent(/May 2022/i);
   },
 };
 


### PR DESCRIPTION
### Proposed behaviour
Story relies on `handleOnKeyDown`, so onBlur is not fired, when switching between two fields.
<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour
DateRange calls `onBlur` even when the user is just switching between the start and end inputs
<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
