### PR TITLE
feat: removes support for uncontrolled inputs

### DIFF
--- a/.storybook/welcome-page/components-demo/demo/demo.component.jsx
+++ b/.storybook/welcome-page/components-demo/demo/demo.component.jsx
@@ -78,7 +78,11 @@ const Demo = () => {
                 />
               </StyledComponentWrapper>
               <StyledComponentWrapper styling={{ width: "30%", padding: "1%" }}>
-                <Decimal aria-label="An example decimal input component" />
+                <Decimal
+                  aria-label="An example decimal input component"
+                  value={decimalValue}
+                  onChange={(e) => setDecimalValue(e.target.value.rawValue)}
+                />
               </StyledComponentWrapper>
             </StyledDemoRow>
             <StyledDemoRow styling={{ display: "flex" }}>

--- a/docs/validations.stories.tsx
+++ b/docs/validations.stories.tsx
@@ -20,31 +20,54 @@ export default meta;
 export const StringValidation: StoryObj = () => {
   return (
     <>
-      <Textbox label="Textbox" value="" error="Error Message" />
-      <Textbox label="Textbox" value="" warning="Warning Message" />
-      <Textbox label="Textbox" value="" info="Info Message" />
+      <Textbox
+        label="Textbox"
+        value=""
+        error="Error Message"
+        onChange={() => {}}
+      />
+      <Textbox
+        label="Textbox"
+        value=""
+        warning="Warning Message"
+        onChange={() => {}}
+      />
+      <Textbox
+        label="Textbox"
+        value=""
+        info="Info Message"
+        onChange={() => {}}
+      />
     </>
   );
 };
 StringValidation.storyName = "String Validation";
 
 export const BooleanValidation: StoryObj = () => {
-  return <Textbox label="Textbox" value="" error />;
+  return <Textbox label="Textbox" value="" error onChange={() => {}} />;
 };
 BooleanValidation.storyName = "Boolean Validation";
 
 export const ValidationOnLabel: StoryObj = () => {
   return (
-    <Textbox label="Textbox" value="" error="Error Message" validationOnLabel />
+    <Textbox
+      label="Textbox"
+      value=""
+      error="Error Message"
+      validationOnLabel
+      onChange={() => {}}
+    />
   );
 };
 ValidationOnLabel.storyName = "Validation on Label";
 
 export const TooltipPosition: StoryObj = () => {
+  const [state, setState] = React.useState("");
   return (
     <Textbox
       label="Textbox"
-      value=""
+      onChange={(e) => setState(e.target.value)}
+      value={state}
       error="Error Message"
       tooltipPosition="bottom"
     />
@@ -53,8 +76,14 @@ export const TooltipPosition: StoryObj = () => {
 TooltipPosition.storyName = "Tooltip Position";
 
 export const GroupedInputValidation: StoryObj = () => {
+  const [state, setState] = React.useState("radio1");
   return (
-    <RadioButtonGroup legend="Radio Button Group" name="errorRadioGroup">
+    <RadioButtonGroup
+      legend="Radio Button Group"
+      name="errorRadioGroup"
+      value={state}
+      onChange={(e) => setState(e.target.value)}
+    >
       <RadioButton
         id="error-radio-1"
         value="radio1"
@@ -79,12 +108,15 @@ export const GroupedInputValidation: StoryObj = () => {
 GroupedInputValidation.storyName = "Grouped Input Validation";
 
 export const GroupedLegendValidation: StoryObj = () => {
+  const [state, setState] = React.useState("radio1");
   return (
     <RadioButtonGroup
       legend="Radio Button Group"
       name="errorRadioGroup"
       required
       error="Error Message"
+      value={state}
+      onChange={(e) => setState(e.target.value)}
     >
       <RadioButton id="radio-1" value="radio1" label="Radio Option 1" />
       <RadioButton id="radio-2" value="radio2" label="Radio Option 2" />
@@ -95,6 +127,7 @@ export const GroupedLegendValidation: StoryObj = () => {
 GroupedLegendValidation.storyName = "Grouped Legend Validation";
 
 export const ValidationRedesign: StoryObj = () => {
+  const [state, setState] = React.useState("");
   return (
     <CarbonProvider validationRedesignOptIn>
       <Form>
@@ -104,14 +137,16 @@ export const ValidationRedesign: StoryObj = () => {
         <Textbox
           label="Textbox"
           inputHint="Hint text"
-          value=""
+          value={state}
+          onChange={(e) => setState(e.target.value)}
           required
           error="Error Message (Fix is required)"
         />
         <Textbox
           label="Textbox"
           inputHint="Hint text"
-          value=""
+          value={state}
+          onChange={(e) => setState(e.target.value)}
           warning="Warning Message (Fix is optional)"
         />
       </Form>
@@ -121,6 +156,9 @@ export const ValidationRedesign: StoryObj = () => {
 ValidationRedesign.storyName = "Validation Redesign";
 
 export const ValidationRedesignWithGroupedInputs: StoryObj = () => {
+  const [state, setState] = React.useState("radio1");
+  const [state2, setState2] = React.useState(true);
+  const [state3, setState3] = React.useState(false);
   return (
     <CarbonProvider validationRedesignOptIn>
       <Form>
@@ -133,6 +171,8 @@ export const ValidationRedesignWithGroupedInputs: StoryObj = () => {
           name="errorRadioGroup"
           required
           error="Error Message (Fix is required)"
+          value={state}
+          onChange={(e) => setState(e.target.value)}
         >
           <RadioButton id="new-radio-1" value="radio1" label="Radio Option 1" />
           <RadioButton id="new-radio-2" value="radio2" label="Radio Option 2" />
@@ -147,11 +187,15 @@ export const ValidationRedesignWithGroupedInputs: StoryObj = () => {
             id="new-checkbox-1"
             value="checkbox1"
             label="Checkbox Option 1"
+            checked={state2}
+            onChange={(e) => setState2(e.target.checked)}
           />
           <Checkbox
             id="new-checkbox-2"
             value="checkbox2"
             label="Checkbox Option 2"
+            checked={state3}
+            onChange={(e) => setState3(e.target.checked)}
           />
         </CheckboxGroup>
       </Form>
@@ -162,6 +206,10 @@ ValidationRedesignWithGroupedInputs.storyName =
   "Validation Redesign with Grouped Inputs";
 
 export const ValidationRedesignMessageBottom: StoryObj = () => {
+  const [state, setState] = React.useState("");
+  const [state2, setState2] = React.useState(true);
+  const [state3, setState3] = React.useState(false);
+
   return (
     <CarbonProvider validationRedesignOptIn>
       <Form>
@@ -172,7 +220,8 @@ export const ValidationRedesignMessageBottom: StoryObj = () => {
         <Textbox
           label="Textbox"
           inputHint="Hint text"
-          value=""
+          value={state}
+          onChange={(e) => setState(e.target.value)}
           required
           error="Error Message (Fix is required)"
           validationMessagePositionTop={false}
@@ -188,11 +237,15 @@ export const ValidationRedesignMessageBottom: StoryObj = () => {
             id="new-checkbox-1-bottom"
             value="checkbox1"
             label="Checkbox Option 1"
+            checked={state2}
+            onChange={(e) => setState2(e.target.checked)}
           />
           <Checkbox
             id="new-checkbox-2-bottom"
             value="checkbox2"
             label="Checkbox Option 2"
+            checked={state3}
+            onChange={(e) => setState3(e.target.checked)}
           />
         </CheckboxGroup>
       </Form>

--- a/src/__internal__/focus-trap/focus-trap.test.tsx
+++ b/src/__internal__/focus-trap/focus-trap.test.tsx
@@ -434,7 +434,12 @@ it("only allows non-disabled elements to be focused", async () => {
 describe("when first focusable elements are radio buttons", () => {
   const WithRadioGroup = () => (
     <MockComponent>
-      <RadioButtonGroup name="Colours" legend="Colours" onChange={() => {}}>
+      <RadioButtonGroup
+        name="Colours"
+        legend="Colours"
+        onChange={() => {}}
+        value=""
+      >
         <RadioButton value="Red" label="Red" />
         <RadioButton value="Green" label="Green" />
       </RadioButtonGroup>
@@ -471,11 +476,21 @@ describe("when first focusable elements are radio buttons", () => {
 describe("with 2 different radio groups", () => {
   const WithTwoGroups = () => (
     <MockComponent>
-      <RadioButtonGroup name="Colours" legend="Colours" onChange={() => {}}>
+      <RadioButtonGroup
+        name="Colours"
+        legend="Colours"
+        onChange={() => {}}
+        value=""
+      >
         <RadioButton value="Red" label="Red" />
         <RadioButton value="Green" label="Green" />
       </RadioButtonGroup>
-      <RadioButtonGroup name="Fruits" legend="Fruits" onChange={() => {}}>
+      <RadioButtonGroup
+        name="Fruits"
+        legend="Fruits"
+        onChange={() => {}}
+        value=""
+      >
         <RadioButton value="Apple" label="Apple" />
         <RadioButton value="Melon" label="Melon" />
       </RadioButtonGroup>
@@ -512,11 +527,21 @@ describe("with 2 different radio groups", () => {
 describe("with 2 different focusable radio groups and a custom selector", () => {
   const WithTwoGroups = () => (
     <MockComponent focusableSelectors="input[type=radio]">
-      <RadioButtonGroup name="Colours" legend="Colours" onChange={() => {}}>
+      <RadioButtonGroup
+        name="Colours"
+        legend="Colours"
+        onChange={() => {}}
+        value=""
+      >
         <RadioButton value="Red" label="Red" />
         <RadioButton value="Green" label="Green" />
       </RadioButtonGroup>
-      <RadioButtonGroup name="Fruits" legend="Fruits" onChange={() => {}}>
+      <RadioButtonGroup
+        name="Fruits"
+        legend="Fruits"
+        onChange={() => {}}
+        value=""
+      >
         <RadioButton value="Apple" label="Apple" />
         <RadioButton value="Melon" label="Melon" />
       </RadioButtonGroup>
@@ -555,7 +580,12 @@ describe("when last focusable elements are radio buttons", () => {
     <MockComponent>
       <button type="button">One</button>
       <button type="button">Two</button>
-      <RadioButtonGroup name="Colours" legend="Colours" onChange={() => {}}>
+      <RadioButtonGroup
+        name="Colours"
+        legend="Colours"
+        onChange={() => {}}
+        value=""
+      >
         <RadioButton value="Red" label="Red" />
         <RadioButton value="Green" label="Green" />
       </RadioButtonGroup>
@@ -588,16 +618,24 @@ describe("when last focusable elements are radio buttons", () => {
 });
 
 describe("when trap contains radio buttons", () => {
-  const WithRadioGroup = () => (
-    <MockComponent>
-      <button type="button">One</button>
-      <RadioButtonGroup name="Colours" legend="Colours" onChange={() => {}}>
-        <RadioButton value="Red" label="Red" />
-        <RadioButton value="Green" label="Green" />
-      </RadioButtonGroup>
-      <button type="button">Two</button>
-    </MockComponent>
-  );
+  const WithRadioGroup = () => {
+    const [value, setValue] = useState("");
+    return (
+      <MockComponent>
+        <button type="button">One</button>
+        <RadioButtonGroup
+          name="Colours"
+          legend="Colours"
+          onChange={(e) => setValue(e.target.value)}
+          value={value}
+        >
+          <RadioButton value="Red" label="Red" />
+          <RadioButton value="Green" label="Green" />
+        </RadioButtonGroup>
+        <button type="button">Two</button>
+      </MockComponent>
+    );
+  };
 
   it("moves focus to the previous focusable element, when focus on first radio button shift-tab pressed", async () => {
     const user = userEvent.setup({ delay: null });
@@ -681,16 +719,24 @@ describe("when trap contains radio buttons", () => {
 });
 
 describe("when trap contains radio buttons when using a custom selector", () => {
-  const WithRadioGroup = () => (
-    <MockComponent focusableSelectors="input[type=radio]">
-      <button type="button">One</button>
-      <RadioButtonGroup name="Colours" legend="Colours" onChange={() => {}}>
-        <RadioButton value="Red" label="Red" />
-        <RadioButton value="Green" label="Green" />
-      </RadioButtonGroup>
-      <button type="button">Two</button>
-    </MockComponent>
-  );
+  const WithRadioGroup = () => {
+    const [value, setValue] = useState("");
+    return (
+      <MockComponent focusableSelectors="input[type=radio]">
+        <button type="button">One</button>
+        <RadioButtonGroup
+          name="Colours"
+          legend="Colours"
+          onChange={(e) => setValue(e.target.value)}
+          value={value}
+        >
+          <RadioButton value="Red" label="Red" />
+          <RadioButton value="Green" label="Green" />
+        </RadioButtonGroup>
+        <button type="button">Two</button>
+      </MockComponent>
+    );
+  };
 
   it("when tabbing into the radio group, focus should move to the first radio button when none were previously selected", async () => {
     const user = userEvent.setup({ delay: null });
@@ -817,7 +863,12 @@ describe("when trap contains only one focusable element according to a custom se
 describe("when trap contains one radio button group and no other focusable elements", () => {
   const WithRadioGroup = () => (
     <MockComponent>
-      <RadioButtonGroup name="Colours" legend="Colours" onChange={() => {}}>
+      <RadioButtonGroup
+        name="Colours"
+        legend="Colours"
+        onChange={() => {}}
+        value=""
+      >
         <RadioButton value="Red" label="Red" />
         <RadioButton value="Green" label="Green" />
       </RadioButtonGroup>
@@ -854,7 +905,12 @@ describe("when trap contains one radio button group and no other focusable eleme
 describe("when trap contains one radio button group and no other focusable elements according to a custom selector", () => {
   const WithRadioGroup = () => (
     <MockComponent focusableSelectors="input[type=radio]">
-      <RadioButtonGroup name="Colours" legend="Colours" onChange={() => {}}>
+      <RadioButtonGroup
+        name="Colours"
+        legend="Colours"
+        onChange={() => {}}
+        value=""
+      >
         <RadioButton value="Red" label="Red" />
         <RadioButton value="Green" label="Green" />
       </RadioButtonGroup>
@@ -1448,10 +1504,15 @@ test("when FocusTrap is closed, focus should move normally through focusable ele
 test("should focus the first input that has the `autoFocus` prop set on it", () => {
   render(
     <MockComponent>
-      <Select onChange={() => {}} autoFocus label="Autofocus me">
+      <Select onChange={() => {}} autoFocus label="Autofocus me" value="">
         <Option value="1" text="one" />
       </Select>
-      <Checkbox label="Do not autofocus me" autoFocus onChange={() => {}} />
+      <Checkbox
+        label="Do not autofocus me"
+        autoFocus
+        onChange={() => {}}
+        checked={false}
+      />
     </MockComponent>,
   );
 
@@ -1462,10 +1523,15 @@ test("should loop to the last element when there is elements with tabIndex of -1
   const user = userEvent.setup({ delay: null });
   render(
     <MockComponent>
-      <Select onChange={() => {}} autoFocus label="Autofocus me">
+      <Select onChange={() => {}} autoFocus label="Autofocus me" value="">
         <Option value="1" text="one" />
       </Select>
-      <Checkbox label="Do not autofocus me" autoFocus onChange={() => {}} />
+      <Checkbox
+        label="Do not autofocus me"
+        autoFocus
+        onChange={() => {}}
+        checked={false}
+      />
     </MockComponent>,
   );
 
@@ -1481,7 +1547,7 @@ test("should set focus on the `focusFirstElement` when it and an input with `aut
   render(
     mockComponentToRender({
       children: (
-        <Select onChange={() => {}} autoFocus label="Autofocus me">
+        <Select onChange={() => {}} autoFocus label="Autofocus me" value="">
           <Option value="1" text="one" />
         </Select>
       ),

--- a/src/__internal__/input-behaviour/useInputBehaviour.test.tsx
+++ b/src/__internal__/input-behaviour/useInputBehaviour.test.tsx
@@ -69,7 +69,7 @@ test("when group behaviour is enabled and the `onMouseDown` function is called, 
     }
   };
 
-  render(<Input ref={inputRefCallback} />);
+  render(<Input ref={inputRefCallback} value="" />);
 
   const input = screen.getByRole("textbox") as HTMLInputElement;
   const focusSpy = jest.spyOn(input, "focus");

--- a/src/__internal__/input/input-presentation.test.tsx
+++ b/src/__internal__/input/input-presentation.test.tsx
@@ -111,7 +111,7 @@ test("applies the correct z-index values when inside an open select", () => {
   render(
     <StyledSelect isOpen>
       <InputPresentation>
-        <Input />
+        <Input value="" />
       </InputPresentation>
       ,
     </StyledSelect>,
@@ -133,7 +133,7 @@ test.each(["left", "right"])(
   (alignValue) => {
     render(
       <InputPresentation hasIcon align={alignValue}>
-        <Input />
+        <Input value="" />
       </InputPresentation>,
     );
 

--- a/src/__internal__/input/input.component.tsx
+++ b/src/__internal__/input/input.component.tsx
@@ -14,7 +14,7 @@ export type EnterKeyHintTypes =
   | "send";
 
 export interface CommonInputProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> {
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type" | "value"> {
   /* The default value alignment on the input */
   align?: "right" | "left";
   /** The ID of the input's description, is set along with hint text and error message. */
@@ -49,6 +49,8 @@ export interface CommonInputProps
   required?: boolean;
   /** Id of the validation icon */
   validationIconId?: string;
+  /** The value of the input */
+  value: string | readonly string[] | number | undefined;
 }
 
 export interface InputProps extends CommonInputProps {

--- a/src/__internal__/input/input.test.tsx
+++ b/src/__internal__/input/input.test.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import Input, { EnterKeyHintTypes } from "./input.component";
+import Input, { EnterKeyHintTypes, InputProps } from "./input.component";
 import { InputContext } from "../input-behaviour";
 
 test("renders an input element with type 'text'", () => {
-  render(<Input />);
+  render(<Input value="" />);
 
   const input = screen.getByRole("textbox");
   expect(input).toBeVisible();
 });
 
 test("focuses the input element when rendered if the `autoFocus` prop is true", () => {
-  render(<Input autoFocus />);
+  render(<Input autoFocus value="" />);
 
   const input = screen.getByRole("textbox");
   expect(input).toHaveFocus();
@@ -29,7 +29,7 @@ test.each([
 ] as EnterKeyHintTypes[])(
   "'enterKeyHint' is correctly passed to the input when prop value is %s",
   (keyHint) => {
-    render(<Input enterKeyHint={keyHint} />);
+    render(<Input enterKeyHint={keyHint} value="" />);
 
     const input = screen.getByRole("textbox");
     expect(input).toHaveAttribute("enterKeyHint", keyHint);
@@ -40,7 +40,7 @@ test("should invoke the `inputRef` callback from the input context provider, whe
   const inputRef = jest.fn();
   render(
     <InputContext.Provider value={{ inputRef }}>
-      <Input />
+      <Input value="" />
     </InputContext.Provider>,
   );
 
@@ -49,7 +49,7 @@ test("should invoke the `inputRef` callback from the input context provider, whe
 
 test("triggers a passed function via the `onFocus` prop when the input is focused", () => {
   const onFocusMock = jest.fn();
-  render(<Input onFocus={onFocusMock} />);
+  render(<Input onFocus={onFocusMock} value="" />);
 
   const input = screen.getByRole("textbox");
   input.focus();
@@ -61,7 +61,7 @@ test("triggers a passed function via the `onFocus` prop from the input context p
   const onFocusMock = jest.fn();
   render(
     <InputContext.Provider value={{ onFocus: onFocusMock }}>
-      <Input />
+      <Input value="" />
     </InputContext.Provider>,
   );
 
@@ -73,7 +73,7 @@ test("triggers a passed function via the `onFocus` prop from the input context p
 
 test("triggers a passed function via the `onBlur` prop when the input is blurred", async () => {
   const onBlurMock = jest.fn();
-  render(<Input onBlur={onBlurMock} />);
+  render(<Input onBlur={onBlurMock} value="" />);
 
   const user = userEvent.setup();
   const input = screen.getByRole("textbox");
@@ -88,7 +88,7 @@ test("triggers a passed function via the `onBlur` prop from the input context pr
   const onBlurMock = jest.fn();
   render(
     <InputContext.Provider value={{ onBlur: onBlurMock }}>
-      <Input />
+      <Input value="" />
     </InputContext.Provider>,
   );
 
@@ -101,9 +101,24 @@ test("triggers a passed function via the `onBlur` prop from the input context pr
   expect(onBlurMock).toHaveBeenCalled();
 });
 
+const ControlledInput = (props: InputProps) => {
+  const [value, setValue] = React.useState(props.value || "");
+
+  return (
+    <Input
+      {...props}
+      value={value}
+      onChange={(e) => {
+        setValue(e.target.value);
+        props.onChange?.(e);
+      }}
+    />
+  );
+};
+
 test("triggers a passed function via the `onChange` prop when the input is changed", async () => {
   const onChangeMock = jest.fn();
-  render(<Input onChange={onChangeMock} />);
+  render(<ControlledInput onChange={onChangeMock} value="" />);
 
   const user = userEvent.setup();
   const input = screen.getByRole("textbox");
@@ -115,7 +130,7 @@ test("triggers a passed function via the `onChange` prop when the input is chang
 
 test("when the `onChangeDeferred `prop is passed and no `deferTimeout` prop is passed, the `handleDeferred` function is triggered after 750 ms", async () => {
   const onChangeDeferredProp = jest.fn();
-  render(<Input onChangeDeferred={onChangeDeferredProp} />);
+  render(<Input onChangeDeferred={onChangeDeferredProp} value="" />);
 
   jest.useFakeTimers();
 
@@ -135,7 +150,13 @@ test("when the `onChangeDeferred `prop is passed and no `deferTimeout` prop is p
 
 test("when the `onChangeDeferred` prop is passed with the `deferTimeout` prop, the `handleDeferred` function is triggered after the time passed to `deferTimeout`", async () => {
   const onChangeDeferredProp = jest.fn();
-  render(<Input onChangeDeferred={onChangeDeferredProp} deferTimeout={1000} />);
+  render(
+    <Input
+      onChangeDeferred={onChangeDeferredProp}
+      deferTimeout={1000}
+      value=""
+    />,
+  );
 
   jest.useFakeTimers();
 
@@ -155,7 +176,7 @@ test("when the `onChangeDeferred` prop is passed with the `deferTimeout` prop, t
 
 test("triggers a passed function via the `onClick` prop when the input is clicked", async () => {
   const onClickMock = jest.fn();
-  render(<Input onClick={onClickMock} />);
+  render(<Input onClick={onClickMock} value="" />);
 
   const user = userEvent.setup();
   const input = screen.getByRole("textbox");
@@ -214,7 +235,7 @@ test("does not select all of the text if an intermediate character within the in
 });
 
 test("when the input is rendered with a type other than 'text', setSelectionRange is not triggered on focus", () => {
-  render(<Input type="radio" />);
+  render(<Input type="radio" value="" />);
 
   jest.useFakeTimers();
 
@@ -229,7 +250,7 @@ test("when the input is rendered with a type other than 'text', setSelectionRang
 });
 
 test("sets the provided `aria-describedby` to the accessible description of the input", () => {
-  render(<Input aria-describedby="description" />);
+  render(<Input aria-describedby="description" value="" />);
 
   const input = screen.getByRole("textbox");
   expect(input).toHaveAttribute("aria-describedby", "description");
@@ -239,7 +260,7 @@ test("does not call onClick handler when input is disabled and is clicked", asyn
   const onClickMock = jest.fn();
   const user = userEvent.setup();
 
-  render(<Input onClick={onClickMock} disabled />);
+  render(<Input onClick={onClickMock} disabled value="" />);
 
   const input = screen.getByRole("textbox");
   await user.click(input);
@@ -251,7 +272,7 @@ test("does not call onClick handler when input is readOnly and is clicked", asyn
   const onClickMock = jest.fn();
   const user = userEvent.setup();
 
-  render(<Input onClick={onClickMock} readOnly />);
+  render(<Input onClick={onClickMock} readOnly value="" />);
 
   const input = screen.getByRole("textbox");
   await user.click(input);

--- a/src/components/accordion/accordion-interaction.stories.tsx
+++ b/src/components/accordion/accordion-interaction.stories.tsx
@@ -5,7 +5,7 @@ import React from "react";
 
 import { Accordion, AccordionGroup } from ".";
 import Box from "../box";
-import Textbox from "../textbox";
+import Textbox, { TextboxProps } from "../textbox";
 
 import { allowInteractions } from "../../../.storybook/interaction-toggle/reduced-motion";
 import DefaultDecorator from "../../../.storybook/utils/default-decorator";
@@ -211,7 +211,11 @@ export const MixedAccordionStates: Story = {
         title="First Accordion"
       >
         <Box p={2}>
-          <Textbox label="Textbox in an Accordion" />
+          <Textbox
+            label="Textbox in an Accordion"
+            value=""
+            onChange={() => {}}
+          />
         </Box>
       </Accordion>
       <Accordion
@@ -220,7 +224,11 @@ export const MixedAccordionStates: Story = {
         title="Second Accordion"
       >
         <Box p={2}>
-          <Textbox label="Textbox in an Accordion" />
+          <Textbox
+            label="Textbox in an Accordion"
+            value=""
+            onChange={() => {}}
+          />
         </Box>
       </Accordion>
       <Accordion
@@ -264,6 +272,18 @@ MixedAccordionStates.parameters = {
   chromatic: { disableSnapshot: false },
 };
 
+const ControlledTextbox = (args: Omit<TextboxProps, "onChange" | "value">) => {
+  const [value, setValue] = React.useState("");
+
+  return (
+    <Textbox
+      {...args}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+};
+
 export const NestedComponentInteractions: Story = {
   render: (args) => (
     <Accordion
@@ -278,7 +298,7 @@ export const NestedComponentInteractions: Story = {
       }}
     >
       <Box p={2}>
-        <Textbox role="textbox" label="Textbox in an Accordion" />
+        <ControlledTextbox role="textbox" label="Textbox in an Accordion" />
       </Box>
     </Accordion>
   ),
@@ -324,7 +344,7 @@ export const ToggleGroupedAccordions: Story = {
         title="First Accordion"
       >
         <Box p={2}>
-          <Textbox label="Textbox in an Accordion" />
+          <ControlledTextbox label="Textbox in an Accordion" />
         </Box>
       </Accordion>
       <Accordion
@@ -333,7 +353,7 @@ export const ToggleGroupedAccordions: Story = {
         title="Second Accordion"
       >
         <Box p={2}>
-          <Textbox label="Textbox in an Accordion" />
+          <ControlledTextbox label="Textbox in an Accordion" />
         </Box>
       </Accordion>
       <Accordion

--- a/src/components/accordion/accordion-test.stories.tsx
+++ b/src/components/accordion/accordion-test.stories.tsx
@@ -87,7 +87,7 @@ export const Grouped = ({ ...args }) => (
       {...args}
     >
       <Box p={2}>
-        <Textbox label="Textbox in an Accordion" />
+        <Textbox label="Textbox in an Accordion" value="" onChange={() => {}} />
       </Box>
     </Accordion>
     <Accordion
@@ -96,7 +96,7 @@ export const Grouped = ({ ...args }) => (
       {...args}
     >
       <Box p={2}>
-        <Textbox label="Textbox in an Accordion" />
+        <Textbox label="Textbox in an Accordion" value="" onChange={() => {}} />
       </Box>
     </Accordion>
     <Accordion

--- a/src/components/accordion/accordion.stories.tsx
+++ b/src/components/accordion/accordion.stories.tsx
@@ -207,12 +207,20 @@ export const Grouped: Story = () => {
     <AccordionGroup>
       <Accordion title="First Accordion">
         <Box p={2}>
-          <Textbox label="Textbox in an Accordion" />
+          <Textbox
+            label="Textbox in an Accordion"
+            value=""
+            onChange={() => {}}
+          />
         </Box>
       </Accordion>
       <Accordion title="Second Accordion">
         <Box p={2}>
-          <Textbox label="Textbox in an Accordion" />
+          <Textbox
+            label="Textbox in an Accordion"
+            value=""
+            onChange={() => {}}
+          />
         </Box>
       </Accordion>
       <Accordion title="Third Accordion">

--- a/src/components/accordion/components.test-pw.tsx
+++ b/src/components/accordion/components.test-pw.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import Box from "../box";
 import { Checkbox } from "../checkbox";
@@ -50,6 +50,7 @@ export const AccordionWithIcon = () => {
   const [expanded, setExpanded] = React.useState({
     one: false,
   });
+  const [checkboxValue, setCheckboxValue] = useState(false);
 
   return (
     <AccordionGroup>
@@ -65,7 +66,11 @@ export const AccordionWithIcon = () => {
         error={errors.one}
         warning={warnings.one}
       >
-        <Checkbox label="Add error" />
+        <Checkbox
+          label="Add error"
+          checked={checkboxValue}
+          onChange={(e) => setCheckboxValue(e.target.checked)}
+        />
       </Accordion>
     </AccordionGroup>
   );
@@ -77,13 +82,19 @@ export const AccordionGroupWithError = () => {
     two: errorVal,
     three: errorVal,
   });
+  const [checkboxValue, setCheckboxValue] = useState(false);
 
   return (
     <Box mt={2}>
       <AccordionGroup>
         <Accordion title="Heading" error={errors.one}>
           <Box p={1}>
-            <Checkbox label="Add error" error={!!errors.one} />
+            <Checkbox
+              label="Add error"
+              error={!!errors.one}
+              checked={checkboxValue}
+              onChange={(e) => setCheckboxValue(e.target.checked)}
+            />
           </Box>
         </Accordion>
       </AccordionGroup>
@@ -95,13 +106,19 @@ export const AccordionGroupWithWarning = () => {
   const [warnings] = React.useState({
     one: warningVal,
   });
+  const [checkboxValue, setCheckboxValue] = useState(false);
 
   return (
     <Box mt={2}>
       <AccordionGroup>
         <Accordion title="Heading" warning={warnings.one}>
           <Box p={1}>
-            <Checkbox label="Add warning" warning={!!warnings.one} />
+            <Checkbox
+              label="Add warning"
+              warning={!!warnings.one}
+              checked={checkboxValue}
+              onChange={(e) => setCheckboxValue(e.target.checked)}
+            />
           </Box>
         </Accordion>
       </AccordionGroup>
@@ -113,13 +130,19 @@ export const AccordionGroupWithInfo = () => {
   const [infos] = React.useState({
     one: infoVal,
   });
+  const [checkboxValue, setCheckboxValue] = useState(false);
 
   return (
     <Box mt={2}>
       <AccordionGroup>
         <Accordion title="Heading" info={infos.one}>
           <Box p={1}>
-            <Checkbox label="Add info" info={!!infos.one} />
+            <Checkbox
+              label="Add info"
+              info={!!infos.one}
+              checked={checkboxValue}
+              onChange={(e) => setCheckboxValue(e.target.checked)}
+            />
           </Box>
         </Accordion>
       </AccordionGroup>
@@ -128,11 +151,17 @@ export const AccordionGroupWithInfo = () => {
 };
 
 export const AccordionGroupComponent = () => {
+  const [textboxValue, setTextboxValue] = useState("");
+
   return (
     <AccordionGroup>
       <Accordion title="First Accordion" onChange={() => {}} width="100%">
         <Box p={2}>
-          <Textbox label="Textbox in an Accordion" />
+          <Textbox
+            label="Textbox in an Accordion"
+            value={textboxValue}
+            onChange={(e) => setTextboxValue(e.target.value)}
+          />
         </Box>
       </Accordion>
       <Accordion title="Second Accordion" onChange={() => {}} width="100%">
@@ -253,16 +282,26 @@ export const AccordionWithBoxAndDifferentPaddings = () => {
 };
 
 export const AccordionGroupDefault = () => {
+  const [textboxValue, setTextboxValue] = useState("");
+
   return (
     <AccordionGroup>
       <Accordion title="First Accordion">
         <Box p={2}>
-          <Textbox label="Textbox in an Accordion" />
+          <Textbox
+            label="Textbox in an Accordion"
+            value={textboxValue}
+            onChange={(e) => setTextboxValue(e.target.value)}
+          />
         </Box>
       </Accordion>
       <Accordion title="Second Accordion">
         <Box p={2}>
-          <Textbox label="Textbox in an Accordion" />
+          <Textbox
+            label="Textbox in an Accordion"
+            value={textboxValue}
+            onChange={(e) => setTextboxValue(e.target.value)}
+          />
         </Box>
       </Accordion>
       <Accordion title="Third Accordion">
@@ -297,6 +336,7 @@ export const AccordionGroupValidation = () => {
     two: false,
     three: true,
   });
+  const [checkboxValue, setCheckboxValue] = useState(false);
 
   const handleChange = (
     id: Validations,
@@ -334,14 +374,20 @@ export const AccordionGroupValidation = () => {
             <Checkbox
               label="Add warning"
               warning={!!warnings.one}
-              onChange={() =>
-                handleChange("one", warnings, setWarnings, "warning")
-              }
+              onChange={(e) => {
+                handleChange("one", warnings, setWarnings, "warning");
+                setCheckboxValue(e.target.checked);
+              }}
+              checked={checkboxValue}
             />
             <Checkbox
               label="Add info"
               info={!!infos.one}
-              onChange={() => handleChange("one", infos, setInfos, "info")}
+              onChange={(e) => {
+                handleChange("one", infos, setInfos, "info");
+                setCheckboxValue(e.target.checked);
+              }}
+              checked={checkboxValue}
             />
           </Box>
         </Accordion>
@@ -369,14 +415,21 @@ export const AccordionGroupValidation = () => {
             <Checkbox
               label="Add warning"
               warning={!!warnings.two}
-              onChange={() =>
-                handleChange("two", warnings, setWarnings, "warning")
-              }
+              onChange={(e) => {
+                handleChange("two", warnings, setWarnings, "warning");
+
+                setCheckboxValue(e.target.checked);
+              }}
+              checked={checkboxValue}
             />
             <Checkbox
               label="Add info"
               info={!!infos.two}
-              onChange={() => handleChange("two", infos, setInfos, "info")}
+              onChange={(e) => {
+                handleChange("two", infos, setInfos, "info");
+                setCheckboxValue(e.target.checked);
+              }}
+              checked={checkboxValue}
             />
           </Box>
         </Accordion>
@@ -404,14 +457,21 @@ export const AccordionGroupValidation = () => {
             <Checkbox
               label="Add warning"
               warning={!!warnings.three}
-              onChange={() =>
-                handleChange("three", warnings, setWarnings, "warning")
-              }
+              onChange={(e) => {
+                handleChange("three", warnings, setWarnings, "warning");
+
+                setCheckboxValue(e.target.checked);
+              }}
+              checked={checkboxValue}
             />
             <Checkbox
               label="Add info"
               info={!!infos.three}
-              onChange={() => handleChange("three", infos, setInfos, "info")}
+              onChange={(e) => {
+                handleChange("three", infos, setInfos, "info");
+                setCheckboxValue(e.target.checked);
+              }}
+              checked={checkboxValue}
             />
           </Box>
         </Accordion>

--- a/src/components/action-popover/action-popover-test.stories.tsx
+++ b/src/components/action-popover/action-popover-test.stories.tsx
@@ -979,7 +979,6 @@ export const ActionPopoverSubmenuClick: Story = {
   play: async ({ canvasElement }) => {
     // This is required due to a known issue with the canvasElement not being the parent of the component when a Portal is used.
     // https://github.com/storybookjs/storybook/issues/26963
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const canvas = within(canvasElement.parentElement!);
     const actionPopoverButtons = canvas.getAllByRole("button");
     await userEvent.click(actionPopoverButtons[0]);

--- a/src/components/adaptive-sidebar/adaptive-sidebar-interaction.stories.tsx
+++ b/src/components/adaptive-sidebar/adaptive-sidebar-interaction.stories.tsx
@@ -69,6 +69,16 @@ const selectOptions = [
 const SimpleForm = () => {
   const [date, setDate] = useState("01/06/1994");
   const [petDate, setPetDate] = useState("14/09/2020");
+
+  const [firstName, setFirstName] = useState("");
+  const [middleName, setMiddleName] = useState("");
+  const [surname, setSurname] = useState("");
+  const [placeOfBirth, setPlaceOfBirth] = useState("");
+  const [address, setAddress] = useState("");
+  const [petName, setPetName] = useState("");
+  const [tcChecked, setTcChecked] = useState(false);
+  const [favouriteColour, setFavouriteColour] = useState("0");
+
   return (
     <Form
       m={2}
@@ -78,12 +88,37 @@ const SimpleForm = () => {
         </Button>
       }
     >
-      <Textbox label="First Name" data-component="first-name" />
-      <Textbox label="Middle Name" data-component="middle-name" />
-      <Textbox label="Surname" data-component="surname" />
-      <Textbox label="Birth Place" data-component="place-of-birth" />
+      <Textbox
+        label="First Name"
+        data-component="first-name"
+        value={firstName}
+        onChange={(e) => setFirstName(e.target.value)}
+      />
+      <Textbox
+        label="Middle Name"
+        data-component="middle-name"
+        value={middleName}
+        onChange={(e) => setMiddleName(e.target.value)}
+      />
+      <Textbox
+        label="Surname"
+        data-component="surname"
+        value={surname}
+        onChange={(e) => setSurname(e.target.value)}
+      />
+      <Textbox
+        label="Birth Place"
+        data-component="place-of-birth"
+        value={placeOfBirth}
+        onChange={(e) => setPlaceOfBirth(e.target.value)}
+      />
 
-      <Textbox label="Address" data-component="Address" />
+      <Textbox
+        label="Address"
+        data-component="Address"
+        value={address}
+        onChange={(e) => setAddress(e.target.value)}
+      />
       <DateInput
         data-component="birthday-input"
         name="date"
@@ -93,12 +128,22 @@ const SimpleForm = () => {
           setDate(e.target.value.formattedValue)
         }
       />
-      <Select label="Favourite Colour" data-role="favourite-colour">
+      <Select
+        label="Favourite Colour"
+        data-role="favourite-colour"
+        value={favouriteColour}
+        onChange={(e) => setFavouriteColour(e.target.value)}
+      >
         {selectOptions.map((option) => (
           <Option key={option.name} value={option} text={option.name} />
         ))}
       </Select>
-      <Textbox label="Pet Name" data-component="pet-name" />
+      <Textbox
+        label="Pet Name"
+        data-component="pet-name"
+        value={petName}
+        onChange={(e) => setPetName(e.target.value)}
+      />
       <DateInput
         data-component="pet-birthday-input"
         name="date"
@@ -112,6 +157,8 @@ const SimpleForm = () => {
         name="checkbox"
         label="Check this box to agree to our terms and conditions"
         data-component="tc-checkbox"
+        checked={tcChecked}
+        onChange={(e) => setTcChecked(e.target.checked)}
       />
     </Form>
   );

--- a/src/components/adaptive-sidebar/adaptive-sidebar-test.stories.tsx
+++ b/src/components/adaptive-sidebar/adaptive-sidebar-test.stories.tsx
@@ -26,6 +26,7 @@ export default {
     chromatic: { disableSnapshot: true },
     layout: "fullscreen",
     info: { disable: true },
+    themeProvider: { chromatic: { theme: "sage" } },
   },
 };
 
@@ -112,6 +113,7 @@ export const WithForm: StoryObj = () => {
   const [adaptiveSidebarOpen, setAdaptiveSidebarOpen] =
     useState(defaultOpenState);
   const [date, setDate] = useState("01/06/2020");
+  const [selected, setSelected] = useState("1");
   const selectOptions = [
     {
       id: "1",
@@ -184,12 +186,12 @@ export const WithForm: StoryObj = () => {
             <Button onClick={() => setAdaptiveSidebarOpen(false)}>Close</Button>
           }
         >
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
+          <Textbox label="First Name" value="" onChange={() => {}} />
+          <Textbox label="Middle Name" value="" onChange={() => {}} />
+          <Textbox label="Surname" value="" onChange={() => {}} />
+          <Textbox label="Birth Place" value="" onChange={() => {}} />
+          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+          <Textbox label="Address" value="" onChange={() => {}} />
           <DateInput
             name="date"
             label="Birthday"
@@ -198,12 +200,16 @@ export const WithForm: StoryObj = () => {
               setDate(e.target.value.formattedValue)
             }
           />
-          <Select label="Color">
+          <Select
+            label="Color"
+            value={selected}
+            onChange={(e) => setSelected(e.target.value)}
+          >
             {selectOptions.map((option) => (
               <Option key={option.name} value={option} text={option.name} />
             ))}
           </Select>
-          <Textbox label="Pet Name" />
+          <Textbox label="Pet Name" value="" onChange={() => {}} />
           <DateInput
             name="date"
             label="Pet's birthday"
@@ -212,7 +218,12 @@ export const WithForm: StoryObj = () => {
               setDate(e.target.value.formattedValue)
             }
           />
-          <Checkbox name="checkbox" label="Do you like my Dog" />
+          <Checkbox
+            name="checkbox"
+            label="Do you like my Dog"
+            checked={false}
+            onChange={() => {}}
+          />
           <div>This is an example of an adaptive with a Form as content</div>
         </Form>
       </AdaptiveSidebar>
@@ -291,7 +302,8 @@ export const ExampleImplementation: StoryObj = () => {
             </Typography>
             <Search
               placeholder="Enter a keyword or phrase"
-              defaultValue=""
+              value=""
+              onChange={() => {}}
               searchButton
             />
             <Typography variant="h3" mt={2} mb={2}>
@@ -463,6 +475,8 @@ export const WithDropdown: StoryObj = () => {
   useLayoutEffect(() => {
     selectRef.current?.focus();
   }, []);
+  const [selected, setSelected] = useState("");
+  const [selected2, setSelected2] = useState("");
 
   return (
     <Box margin="var(--spacing200)" display="flex" flexDirection="row">
@@ -474,6 +488,8 @@ export const WithDropdown: StoryObj = () => {
           name="simple"
           id="simple"
           label="open dropdown and decrease screen size until sidebar changes to modal"
+          value={selected}
+          onChange={(e) => setSelected(e.target.value)}
         >
           <Option text="Amber" value="1" />
           <Option text="Black" value="2" />
@@ -495,6 +511,8 @@ export const WithDropdown: StoryObj = () => {
             name="simple-2"
             id="simple-2"
             label="open to test that the input and dropdowns show when the adaptive sidebar is open & triggered"
+            value={selected2}
+            onChange={(e) => setSelected2(e.target.value)}
           >
             <Option text="Amber" value="1" />
             <Option text="Black" value="2" />

--- a/src/components/advanced-color-picker/advanced-color-picker-test.stories.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker-test.stories.tsx
@@ -39,7 +39,6 @@ export const Default = (args: Partial<AdvancedColorPickerProps>) => {
         { value: "#AEECEB", label: "turquoise" },
         { value: "#AEECD6", label: "mint" },
       ]}
-      defaultColor="#EBAEDE"
       selectedColor={color}
       onChange={onChange}
       onOpen={() => {

--- a/src/components/advanced-color-picker/advanced-color-picker.component.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.component.tsx
@@ -13,11 +13,8 @@ import { filterStyledSystemMarginProps } from "../../style/utils";
 import guid from "../../__internal__/utils/helpers/guid";
 import useLocale from "../../hooks/__internal__/useLocale";
 import { Dt, Dd } from "../definition-list";
-import Logger from "../../__internal__/utils/logger";
 import { ModalProps } from "../modal";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
-
-let deprecateUncontrolledWarnTriggered = false;
 export interface AdvancedColor {
   label: string;
   value: string;
@@ -42,14 +39,12 @@ export interface AdvancedColorPickerProps
   "aria-labelledby"?: string;
   /** Prop for `availableColors` containing array of objects of colors */
   availableColors: AdvancedColor[];
-  /** Prop for `defaultColor` containing the default color for `uncontrolled` use */
-  defaultColor: string;
   /** Specifies the name prop to be applied to each color in the group */
   name: string;
   /** Prop for `onBlur` event */
   onBlur?: (ev: React.FocusEvent<HTMLInputElement>) => void;
   /** Prop for `onChange` event */
-  onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   /** Prop for `onClose` event */
   onClose?: (
     ev:
@@ -66,7 +61,7 @@ export interface AdvancedColorPickerProps
   /** The ARIA role to be applied to the component container */
   role?: string;
   /** Prop for `selectedColor` containing pre-selected color for `controlled` use */
-  selectedColor?: string;
+  selectedColor: string;
 }
 
 export const AdvancedColorPicker = ({
@@ -74,7 +69,6 @@ export const AdvancedColorPicker = ({
   "aria-label": ariaLabel,
   "aria-labelledby": ariaLabelledBy,
   availableColors,
-  defaultColor,
   name,
   onOpen,
   onClose,
@@ -87,7 +81,6 @@ export const AdvancedColorPicker = ({
   ...props
 }: AdvancedColorPickerProps) => {
   const [dialogOpen, setDialogOpen] = useState<boolean>();
-  const currentColor = selectedColor || defaultColor;
   const [selectedColorRef, setSelectedColorRef] =
     useState<HTMLInputElement | null>(null);
 
@@ -113,22 +106,22 @@ export const AdvancedColorPicker = ({
 
   const currentSelectedColor = () => {
     const returnedColor = availableColors.find(
-      (color) => color.value === currentColor,
+      (color) => color.value === selectedColor,
     )?.label as string;
 
-    return returnedColor || currentColor;
+    return returnedColor || selectedColor;
   };
 
   useEffect(() => {
     if (dialogOpen || open) {
-      const newColor = colors?.find((c) => currentColor === c.value);
+      const newColor = colors?.find((c) => selectedColor === c.value);
 
       /* istanbul ignore else */
       if (newColor) {
         setSelectedColorRef(newColor.getRef());
       }
     }
-  }, [colors, currentColor, dialogOpen, open]);
+  }, [colors, selectedColor, dialogOpen, open]);
 
   const handleFocus = useCallback(
     (e: KeyboardEvent, firstFocusableElement?: HTMLElement) => {
@@ -224,13 +217,6 @@ export const AdvancedColorPicker = ({
     [onBlur],
   );
 
-  if (!deprecateUncontrolledWarnTriggered && !onChange) {
-    deprecateUncontrolledWarnTriggered = true;
-    Logger.deprecate(
-      "Uncontrolled behaviour in `Advanced Color Picker` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-    );
-  }
-
   return (
     <StyledAdvancedColorPickerWrapper
       m="15px auto auto 15px"
@@ -243,7 +229,7 @@ export const AdvancedColorPicker = ({
         aria-describedby={descriptionId.current}
         onClick={handleOnOpen}
         onKeyDown={handleOnKeyDown}
-        color={currentColor}
+        color={selectedColor}
         tabIndex={0}
       />
       <HiddenCurrentColorList
@@ -273,7 +259,7 @@ export const AdvancedColorPicker = ({
       >
         <StyledAdvancedColorPickerPreview
           data-element="color-picker-preview"
-          color={currentColor}
+          color={selectedColor}
         />
         <SimpleColorPicker
           name={name}
@@ -282,6 +268,7 @@ export const AdvancedColorPicker = ({
           onBlur={handleOnBlur}
           onKeyDown={handleColorOnKeyDown}
           ref={simpleColorPickerData}
+          value={selectedColor}
         >
           {colors?.map(({ value, label }) => (
             <SimpleColor
@@ -289,7 +276,7 @@ export const AdvancedColorPicker = ({
               key={value}
               aria-label={label}
               id={value}
-              defaultChecked={value === currentColor}
+              checked={value === selectedColor}
             />
           ))}
         </SimpleColorPicker>

--- a/src/components/advanced-color-picker/advanced-color-picker.interactions.stories.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.interactions.stories.tsx
@@ -44,7 +44,6 @@ const AdvancedColorPickerWithState = ({
       onChange={(e) => setSelectedColor(e.target.value)}
       availableColors={mockColors}
       name="color-picker"
-      defaultColor="#EBAEDE"
     />
   );
 };

--- a/src/components/advanced-color-picker/advanced-color-picker.pw.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.pw.tsx
@@ -267,7 +267,7 @@ test.describe("should render AdvancedColorPicker component and check props", () 
     await mount(
       <AdvancedColorPickerCustom
         availableColors={colors}
-        defaultColor="#111222"
+        selectedColor="#111222"
       />,
     );
 

--- a/src/components/advanced-color-picker/advanced-color-picker.stories.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.stories.tsx
@@ -67,7 +67,6 @@ export const Default: Story = () => {
         { value: "#AEECEB", label: "turquoise" },
         { value: "#AEECD6", label: "mint" },
       ]}
-      defaultColor="#EBAEDE"
       selectedColor={color}
       onChange={onChange}
       onOpen={() => {
@@ -110,7 +109,6 @@ export const RestoreFocusOnCloseStory: Story = () => {
           { value: "#AEECEB", label: "turquoise" },
           { value: "#AEECD6", label: "mint" },
         ]}
-        defaultColor="#EBAEDE"
         selectedColor={color}
         onChange={onChange}
         onOpen={() => {

--- a/src/components/advanced-color-picker/advanced-color-picker.test.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.test.tsx
@@ -5,17 +5,13 @@ import AdvancedColorPicker, {
   AdvancedColorPickerProps,
 } from "./advanced-color-picker.component";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
-import Logger from "../../__internal__/utils/logger";
 
 const ControlledColorPicker = (props: Partial<AdvancedColorPickerProps>) => {
-  const [color, setColor] = useState<string | undefined>(
-    props.selectedColor || "",
-  );
+  const [color, setColor] = useState<string>("");
 
   return (
     <AdvancedColorPicker
       name="advancedPicker"
-      defaultColor=""
       availableColors={[
         { value: "#FFFFFF", label: "white" },
         { value: "transparent", label: "transparent" },
@@ -55,38 +51,6 @@ testStyledSystemMargin(
   ),
   () => screen.getByTestId("advanced-color-picker-wrapper"),
 );
-
-test("should display deprecation warning once when rendered as uncontrolled", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(
-    <AdvancedColorPicker
-      name="advancedPicker"
-      availableColors={[
-        { value: "#FFFFFF", label: "white" },
-        { value: "transparent", label: "transparent" },
-        { value: "#000000", label: "black" },
-        { value: "#A3CAF0", label: "blue" },
-        { value: "#FD9BA3", label: "pink" },
-        { value: "#B4AEEA", label: "purple" },
-        { value: "#ECE6AF", label: "goldenrod" },
-        { value: "#EBAEDE", label: "orchid" },
-        { value: "#EBC7AE", label: "desert" },
-        { value: "#AEECEB", label: "turquoise" },
-        { value: "#AEECD6", label: "mint" },
-      ]}
-      defaultColor="#EBAEDE"
-    />,
-  );
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "Uncontrolled behaviour in `Advanced Color Picker` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
-});
 
 test("when the main button is clicked, the dialog opens and the onOpen callback is called", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });

--- a/src/components/advanced-color-picker/components.test-pw.tsx
+++ b/src/components/advanced-color-picker/components.test-pw.tsx
@@ -6,7 +6,7 @@ export const AdvancedColorPickerCustom = ({
   ...props
 }: Partial<AdvancedColorPickerProps>) => {
   const [open, setOpen] = React.useState(true);
-  const [color, setColor] = React.useState("");
+  const [color, setColor] = React.useState("#EBAEDE");
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
@@ -32,7 +32,6 @@ export const AdvancedColorPickerCustom = ({
         { value: "#AEECEB", label: "turquoise" },
         { value: "#AEECD6", label: "mint" },
       ]}
-      defaultColor="#EBAEDE"
       selectedColor={color}
       onChange={handleChange}
       onOpen={() => {

--- a/src/components/alert/components.test-pw.tsx
+++ b/src/components/alert/components.test-pw.tsx
@@ -34,6 +34,7 @@ export const TopModalOverride = () => {
   const [isOpenDialog, setIsOpenDialog] = useState(true);
   const [isOpenAlert, setIsOpenAlert] = useState(true);
   const [isOpenSidebar, setIsOpenSidebar] = useState(false);
+  const [textboxValue, setTextboxValue] = useState("");
 
   useEffect(() => {
     setTimeout(() => {
@@ -49,7 +50,11 @@ export const TopModalOverride = () => {
         onCancel={() => setIsOpenDialog(false)}
         title="Dialog fullscreen"
       >
-        <Textbox label="Fullscreen textbox" />
+        <Textbox
+          label="Fullscreen textbox"
+          value={textboxValue}
+          onChange={(e) => setTextboxValue(e.target.value)}
+        />
       </Dialog>
       <Alert
         open={isOpenAlert}
@@ -57,14 +62,22 @@ export const TopModalOverride = () => {
         title="Alert"
         topModalOverride
       >
-        <Textbox label="Alert textbox" />
+        <Textbox
+          label="Alert textbox"
+          value={textboxValue}
+          onChange={(e) => setTextboxValue(e.target.value)}
+        />
       </Alert>
       <Sidebar
         open={isOpenSidebar}
         onCancel={() => setIsOpenSidebar(false)}
         header="sidebar"
       >
-        <Textbox label="Sidebar textbox" />
+        <Textbox
+          label="Sidebar textbox"
+          value={textboxValue}
+          onChange={(e) => setTextboxValue(e.target.value)}
+        />
       </Sidebar>
     </>
   );

--- a/src/components/anchor-navigation/anchor-navigation-test.stories.tsx
+++ b/src/components/anchor-navigation/anchor-navigation-test.stories.tsx
@@ -34,7 +34,7 @@ const Content = ({ title, noTextbox }: ContentProps) => (
   <>
     <div>
       <h2>{title}</h2>
-      {!noTextbox && <Textbox label={title} />}
+      {!noTextbox && <Textbox label={title} value="" onChange={() => {}} />}
       <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
       <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
       <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>

--- a/src/components/anchor-navigation/anchor-navigation.stories.tsx
+++ b/src/components/anchor-navigation/anchor-navigation.stories.tsx
@@ -32,7 +32,7 @@ export const DefaultStory: Story = () => {
   const Content = ({ title, noTextbox }: ContentProps) => (
     <Box>
       <h2>{title}</h2>
-      {!noTextbox && <Textbox label={title} />}
+      {!noTextbox && <Textbox label={title} value="" onChange={() => {}} />}
       <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
       <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
       <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
@@ -89,7 +89,7 @@ export const InFullScreenDialogStory: Story = () => {
   const Content = ({ title, noTextbox }: ContentProps) => (
     <Box>
       <h2>{title}</h2>
-      {!noTextbox && <Textbox label={title} />}
+      {!noTextbox && <Textbox label={title} value="" onChange={() => {}} />}
       <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
       <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
       <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>

--- a/src/components/anchor-navigation/components.test-pw.tsx
+++ b/src/components/anchor-navigation/components.test-pw.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from "react";
 
 import Textbox from "../textbox";
+import Typography from "../typography";
 import Button from "../button";
 import Dialog from "../dialog";
 import {
@@ -13,20 +14,29 @@ interface ContentProps {
   title: string;
   noTextbox?: boolean;
 }
-const Content = ({ title, noTextbox }: ContentProps) => (
-  <>
-    <div>
-      <h2>{title}</h2>
-      {!noTextbox && <Textbox label={title} />}
-      <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
-      <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
-      <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
-      <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
-      <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
-      <p style={{ marginTop: 30, marginBottom: 30 }}>Content</p>
-    </div>
-  </>
-);
+const Content = ({ title, noTextbox }: ContentProps) => {
+  const [value, setValue] = useState("");
+  return (
+    <>
+      <div>
+        <h2>{title}</h2>
+        {!noTextbox && (
+          <Textbox
+            label={title}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+          />
+        )}
+        <Typography my={"30px"}>Content</Typography>
+        <Typography my={"30px"}>Content</Typography>
+        <Typography my={"30px"}>Content</Typography>
+        <Typography my={"30px"}>Content</Typography>
+        <Typography my={"30px"}>Content</Typography>
+        <Typography my={"30px"}>Content</Typography>
+      </div>
+    </>
+  );
+};
 
 export const InFullScreenDialog = () => {
   const [isOpen, setIsOpen] = useState(false);

--- a/src/components/batch-selection/batch-selection.test.tsx
+++ b/src/components/batch-selection/batch-selection.test.tsx
@@ -90,7 +90,6 @@ test("`ButtonMinor` children should be automatically disabled via context", () =
 test("`Link` children should be automatically disabled via context", () => {
   render(
     <BatchSelection selectedCount={0} disabled>
-      {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
       <Link>Link as an anchor</Link>
     </BatchSelection>,
   );
@@ -107,7 +106,6 @@ test("`Link` children should be automatically disabled via context", () => {
 test("`Link` children rendered as a button should be automatically disabled via context", () => {
   render(
     <BatchSelection selectedCount={0} disabled>
-      {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
       <Link onClick={() => {}}>Link as a button</Link>
     </BatchSelection>,
   );

--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.component.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.component.tsx
@@ -16,9 +16,6 @@ import Events from "../../../__internal__/utils/helpers/events";
 import NewValidationContext from "../../carbon-provider/__internal__/new-validation.context";
 import { ButtonToggleGroupProvider } from "./__internal__/button-toggle-group.context";
 import HintText from "../../../__internal__/hint-text";
-import Logger from "../../../__internal__/utils/logger";
-
-let deprecateUncontrolledWarnTriggered = false;
 
 export interface ButtonToggleGroupProps extends MarginProps, TagProps {
   /** Unique id for the root element of the component */
@@ -47,10 +44,10 @@ export interface ButtonToggleGroupProps extends MarginProps, TagProps {
   labelWidth?: number;
   /** If true all ButtonToggle children will flex to the full width of the ButtonToggleGroup parent */
   fullWidth?: boolean;
-  /** Callback triggered by pressing one of the child buttons. Use with controlled components to set the value prop to the value argument */
-  onChange?: (ev: React.MouseEvent<HTMLButtonElement>, value?: string) => void;
-  /** Determines which child button is selected when the component is used as a controlled component */
-  value?: string;
+  /** Callback triggered by pressing one of the child buttons. */
+  onChange: (ev: React.MouseEvent<HTMLButtonElement>, value?: string) => void;
+  /** Determines which child button is selected */
+  value: string;
   /** [Legacy] Aria label for rendered help component */
   helpAriaLabel?: string;
   /** Allow buttons within the group to be deselected when already selected, leaving no selected button */
@@ -98,32 +95,14 @@ const ButtonToggleGroup = ({
     `\`ButtonToggleGroup\` only accepts children of type \`${ButtonToggle.displayName}\``,
   );
 
-  if (!deprecateUncontrolledWarnTriggered && !onChange) {
-    deprecateUncontrolledWarnTriggered = true;
-    Logger.deprecate(
-      "Uncontrolled behaviour in `Button Toggle Group` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-    );
-  }
-
   const labelId = useRef(guid());
   const hintTextId = useRef(guid());
 
   const wrapperRef = useRef<HTMLDivElement>(null);
 
-  const [pressedButtonValue, setPressedButtonValue] = useState<string>();
-
   const { validationRedesignOptIn } = useContext(NewValidationContext);
   const computeLabelPropValues = <T,>(prop: T): undefined | T =>
     validationRedesignOptIn ? undefined : prop;
-
-  const onButtonClick = (buttonValue: string) => {
-    let newValue: string | undefined = buttonValue;
-    const currentValue = value || pressedButtonValue;
-    if (allowDeselect && currentValue === buttonValue) {
-      newValue = undefined;
-    }
-    setPressedButtonValue(newValue);
-  };
 
   const getInnerButtons = () =>
     wrapperRef.current?.querySelectorAll(BUTTON_TOGGLE_SELECTOR);
@@ -196,9 +175,9 @@ const ButtonToggleGroup = ({
         >
           <ButtonToggleGroupProvider
             value={{
-              onButtonClick,
+              onButtonClick: () => {},
               handleKeyDown,
-              pressedButtonValue: value || pressedButtonValue,
+              pressedButtonValue: value,
               onChange,
               allowDeselect,
               isInGroup: true,

--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.test.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.test.tsx
@@ -4,28 +4,14 @@ import userEvent from "@testing-library/user-event";
 import { ButtonToggle, ButtonToggleGroup } from "..";
 import CarbonProvider from "../../carbon-provider/carbon-provider.component";
 import { testStyledSystemMargin } from "../../../__spec_helper__/__internal__/test-utils";
-import Logger from "../../../__internal__/utils/logger";
-
-test("should display a deprecation warning for uncontrolled behaviour which is triggered only once", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-
-  render(
-    <ButtonToggleGroup id="test">
-      <ButtonToggle>Button</ButtonToggle>
-    </ButtonToggleGroup>,
-  );
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "Uncontrolled behaviour in `Button Toggle Group` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-});
 
 test("should render with provided children", () => {
   render(
-    <ButtonToggleGroup id="button-toggle-group-id" onChange={() => {}}>
+    <ButtonToggleGroup
+      id="button-toggle-group-id"
+      value="foo"
+      onChange={() => {}}
+    >
       <ButtonToggle value="foo">Foo</ButtonToggle>
       <ButtonToggle value="bar">Bar</ButtonToggle>
     </ButtonToggleGroup>,
@@ -40,7 +26,11 @@ test("should throw an error when children are not of type ButtonToggle", () => {
 
   expect(() =>
     render(
-      <ButtonToggleGroup id="button-toggle-group-id" onChange={() => {}}>
+      <ButtonToggleGroup
+        value="foo"
+        id="button-toggle-group-id"
+        onChange={() => {}}
+      >
         <div>Foo</div>
       </ButtonToggleGroup>,
     ),
@@ -56,6 +46,7 @@ test("should render with provided label and use it as its accessible name", () =
       label="Group Label"
       aria-label="Group Aria Label"
       onChange={() => {}}
+      value="foo"
     >
       <ButtonToggle value="foo">Foo</ButtonToggle>
       <ButtonToggle value="bar">Bar</ButtonToggle>
@@ -69,6 +60,7 @@ test("should render with provided label and use it as its accessible name", () =
 test("should render with aria-label as its accessible name when the label is not set", () => {
   render(
     <ButtonToggleGroup
+      value="foo"
       id="button-toggle-group-id"
       aria-label="Group Aria Label"
       onChange={() => {}}
@@ -84,6 +76,7 @@ test("should render with aria-label as its accessible name when the label is not
 test("should render with provided hintText and use it as the accessible description for each child button", () => {
   render(
     <ButtonToggleGroup
+      value="foo"
       id="button-toggle-group-id"
       inputHint="Group Hint Text"
       onChange={() => {}}
@@ -106,7 +99,11 @@ test("should call onChange with the value of the ButtonToggle that is clicked", 
   const onChange = jest.fn();
   const user = userEvent.setup();
   render(
-    <ButtonToggleGroup id="button-toggle-group-id" onChange={onChange}>
+    <ButtonToggleGroup
+      id="button-toggle-group-id"
+      onChange={onChange}
+      value="bar"
+    >
       <ButtonToggle value="foo">Foo</ButtonToggle>
       <ButtonToggle value="bar">Bar</ButtonToggle>
     </ButtonToggleGroup>,
@@ -145,6 +142,7 @@ test("should render with disabled child buttons and expected styles when disable
       inputHint="Group Hint Text"
       onChange={() => {}}
       disabled
+      value=""
     >
       <ButtonToggle value="foo">Foo</ButtonToggle>
       <ButtonToggle value="bar">Bar</ButtonToggle>
@@ -172,6 +170,7 @@ test("should render with expected styles when fullWidth prop is set", () => {
       label="Group Label"
       onChange={() => {}}
       fullWidth
+      value="foo"
     >
       <ButtonToggle value="foo" data-role="foo">
         Foo
@@ -191,6 +190,7 @@ test("should render with expected styles when inputWidth prop is set", () => {
       label="Group Label"
       onChange={() => {}}
       inputWidth={50}
+      value="foo"
     >
       <ButtonToggle value="foo">Foo</ButtonToggle>
       <ButtonToggle value="bar">Bar</ButtonToggle>
@@ -207,6 +207,7 @@ test("should render with expected styles when labelInline prop is set", () => {
       label="Group Label"
       onChange={() => {}}
       labelInline
+      value="foo"
     >
       <ButtonToggle value="foo">Foo</ButtonToggle>
       <ButtonToggle value="bar">Bar</ButtonToggle>
@@ -225,6 +226,7 @@ test("should not render labelHelp or filedHelp when validationRedesignOptIn is t
         labelHelp="Label Help"
         fieldHelp="Field Help"
         onChange={() => {}}
+        value="foo"
       >
         <ButtonToggle value="foo">Foo</ButtonToggle>
         <ButtonToggle value="bar">Bar</ButtonToggle>
@@ -239,11 +241,7 @@ test("should not render labelHelp or filedHelp when validationRedesignOptIn is t
 test("should only allow the first button to be tabbable when none are selected", async () => {
   const user = userEvent.setup();
   render(
-    <ButtonToggleGroup
-      id="button-toggle-group-id"
-      onChange={() => {}}
-      value={undefined}
-    >
+    <ButtonToggleGroup id="button-toggle-group-id" onChange={() => {}} value="">
       <ButtonToggle value="foo">Foo</ButtonToggle>
       <ButtonToggle value="bar">Bar</ButtonToggle>
     </ButtonToggleGroup>,
@@ -380,6 +378,7 @@ testStyledSystemMargin(
       id="button-toggle-group-id"
       onChange={() => {}}
       data-role="button-toggle-group"
+      value="foo"
       {...props}
     >
       <ButtonToggle value="foo">Foo</ButtonToggle>

--- a/src/components/button-toggle/button-toggle-test.stories.tsx
+++ b/src/components/button-toggle/button-toggle-test.stories.tsx
@@ -60,14 +60,15 @@ export const DefaultStory = ({
   buttonIconSize,
   ...args
 }: Partial<ButtonToggleProps>) => {
-  const [value, setValue] = useState<string | undefined>("");
+  const [value, setValue] = useState<string>("");
   function onChangeHandler(
     event: React.MouseEvent<HTMLButtonElement>,
     selectedButtonValue?: string,
   ) {
-    setValue(selectedButtonValue);
+    setValue(selectedButtonValue ?? "");
     action("value set")(selectedButtonValue);
   }
+
   return (
     <ButtonToggleGroup
       id="button-toggle-group"
@@ -115,9 +116,23 @@ DefaultStory.story = {
 };
 
 export const LargeIconWithLongText = () => {
+  const [value, setValue] = useState<string>("");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedButtonValue?: string,
+  ) {
+    setValue(selectedButtonValue ?? "");
+    action("value set")(selectedButtonValue);
+  }
+
   return (
     <Box width="135px">
-      <ButtonToggleGroup id="button-toggle-group" fullWidth>
+      <ButtonToggleGroup
+        id="button-toggle-group"
+        fullWidth
+        value={value}
+        onChange={onChangeHandler}
+      >
         <ButtonToggle
           value="foo"
           size="large"

--- a/src/components/button-toggle/button-toggle.mdx
+++ b/src/components/button-toggle/button-toggle.mdx
@@ -43,10 +43,6 @@ import {
 
 <Canvas of={ButtonToggleStories.InputHint} />
 
-### Controlled
-
-<Canvas of={ButtonToggleStories.Controlled} />
-
 ### With aria-label
 
 If you do not want a visible label to appear above the group, you should pass the `aria-label` prop to `ButtonToggleGroup` to give it an
@@ -56,7 +52,7 @@ accessible name to be announced by screen readers. Failure to do this will resul
 
 ### With fullWidth
 
-When the `fullWidth` prop is `true`, the buttons will expand in size to evenly take up the full width of the container. 
+When the `fullWidth` prop is `true`, the buttons will expand in size to evenly take up the full width of the container.
 
 <Canvas of={ButtonToggleStories.FullWidth} />
 
@@ -79,7 +75,7 @@ If you use this, you should include text in the `inputHint` prop which makes cle
 
 ### Icon only
 
-While we do not advocate the use of icon-only buttons for accessibility reasons, the `aria-label` or `aria-labelledby` props can be passed to  
+While we do not advocate the use of icon-only buttons for accessibility reasons, the `aria-label` or `aria-labelledby` props can be passed to
 an icon-only `ButtonToggle` so that assistive technology users are aware of the action that will be taken when the button is pressed.
 
 <Canvas of={ButtonToggleStories.IconOnly} />
@@ -119,7 +115,7 @@ an icon-only `ButtonToggle` so that assistive technology users are aware of the 
 ### Wrapped Group
 
 When buttons can no longer fit in a single row, they will wrap onto the next line.
-The `fullWidth` prop can provide a more consistent layout across different screen sizes, so we recommend using it if buttons are likely to wrap in smaller screens. 
+The `fullWidth` prop can provide a more consistent layout across different screen sizes, so we recommend using it if buttons are likely to wrap in smaller screens.
 
 <Canvas of={ButtonToggleStories.WrappedButtons} />
 

--- a/src/components/button-toggle/button-toggle.pw.tsx
+++ b/src/components/button-toggle/button-toggle.pw.tsx
@@ -662,7 +662,7 @@ test.describe("Navigation tests", () => {
     mount,
     page,
   }) => {
-    await mount(<WithOutsideButtons />);
+    await mount(<WithOutsideButtons value="" />);
 
     const buttonBefore = page
       .getByRole("button")
@@ -682,7 +682,7 @@ test.describe("Navigation tests", () => {
     mount,
     page,
   }) => {
-    await mount(<WithOutsideButtons />);
+    await mount(<WithOutsideButtons value="" />);
 
     const buttonBefore = page
       .getByRole("button")
@@ -702,7 +702,7 @@ test.describe("Navigation tests", () => {
     mount,
     page,
   }) => {
-    await mount(<WithOutsideButtons />);
+    await mount(<WithOutsideButtons value="bar" />);
 
     const buttonBefore = page
       .getByRole("button")
@@ -723,7 +723,7 @@ test.describe("Navigation tests", () => {
     mount,
     page,
   }) => {
-    await mount(<WithOutsideButtons />);
+    await mount(<WithOutsideButtons value="bar" />);
 
     const buttonBefore = page
       .getByRole("button")

--- a/src/components/button-toggle/button-toggle.stories.tsx
+++ b/src/components/button-toggle/button-toggle.stories.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
-import isChromatic from "../../../.storybook/isChromatic";
 import { ButtonToggle, ButtonToggleGroup } from ".";
 import Box from "../box";
 
@@ -13,12 +12,23 @@ const meta: Meta<typeof ButtonToggle> = {
 export default meta;
 type Story = StoryObj<typeof ButtonToggle>;
 
-const inChromatic = isChromatic();
-
 export const Default: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedValue?: string,
+  ) {
+    setValue(selectedValue as string);
+  }
+
   return (
     <Box margin={4} width="250px" display="flex" flexWrap="nowrap">
-      <ButtonToggleGroup id="button-toggle-group-id" label="Default example">
+      <ButtonToggleGroup
+        id="button-toggle-group-id"
+        label="Default example"
+        value={value}
+        onChange={onChangeHandler}
+      >
         <ButtonToggle value="foo">Foo</ButtonToggle>
         <ButtonToggle value="bar">Bar</ButtonToggle>
         <ButtonToggle value="baz">Baz</ButtonToggle>
@@ -29,12 +39,22 @@ export const Default: Story = () => {
 Default.storyName = "Default";
 
 export const InputHint: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedValue?: string,
+  ) {
+    setValue(selectedValue as string);
+  }
+
   return (
     <Box margin={4} width="250px" display="flex" flexWrap="nowrap">
       <ButtonToggleGroup
         id="button-toggle-group-id"
         label="inputHint example"
         inputHint="Hint text"
+        value={value}
+        onChange={onChangeHandler}
       >
         <ButtonToggle value="foo">Foo</ButtonToggle>
         <ButtonToggle value="bar">Bar</ButtonToggle>
@@ -45,31 +65,6 @@ export const InputHint: Story = () => {
 };
 InputHint.storyName = "Input Hint";
 
-export const Controlled: Story = () => {
-  const [value, setValue] = useState("bar");
-  function onChangeHandler(
-    event: React.MouseEvent<HTMLButtonElement>,
-    selectedValue?: string,
-  ) {
-    setValue(selectedValue as string);
-  }
-  return (
-    <Box margin={4} width="250px" display="flex" flexWrap="nowrap">
-      <ButtonToggleGroup
-        id="button-toggle-group-controlled-id"
-        label="Controlled example"
-        onChange={onChangeHandler}
-        value={value}
-      >
-        <ButtonToggle value="foo">Foo</ButtonToggle>
-        <ButtonToggle value="bar">Bar</ButtonToggle>
-        <ButtonToggle value="baz">Baz</ButtonToggle>
-      </ButtonToggleGroup>
-    </Box>
-  );
-};
-Controlled.storyName = "Controlled";
-
 export const AriaLabel: Story = () => {
   const [value, setValue] = useState("bar");
   function onChangeHandler(
@@ -78,6 +73,7 @@ export const AriaLabel: Story = () => {
   ) {
     setValue(selectedValue as string);
   }
+
   return (
     <Box margin={4} width="250px" display="flex" flexWrap="nowrap">
       <ButtonToggleGroup
@@ -97,13 +93,22 @@ export const AriaLabel: Story = () => {
 AriaLabel.storyName = "Aria Label";
 
 export const FullWidth: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedValue?: string,
+  ) {
+    setValue(selectedValue as string);
+  }
+
   return (
     <Box margin={4}>
       <ButtonToggleGroup
         id="button-toggle-group-fullWidth-id"
         fullWidth
         label="fullWidth example"
-        onChange={() => {}}
+        value={value}
+        onChange={onChangeHandler}
       >
         <ButtonToggle value="foo">Foo</ButtonToggle>
         <ButtonToggle value="bar">Bar</ButtonToggle>
@@ -122,6 +127,7 @@ export const AllowDeselection: Story = () => {
   ) {
     setValue(selectedValue as string);
   }
+
   return (
     <Box margin={4} width="250px" display="flex" flexWrap="nowrap">
       <ButtonToggleGroup
@@ -142,9 +148,22 @@ export const AllowDeselection: Story = () => {
 AllowDeselection.storyName = "Allow Deselection";
 
 export const DefaultSmallIcon: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedValue?: string,
+  ) {
+    setValue(selectedValue as string);
+  }
+
   return (
     <Box margin={4} width="300px" display="flex" flexWrap="nowrap">
-      <ButtonToggleGroup id="button-toggle-group-id" label="Small icon example">
+      <ButtonToggleGroup
+        id="button-toggle-group-id"
+        label="Small icon example"
+        value={value}
+        onChange={onChangeHandler}
+      >
         <ButtonToggle value="foo" buttonIcon="add">
           Add
         </ButtonToggle>
@@ -161,9 +180,22 @@ export const DefaultSmallIcon: Story = () => {
 DefaultSmallIcon.storyName = "Small Icon";
 
 export const DefaultLargeIcon: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedValue?: string,
+  ) {
+    setValue(selectedValue as string);
+  }
+
   return (
     <Box margin={4} width="400px" display="flex" flexWrap="nowrap">
-      <ButtonToggleGroup id="button-toggle-group-id" label="Large icon example">
+      <ButtonToggleGroup
+        id="button-toggle-group-id"
+        label="Large icon example"
+        value={value}
+        onChange={onChangeHandler}
+      >
         <ButtonToggle value="foo" buttonIcon="add" buttonIconSize="large">
           Add
         </ButtonToggle>
@@ -180,9 +212,22 @@ export const DefaultLargeIcon: Story = () => {
 DefaultLargeIcon.storyName = "Large Icon";
 
 export const IconOnly: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedValue?: string,
+  ) {
+    setValue(selectedValue as string);
+  }
+
   return (
     <Box margin={4} width="250px" display="flex" flexWrap="nowrap">
-      <ButtonToggleGroup id="button-toggle-group-id" label="Icon only example">
+      <ButtonToggleGroup
+        id="button-toggle-group-id"
+        label="Icon only example"
+        value={value}
+        onChange={onChangeHandler}
+      >
         <ButtonToggle value="foo" buttonIcon="add" aria-label="add" />
         <ButtonToggle value="bar" buttonIcon="share" aria-label="share" />
         <ButtonToggle value="baz" buttonIcon="tick" aria-label="tick" />
@@ -193,9 +238,22 @@ export const IconOnly: Story = () => {
 IconOnly.storyName = "Icon Only";
 
 export const Small: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedValue?: string,
+  ) {
+    setValue(selectedValue as string);
+  }
+
   return (
     <Box margin={4} width="250px" display="flex" flexWrap="nowrap">
-      <ButtonToggleGroup id="button-toggle-group-id" label="Small example">
+      <ButtonToggleGroup
+        id="button-toggle-group-id"
+        label="Small example"
+        value={value}
+        onChange={onChangeHandler}
+      >
         <ButtonToggle size="small" value="foo">
           Add
         </ButtonToggle>
@@ -212,11 +270,21 @@ export const Small: Story = () => {
 Small.storyName = "Small";
 
 export const SmallSmallIcon: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedValue?: string,
+  ) {
+    setValue(selectedValue as string);
+  }
+
   return (
     <Box margin={4} width="300px" display="flex" flexWrap="nowrap">
       <ButtonToggleGroup
         id="button-toggle-group-id"
         label="Small with small icon example"
+        value={value}
+        onChange={onChangeHandler}
       >
         <ButtonToggle size="small" value="foo" buttonIcon="add">
           Add
@@ -234,11 +302,21 @@ export const SmallSmallIcon: Story = () => {
 SmallSmallIcon.storyName = "Small with Small Icon";
 
 export const SmallLargeIcon: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedValue?: string,
+  ) {
+    setValue(selectedValue as string);
+  }
+
   return (
     <Box margin={4} width="300px" display="flex" flexWrap="nowrap">
       <ButtonToggleGroup
         id="button-toggle-group-id"
         label="Small with large icon example"
+        value={value}
+        onChange={onChangeHandler}
       >
         <ButtonToggle
           size="small"
@@ -271,9 +349,22 @@ export const SmallLargeIcon: Story = () => {
 SmallLargeIcon.storyName = "Small with Large Icon";
 
 export const Large: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedValue?: string,
+  ) {
+    setValue(selectedValue as string);
+  }
+
   return (
     <Box margin={4} width="250px" display="flex" flexWrap="nowrap">
-      <ButtonToggleGroup id="button-toggle-group-id" label="Large example">
+      <ButtonToggleGroup
+        id="button-toggle-group-id"
+        label="Large example"
+        value={value}
+        onChange={onChangeHandler}
+      >
         <ButtonToggle size="large" value="foo">
           Add
         </ButtonToggle>
@@ -290,11 +381,21 @@ export const Large: Story = () => {
 Large.storyName = "Large";
 
 export const LargeSmallIcon: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedValue?: string,
+  ) {
+    setValue(selectedValue as string);
+  }
+
   return (
     <Box margin={4} width="300px" display="flex" flexWrap="nowrap">
       <ButtonToggleGroup
         id="button-toggle-group-id"
         label="Large with small icon example"
+        value={value}
+        onChange={onChangeHandler}
       >
         <ButtonToggle size="large" value="foo" buttonIcon="add">
           Add
@@ -312,11 +413,21 @@ export const LargeSmallIcon: Story = () => {
 LargeSmallIcon.storyName = "Large with Small Icon";
 
 export const LargeLargeIcon: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedValue?: string,
+  ) {
+    setValue(selectedValue as string);
+  }
+
   return (
     <Box margin={4} width="450px" display="flex" flexWrap="nowrap">
       <ButtonToggleGroup
         id="button-toggle-group-id"
         label="Large with large icon example"
+        value={value}
+        onChange={onChangeHandler}
       >
         <ButtonToggle
           size="large"
@@ -349,9 +460,22 @@ export const LargeLargeIcon: Story = () => {
 LargeLargeIcon.storyName = "Large Large Icon";
 
 export const DisabledButton: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedValue?: string,
+  ) {
+    setValue(selectedValue as string);
+  }
+
   return (
     <Box margin={4} width="250px" display="flex" flexWrap="nowrap">
-      <ButtonToggleGroup id="button-toggle-group-id" label="Disabled Button">
+      <ButtonToggleGroup
+        id="button-toggle-group-id"
+        label="Disabled Button"
+        value={value}
+        onChange={onChangeHandler}
+      >
         <ButtonToggle value="foo" disabled>
           Foo
         </ButtonToggle>
@@ -363,49 +487,73 @@ export const DisabledButton: Story = () => {
 };
 DisabledButton.storyName = "Disabled Button";
 
-export const DisabledGroup: Story = () => (
-  <Box margin={4} width="250px" display="flex" flexWrap="nowrap">
-    <ButtonToggleGroup
-      id="button-toggle-group-disabled-id"
-      label="Disabled Group"
-      inputHint="Hint text"
-      disabled
-    >
-      <ButtonToggle value="foo">Foo</ButtonToggle>
-      <ButtonToggle value="bar">Bar</ButtonToggle>
-      <ButtonToggle value="baz">Baz</ButtonToggle>
-    </ButtonToggleGroup>
-  </Box>
-);
+export const DisabledGroup: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedValue?: string,
+  ) {
+    setValue(selectedValue as string);
+  }
+
+  return (
+    <Box margin={4} width="250px" display="flex" flexWrap="nowrap">
+      <ButtonToggleGroup
+        id="button-toggle-group-disabled-id"
+        label="Disabled Group"
+        inputHint="Hint text"
+        disabled
+        value={value}
+        onChange={onChangeHandler}
+      >
+        <ButtonToggle value="foo">Foo</ButtonToggle>
+        <ButtonToggle value="bar">Bar</ButtonToggle>
+        <ButtonToggle value="baz">Baz</ButtonToggle>
+      </ButtonToggleGroup>
+    </Box>
+  );
+};
 DisabledGroup.storyName = "Disabled Group";
 
-export const WrappedButtons: Story = () => (
-  <Box width={inChromatic ? "175px" : "375px"} display="flex" flexWrap="nowrap">
-    <ButtonToggleGroup
-      m={4}
-      id="button-toggle-group-wrapped-id"
-      label="Wrapped Group"
-      fullWidth
-    >
-      <ButtonToggle value="add" buttonIcon="add">
-        Add
-      </ButtonToggle>
-      <ButtonToggle value="share" buttonIcon="share">
-        Share
-      </ButtonToggle>
-      <ButtonToggle value="tick" buttonIcon="tick">
-        Tick
-      </ButtonToggle>
-      <ButtonToggle value="email" buttonIcon="email">
-        Email
-      </ButtonToggle>
-      <ButtonToggle value="alert" buttonIcon="alert">
-        Alert
-      </ButtonToggle>
-      <ButtonToggle value="calendar" buttonIcon="calendar">
-        Calendar
-      </ButtonToggle>
-    </ButtonToggleGroup>
-  </Box>
-);
+export const WrappedButtons: Story = () => {
+  const [value, setValue] = useState("bar");
+  function onChangeHandler(
+    event: React.MouseEvent<HTMLButtonElement>,
+    selectedValue?: string,
+  ) {
+    setValue(selectedValue as string);
+  }
+
+  return (
+    <Box width={"375px"} display="flex" flexWrap="nowrap">
+      <ButtonToggleGroup
+        m={4}
+        id="button-toggle-group-wrapped-id"
+        label="Wrapped Group"
+        fullWidth
+        value={value}
+        onChange={onChangeHandler}
+      >
+        <ButtonToggle value="add" buttonIcon="add">
+          Add
+        </ButtonToggle>
+        <ButtonToggle value="share" buttonIcon="share">
+          Share
+        </ButtonToggle>
+        <ButtonToggle value="tick" buttonIcon="tick">
+          Tick
+        </ButtonToggle>
+        <ButtonToggle value="email" buttonIcon="email">
+          Email
+        </ButtonToggle>
+        <ButtonToggle value="alert" buttonIcon="alert">
+          Alert
+        </ButtonToggle>
+        <ButtonToggle value="calendar" buttonIcon="calendar">
+          Calendar
+        </ButtonToggle>
+      </ButtonToggleGroup>
+    </Box>
+  );
+};
 WrappedButtons.storyName = "Wrapped Buttons";

--- a/src/components/button-toggle/button-toggle.test.tsx
+++ b/src/components/button-toggle/button-toggle.test.tsx
@@ -24,7 +24,7 @@ test("should call `onClick` when the button is clicked", async () => {
   const onClick = jest.fn();
   const user = userEvent.setup();
   render(
-    <ButtonToggleGroup id="test" onChange={() => {}}>
+    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
       <ButtonToggle onClick={onClick}>Button</ButtonToggle>
     </ButtonToggleGroup>,
   );
@@ -37,7 +37,7 @@ test("should call `onFocus` when the button is focused", async () => {
   const onFocus = jest.fn();
   const user = userEvent.setup();
   render(
-    <ButtonToggleGroup id="test" onChange={() => {}}>
+    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
       <ButtonToggle onFocus={onFocus}>Button</ButtonToggle>
     </ButtonToggleGroup>,
   );
@@ -50,7 +50,7 @@ test("should call `onBlur` when the button is blurred", async () => {
   const onBlur = jest.fn();
   const user = userEvent.setup();
   render(
-    <ButtonToggleGroup id="test" onChange={() => {}}>
+    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
       <ButtonToggle onBlur={onBlur}>Button</ButtonToggle>
     </ButtonToggleGroup>,
   );
@@ -76,7 +76,7 @@ test("logs deprecation warning if pressed prop is used", () => {
 
 test("should render disabled button with expected styles", () => {
   render(
-    <ButtonToggleGroup id="test" onChange={() => {}}>
+    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
       <ButtonToggle disabled>Button</ButtonToggle>
     </ButtonToggleGroup>,
   );
@@ -87,7 +87,7 @@ test("should render disabled button with expected styles", () => {
 
 test("should render with expected styles when buttonIcon is set", () => {
   render(
-    <ButtonToggleGroup id="test" onChange={() => {}}>
+    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
       <ButtonToggle buttonIcon="add">Button</ButtonToggle>
     </ButtonToggleGroup>,
   );
@@ -99,7 +99,7 @@ test("should render with expected styles when buttonIcon is set", () => {
 
 test("should render with expected styles when buttonIcon is set and buttonIconSize is large'", () => {
   render(
-    <ButtonToggleGroup id="test" onChange={() => {}}>
+    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
       <ButtonToggle buttonIcon="add" buttonIconSize="large">
         Button
       </ButtonToggle>
@@ -125,7 +125,7 @@ test("should throw an error when neither children or a `buttonIcon` is provided"
 
   expect(() =>
     render(
-      <ButtonToggleGroup id="test" onChange={() => {}}>
+      <ButtonToggleGroup id="test" value="" onChange={() => {}}>
         <ButtonToggle />
       </ButtonToggleGroup>,
     ),

--- a/src/components/button-toggle/components.test-pw.tsx
+++ b/src/components/button-toggle/components.test-pw.tsx
@@ -37,6 +37,7 @@ export const ButtonToggleGroupComponent = (
       helpAriaLabel="Help"
       fieldHelp="field help message"
       onChange={() => {}}
+      value=""
       {...props}
     >
       <ButtonToggle value="foo">Foo</ButtonToggle>
@@ -52,6 +53,8 @@ export const ButtonToggleGroupNotInBox = (
   <ButtonToggleGroup
     id="button-toggle-group-id"
     label="Grouped example"
+    onChange={() => {}}
+    value=""
     {...props}
   >
     <ButtonToggle value="foo">Foo</ButtonToggle>
@@ -60,7 +63,7 @@ export const ButtonToggleGroupNotInBox = (
   </ButtonToggleGroup>
 );
 
-export const WithOutsideButtons = () => {
+export const WithOutsideButtons = ({ value = "" }: { value: string }) => {
   return (
     <>
       <button type="button" id="button-before">
@@ -69,6 +72,8 @@ export const WithOutsideButtons = () => {
       <ButtonToggleGroup
         id="button-toggle-group"
         label="Button Toggle Group test"
+        onChange={() => {}}
+        value={value}
       >
         <ButtonToggle value="foo">Foo</ButtonToggle>
         <ButtonToggle value="bar">Bar</ButtonToggle>

--- a/src/components/card/components.test-pw.tsx
+++ b/src/components/card/components.test-pw.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unstable-nested-components */
 import React, { useState } from "react";
 import { DndProvider, useDrag, useDrop } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";

--- a/src/components/checkbox/checkbox-group/checkbox-group.stories.tsx
+++ b/src/components/checkbox/checkbox-group/checkbox-group.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import generateStyledSystemProps from "../../../../.storybook/utils/styled-system-props";
 import CarbonProvider from "../../carbon-provider";
 
-import { CheckboxGroup, Checkbox } from "..";
+import { CheckboxGroup, Checkbox, CheckboxGroupProps } from "..";
 
 const styledSystemProps = generateStyledSystemProps({
   margin: true,
@@ -23,11 +23,45 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof CheckboxGroup>;
 
+const ControlledCheckboxGroup = (args: CheckboxGroupProps) => {
+  const [selectedValues, setSelectedValues] = React.useState<string[]>([]);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { value, checked } = event.target;
+    if (checked) {
+      setSelectedValues((prev) => [...prev, value]);
+    } else {
+      setSelectedValues((prev) => prev.filter((val) => val !== value));
+    }
+  };
+  return (
+    <CheckboxGroup {...args}>
+      {["Apple", "Banana", "Cherry", "Date"].map((label) => (
+        <Checkbox
+          key={label}
+          name="fruits"
+          label={label}
+          value={label}
+          checked={selectedValues.includes(label)}
+          onChange={handleChange}
+        />
+      ))}
+    </CheckboxGroup>
+  );
+};
+
 export const Default: Story = {
   render: (args) => (
     <CheckboxGroup {...args}>
       {["Apple", "Banana", "Cherry", "Date"].map((label) => (
-        <Checkbox key={label} name="fruits" label={label} />
+        <Checkbox
+          key={label}
+          name="fruits"
+          label={label}
+          value={label}
+          checked={false}
+          onChange={() => {}}
+        />
       ))}
     </CheckboxGroup>
   ),
@@ -39,11 +73,7 @@ export const Default: Story = {
 export const WithLegendHelp: Story = {
   render: (args) => (
     <CarbonProvider validationRedesignOptIn>
-      <CheckboxGroup {...args}>
-        {["Apple", "Banana", "Cherry", "Date"].map((label) => (
-          <Checkbox key={label} name="fruits" label={label} />
-        ))}
-      </CheckboxGroup>
+      <ControlledCheckboxGroup {...args} />
     </CarbonProvider>
   ),
   args: {
@@ -63,11 +93,7 @@ export const RequiredGroup: Story = {
 export const Inline: Story = {
   render: (args) => (
     <CarbonProvider validationRedesignOptIn>
-      <CheckboxGroup {...args}>
-        {["Apple", "Banana", "Cherry", "Date"].map((label) => (
-          <Checkbox key={label} name="fruits" label={label} />
-        ))}
-      </CheckboxGroup>
+      <ControlledCheckboxGroup {...args} />
     </CarbonProvider>
   ),
   args: {

--- a/src/components/checkbox/checkbox-group/checkbox-group.test.tsx
+++ b/src/components/checkbox/checkbox-group/checkbox-group.test.tsx
@@ -7,8 +7,8 @@ import { testStyledSystemMargin } from "../../../__spec_helper__/__internal__/te
 test("should render with the provided children", () => {
   render(
     <CheckboxGroup>
-      <Checkbox value="1" label="label-1" onChange={() => {}} />
-      <Checkbox value="2" label="label-2" onChange={() => {}} />
+      <Checkbox value="1" label="label-1" onChange={() => {}} checked />
+      <Checkbox value="2" label="label-2" onChange={() => {}} checked />
     </CheckboxGroup>,
   );
 
@@ -19,7 +19,7 @@ test("should render with the provided children", () => {
 test("should render with the provided legend", () => {
   render(
     <CheckboxGroup legend="legend">
-      <Checkbox value="1" label="label" onChange={() => {}} />
+      <Checkbox value="1" label="label" onChange={() => {}} checked />
     </CheckboxGroup>,
   );
 
@@ -29,8 +29,8 @@ test("should render with the provided legend", () => {
 test("should render required checkbox children when required prop is set", () => {
   render(
     <CheckboxGroup legend="legend" required>
-      <Checkbox value="1" label="label-1" onChange={() => {}} />
-      <Checkbox value="2" label="label-2" onChange={() => {}} />
+      <Checkbox value="1" label="label-1" onChange={() => {}} checked />
+      <Checkbox value="2" label="label-2" onChange={() => {}} checked />
     </CheckboxGroup>,
   );
 
@@ -42,7 +42,7 @@ test("should render required checkbox children when required prop is set", () =>
 it("should render with accessible description when `error` prop is set", () => {
   render(
     <CheckboxGroup legend="legend" error="error message">
-      <Checkbox value="1" label="label" onChange={() => {}} />
+      <Checkbox value="1" label="label" onChange={() => {}} checked />
     </CheckboxGroup>,
   );
 
@@ -53,7 +53,7 @@ it("should render with accessible description when `error` prop is set", () => {
 it("should render with accessible description when `warning` prop is set", () => {
   render(
     <CheckboxGroup legend="legend" warning="warning message">
-      <Checkbox value="1" label="label" onChange={() => {}} />
+      <Checkbox value="1" label="label" onChange={() => {}} checked />
     </CheckboxGroup>,
   );
 
@@ -64,7 +64,7 @@ it("should render with accessible description when `warning` prop is set", () =>
 it("should render with accessible description when `info` prop is set", () => {
   render(
     <CheckboxGroup legend="legend" info="info message">
-      <Checkbox value="1" label="label" onChange={() => {}} />
+      <Checkbox value="1" label="label" onChange={() => {}} checked />
     </CheckboxGroup>,
   );
 
@@ -80,8 +80,9 @@ test("should render with expected styles when legendInline is true", () => {
         value="1"
         label="label-1"
         onChange={() => {}}
+        checked
       />
-      <Checkbox value="2" label="label-2" onChange={() => {}} />
+      <Checkbox value="2" label="label-2" onChange={() => {}} checked />
     </CheckboxGroup>,
   );
 
@@ -92,8 +93,8 @@ test("should render with expected styles when inline is true", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
       <CheckboxGroup legend="legend" inline>
-        <Checkbox value="1" label="label-1" onChange={() => {}} />
-        <Checkbox value="2" label="label-2" onChange={() => {}} />
+        <Checkbox value="1" label="label-1" onChange={() => {}} checked />
+        <Checkbox value="2" label="label-2" onChange={() => {}} checked />
       </CheckboxGroup>
     </CarbonProvider>,
   );
@@ -108,7 +109,7 @@ describe("when the `validationRedesignOptIn` flag is true", () => {
     render(
       <CarbonProvider validationRedesignOptIn>
         <CheckboxGroup legend="legend" legendHelp="legendHelp">
-          <Checkbox value="1" label="label" onChange={() => {}} />
+          <Checkbox value="1" label="label" onChange={() => {}} checked />
         </CheckboxGroup>
       </CarbonProvider>,
     );
@@ -122,7 +123,7 @@ describe("when the `validationRedesignOptIn` flag is true", () => {
     render(
       <CarbonProvider validationRedesignOptIn>
         <CheckboxGroup legend="legend" error="error message">
-          <Checkbox value="1" label="label" onChange={() => {}} />
+          <Checkbox value="1" label="label" onChange={() => {}} checked />
         </CheckboxGroup>
       </CarbonProvider>,
     );
@@ -137,7 +138,7 @@ describe("when the `validationRedesignOptIn` flag is true", () => {
     render(
       <CarbonProvider validationRedesignOptIn>
         <CheckboxGroup legend="legend" warning="warning message">
-          <Checkbox value="1" label="label" onChange={() => {}} />
+          <Checkbox value="1" label="label" onChange={() => {}} checked />
         </CheckboxGroup>
       </CarbonProvider>,
     );
@@ -157,7 +158,7 @@ describe("when the `validationRedesignOptIn` flag is true", () => {
           legendHelp="Legend Help"
           validationMessagePositionTop={false}
         >
-          <Checkbox value="1" label="label" onChange={() => {}} />
+          <Checkbox value="1" label="label" onChange={() => {}} checked />
         </CheckboxGroup>
       </CarbonProvider>,
     );
@@ -177,7 +178,7 @@ describe("when the `validationRedesignOptIn` flag is true", () => {
           legendHelp="Legend Help"
           validationMessagePositionTop={false}
         >
-          <Checkbox value="1" label="label" onChange={() => {}} />
+          <Checkbox value="1" label="label" onChange={() => {}} checked />
         </CheckboxGroup>
       </CarbonProvider>,
     );
@@ -196,7 +197,7 @@ describe("when the `validationRedesignOptIn` flag is true", () => {
           legendHelp="legendHelp"
           error="error message"
         >
-          <Checkbox value="1" label="label" onChange={() => {}} />
+          <Checkbox value="1" label="label" onChange={() => {}} checked />
         </CheckboxGroup>
       </CarbonProvider>,
     );
@@ -214,7 +215,7 @@ testStyledSystemMargin(
       legend="legend"
       {...props}
     >
-      <Checkbox value="1" label="label" onChange={() => {}} />
+      <Checkbox value="1" label="label" onChange={() => {}} checked />
     </CheckboxGroup>
   ),
   () => screen.getByTestId("checkbox-group-wrapper"),

--- a/src/components/checkbox/checkbox-interaction.stories.tsx
+++ b/src/components/checkbox/checkbox-interaction.stories.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { StoryObj } from "@storybook/react";
 import { userEvent, within, expect } from "@storybook/test";
 
-import { Checkbox } from ".";
+import { Checkbox, CheckboxProps } from ".";
 
 import { allowInteractions } from "../../../.storybook/interaction-toggle/reduced-motion";
 import DefaultDecorator from "../../../.storybook/utils/default-decorator";
@@ -18,25 +18,38 @@ export default {
   },
 };
 
+const ControlledCheckbox = (
+  props: Omit<CheckboxProps, "onChange" | "checked">,
+) => {
+  const [checked, setChecked] = React.useState(false);
+  return (
+    <Checkbox
+      {...props}
+      checked={checked}
+      onChange={() => setChecked((prevChecked) => !prevChecked)}
+    />
+  );
+};
+
 export const hoverCheckbox: Story = {
   render: () => (
     <>
-      <Checkbox mb={4} label="Small" required data-testid="target" />
-      <Checkbox
+      <ControlledCheckbox mb={4} label="Small" required data-testid="target" />
+      <ControlledCheckbox
         mb={4}
         label="Info"
         info="Info"
         tooltipPosition="right"
         data-testid="target"
       />
-      <Checkbox
+      <ControlledCheckbox
         mb={4}
         label="Warning"
         warning="Warning"
         tooltipPosition="right"
         data-testid="target"
       />
-      <Checkbox
+      <ControlledCheckbox
         mb={4}
         label="Error"
         error="Error"
@@ -76,9 +89,9 @@ hoverCheckbox.parameters = {
 export const clickAndKeyInteraction: Story = {
   render: () => (
     <>
-      <Checkbox mb={2} label="Small" />
-      <Checkbox mb={2} label="Default" disabled />
-      <Checkbox mb={2} label="Small" />
+      <ControlledCheckbox mb={2} label="Small" />
+      <ControlledCheckbox mb={2} label="Default" disabled />
+      <ControlledCheckbox mb={2} label="Small" />
     </>
   ),
   play: async ({ canvasElement }) => {

--- a/src/components/checkbox/checkbox-test.stories.tsx
+++ b/src/components/checkbox/checkbox-test.stories.tsx
@@ -12,10 +12,13 @@ export default {
     chromatic: {
       disableSnapshot: false,
     },
+    themeProvider: { chromatic: { theme: "sage" } },
   },
 };
 
-export const Default = ({ ...args }: CheckboxProps) => {
+export const Default = ({
+  ...args
+}: Omit<CheckboxProps, "checked" | "onChange">) => {
   const [isChecked, setIsChecked] = useState(false);
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { checked } = event.target;
@@ -90,19 +93,50 @@ WithLongLabel.args = {
 };
 
 export const Validation = ({ ...args }: CheckboxGroupProps) => {
+  const [state1, setState1] = useState(false);
+  const [state2, setState2] = useState(false);
+  const [state3, setState3] = useState(false);
+  const [state4, setState4] = useState(false);
+  const [state5, setState5] = useState(false);
+  const [state6, setState6] = useState(false);
+
   return (
     <>
       <CheckboxGroup error="Error Message" mb={2} {...args}>
-        <Checkbox label="Checkbox 1" />
-        <Checkbox label="Checkbox 2" />
+        <Checkbox
+          label="Checkbox 1"
+          checked={state1}
+          onChange={(e) => setState1(e.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox 2"
+          checked={state2}
+          onChange={(e) => setState2(e.target.checked)}
+        />
       </CheckboxGroup>
       <CheckboxGroup warning="Warning Message" mb={2} {...args}>
-        <Checkbox label="Checkbox 1" />
-        <Checkbox label="Checkbox 2" />
+        <Checkbox
+          label="Checkbox 1"
+          checked={state3}
+          onChange={(e) => setState3(e.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox 2"
+          checked={state4}
+          onChange={(e) => setState4(e.target.checked)}
+        />
       </CheckboxGroup>
       <CheckboxGroup info="Info Message" {...args}>
-        <Checkbox label="Checkbox 1" />
-        <Checkbox label="Checkbox 2" />
+        <Checkbox
+          label="Checkbox 1"
+          checked={state5}
+          onChange={(e) => setState5(e.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox 2"
+          checked={state6}
+          onChange={(e) => setState6(e.target.checked)}
+        />
       </CheckboxGroup>
     </>
   );
@@ -132,6 +166,15 @@ Validation.parameters = {
 };
 
 export const NewValidation = () => {
+  const [state1, setState1] = useState(false);
+  const [state2, setState2] = useState(false);
+  const [state3, setState3] = useState(false);
+  const [state4, setState4] = useState(false);
+  const [state5, setState5] = useState(false);
+  const [state6, setState6] = useState(false);
+  const [state7, setState7] = useState(false);
+  const [state8, setState8] = useState(false);
+
   return (
     <CarbonProvider validationRedesignOptIn>
       <CheckboxGroup
@@ -140,8 +183,16 @@ export const NewValidation = () => {
         legendHelp="Hint Text"
         required
       >
-        <Checkbox label="Checkbox 1" />
-        <Checkbox label="Checkbox 2" />
+        <Checkbox
+          label="Checkbox 1"
+          checked={state1}
+          onChange={(e) => setState1(e.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox 2"
+          checked={state2}
+          onChange={(e) => setState2(e.target.checked)}
+        />
       </CheckboxGroup>
       <CheckboxGroup
         mt={2}
@@ -150,8 +201,16 @@ export const NewValidation = () => {
         legendHelp="Hint text"
         required
       >
-        <Checkbox label="Checkbox 1" />
-        <Checkbox label="Checkbox 2" />
+        <Checkbox
+          label="Checkbox 1"
+          checked={state3}
+          onChange={(e) => setState3(e.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox 2"
+          checked={state4}
+          onChange={(e) => setState4(e.target.checked)}
+        />
       </CheckboxGroup>
       <CheckboxGroup
         validationMessagePositionTop={false}
@@ -161,8 +220,16 @@ export const NewValidation = () => {
         legendHelp="Hint Text"
         required
       >
-        <Checkbox label="Checkbox 1" />
-        <Checkbox label="Checkbox 2" />
+        <Checkbox
+          label="Checkbox 1"
+          checked={state5}
+          onChange={(e) => setState5(e.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox 2"
+          checked={state6}
+          onChange={(e) => setState6(e.target.checked)}
+        />
       </CheckboxGroup>
       <CheckboxGroup
         validationMessagePositionTop={false}
@@ -172,8 +239,16 @@ export const NewValidation = () => {
         legendHelp="Hint text"
         required
       >
-        <Checkbox label="Checkbox 1" />
-        <Checkbox label="Checkbox 2" />
+        <Checkbox
+          label="Checkbox 1"
+          checked={state7}
+          onChange={(e) => setState7(e.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox 2"
+          checked={state8}
+          onChange={(e) => setState8(e.target.checked)}
+        />
       </CheckboxGroup>
     </CarbonProvider>
   );
@@ -185,6 +260,19 @@ NewValidation.parameters = {
 };
 
 export const NewValidationInline = () => {
+  const [state1, setState1] = useState(false);
+  const [state2, setState2] = useState(false);
+  const [state3, setState3] = useState(false);
+  const [state4, setState4] = useState(false);
+  const [state5, setState5] = useState(false);
+  const [state6, setState6] = useState(false);
+  const [state7, setState7] = useState(false);
+  const [state8, setState8] = useState(false);
+  const [state9, setState9] = useState(false);
+  const [state10, setState10] = useState(false);
+  const [state11, setState11] = useState(false);
+  const [state12, setState12] = useState(false);
+
   return (
     <CarbonProvider validationRedesignOptIn>
       <CheckboxGroup
@@ -194,9 +282,21 @@ export const NewValidationInline = () => {
         required
         inline
       >
-        <Checkbox label="Checkbox 1" />
-        <Checkbox label="Checkbox 2" />
-        <Checkbox label="Checkbox 3" />
+        <Checkbox
+          label="Checkbox 1"
+          checked={state1}
+          onChange={(e) => setState1(e.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox 2"
+          checked={state2}
+          onChange={(e) => setState2(e.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox 3"
+          checked={state3}
+          onChange={(e) => setState3(e.target.checked)}
+        />
       </CheckboxGroup>
       <CheckboxGroup
         mt={2}
@@ -206,9 +306,21 @@ export const NewValidationInline = () => {
         required
         inline
       >
-        <Checkbox label="Checkbox 1" />
-        <Checkbox label="Checkbox 2" />
-        <Checkbox label="Checkbox 3" />
+        <Checkbox
+          label="Checkbox 1"
+          checked={state4}
+          onChange={(e) => setState4(e.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox 2"
+          checked={state5}
+          onChange={(e) => setState5(e.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox 3"
+          checked={state6}
+          onChange={(e) => setState6(e.target.checked)}
+        />
       </CheckboxGroup>
       <CheckboxGroup
         mt={2}
@@ -219,9 +331,21 @@ export const NewValidationInline = () => {
         required
         inline
       >
-        <Checkbox label="Checkbox 1" />
-        <Checkbox label="Checkbox 2" />
-        <Checkbox label="Checkbox 3" />
+        <Checkbox
+          label="Checkbox 1"
+          checked={state7}
+          onChange={(e) => setState7(e.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox 2"
+          checked={state8}
+          onChange={(e) => setState8(e.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox 3"
+          checked={state9}
+          onChange={(e) => setState9(e.target.checked)}
+        />
       </CheckboxGroup>
       <CheckboxGroup
         mt={2}
@@ -232,9 +356,21 @@ export const NewValidationInline = () => {
         required
         inline
       >
-        <Checkbox label="Checkbox 1" />
-        <Checkbox label="Checkbox 2" />
-        <Checkbox label="Checkbox 3" />
+        <Checkbox
+          label="Checkbox 1"
+          checked={state10}
+          onChange={(e) => setState10(e.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox 2"
+          checked={state11}
+          onChange={(e) => setState11(e.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox 3"
+          checked={state12}
+          onChange={(e) => setState12(e.target.checked)}
+        />
       </CheckboxGroup>
     </CarbonProvider>
   );
@@ -246,15 +382,38 @@ NewValidationInline.parameters = {
 };
 
 export const WithLegendAlignment = ({ ...args }: CheckboxGroupProps) => {
+  const [state1, setState1] = useState(false);
+  const [state2, setState2] = useState(false);
+  const [state3, setState3] = useState(false);
+  const [state4, setState4] = useState(false);
+
   return (
     <CarbonProvider validationRedesignOptIn>
       <CheckboxGroup {...args} legendAlign="left" mb={2}>
-        <Checkbox label="Checkbox option 1" />
-        <Checkbox label="Checkbox option 2" fieldHelp="fieldHelp Text" />
+        <Checkbox
+          label="Checkbox option 1"
+          checked={state1}
+          onChange={(ev) => setState1(ev.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox option 2"
+          fieldHelp="fieldHelp Text"
+          checked={state2}
+          onChange={(ev) => setState2(ev.target.checked)}
+        />
       </CheckboxGroup>
       <CheckboxGroup {...args} legendAlign="right">
-        <Checkbox label="Checkbox option 1" />
-        <Checkbox label="Checkbox option 2" fieldHelp="fieldHelp Text" />
+        <Checkbox
+          label="Checkbox option 1"
+          checked={state3}
+          onChange={(ev) => setState3(ev.target.checked)}
+        />
+        <Checkbox
+          label="Checkbox option 2"
+          fieldHelp="fieldHelp Text"
+          checked={state4}
+          onChange={(ev) => setState4(ev.target.checked)}
+        />
       </CheckboxGroup>
     </CarbonProvider>
   );

--- a/src/components/checkbox/checkbox.component.tsx
+++ b/src/components/checkbox/checkbox.component.tsx
@@ -10,7 +10,6 @@ import CheckboxSvg from "./checkbox-svg.component";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import CheckboxGroupContext from "./checkbox-group/__internal__/checkbox-group.context";
-import Logger from "../../__internal__/utils/logger";
 import NewValidationContext from "../carbon-provider/__internal__/new-validation.context";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 
@@ -32,9 +31,11 @@ export interface CheckboxProps
   tooltipPosition?: "top" | "bottom" | "left" | "right";
   /** The value of the checkbox, passed on form submit */
   value?: string;
+  /** Handler for change events */
+  onChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
+  /** Checked state of the input */
+  checked: boolean;
 }
-
-let deprecateUncontrolledWarnTriggered = false;
 
 export const Checkbox = React.forwardRef(
   (
@@ -85,13 +86,6 @@ export const Checkbox = React.forwardRef(
       warning: contextWarning,
       info: contextInfo,
     } = checkboxGroupContext;
-
-    if (!deprecateUncontrolledWarnTriggered && !onChange) {
-      deprecateUncontrolledWarnTriggered = true;
-      Logger.deprecate(
-        "Uncontrolled behaviour in `Checkbox` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-      );
-    }
 
     const inputProps = {
       ariaLabelledBy,

--- a/src/components/checkbox/checkbox.pw.tsx
+++ b/src/components/checkbox/checkbox.pw.tsx
@@ -597,10 +597,12 @@ test.describe("should render CheckboxGroup component and check props", () => {
     await mount(
       <CheckboxGroupComponent>
         <Checkbox
+          checked={false}
           id="checkbox_id three"
           key="checkbox_id-three"
           name="checkbox_id-three"
           label="Checkbox 3"
+          onChange={() => {}}
         />
       </CheckboxGroupComponent>,
     );

--- a/src/components/checkbox/checkbox.stories.tsx
+++ b/src/components/checkbox/checkbox.stories.tsx
@@ -13,6 +13,9 @@ const meta = {
   argTypes: {
     ...styledSystemProps,
   },
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
+  },
 } satisfies Meta<typeof Checkbox>;
 
 export default meta;
@@ -33,6 +36,9 @@ export const Default: Story = () => {
 Default.storyName = "Default";
 
 export const Sizes: Story = () => {
+  const [isChecked, setIsChecked] = useState(false);
+  const [isChecked2, setIsChecked2] = useState(false);
+
   return (
     <>
       <Checkbox
@@ -41,12 +47,16 @@ export const Sizes: Story = () => {
         key="checkbox-small"
         name="checkbox-small"
         size="small"
+        onChange={(e) => setIsChecked(e.target.checked)}
+        checked={isChecked}
       />
       <Checkbox
         label="Large"
         key="checkbox-large"
         name="checkbox-large"
         size="large"
+        onChange={(e) => setIsChecked2(e.target.checked)}
+        checked={isChecked2}
       />
     </>
   );
@@ -55,13 +65,29 @@ Sizes.storyName = "Sizes";
 
 export const Disabled: Story = () => {
   return (
-    <Checkbox disabled label="Disabled checkbox" name="checkbox-disabled" />
+    <Checkbox
+      disabled
+      label="Disabled checkbox"
+      name="checkbox-disabled"
+      onChange={() => {}}
+      checked={false}
+    />
   );
 };
 Disabled.storyName = "Disabled";
 
 export const Reversed: Story = () => {
-  return <Checkbox label="Reversed checkbox" name="checkbox-reverse" reverse />;
+  const [isChecked, setIsChecked] = useState(false);
+
+  return (
+    <Checkbox
+      label="Reversed checkbox"
+      name="checkbox-reverse"
+      reverse
+      onChange={(e) => setIsChecked(e.target.checked)}
+      checked={isChecked}
+    />
+  );
 };
 Reversed.storyName = "Reversed";
 
@@ -80,6 +106,8 @@ export const Required: Story = () => {
 };
 
 export const WithFieldHelp: Story = () => {
+  const [isChecked, setIsChecked] = useState(false);
+  const [isChecked2, setIsChecked2] = useState(false);
   return (
     <>
       <Checkbox
@@ -87,6 +115,8 @@ export const WithFieldHelp: Story = () => {
         label="With fieldHelp"
         key="checkbox-fieldhelp"
         name="checkbox-fieldhelp"
+        onChange={(e) => setIsChecked(e.target.checked)}
+        checked={isChecked}
       />
       <Checkbox
         fieldHelp="This text provides help for the input."
@@ -94,6 +124,8 @@ export const WithFieldHelp: Story = () => {
         label="With inline fieldHelp"
         key="checkbox-fieldhelp-inline"
         name="checkbox-fieldhelp-inline"
+        onChange={(e) => setIsChecked2(e.target.checked)}
+        checked={isChecked2}
       />
     </>
   );
@@ -101,22 +133,30 @@ export const WithFieldHelp: Story = () => {
 WithFieldHelp.storyName = "With fieldHelp";
 
 export const CustomLabelWidth: Story = () => {
+  const [isChecked, setIsChecked] = useState(false);
+
   return (
     <Checkbox
       label="With custom labelWidth"
       labelWidth={100}
       name="checkbox-custom-label"
+      onChange={(e) => setIsChecked(e.target.checked)}
+      checked={isChecked}
     />
   );
 };
 
 export const LegacyLabelHelp: Story = () => {
+  const [isChecked, setIsChecked] = useState(false);
+
   return (
     <Checkbox
       helpAriaLabel="This text provides more information for the label."
       label="With labelHelp"
       labelHelp="This text provides more information for the label."
       name="checkbox-labelHelp"
+      onChange={(e) => setIsChecked(e.target.checked)}
+      checked={isChecked}
     />
   );
 };

--- a/src/components/checkbox/checkbox.test.tsx
+++ b/src/components/checkbox/checkbox.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import Logger from "../../__internal__/utils/logger";
 import { Checkbox } from ".";
 import CarbonProvider from "../carbon-provider";
 import {
@@ -9,23 +8,10 @@ import {
   testStyledSystemMargin,
 } from "../../__spec_helper__/__internal__/test-utils";
 
-test("should display a deprecation warning for uncontrolled behaviour which is triggered only once", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(<Checkbox />);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "Uncontrolled behaviour in `Checkbox` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-  loggerSpy.mockRestore();
-});
-
 test("should call onChange when checkbox is clicked", async () => {
   const user = userEvent.setup();
   const onChange = jest.fn();
-  render(<Checkbox onChange={onChange} />);
+  render(<Checkbox checked onChange={onChange} />);
 
   await user.click(screen.getByRole("checkbox"));
   expect(onChange).toHaveBeenCalledTimes(1);
@@ -34,7 +20,7 @@ test("should call onChange when checkbox is clicked", async () => {
 test("should call onClick when checkbox is clicked", async () => {
   const user = userEvent.setup();
   const onClick = jest.fn();
-  render(<Checkbox onChange={() => {}} onClick={onClick} />);
+  render(<Checkbox checked onChange={() => {}} onClick={onClick} />);
 
   await user.click(screen.getByRole("checkbox"));
   expect(onClick).toHaveBeenCalledTimes(1);
@@ -43,7 +29,7 @@ test("should call onClick when checkbox is clicked", async () => {
 test("should call onFocus when checkbox is focused", async () => {
   const user = userEvent.setup();
   const onFocus = jest.fn();
-  render(<Checkbox onChange={() => {}} onFocus={onFocus} />);
+  render(<Checkbox checked onChange={() => {}} onFocus={onFocus} />);
 
   await user.tab();
   expect(onFocus).toHaveBeenCalledTimes(1);
@@ -52,7 +38,7 @@ test("should call onFocus when checkbox is focused", async () => {
 test("should call onBlur when checkbox is blurred", async () => {
   const user = userEvent.setup();
   const onBlur = jest.fn();
-  render(<Checkbox onChange={() => {}} onBlur={onBlur} />);
+  render(<Checkbox checked onChange={() => {}} onBlur={onBlur} />);
 
   await user.tab();
   await user.tab();
@@ -61,34 +47,36 @@ test("should call onBlur when checkbox is blurred", async () => {
 
 test("should accept ref as an object", () => {
   const ref = { current: null };
-  render(<Checkbox onChange={() => {}} ref={ref} />);
+  render(<Checkbox checked onChange={() => {}} ref={ref} />);
 
   expect(ref.current).not.toBeNull();
 });
 
 test("should accept ref as a callback", () => {
   const ref = jest.fn();
-  render(<Checkbox onChange={() => {}} ref={ref} />);
+  render(<Checkbox checked onChange={() => {}} ref={ref} />);
 
   expect(ref).toHaveBeenCalledTimes(1);
 });
 
 test("should set ref to empty after unmount", () => {
   const ref = { current: null };
-  const { unmount } = render(<Checkbox onChange={() => {}} ref={ref} />);
+  const { unmount } = render(
+    <Checkbox checked onChange={() => {}} ref={ref} />,
+  );
 
   unmount();
   expect(ref.current).toBeNull();
 });
 
 test("should render with provided label", () => {
-  render(<Checkbox label="label" onChange={() => {}} />);
+  render(<Checkbox label="label" checked onChange={() => {}} />);
 
   expect(screen.getByText("label")).toBeVisible();
 });
 
 test("should render with provided aria-labelledby", () => {
-  render(<Checkbox aria-labelledby="labelId" onChange={() => {}} />);
+  render(<Checkbox aria-labelledby="labelId" checked onChange={() => {}} />);
 
   expect(screen.getByRole("checkbox")).toHaveAttribute(
     "aria-labelledby",
@@ -103,6 +91,7 @@ test("should render tooltip with provided labelHelp and helpAriaLabel", async ()
       label="label"
       labelHelp="labelHelp"
       helpAriaLabel="helpAriaLabel"
+      checked
       onChange={() => {}}
     />,
   );
@@ -116,7 +105,7 @@ test("should render tooltip with provided labelHelp and helpAriaLabel", async ()
 
 test("should render input with validation tooltip as its accessible description when the input is focused", async () => {
   const user = userEvent.setup();
-  render(<Checkbox label="label" onChange={() => {}} error="error" />);
+  render(<Checkbox label="label" checked onChange={() => {}} error="error" />);
 
   const checkbox = screen.getByRole("checkbox");
   expect(checkbox).not.toHaveAttribute("aria-describedby");
@@ -130,6 +119,7 @@ test("should append the validation tooltip to the input's accessible description
   render(
     <Checkbox
       label="label"
+      checked
       onChange={() => {}}
       fieldHelp="fieldHelp"
       error="error"
@@ -144,13 +134,13 @@ test("should append the validation tooltip to the input's accessible description
 });
 
 test("should render a required checkbox when the required prop is true", () => {
-  render(<Checkbox label="label" onChange={() => {}} required />);
+  render(<Checkbox label="label" checked onChange={() => {}} required />);
 
   expect(screen.getByRole("checkbox")).toBeRequired();
 });
 
 test("should render a disabled checkbox when disabled prop is true", () => {
-  render(<Checkbox label="label" onChange={() => {}} disabled />);
+  render(<Checkbox label="label" checked onChange={() => {}} disabled />);
 
   expect(screen.getByRole("checkbox")).toBeDisabled();
 });
@@ -166,6 +156,7 @@ test("should render fieldHelp with expected styles when inputWidth is set", () =
     <Checkbox
       label="label"
       fieldHelp="fieldHelp"
+      checked
       onChange={() => {}}
       inputWidth={50}
     />,
@@ -181,6 +172,7 @@ test("should render fieldHelp with expected styles when inputWidth is set and re
     <Checkbox
       label="label"
       fieldHelp="fieldHelp"
+      checked
       onChange={() => {}}
       inputWidth={50}
       reverse
@@ -197,6 +189,7 @@ test("should render fieldHelp with expected styles when labelSpacing is 2", () =
     <Checkbox
       label="label"
       fieldHelp="fieldHelp"
+      checked
       onChange={() => {}}
       labelSpacing={2}
     />,
@@ -212,6 +205,7 @@ test("should render with expected styles when fieldHelpInline is true", () => {
     <Checkbox
       label="label"
       fieldHelp="fieldHelp"
+      checked
       onChange={() => {}}
       fieldHelpInline
     />,
@@ -226,6 +220,7 @@ test("should render with expected styles when fieldHelpInline is true and revers
     <Checkbox
       label="label"
       fieldHelp="fieldHelp"
+      checked
       onChange={() => {}}
       fieldHelpInline
       reverse
@@ -240,6 +235,7 @@ test("should render with expected styles when size is large", () => {
     <Checkbox
       label="label"
       fieldHelp="fieldHelp"
+      checked
       onChange={() => {}}
       size="large"
     />,
@@ -258,6 +254,7 @@ test("should render with expected styles when size is large and fieldHelpInline 
     <Checkbox
       label="label"
       fieldHelp="fieldHelp"
+      checked
       onChange={() => {}}
       size="large"
       fieldHelpInline
@@ -273,9 +270,9 @@ test("should render with expected styles when size is large and fieldHelpInline 
 test("should render checkbox svg with expected styles when validation props are true", () => {
   render(
     <>
-      <Checkbox label="label-1" onChange={() => {}} error />
-      <Checkbox label="label-2" onChange={() => {}} warning />
-      <Checkbox label="label-3" onChange={() => {}} info />
+      <Checkbox label="label-1" checked onChange={() => {}} error />
+      <Checkbox label="label-2" checked onChange={() => {}} warning />
+      <Checkbox label="label-3" checked onChange={() => {}} info />
     </>,
   );
 
@@ -294,8 +291,8 @@ test("should render checkbox svg with expected styles when validation props are 
 test("should render checkbox svg with expected styles when validationRedesignOptIn is true", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Checkbox label="label-1" onChange={() => {}} warning />
-      <Checkbox label="label-2" onChange={() => {}} info />
+      <Checkbox label="label-1" checked onChange={() => {}} warning />
+      <Checkbox label="label-2" checked onChange={() => {}} info />
     </CarbonProvider>,
   );
 
@@ -314,6 +311,7 @@ test("should render with expected styles when adaptiveSpacingBreakpoint set and 
     <Checkbox
       data-role="checkbox-1"
       label="label"
+      checked
       onChange={() => {}}
       adaptiveSpacingBreakpoint={1000}
       ml="10%"
@@ -329,6 +327,7 @@ test("should render with expected styles when adaptiveSpacingBreakpoint set and 
     <Checkbox
       data-role="checkbox-1"
       label="label"
+      checked
       onChange={() => {}}
       adaptiveSpacingBreakpoint={1000}
       ml="10%"
@@ -342,6 +341,7 @@ testStyledSystemMargin(
   (props) => (
     <Checkbox
       label="label"
+      checked
       onChange={() => {}}
       data-role="checkbox-1"
       {...props}

--- a/src/components/checkbox/components.test-pw.tsx
+++ b/src/components/checkbox/components.test-pw.tsx
@@ -1,23 +1,20 @@
 import React, { useState } from "react";
 import { Checkbox, CheckboxProps, CheckboxGroup, CheckboxGroupProps } from ".";
 import CarbonProvider from "../carbon-provider";
+import Box from "../box";
 
 export const CheckboxComponent = (props: Partial<CheckboxProps>) => {
   const [isChecked, setIsChecked] = useState(false);
   return (
     <>
-      <div
-        style={{
-          marginTop: "64px",
-        }}
-      >
+      <Box mt={8}>
         <Checkbox
           label="Checkbox 1"
           checked={isChecked}
           onChange={(e) => setIsChecked(e.target.checked)}
           {...props}
         />
-      </div>
+      </Box>
     </>
   );
 };
@@ -28,12 +25,7 @@ export const CheckboxGroupComponent = ({
 }: Partial<CheckboxGroupProps>) => {
   const [isChecked, setIsChecked] = useState(false);
   return (
-    <div
-      style={{
-        marginTop: "64px",
-        marginLeft: "64px",
-      }}
-    >
+    <Box mt={8} ml={8}>
       <CheckboxGroup legend="Test CheckboxGroup Label" {...props}>
         {children || (
           <>
@@ -50,7 +42,7 @@ export const CheckboxGroupComponent = ({
           </>
         )}
       </CheckboxGroup>
-    </div>
+    </Box>
   );
 };
 
@@ -60,12 +52,7 @@ export const CheckboxGroupComponentNewValidation = ({
 }: Partial<CheckboxGroupProps>) => {
   const [isChecked, setIsChecked] = useState(false);
   return (
-    <div
-      style={{
-        marginTop: "64px",
-        marginLeft: "64px",
-      }}
-    >
+    <Box mt={8} ml={8}>
       <CarbonProvider validationRedesignOptIn>
         <CheckboxGroup
           legend="Checkbox Group Label"
@@ -89,7 +76,7 @@ export const CheckboxGroupComponentNewValidation = ({
           )}
         </CheckboxGroup>
       </CarbonProvider>
-    </div>
+    </Box>
   );
 };
 
@@ -101,19 +88,31 @@ export const Sizes = () => {
         key="checkbox-small"
         name="checkbox-small"
         size="small"
+        checked
+        onChange={() => {}}
       />
       <Checkbox
         label="Large"
         key="checkbox-large"
         name="checkbox-large"
         size="large"
+        checked
+        onChange={() => {}}
       />
     </>
   );
 };
 
 export const Reversed = () => {
-  return <Checkbox label="Reversed checkbox" name="checkbox-reverse" reverse />;
+  return (
+    <Checkbox
+      label="Reversed checkbox"
+      name="checkbox-reverse"
+      reverse
+      checked
+      onChange={() => {}}
+    />
+  );
 };
 
 export const WithCustomLabelWidth = () => {
@@ -122,6 +121,8 @@ export const WithCustomLabelWidth = () => {
       label="With custom labelWidth and label aligned to right"
       labelWidth={100}
       name="checkbox-custom-label"
+      checked
+      onChange={() => {}}
     />
   );
 };

--- a/src/components/confirm/components.test-pw.tsx
+++ b/src/components/confirm/components.test-pw.tsx
@@ -87,6 +87,7 @@ export const TopModalOverride = () => {
   const [isOpenDialogFullScreen, setIsOpenDialogFullScreen] = useState(true);
   const [isOpenConfirm, setIsOpenConfirm] = useState(true);
   const [isOpenSidebar, setIsOpenSidebar] = useState(false);
+  const [textboxValue, setTextboxValue] = useState("");
 
   useEffect(() => {
     setTimeout(() => {
@@ -102,7 +103,11 @@ export const TopModalOverride = () => {
         onCancel={() => setIsOpenDialogFullScreen(false)}
         title="Dialog fullscreen"
       >
-        <Textbox label="Fullscreen textbox" />
+        <Textbox
+          label="Fullscreen textbox"
+          value={textboxValue}
+          onChange={(e) => setTextboxValue(e.target.value)}
+        />
       </Dialog>
       <Confirm
         open={isOpenConfirm}
@@ -111,14 +116,22 @@ export const TopModalOverride = () => {
         onConfirm={() => setIsOpenConfirm(false)}
         onCancel={() => setIsOpenConfirm(false)}
       >
-        <Textbox label="Confirm textbox" />
+        <Textbox
+          label="Confirm textbox"
+          value={textboxValue}
+          onChange={(e) => setTextboxValue(e.target.value)}
+        />
       </Confirm>
       <Sidebar
         open={isOpenSidebar}
         onCancel={() => setIsOpenSidebar(false)}
         header="sidebar"
       >
-        <Textbox label="Sidebar textbox" />
+        <Textbox
+          label="Sidebar textbox"
+          value={textboxValue}
+          onChange={(e) => setTextboxValue(e.target.value)}
+        />
       </Sidebar>
     </>
   );

--- a/src/components/decimal/components.test-pw.tsx
+++ b/src/components/decimal/components.test-pw.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 
 import Decimal, { DecimalProps, CustomEvent } from ".";
+import Box from "../box/box.component";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 
 export const DefaultStory = (
@@ -128,7 +129,8 @@ export const Validations = (
           />
           <Decimal
             label="Decimal - readOnly"
-            value="0.01"
+            value={state[validationType]}
+            onChange={handleChange(validationType)}
             readOnly
             {...{ [validationType]: args.message }}
             mb={2}
@@ -162,7 +164,7 @@ export const ValidationsRedesign = () => {
     <CarbonProvider validationRedesignOptIn>
       {(["error", "warning"] as const).map((validationType) =>
         (["small", "medium", "large"] as const).map((size) => (
-          <div style={{ width: "296px" }} key={`${size}-${validationType}`}>
+          <Box width="296px" key={`${size}-${validationType}`}>
             <Decimal
               label={`${size} - ${validationType}`}
               value={state[validationType]}
@@ -173,13 +175,14 @@ export const ValidationsRedesign = () => {
             />
             <Decimal
               label={`readOnly - ${size} - ${validationType}`}
-              value="0.01"
+              value={state[validationType]}
+              onChange={handleChange(validationType)}
               size={size}
               readOnly
               {...{ [validationType]: "Message" }}
               m={4}
             />
-          </div>
+          </Box>
         )),
       )}
     </CarbonProvider>

--- a/src/components/decimal/decimal-test.stories.tsx
+++ b/src/components/decimal/decimal-test.stories.tsx
@@ -66,26 +66,6 @@ export const DecimalStory = (args: CommonTextboxArgs) => {
 DecimalStory.storyName = "Default";
 DecimalStory.args = commonArgs;
 
-export const UncontrolledDecimalStory = (args: CommonTextboxArgs) => {
-  const handleChange = (ev: CustomEvent) => {
-    action("onChange")(ev.target.value);
-  };
-
-  const handleBlur = (event: CustomEvent) => {
-    action("onBlur")(event.target.value);
-  };
-  return (
-    <Decimal
-      defaultValue="0.03"
-      onChange={handleChange}
-      onBlur={handleBlur}
-      {...getCommonTextboxArgsWithSpecialCharacters(args)}
-    />
-  );
-};
-UncontrolledDecimalStory.storyName = "Uncontrolled Default";
-UncontrolledDecimalStory.args = commonArgs;
-
 type Locale = {
   options: string[];
   control: { type: string };

--- a/src/components/decimal/decimal.pw.tsx
+++ b/src/components/decimal/decimal.pw.tsx
@@ -104,7 +104,7 @@ test.describe("check props for Decimal component", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal precision={precision} />);
+      await mount(<DefaultStory precision={precision} />);
 
       const commonDataElementInputPreviewElement =
         commonDataElementInputPreview(page);
@@ -139,7 +139,7 @@ test.describe("check props for Decimal component", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal locale={locale} precision={3} />);
+      await mount(<DefaultStory locale={locale} precision={3} />);
 
       const commonDataElementInputPreviewElement =
         commonDataElementInputPreview(page);
@@ -157,7 +157,7 @@ test.describe("check props for Decimal component", () => {
   });
 
   test("should render Decimal with readOnly prop", async ({ mount, page }) => {
-    await mount(<Decimal readOnly />);
+    await mount(<DefaultStory readOnly />);
 
     const inputValue = "test";
     const commonDataElementInputPreviewElement =
@@ -176,7 +176,7 @@ test.describe("check props for Decimal component", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal maxWidth={maxWidth} />);
+      await mount(<DefaultStory maxWidth={maxWidth} />);
 
       const textboxParent = await textbox(page).evaluateHandle(
         (element: Element) => {
@@ -195,7 +195,7 @@ test.describe("check props for Decimal component", () => {
     mount,
     page,
   }) => {
-    await mount(<Decimal maxWidth="" />);
+    await mount(<DefaultStory maxWidth="" />);
 
     const textboxParent = await textbox(page).evaluateHandle(
       (element: Element) => {
@@ -217,7 +217,7 @@ test.describe("check Decimal input", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal fieldHelp={specificValue} />);
+      await mount(<DefaultStory fieldHelp={specificValue} />);
 
       const fieldHelpPreviewElement = fieldHelpPreview(page);
       await expect(fieldHelpPreviewElement).toHaveText(specificValue);
@@ -229,7 +229,7 @@ test.describe("check Decimal input", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal label={specificValue} />);
+      await mount(<DefaultStory label={specificValue} />);
 
       const getDataElementByValueElementLabel = getDataElementByValue(
         page,
@@ -244,7 +244,7 @@ test.describe("check Decimal input", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal label="Label" labelHelp={specificValue} />);
+      await mount(<DefaultStory label="Label" labelHelp={specificValue} />);
 
       const getDataElementByValueElementQuestion = getDataElementByValue(
         page,
@@ -261,7 +261,7 @@ test.describe("check Decimal input", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal prefix={prefix} />);
+      await mount(<DefaultStory prefix={prefix} />);
 
       const textboxPrefixElement = textboxPrefix(page);
       await expect(textboxPrefixElement).toHaveText(prefix);
@@ -275,7 +275,7 @@ test.describe("check Decimal input", () => {
     mount,
     page,
   }) => {
-    await mount(<Decimal prefix="foo" />);
+    await mount(<DefaultStory prefix="foo" />);
 
     const textboxInput = textbox(page);
     await expect(textboxInput).toHaveCSS("flex-direction", "row");
@@ -286,7 +286,7 @@ test.describe("check Decimal input", () => {
       mount,
       page,
     }) => {
-      await mount(<Decimal />);
+      await mount(<DefaultStory />);
 
       const commonDataElementInputPreviewElement =
         commonDataElementInputPreview(page);
@@ -307,7 +307,7 @@ test.describe("check Decimal input", () => {
     mount,
     page,
   }) => {
-    await mount(<Decimal />);
+    await mount(<DefaultStory />);
 
     const commonDataElementInputPreviewElement =
       commonDataElementInputPreview(page);
@@ -342,7 +342,7 @@ test.describe("allowEmptyValue", () => {
       page,
     }) => {
       await mount(
-        <Decimal
+        <DefaultStory
           precision={precisionValue}
           locale={localeValue}
           allowEmptyValue={false}
@@ -382,7 +382,7 @@ test.describe("allowEmptyValue", () => {
       page,
     }) => {
       await mount(
-        <Decimal
+        <DefaultStory
           precision={precisionValue}
           locale={localeValue}
           allowEmptyValue
@@ -400,55 +400,6 @@ test.describe("allowEmptyValue", () => {
         "",
       );
     });
-  });
-});
-
-test.describe("check events for Decimal component", () => {
-  (
-    [
-      ["1", "1.00"],
-      ["12", "12.00"],
-      ["123", "123.00"],
-    ] as [string, string][]
-  ).forEach(([rawValueTest, formattedValueTest]) => {
-    test(`should call onChange callback when a type event is triggered with ${rawValueTest} value`, async ({
-      mount,
-      page,
-    }) => {
-      let callbackCount = 0;
-      const callback: DecimalProps["onChange"] = () => {
-        callbackCount += 1;
-      };
-      await mount(<Decimal precision={2} onChange={callback} />);
-
-      const commonDataElementInputPreviewElement =
-        commonDataElementInputPreview(page);
-      await commonDataElementInputPreviewElement.fill(rawValueTest);
-      expect(callbackCount).toBe(1);
-      await commonDataElementInputPreviewElement.blur();
-      await expect(commonDataElementInputPreviewElement).toHaveAttribute(
-        "value",
-        formattedValueTest,
-      );
-    });
-  });
-
-  test("should call onBlur callback when a blur event is triggered", async ({
-    mount,
-    page,
-  }) => {
-    let callbackCount = 0;
-    const callback: DecimalProps["onBlur"] = () => {
-      callbackCount += 1;
-    };
-    await mount(<Decimal onBlur={callback} />);
-
-    const inputValue = "123";
-    const commonDataElementInputPreviewElement =
-      commonDataElementInputPreview(page);
-    await commonDataElementInputPreviewElement.fill(inputValue);
-    await commonDataElementInputPreviewElement.blur();
-    expect(callbackCount).toBe(1);
   });
 });
 
@@ -604,7 +555,7 @@ test("should have the expected border radius styling", async ({
   mount,
   page,
 }) => {
-  await mount(<Decimal />);
+  await mount(<DefaultStory />);
 
   const getElementElementInput = getElement(page, "input");
   await expect(getElementElementInput).toHaveCSS("border-radius", "4px");

--- a/src/components/decimal/decimal.stories.tsx
+++ b/src/components/decimal/decimal.stories.tsx
@@ -29,7 +29,7 @@ export const DefaultStory: Story = {
     const setValue = ({ target }: CustomEvent) => {
       setState(target.value.rawValue);
     };
-    return <Decimal value={state} onChange={setValue} {...args} />;
+    return <Decimal {...args} value={state} onChange={setValue} />;
   },
   args: { label: "Decimal" },
   name: "Default",

--- a/src/components/decimal/decimal.test.tsx
+++ b/src/components/decimal/decimal.test.tsx
@@ -14,7 +14,7 @@ const ControlledDecimal = ({
   onChange,
   startingValue,
   ...rest
-}: Partial<DecimalProps> & { startingValue?: string }) => {
+}: Partial<DecimalProps> & { startingValue: string }) => {
   const [value, setValue] = useState(startingValue);
   const handleChange = (e: CustomEvent) => {
     setValue(e.target.value.rawValue);
@@ -25,1365 +25,238 @@ const ControlledDecimal = ({
 };
 
 testStyledSystemMargin(
-  (props) => <Decimal data-role="decimal" {...props} />,
+  (props) => (
+    <Decimal
+      data-role="decimal"
+      value="0.01"
+      onChange={() => jest.fn()}
+      {...props}
+    />
+  ),
   () => screen.getByTestId("decimal"),
   { modifier: "&&&" },
 );
 
-describe("when the component is uncontrolled", () => {
-  it("displays a deprecation warning for uncontrolled", () => {
-    const loggerSpy = jest.spyOn(Logger, "deprecate");
-    render(<Decimal defaultValue="0.01" />);
-
-    expect(loggerSpy).toHaveBeenCalledWith(
-      "Uncontrolled behaviour in `Decimal` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-    );
-    expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-    loggerSpy.mockRestore();
-  });
-
-  it("has a default value of 0.00 when no defaultValue prop is provided", () => {
-    render(<Decimal />);
-    expect(screen.getByRole("textbox")).toHaveValue("0.00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.00");
-  });
-
-  it("has a default value specified by the defaultValue prop", () => {
-    render(<Decimal defaultValue="12345.67" />);
-    expect(screen.getByRole("textbox")).toHaveValue("12,345.67");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("12345.67");
-  });
-
-  it("has a default value specified by the defaultValue prop when the value is negative", () => {
-    render(<Decimal defaultValue="-1234.56" />);
-    expect(screen.getByRole("textbox")).toHaveValue("-1,234.56");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("-1234.56");
-  });
-
-  it("removes unnecessary separators on blur", async () => {
-    const user = userEvent.setup();
-    render(<Decimal />);
-    const decimalInput = screen.getByRole("textbox");
-
-    await user.type(decimalInput, "1,1");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("11.00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("11.00");
-  });
-
-  it("fixes incorrectly placed separators on blur", async () => {
-    const user = userEvent.setup();
-    render(<Decimal />);
-    const decimalInput = screen.getByRole("textbox");
-
-    await user.type(decimalInput, "1,2,34576.00");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("1,234,576.00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1234576.00");
-  });
-
-  it("does not change the value on blur when it contains numbers, letters and too many separators", async () => {
-    const user = userEvent.setup();
-    render(<Decimal />);
-    const decimalInput = screen.getByRole("textbox");
-
-    await user.type(decimalInput, "123a,123a,123a");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("123a,123a,123a");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("123a,123a,123a");
-  });
-
-  it("does not change the value on blur when it contains numbers, letters and too many separators, and ends with a separator", async () => {
-    const user = userEvent.setup();
-    render(<Decimal />);
-    const decimalInput = screen.getByRole("textbox");
-
-    await user.type(decimalInput, "123a,123a,123a,");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("123a,123a,123a,");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("123a,123a,123a,");
-  });
-
-  it("does not revert to the defaultValue on blur when allowEmptyValue is not set and the user enters just a negative sign", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="-1234.56" />);
-    const decimalInput = screen.getByRole("textbox");
-
-    await user.type(decimalInput, "-");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("-");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("-");
-  });
-
-  it("does not revert to an empty value on blur when allowEmptyValue is set and the user enters just a negative sign", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="-1234.56" allowEmptyValue />);
-    const decimalInput = screen.getByRole("textbox");
-
-    await user.type(decimalInput, "-");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("-");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("-");
-  });
-
-  it("fires a console error if precision is changed", () => {
-    const loggerSpy = jest.spyOn(Logger, "error").mockImplementation(() => {});
-
-    const { rerender } = render(<Decimal defaultValue="12345" precision={2} />);
-
-    rerender(<Decimal precision={1} />);
-    expect(loggerSpy).toHaveBeenCalledWith(
-      "Decimal `precision` prop has changed value. Changing the Decimal `precision` prop has no effect.",
-    );
-    loggerSpy.mockRestore();
-  });
-
-  it("supports having a precision of 0", () => {
-    render(<Decimal defaultValue="12345.65" precision={0} />);
-    expect(screen.getByRole("textbox")).toHaveValue("12,345.65");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("12345.65");
-  });
-
-  it("does not round the default value if it has more precision than the `precision` prop", () => {
-    render(<Decimal defaultValue="12345.655" precision={2} />);
-    expect(screen.getByRole("textbox")).toHaveValue("12,345.655");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("12345.655");
-  });
-
-  it("supports having a bigger precision than the default of 2", () => {
-    render(<Decimal defaultValue="12345.654" precision={3} />);
-    expect(screen.getByRole("textbox")).toHaveValue("12,345.654");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("12345.654");
-  });
-
-  it.each<[DecimalProps["precision"], string]>([
-    [0, "150"],
-    [1, "130.4"],
-    [2, "136.42"],
-    [3, "150.456"],
-    [4, "130.5776"],
-    [5, "136.42345"],
-    [6, "150.234543"],
-    [7, "130.4234435"],
-    [8, "136.87556431"],
-    [9, "150.192837564"],
-    [10, "130.1988745670"],
-    [11, "136.10029938475"],
-    [12, "136.129034895673"],
-    [13, "150.1290238945785"],
-    [14, "130.10299288377462"],
-    [15, "136.896647588492756"],
-  ])(
-    "formats the default value correctly when the precision is (%s)",
-    (precisionValue, decimalValue) => {
-      render(
-        <Decimal defaultValue={decimalValue} precision={precisionValue} />,
-      );
-      expect(screen.getByRole("textbox")).toHaveValue(decimalValue);
-      expect(screen.getByTestId("hidden-input")).toHaveValue(decimalValue);
-    },
-  );
-
-  it("pads the value with 0s if the precision is greater than the number of decimal places", () => {
-    render(<Decimal defaultValue="12345" precision={3} />);
-    expect(screen.getByRole("textbox")).toHaveValue("12,345.000");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("12345.000");
-  });
-
-  it("calls onChange when the user enters a value", async () => {
-    const onChange = jest.fn();
-    const user = userEvent.setup();
-
-    render(<Decimal onChange={onChange} />);
-
-    await user.type(screen.getByRole("textbox"), "12345.56");
-
-    expect(onChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: {
-          value: {
-            formattedValue: "12,345.56",
-            rawValue: "12345.56",
-          },
-        },
-      }),
-    );
-  });
-
-  it("calls onBlur when the field loses focus", async () => {
-    const onBlur = jest.fn();
-    const user = userEvent.setup();
-
-    render(<Decimal onBlur={onBlur} />);
-
-    await user.type(screen.getByRole("textbox"), "12345.56");
-    await user.tab();
-
-    expect(onBlur).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: {
-          value: {
-            formattedValue: "12,345.56",
-            rawValue: "12345.56",
-          },
-        },
-      }),
-    );
-  });
-
-  it.each([
-    "1a",
-    "1b",
-    "1c",
-    "1d",
-    "1e",
-    "1f",
-    "1g",
-    "1h",
-    "1i",
-    "1j",
-    "1k",
-    "1l",
-    "1m",
-    "1n",
-    "1o",
-    "1p",
-    "1q",
-    "1r",
-    "1s",
-    "1t",
-    "1u",
-    "1v",
-    "1w",
-    "1x",
-    "1y",
-    "1z",
-    "1A",
-    "1B",
-    "1C",
-    "1D",
-    "1E",
-    "1F",
-    "1G",
-    "1H",
-    "1I",
-    "1J",
-    "1K",
-    "1L",
-    "1M",
-    "1N",
-    "1O",
-    "1P",
-    "1Q",
-    "1R",
-    "1S",
-    "1T",
-    "1U",
-    "1V",
-    "1W",
-    "1X",
-    "1Y",
-    "1Z",
-    "1!",
-    '1"',
-    "1£",
-    "1$",
-    "1%",
-    "1^",
-    "1&",
-    "1*",
-    "1(",
-    "1)",
-    "1_",
-    "1+",
-    "1`",
-    "1¬",
-    "1\\",
-    "1|",
-    "1[",
-    "1{",
-    "1]",
-    "1}",
-    "1:",
-    "1;",
-    "1@",
-    "1'",
-    "1~",
-    "1#",
-    "1<",
-    "1>",
-    "1?",
-    "1/",
-    "a1",
-    "b1",
-    "c1",
-    "d1",
-    "e1",
-    "f1",
-    "g1",
-    "h1",
-    "i1",
-    "j1",
-    "k1",
-    "l1",
-    "m1",
-    "n1",
-    "o1",
-    "p1",
-    "q1",
-    "r1",
-    "s1",
-    "t1",
-    "u1",
-    "v1",
-    "w1",
-    "x1",
-    "y1",
-    "z1",
-    "A1",
-    "B1",
-    "C1",
-    "D1",
-    "E1",
-    "F1",
-    "G1",
-    "H1",
-    "I1",
-    "J1",
-    "K1",
-    "L1",
-    "M1",
-    "N1",
-    "O1",
-    "P1",
-    "Q1",
-    "R1",
-    "S1",
-    "T1",
-    "U1",
-    "V1",
-    "W1",
-    "X1",
-    "Y1",
-    "Z1",
-    "!1",
-    '"1',
-    "£1",
-    "$1",
-    "%1",
-    "^1",
-    "&1",
-    "*1",
-    "(1",
-    ")1",
-    "_1",
-    "`1",
-    "¬1",
-    "\\1",
-    "|1",
-    "[1",
-    "{1",
-    "]1",
-    "}1",
-    ":1",
-    ";1",
-    "@1",
-    "'1",
-    "~1",
-    "#1",
-    "<1",
-    ">1",
-    "?1",
-    "/1",
-    "11111a",
-    "a111111",
-    "1111a1111",
-  ])(
-    "allows the user to paste `%s` and calls onChange with the pasted value",
-    async (pastedText) => {
-      const onChange = jest.fn();
-      const user = userEvent.setup();
-      render(<Decimal onChange={onChange} />);
-
-      const textbox = screen.getByRole("textbox");
-
-      await user.click(textbox);
-      await user.keyboard("{Control>}{a}{/Control}");
-      await user.paste(pastedText);
-
-      expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          target: {
-            value: {
-              formattedValue: pastedText,
-              rawValue: pastedText,
-            },
-          },
-        }),
-      );
-    },
-  );
-
-  it.each([
-    [1, "0-.00"],
-    [2, "0.-00"],
-    [3, "0.0-0"],
-  ])(
-    "allows the user to type the negative symbol within the number at index %s",
-    async (insertionIndex, result) => {
-      const user = userEvent.setup();
-      render(<Decimal defaultValue="0.00" />);
-
-      const decimalInput = screen.getByRole("textbox");
-
-      await user.type(decimalInput, "-", {
-        initialSelectionStart: insertionIndex,
-      });
-
-      expect(decimalInput).toHaveValue(result);
-      expect(screen.getByTestId("hidden-input")).toHaveValue(result);
-    },
-  );
-
-  // insertions at start and end have to be handled separately from the cases above, as setting the
-  // initialSelectionStart to 0 or 4 (the default input length) seems to result in the entire value
-  // being selected. So we explicitly use arrow-key manipulation to handle these cases correctly.
-  it("allows the user to type a negative symbol at the start of the number", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="0.00" />);
-
-    const decimalInput = screen.getByRole("textbox");
-
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{ArrowLeft}");
-    await user.keyboard("-");
-
-    expect(decimalInput).toHaveValue("-0.00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("-0.00");
-  });
-
-  it("allows the user to type a negative symbol at the end of the number", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="0.00" />);
-
-    const decimalInput = screen.getByRole("textbox");
-
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{ArrowRight}");
-    await user.keyboard("-");
-
-    expect(decimalInput).toHaveValue("0.00-");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.00-");
-  });
-
-  it.each([
-    [1, 1, ",234.56", ",234.56"],
-    [2, 2, "1234.56", "1234.56"],
-    [3, 3, "1,34.56", "134.56"],
-    [4, 4, "1,24.56", "124.56"],
-    [5, 5, "1,23.56", "123.56"],
-    [6, 6, "1,23456", "123456"],
-    [7, 7, "1,234.6", "1234.6"],
-    [0, 1, ",234.56", ",234.56"],
-    [0, 2, "234.56", "234.56"],
-    [0, 3, "34.56", "34.56"],
-    [0, 4, "4.56", "4.56"],
-    [0, 5, ".56", ".56"],
-    [0, 6, "56", "56"],
-    [0, 7, "6", "6"],
-    [0, 8, "", ""],
-    [1, 2, "1234.56", "1234.56"],
-    [1, 3, "134.56", "134.56"],
-    [1, 4, "14.56", "14.56"],
-    [1, 5, "1.56", "1.56"],
-    [1, 6, "156", "156"],
-    [1, 7, "16", "16"],
-    [1, 8, "1", "1"],
-    [2, 3, "1,34.56", "134.56"],
-    [2, 4, "1,4.56", "14.56"],
-    [2, 5, "1,.56", "1,.56"],
-    [2, 6, "1,56", "156"],
-    [2, 7, "1,6", "16"],
-    [2, 8, "1,", "1,"],
-    [3, 4, "1,24.56", "124.56"],
-    [3, 5, "1,2.56", "12.56"],
-    [3, 6, "1,256", "1256"],
-    [3, 7, "1,26", "126"],
-    [3, 8, "1,2", "12"],
-    [4, 5, "1,23.56", "123.56"],
-    [4, 6, "1,2356", "12356"],
-    [4, 7, "1,236", "1236"],
-    [4, 8, "1,23", "123"],
-    [5, 6, "1,23456", "123456"],
-    [5, 7, "1,2346", "12346"],
-    [5, 8, "1,234", "1234"],
-    [6, 7, "1,234.6", "1234.6"],
-    [6, 8, "1,234.", "1,234."],
-    [7, 8, "1,234.5", "1234.5"],
-  ])(
-    "allows deletion of content using the backspace key for a selection starting at index %s and ending at index %s",
-    async (selectionStart, selectionEnd, rawValue, sanitisedValue) => {
-      const user = userEvent.setup();
-      render(<Decimal defaultValue="1234.56" />);
-
-      const decimalInput = screen.getByRole("textbox") as HTMLInputElement;
-      act(() => {
-        decimalInput.focus();
-      });
-      decimalInput.setSelectionRange(selectionStart, selectionEnd);
-      await user.keyboard("{Backspace}");
-
-      expect(decimalInput).toHaveValue(rawValue);
-      expect(screen.getByTestId("hidden-input")).toHaveValue(sanitisedValue);
-    },
-  );
-
-  // as above, a simple cursor placement (no selection) at the start or end need special handling
-  it("doesn't delete anything when backspace is pressed with the cursor at the start of the input", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="1234.56" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{ArrowLeft}");
-    await user.keyboard("{Backspace}");
-
-    expect(decimalInput).toHaveValue("1,234.56");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1234.56");
-  });
-
-  it("allows deletion of the final character using the backspace key with the cursor at the end of the input", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="1234.56" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{ArrowRight}");
-    await user.keyboard("{Backspace}");
-
-    expect(decimalInput).toHaveValue("1,234.5");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1234.5");
-  });
-
-  it.each([
-    [1, 1, "1234.56", "1234.56"],
-    [2, 2, "1,34.56", "134.56"],
-    [3, 3, "1,24.56", "124.56"],
-    [4, 4, "1,23.56", "123.56"],
-    [5, 5, "1,23456", "123456"],
-    [6, 6, "1,234.6", "1234.6"],
-    [7, 7, "1,234.5", "1234.5"],
-    [0, 1, ",234.56", ",234.56"],
-    [0, 2, "234.56", "234.56"],
-    [0, 3, "34.56", "34.56"],
-    [0, 4, "4.56", "4.56"],
-    [0, 5, ".56", ".56"],
-    [0, 6, "56", "56"],
-    [0, 7, "6", "6"],
-    [0, 8, "", ""],
-    [1, 2, "1234.56", "1234.56"],
-    [1, 3, "134.56", "134.56"],
-    [1, 4, "14.56", "14.56"],
-    [1, 5, "1.56", "1.56"],
-    [1, 6, "156", "156"],
-    [1, 7, "16", "16"],
-    [1, 8, "1", "1"],
-    [2, 3, "1,34.56", "134.56"],
-    [2, 4, "1,4.56", "14.56"],
-    [2, 5, "1,.56", "1,.56"],
-    [2, 6, "1,56", "156"],
-    [2, 7, "1,6", "16"],
-    [2, 8, "1,", "1,"],
-    [3, 4, "1,24.56", "124.56"],
-    [3, 5, "1,2.56", "12.56"],
-    [3, 6, "1,256", "1256"],
-    [3, 7, "1,26", "126"],
-    [3, 8, "1,2", "12"],
-    [4, 5, "1,23.56", "123.56"],
-    [4, 6, "1,2356", "12356"],
-    [4, 7, "1,236", "1236"],
-    [4, 8, "1,23", "123"],
-    [5, 6, "1,23456", "123456"],
-    [5, 7, "1,2346", "12346"],
-    [5, 8, "1,234", "1234"],
-    [6, 7, "1,234.6", "1234.6"],
-    [6, 8, "1,234.", "1,234."],
-    [7, 8, "1,234.5", "1234.5"],
-  ])(
-    "allows deletion of content using the delete key for a selection starting at index %s and ending at index %s",
-    async (selectionStart, selectionEnd, rawValue, sanitisedValue) => {
-      const user = userEvent.setup();
-      render(<Decimal defaultValue="1234.56" />);
-
-      const decimalInput = screen.getByRole("textbox") as HTMLInputElement;
-      act(() => {
-        decimalInput.focus();
-      });
-      decimalInput.setSelectionRange(selectionStart, selectionEnd);
-      await user.keyboard("{Delete}");
-
-      expect(decimalInput).toHaveValue(rawValue);
-      expect(screen.getByTestId("hidden-input")).toHaveValue(sanitisedValue);
-    },
-  );
-
-  // as above, a simple cursor placement (no selection) at the start or end need special handling
-  it("deletes the first character when delete is pressed with the cursor at the start of the input", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="1234.56" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{ArrowLeft}");
-    await user.keyboard("{Delete}");
-
-    expect(decimalInput).toHaveValue(",234.56");
-    expect(screen.getByTestId("hidden-input")).toHaveValue(",234.56");
-  });
-
-  it("doesn't delete anything when delete is pressed with the cursor at the end of the input", async () => {
-    const user = userEvent.setup();
-    render(<Decimal defaultValue="1234.56" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{ArrowRight}");
-    await user.keyboard("{Delete}");
-
-    expect(decimalInput).toHaveValue("1,234.56");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1234.56");
-  });
-
-  it.each([",", ".", "£", "$", "%", "@", "!", "*", "#"])(
-    "should not format multiple `%s` characters",
-    async (char) => {
-      const user = userEvent.setup();
-      render(<Decimal />);
-
-      const input = char.repeat(4);
-      await user.type(screen.getByRole("textbox"), input);
-      await user.tab();
-
-      expect(screen.getByRole("textbox")).toHaveValue(input);
-      expect(screen.getByTestId("hidden-input")).toHaveValue(input);
-    },
-  );
-
-  it("calls the onKeyDown callback when a key is pressed", async () => {
-    const user = userEvent.setup();
-    const onKeyDown = jest.fn();
-    render(<Decimal defaultValue="0.00" onKeyDown={onKeyDown} />);
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{ArrowRight}");
-    await user.keyboard("1");
-
-    expect(onKeyDown).toHaveBeenCalledWith(
-      expect.objectContaining({ key: "1" }),
-    );
-  });
-
-  it("has the correct data tag", () => {
-    render(
-      <Decimal data-role="test-data-role" data-element="test-data-element" />,
-    );
-    expect(screen.getByTestId("test-data-role")).toHaveAttribute(
-      "data-component",
-      "decimal",
-    );
-    expect(screen.getByTestId("test-data-role")).toHaveAttribute(
-      "data-element",
-      "test-data-element",
-    );
-  });
-
-  it("adds the expected HTML attributes to the hidden input", async () => {
-    const user = userEvent.setup();
-    render(<Decimal name="example" />);
-
-    await user.type(screen.getByRole("textbox"), "1.23");
-
-    const hiddenInput = screen.getByTestId("hidden-input");
-    expect(hiddenInput).toHaveAttribute("data-component", "hidden-input");
-    expect(hiddenInput).toHaveAttribute("type", "hidden");
-    expect(hiddenInput).toHaveValue("1.23");
-    expect(hiddenInput).toHaveAttribute("name", "example");
-  });
-
-  it("does not fire onChange when the input blurs with no change in value", async () => {
-    const user = userEvent.setup();
-    const onChange = jest.fn();
-    render(<Decimal allowEmptyValue onChange={onChange} />);
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.tab();
-
-    expect(onChange).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    ["1,1,1,1,1.1", "11,111.10", "11111.1"],
-    ["1,1,1222,12,1.1", "111,222,121.10", "111222121.1"],
-    ["1,,1,,1", "1,,1,,1", "1,,1,,1"],
-  ])(
-    "formats %s to %s and rawValue %s when the `en` locale is set",
-    async (input, formatted, rawValue) => {
-      const user = userEvent.setup();
-      const onBlur = jest.fn();
-      render(<Decimal locale="en" onBlur={onBlur} />);
-
-      await user.type(screen.getByRole("textbox"), input);
-      await user.tab();
-
-      expect(screen.getByRole("textbox")).toHaveValue(formatted);
-      expect(onBlur).toHaveBeenCalledWith(
-        expect.objectContaining({
-          target: {
-            value: {
-              formattedValue: formatted,
-              rawValue,
-            },
-          },
-        }),
-      );
-    },
-  );
-
-  it.each([
-    ["1000.23", "1000,23"],
-    ["10000.00", "10.000,00"],
-    ["10000.23", "10.000,23"],
-    ["100000.00", "100.000,00"],
-    ["1000000.00", "1.000.000,00"],
-  ])(
-    "formats %s to %s when provided as the defaultValue prop and the `es-ES` locale is set",
-    async (input, formatted) => {
-      render(<Decimal locale="es-ES" defaultValue={input} />);
-
-      expect(screen.getByRole("textbox")).toHaveValue(formatted);
-      expect(screen.getByTestId("hidden-input")).toHaveValue(input);
-    },
-  );
-
-  it.each([
-    ["1.1.1.1.1.1,1", "111.111,10", "111111.1"],
-    ["2.123", "2123,00", "2123"],
-    ["21.21.111.1,013", "21.211.111,013", "21211111.013"],
-    ["2.,12.,1", "2.,12.,1", "2.,12.,1"],
-    ["100", "100,00", "100"],
-    ["1000", "1000,00", "1000"],
-    ["1000,23", "1000,23", "1000.23"],
-    ["10000", "10.000,00", "10000"],
-    ["10000,23", "10.000,23", "10000.23"],
-    ["100000", "100.000,00", "100000"],
-    ["1000000", "1.000.000,00", "1000000"],
-  ])(
-    "formats %s to %s and rawValue %s when the `es-ES` locale is set",
-    async (input, formatted, rawValue) => {
-      const user = userEvent.setup();
-      const onBlur = jest.fn();
-      render(<Decimal locale="es-ES" onBlur={onBlur} />);
-
-      await user.type(screen.getByRole("textbox"), input);
-      await user.tab();
-
-      expect(screen.getByRole("textbox")).toHaveValue(formatted);
-      expect(onBlur).toHaveBeenCalledWith(
-        expect.objectContaining({
-          target: {
-            value: {
-              formattedValue: formatted,
-              rawValue,
-            },
-          },
-        }),
-      );
-    },
-  );
-
-  it("formats an empty value correctly when precision is 0, allowEmptyValue is false, and the `es-ES` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={0}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="es-ES"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0");
-  });
-
-  it("formats an empty value correctly when precision is 1, allowEmptyValue is false, and the `es-ES` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={1}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="es-ES"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0,0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.0");
-  });
-
-  it.each([
-    ["1000.23", "1000,23"],
-    ["10000.00", "10\xa0000,00"],
-    ["10000.23", "10\xa0000,23"],
-    ["100000.00", "100\xa0000,00"],
-    ["1000000.00", "1\xa0000\xa0000,00"],
-  ])(
-    "formats %s to %s when provided as the defaultValue prop and the `pt-PT` locale is set",
-    async (input, formatted) => {
-      render(<Decimal locale="pt-PT" defaultValue={input} />);
-
-      expect(screen.getByRole("textbox")).toHaveValue(formatted);
-      expect(screen.getByTestId("hidden-input")).toHaveValue(input);
-    },
-  );
-
-  it.each([
-    ["1111,2", "1111,20", "1111.2"],
-    ["100", "100,00", "100"],
-    ["1000", "1000,00", "1000"],
-    ["1000.23", "1000,23", "1000.23"],
-    ["10000", "10\xa0000,00", "10000"],
-    ["10000.23", "10\xa0000,23", "10000.23"],
-    ["100000", "100\xa0000,00", "100000"],
-    ["1000000", "1\xa0000\xa0000,00", "1000000"],
-  ])(
-    "formats %s to %s and rawValue %s when the `pt-PT` locale is set",
-    async (input, formatted, rawValue) => {
-      const user = userEvent.setup();
-      const onBlur = jest.fn();
-      render(<Decimal locale="pt-PT" onBlur={onBlur} />);
-
-      await user.type(screen.getByRole("textbox"), input);
-      await user.tab();
-
-      expect(screen.getByRole("textbox")).toHaveValue(formatted);
-      expect(onBlur).toHaveBeenCalledWith(
-        expect.objectContaining({
-          target: {
-            value: {
-              formattedValue: formatted,
-              rawValue,
-            },
-          },
-        }),
-      );
-    },
-  );
-
-  it("correctly handles a value that has white-spaces when the `pt-PT` locale is set", async () => {
-    const user = userEvent.setup();
-    render(<Decimal locale="pt-PT" />);
-
-    await user.type(screen.getByRole("textbox"), "10 000,00");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("10\xa0000,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("10000.00");
-  });
-
-  it("correctly handles a value that has white-spaces in the wrong place when the `pt-PT` locale is set", async () => {
-    const user = userEvent.setup();
-    render(<Decimal locale="pt-PT" />);
-
-    await user.type(screen.getByRole("textbox"), "1 0000,00");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("10\xa0000,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("10000.00");
-  });
-
-  it("correctly handles a value that has multiple white-spaces when the `pt-PT` locale is set", async () => {
-    const user = userEvent.setup();
-    render(<Decimal locale="pt-PT" />);
-
-    await user.type(screen.getByRole("textbox"), "1  0000,00");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("1  0000,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1  0000,00");
-  });
-
-  it("correctly handles a value that has multiple groups with white-spaces when the `pt-PT` locale is set", async () => {
-    const user = userEvent.setup();
-    render(<Decimal locale="pt-PT" />);
-
-    await user.type(screen.getByRole("textbox"), "1 0000 000,00");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("10\xa0000\xa0000,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("10000000.00");
-  });
-
-  it("formats an empty value correctly when precision is 0, allowEmptyValue is false, and the `pt-PT` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={0}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="pt-PT"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0");
-  });
-
-  it("formats an empty value correctly when precision is 1, allowEmptyValue is false, and the `pt-PT` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={1}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="pt-PT"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0,0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.0");
-  });
-
-  it("formats %s to %s and rawValue %s when the `fr` locale is set", async () => {
-    const user = userEvent.setup();
-    const onBlur = jest.fn();
-    render(<Decimal locale="fr" onBlur={onBlur} />);
-
-    await user.type(screen.getByRole("textbox"), "11111,25");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("11 111,25");
-    expect(onBlur).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: {
-          value: {
-            formattedValue: "11 111,25",
-            rawValue: "11111.25",
-          },
-        },
-      }),
-    );
-  });
-
-  it("formats an empty value correctly when precision is 0, allowEmptyValue is false, and the `fr` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={0}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="fr"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0");
-  });
-
-  it("formats an empty value correctly when precision is 1, allowEmptyValue is false, and the `fr` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={1}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="fr"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0,0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.0");
-  });
-
-  it("has a defaultValue of 0,00 when the `it` locale is set", () => {
-    render(<Decimal locale="it" />);
-
-    expect(screen.getByRole("textbox")).toHaveValue("0,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.00");
-  });
-
-  it("formats the defaultValue prop correctly when the `it` locale is set", () => {
-    render(<Decimal defaultValue="12345.67" locale="it" />);
-
-    expect(screen.getByRole("textbox")).toHaveValue("12.345,67");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("12345.67");
-  });
-
-  it("formats a user-entered value correctly when the `it` locale is set", async () => {
-    const user = userEvent.setup();
-    render(<Decimal locale="it" />);
-
-    await user.type(screen.getByRole("textbox"), "1234576");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("1.234.576,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1234576.00");
-  });
-
-  it("formats a value correctly when it has an extra separator and the `it` locale is set", async () => {
-    const user = userEvent.setup();
-    render(<Decimal locale="it" />);
-
-    await user.type(screen.getByRole("textbox"), "1.2.34576,00");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("1.234.576,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1234576.00");
-  });
-
-  it("fixes incorrectly placed delimiters when the `it` locale is set", async () => {
-    const user = userEvent.setup();
-    render(<Decimal locale="it" />);
-
-    await user.type(screen.getByRole("textbox"), "1.1");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("11,00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("11.00");
-  });
-
-  it("renders a negative value with correct formatting when the `it` locale is set", () => {
-    render(<Decimal defaultValue="-1234.56" locale="it" />);
-
-    const formatter = new Intl.NumberFormat("it", { minimumFractionDigits: 2 });
-    const formatted = formatter.format(-1234.56);
-
-    expect(screen.getByRole("textbox")).toHaveValue(formatted);
-    expect(screen.getByTestId("hidden-input")).toHaveValue("-1234.56");
-  });
-
-  it("formats an empty value correctly when precision is 0, allowEmptyValue is false and the `it` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={0}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="it"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0");
-  });
-
-  it("formats an empty value correctly when precision is 1, allowEmptyValue is false, and the `it` locale is set", async () => {
-    const user = userEvent.setup();
-    render(
-      <Decimal
-        precision={1}
-        defaultValue="123.45"
-        allowEmptyValue={false}
-        locale="it"
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.keyboard("{Delete}");
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0,0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.0");
-  });
+it.each([
+  ["123", "123.00"],
+  ["456", "456.00"],
+  ["", ""],
+])("renders the value prop %s in the input", (rawValue, formattedValue) => {
+  render(<Decimal value={rawValue} onChange={jest.fn} />);
+
+  expect(screen.getByRole("textbox")).toHaveValue(formattedValue);
+  expect(screen.getByTestId("hidden-input")).toHaveValue(formattedValue);
 });
 
-describe("when the component is controlled", () => {
-  it.each([
-    ["123", "123.00"],
-    ["456", "456.00"],
-    ["", ""],
-  ])("renders the value prop %s in the input", (rawValue, formattedValue) => {
-    render(<Decimal value={rawValue} />);
+it("does not fire onChange when the input blurs with no change in value", async () => {
+  const user = userEvent.setup();
+  const onChange = jest.fn();
+  render(<Decimal value="123" onChange={onChange} />);
 
-    expect(screen.getByRole("textbox")).toHaveValue(formattedValue);
-    expect(screen.getByTestId("hidden-input")).toHaveValue(formattedValue);
+  act(() => {
+    screen.getByRole("textbox").focus();
   });
+  await user.tab();
 
-  it("does not fire onChange when the input blurs with no change in value", async () => {
-    const user = userEvent.setup();
-    const onChange = jest.fn();
-    render(<Decimal value="123" onChange={onChange} />);
+  expect(onChange).not.toHaveBeenCalled();
+});
 
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.tab();
+it("does not revert to the default value on blur when the user enters just a negative sign", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="123" />);
+  const decimalInput = screen.getByRole("textbox");
 
-    expect(onChange).not.toHaveBeenCalled();
+  await user.type(decimalInput, "-");
+  await user.tab();
+
+  expect(decimalInput).toHaveValue("-");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("-");
+});
+
+it("formats the default value correctly on blur when precision is 0 and allowEmptyValue is false", async () => {
+  const user = userEvent.setup();
+  render(
+    <ControlledDecimal
+      precision={0}
+      startingValue=""
+      allowEmptyValue={false}
+    />,
+  );
+
+  act(() => {
+    screen.getByRole("textbox").focus();
   });
+  await user.tab();
 
-  it("does not revert to the default value on blur when the user enters just a negative sign", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="123" />);
-    const decimalInput = screen.getByRole("textbox");
+  expect(screen.getByRole("textbox")).toHaveValue("0");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("0");
+});
 
-    await user.type(decimalInput, "-");
-    await user.tab();
+it("formats the default value correctly on blur when precision is 1 and allowEmptyValue is false", async () => {
+  const user = userEvent.setup();
+  render(
+    <ControlledDecimal
+      precision={1}
+      startingValue=""
+      allowEmptyValue={false}
+    />,
+  );
 
-    expect(decimalInput).toHaveValue("-");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("-");
+  act(() => {
+    screen.getByRole("textbox").focus();
   });
+  await user.tab();
 
-  it("formats the default value correctly on blur when precision is 0 and allowEmptyValue is false", async () => {
-    const user = userEvent.setup();
-    render(
-      <ControlledDecimal
-        precision={0}
-        startingValue=""
-        allowEmptyValue={false}
-      />,
-    );
+  expect(screen.getByRole("textbox")).toHaveValue("0.0");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("0.0");
+});
 
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.tab();
+it("does not revert to the empty value when allowEmptyValue is true and the user enters just a negative sign", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="" allowEmptyValue />);
+  const decimalInput = screen.getByRole("textbox");
 
-    expect(screen.getByRole("textbox")).toHaveValue("0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0");
+  await user.type(decimalInput, "-");
+  await user.tab();
+
+  expect(decimalInput).toHaveValue("-");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("-");
+});
+
+it("does not format a value that is not a number", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="" />);
+
+  const decimalInput = screen.getByRole("textbox");
+  await user.type(decimalInput, "FooBar");
+  expect(decimalInput).toHaveValue("FooBar");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("FooBar");
+});
+
+it("does not format a value that is white-space only", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="" />);
+
+  const decimalInput = screen.getByRole("textbox");
+  await user.type(decimalInput, "     ");
+  expect(decimalInput).toHaveValue("     ");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("     ");
+});
+
+it("does not format a value that is delimiters only", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="" />);
+
+  const decimalInput = screen.getByRole("textbox");
+  await user.type(decimalInput, ",,,");
+  expect(decimalInput).toHaveValue(",,,");
+  expect(screen.getByTestId("hidden-input")).toHaveValue(",,,");
+});
+
+it("does not format a value that is special characters and delimiters only", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="" />);
+
+  const decimalInput = screen.getByRole("textbox");
+  await user.type(decimalInput, "^^&^%%$,,,,");
+  expect(decimalInput).toHaveValue("^^&^%%$,,,,");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("^^&^%%$,,,,");
+});
+
+it("does not format a value that has numbers and has too many delimiters", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="" />);
+
+  const decimalInput = screen.getByRole("textbox");
+  await user.type(decimalInput, "10,.10,.11,.6");
+  expect(decimalInput).toHaveValue("10,.10,.11,.6");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("10,.10,.11,.6");
+});
+
+it("handles a value that is numbers, delimiters and special characters only", async () => {
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="" />);
+
+  const decimalInput = screen.getByRole("textbox");
+  await user.type(decimalInput, "1,234$");
+  expect(decimalInput).toHaveValue("1,234$");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("1,234$");
+});
+
+it("handles an empty value on blur when allowEmptyValue is true", async () => {
+  const onBlur = jest.fn();
+  const user = userEvent.setup();
+  render(
+    <ControlledDecimal startingValue="1" onBlur={onBlur} allowEmptyValue />,
+  );
+
+  const decimalInput = screen.getByRole("textbox");
+  act(() => {
+    decimalInput.focus();
   });
+  await user.keyboard("{Backspace}");
+  await user.tab();
 
-  it("formats the default value correctly on blur when precision is 1 and allowEmptyValue is false", async () => {
-    const user = userEvent.setup();
-    render(
-      <ControlledDecimal
-        precision={1}
-        startingValue=""
-        allowEmptyValue={false}
-      />,
-    );
-
-    act(() => {
-      screen.getByRole("textbox").focus();
-    });
-    await user.tab();
-
-    expect(screen.getByRole("textbox")).toHaveValue("0.0");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.0");
-  });
-
-  it("does not revert to the empty value when allowEmptyValue is true and the user enters just a negative sign", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="" allowEmptyValue />);
-    const decimalInput = screen.getByRole("textbox");
-
-    await user.type(decimalInput, "-");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("-");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("-");
-  });
-
-  it("does not format a value that is not a number", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    await user.type(decimalInput, "FooBar");
-    expect(decimalInput).toHaveValue("FooBar");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("FooBar");
-  });
-
-  it("does not format a value that is white-space only", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    await user.type(decimalInput, "     ");
-    expect(decimalInput).toHaveValue("     ");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("     ");
-  });
-
-  it("does not format a value that is delimiters only", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    await user.type(decimalInput, ",,,");
-    expect(decimalInput).toHaveValue(",,,");
-    expect(screen.getByTestId("hidden-input")).toHaveValue(",,,");
-  });
-
-  it("does not format a value that is special characters and delimiters only", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    await user.type(decimalInput, "^^&^%%$,,,,");
-    expect(decimalInput).toHaveValue("^^&^%%$,,,,");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("^^&^%%$,,,,");
-  });
-
-  it("does not format a value that has numbers and has too many delimiters", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    await user.type(decimalInput, "10,.10,.11,.6");
-    expect(decimalInput).toHaveValue("10,.10,.11,.6");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("10,.10,.11,.6");
-  });
-
-  it("handles a value that is numbers, delimiters and special characters only", async () => {
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="" />);
-
-    const decimalInput = screen.getByRole("textbox");
-    await user.type(decimalInput, "1,234$");
-    expect(decimalInput).toHaveValue("1,234$");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("1,234$");
-  });
-
-  it("handles an empty value on blur when allowEmptyValue is true", async () => {
-    const onBlur = jest.fn();
-    const user = userEvent.setup();
-    render(
-      <ControlledDecimal startingValue="1" onBlur={onBlur} allowEmptyValue />,
-    );
-
-    const decimalInput = screen.getByRole("textbox");
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{Backspace}");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("");
-    expect(onBlur).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: {
-          value: {
-            formattedValue: "",
-            rawValue: "",
-          },
+  expect(decimalInput).toHaveValue("");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("");
+  expect(onBlur).toHaveBeenCalledWith(
+    expect.objectContaining({
+      target: {
+        value: {
+          formattedValue: "",
+          rawValue: "",
         },
-      }),
-    );
+      },
+    }),
+  );
+});
+
+it("handles an empty value on blur when allowEmptyValue is false", async () => {
+  const onBlur = jest.fn();
+  const user = userEvent.setup();
+  render(<ControlledDecimal startingValue="1" onBlur={onBlur} />);
+
+  const decimalInput = screen.getByRole("textbox");
+  act(() => {
+    decimalInput.focus();
   });
+  await user.keyboard("{Backspace}");
+  await user.tab();
 
-  it("handles an empty value on blur when allowEmptyValue is false", async () => {
-    const onBlur = jest.fn();
-    const user = userEvent.setup();
-    render(<ControlledDecimal startingValue="1" onBlur={onBlur} />);
-
-    const decimalInput = screen.getByRole("textbox");
-    act(() => {
-      decimalInput.focus();
-    });
-    await user.keyboard("{Backspace}");
-    await user.tab();
-
-    expect(decimalInput).toHaveValue("0.00");
-    expect(screen.getByTestId("hidden-input")).toHaveValue("0.00");
-    expect(onBlur).toHaveBeenCalledWith(
-      expect.objectContaining({
-        target: {
-          value: {
-            formattedValue: "0.00",
-            rawValue: "0.00",
-          },
+  expect(decimalInput).toHaveValue("0.00");
+  expect(screen.getByTestId("hidden-input")).toHaveValue("0.00");
+  expect(onBlur).toHaveBeenCalledWith(
+    expect.objectContaining({
+      target: {
+        value: {
+          formattedValue: "0.00",
+          rawValue: "0.00",
         },
-      }),
-    );
-  });
+      },
+    }),
+  );
 });
 
 describe("refs", () => {
   it("accepts ref as a ref object", () => {
     const ref = { current: null };
-    render(<Decimal ref={ref} />);
+    render(<Decimal ref={ref} onChange={jest.fn} value="0.01" />);
 
     expect(ref.current).toBe(screen.getByRole("textbox"));
   });
 
   it("accepts ref as a ref callback", () => {
     const ref = jest.fn();
-    render(<Decimal ref={ref} />);
+    render(<Decimal ref={ref} onChange={jest.fn} value="0.01" />);
 
     expect(ref).toHaveBeenCalledWith(screen.getByRole("textbox"));
   });
 
   it("sets ref to empty after unmount", () => {
     const ref = { current: null };
-    const { unmount } = render(<Decimal ref={ref} />);
+    const { unmount } = render(
+      <Decimal ref={ref} onChange={jest.fn} value="0.01" />,
+    );
 
     unmount();
 
@@ -1399,7 +272,7 @@ test("when wrapped in an I18nProvider, the appropriate locale is used, and the f
         locale: () => "fr-FR",
       }}
     >
-      <Decimal />
+      <Decimal onChange={jest.fn} value="0.00" />
     </I18nProvider>,
   );
   expect(screen.getByRole("textbox")).toHaveValue("0,00");
@@ -1410,7 +283,7 @@ test("when wrapped in an I18nProvider, the appropriate locale is used, and the f
         locale: () => "en-GB",
       }}
     >
-      <Decimal />
+      <Decimal onChange={jest.fn} value="0.00" />
     </I18nProvider>,
   );
   act(() => {
@@ -1421,7 +294,7 @@ test("when wrapped in an I18nProvider, the appropriate locale is used, and the f
 });
 
 test("the `id` prop is passed to the input element", () => {
-  render(<Decimal id="decimalId" />);
+  render(<Decimal id="decimalId" onChange={jest.fn} value="0.01" />);
 
   expect(screen.getByRole("textbox")).toHaveAttribute("id", "decimalId");
 });
@@ -1431,20 +304,20 @@ test("no error message is triggered if the `precision` prop is not specified", (
     .spyOn(global.console, "error")
     .mockImplementation(() => {});
 
-  render(<Decimal defaultValue="12345.654" />);
+  render(<Decimal value="12345.654" onChange={jest.fn} />);
   expect(consoleSpy).not.toHaveBeenCalled();
 
   consoleSpy.mockRestore();
 });
 
 test("the `required` prop is passed to the visible input", () => {
-  render(<Decimal label="required" required />);
+  render(<Decimal label="required" required onChange={jest.fn} value="0.01" />);
 
   expect(screen.getByRole("textbox")).toBeRequired();
 });
 
 test("the `required` prop is not passed to the hidden input", () => {
-  render(<Decimal label="required" required />);
+  render(<Decimal label="required" required onChange={jest.fn} value="0.01" />);
 
   expect(screen.getByTestId("hidden-input")).not.toBeRequired();
 });
@@ -1467,4 +340,58 @@ test("component should render without invariant firing in strict mode", () => {
   );
 
   consoleErrorSpy.mockRestore();
+});
+
+test("logs an error when precision changes", () => {
+  const loggerSpy = jest.spyOn(Logger, "error");
+
+  const { rerender } = render(
+    <Decimal onChange={jest.fn} value="0.01" precision={2} />,
+  );
+
+  rerender(<Decimal onChange={jest.fn} value="0.01" precision={4} />);
+
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "Decimal `precision` prop has changed value. Changing the Decimal `precision` prop has no effect.",
+  );
+});
+
+describe("check events for Decimal component", () => {
+  (
+    [
+      ["1", "1.00"],
+      ["12", "12.00"],
+      ["123", "123.00"],
+    ] as [string, string][]
+  ).forEach(([rawValueTest, formattedValueTest]) => {
+    it(`should call onChange callback when a type event is triggered with ${rawValueTest} value`, async () => {
+      const user = userEvent.setup();
+      render(<ControlledDecimal startingValue="" />);
+
+      const decimalInput = screen.getByRole("textbox");
+      await user.type(decimalInput, rawValueTest);
+      act(() => {
+        decimalInput.blur();
+      });
+      expect(decimalInput).toHaveValue(formattedValueTest);
+    });
+  });
+
+  test("should call onBlur callback when a blur event is triggered", async () => {
+    let callbackCount = 0;
+    const callback: DecimalProps["onBlur"] = () => {
+      callbackCount += 1;
+    };
+    const user = userEvent.setup();
+    render(<ControlledDecimal startingValue="" onBlur={callback} />);
+
+    const decimalInput = screen.getByRole("textbox");
+    await user.type(decimalInput, "123");
+    act(() => {
+      decimalInput.blur();
+    });
+
+    expect(decimalInput).toHaveValue("123.00");
+    expect(callbackCount).toBe(1);
+  });
 });

--- a/src/components/detail/detail.pw.tsx
+++ b/src/components/detail/detail.pw.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-unescaped-entities */
 import React from "react";
 import { test, expect } from "../../../playwright/helpers/base-test";
 import Detail from "./detail.component";

--- a/src/components/dialog/components.test-pw.tsx
+++ b/src/components/dialog/components.test-pw.tsx
@@ -42,9 +42,9 @@ export const DialogComponent = (props: Partial<DialogProps>) => {
       onCancel={() => setIsOpen(false)}
       {...props}
     >
-      <Textbox label="Textbox1" value="Textbox1" />
-      <Textbox label="Textbox2" value="Textbox2" />
-      <Textbox label="Textbox3" value="Textbox3" />
+      <Textbox onChange={() => {}} label="Textbox1" value="Textbox1" />
+      <Textbox onChange={() => {}} label="Textbox2" value="Textbox2" />
+      <Textbox onChange={() => {}} label="Textbox3" value="Textbox3" />
     </Dialog>
   );
 };
@@ -59,9 +59,9 @@ export const DialogWithFirstFocusableElement = (
       <Button ref={ref} onClick={() => {}}>
         Press me
       </Button>
-      <Textbox label="Textbox1" value="Textbox1" />
-      <Textbox label="Textbox2" value="Textbox2" />
-      <Textbox label="Textbox3" value="Textbox3" />
+      <Textbox onChange={() => {}} label="Textbox1" value="Textbox1" />
+      <Textbox onChange={() => {}} label="Textbox2" value="Textbox2" />
+      <Textbox onChange={() => {}} label="Textbox3" value="Textbox3" />
     </Dialog>
   );
 };
@@ -92,7 +92,7 @@ export const DialogBackgroundScrollTest = () => {
         I should not be scrolled into view
       </Box>
       <Dialog open title="My dialog" onCancel={() => {}}>
-        <Textbox label="textbox" />
+        <Textbox value="" onChange={() => {}} label="textbox" />
       </Dialog>
     </Box>
   );
@@ -112,7 +112,7 @@ export const DialogWithOpenToastsBackgroundScrollTest = () => {
         onCancel={() => {}}
         focusableContainers={[toast1Ref, toast2Ref]}
       >
-        <Textbox label="textbox" />
+        <Textbox value="" onChange={() => {}} label="textbox" />
       </Dialog>
       <Toast open onDismiss={() => {}} ref={toast1Ref} targetPortalId="stacked">
         Toast message 1
@@ -143,7 +143,7 @@ export const TopModalOverride = () => {
         onCancel={() => setIsOpenDialogFullSreen(false)}
         title="Dialog fullscreen"
       >
-        <Textbox label="Fullscreen textbox" />
+        <Textbox value="" onChange={() => {}} label="Fullscreen textbox" />
       </Dialog>
       <Dialog
         open={isOpenDialog}
@@ -151,14 +151,14 @@ export const TopModalOverride = () => {
         title="Dialog"
         topModalOverride
       >
-        <Textbox label="Dialog textbox" />
+        <Textbox value="" onChange={() => {}} label="Dialog textbox" />
       </Dialog>
       <Sidebar
         open={isOpenSidebar}
         onCancel={() => setIsOpenSidebar(false)}
         header="sidebar"
       >
-        <Textbox label="Sidebar textbox" />
+        <Textbox value="" onChange={() => {}} label="Sidebar textbox" />
       </Sidebar>
     </>
   );
@@ -167,10 +167,10 @@ export const TopModalOverride = () => {
 export const DialogWithAutoFocusSelect = () => {
   return (
     <Dialog open title="My dialog" onCancel={() => {}}>
-      <Select autoFocus label="select">
+      <Select autoFocus label="select" value="1" onChange={() => {}}>
         <Option value="1" text="one" />
       </Select>
-      <Textbox label="textbox" />
+      <Textbox value="" onChange={() => {}} label="textbox" />
     </Dialog>
   );
 };
@@ -193,10 +193,10 @@ export const DialogComponentFocusableSelectors = (
         {...props}
       >
         <Box className="focusable-container">
-          <Textbox label="First Name" />
+          <Textbox value="" onChange={() => {}} label="First Name" />
         </Box>
         <Box>
-          <Textbox label="Surname" />
+          <Textbox value="" onChange={() => {}} label="Surname" />
         </Box>
         <Box className="focusable-container">
           <Button
@@ -253,18 +253,18 @@ export const DefaultStory = ({
           <Typography>
             This is an example of a dialog with a Form as content
           </Typography>
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
+          <Textbox value="" onChange={() => {}} label="First Name" />
+          <Textbox value="" onChange={() => {}} label="Middle Name" />
+          <Textbox value="" onChange={() => {}} label="Surname" />
+          <Textbox value="" onChange={() => {}} label="Birth Place" />
+          <Textbox value="" onChange={() => {}} label="Favourite Colour" />
+          <Textbox value="" onChange={() => {}} label="Address" />
+          <Textbox value="" onChange={() => {}} label="First Name" />
+          <Textbox value="" onChange={() => {}} label="Middle Name" />
+          <Textbox value="" onChange={() => {}} label="Surname" />
+          <Textbox value="" onChange={() => {}} label="Birth Place" />
+          <Textbox value="" onChange={() => {}} label="Favourite Colour" />
+          <Textbox value="" onChange={() => {}} label="Address" />
         </Form>
       </Dialog>
     </>
@@ -293,7 +293,7 @@ export const DefaultNestedStory = () => {
           onCancel={() => setIsNestedDialogOpen(false)}
           title="Nested Dialog"
         >
-          <Textbox label="Nested Dialog Textbox" />
+          <Textbox value="" onChange={() => {}} label="Nested Dialog Textbox" />
         </Dialog>
       </Dialog>
     </>
@@ -352,13 +352,33 @@ export const Editable = () => {
             />
           </RadioButtonGroup>
           <Box p="24px" bg="slateTint90" ml="88px">
-            <Textbox labelInline label="Property Name" />
+            <Textbox
+              value=""
+              onChange={() => {}}
+              labelInline
+              label="Property Name"
+            />
             <Fieldset>
-              <Textbox labelInline label="Address Line 1" />
-              <Textbox labelInline label="Address Line 2" />
-              <Textbox labelInline label="Town" />
-              <Textbox labelInline label="City" />
-              <Textbox labelInline label="Postcode" />
+              <Textbox
+                value=""
+                onChange={() => {}}
+                labelInline
+                label="Address Line 1"
+              />
+              <Textbox
+                value=""
+                onChange={() => {}}
+                labelInline
+                label="Address Line 2"
+              />
+              <Textbox value="" onChange={() => {}} labelInline label="Town" />
+              <Textbox value="" onChange={() => {}} labelInline label="City" />
+              <Textbox
+                value=""
+                onChange={() => {}}
+                labelInline
+                label="Postcode"
+              />
             </Fieldset>
           </Box>
         </Form>
@@ -390,13 +410,33 @@ export const WithHelp = () => {
           }
         >
           <Box p="24px" bg="slateTint90" ml="88px">
-            <Textbox labelInline label="Property Name" />
+            <Textbox
+              value=""
+              onChange={() => {}}
+              labelInline
+              label="Property Name"
+            />
             <Fieldset>
-              <Textbox labelInline label="Address Line 1" />
-              <Textbox labelInline label="Address Line 2" />
-              <Textbox labelInline label="Town" />
-              <Textbox labelInline label="City" />
-              <Textbox labelInline label="Postcode" />
+              <Textbox
+                value=""
+                onChange={() => {}}
+                labelInline
+                label="Address Line 1"
+              />
+              <Textbox
+                value=""
+                onChange={() => {}}
+                labelInline
+                label="Address Line 2"
+              />
+              <Textbox value="" onChange={() => {}} labelInline label="Town" />
+              <Textbox value="" onChange={() => {}} labelInline label="City" />
+              <Textbox
+                value=""
+                onChange={() => {}}
+                labelInline
+                label="Postcode"
+              />
             </Fieldset>
           </Box>
         </Form>
@@ -430,13 +470,49 @@ export const LoadingContent = () => {
           <Loader isActive isInsideButton={false} size="small" />
         ) : (
           <>
-            <Textbox label="Textbox 1" labelInline autoFocus />
-            <Textbox label="Textbox 2" labelInline />
-            <Textbox label="Textbox 3" labelInline />
-            <Textbox label="Textbox 4" labelInline />
-            <Textbox label="Textbox 5" labelInline />
-            <Textbox label="Textbox 6" labelInline />
-            <Textbox label="Textbox 7" labelInline />
+            <Textbox
+              value=""
+              onChange={() => {}}
+              label="Textbox 1"
+              labelInline
+              autoFocus
+            />
+            <Textbox
+              value=""
+              onChange={() => {}}
+              label="Textbox 2"
+              labelInline
+            />
+            <Textbox
+              value=""
+              onChange={() => {}}
+              label="Textbox 3"
+              labelInline
+            />
+            <Textbox
+              value=""
+              onChange={() => {}}
+              label="Textbox 4"
+              labelInline
+            />
+            <Textbox
+              value=""
+              onChange={() => {}}
+              label="Textbox 5"
+              labelInline
+            />
+            <Textbox
+              value=""
+              onChange={() => {}}
+              label="Textbox 6"
+              labelInline
+            />
+            <Textbox
+              value=""
+              onChange={() => {}}
+              label="Textbox 7"
+              labelInline
+            />
           </>
         )}
       </Dialog>
@@ -473,7 +549,7 @@ export const FocusingADifferentFirstElement = () => {
             This should be focused first now
           </Button>
         </Box>
-        <Textbox label="Not focused" />
+        <Textbox value="" onChange={() => {}} label="Not focused" />
       </Dialog>
       <Button ml={2} onClick={() => setIsOpenTwo(true)}>
         Open Demo using autoFocus
@@ -494,7 +570,12 @@ export const FocusingADifferentFirstElement = () => {
           <Button onClick={() => setIsOpenTwo(false)}>Not focused</Button>
           <Button onClick={() => setIsOpenTwo(false)}>Not focused</Button>
         </Box>
-        <Textbox autoFocus label="This should be focused first now" />
+        <Textbox
+          value=""
+          onChange={() => {}}
+          autoFocus
+          label="This should be focused first now"
+        />
       </Dialog>
     </>
   );
@@ -526,18 +607,18 @@ export const OverridingContentPadding = () => {
           <Typography>
             This is an example of a dialog with a Form as content
           </Typography>
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
+          <Textbox value="" onChange={() => {}} label="First Name" />
+          <Textbox value="" onChange={() => {}} label="Middle Name" />
+          <Textbox value="" onChange={() => {}} label="Surname" />
+          <Textbox value="" onChange={() => {}} label="Birth Place" />
+          <Textbox value="" onChange={() => {}} label="Favourite Colour" />
+          <Textbox value="" onChange={() => {}} label="Address" />
+          <Textbox value="" onChange={() => {}} label="First Name" />
+          <Textbox value="" onChange={() => {}} label="Middle Name" />
+          <Textbox value="" onChange={() => {}} label="Surname" />
+          <Textbox value="" onChange={() => {}} label="Birth Place" />
+          <Textbox value="" onChange={() => {}} label="Favourite Colour" />
+          <Textbox value="" onChange={() => {}} label="Address" />
         </Form>
       </Dialog>
     </>
@@ -575,9 +656,9 @@ export const OtherFocusableContainers = () => {
           <Typography>
             This is an example of a dialog with a Form as content
           </Typography>
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
+          <Textbox value="" onChange={() => {}} label="First Name" />
+          <Textbox value="" onChange={() => {}} label="Middle Name" />
+          <Textbox value="" onChange={() => {}} label="Surname" />
           <Button onClick={() => setIsToast1Open(true)}>
             Show first toast
           </Button>
@@ -646,12 +727,12 @@ export const Responsive = () => {
           <Typography>
             This is an example of a dialog with a Form as content
           </Typography>
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
+          <Textbox value="" onChange={() => {}} label="First Name" />
+          <Textbox value="" onChange={() => {}} label="Middle Name" />
+          <Textbox value="" onChange={() => {}} label="Surname" />
+          <Textbox value="" onChange={() => {}} label="Birth Place" />
+          <Textbox value="" onChange={() => {}} label="Favourite Colour" />
+          <Textbox value="" onChange={() => {}} label="Address" />
         </Form>
       </Dialog>
     </>
@@ -731,9 +812,9 @@ export const FullScreenDialogComponent = ({
           This should be focused first now
         </Button>
 
-        <Textbox label="Textbox1" value="Textbox1" />
-        <Textbox label="Textbox2" value="Textbox2" />
-        <Textbox label="Textbox3" value="Textbox3" />
+        <Textbox label="Textbox1" value="Textbox1" onChange={() => {}} />
+        <Textbox label="Textbox2" value="Textbox2" onChange={() => {}} />
+        <Textbox label="Textbox3" value="Textbox3" onChange={() => {}} />
         <Form>{children}</Form>
       </Dialog>
     </>
@@ -849,12 +930,12 @@ export const FullScreenWithHeaderChildren = () => {
           <div>
             This is an example of a full screen Dialog with a Form as content
           </div>
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
+          <Textbox label="First Name" onChange={() => {}} value="" />
+          <Textbox label="Middle Name" onChange={() => {}} value="" />
+          <Textbox label="Surname" onChange={() => {}} value="" />
+          <Textbox label="Birth Place" onChange={() => {}} value="" />
+          <Textbox label="Favourite Colour" onChange={() => {}} value="" />
+          <Textbox label="Address" onChange={() => {}} value="" />
         </Form>
       </Dialog>
     </>
@@ -864,7 +945,7 @@ export const FullScreenWithHeaderChildren = () => {
 export const FullScreenBackgroundScrollTestComponent = () => {
   return (
     <Dialog fullscreen open onCancel={() => {}}>
-      <Textbox label="textbox" />
+      <Textbox label="textbox" onChange={() => {}} value="" />
       <Box height="2000px" position="relative">
         <Box height="100px" position="absolute" bottom="0px">
           I should not be scrolled into view
@@ -885,7 +966,7 @@ export const FullScreenBackgroundScrollWithOtherFocusableContainers = () => {
         onCancel={() => {}}
         focusableContainers={[toast1Ref, toast2Ref]}
       >
-        <Textbox label="textbox" />
+        <Textbox label="textbox" onChange={() => {}} value="" />
         <Box height="2000px" position="relative">
           <Box height="100px" position="absolute" bottom="0px">
             I should not be scrolled into view
@@ -929,12 +1010,12 @@ export const FullScreenWithHelp = () => {
           <div>
             This is an example of a full screen Dialog with a Form as content
           </div>
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
+          <Textbox label="First Name" onChange={() => {}} value="" />
+          <Textbox label="Middle Name" onChange={() => {}} value="" />
+          <Textbox label="Surname" onChange={() => {}} value="" />
+          <Textbox label="Birth Place" onChange={() => {}} value="" />
+          <Textbox label="Favourite Colour" onChange={() => {}} value="" />
+          <Textbox label="Address" onChange={() => {}} value="" />
         </Form>
       </Dialog>
     </>
@@ -999,12 +1080,12 @@ export const FullScreenWithHideableHeaderChildren = () => {
           <div>
             This is an example of a full screen Dialog with a Form as content
           </div>
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
+          <Textbox label="First Name" onChange={() => {}} value="" />
+          <Textbox label="Middle Name" onChange={() => {}} value="" />
+          <Textbox label="Surname" onChange={() => {}} value="" />
+          <Textbox label="Birth Place" onChange={() => {}} value="" />
+          <Textbox label="Favourite Colour" onChange={() => {}} value="" />
+          <Textbox label="Address" onChange={() => {}} value="" />
         </Form>
       </Dialog>
     </>
@@ -1038,12 +1119,12 @@ export const FullScreenWithBox = () => {
             <div>
               This is an example of a full screen Dialog with a Form as content
             </div>
-            <Textbox label="First Name" />
-            <Textbox label="Middle Name" />
-            <Textbox label="Surname" />
-            <Textbox label="Birth Place" />
-            <Textbox label="Favourite Colour" />
-            <Textbox label="Address" />
+            <Textbox label="First Name" onChange={() => {}} value="" />
+            <Textbox label="Middle Name" onChange={() => {}} value="" />
+            <Textbox label="Surname" onChange={() => {}} value="" />
+            <Textbox label="Birth Place" onChange={() => {}} value="" />
+            <Textbox label="Favourite Colour" onChange={() => {}} value="" />
+            <Textbox label="Address" onChange={() => {}} value="" />
           </Form>
         </Box>
       </Dialog>
@@ -1080,7 +1161,7 @@ export const FullScreenFocusingADifferentFirstElement = () => {
             This should be focused first now
           </Button>
         </Box>
-        <Textbox label="Not Focused" />
+        <Textbox label="Not Focused" onChange={() => {}} value="" />
       </Dialog>
       <Button ml={2} onClick={() => setIsOpenTwo(true)}>
         Open Demo using autoFocus
@@ -1103,7 +1184,12 @@ export const FullScreenFocusingADifferentFirstElement = () => {
           <Button onClick={() => setIsOpenTwo(false)}>Not focused</Button>
           <Button onClick={() => setIsOpenTwo(false)}>Not focused</Button>
         </Box>
-        <Textbox label="This should be focused first now" autoFocus />
+        <Textbox
+          label="This should be focused first now"
+          autoFocus
+          onChange={() => {}}
+          value=""
+        />
       </Dialog>
     </>
   );
@@ -1141,9 +1227,9 @@ export const FullScreenOtherFocusableContainers = () => {
           <Typography>
             This is an example of a dialog with a Form as content
           </Typography>
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
+          <Textbox label="First Name" onChange={() => {}} value="" />
+          <Textbox label="Middle Name" onChange={() => {}} value="" />
+          <Textbox label="Surname" onChange={() => {}} value="" />
           <Button onClick={() => setIsToast1Open(true)}>
             Show first toast
           </Button>
@@ -1193,7 +1279,7 @@ export const FullScreenWithTitleAsReactComponent = (
       onCancel={() => {}}
       {...props}
     >
-      <Textbox label="textbox" />
+      <Textbox label="textbox" onChange={() => {}} value="" />
     </Dialog>
   );
 };
@@ -1621,21 +1707,21 @@ export const FullScreenTopModalOverride = () => {
         title="Dialog fullscreen"
         topModalOverride
       >
-        <Textbox label="Fullscreen textbox" />
+        <Textbox label="Fullscreen textbox" onChange={() => {}} value="" />
       </Dialog>
       <Dialog
         open={isOpenDialog}
         onCancel={() => setIsOpenDialog(false)}
         title="Dialog"
       >
-        <Textbox label="Dialog textbox" />
+        <Textbox label="Dialog textbox" onChange={() => {}} value="" />
       </Dialog>
       <Sidebar
         open={isOpenSidebar}
         onCancel={() => setIsOpenSidebar(false)}
         header="sidebar"
       >
-        <Textbox label="Sidebar textbox" />
+        <Textbox label="Sidebar textbox" onChange={() => {}} value="" />
       </Sidebar>
     </>
   );
@@ -1644,10 +1730,10 @@ export const FullScreenTopModalOverride = () => {
 export const FullScreenWithAutoFocusSelect = () => {
   return (
     <Dialog fullscreen open title="My dialog" onCancel={() => {}}>
-      <Select autoFocus label="select">
+      <Select autoFocus label="select" value={"1"} onChange={() => {}}>
         <Option value="1" text="one" />
       </Select>
-      <Textbox label="textbox" />
+      <Textbox label="textbox" onChange={() => {}} value="" />
     </Dialog>
   );
 };
@@ -1671,10 +1757,10 @@ export const FullScreenComponentFocusableSelectors = (
         {...props}
       >
         <Box className="focusable-container">
-          <Textbox label="First Name" />
+          <Textbox label="First Name" onChange={() => {}} value="" />
         </Box>
         <Box>
-          <Textbox label="Surname" />
+          <Textbox label="Surname" onChange={() => {}} value="" />
         </Box>
         <Box className="focusable-container">
           <Button

--- a/src/components/dialog/dialog-test.stories.tsx
+++ b/src/components/dialog/dialog-test.stories.tsx
@@ -69,6 +69,7 @@ export const Default = ({
     setIsOpen(true);
     action("open")(evt);
   };
+  const [selected, setSelected] = useState("1");
 
   const selectOptions = [
     {
@@ -135,12 +136,12 @@ export const Default = ({
             </Button>
           }
         >
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
+          <Textbox label="First Name" value="" onChange={() => {}} />
+          <Textbox label="Middle Name" value="" onChange={() => {}} />
+          <Textbox label="Surname" value="" onChange={() => {}} />
+          <Textbox label="Birth Place" value="" onChange={() => {}} />
+          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+          <Textbox label="Address" value="" onChange={() => {}} />
           <DateInput
             name="date"
             label="Birthday"
@@ -149,12 +150,16 @@ export const Default = ({
               setDate(e.target.value.formattedValue)
             }
           />
-          <Select label="Color">
+          <Select
+            label="Color"
+            value={selected}
+            onChange={(e) => setSelected(e.target.value)}
+          >
             {selectOptions.map((option) => (
               <Option key={option.name} value={option} text={option.name} />
             ))}
           </Select>
-          <Textbox label="Pet Name" />
+          <Textbox label="Pet Name" value="" onChange={() => {}} />
           <DateInput
             name="date"
             label="Pet's birthday"
@@ -164,7 +169,12 @@ export const Default = ({
             }
           />
           <TextEditor labelText="Additional notes" />
-          <Checkbox name="checkbox" label="Do you like my Dog" />
+          <Checkbox
+            name="checkbox"
+            label="Do you like my Dog"
+            checked={false}
+            onChange={() => {}}
+          />
           <div>This is an example of a dialog with a Form as content</div>
         </Form>
       </Dialog>
@@ -205,9 +215,9 @@ export const WithTwoDifferentNodes: StoryType = (
       onCancel={() => setIsOpen(false)}
       {...props}
     >
-      <Textbox label="Textbox1" value="Textbox1" />
-      <Textbox label="Textbox2" value="Textbox2" />
-      <Textbox label="Textbox3" value="Textbox3" />
+      <Textbox label="Textbox1" value="Textbox1" onChange={() => {}} />
+      <Textbox label="Textbox2" value="Textbox2" onChange={() => {}} />
+      <Textbox label="Textbox3" value="Textbox3" onChange={() => {}} />
     </Dialog>
   );
 };
@@ -234,18 +244,18 @@ export const MaxSizeTest: StoryType = () => {
           </Button>
         }
       >
-        <Textbox label="First Name" />
-        <Textbox label="Middle Name" />
-        <Textbox label="Surname" />
-        <Textbox label="Birth Place" />
-        <Textbox label="Favourite Colour" />
-        <Textbox label="Address" />
-        <Textbox label="First Name" />
-        <Textbox label="Middle Name" />
-        <Textbox label="Surname" />
-        <Textbox label="Birth Place" />
-        <Textbox label="Favourite Colour" />
-        <Textbox label="Address" />
+        <Textbox label="First Name" value="" onChange={() => {}} />
+        <Textbox label="Middle Name" value="" onChange={() => {}} />
+        <Textbox label="Surname" value="" onChange={() => {}} />
+        <Textbox label="Birth Place" value="" onChange={() => {}} />
+        <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+        <Textbox label="Address" value="" onChange={() => {}} />
+        <Textbox label="First Name" value="" onChange={() => {}} />
+        <Textbox label="Middle Name" value="" onChange={() => {}} />
+        <Textbox label="Surname" value="" onChange={() => {}} />
+        <Textbox label="Birth Place" value="" onChange={() => {}} />
+        <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+        <Textbox label="Address" value="" onChange={() => {}} />
       </Form>
     </Dialog>
   );
@@ -278,7 +288,7 @@ export const MaxSizeTestNonOverflowedForm: StoryType = () => {
           </Button>
         }
       >
-        <Textbox label="First Name" />
+        <Textbox label="First Name" value="" onChange={() => {}} />
       </Form>
     </Dialog>
   );
@@ -419,12 +429,12 @@ export const WithWrappedStickyForm: StoryType = {
             </Button>
           }
         >
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
+          <Textbox label="First Name" value="" onChange={() => {}} />
+          <Textbox label="Middle Name" value="" onChange={() => {}} />
+          <Textbox label="Surname" value="" onChange={() => {}} />
+          <Textbox label="Birth Place" value="" onChange={() => {}} />
+          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+          <Textbox label="Address" value="" onChange={() => {}} />
         </Form>
       </Box>
     ),

--- a/src/components/dialog/dialog.stories.tsx
+++ b/src/components/dialog/dialog.stories.tsx
@@ -92,18 +92,18 @@ export const DefaultStory: Story = {
             <Typography>
               This is an example of a dialog with a Form as content
             </Typography>
-            <Textbox label="First Name" />
-            <Textbox label="Middle Name" />
-            <Textbox label="Surname" />
-            <Textbox label="Birth Place" />
-            <Textbox label="Favourite Colour" />
-            <Textbox label="Address" />
-            <Textbox label="First Name" />
-            <Textbox label="Middle Name" />
-            <Textbox label="Surname" />
-            <Textbox label="Birth Place" />
-            <Textbox label="Favourite Colour" />
-            <Textbox label="Address" />
+            <Textbox label="First Name" value="" onChange={() => {}} />
+            <Textbox label="Middle Name" value="" onChange={() => {}} />
+            <Textbox label="Surname" value="" onChange={() => {}} />
+            <Textbox label="Birth Place" value="" onChange={() => {}} />
+            <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+            <Textbox label="Address" value="" onChange={() => {}} />
+            <Textbox label="First Name" value="" onChange={() => {}} />
+            <Textbox label="Middle Name" value="" onChange={() => {}} />
+            <Textbox label="Surname" value="" onChange={() => {}} />
+            <Textbox label="Birth Place" value="" onChange={() => {}} />
+            <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+            <Textbox label="Address" value="" onChange={() => {}} />
           </Form>
         </Dialog>
       </>
@@ -161,18 +161,18 @@ export const RestoreFocusOnCloseStory: Story = () => {
           <Typography>
             This is an example of a dialog with a Form as content
           </Typography>
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
+          <Textbox label="First Name" value="" onChange={() => {}} />
+          <Textbox label="Middle Name" value="" onChange={() => {}} />
+          <Textbox label="Surname" value="" onChange={() => {}} />
+          <Textbox label="Birth Place" value="" onChange={() => {}} />
+          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+          <Textbox label="Address" value="" onChange={() => {}} />
+          <Textbox label="First Name" value="" onChange={() => {}} />
+          <Textbox label="Middle Name" value="" onChange={() => {}} />
+          <Textbox label="Surname" value="" onChange={() => {}} />
+          <Textbox label="Birth Place" value="" onChange={() => {}} />
+          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+          <Textbox label="Address" value="" onChange={() => {}} />
         </Form>
       </Dialog>
     </>
@@ -221,13 +221,33 @@ export const WithHelp: Story = () => {
           }
         >
           <Box p="24px" bg="slateTint90" ml="88px">
-            <Textbox labelInline label="Property Name" />
+            <Textbox
+              labelInline
+              label="Property Name"
+              value=""
+              onChange={() => {}}
+            />
             <Fieldset>
-              <Textbox labelInline label="Address Line 1" />
-              <Textbox labelInline label="Address Line 2" />
-              <Textbox labelInline label="Town" />
-              <Textbox labelInline label="City" />
-              <Textbox labelInline label="Postcode" />
+              <Textbox
+                labelInline
+                label="Address Line 1"
+                value=""
+                onChange={() => {}}
+              />
+              <Textbox
+                labelInline
+                label="Address Line 2"
+                value=""
+                onChange={() => {}}
+              />
+              <Textbox labelInline label="Town" value="" onChange={() => {}} />
+              <Textbox labelInline label="City" value="" onChange={() => {}} />
+              <Textbox
+                labelInline
+                label="Postcode"
+                value=""
+                onChange={() => {}}
+              />
             </Fieldset>
           </Box>
         </Form>
@@ -262,13 +282,49 @@ export const LoadingContent: Story = () => {
           <Loader isActive isInsideButton={false} size="small" />
         ) : (
           <>
-            <Textbox label="Textbox 1" labelInline autoFocus />
-            <Textbox label="Textbox 2" labelInline />
-            <Textbox label="Textbox 3" labelInline />
-            <Textbox label="Textbox 4" labelInline />
-            <Textbox label="Textbox 5" labelInline />
-            <Textbox label="Textbox 6" labelInline />
-            <Textbox label="Textbox 7" labelInline />
+            <Textbox
+              label="Textbox 1"
+              labelInline
+              autoFocus
+              value=""
+              onChange={() => {}}
+            />
+            <Textbox
+              label="Textbox 2"
+              labelInline
+              value=""
+              onChange={() => {}}
+            />
+            <Textbox
+              label="Textbox 3"
+              labelInline
+              value=""
+              onChange={() => {}}
+            />
+            <Textbox
+              label="Textbox 4"
+              labelInline
+              value=""
+              onChange={() => {}}
+            />
+            <Textbox
+              label="Textbox 5"
+              labelInline
+              value=""
+              onChange={() => {}}
+            />
+            <Textbox
+              label="Textbox 6"
+              labelInline
+              value=""
+              onChange={() => {}}
+            />
+            <Textbox
+              label="Textbox 7"
+              labelInline
+              value=""
+              onChange={() => {}}
+            />
           </>
         )}
       </Dialog>
@@ -307,7 +363,7 @@ export const FocusingADifferentFirstElement: Story = () => {
             This should be focused first now
           </Button>
         </Box>
-        <Textbox label="Not focused" />
+        <Textbox label="Not focused" value="" onChange={() => {}} />
       </Dialog>
       <Button ml={2} onClick={() => setIsOpenTwo(true)}>
         Open Demo using autoFocus
@@ -328,7 +384,12 @@ export const FocusingADifferentFirstElement: Story = () => {
           <Button onClick={() => setIsOpenTwo(false)}>Not focused</Button>
           <Button onClick={() => setIsOpenTwo(false)}>Not focused</Button>
         </Box>
-        <Textbox autoFocus label="This should be focused first now" />
+        <Textbox
+          autoFocus
+          label="This should be focused first now"
+          value=""
+          onChange={() => {}}
+        />
       </Dialog>
     </>
   );
@@ -378,9 +439,9 @@ export const OtherFocusableContainers: Story = () => {
           <Typography>
             This is an example of a dialog with a Form as content
           </Typography>
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
+          <Textbox label="First Name" value="" onChange={() => {}} />
+          <Textbox label="Middle Name" value="" onChange={() => {}} />
+          <Textbox label="Surname" value="" onChange={() => {}} />
           <Button onClick={() => setIsToast1Open(true)}>
             Show first toast
           </Button>
@@ -453,12 +514,12 @@ export const Responsive: Story = () => {
           <Typography>
             This is an example of a dialog with a Form as content
           </Typography>
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
+          <Textbox label="First Name" value="" onChange={() => {}} />
+          <Textbox label="Middle Name" value="" onChange={() => {}} />
+          <Textbox label="Surname" value="" onChange={() => {}} />
+          <Textbox label="Birth Place" value="" onChange={() => {}} />
+          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+          <Textbox label="Address" value="" onChange={() => {}} />
         </Form>
       </Dialog>
     </>
@@ -542,8 +603,8 @@ export const TopModalOverride: Story = () => {
         subtitle="Yet I am not the bottom modal"
         topModalOverride
       >
-        <Textbox label="First Name" />
-        <Textbox label="Middle Name" />
+        <Textbox label="First Name" value="" onChange={() => {}} />
+        <Textbox label="Middle Name" value="" onChange={() => {}} />
       </Dialog>
       <Dialog
         open={isOpenDialog2 && isOpenAll}
@@ -552,8 +613,8 @@ export const TopModalOverride: Story = () => {
         subtitle="Yet I am the top modal"
         topModalOverride
       >
-        <Textbox label="First Name" />
-        <Textbox label="Middle Name" />
+        <Textbox label="First Name" value="" onChange={() => {}} />
+        <Textbox label="Middle Name" value="" onChange={() => {}} />
       </Dialog>
       <Dialog
         open={isOpenDialog3 && isOpenAll}
@@ -561,8 +622,8 @@ export const TopModalOverride: Story = () => {
         title="I rendered last"
         subtitle="Yet I am the bottom modal"
       >
-        <Textbox label="First Name" />
-        <Textbox label="Middle Name" />
+        <Textbox label="First Name" value="" onChange={() => {}} />
+        <Textbox label="Middle Name" value="" onChange={() => {}} />
       </Dialog>
     </>
   );
@@ -620,30 +681,30 @@ export const FullScreenDefault: Story = () => {
           <Box>
             This is an example of a full screen Dialog with a Form as content
           </Box>
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
-          <Textbox label="Birth Place" />
-          <Textbox label="Favourite Colour" />
-          <Textbox label="Address" />
+          <Textbox label="First Name" value="" onChange={() => {}} />
+          <Textbox label="Middle Name" value="" onChange={() => {}} />
+          <Textbox label="Surname" value="" onChange={() => {}} />
+          <Textbox label="Birth Place" value="" onChange={() => {}} />
+          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+          <Textbox label="Address" value="" onChange={() => {}} />
+          <Textbox label="First Name" value="" onChange={() => {}} />
+          <Textbox label="Middle Name" value="" onChange={() => {}} />
+          <Textbox label="Surname" value="" onChange={() => {}} />
+          <Textbox label="Birth Place" value="" onChange={() => {}} />
+          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+          <Textbox label="Address" value="" onChange={() => {}} />
+          <Textbox label="First Name" value="" onChange={() => {}} />
+          <Textbox label="Middle Name" value="" onChange={() => {}} />
+          <Textbox label="Surname" value="" onChange={() => {}} />
+          <Textbox label="Birth Place" value="" onChange={() => {}} />
+          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+          <Textbox label="Address" value="" onChange={() => {}} />
+          <Textbox label="First Name" value="" onChange={() => {}} />
+          <Textbox label="Middle Name" value="" onChange={() => {}} />
+          <Textbox label="Surname" value="" onChange={() => {}} />
+          <Textbox label="Birth Place" value="" onChange={() => {}} />
+          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+          <Textbox label="Address" value="" onChange={() => {}} />
         </Form>
       </Dialog>
     </>

--- a/src/components/draggable/components.test-pw.tsx
+++ b/src/components/draggable/components.test-pw.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { DraggableContainer, DraggableContainerProps, DraggableItem } from ".";
 import { Checkbox } from "../checkbox";
 
@@ -12,16 +12,24 @@ export const SimpleDraggable = ({ getOrder }: DraggableContainerProps) => (
 
 export const WithDraggableCheckbox = ({
   getOrder,
-}: DraggableContainerProps) => (
-  <DraggableContainer getOrder={getOrder}>
-    <DraggableItem id="apple">
-      <Checkbox label="Apple" />
-    </DraggableItem>
-    <DraggableItem id="saturn">Saturn</DraggableItem>
-    <DraggableItem id="uranus">Uranus</DraggableItem>
-    <DraggableItem id="neptune">Neptune</DraggableItem>
-  </DraggableContainer>
-);
+}: DraggableContainerProps) => {
+  const [value, setValue] = useState(false);
+
+  return (
+    <DraggableContainer getOrder={getOrder}>
+      <DraggableItem id="apple">
+        <Checkbox
+          label="Apple"
+          checked={value}
+          onChange={() => setValue(!value)}
+        />
+      </DraggableItem>
+      <DraggableItem id="saturn">Saturn</DraggableItem>
+      <DraggableItem id="uranus">Uranus</DraggableItem>
+      <DraggableItem id="neptune">Neptune</DraggableItem>
+    </DraggableContainer>
+  );
+};
 
 export const WithMultipleContainers = ({
   getOrder,

--- a/src/components/draggable/draggable-test.stories.tsx
+++ b/src/components/draggable/draggable-test.stories.tsx
@@ -26,19 +26,35 @@ export const Default = () => {
   return (
     <DraggableContainer getOrder={handleUpdate}>
       <DraggableItem key="1" id={1}>
-        <Checkbox label="Draggable Label One" />
+        <Checkbox
+          label="Draggable Label One"
+          checked={false}
+          onChange={() => {}}
+        />
       </DraggableItem>
       <DraggableItem key="2" id={2}>
-        <Checkbox label="Draggable Label Two" />
+        <Checkbox
+          label="Draggable Label Two"
+          checked={false}
+          onChange={() => {}}
+        />
       </DraggableItem>
       <DraggableItem key="3" id={3}>
-        <Checkbox label="Draggable Label Three" />
+        <Checkbox
+          label="Draggable Label Three"
+          checked={false}
+          onChange={() => {}}
+        />
       </DraggableItem>
       <DraggableItem key="4" id={4}>
-        <Checkbox label="Draggable Label Four" />
+        <Checkbox
+          label="Draggable Label Four"
+          checked={false}
+          onChange={() => {}}
+        />
       </DraggableItem>
       <DraggableItem key="5" id={5}>
-        <Textbox label="Draggable Textbox" />
+        <Textbox label="Draggable Textbox" value="" onChange={() => {}} />
       </DraggableItem>
     </DraggableContainer>
   );
@@ -55,19 +71,35 @@ export const DraggableFlexDirection = () => {
   return (
     <DraggableContainer getOrder={handleUpdate} flexDirection="row-reverse">
       <DraggableItem key="1" id={1}>
-        <Checkbox label="Draggable Label One" />
+        <Checkbox
+          label="Draggable Label One"
+          checked={false}
+          onChange={() => {}}
+        />
       </DraggableItem>
       <DraggableItem key="2" id={2}>
-        <Checkbox label="Draggable Label Two" />
+        <Checkbox
+          label="Draggable Label Two"
+          checked={false}
+          onChange={() => {}}
+        />
       </DraggableItem>
       <DraggableItem key="3" id={3}>
-        <Checkbox label="Draggable Label Three" />
+        <Checkbox
+          label="Draggable Label Three"
+          checked={false}
+          onChange={() => {}}
+        />
       </DraggableItem>
       <DraggableItem key="4" id={4}>
-        <Checkbox label="Draggable Label Four" />
+        <Checkbox
+          label="Draggable Label Four"
+          checked={false}
+          onChange={() => {}}
+        />
       </DraggableItem>
       <DraggableItem key="5" id={5}>
-        <Textbox label="Draggable Textbox" />
+        <Textbox label="Draggable Textbox" value="" onChange={() => {}} />
       </DraggableItem>
     </DraggableContainer>
   );
@@ -90,16 +122,32 @@ export const DraggableCustom = ({
   return (
     <DraggableContainer {...props} getOrder={handleUpdate}>
       <DraggableItem key="1" id={1}>
-        <Checkbox label="Draggable Label One" />
+        <Checkbox
+          label="Draggable Label One"
+          checked={false}
+          onChange={() => {}}
+        />
       </DraggableItem>
       <DraggableItem key="2" id={2}>
-        <Checkbox label="Draggable Label Two" />
+        <Checkbox
+          label="Draggable Label Two"
+          checked={false}
+          onChange={() => {}}
+        />
       </DraggableItem>
       <DraggableItem key="3" id={3}>
-        <Checkbox label="Draggable Label Three" />
+        <Checkbox
+          label="Draggable Label Three"
+          checked={false}
+          onChange={() => {}}
+        />
       </DraggableItem>
       <DraggableItem key="4" id={4}>
-        <Checkbox label="Draggable Label Four" />
+        <Checkbox
+          label="Draggable Label Four"
+          checked={false}
+          onChange={() => {}}
+        />
       </DraggableItem>
     </DraggableContainer>
   );
@@ -119,18 +167,34 @@ export const DraggableDifferentContainers = ({
     <Box>
       <DraggableContainer mb={9} getOrder={handleUpdate} {...props}>
         <DraggableItem key="4" id={4}>
-          <Checkbox label="Draggable Label Four" />
+          <Checkbox
+            label="Draggable Label Four"
+            checked={false}
+            onChange={() => {}}
+          />
         </DraggableItem>
         <DraggableItem key="5" id={5}>
-          <Checkbox label="Draggable Label Five" />
+          <Checkbox
+            label="Draggable Label Five"
+            checked={false}
+            onChange={() => {}}
+          />
         </DraggableItem>
         <DraggableItem key="6" id={6}>
-          <Checkbox label="Draggable Label Six" />
+          <Checkbox
+            label="Draggable Label Six"
+            checked={false}
+            onChange={() => {}}
+          />
         </DraggableItem>
       </DraggableContainer>
       <DraggableContainer mt={9}>
         <DraggableItem key="7" id={7}>
-          <Checkbox label="Draggable Label Seven" />
+          <Checkbox
+            label="Draggable Label Seven"
+            checked={false}
+            onChange={() => {}}
+          />
         </DraggableItem>
       </DraggableContainer>
     </Box>

--- a/src/components/draggable/draggable.stories.tsx
+++ b/src/components/draggable/draggable.stories.tsx
@@ -67,16 +67,36 @@ FlexDirectionStory.storyName = "With Flex Direction";
 export const ComponentsAsChildrenStory: Story = () => (
   <DraggableContainer>
     <DraggableItem key="1" id={1}>
-      <Checkbox label="checkbox one" mb={0} />
+      <Checkbox
+        label="checkbox one"
+        mb={0}
+        checked={false}
+        onChange={() => {}}
+      />
     </DraggableItem>
     <DraggableItem key="2" id={2}>
-      <Checkbox label="checkbox two" mb={0} />
+      <Checkbox
+        label="checkbox two"
+        mb={0}
+        checked={false}
+        onChange={() => {}}
+      />
     </DraggableItem>
     <DraggableItem key="3" id={3}>
-      <Checkbox label="checkbox three" mb={0} />
+      <Checkbox
+        label="checkbox three"
+        mb={0}
+        checked={false}
+        onChange={() => {}}
+      />
     </DraggableItem>
     <DraggableItem key="4" id={4}>
-      <Checkbox label="checkbox four" mb={0} />
+      <Checkbox
+        label="checkbox four"
+        mb={0}
+        checked={false}
+        onChange={() => {}}
+      />
     </DraggableItem>
   </DraggableContainer>
 );
@@ -85,16 +105,32 @@ ComponentsAsChildrenStory.storyName = "Components As Children";
 export const GetOrderCallbackStory: Story = () => (
   <DraggableContainer getOrder={() => {}}>
     <DraggableItem key="1" id={1}>
-      <Checkbox label="Draggable Label One" />
+      <Checkbox
+        label="Draggable Label One"
+        checked={false}
+        onChange={() => {}}
+      />
     </DraggableItem>
     <DraggableItem key="2" id={2}>
-      <Checkbox label="Draggable Label Two" />
+      <Checkbox
+        label="Draggable Label Two"
+        checked={false}
+        onChange={() => {}}
+      />
     </DraggableItem>
     <DraggableItem key="3" id={3}>
-      <Checkbox label="Draggable Label Three" />
+      <Checkbox
+        label="Draggable Label Three"
+        checked={false}
+        onChange={() => {}}
+      />
     </DraggableItem>
     <DraggableItem key="4" id={4}>
-      <Checkbox label="Draggable Label Four" />
+      <Checkbox
+        label="Draggable Label Four"
+        checked={false}
+        onChange={() => {}}
+      />
     </DraggableItem>
   </DraggableContainer>
 );

--- a/src/components/drawer/components.test-pw.tsx
+++ b/src/components/drawer/components.test-pw.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import Drawer, { DrawerProps } from ".";
 import Typography from "../typography";
@@ -36,6 +36,7 @@ export const DrawerCustomFooterHeader = (props: Partial<DrawerProps>) => {
   const onChangeHandler = React.useCallback(() => {
     setIsExpanded(!isExpanded);
   }, [isExpanded]);
+  const [checked, setChecked] = useState(false);
 
   return (
     <Drawer
@@ -48,90 +49,120 @@ export const DrawerCustomFooterHeader = (props: Partial<DrawerProps>) => {
             name="checkbox-default"
             ml="40px"
             mt="40px"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="40px"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="40px"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="40px"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="40px"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="40px"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="40px"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="40px"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="40px"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="40px"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="40px"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="40px"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="40px"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="40px"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="40px"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
           />
         </Box>
       }

--- a/src/components/drawer/drawer-test.stories.tsx
+++ b/src/components/drawer/drawer-test.stories.tsx
@@ -332,48 +332,64 @@ export const DefaultStory = () => {
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
@@ -381,6 +397,8 @@ export const DefaultStory = () => {
                 ml="40px"
                 mt="30px"
                 mb={4}
+                checked={false}
+                onChange={() => {}}
               />
             </>
           }
@@ -412,48 +430,64 @@ export const DefaultStory = () => {
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
                 name="checkbox-default"
                 ml="40px"
                 mt="30px"
+                checked={false}
+                onChange={() => {}}
               />
               <Checkbox
                 label="Example checkbox"
@@ -461,6 +495,8 @@ export const DefaultStory = () => {
                 ml="40px"
                 mt="30px"
                 mb={4}
+                checked={false}
+                onChange={() => {}}
               />
             </>
           }

--- a/src/components/drawer/drawer.stories.tsx
+++ b/src/components/drawer/drawer.stories.tsx
@@ -247,48 +247,64 @@ export const WithStickyHeader: Story = (args: DrawerProps) => (
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
@@ -296,6 +312,8 @@ export const WithStickyHeader: Story = (args: DrawerProps) => (
             ml="40px"
             mt="30px"
             mb={4}
+            checked={false}
+            onChange={() => {}}
           />
         </>
       }
@@ -334,48 +352,64 @@ export const WithFooter: Story = (args: DrawerProps) => (
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
@@ -383,6 +417,8 @@ export const WithFooter: Story = (args: DrawerProps) => (
             ml="40px"
             mt="30px"
             mb={4}
+            checked={false}
+            onChange={() => {}}
           />
         </>
       }
@@ -421,48 +457,64 @@ export const WithStickyFooter: Story = (args: DrawerProps) => (
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
             name="checkbox-default"
             ml="40px"
             mt="30px"
+            checked={false}
+            onChange={() => {}}
           />
           <Checkbox
             label="Example checkbox"
@@ -470,6 +522,8 @@ export const WithStickyFooter: Story = (args: DrawerProps) => (
             ml="40px"
             mt="30px"
             mb={4}
+            checked={false}
+            onChange={() => {}}
           />
         </>
       }
@@ -1110,6 +1164,7 @@ export const WithTabControls: Story = () => {
               label="Add error"
               error={errors.four}
               onChange={() => setErrors({ ...errors, four: !errors.four })}
+              checked
             />
             <Checkbox
               label="Add warning"
@@ -1117,11 +1172,13 @@ export const WithTabControls: Story = () => {
               onChange={() =>
                 setWarnings({ ...warnings, four: !warnings.four })
               }
+              checked
             />
             <Checkbox
               label="Add info"
               info={infos.four}
               onChange={() => setInfos({ ...infos, four: !infos.four })}
+              checked
             />
           </Box>
           <Box display={active === "tab-5" ? "block" : "none"}>

--- a/src/components/fieldset/components.test-pw.tsx
+++ b/src/components/fieldset/components.test-pw.tsx
@@ -1,10 +1,13 @@
-import React from "react";
+import React, { useState } from "react";
 import Fieldset from "./fieldset.component";
 import { FieldsetProps } from "../../../src/components/fieldset";
 import Textbox from "../textbox";
 import Checkbox from "../checkbox/checkbox.component";
 
 const FieldsetComponent = (props: FieldsetProps) => {
+  const [textboxValue, setTextboxValue] = useState("");
+  const [checkboxValue, setCheckboxValue] = useState(false);
+
   return (
     <div>
       <Fieldset legend="Fieldset" {...props}>
@@ -13,32 +16,56 @@ const FieldsetComponent = (props: FieldsetProps) => {
           labelInline
           labelAlign="right"
           labelWidth={30}
+          value={textboxValue}
+          onChange={(e) => setTextboxValue(e.target.value)}
         />
         <Textbox
           label="Last Name"
           labelInline
           labelAlign="right"
           labelWidth={30}
+          value={textboxValue}
+          onChange={(e) => setTextboxValue(e.target.value)}
         />
         <Textbox
           label="Address"
           labelInline
           labelAlign="right"
           labelWidth={30}
+          value={textboxValue}
+          onChange={(e) => setTextboxValue(e.target.value)}
         />
-        <Checkbox label="Checkbox" labelWidth={30} labelSpacing={2} reverse />
-        <Textbox label="City" labelInline labelAlign="right" labelWidth={30} />
+        <Checkbox
+          label="Checkbox"
+          labelWidth={30}
+          labelSpacing={2}
+          reverse
+          checked={checkboxValue}
+          onChange={(e) => setCheckboxValue(e.target.checked)}
+        />
+        <Textbox
+          label="City"
+          labelInline
+          labelAlign="right"
+          labelWidth={30}
+          value={textboxValue}
+          onChange={(e) => setTextboxValue(e.target.value)}
+        />
         <Textbox
           label="Country"
           labelInline
           labelAlign="right"
           labelWidth={30}
+          value={textboxValue}
+          onChange={(e) => setTextboxValue(e.target.value)}
         />
         <Textbox
           label="Telephone"
           labelInline
           labelAlign="right"
           labelWidth={30}
+          value={textboxValue}
+          onChange={(e) => setTextboxValue(e.target.value)}
         />
       </Fieldset>
     </div>

--- a/src/components/fieldset/fieldset-test.stories.tsx
+++ b/src/components/fieldset/fieldset-test.stories.tsx
@@ -30,23 +30,57 @@ export const Default: Story = ({ ...args }) => {
         labelInline
         labelAlign="right"
         labelWidth={30}
+        value={""}
+        onChange={() => {}}
       />
       <Textbox
         label="Last Name"
         labelInline
         labelAlign="right"
         labelWidth={30}
+        value={""}
+        onChange={() => {}}
       />
-      <Textbox label="Address" labelInline labelAlign="right" labelWidth={30} />
-      <Textbox label="City" labelInline labelAlign="right" labelWidth={30} />
-      <Checkbox label="Checkbox" labelWidth={30} labelSpacing={2} reverse />
-      <Select label="Country" labelInline labelAlign="right" labelWidth={30}>
+      <Textbox
+        label="Address"
+        labelInline
+        labelAlign="right"
+        labelWidth={30}
+        value={""}
+        onChange={() => {}}
+      />
+      <Textbox
+        label="City"
+        labelInline
+        labelAlign="right"
+        labelWidth={30}
+        value={""}
+        onChange={() => {}}
+      />
+      <Checkbox
+        label="Checkbox"
+        labelWidth={30}
+        labelSpacing={2}
+        reverse
+        checked={false}
+        onChange={() => {}}
+      />
+      <Select
+        label="Country"
+        labelInline
+        labelAlign="right"
+        labelWidth={30}
+        value={""}
+        onChange={() => {}}
+      >
         <Option text="United Kingdom" value="uk" />
         <Option text="Spain" value="sp" />
         <Option text="France" value="fr" />
         <Option text="Germany" value="ge" />
       </Select>
       <Textbox
+        value={""}
+        onChange={() => {}}
         label="Telephone"
         labelInline
         labelAlign="right"
@@ -62,16 +96,46 @@ Default.args = {
 
 export const InFormFieldSpacing: Story = () => (
   <Form fieldSpacing={1}>
-    <Textbox label="Separate Field" labelInline />
+    <Textbox
+      label="Separate Field"
+      labelInline
+      value={""}
+      onChange={() => {}}
+    />
     <Fieldset>
-      <Textbox label="Fieldset 1 Field 1" labelInline />
-      <Textbox label="Fieldset 1 Field 2" labelInline />
+      <Textbox
+        label="Fieldset 1 Field 1"
+        labelInline
+        value={""}
+        onChange={() => {}}
+      />
+      <Textbox
+        label="Fieldset 1 Field 2"
+        labelInline
+        value={""}
+        onChange={() => {}}
+      />
     </Fieldset>
     <Fieldset>
-      <Textbox label="Fieldset 2 Field 1" labelInline />
-      <Textbox label="Fieldset 2 Field 2" labelInline />
+      <Textbox
+        label="Fieldset 2 Field 1"
+        labelInline
+        value={""}
+        onChange={() => {}}
+      />
+      <Textbox
+        label="Fieldset 2 Field 2"
+        labelInline
+        value={""}
+        onChange={() => {}}
+      />
     </Fieldset>
-    <Textbox label="Separate Field" labelInline />
+    <Textbox
+      label="Separate Field"
+      labelInline
+      value={""}
+      onChange={() => {}}
+    />
   </Form>
 );
 InFormFieldSpacing.storyName = "In Form with fieldSpacing (legacy)";
@@ -79,9 +143,27 @@ InFormFieldSpacing.storyName = "In Form with fieldSpacing (legacy)";
 export const Validation: Story = () => (
   <Form>
     <Fieldset>
-      <Textbox label="Error String" labelInline error="Error Message" />
-      <Textbox label="Warning String" labelInline warning="Warning Message" />
-      <Textbox label="Info String" labelInline info="Info Message" />
+      <Textbox
+        label="Error String"
+        labelInline
+        error="Error Message"
+        value={""}
+        onChange={() => {}}
+      />
+      <Textbox
+        label="Warning String"
+        labelInline
+        warning="Warning Message"
+        value={""}
+        onChange={() => {}}
+      />
+      <Textbox
+        label="Info String"
+        labelInline
+        info="Info Message"
+        value={""}
+        onChange={() => {}}
+      />
     </Fieldset>
     <Fieldset>
       <Textbox
@@ -89,24 +171,48 @@ export const Validation: Story = () => (
         labelInline
         error="Error Message"
         validationOnLabel
+        value={""}
+        onChange={() => {}}
       />
       <Textbox
         label="Warning on Label"
         labelInline
         warning="Warning Message"
         validationOnLabel
+        value={""}
+        onChange={() => {}}
       />
       <Textbox
         label="Info on Label"
         labelInline
         info="Info Message"
         validationOnLabel
+        value={""}
+        onChange={() => {}}
       />
     </Fieldset>
     <Fieldset>
-      <Textbox label="Error Boolean" labelInline error />
-      <Textbox label="Warning Boolean" labelInline warning />
-      <Textbox label="Info Boolean" labelInline info />
+      <Textbox
+        label="Error Boolean"
+        labelInline
+        error
+        value={""}
+        onChange={() => {}}
+      />
+      <Textbox
+        label="Warning Boolean"
+        labelInline
+        warning
+        value={""}
+        onChange={() => {}}
+      />
+      <Textbox
+        label="Info Boolean"
+        labelInline
+        info
+        value={""}
+        onChange={() => {}}
+      />
     </Fieldset>
   </Form>
 );
@@ -119,21 +225,47 @@ Validation.parameters = {
 export const NewValidation: Story = ({ ...args }) => (
   <CarbonProvider validationRedesignOptIn>
     <Form>
-      <Textbox label="Separate Field" />
+      <Textbox label="Separate Field" value={""} onChange={() => {}} />
       <Fieldset legend="Fieldset" {...args}>
-        <Textbox label="Address Line 1" error="Message" />
-        <Textbox label="Address Line 2" error="Message" />
-        <Checkbox label="Checkbox" />
-        <Textbox label="City" warning="Message" />
-        <Select label="Country" warning="Message">
+        <Textbox
+          label="Address Line 1"
+          error="Message"
+          value={""}
+          onChange={() => {}}
+        />
+        <Textbox
+          label="Address Line 2"
+          error="Message"
+          value={""}
+          onChange={() => {}}
+        />
+        <Checkbox label="Checkbox" checked={false} onChange={() => {}} />
+        <Textbox
+          label="City"
+          warning="Message"
+          value={""}
+          onChange={() => {}}
+        />
+        <Select
+          label="Country"
+          warning="Message"
+          value={""}
+          onChange={() => {}}
+        >
           <Option text="United Kingdom" value="uk" />
           <Option text="Spain" value="sp" />
           <Option text="France" value="fr" />
           <Option text="Germany" value="ge" />
         </Select>
-        <Textbox label="Postcode" maxWidth="100px" warning="Message" />
+        <Textbox
+          label="Postcode"
+          maxWidth="100px"
+          warning="Message"
+          value={""}
+          onChange={() => {}}
+        />
       </Fieldset>
-      <Textbox label="Separate Field" />
+      <Textbox label="Separate Field" value={""} onChange={() => {}} />
     </Form>
   </CarbonProvider>
 );

--- a/src/components/fieldset/fieldset.pw.tsx
+++ b/src/components/fieldset/fieldset.pw.tsx
@@ -42,6 +42,8 @@ test.describe("should render Fieldset component", () => {
             labelInline
             labelAlign="right"
             {...{ [type]: "Message" }}
+            value=""
+            onChange={() => {}}
           />
         </Fieldset>,
       );
@@ -67,6 +69,8 @@ test.describe("should render Fieldset component", () => {
             labelAlign="right"
             validationOnLabel
             {...{ [type]: "Message" }}
+            value=""
+            onChange={() => {}}
           />
         </Fieldset>,
       );
@@ -100,6 +104,8 @@ test.describe("should render Fieldset component", () => {
             labelInline
             labelAlign="right"
             {...{ [type]: bool }}
+            value=""
+            onChange={() => {}}
           />
         </Fieldset>,
       );
@@ -123,10 +129,25 @@ test.describe("should render Fieldset component", () => {
       await mount(
         <Form fieldSpacing={spacing} data-element="form">
           <Fieldset>
-            <Textbox label="Fieldset 1 Field 1" labelInline />
-            <Textbox label="Fieldset 1 Field 2" labelInline />
+            <Textbox
+              label="Fieldset 1 Field 1"
+              labelInline
+              value=""
+              onChange={() => {}}
+            />
+            <Textbox
+              label="Fieldset 1 Field 2"
+              labelInline
+              value=""
+              onChange={() => {}}
+            />
           </Fieldset>
-          <Textbox label="Separate Field" labelInline />
+          <Textbox
+            label="Separate Field"
+            labelInline
+            value=""
+            onChange={() => {}}
+          />
         </Form>,
       );
 
@@ -177,6 +198,8 @@ test.describe("Accessibility tests for Fieldset component", () => {
             labelInline
             labelAlign="right"
             {...{ [type]: bool }}
+            value=""
+            onChange={() => {}}
           />
         </Fieldset>,
       );
@@ -193,10 +216,25 @@ test.describe("Accessibility tests for Fieldset component", () => {
       await mount(
         <Form fieldSpacing={spacing} data-element="form">
           <Fieldset>
-            <Textbox label="Fieldset 1 Field 1" labelInline />
-            <Textbox label="Fieldset 1 Field 2" labelInline />
+            <Textbox
+              label="Fieldset 1 Field 1"
+              labelInline
+              value=""
+              onChange={() => {}}
+            />
+            <Textbox
+              label="Fieldset 1 Field 2"
+              labelInline
+              value=""
+              onChange={() => {}}
+            />
           </Fieldset>
-          <Textbox label="Separate Field" labelInline />
+          <Textbox
+            label="Separate Field"
+            labelInline
+            value=""
+            onChange={() => {}}
+          />
         </Form>,
       );
       await checkAccessibility(page);
@@ -215,6 +253,8 @@ test.describe("Accessibility tests for Fieldset component", () => {
             labelInline
             labelAlign="right"
             {...{ [type]: "Message" }}
+            value=""
+            onChange={() => {}}
           />
         </Fieldset>,
       );
@@ -236,6 +276,8 @@ test.describe("Accessibility tests for Fieldset component", () => {
             labelAlign="right"
             validationOnLabel
             {...{ [type]: "Message" }}
+            value=""
+            onChange={() => {}}
           />
         </Fieldset>,
       );

--- a/src/components/fieldset/fieldset.stories.tsx
+++ b/src/components/fieldset/fieldset.stories.tsx
@@ -19,6 +19,9 @@ const meta: Meta<typeof Fieldset> = {
   argTypes: {
     ...styledSystemProps,
   },
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
+  },
 };
 
 export default meta;
@@ -28,16 +31,21 @@ export const Default: Story = () => (
   <CarbonProvider validationRedesignOptIn>
     <Form>
       <Fieldset legend="Fieldset">
-        <Textbox label="Address Line 1" />
-        <Textbox label="Address Line 2" />
-        <Textbox label="City" />
-        <Select label="Country">
+        <Textbox label="Address Line 1" value={""} onChange={() => {}} />
+        <Textbox label="Address Line 2" value={""} onChange={() => {}} />
+        <Textbox label="City" value={""} onChange={() => {}} />
+        <Select label="Country" value={""} onChange={() => {}}>
           <Option text="United Kingdom" value="uk" />
           <Option text="Spain" value="sp" />
           <Option text="France" value="fr" />
           <Option text="Germany" value="ge" />
         </Select>
-        <Textbox label="Postcode" maxWidth="100px" />
+        <Textbox
+          label="Postcode"
+          maxWidth="100px"
+          value={""}
+          onChange={() => {}}
+        />
       </Fieldset>
     </Form>
   </CarbonProvider>
@@ -48,16 +56,21 @@ export const InFormFieldSpacing: Story = () => (
   <CarbonProvider validationRedesignOptIn>
     <Form fieldSpacing={1}>
       <Fieldset legend="Fieldset">
-        <Textbox label="Address Line 1" />
-        <Textbox label="Address Line 2" />
-        <Textbox label="City" />
-        <Select label="Country">
+        <Textbox label="Address Line 1" value={""} onChange={() => {}} />
+        <Textbox label="Address Line 2" value={""} onChange={() => {}} />
+        <Textbox label="City" value={""} onChange={() => {}} />
+        <Select label="Country" value={""} onChange={() => {}}>
           <Option text="United Kingdom" value="uk" />
           <Option text="Spain" value="sp" />
           <Option text="France" value="fr" />
           <Option text="Germany" value="ge" />
         </Select>
-        <Textbox label="Postcode" maxWidth="100px" />
+        <Textbox
+          label="Postcode"
+          maxWidth="100px"
+          value={""}
+          onChange={() => {}}
+        />
       </Fieldset>
     </Form>
   </CarbonProvider>
@@ -68,16 +81,21 @@ export const Required: Story = () => (
   <CarbonProvider validationRedesignOptIn>
     <Form>
       <Fieldset legend="Fieldset" required>
-        <Textbox label="Address Line 1" />
-        <Textbox label="Address Line 2" />
-        <Textbox label="City" />
-        <Select label="Country">
+        <Textbox label="Address Line 1" value={""} onChange={() => {}} />
+        <Textbox label="Address Line 2" value={""} onChange={() => {}} />
+        <Textbox label="City" value={""} onChange={() => {}} />
+        <Select label="Country" value={""} onChange={() => {}}>
           <Option text="United Kingdom" value="uk" />
           <Option text="Spain" value="sp" />
           <Option text="France" value="fr" />
           <Option text="Germany" value="ge" />
         </Select>
-        <Textbox label="Postcode" maxWidth="100px" />
+        <Textbox
+          label="Postcode"
+          maxWidth="100px"
+          value={""}
+          onChange={() => {}}
+        />
       </Fieldset>
     </Form>
   </CarbonProvider>

--- a/src/components/fieldset/fieldset.test.tsx
+++ b/src/components/fieldset/fieldset.test.tsx
@@ -39,7 +39,7 @@ test("Fieldset does not add the required attribute to any child inputs when isRe
 test("Fieldset Legend adds an asterisk after the text when the field is mandatory", () => {
   render(
     <Fieldset legend="This is my custom legend" required>
-      <Textbox onChange={() => {}} />
+      <Textbox onChange={() => {}} value="" />
     </Fieldset>,
   );
 
@@ -52,8 +52,8 @@ test("renders with default margin between inputs when the validationRedesignOptI
   render(
     <CarbonProvider validationRedesignOptIn>
       <Fieldset>
-        <Textbox data-role="textbox" onChange={() => {}} />
-        <Textbox data-role="textbox 2" onChange={() => {}} />
+        <Textbox data-role="textbox" value={""} onChange={() => {}} />
+        <Textbox data-role="textbox 2" value={""} onChange={() => {}} />
       </Fieldset>
     </CarbonProvider>,
   );

--- a/src/components/file-input/file-input.style.tsx
+++ b/src/components/file-input/file-input.style.tsx
@@ -3,7 +3,14 @@ import type { InputProps } from "../../__internal__/input";
 import type { ValidationProps } from "../../__internal__/validations";
 import StyledTypography from "../typography/typography.style";
 
-export const StyledHiddenFileInput = styled.input<InputProps>`
+// Because inputs with type="file" cannot have a value, we need to omit it from the InputProps type.
+// This is a workaround to avoid TypeScript errors when using the InputProps type.
+// The value prop is not used in the FileInput component, so we can safely omit it
+type CustomFileInputProps = Omit<InputProps, "value"> & {
+  value?: string;
+};
+
+export const StyledHiddenFileInput = styled.input<CustomFileInputProps>`
   display: none;
 `;
 

--- a/src/components/flat-table/components.test-pw.tsx
+++ b/src/components/flat-table/components.test-pw.tsx
@@ -709,6 +709,7 @@ export const FlatTableCustomPaddingComponent = (
 export const FlatTableTruncateBgComponent = (
   props: Partial<FlatTableProps>,
 ) => {
+  const [value, setValue] = useState("");
   return (
     <div
       style={{
@@ -733,7 +734,12 @@ export const FlatTableTruncateBgComponent = (
                 London
               </FlatTableCell>
               <FlatTableCell>
-                <Textbox size="small" aria-label="textbox" />
+                <Textbox
+                  size="small"
+                  aria-label="textbox"
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                />
               </FlatTableCell>
             </FlatTableRow>
           ))}
@@ -746,6 +752,7 @@ export const FlatTableTruncateBgComponent = (
 export const FlatTableTruncateHeaderComponent = (
   props: Partial<FlatTableProps>,
 ) => {
+  const [value, setValue] = useState("");
   return (
     <div
       style={{
@@ -772,7 +779,12 @@ export const FlatTableTruncateHeaderComponent = (
                 London
               </FlatTableRowHeader>
               <FlatTableCell>
-                <Textbox size="small" aria-label="textbox" />
+                <Textbox
+                  size="small"
+                  aria-label="textbox"
+                  value={value}
+                  onChange={(e) => setValue(e.target.value)}
+                />
               </FlatTableCell>
             </FlatTableRow>
           ))}
@@ -1301,6 +1313,8 @@ export const FlatTableCustomBordersComponent = (
 export const FlatTableTitleAlignComponent = (
   props: Partial<FlatTableProps>,
 ) => {
+  const [value, setValue] = useState("");
+
   return (
     <div
       style={{
@@ -1336,7 +1350,12 @@ export const FlatTableTitleAlignComponent = (
               London
             </FlatTableRowHeader>
             <FlatTableCell>
-              <Textbox size="small" aria-label="textbox" />
+              <Textbox
+                size="small"
+                aria-label="textbox"
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+              />
             </FlatTableCell>
           </FlatTableRow>
           <FlatTableRow>
@@ -1359,7 +1378,12 @@ export const FlatTableTitleAlignComponent = (
               London
             </FlatTableRowHeader>
             <FlatTableCell>
-              <Textbox size="small" aria-label="textbox" />
+              <Textbox
+                size="small"
+                aria-label="textbox"
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+              />
             </FlatTableCell>
           </FlatTableRow>
           <FlatTableRow>
@@ -1382,7 +1406,12 @@ export const FlatTableTitleAlignComponent = (
               London
             </FlatTableRowHeader>
             <FlatTableCell>
-              <Textbox size="small" aria-label="textbox" />
+              <Textbox
+                size="small"
+                aria-label="textbox"
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+              />
             </FlatTableCell>
           </FlatTableRow>
           <FlatTableRow>
@@ -1403,7 +1432,12 @@ export const FlatTableTitleAlignComponent = (
               London
             </FlatTableRowHeader>
             <FlatTableCell>
-              <Textbox size="small" aria-label="textbox" />
+              <Textbox
+                size="small"
+                aria-label="textbox"
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+              />
             </FlatTableCell>
           </FlatTableRow>
         </FlatTableBody>
@@ -2268,6 +2302,7 @@ export const FlatTableParentSubrowSelectableComponent = () => {
 
 export const FlatTableChildSubrowSelectableComponent = () => {
   const [selectAll, setSelectAll] = useState(false);
+  const [checked, setChecked] = useState(false);
   const [selectedRows, setSelectedRows] =
     useState<SelectedRowsChildrenOnlySelectableStory>({
       one: {
@@ -2429,6 +2464,8 @@ export const FlatTableChildSubrowSelectableComponent = () => {
               ariaLabelledBy="ft-row-1-cell-1 ft-row-1-cell-2 ft-row-1-cell-3"
               onClick={(e) => e.stopPropagation()}
               selectable={false}
+              checked={checked}
+              onChange={(e) => setChecked(e.target.checked)}
             />
             <FlatTableCell id="ft-row-1-cell-1">John Doe</FlatTableCell>
             <FlatTableCell id="ft-row-1-cell-2">London</FlatTableCell>
@@ -2445,6 +2482,8 @@ export const FlatTableChildSubrowSelectableComponent = () => {
               ariaLabelledBy="ft-row-2-cell-1 ft-row-2-cell-2 ft-row-2-cell-3"
               onClick={(e) => e.stopPropagation()}
               selectable={false}
+              checked={checked}
+              onChange={(e) => setChecked(e.target.checked)}
             />
             <FlatTableCell id="ft-row-2-cell-1">Jane Doe</FlatTableCell>
             <FlatTableCell id="ft-row-2-cell-2">York</FlatTableCell>
@@ -2461,6 +2500,8 @@ export const FlatTableChildSubrowSelectableComponent = () => {
               ariaLabelledBy="ft-row-3-cell-1 ft-row-3-cell-2 ft-row-3-cell-3"
               onClick={(e) => e.stopPropagation()}
               selectable={false}
+              checked={checked}
+              onChange={(e) => setChecked(e.target.checked)}
             />
             <FlatTableCell id="ft-row-3-cell-1">John Smith</FlatTableCell>
             <FlatTableCell id="ft-row-3-cell-2">Edinburgh</FlatTableCell>
@@ -2477,6 +2518,8 @@ export const FlatTableChildSubrowSelectableComponent = () => {
               ariaLabelledBy="ft-row-4-cell-1 ft-row-4-cell-2 ft-row-4-cell-3"
               onClick={(e) => e.stopPropagation()}
               selectable={false}
+              checked={checked}
+              onChange={(e) => setChecked(e.target.checked)}
             />
             <FlatTableCell id="ft-row-4-cell-1">Jane Smith</FlatTableCell>
             <FlatTableCell id="ft-row-4-cell-2">Newcastle</FlatTableCell>
@@ -2813,7 +2856,10 @@ export const FlatTableWithStickyColumn = () => (
         <FlatTableCell>Bar</FlatTableCell>
         <FlatTableCell>Bar</FlatTableCell>
         <FlatTableCell>
-          <input />
+          <label>
+            Input
+            <input />
+          </label>
         </FlatTableCell>
       </FlatTableRow>
     </FlatTableBody>

--- a/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.component.tsx
+++ b/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.component.tsx
@@ -12,9 +12,9 @@ export interface FlatTableCheckboxProps extends TagProps {
   /** Prop to polymorphically render either a 'th' or 'td' element */
   as?: "td" | "th";
   /** Prop to set checked prop on Checkbox */
-  checked?: boolean;
+  checked: boolean;
   /** Callback to be called onChange in Checkbox */
-  onChange?: (ev: React.ChangeEvent<HTMLElement>) => void;
+  onChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   /** Whether to render the checkbox or not, defaults to true */
   selectable?: boolean;
   /** Callback function to be called when click event received */

--- a/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.test.tsx
+++ b/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.test.tsx
@@ -2,13 +2,38 @@ import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import FlatTableCheckbox from "./flat-table-checkbox.component";
+import FlatTableCheckbox, {
+  FlatTableCheckboxProps,
+} from "./flat-table-checkbox.component";
 import guid from "../../../__internal__/utils/helpers/guid";
 
 jest.mock("../../../__internal__/utils/helpers/guid");
 (guid as jest.MockedFunction<typeof guid>).mockImplementation(
   () => "guid-12345",
 );
+
+interface ControlledCheckboxProps
+  extends Omit<FlatTableCheckboxProps, "checked"> {
+  initialChecked?: boolean;
+}
+
+const ControlledCheckbox = ({
+  initialChecked = false,
+  ...props
+}: ControlledCheckboxProps) => {
+  const [checked, setChecked] = React.useState(initialChecked);
+  return (
+    <FlatTableCheckbox
+      {...props}
+      checked={checked}
+      onChange={(e) => {
+        setChecked(!checked);
+        props.onChange?.(e);
+      }}
+      data-testid="checkbox"
+    />
+  );
+};
 
 test("should stop propagation when the user clicks on the input element", async () => {
   const parentOnClick = jest.fn();
@@ -18,7 +43,7 @@ test("should stop propagation when the user clicks on the input element", async 
     <table>
       <tbody>
         <tr onClick={parentOnClick}>
-          <FlatTableCheckbox onChange={() => {}} onClick={childOnClick} />
+          <ControlledCheckbox onChange={() => {}} onClick={childOnClick} />
         </tr>
       </tbody>
     </table>,
@@ -37,7 +62,7 @@ test("should stop propagation when the user presses a key that is not up or down
     <table>
       <tbody>
         <tr onKeyDown={parentOnKeyDown}>
-          <FlatTableCheckbox onChange={() => {}} />
+          <ControlledCheckbox onChange={() => {}} />
         </tr>
       </tbody>
     </table>,
@@ -57,7 +82,7 @@ test("should not stop propagation when the user presses down arrow key", async (
     <table>
       <tbody>
         <tr onKeyDown={parentOnKeyDown}>
-          <FlatTableCheckbox onChange={() => {}} />
+          <ControlledCheckbox onChange={() => {}} />
         </tr>
       </tbody>
     </table>,
@@ -77,7 +102,7 @@ test("should not stop propagation when the user presses up arrow key", async () 
     <table>
       <tbody>
         <tr onKeyDown={parentOnKeyDown}>
-          <FlatTableCheckbox onChange={() => {}} />
+          <ControlledCheckbox onChange={() => {}} />
         </tr>
       </tbody>
     </table>,
@@ -95,7 +120,7 @@ test("should render a 'td' element by default and have the expected data-element
     <table>
       <tbody>
         <tr>
-          <FlatTableCheckbox onChange={() => {}} />
+          <ControlledCheckbox onChange={() => {}} />
         </tr>
       </tbody>
     </table>,
@@ -113,7 +138,7 @@ test("should render an element to match the `as` prop value when it is set and h
     <table>
       <thead>
         <tr>
-          <FlatTableCheckbox onChange={() => {}} as="th" />
+          <ControlledCheckbox onChange={() => {}} as="th" />
         </tr>
       </thead>
     </table>,
@@ -131,7 +156,7 @@ test("should not render the checkbox when the selectable prop is false", () => {
     <table>
       <tbody>
         <tr>
-          <FlatTableCheckbox onChange={() => {}} selectable={false} />
+          <ControlledCheckbox onChange={() => {}} selectable={false} />
         </tr>
       </tbody>
     </table>,
@@ -145,7 +170,7 @@ test("should render the component with the expeced `data-attributes`", () => {
     <table>
       <tbody>
         <tr>
-          <FlatTableCheckbox
+          <ControlledCheckbox
             onChange={() => {}}
             data-role="ft-checkbox"
             data-element="overridden-data-element"

--- a/src/components/flat-table/flat-table-expandable.stories.tsx
+++ b/src/components/flat-table/flat-table-expandable.stories.tsx
@@ -1176,6 +1176,8 @@ export const ChildrenOnlySelectable: Story = () => {
               ariaLabelledBy="ft-row-1-cell-1 ft-row-1-cell-2 ft-row-1-cell-3"
               onClick={(e) => e.stopPropagation()}
               selectable={false}
+              checked={false}
+              onChange={() => {}}
             />
             <FlatTableCell id="ft-row-1-cell-1">John Doe</FlatTableCell>
             <FlatTableCell id="ft-row-1-cell-2">London</FlatTableCell>
@@ -1192,6 +1194,8 @@ export const ChildrenOnlySelectable: Story = () => {
               ariaLabelledBy="ft-row-2-cell-1 ft-row-2-cell-2 ft-row-2-cell-3"
               onClick={(e) => e.stopPropagation()}
               selectable={false}
+              checked={false}
+              onChange={() => {}}
             />
             <FlatTableCell id="ft-row-2-cell-1">Jane Doe</FlatTableCell>
             <FlatTableCell id="ft-row-2-cell-2">York</FlatTableCell>
@@ -1208,6 +1212,8 @@ export const ChildrenOnlySelectable: Story = () => {
               ariaLabelledBy="ft-row-3-cell-1 ft-row-3-cell-2 ft-row-3-cell-3"
               onClick={(e) => e.stopPropagation()}
               selectable={false}
+              checked={false}
+              onChange={() => {}}
             />
             <FlatTableCell id="ft-row-3-cell-1">John Smith</FlatTableCell>
             <FlatTableCell id="ft-row-3-cell-2">Edinburgh</FlatTableCell>
@@ -1224,6 +1230,8 @@ export const ChildrenOnlySelectable: Story = () => {
               ariaLabelledBy="ft-row-4-cell-1 ft-row-4-cell-2 ft-row-4-cell-3"
               onClick={(e) => e.stopPropagation()}
               selectable={false}
+              checked={false}
+              onChange={() => {}}
             />
             <FlatTableCell id="ft-row-4-cell-1">Jane Smith</FlatTableCell>
             <FlatTableCell id="ft-row-4-cell-2">Newcastle</FlatTableCell>
@@ -1469,7 +1477,7 @@ export const Sizes: Story = () => {
   return (
     <Box>
       {sizes.map((size, index) => (
-        <Box mb={3} key={String(index)}>
+        <Box mb={3} key={String(`${index}-${size}`)}>
           <FlatTable size={size} aria-label={`flat-table-${size}`}>
             <FlatTableHead>
               <FlatTableRow>

--- a/src/components/flat-table/flat-table-row/flat-table-row.test.tsx
+++ b/src/components/flat-table/flat-table-row/flat-table-row.test.tsx
@@ -385,7 +385,7 @@ describe("when FlatTableRowHeader children are passed", () => {
           <FlatTableRow>
             <FlatTableHeader>cell1</FlatTableHeader>
             <FlatTableCell>cell2</FlatTableCell>
-            <FlatTableCheckbox onChange={() => {}} data-role="cell3" />
+            <FlatTableCheckbox onChange={() => {}} data-role="cell3" checked />
             <FlatTableRowHeader>cell4</FlatTableRowHeader>
             <FlatTableHeader>cell5</FlatTableHeader>
             <FlatTableCell>cell6</FlatTableCell>
@@ -416,7 +416,7 @@ describe("when FlatTableRowHeader children are passed", () => {
           <FlatTableRow>
             <FlatTableHeader>cell1</FlatTableHeader>
             <FlatTableCell>cell2</FlatTableCell>
-            <FlatTableCheckbox onChange={() => {}} data-role="cell3" />
+            <FlatTableCheckbox onChange={() => {}} data-role="cell3" checked />
             <FlatTableRowHeader stickyAlignment="left">
               cell4
             </FlatTableRowHeader>
@@ -450,7 +450,7 @@ describe("when FlatTableRowHeader children are passed", () => {
           <FlatTableRow onClick={() => {}}>
             <FlatTableCell>cell1</FlatTableCell>
             <FlatTableCell>cell2</FlatTableCell>
-            <FlatTableCheckbox onChange={() => {}} data-role="cell3" />
+            <FlatTableCheckbox onChange={() => {}} data-role="cell3" checked />
             <FlatTableRowHeader>cell4</FlatTableRowHeader>
             <FlatTableHeader>cell5</FlatTableHeader>
             <FlatTableCell>cell6</FlatTableCell>
@@ -477,7 +477,7 @@ describe("when FlatTableRowHeader children are passed", () => {
             <FlatTableRowHeader stickyAlignment="right">
               cell3
             </FlatTableRowHeader>
-            <FlatTableCheckbox onChange={() => {}} data-role="cell4" />
+            <FlatTableCheckbox onChange={() => {}} data-role="cell4" checked />
             <FlatTableHeader>cell5</FlatTableHeader>
             <FlatTableCell>cell6</FlatTableCell>
           </FlatTableRow>
@@ -644,16 +644,16 @@ describe("when the row is `expandable`", () => {
             expandable
             subRows={[
               <FlatTableRow key="sub-row-1">
-                <FlatTableCheckbox onChange={() => {}} />
+                <FlatTableCheckbox onChange={() => {}} checked />
                 <FlatTableCell>sub1cell2</FlatTableCell>
               </FlatTableRow>,
               <FlatTableRow key="sub-row-2">
-                <FlatTableCheckbox onChange={() => {}} />
+                <FlatTableCheckbox onChange={() => {}} checked />
                 <FlatTableCell>sub2cell2</FlatTableCell>
               </FlatTableRow>,
             ]}
           >
-            <FlatTableCheckbox onChange={() => {}} />
+            <FlatTableCheckbox onChange={() => {}} checked />
             <FlatTableCell>cell2</FlatTableCell>
           </FlatTableRow>
         </thead>
@@ -1547,17 +1547,17 @@ describe("when the row is `expandable`", () => {
             expandableArea="firstColumn"
             subRows={[
               <FlatTableRow key="sub-row-1">
-                <FlatTableCheckbox onChange={() => {}} />
-                <FlatTableCheckbox onChange={() => {}} />
+                <FlatTableCheckbox onChange={() => {}} checked />
+                <FlatTableCheckbox onChange={() => {}} checked />
               </FlatTableRow>,
               <FlatTableRow key="sub-row-2">
-                <FlatTableCheckbox onChange={() => {}} />
-                <FlatTableCheckbox onChange={() => {}} />
+                <FlatTableCheckbox onChange={() => {}} checked />
+                <FlatTableCheckbox onChange={() => {}} checked />
               </FlatTableRow>,
             ]}
           >
-            <FlatTableCheckbox onChange={() => {}} data-role="cell1" />
-            <FlatTableCheckbox onChange={() => {}} />
+            <FlatTableCheckbox onChange={() => {}} data-role="cell1" checked />
+            <FlatTableCheckbox onChange={() => {}} checked />
           </FlatTableRow>
         </thead>
       </FlatTable>,
@@ -1652,7 +1652,7 @@ test("should render the expected background color styles when `bgColor` prop is 
       <tbody>
         <FlatTableRow bgColor="red">
           <FlatTableCell>cell1</FlatTableCell>
-          <FlatTableCheckbox onChange={() => {}} data-role="cell2" />
+          <FlatTableCheckbox onChange={() => {}} data-role="cell2" checked />
           <FlatTableRowHeader>cell3</FlatTableRowHeader>
         </FlatTableRow>
       </tbody>
@@ -1674,7 +1674,7 @@ test("should render the expected border bottom color styles when `horizontalBord
       <tbody>
         <FlatTableRow horizontalBorderColor="red">
           <FlatTableCell>cell1</FlatTableCell>
-          <FlatTableCheckbox onChange={() => {}} data-role="cell2" />
+          <FlatTableCheckbox onChange={() => {}} data-role="cell2" checked />
           <FlatTableRowHeader>cell3</FlatTableRowHeader>
         </FlatTableRow>
       </tbody>

--- a/src/components/flat-table/flat-table-test.stories.tsx
+++ b/src/components/flat-table/flat-table-test.stories.tsx
@@ -165,22 +165,22 @@ function getRowWithInputs(onClickFn: OnClick, hasHeaderRow?: boolean) {
     <FlatTableRow key="rowWithInputs" onClick={onClickFn}>
       {firstRow}
       <FlatTableCell>
-        <input />
+        <input title="input 1" />
       </FlatTableCell>
       <FlatTableCell>
-        <input />
+        <input title="input 2" />
       </FlatTableCell>
       <FlatTableCell>
-        <input />
+        <input title="input 3" />
       </FlatTableCell>
       <FlatTableCell>
-        <input />
+        <input title="input 4" />
       </FlatTableCell>
       <FlatTableCell>
-        <input />
+        <input title="input 5" />
       </FlatTableCell>
       <FlatTableCell>
-        <input />
+        <input title="input 6" />
       </FlatTableCell>
     </FlatTableRow>
   );
@@ -722,7 +722,13 @@ export const FlatRowHeaderWithNoPaddingAndButtons = () => {
       <FlatTableCell>subrow content</FlatTableCell>
       <FlatTableCell>subrow content</FlatTableCell>
       <FlatTableCell>
-        <Textbox label="" labelInline labelAlign="right" />
+        <Textbox
+          label=""
+          labelInline
+          labelAlign="right"
+          value=""
+          onChange={() => {}}
+        />
       </FlatTableCell>
       <FlatTableCell>subrow content</FlatTableCell>
       <FlatTableCell>subrow content</FlatTableCell>
@@ -741,7 +747,13 @@ export const FlatRowHeaderWithNoPaddingAndButtons = () => {
       </FlatTableCell>
       <FlatTableCell>subrow content</FlatTableCell>
       <FlatTableCell>
-        <Textbox label="" labelInline labelAlign="right" />
+        <Textbox
+          label=""
+          labelInline
+          labelAlign="right"
+          value=""
+          onChange={() => {}}
+        />
       </FlatTableCell>
       <FlatTableCell>subrow content</FlatTableCell>
       <FlatTableCell>subrow content</FlatTableCell>
@@ -775,7 +787,13 @@ export const FlatRowHeaderWithNoPaddingAndButtons = () => {
       <FlatTableBody>
         <FlatTableRow>
           <FlatTableCell>
-            <Textbox label="" labelInline labelAlign="right" />
+            <Textbox
+              label=""
+              labelInline
+              labelAlign="right"
+              value=""
+              onChange={() => {}}
+            />
           </FlatTableCell>
           <FlatTableRowHeader p={0} stickyAlignment="left">
             <Button>Button</Button>
@@ -820,7 +838,13 @@ export const FlatRowHeaderWithNoPaddingAndButtons = () => {
           </FlatTableRowHeader>
           <FlatTableCell>text content</FlatTableCell>
           <FlatTableCell>
-            <Textbox label="" labelInline labelAlign="right" />
+            <Textbox
+              label=""
+              labelInline
+              labelAlign="right"
+              value=""
+              onChange={() => {}}
+            />
           </FlatTableCell>
           <FlatTableCell>text content</FlatTableCell>
           <FlatTableCell>text content</FlatTableCell>
@@ -841,11 +865,23 @@ export const FlatRowHeaderWithNoPaddingAndButtons = () => {
           <FlatTableCell>text content</FlatTableCell>
           <FlatTableCell>text content</FlatTableCell>
           <FlatTableCell>
-            <Textbox label="" labelInline labelAlign="right" />
+            <Textbox
+              label=""
+              labelInline
+              labelAlign="right"
+              value=""
+              onChange={() => {}}
+            />
           </FlatTableCell>
           <FlatTableCell>text content</FlatTableCell>
           <FlatTableCell>
-            <Textbox label="" labelInline labelAlign="right" />
+            <Textbox
+              label=""
+              labelInline
+              labelAlign="right"
+              value=""
+              onChange={() => {}}
+            />
           </FlatTableCell>
           <FlatTableCell>text content</FlatTableCell>
           <FlatTableRowHeader p={0} stickyAlignment="right">

--- a/src/components/flat-table/flat-table.stories.tsx
+++ b/src/components/flat-table/flat-table.stories.tsx
@@ -44,6 +44,9 @@ type HighlightedRow = "one" | "two" | "three" | "four" | "";
 const meta: Meta<typeof FlatTable> = {
   title: "Flat Table",
   component: FlatTable,
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
+  },
 };
 
 export default meta;
@@ -398,7 +401,12 @@ export const WithCustomColumnWidth: Story = () => {
             <FlatTableCell>John Doe</FlatTableCell>
             <FlatTableCell>London</FlatTableCell>
             <FlatTableCell>
-              <Textbox placeholder="Notes for John Doe" size="small" />
+              <Textbox
+                placeholder="Notes for John Doe"
+                size="small"
+                value=""
+                onChange={() => {}}
+              />
             </FlatTableCell>
             <FlatTableCell px={1}>
               <ActionPopover>
@@ -434,7 +442,11 @@ export const WithCustomRowBackgroundColor: Story = () => {
       <FlatTableBody>
         <FlatTableRow bgColor="#B1D345">
           <FlatTableRowHeader>1</FlatTableRowHeader>
-          <FlatTableCheckbox ariaLabelledBy="ft-row-1-cell-1 ft-row-1-cell-2 ft-row-1-cell-3" />
+          <FlatTableCheckbox
+            ariaLabelledBy="ft-row-1-cell-1 ft-row-1-cell-2 ft-row-1-cell-3"
+            checked={false}
+            onChange={() => {}}
+          />
           <FlatTableCell id="ft-row-1-cell-1">John Doe</FlatTableCell>
           <FlatTableCell id="ft-row-1-cell-2">London</FlatTableCell>
           <FlatTableCell id="ft-row-1-cell-3">Single</FlatTableCell>
@@ -442,7 +454,11 @@ export const WithCustomRowBackgroundColor: Story = () => {
         </FlatTableRow>
         <FlatTableRow>
           <FlatTableRowHeader>2</FlatTableRowHeader>
-          <FlatTableCheckbox ariaLabelledBy="ft-row-2-cell-1 ft-row-2-cell-2 ft-row-2-cell-3" />
+          <FlatTableCheckbox
+            ariaLabelledBy="ft-row-2-cell-1 ft-row-2-cell-2 ft-row-2-cell-3"
+            checked={false}
+            onChange={() => {}}
+          />
           <FlatTableCell id="ft-row-2-cell-1">Jane Doe</FlatTableCell>
           <FlatTableCell id="ft-row-2-cell-2">York</FlatTableCell>
           <FlatTableCell id="ft-row-2-cell-3">Married</FlatTableCell>
@@ -450,7 +466,11 @@ export const WithCustomRowBackgroundColor: Story = () => {
         </FlatTableRow>
         <FlatTableRow bgColor="#B1D345">
           <FlatTableRowHeader>3</FlatTableRowHeader>
-          <FlatTableCheckbox ariaLabelledBy="ft-row-3-cell-1 ft-row-3-cell-2 ft-row-3-cell-3" />
+          <FlatTableCheckbox
+            ariaLabelledBy="ft-row-3-cell-1 ft-row-3-cell-2 ft-row-3-cell-3"
+            checked={false}
+            onChange={() => {}}
+          />
           <FlatTableCell id="ft-row-3-cell-1">John Smith</FlatTableCell>
           <FlatTableCell id="ft-row-3-cell-2">Edinburgh</FlatTableCell>
           <FlatTableCell id="ft-row-3-cell-3">Single</FlatTableCell>
@@ -458,7 +478,11 @@ export const WithCustomRowBackgroundColor: Story = () => {
         </FlatTableRow>
         <FlatTableRow>
           <FlatTableRowHeader>4</FlatTableRowHeader>
-          <FlatTableCheckbox ariaLabelledBy="ft-row-4-cell-1 ft-row-4-cell-2 ft-row-4-cell-3" />
+          <FlatTableCheckbox
+            ariaLabelledBy="ft-row-4-cell-1 ft-row-4-cell-2 ft-row-4-cell-3"
+            checked={false}
+            onChange={() => {}}
+          />
           <FlatTableCell id="ft-row-4-cell-1">Jane Smith</FlatTableCell>
           <FlatTableCell id="ft-row-4-cell-2">Newcastle</FlatTableCell>
           <FlatTableCell id="ft-row-4-cell-3">Married</FlatTableCell>
@@ -756,7 +780,12 @@ export const WithTruncatedCellContent: Story = () => {
               London
             </FlatTableCell>
             <FlatTableCell>
-              <Textbox size="small" aria-label="textbox" />
+              <Textbox
+                size="small"
+                aria-label="textbox"
+                value=""
+                onChange={() => {}}
+              />
             </FlatTableCell>
           </FlatTableRow>
         ))}

--- a/src/components/flat-table/flat-table.test.tsx
+++ b/src/components/flat-table/flat-table.test.tsx
@@ -346,7 +346,7 @@ describe("when rows are interactive", () => {
       <FlatTable>
         <FlatTableBody>
           <FlatTableRow onClick={() => {}}>
-            <FlatTableCheckbox onChange={() => {}} />
+            <FlatTableCheckbox onChange={() => {}} checked={false} />
             <FlatTableCell>two</FlatTableCell>
           </FlatTableRow>
           <FlatTableRow onClick={() => {}}>
@@ -377,7 +377,7 @@ describe("when rows are interactive", () => {
             <FlatTableCell>two</FlatTableCell>
           </FlatTableRow>
           <FlatTableRow onClick={() => {}}>
-            <FlatTableCheckbox onChange={() => {}} />
+            <FlatTableCheckbox onChange={() => {}} checked={false} />
             <FlatTableCell>four</FlatTableCell>
           </FlatTableRow>
         </FlatTableBody>

--- a/src/components/form/components.test-pw.tsx
+++ b/src/components/form/components.test-pw.tsx
@@ -27,9 +27,9 @@ export const FormComponent = (props: Partial<FormProps>) => {
       }
       {...props}
     >
-      <Textbox label="Textbox1" />
-      <Textbox label="Textbox2" />
-      <Textbox label="Textbox3" />
+      <Textbox value="" onChange={() => {}} label="Textbox1" />
+      <Textbox value="" onChange={() => {}} label="Textbox2" />
+      <Textbox value="" onChange={() => {}} label="Textbox3" />
     </Form>
   );
 };
@@ -50,7 +50,7 @@ export const FormWithLeftSidedButtons = () => (
     }
     buttonAlignment="left"
   >
-    <Textbox label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
   </Form>
 );
 
@@ -70,7 +70,7 @@ export const FormWithRightSidedButtons = () => (
     }
     buttonAlignment="right"
   >
-    <Textbox label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
   </Form>
 );
 
@@ -83,7 +83,7 @@ export const FormWithFullWidthButtons = (props: Partial<FormProps>) => (
     }
     {...props}
   >
-    <Textbox label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
   </Form>
 );
 
@@ -102,13 +102,13 @@ export const WithFooterChildren = (props: Partial<FormProps>) => {
 
   return (
     <Form {...props} footerChildren={footerNode}>
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
+      <Textbox value="" onChange={() => {}} label="Textbox" />
+      <Textbox value="" onChange={() => {}} label="Textbox" />
+      <Textbox value="" onChange={() => {}} label="Textbox" />
+      <Textbox value="" onChange={() => {}} label="Textbox" />
+      <Textbox value="" onChange={() => {}} label="Textbox" />
+      <Textbox value="" onChange={() => {}} label="Textbox" />
+      <Textbox value="" onChange={() => {}} label="Textbox" />
     </Form>
   );
 };
@@ -135,13 +135,13 @@ export const DefaultWithStickyFooter = () => (
         tabId="tab1"
       />
     </Tabs>
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
   </Form>
 );
 
@@ -168,13 +168,13 @@ export const StickyFooterVariant = () => (
         tabId="tab1"
       />
     </Tabs>
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
   </Form>
 );
 
@@ -208,13 +208,13 @@ export const WithFullWidthButtons = () => (
           tabId="tab1"
         />
       </Tabs>
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
+      <Textbox value="" onChange={() => {}} label="Textbox" />
+      <Textbox value="" onChange={() => {}} label="Textbox" />
+      <Textbox value="" onChange={() => {}} label="Textbox" />
+      <Textbox value="" onChange={() => {}} label="Textbox" />
+      <Textbox value="" onChange={() => {}} label="Textbox" />
+      <Textbox value="" onChange={() => {}} label="Textbox" />
+      <Textbox value="" onChange={() => {}} label="Textbox" />
     </Form>
   </CarbonProvider>
 );
@@ -230,7 +230,7 @@ export const WithErrorsSummary = () => (
     }
     errorCount={1}
   >
-    <Textbox label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
   </Form>
 );
 
@@ -245,7 +245,7 @@ export const WithWarningsSummary = () => (
     }
     warningCount={1}
   >
-    <Textbox label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
   </Form>
 );
 
@@ -261,7 +261,7 @@ export const WithBothErrorsAndWarningsSummary = () => (
     errorCount={2}
     warningCount={2}
   >
-    <Textbox label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
   </Form>
 );
 
@@ -290,7 +290,7 @@ export const WithAdditionalButtons = () => (
       </>
     }
   >
-    <Textbox label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
   </Form>
 );
 
@@ -320,7 +320,7 @@ export const WithButtonsAlignedToTheLeft = () => (
     }
     buttonAlignment="left"
   >
-    <Textbox label="Textbox" />
+    <Textbox value="" onChange={() => {}} label="Textbox" />
   </Form>
 );
 
@@ -345,7 +345,7 @@ export const InDialog = () => {
             </Button>
           }
         >
-          <Textbox label="Textbox" />
+          <Textbox value="" onChange={() => {}} label="Textbox" />
         </Form>
       </Dialog>
     </>
@@ -376,7 +376,12 @@ export const InDialogWithStickyFooter = () => {
           stickyFooter
         >
           {Array.from({ length: 10 }).map((_, index) => (
-            <Textbox key={`textbox-${index + 1}`} label="Textbox" />
+            <Textbox
+              value=""
+              onChange={() => {}}
+              key={`textbox-${index + 1}`}
+              label="Textbox"
+            />
           ))}
           <DateInput
             label="Date"
@@ -391,6 +396,8 @@ export const InDialogWithStickyFooter = () => {
             name="simple-disabled-portal"
             id="simple-disabled-portal"
             label="Simple Select - disabled portal"
+            value="1"
+            onChange={() => {}}
           >
             <Option text="Amber" value="1" />
             <Option text="Black" value="2" />
@@ -408,6 +415,8 @@ export const InDialogWithStickyFooter = () => {
             name="multi-disabled-portal"
             id="multi-disabled-portal"
             label="Multi Select - disabled portal"
+            value={["1"]}
+            onChange={() => {}}
           >
             <Option text="Amber" value="1" />
             <Option text="Black" value="2" />
@@ -421,7 +430,13 @@ export const InDialogWithStickyFooter = () => {
             <Option text="White" value="10" />
             <Option text="Yellow" value="11" />
           </MultiSelect>
-          <Select name="simple" id="simple" label="Simple Select">
+          <Select
+            name="simple"
+            id="simple"
+            label="Simple Select"
+            value="1"
+            onChange={() => {}}
+          >
             <Option text="Amber" value="1" />
             <Option text="Black" value="2" />
             <Option text="Blue" value="3" />
@@ -434,7 +449,13 @@ export const InDialogWithStickyFooter = () => {
             <Option text="White" value="10" />
             <Option text="Yellow" value="11" />
           </Select>
-          <MultiSelect name="multi" id="multi" label="Multi Select">
+          <MultiSelect
+            name="multi"
+            id="multi"
+            label="Multi Select"
+            value={["1"]}
+            onChange={() => {}}
+          >
             <Option text="Amber" value="1" />
             <Option text="Black" value="2" />
             <Option text="Blue" value="3" />
@@ -448,7 +469,12 @@ export const InDialogWithStickyFooter = () => {
             <Option text="Yellow" value="11" />
           </MultiSelect>
           {Array.from({ length: 10 }).map((_, index) => (
-            <Textbox key={`textbox-${index + 1}`} label="Textbox" />
+            <Textbox
+              value=""
+              onChange={() => {}}
+              key={`textbox-${index + 1}`}
+              label="Textbox"
+            />
           ))}
         </Form>
       </Dialog>
@@ -479,7 +505,7 @@ export const InDialogFullScreen = () => {
               </Button>
             }
           >
-            <Textbox label="Textbox" />
+            <Textbox value="" onChange={() => {}} label="Textbox" />
           </Form>
         </Box>
       </Dialog>
@@ -512,7 +538,12 @@ export const InDialogFullScreenWithStickyFooter = () => {
           stickyFooter
         >
           {Array.from({ length: 15 }).map((_, index) => (
-            <Textbox key={`textbox-${index + 1}`} label="Textbox" />
+            <Textbox
+              value=""
+              onChange={() => {}}
+              key={`textbox-${index + 1}`}
+              label="Textbox"
+            />
           ))}
           <DateInput
             label="Date"
@@ -522,7 +553,13 @@ export const InDialogFullScreenWithStickyFooter = () => {
               setDate(ev.target.value.formattedValue)
             }
           />
-          <Select name="simple" id="simple" label="label">
+          <Select
+            name="simple"
+            id="simple"
+            label="label"
+            value="1"
+            onChange={() => {}}
+          >
             <Option text="Amber" value="1" />
             <Option text="Black" value="2" />
             <Option text="Blue" value="3" />
@@ -536,7 +573,12 @@ export const InDialogFullScreenWithStickyFooter = () => {
             <Option text="Yellow" value="11" />
           </Select>
           {Array.from({ length: 15 }).map((_, index) => (
-            <Textbox key={`textbox-${index + 1}`} label="Textbox" />
+            <Textbox
+              value=""
+              onChange={() => {}}
+              key={`textbox-${index + 1}`}
+              label="Textbox"
+            />
           ))}
         </Form>
       </Dialog>
@@ -558,6 +600,8 @@ export const FormAlignmentExample = () => {
       fieldSpacing={4}
     >
       <Textbox
+        value=""
+        onChange={() => {}}
         key="input-one"
         label="Field 1"
         placeholder="placeholder"
@@ -568,6 +612,8 @@ export const FormAlignmentExample = () => {
         fieldHelp="This is some help text"
       />
       <Textbox
+        value=""
+        onChange={() => {}}
         key="input-two"
         label="Field 2"
         placeholder="placeholder"
@@ -645,18 +691,22 @@ export const FormAlignmentExample = () => {
         onChange={() => "CHECKBOX 1"}
         label="Checkbox 1"
         ml="10%"
+        checked
       />
       <Checkbox
         name="checkbox2"
         onChange={() => "CHECKBOX 2"}
         label="Checkbox 2"
         ml="10%"
+        checked={false}
       />
       <Hr ml="10%" mr="60%" mb={7} />
       <Button buttonType="tertiary" ml="calc(10% - 24px)">
         Tertiary
       </Button>
       <Textbox
+        value=""
+        onChange={() => {}}
         key="input-four"
         label="Field 4"
         placeholder="placeholder"
@@ -676,6 +726,8 @@ export const FormAlignmentExample = () => {
         checked
       />
       <Textbox
+        value=""
+        onChange={() => {}}
         key="input-five"
         label="Field 5"
         placeholder="placeholder"
@@ -696,16 +748,22 @@ export const WithLabelsInline = () => (
       </Button>
     }
   >
-    <Textbox label="Textbox" labelInline labelWidth={30} />
+    <Textbox
+      value=""
+      onChange={() => {}}
+      label="Textbox"
+      labelInline
+      labelWidth={30}
+    />
     <InlineInputs
       label="Inline Inputs"
       gutter="none"
       labelWidth={30}
       labelId="inline-inputs"
     >
-      <Textbox aria-labelledby="inline-inputs" />
-      <Textbox aria-labelledby="inline-inputs" />
-      <Select aria-labelledby="inline-inputs">
+      <Textbox value="" onChange={() => {}} aria-labelledby="inline-inputs" />
+      <Textbox value="" onChange={() => {}} aria-labelledby="inline-inputs" />
+      <Select aria-labelledby="inline-inputs" value="1" onChange={() => {}}>
         <Option value="1" text="option 1" key="1" />
         <Option value="2" text="option 2" key="1" />
         <Option value="3" text="option 3" key="1" />
@@ -717,9 +775,21 @@ export const WithLabelsInline = () => (
       labelWidth={30}
       labelId="inline-inputs-second"
     >
-      <Textbox aria-labelledby="inline-inputs-second" />
-      <Textbox aria-labelledby="inline-inputs-second" />
-      <Select aria-labelledby="inline-inputs-second">
+      <Textbox
+        value=""
+        onChange={() => {}}
+        aria-labelledby="inline-inputs-second"
+      />
+      <Textbox
+        value=""
+        onChange={() => {}}
+        aria-labelledby="inline-inputs-second"
+      />
+      <Select
+        aria-labelledby="inline-inputs-second"
+        value="1"
+        onChange={() => {}}
+      >
         <Option value="1" text="option 1" key="1" />
         <Option value="2" text="option 2" key="1" />
         <Option value="3" text="option 3" key="1" />
@@ -750,7 +820,7 @@ export const WithCustomFooterPadding = () => {
           stickyFooter
           footerPadding={{ px: 8 }}
         >
-          <Textbox label="Textbox" />
+          <Textbox value="" onChange={() => {}} label="Textbox" />
         </Form>
       </Dialog>
     </>

--- a/src/components/form/form-test.stories.tsx
+++ b/src/components/form/form-test.stories.tsx
@@ -37,6 +37,7 @@ export default {
     chromatic: {
       disableSnapshot: true,
     },
+    themeProvider: { chromatic: { theme: "sage" } },
   },
   args: {
     onSubmit: (ev: React.FormEvent) => {
@@ -58,8 +59,18 @@ type StoryType = StoryObj<typeof Form>;
 
 export const AllInputs: StoryType = (args: FormProps) => (
   <CarbonProvider validationRedesignOptIn>
-    <Textbox label="Outside of Form" characterLimit={100} />
-    <Textbox label="Outside of Form" characterLimit={100} />
+    <Textbox
+      onChange={() => {}}
+      value=""
+      label="Outside of Form"
+      characterLimit={100}
+    />
+    <Textbox
+      onChange={() => {}}
+      value=""
+      label="Outside of Form"
+      characterLimit={100}
+    />
     <Hr />
     <Form
       {...args}
@@ -71,22 +82,40 @@ export const AllInputs: StoryType = (args: FormProps) => (
       }
     >
       <Box>
-        <Textbox label="Textbox" characterLimit={100} />
-        <Number label="Number" />
-        <Decimal label="Decimal" />
+        <Textbox
+          onChange={() => {}}
+          value=""
+          label="Textbox"
+          characterLimit={100}
+        />
+        <Number label="Number" onChange={() => {}} value="" />
+        <Decimal label="Decimal" onChange={() => {}} value="" />
         <GroupedCharacter
           label="GroupedCharacter"
           groups={[2, 3, 2]}
           separator="-"
+          onChange={() => {}}
+          value=""
         />
-        <Password label="Password" characterLimit={100} />
+        <Password
+          label="Password"
+          characterLimit={100}
+          onChange={() => {}}
+          value=""
+        />
         <Fieldset legend="Fieldset">
-          <Textbox label="Textbox in Fieldset" />
-          <Checkbox label="Checkbox in Fieldset" />
+          <Textbox onChange={() => {}} value="" label="Textbox in Fieldset" />
+          <Checkbox
+            label="Checkbox in Fieldset"
+            onChange={() => {}}
+            checked={false}
+          />
           <Select
             name="simple-select"
             id="simple-select"
             label="Select in Fieldset"
+            onChange={() => {}}
+            value=""
           >
             <Option text="Amber" value="1" />
             <Option text="Black" value="2" />
@@ -102,8 +131,17 @@ export const AllInputs: StoryType = (args: FormProps) => (
           onChange={() => {}}
           label="Time"
         />
-        <NumeralDate label="Numeral Date" />
-        <RadioButtonGroup name="legend" legend="RadioButtonGroup">
+        <NumeralDate
+          label="Numeral Date"
+          onChange={() => {}}
+          value={{ dd: "", mm: "", yyyy: "" }}
+        />
+        <RadioButtonGroup
+          name="legend"
+          legend="RadioButtonGroup"
+          onChange={() => {}}
+          value="group-1-input-1"
+        >
           <RadioButton
             id="group-1-input-1"
             value="group-1-input-1"
@@ -115,10 +153,10 @@ export const AllInputs: StoryType = (args: FormProps) => (
             label="Radio Option 2"
           />
         </RadioButtonGroup>
-        <Checkbox label="Checkbox" />
+        <Checkbox label="Checkbox" checked={false} onChange={() => {}} />
         <CheckboxGroup legend="Checkbox Group">
-          <Checkbox label="Checkbox-1" />
-          <Checkbox label="Checkbox-2" />
+          <Checkbox label="Checkbox-1" checked={false} onChange={() => {}} />
+          <Checkbox label="Checkbox-2" checked={false} onChange={() => {}} />
         </CheckboxGroup>
         <DateInput name="date" label="Date" value="" onChange={() => {}} />
         <DateRange
@@ -129,12 +167,18 @@ export const AllInputs: StoryType = (args: FormProps) => (
           onChange={() => {}}
         />
         <InlineInputs label="Inline inputs">
-          <Textbox onChange={() => {}} />
-          <Textbox onChange={() => {}} />
-          <Textbox onChange={() => {}} />
+          <Textbox value="" onChange={() => {}} />
+          <Textbox value="" onChange={() => {}} />
+          <Textbox value="" onChange={() => {}} />
         </InlineInputs>
         <Search value="" onChange={() => {}} />
-        <Select name="simple-select" id="simple-select" label="Simple Select">
+        <Select
+          name="simple-select"
+          id="simple-select"
+          label="Simple Select"
+          value=""
+          onChange={() => {}}
+        >
           <Option text="Amber" value="1" />
           <Option text="Black" value="2" />
           <Option text="Blue" value="3" />
@@ -143,21 +187,37 @@ export const AllInputs: StoryType = (args: FormProps) => (
           name="filterable-select"
           id="filterable-select"
           label="Filterable Select"
+          value=""
+          onChange={() => {}}
         >
           <Option text="Amber" value="1" />
           <Option text="Black" value="2" />
           <Option text="Blue" value="3" />
         </FilterableSelect>
-        <MultiSelect name="multi-select" id="multi-select" label="Multi Select">
+        <MultiSelect
+          name="multi-select"
+          id="multi-select"
+          label="Multi Select"
+          value={[]}
+          onChange={() => {}}
+        >
           <Option text="Amber" value="1" />
           <Option text="Black" value="2" />
           <Option text="Blue" value="3" />
         </MultiSelect>
-        <Textarea label="Textarea" name="textarea" characterLimit={100} />
+        <Textarea
+          label="Textarea"
+          name="textarea"
+          characterLimit={100}
+          value=""
+          onChange={() => {}}
+        />
         <TextEditor labelText="Text Editor" characterLimit={100} />
         <SimpleColorPicker
           name="simple-color-picker"
           legend="Simple Color Picker"
+          value=""
+          onChange={() => {}}
         >
           {[
             { color: "transparent", label: "transparent" },
@@ -172,13 +232,18 @@ export const AllInputs: StoryType = (args: FormProps) => (
             />
           ))}
         </SimpleColorPicker>
-        <Switch name="switch" label="Switch" onChange={() => {}} />
+        <Switch
+          name="switch"
+          label="Switch"
+          onChange={() => {}}
+          checked={false}
+        />
       </Box>
     </Form>
   </CarbonProvider>
 );
 
-AllInputs.storyName = "all inputs";
+AllInputs.storyName = "All inputs";
 AllInputs.args = {
   stickyFooter: false,
   errorCount: 0,
@@ -203,12 +268,16 @@ export const FormAlignmentCustomMarginsTextInputs = (args: FormProps) => {
           labelInline
           labelAlign="right"
           labelWidth={30}
+          value=""
+          onChange={() => {}}
         />
         <Checkbox
           label="Checkbox in Fieldset"
           labelWidth={30}
           labelSpacing={2}
           reverse
+          checked
+          onChange={() => {}}
         />
       </Fieldset>
       <Decimal
@@ -220,6 +289,8 @@ export const FormAlignmentCustomMarginsTextInputs = (args: FormProps) => {
         inputWidth={30}
         fieldHelp="This is some help text"
         mb={1}
+        value="0"
+        onChange={() => {}}
       />
       <Textbox
         label="Textbox"
@@ -230,6 +301,8 @@ export const FormAlignmentCustomMarginsTextInputs = (args: FormProps) => {
         inputWidth={30}
         labelSpacing={2}
         mb={1}
+        value=""
+        onChange={() => {}}
       />
       <Number
         label="Number"
@@ -240,6 +313,8 @@ export const FormAlignmentCustomMarginsTextInputs = (args: FormProps) => {
         inputWidth={30}
         labelSpacing={2}
         mb={1}
+        value=""
+        onChange={() => {}}
       />
       <GroupedCharacter
         placeholder="placeholder"
@@ -249,6 +324,8 @@ export const FormAlignmentCustomMarginsTextInputs = (args: FormProps) => {
         groups={[2, 2, 3]}
         separator="-"
         mb={1}
+        value=""
+        onChange={() => {}}
       />
       <Textarea
         key="input-three"
@@ -259,6 +336,8 @@ export const FormAlignmentCustomMarginsTextInputs = (args: FormProps) => {
         labelWidth={10}
         inputWidth={30}
         mb={1}
+        value=""
+        onChange={() => {}}
       />
       <DateInput
         name="date"
@@ -285,6 +364,8 @@ export const FormAlignmentCustomMarginsTextInputs = (args: FormProps) => {
         id="simple-select"
         labelInline
         label="Simple Select"
+        value=""
+        onChange={() => {}}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -304,6 +385,8 @@ export const FormAlignmentCustomMarginsTextInputs = (args: FormProps) => {
         id="fiterable-select"
         labelInline
         label="Filterable Select"
+        value=""
+        onChange={() => {}}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -323,6 +406,8 @@ export const FormAlignmentCustomMarginsTextInputs = (args: FormProps) => {
         id="multi-select"
         labelInline
         label="Multi Select"
+        value={[]}
+        onChange={() => {}}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -336,11 +421,17 @@ export const FormAlignmentCustomMarginsTextInputs = (args: FormProps) => {
         <Option text="White" value="10" />
         <Option text="Yellow" value="11" />
       </MultiSelect>
-      <NumeralDate label="Numeral date" labelInline mb={1} />
+      <NumeralDate
+        label="Numeral date"
+        labelInline
+        mb={1}
+        value={{ dd: "", mm: "", yyyy: "" }}
+        onChange={() => {}}
+      />
       <InlineInputs label="Inline inputs" mb={1}>
-        <Textbox />
-        <Textbox />
-        <Textbox />
+        <Textbox value="" onChange={() => {}} />
+        <Textbox value="" onChange={() => {}} />
+        <Textbox value="" onChange={() => {}} />
       </InlineInputs>
       <Hr mx={1} my={0} />
     </Form>
@@ -366,6 +457,8 @@ export const FormAlignmentCustomMarginNonTextInputs = (args: FormProps) => {
         legendWidth={10}
         legendSpacing={2}
         mb={1}
+        value=""
+        onChange={() => {}}
       >
         <RadioButton
           id="group-1-input-1"
@@ -380,7 +473,13 @@ export const FormAlignmentCustomMarginNonTextInputs = (args: FormProps) => {
           labelWidth={10}
         />
       </RadioButtonGroup>
-      <Checkbox name="checkbox1" label="Checkbox 1" mb={1} />
+      <Checkbox
+        name="checkbox1"
+        label="Checkbox 1"
+        mb={1}
+        checked={false}
+        onChange={() => {}}
+      />
       <CheckboxGroup legend="Checkbox Group" mb={1}>
         {["One", "Two", "Three"].map((label) => (
           <Checkbox
@@ -388,6 +487,8 @@ export const FormAlignmentCustomMarginNonTextInputs = (args: FormProps) => {
             key={`checkbox-group-${label}`}
             name={`checkbox-group-${label}`}
             label={label}
+            checked={false}
+            onChange={() => {}}
           />
         ))}
       </CheckboxGroup>
@@ -398,11 +499,15 @@ export const FormAlignmentCustomMarginNonTextInputs = (args: FormProps) => {
         labelWidth={10}
         labelSpacing={2}
         mb={1}
+        checked={false}
+        onChange={() => {}}
       />
       <SimpleColorPicker
         name="picker-disabled-example"
         legend="Simple Color Picker"
         mb={1}
+        value=""
+        onChange={() => {}}
       >
         {[
           { color: "transparent", label: "transparent" },
@@ -454,13 +559,13 @@ export const DefaultWithPager = (args: FormProps) => (
         tabId="tab1"
       />
     </Tabs>
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
     <Pager
       totalRecords={25}
       currentPage={1}
@@ -592,8 +697,8 @@ export const FullWidthWithLeftAndRight = (args: FormProps) => {
       errorCount={1}
       warningCount={2}
     >
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
     </Form>
   );
 };
@@ -617,8 +722,8 @@ export const WithSetHeight = (args: FormProps) => (
   >
     <Form height="80%" {...args}>
       <Box backgroundColor="white" height="100%">
-        <Textbox label="Textbox" />
-        <Textbox label="Textbox" />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
       </Box>
     </Form>
   </Box>

--- a/src/components/form/form.pw.tsx
+++ b/src/components/form/form.pw.tsx
@@ -58,7 +58,7 @@ test.describe("check props for Form component", () => {
   test(`should render with children`, async ({ mount, page }) => {
     await mount(
       <Form>
-        <Textbox label="Textbox" />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
       </Form>,
     );
 

--- a/src/components/form/form.stories.tsx
+++ b/src/components/form/form.stories.tsx
@@ -40,6 +40,7 @@ const meta: Meta<typeof Form> = {
     ...styledSystemProps,
   },
   parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
     controls: { disable: true },
   },
   decorators: [
@@ -75,13 +76,13 @@ export const WithFooterNode: Story = (args: FormProps) => {
 
   return (
     <Form {...args} footerChildren={footerNode}>
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
     </Form>
   );
 };
@@ -102,13 +103,13 @@ export const DefaultWithStickyFooter: Story = (args: FormProps) => (
     }
     stickyFooter
   >
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
   </Form>
 );
 DefaultWithStickyFooter.storyName = "Default with sticky footer";
@@ -129,13 +130,13 @@ export const StickyFooterVariant: Story = (args: FormProps) => (
     stickyFooter
     stickyFooterVariant="grey"
   >
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
   </Form>
 );
 StickyFooterVariant.storyName = "Sticky footer with grey variant";
@@ -159,13 +160,13 @@ export const WithFullWidthButtons: Story = (args: FormProps) => (
       errorCount={3}
       warningCount={2}
     >
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
     </Form>
   </CarbonProvider>
 );
@@ -192,9 +193,9 @@ export const FieldSpacing: Story = (args: FormProps) => {
       }
       fieldSpacing={5}
     >
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
+      <Textbox onChange={() => {}} value="" label="Textbox" />
       <Textarea
         label="Textarea with Character Limit"
         characterLimit={50}
@@ -216,10 +217,10 @@ export const OverrideFieldSpacing: Story = (args: FormProps) => (
       </Button>
     }
   >
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" mb={7} />
-    <Textbox label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" mb={7} />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
   </Form>
 );
 OverrideFieldSpacing.storyName = "Override field spacing";
@@ -235,7 +236,7 @@ export const WithErrorsSummary: Story = (args: FormProps) => (
     }
     errorCount={1}
   >
-    <Textbox label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
   </Form>
 );
 WithErrorsSummary.storyName = "With Errors Summary";
@@ -254,7 +255,7 @@ export const WithWarningsSummary: Story = (args: FormProps) => (
     }
     warningCount={1}
   >
-    <Textbox label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
   </Form>
 );
 WithWarningsSummary.storyName = "With Warnings Summary";
@@ -274,7 +275,7 @@ export const WithBothErrorsAndWarningsSummary: Story = (args: FormProps) => (
     errorCount={2}
     warningCount={2}
   >
-    <Textbox label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
   </Form>
 );
 WithBothErrorsAndWarningsSummary.storyName =
@@ -304,7 +305,7 @@ export const WithAdditionalButtons: Story = (args: FormProps) => (
       </>
     }
   >
-    <Textbox label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
   </Form>
 );
 WithAdditionalButtons.storyName = "With Additional Buttons";
@@ -331,7 +332,7 @@ export const WithButtonsAlignedToTheLeft: Story = (args: FormProps) => (
     }
     buttonAlignment="left"
   >
-    <Textbox label="Textbox" />
+    <Textbox onChange={() => {}} value="" label="Textbox" />
   </Form>
 );
 WithButtonsAlignedToTheLeft.storyName = "With Buttons Aligned to the Left";
@@ -350,12 +351,14 @@ export const WithBothOptionalOrRequired: Story = (args: FormProps) => (
         </Button>
       }
     >
-      <Textbox label="Textbox" required />
+      <Textbox onChange={() => {}} value="" label="Textbox" required />
       <Select
         name="simple-required"
         id="simple-required"
         label="Simple Select"
         required
+        value=""
+        onChange={() => {}}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -365,6 +368,8 @@ export const WithBothOptionalOrRequired: Story = (args: FormProps) => (
         name="multi-optional"
         id="multi-optional"
         label="Multi Select"
+        value={[]}
+        onChange={() => {}}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -375,6 +380,8 @@ export const WithBothOptionalOrRequired: Story = (args: FormProps) => (
         id="multi-required"
         label="Multi Select"
         required
+        value={[]}
+        onChange={() => {}}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -419,7 +426,13 @@ export const WithBothOptionalOrRequired: Story = (args: FormProps) => (
           labelWidth={10}
         />
       </RadioButtonGroup>
-      <Checkbox name="checkbox" label="Checkbox" required />
+      <Checkbox
+        name="checkbox"
+        label="Checkbox"
+        required
+        checked={false}
+        onChange={() => {}}
+      />
     </Form>
   </Box>
 );
@@ -445,7 +458,7 @@ export const InDialog = () => {
           }
           saveButton={<Button buttonType="primary">Submit</Button>}
         >
-          <Textbox label="Textbox" />
+          <Textbox onChange={() => {}} value="" label="Textbox" />
         </Form>
       </Dialog>
     </>
@@ -473,7 +486,12 @@ export const InDialogWithStickyFooter = () => {
           stickyFooter
         >
           {Array.from({ length: 10 }).map((_, index) => (
-            <Textbox key={`textbox-${index + 1}`} label="Textbox" />
+            <Textbox
+              key={`textbox-${index + 1}`}
+              label="Textbox"
+              value=""
+              onChange={() => {}}
+            />
           ))}
           <DateInput
             label="Date"
@@ -488,6 +506,8 @@ export const InDialogWithStickyFooter = () => {
             name="simple-disabled-portal"
             id="simple-disabled-portal"
             label="Simple Select - disabled portal"
+            value="1"
+            onChange={() => {}}
           >
             <Option text="Amber" value="1" />
             <Option text="Black" value="2" />
@@ -505,6 +525,8 @@ export const InDialogWithStickyFooter = () => {
             name="multi-disabled-portal"
             id="multi-disabled-portal"
             label="Multi Select - disabled portal"
+            value={["1"]}
+            onChange={() => {}}
           >
             <Option text="Amber" value="1" />
             <Option text="Black" value="2" />
@@ -518,7 +540,13 @@ export const InDialogWithStickyFooter = () => {
             <Option text="White" value="10" />
             <Option text="Yellow" value="11" />
           </MultiSelect>
-          <Select name="simple" id="simple" label="Simple Select">
+          <Select
+            name="simple"
+            id="simple"
+            label="Simple Select"
+            value="1"
+            onChange={() => {}}
+          >
             <Option text="Amber" value="1" />
             <Option text="Black" value="2" />
             <Option text="Blue" value="3" />
@@ -531,7 +559,13 @@ export const InDialogWithStickyFooter = () => {
             <Option text="White" value="10" />
             <Option text="Yellow" value="11" />
           </Select>
-          <MultiSelect name="multi" id="multi" label="Multi Select">
+          <MultiSelect
+            name="multi"
+            id="multi"
+            label="Multi Select"
+            value={["1"]}
+            onChange={() => {}}
+          >
             <Option text="Amber" value="1" />
             <Option text="Black" value="2" />
             <Option text="Blue" value="3" />
@@ -545,7 +579,12 @@ export const InDialogWithStickyFooter = () => {
             <Option text="Yellow" value="11" />
           </MultiSelect>
           {Array.from({ length: 10 }).map((_, index) => (
-            <Textbox key={`textbox-${index + 1}`} label="Textbox" />
+            <Textbox
+              key={`textbox-${index + 1}`}
+              label="Textbox"
+              value=""
+              onChange={() => {}}
+            />
           ))}
         </Form>
       </Dialog>
@@ -577,7 +616,7 @@ export const InDialogFullScreen = () => {
             }
             saveButton={<Button buttonType="primary">Submit</Button>}
           >
-            <Textbox label="Textbox" />
+            <Textbox onChange={() => {}} value="" label="Textbox" />
           </Form>
         </Box>
       </Dialog>
@@ -607,7 +646,12 @@ export const InDialogFullScreenWithStickyFooter = () => {
           stickyFooter
         >
           {Array.from({ length: 15 }).map((_, index) => (
-            <Textbox key={`textbox-${index + 1}`} label="Textbox" />
+            <Textbox
+              key={`textbox-${index + 1}`}
+              label="Textbox"
+              value=""
+              onChange={() => {}}
+            />
           ))}
           <DateInput
             label="Date"
@@ -617,7 +661,13 @@ export const InDialogFullScreenWithStickyFooter = () => {
               setDate(ev.target.value.formattedValue)
             }
           />
-          <Select name="simple" id="simple" label="label">
+          <Select
+            name="simple"
+            id="simple"
+            label="label"
+            value="1"
+            onChange={() => {}}
+          >
             <Option text="Amber" value="1" />
             <Option text="Black" value="2" />
             <Option text="Blue" value="3" />
@@ -631,7 +681,12 @@ export const InDialogFullScreenWithStickyFooter = () => {
             <Option text="Yellow" value="11" />
           </Select>
           {Array.from({ length: 15 }).map((_, index) => (
-            <Textbox key={`textbox-${index + 1}`} label="Textbox" />
+            <Textbox
+              key={`textbox-${index + 1}`}
+              label="Textbox"
+              value=""
+              onChange={() => {}}
+            />
           ))}
         </Form>
       </Dialog>
@@ -667,6 +722,8 @@ export const FormAlignmentExample: Story = (args: FormProps) => {
         labelWidth={10}
         inputWidth={30}
         fieldHelp="This is some help text"
+        value=""
+        onChange={() => {}}
       />
       <Textbox
         key="input-two"
@@ -677,6 +734,8 @@ export const FormAlignmentExample: Story = (args: FormProps) => {
         labelWidth={10}
         inputWidth={30}
         labelSpacing={2}
+        value=""
+        onChange={() => {}}
       />
       <RadioButtonGroup
         name="legend"
@@ -742,8 +801,20 @@ export const FormAlignmentExample: Story = (args: FormProps) => {
         value=""
         onChange={() => {}}
       />
-      <Checkbox name="checkbox1" label="Checkbox 1" ml="10%" />
-      <Checkbox name="checkbox2" label="Checkbox 2" ml="10%" />
+      <Checkbox
+        name="checkbox1"
+        label="Checkbox 1"
+        ml="10%"
+        checked={false}
+        onChange={() => {}}
+      />
+      <Checkbox
+        name="checkbox2"
+        label="Checkbox 2"
+        ml="10%"
+        checked={false}
+        onChange={() => {}}
+      />
       <Box ml="10%" mr="60%">
         <Hr mb={7} />
       </Box>
@@ -758,6 +829,8 @@ export const FormAlignmentExample: Story = (args: FormProps) => {
         labelInline
         labelWidth={10}
         inputWidth={30}
+        value=""
+        onChange={() => {}}
       />
       <Switch
         name="switch"
@@ -777,6 +850,8 @@ export const FormAlignmentExample: Story = (args: FormProps) => {
         labelInline
         labelWidth={10}
         inputWidth={30}
+        value=""
+        onChange={() => {}}
       />
     </Form>
   );
@@ -791,19 +866,25 @@ export const WithLabelsInline: Story = () => (
       </Button>
     }
   >
-    <Textbox label="Textbox" labelInline labelWidth={30} />
+    <Textbox
+      onChange={() => {}}
+      value=""
+      label="Textbox"
+      labelInline
+      labelWidth={30}
+    />
     <InlineInputs
       label="Inline Inputs"
       gutter="none"
       labelWidth={30}
       labelId="inline-inputs"
     >
-      <Textbox aria-labelledby="inline-inputs" />
-      <Textbox aria-labelledby="inline-inputs" />
-      <Select aria-labelledby="inline-inputs">
+      <Textbox aria-labelledby="inline-inputs" value="" onChange={() => {}} />
+      <Textbox aria-labelledby="inline-inputs" value="" onChange={() => {}} />
+      <Select aria-labelledby="inline-inputs" value="" onChange={() => {}}>
         <Option value="1" text="option 1" key="1" />
-        <Option value="2" text="option 2" key="1" />
-        <Option value="3" text="option 3" key="1" />
+        <Option value="2" text="option 2" key="2" />
+        <Option value="3" text="option 3" key="3" />
       </Select>
     </InlineInputs>
     <InlineInputs
@@ -812,12 +893,24 @@ export const WithLabelsInline: Story = () => (
       labelWidth={30}
       labelId="inline-inputs-second"
     >
-      <Textbox aria-labelledby="inline-inputs-second" />
-      <Textbox aria-labelledby="inline-inputs-second" />
-      <Select aria-labelledby="inline-inputs-second">
+      <Textbox
+        aria-labelledby="inline-inputs-second"
+        value=""
+        onChange={() => {}}
+      />
+      <Textbox
+        aria-labelledby="inline-inputs-second"
+        value=""
+        onChange={() => {}}
+      />
+      <Select
+        aria-labelledby="inline-inputs-second"
+        value=""
+        onChange={() => {}}
+      >
         <Option value="1" text="option 1" key="1" />
-        <Option value="2" text="option 2" key="1" />
-        <Option value="3" text="option 3" key="1" />
+        <Option value="2" text="option 2" key="2" />
+        <Option value="3" text="option 3" key="3" />
       </Select>
     </InlineInputs>
   </Form>
@@ -846,7 +939,7 @@ export const WithCustomFooterPadding: Story = (args: FormProps) => {
           stickyFooter
           footerPadding={{ px: 8 }}
         >
-          <Textbox label="Textbox" />
+          <Textbox onChange={() => {}} value="" label="Textbox" />
         </Form>
       </Dialog>
     </>

--- a/src/components/grouped-character/components.test-pw.tsx
+++ b/src/components/grouped-character/components.test-pw.tsx
@@ -3,6 +3,7 @@ import GroupedCharacter, {
   CustomEvent,
   GroupedCharacterProps,
 } from "./grouped-character.component";
+import Box from "../box";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 
 export const GroupedCharacterComponent = ({
@@ -63,6 +64,7 @@ export const Validations = (
             label="GroupedCharacter - readOnly"
             value="1231231"
             groups={[2, 2, 3]}
+            onChange={() => {}}
             separator="-"
             readOnly
             {...{ [validationType]: args.message }}
@@ -106,6 +108,7 @@ export const ValidationsStringComponent = (
             label="GroupedCharacter - readOnly"
             value="1231231"
             groups={[2, 2, 3]}
+            onChange={() => {}}
             separator="-"
             readOnly
             {...{ [validationType]: "Message" }}
@@ -150,6 +153,7 @@ export const ValidationsStringLabel = (
             label="GroupedCharacter - readOnly"
             value="1231231"
             groups={[2, 2, 3]}
+            onChange={() => {}}
             separator="-"
             readOnly
             validationOnLabel
@@ -194,6 +198,7 @@ export const ValidationsBoolean = (
             label="GroupedCharacter - readOnly"
             value="1231231"
             groups={[2, 2, 3]}
+            onChange={() => {}}
             separator="-"
             readOnly
             {...{ [validationType]: true }}
@@ -220,10 +225,7 @@ export const ValidationsRedesign = () => {
     <CarbonProvider validationRedesignOptIn>
       {(["error", "warning"] as const).map((validationType) =>
         (["small", "medium", "large"] as const).map((size) => (
-          <div
-            style={{ width: "296px" }}
-            key={`${size}-${validationType}-string-component`}
-          >
+          <Box width="296px" key={`${size}-${validationType}-string-component`}>
             <GroupedCharacter
               label={`${size} - ${validationType}`}
               value={state[validationType]}
@@ -237,6 +239,7 @@ export const ValidationsRedesign = () => {
             <GroupedCharacter
               label={`readOnly - ${size} - ${validationType}`}
               value="1231231"
+              onChange={() => {}}
               groups={[2, 2, 3]}
               size={size}
               separator="-"
@@ -244,7 +247,7 @@ export const ValidationsRedesign = () => {
               {...{ [validationType]: "Message" }}
               m={4}
             />
-          </div>
+          </Box>
         )),
       )}
     </CarbonProvider>

--- a/src/components/grouped-character/grouped-character.component.tsx
+++ b/src/components/grouped-character/grouped-character.component.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from "react";
+import React from "react";
 
 import Textbox, { TextboxProps } from "../textbox";
 import { generateGroups, toSum } from "./grouped-character.utils";
-import Logger from "../../__internal__/utils/logger";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 
 type EventValue = {
@@ -35,58 +34,40 @@ const buildCustomTarget = (
 
 export interface GroupedCharacterProps
   extends Omit<TextboxProps, "onChange" | "onBlur" | "data-component"> {
-  /** Default input value if component is meant to be used as an uncontrolled component */
-  defaultValue?: string;
   /** pattern by which input value should be grouped */
   groups: number[];
   /** Handler for blur event */
   onBlur?: (ev: CustomEvent) => void;
-  /** Handler for change event if input is meant to be used as a controlled component */
-  onChange?: (ev: CustomEvent) => void;
+  /** Handler for change event */
+  onChange: (ev: CustomEvent) => void;
   /** character to be used as separator - has to be a 1 character string */
   separator: string;
-  /** Input value if component is meant to be used as a controlled component */
-  value?: string;
+  /** Input value */
+  value: string;
 }
-
-let deprecateUncontrolledWarnTriggered = false;
 
 export const GroupedCharacter = React.forwardRef(
   (
     {
-      defaultValue,
       groups,
       onBlur,
       onChange,
       onKeyDown,
       separator: rawSeparator,
-      value: externalValue,
+      value,
       ...rest
     }: GroupedCharacterProps,
     ref: React.ForwardedRef<HTMLInputElement>,
   ) => {
-    const [internalValue, setInternalValue] = useState(defaultValue || "");
-
-    const isControlled = externalValue !== undefined;
-
     const separator = rawSeparator.substring(0, 1); // Ensure max length is 1
 
     const maxRawLength = groups.reduce(toSum);
-
-    if (!deprecateUncontrolledWarnTriggered && !isControlled) {
-      deprecateUncontrolledWarnTriggered = true;
-      Logger.deprecate(
-        "Uncontrolled behaviour in `Grouped Character` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-      );
-    }
 
     const formatValue = (val: string) =>
       generateGroups(groups, val).join(separator);
 
     const sanitizeValue = (val: string) =>
       val.split(separator).join("").substring(0, maxRawLength);
-
-    const value = isControlled ? externalValue : internalValue;
 
     const handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
       const { target } = ev;
@@ -122,9 +103,7 @@ export const GroupedCharacter = React.forwardRef(
       });
 
       onChange?.(modifiedEvent);
-      if (!isControlled) {
-        setInternalValue(rawValue);
-      }
+
       setTimeout(() => target.setSelectionRange(newCursorPos, newCursorPos));
     };
 

--- a/src/components/grouped-character/grouped-character.test.tsx
+++ b/src/components/grouped-character/grouped-character.test.tsx
@@ -4,7 +4,6 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import GroupedCharacter, { CustomEvent } from "./grouped-character.component";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
-import Logger from "../../__internal__/utils/logger";
 
 jest.mock("../../__internal__/utils/logger");
 
@@ -49,32 +48,19 @@ afterEach(() => {
 });
 
 testStyledSystemMargin(
-  (props) => (
-    <GroupedCharacter
-      data-role="grouped-character"
-      groups={[2, 2, 3]}
-      separator="-"
-      {...props}
-    />
-  ),
+  (props) => {
+    return (
+      <ControlledGroupedCharacter
+        data-role="grouped-character"
+        groupsConfig={[2, 2, 3]}
+        initialValue="12345678"
+        {...props}
+      />
+    );
+  },
   () => screen.getByTestId("grouped-character"),
   { modifier: "&&&" },
 );
-
-test("deprecation warning for uncontrolled should display warning once", () => {
-  const loggerSpy = jest.spyOn(Logger, "deprecate");
-
-  render(<GroupedCharacter groups={[2, 2, 3]} separator="-" />);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "Uncontrolled behaviour in `Grouped Character` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-  );
-
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
-  loggerSpy.mockClear();
-});
 
 test("should render with the provided data- attributes", () => {
   render(
@@ -83,56 +69,22 @@ test("should render with the provided data- attributes", () => {
       data-role="baz"
       groups={[2, 2, 3]}
       separator="-"
+      value=""
+      onChange={() => {}}
     />,
   );
 
   expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
 });
 
-test("when component is uncontrolled, it should set the default input value same as defaultValue provided", () => {
-  render(
-    <GroupedCharacter
-      separator="-"
-      defaultValue="aabbcccc"
-      groups={[2, 2, 4]}
-    />,
-  );
-
-  const input = screen.getByRole("textbox");
-
-  expect(input).toHaveValue("aa-bb-cccc");
-});
-
-test("when component is uncontrolled, it should invoke the provided onChange handler with the expected value", async () => {
-  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-  const onChange = jest.fn();
-
-  render(
-    <GroupedCharacter
-      separator="-"
-      defaultValue="aabbcccc"
-      groups={[2, 2, 4]}
-      onChange={onChange}
-    />,
-  );
-
-  await user.type(screen.getByRole("textbox"), "cc-aa-aabb");
-
-  expect(onChange).toHaveBeenLastCalledWith(
-    expect.objectContaining({
-      target: expect.objectContaining({
-        value: {
-          formattedValue: "cc-aa-aabb",
-          rawValue: "ccaaaabb",
-        },
-      }),
-    }),
-  );
-});
-
 test("the component takes configuration for how characters should be grouped", () => {
   render(
-    <GroupedCharacter separator="-" value="12345678" groups={[2, 2, 4]} />,
+    <GroupedCharacter
+      separator="-"
+      value="12345678"
+      groups={[2, 2, 4]}
+      onChange={() => {}}
+    />,
   );
 
   expect(screen.getByRole("textbox")).toHaveValue("12-34-5678");
@@ -237,6 +189,7 @@ test("does nothing if onBlur is not provided", async () => {
       value="12345678"
       groups={[2, 2, 4]}
       onBlur={undefined}
+      onChange={() => {}}
     />,
   );
 
@@ -260,6 +213,7 @@ test("calls provided onKeyDown handler", async () => {
       value="12345678"
       groups={[2, 2, 4]}
       onKeyDown={onKeyDown}
+      onChange={() => {}}
     />,
   );
 
@@ -273,7 +227,12 @@ test("calls provided onKeyDown handler", async () => {
 
 test("does not allow values of length greater than that allowed by the group config", () => {
   render(
-    <GroupedCharacter separator="-" value="1234567890" groups={[2, 2, 4]} />,
+    <GroupedCharacter
+      separator="-"
+      value="1234567890"
+      onChange={() => {}}
+      groups={[2, 2, 4]}
+    />,
   );
 
   expect(screen.getByRole("textbox")).toHaveValue("12-34-5678");
@@ -485,6 +444,7 @@ test("the required prop is passed to the input", () => {
       value="12345678"
       groups={[2, 2, 4]}
       required
+      onChange={() => {}}
     />,
   );
 
@@ -500,6 +460,7 @@ describe("refs", () => {
         value="12345678"
         groups={[2, 2, 4]}
         ref={ref}
+        onChange={() => {}}
       />,
     );
 
@@ -515,6 +476,7 @@ describe("refs", () => {
         value="12345678"
         groups={[2, 2, 4]}
         ref={ref}
+        onChange={() => {}}
       />,
     );
 
@@ -528,6 +490,7 @@ describe("refs", () => {
       <GroupedCharacter
         separator="-"
         value="12345678"
+        onChange={() => {}}
         groups={[2, 2, 4]}
         ref={ref}
       />,

--- a/src/components/hr/components.test-pw.tsx
+++ b/src/components/hr/components.test-pw.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Hr, { HrProps } from ".";
 import Form from "../form";
 import Textbox from "../textbox";
@@ -10,59 +10,96 @@ export const Default = (props: HrProps) => {
 
 export const DifferentSpacing = () => <Hr mt={7} mb={7} />;
 
-export const InsideForm = () => (
-  <Form
-    onSubmit={() => {}}
-    leftSideButtons={<Button onClick={() => {}}>Cancel</Button>}
-    saveButton={
-      <Button buttonType="primary" type="submit">
-        Save
-      </Button>
-    }
-    stickyFooter={false}
-  >
-    <Textbox label="Textbox" />
-    <Textbox label="Textbox" />
-    <Hr mb={7} mt={7} />
-    <Textbox label="Textbox" />
-  </Form>
-);
+export const InsideForm = () => {
+  const [value, setValue] = useState("");
+  return (
+    <Form
+      onSubmit={() => {}}
+      leftSideButtons={<Button onClick={() => {}}>Cancel</Button>}
+      saveButton={
+        <Button buttonType="primary" type="submit">
+          Save
+        </Button>
+      }
+      stickyFooter={false}
+    >
+      <Textbox
+        label="Textbox"
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+        }}
+      />
+      <Textbox
+        label="Textbox"
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+        }}
+      />
+      <Hr mb={7} mt={7} />
+      <Textbox
+        label="Textbox"
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+        }}
+      />
+    </Form>
+  );
+};
 
-export const InsideFormInlineLabels = () => (
-  <Form
-    onSubmit={() => {}}
-    leftSideButtons={<Button onClick={() => {}}>Cancel</Button>}
-    saveButton={
-      <Button buttonType="primary" type="submit">
-        Save
-      </Button>
-    }
-    stickyFooter={false}
-  >
-    <Textbox
-      label="Textbox"
-      labelAlign="right"
-      labelInline
-      labelWidth={10}
-      inputWidth={50}
-    />
-    <Textbox
-      label="Textbox"
-      labelAlign="right"
-      labelInline
-      labelWidth={10}
-      inputWidth={50}
-    />
-    <Hr mb={7} mt={7} ml="10%" mr="40%" />
-    <Textbox
-      label="Textbox"
-      labelAlign="right"
-      labelInline
-      labelWidth={10}
-      inputWidth={50}
-    />
-  </Form>
-);
+export const InsideFormInlineLabels = () => {
+  const [value, setValue] = useState("");
+
+  return (
+    <Form
+      onSubmit={() => {}}
+      leftSideButtons={<Button onClick={() => {}}>Cancel</Button>}
+      saveButton={
+        <Button buttonType="primary" type="submit">
+          Save
+        </Button>
+      }
+      stickyFooter={false}
+    >
+      <Textbox
+        label="Textbox"
+        labelAlign="right"
+        labelInline
+        labelWidth={10}
+        inputWidth={50}
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+        }}
+      />
+      <Textbox
+        label="Textbox"
+        labelAlign="right"
+        labelInline
+        labelWidth={10}
+        inputWidth={50}
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+        }}
+      />
+      <Hr mb={7} mt={7} ml="10%" mr="40%" />
+      <Textbox
+        label="Textbox"
+        labelAlign="right"
+        labelInline
+        labelWidth={10}
+        inputWidth={50}
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+        }}
+      />
+    </Form>
+  );
+};
 
 export const EnablingAdaptiveBehaviour = () => (
   <Hr mb={7} mt={7} ml="10%" mr="40%" adaptiveMxBreakpoint={960} />

--- a/src/components/hr/hr.stories.tsx
+++ b/src/components/hr/hr.stories.tsx
@@ -78,10 +78,10 @@ export const InsideForm: Story = () => {
       }
       stickyFooter={false}
     >
-      <Textbox label="Textbox" />
-      <Textbox label="Textbox" />
+      <Textbox label="Textbox" value="" onChange={() => {}} />
+      <Textbox label="Textbox" value="" onChange={() => {}} />
       <Hr mb={7} mt={7} />
-      <Textbox label="Textbox" />
+      <Textbox label="Textbox" value="" onChange={() => {}} />
     </Form>
   );
 };
@@ -104,6 +104,8 @@ export const InsideFormInlineLabels: Story = () => {
         labelInline
         labelWidth={10}
         inputWidth={50}
+        value=""
+        onChange={() => {}}
       />
       <Textbox
         label="Textbox"
@@ -111,6 +113,8 @@ export const InsideFormInlineLabels: Story = () => {
         labelInline
         labelWidth={10}
         inputWidth={50}
+        value=""
+        onChange={() => {}}
       />
       <Box ml="10%" mr="40%">
         <Hr mb={7} mt={7} />
@@ -121,6 +125,8 @@ export const InsideFormInlineLabels: Story = () => {
         labelInline
         labelWidth={10}
         inputWidth={50}
+        value=""
+        onChange={() => {}}
       />
     </Form>
   );

--- a/src/components/icon/icon-unicodes.js
+++ b/src/components/icon/icon-unicodes.js
@@ -299,9 +299,7 @@ const legacyNames = {
   // it tries to use `delete` as an identifier, but `delete` is a reserved keyword.
   // By using ["delete"] instead, tsc generates a different - valid - .d.ts file
   // See also: https://github.com/microsoft/TypeScript/issues/53111
-  /* eslint-disable-next-line dot-notation */
   bin: batchActions["delete"],
-  /* eslint-disable-next-line dot-notation */
   bulk_destroy: batchActions["delete"],
   caret_down: actions.dropdown,
   collaborate: actions.share,

--- a/src/components/inline-inputs/components.test-pw.tsx
+++ b/src/components/inline-inputs/components.test-pw.tsx
@@ -14,6 +14,7 @@ export const Default = () => {
   };
   const [decimalValue, setDecimalValue] = useState("0.00");
   const [selectValue, setSelectValue] = useState("");
+  const [textValue, setTextValue] = useState("");
   const handleDecimalChange = (ev: {
     target: { value: { rawValue: React.SetStateAction<string> } };
   }) => {
@@ -30,7 +31,12 @@ export const Default = () => {
       labelId="inline-inputs-default"
       gutter="none"
     >
-      <Textbox aria-labelledby="inline-inputs-default" {...validationProps} />
+      <Textbox
+        aria-labelledby="inline-inputs-default"
+        {...validationProps}
+        value={textValue}
+        onChange={(e) => setTextValue(e.target.value)}
+      />
       <Decimal
         aria-labelledby="inline-inputs-default"
         value={decimalValue}
@@ -58,6 +64,8 @@ export const Default = () => {
 };
 
 export const WithAdaptiveLabelBreakpoint = () => {
+  const [textValue, setTextValue] = useState("");
+
   return (
     <Box p={4}>
       <InlineInputs
@@ -67,23 +75,46 @@ export const WithAdaptiveLabelBreakpoint = () => {
         labelWidth={30}
         gutter="none"
       >
-        <Textbox aria-labelledby="inline-inputs-adaptive" />
-        <Textbox aria-labelledby="inline-inputs-adaptive" />
+        <Textbox
+          aria-labelledby="inline-inputs-adaptive"
+          value={textValue}
+          onChange={(e) => setTextValue(e.target.value)}
+        />
+
+        <Textbox
+          aria-labelledby="inline-inputs-adaptive"
+          value={textValue}
+          onChange={(e) => setTextValue(e.target.value)}
+        />
       </InlineInputs>
-      <Textbox label="My Textbox" adaptiveLabelBreakpoint={768} />
+      <Textbox
+        label="My Textbox"
+        adaptiveLabelBreakpoint={768}
+        value={textValue}
+        onChange={(e) => setTextValue(e.target.value)}
+      />
     </Box>
   );
 };
 
 export const Required = () => {
+  const [textValue, setTextValue] = useState("");
   return (
     <InlineInputs
       label="Inline Inputs"
       labelId="inline-inputs-required"
       required
     >
-      <Textbox aria-labelledby="inline-inputs-required" />
-      <Textbox aria-labelledby="inline-inputs-required" />
+      <Textbox
+        aria-labelledby="inline-inputs-required"
+        value={textValue}
+        onChange={(e) => setTextValue(e.target.value)}
+      />
+      <Textbox
+        aria-labelledby="inline-inputs-required"
+        value={textValue}
+        onChange={(e) => setTextValue(e.target.value)}
+      />
     </InlineInputs>
   );
 };

--- a/src/components/inline-inputs/inline-inputs-test.stories.tsx
+++ b/src/components/inline-inputs/inline-inputs-test.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import InlineInputs, { InlineInputsProps } from ".";
 import Textbox from "../textbox";
 import Decimal from "../decimal";
@@ -17,9 +17,16 @@ export default {
 };
 
 export const Default = (props: InlineInputsProps) => {
+  const [textValue, setTextValue] = useState("");
+
   return (
     <InlineInputs label="Inline Input" {...props}>
-      <Textbox warning inputIcon="warning" />
+      <Textbox
+        warning
+        inputIcon="warning"
+        value={textValue}
+        onChange={(e) => setTextValue(e.target.value)}
+      />
 
       <Decimal onChange={() => {}} value="0.00" />
 

--- a/src/components/inline-inputs/inline-inputs.pw.tsx
+++ b/src/components/inline-inputs/inline-inputs.pw.tsx
@@ -87,7 +87,9 @@ test.describe("InlineInputs", () => {
     test(`should check children as ${children}`, async ({ mount, page }) => {
       await mount(
         <InlineInputs label="Inline Input">
-          <Textbox>{children}</Textbox>
+          <Textbox value={""} onChange={() => {}}>
+            {children}
+          </Textbox>
         </InlineInputs>,
       );
 
@@ -204,7 +206,7 @@ test.describe("rounded corners", () => {
 
       await mount(
         <InlineInputs label="Inline Input" gutter={gutter}>
-          <Textbox warning inputIcon="warning" />
+          <Textbox warning inputIcon="warning" value={""} onChange={() => {}} />
           <Decimal onChange={() => {}} value="0.00" />
         </InlineInputs>,
       );
@@ -226,7 +228,7 @@ test.describe("rounded corners", () => {
     }) => {
       await mount(
         <InlineInputs label="Inline Input" gutter={gutter}>
-          <Textbox warning inputIcon="warning" />
+          <Textbox warning inputIcon="warning" value={""} onChange={() => {}} />
         </InlineInputs>,
       );
 

--- a/src/components/inline-inputs/inline-inputs.stories.tsx
+++ b/src/components/inline-inputs/inline-inputs.stories.tsx
@@ -57,7 +57,12 @@ export const Default: Story = () => {
       labelId="inline-inputs-default"
       gutter="none"
     >
-      <Textbox aria-labelledby="inline-inputs-default" {...validationProps} />
+      <Textbox
+        aria-labelledby="inline-inputs-default"
+        {...validationProps}
+        value=""
+        onChange={() => {}}
+      />
       <Decimal
         aria-labelledby="inline-inputs-default"
         value={decimalValue}
@@ -95,10 +100,23 @@ export const WithAdaptiveLabelBreakpoint: Story = () => {
         labelWidth={30}
         gutter="none"
       >
-        <Textbox aria-labelledby="inline-inputs-adaptive" />
-        <Textbox aria-labelledby="inline-inputs-adaptive" />
+        <Textbox
+          aria-labelledby="inline-inputs-adaptive"
+          value=""
+          onChange={() => {}}
+        />
+        <Textbox
+          aria-labelledby="inline-inputs-adaptive"
+          value=""
+          onChange={() => {}}
+        />
       </InlineInputs>
-      <Textbox label="My Textbox" adaptiveLabelBreakpoint={768} />
+      <Textbox
+        label="My Textbox"
+        adaptiveLabelBreakpoint={768}
+        value=""
+        onChange={() => {}}
+      />
     </Box>
   );
 };
@@ -111,8 +129,16 @@ export const Required: Story = () => {
       labelId="inline-inputs-required"
       required
     >
-      <Textbox aria-labelledby="inline-inputs-required" />
-      <Textbox aria-labelledby="inline-inputs-required" />
+      <Textbox
+        aria-labelledby="inline-inputs-required"
+        value=""
+        onChange={() => {}}
+      />
+      <Textbox
+        aria-labelledby="inline-inputs-required"
+        value=""
+        onChange={() => {}}
+      />
     </InlineInputs>
   );
 };
@@ -129,8 +155,16 @@ export const LabelAlign: Story = () => {
           labelId="inline-inputs-align"
           labelWidth={30}
         >
-          <Textbox aria-labelledby="inline-inputs-align" />
-          <Textbox aria-labelledby="inline-inputs-align" />
+          <Textbox
+            aria-labelledby="inline-inputs-align"
+            value=""
+            onChange={() => {}}
+          />
+          <Textbox
+            aria-labelledby="inline-inputs-align"
+            value=""
+            onChange={() => {}}
+          />
         </InlineInputs>
       ))}
     </Box>

--- a/src/components/inline-inputs/inline-inputs.test.tsx
+++ b/src/components/inline-inputs/inline-inputs.test.tsx
@@ -10,7 +10,7 @@ import {
 test("renders single child", () => {
   render(
     <InlineInputs>
-      <Textbox onChange={() => {}} />
+      <Textbox value="" onChange={() => {}} />
     </InlineInputs>,
   );
 
@@ -20,8 +20,8 @@ test("renders single child", () => {
 test("renders multiple children", () => {
   render(
     <InlineInputs>
-      <Textbox onChange={() => {}} />
-      <Textbox onChange={() => {}} />
+      <Textbox value="" onChange={() => {}} />
+      <Textbox value="" onChange={() => {}} />
     </InlineInputs>,
   );
 
@@ -31,7 +31,7 @@ test("renders multiple children", () => {
 test("renders with provided label", () => {
   render(
     <InlineInputs label="Inputs Label">
-      <Textbox onChange={() => {}} />
+      <Textbox value="" onChange={() => {}} />
     </InlineInputs>,
   );
 
@@ -41,7 +41,7 @@ test("renders with provided label", () => {
 test("renders with provided labelId", () => {
   render(
     <InlineInputs label="Inputs Label" labelId="inputs-label">
-      <Textbox onChange={() => {}} />
+      <Textbox value="" onChange={() => {}} />
     </InlineInputs>,
   );
 
@@ -54,7 +54,7 @@ test("renders with provided labelId", () => {
 test("renders with provided htmlFor", () => {
   render(
     <InlineInputs label="Inputs Label" htmlFor="inputs">
-      <Textbox onChange={() => {}} />
+      <Textbox value="" onChange={() => {}} />
     </InlineInputs>,
   );
 
@@ -64,7 +64,7 @@ test("renders with provided htmlFor", () => {
 test("renders required children when required prop is true", () => {
   render(
     <InlineInputs required>
-      <Textbox onChange={() => {}} />
+      <Textbox value="" onChange={() => {}} />
     </InlineInputs>,
   );
 
@@ -74,7 +74,7 @@ test("renders required children when required prop is true", () => {
 test("renders with provided data-attributes", () => {
   render(
     <InlineInputs data-element="bar" data-role="baz">
-      <Textbox onChange={() => {}} />
+      <Textbox value="" onChange={() => {}} />
     </InlineInputs>,
   );
 
@@ -90,7 +90,7 @@ test("should render with expected styles when adaptiveLabelBreakpoint set and sc
       label="Inputs Label"
       adaptiveLabelBreakpoint={1000}
     >
-      <Textbox onChange={() => {}} />
+      <Textbox value="" onChange={() => {}} />
     </InlineInputs>,
   );
 
@@ -111,7 +111,7 @@ test("should render with expected styles when adaptiveLabelBreakpoint set and sc
       label="Inputs Label"
       adaptiveLabelBreakpoint={1000}
     >
-      <Textbox onChange={() => {}} />
+      <Textbox value="" onChange={() => {}} />
     </InlineInputs>,
   );
 
@@ -128,7 +128,7 @@ test("renders with expected styles when labelWidth is provided", () => {
       label="Inputs Label"
       labelWidth={50}
     >
-      <Textbox onChange={() => {}} />
+      <Textbox value="" onChange={() => {}} />
     </InlineInputs>,
   );
 
@@ -141,7 +141,7 @@ test("renders with expected styles when labelWidth is provided", () => {
 test("renders with expected styles when inputWidth is provided", () => {
   render(
     <InlineInputs inputWidth={50}>
-      <Textbox onChange={() => {}} />
+      <Textbox value="" onChange={() => {}} />
     </InlineInputs>,
   );
 

--- a/src/components/link/link.test.tsx
+++ b/src/components/link/link.test.tsx
@@ -1,5 +1,4 @@
 /* TODO: FE-6579 To re-enable once button-related props are removed from Link */
-/* eslint-disable jsx-a11y/anchor-is-valid */
 import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/src/components/menu/component.test-pw.tsx
+++ b/src/components/menu/component.test-pw.tsx
@@ -227,6 +227,7 @@ export const MenuComponentScrollableWithSearch = () => {
 };
 
 export const MenuComponentSearch = () => {
+  const [searchValue, setSearchValue] = useState("");
   return (
     <Box mb={150}>
       {menuTypes.map((menuType) => (
@@ -243,7 +244,8 @@ export const MenuComponentSearch = () => {
                 <Search
                   placeholder="Dark variant"
                   variant="dark"
-                  defaultValue=""
+                  value={searchValue}
+                  onChange={(e) => setSearchValue(e.target.value)}
                 />
               </MenuItem>
               <MenuItem href="#">Item Submenu Two</MenuItem>
@@ -573,22 +575,27 @@ export const MenuFullScreenWithSearchButton = ({
   searchValue,
 }: {
   searchValue?: string;
-}) => (
-  <MenuFullscreen isOpen onClose={() => {}}>
-    <MenuItem href="#">Menu Item before Search</MenuItem>
-    <MenuItem variant="alternate">
-      <Search
-        placeholder="Dark variant"
-        variant="dark"
-        defaultValue={searchValue}
-        searchButton
-      />
-    </MenuItem>
-    <MenuItem variant="alternate" href="#">
-      Menu Item after Search
-    </MenuItem>
-  </MenuFullscreen>
-);
+}) => {
+  const [value, setValue] = useState(searchValue || "");
+
+  return (
+    <MenuFullscreen isOpen onClose={() => {}}>
+      <MenuItem href="#">Menu Item before Search</MenuItem>
+      <MenuItem variant="alternate">
+        <Search
+          placeholder="Dark variant"
+          variant="dark"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          searchButton
+        />
+      </MenuItem>
+      <MenuItem variant="alternate" href="#">
+        Menu Item after Search
+      </MenuItem>
+    </MenuFullscreen>
+  );
+};
 
 export const MenuComponentScrollableParent = (
   props: Partial<ScrollableBlockProps>,

--- a/src/components/menu/menu-interactions.stories.tsx
+++ b/src/components/menu/menu-interactions.stories.tsx
@@ -33,30 +33,34 @@ interface StoryProps {
   menuType?: MenuProps["menuType"];
 }
 
-const MenuWithSearch = ({ menuType }: StoryProps) => (
-  <Menu menuType={menuType}>
-    <MenuItem submenu={`Menu Item ${menuType}`}>
-      <MenuItem>
-        <Search
-          placeholder="Search..."
-          defaultValue=""
-          variant={
-            menuType === "white" || menuType === "light" ? "default" : "dark"
-          }
-        />
+const MenuWithSearch = ({ menuType }: StoryProps) => {
+  const [searchValue, setSearchValue] = React.useState("");
+  return (
+    <Menu menuType={menuType}>
+      <MenuItem submenu={`Menu Item ${menuType}`}>
+        <MenuItem>
+          <Search
+            placeholder="Search..."
+            value={searchValue}
+            onChange={(e) => setSearchValue(e.target.value)}
+            variant={
+              menuType === "white" || menuType === "light" ? "default" : "dark"
+            }
+          />
+        </MenuItem>
+        <MenuDivider />
+        <MenuItem href="#">Item Link One</MenuItem>
+        <MenuItem data-role="target" icon="settings" href="#">
+          Item Link Two
+        </MenuItem>
+        <MenuItem onClick={() => {}}>Item Button Three</MenuItem>
+        <MenuItem data-role="target" icon="settings" onClick={() => {}}>
+          Item Button Four
+        </MenuItem>
       </MenuItem>
-      <MenuDivider />
-      <MenuItem href="#">Item Link One</MenuItem>
-      <MenuItem data-role="target" icon="settings" href="#">
-        Item Link Two
-      </MenuItem>
-      <MenuItem onClick={() => {}}>Item Button Three</MenuItem>
-      <MenuItem data-role="target" icon="settings" onClick={() => {}}>
-        Item Button Four
-      </MenuItem>
-    </MenuItem>
-  </Menu>
-);
+    </Menu>
+  );
+};
 
 const MenuWithScrollableBlock = ({ menuType }: StoryProps) => (
   <Menu menuType={menuType}>
@@ -189,31 +193,39 @@ const FullScreenWithSegmentTitle = () => (
   </Menu>
 );
 
-const FullScreenWithScrollableBlock = () => (
-  <Menu menuType="white">
-    <MenuFullscreen isOpen onClose={() => {}}>
-      <MenuItem>
-        <Search placeholder="Search..." defaultValue="" searchButton />
-      </MenuItem>
-      <MenuItem submenu="Item Three With Submenu">
-        <MenuItem data-role="target" href="#">
-          Item Submenu One
+const FullScreenWithScrollableBlock = () => {
+  const [searchValue, setSearchValue] = React.useState("");
+  return (
+    <Menu menuType="white">
+      <MenuFullscreen isOpen onClose={() => {}}>
+        <MenuItem>
+          <Search
+            placeholder="Search..."
+            value={searchValue}
+            onChange={(e) => setSearchValue(e.target.value)}
+            searchButton
+          />
         </MenuItem>
-        <MenuItem href="#">Item Submenu Two</MenuItem>
-        <ScrollableBlock height="150px">
-          <MenuItem onClick={() => {}}>Item Scrollable One</MenuItem>
-          <MenuItem onClick={() => {}}>Item Scrollable Two</MenuItem>
-          <MenuItem onClick={() => {}}>Item Scrollable Three</MenuItem>
-          <MenuItem data-role="target" onClick={() => {}}>
-            Item Scrollable Four
+        <MenuItem submenu="Item Three With Submenu">
+          <MenuItem data-role="target" href="#">
+            Item Submenu One
           </MenuItem>
-          <MenuItem onClick={() => {}}>Item Scrollable Five</MenuItem>
-          <MenuItem onClick={() => {}}>Item Scrollable Six</MenuItem>
-        </ScrollableBlock>
-      </MenuItem>
-    </MenuFullscreen>
-  </Menu>
-);
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+          <ScrollableBlock height="150px">
+            <MenuItem onClick={() => {}}>Item Scrollable One</MenuItem>
+            <MenuItem onClick={() => {}}>Item Scrollable Two</MenuItem>
+            <MenuItem onClick={() => {}}>Item Scrollable Three</MenuItem>
+            <MenuItem data-role="target" onClick={() => {}}>
+              Item Scrollable Four
+            </MenuItem>
+            <MenuItem onClick={() => {}}>Item Scrollable Five</MenuItem>
+            <MenuItem onClick={() => {}}>Item Scrollable Six</MenuItem>
+          </ScrollableBlock>
+        </MenuItem>
+      </MenuFullscreen>
+    </Menu>
+  );
+};
 
 export const WithSearch: Story = {
   render: () => (

--- a/src/components/menu/menu-test.stories.tsx
+++ b/src/components/menu/menu-test.stories.tsx
@@ -93,7 +93,8 @@ export const MenuFullScreenStory: StoryFullScreen = ({
           <Search
             placeholder="Search..."
             variant={searchVariant}
-            defaultValue=""
+            value=""
+            onChange={() => {}}
             searchButton={searchButton}
           />
         </MenuItem>

--- a/src/components/menu/menu.pw.tsx
+++ b/src/components/menu/menu.pw.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import React from "react";
 import { test, expect } from "../../../playwright/helpers/base-test";
 import {

--- a/src/components/menu/menu.stories.tsx
+++ b/src/components/menu/menu.stories.tsx
@@ -640,7 +640,8 @@ export const SubmenuWithSearch: MenuStory = () => {
                   <Search
                     placeholder="Dark variant"
                     variant="dark"
-                    defaultValue=""
+                    value=""
+                    onChange={() => {}}
                   />
                 </MenuItem>
                 <MenuItem variant="alternate" href="#">

--- a/src/components/message/message.stories.tsx
+++ b/src/components/message/message.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { useEffect, useRef, useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 

--- a/src/components/number/components.test-pw.tsx
+++ b/src/components/number/components.test-pw.tsx
@@ -24,6 +24,10 @@ export const Default = (props: Partial<NumberProps>) => {
 
 export const Sizes = () => {
   const sizes: NumberProps["size"][] = ["small", "medium", "large"];
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
 
   return (
     <>
@@ -31,7 +35,8 @@ export const Sizes = () => {
         <Number
           key={`Number - ${size}`}
           label={`Number - ${size}`}
-          value="123456"
+          value={state}
+          onChange={setValue}
           size={size}
           mb={2}
         />
@@ -40,22 +45,49 @@ export const Sizes = () => {
   );
 };
 
-export const Disabled = () => <Number label="Number" value="123456" disabled />;
+export const Disabled = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
 
-export const ReadOnly = () => <Number label="Number" value="123456" readOnly />;
+  return <Number label="Number" value={state} onChange={setValue} disabled />;
+};
 
-export const AutoFocus = () => (
-  <Number label="Number" value="123456" autoFocus />
-);
+export const ReadOnly = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Number label="Number" value={state} onChange={setValue} readOnly />;
+};
+
+export const AutoFocus = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Number label="Number" value={state} onChange={setValue} autoFocus />;
+};
 AutoFocus.parameters = { chromatic: { disableSnapshot: true } };
 
-export const WithLabelInline = () => (
-  <Number label="Number" value="123456" labelInline />
-);
+export const WithLabelInline = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number label="Number" value={state} onChange={setValue} labelInline />
+  );
+};
 WithLabelInline.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithLabelAlign = () => {
   const alignments: NumberProps["align"][] = ["right", "left"];
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
 
   return (
     <>
@@ -63,7 +95,8 @@ export const WithLabelAlign = () => {
         <Number
           label="Number"
           labelInline
-          value="123456"
+          value={state}
+          onChange={setValue}
           inputWidth={50}
           key={alignment}
           labelAlign={alignment}
@@ -73,31 +106,73 @@ export const WithLabelAlign = () => {
   );
 };
 
-export const WithCustomLabelWidthAndInputWidth = () => (
-  <Number
-    label="Number"
-    value="123456"
-    labelInline
-    labelWidth={50}
-    inputWidth={50}
-  />
-);
+export const WithCustomLabelWidthAndInputWidth = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number
+      label="Number"
+      value={state}
+      onChange={setValue}
+      labelInline
+      labelWidth={50}
+      inputWidth={50}
+    />
+  );
+};
 
-export const WithCustomMaxWidth = () => (
-  <Number label="Number" value="123456" maxWidth="50%" />
-);
+export const WithCustomMaxWidth = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number label="Number" value={state} onChange={setValue} maxWidth="50%" />
+  );
+};
 
-export const WithFieldHelp = () => (
-  <Number label="Number" value="123456" fieldHelp="Help" />
-);
+export const WithFieldHelp = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number label="Number" value={state} onChange={setValue} fieldHelp="Help" />
+  );
+};
 
-export const WithInputHint = () => (
-  <Number label="Number" value="123456" inputHint="Hint text (optional)." />
-);
+export const WithInputHint = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number
+      label="Number"
+      value={state}
+      onChange={setValue}
+      inputHint="Hint text (optional)."
+    />
+  );
+};
 
-export const WithLabelHelp = () => (
-  <Number label="Number" value="123456" labelHelp="Help" helpAriaLabel="Help" />
-);
+export const WithLabelHelp = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number
+      label="Number"
+      value={state}
+      onChange={setValue}
+      labelHelp="Help"
+      helpAriaLabel="Help"
+    />
+  );
+};
 
 export const WithPositionedChildren = () => {
   const [state, setState] = useState("123456");

--- a/src/components/number/number-test.stories.tsx
+++ b/src/components/number/number-test.stories.tsx
@@ -63,37 +63,77 @@ Default.args = {
 };
 
 export const Validation = () => {
+  const [state, setState] = useState("123456");
   return (
     <>
-      <Number label="Number" value="123456" error="Error Message" mb={2} />
-      <Number label="Number" value="123456" warning="Warning Message" mb={2} />
-      <Number label="Number" value="123456" info="Info Message" mb={2} />
+      <Number
+        label="Number"
+        value={state}
+        error="Error Message"
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
+      <Number
+        label="Number"
+        value={state}
+        warning="Warning Message"
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
+      <Number
+        label="Number"
+        value={state}
+        info="Info Message"
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
 
       <Number
         label="Number"
-        value="123456"
+        value={state}
         error="Error Message"
         validationOnLabel
         mb={2}
+        onChange={(e) => setState(e.target.value)}
       />
       <Number
         label="Number"
-        value="123456"
+        value={state}
         warning="Warning Message"
         validationOnLabel
         mb={2}
+        onChange={(e) => setState(e.target.value)}
       />
       <Number
         label="Number"
-        value="123456"
+        value={state}
         info="Info Message"
         validationOnLabel
         mb={2}
+        onChange={(e) => setState(e.target.value)}
       />
 
-      <Number label="Number" value="123456" error mb={2} />
-      <Number label="Number" value="123456" warning mb={2} />
-      <Number label="Number" value="123456" info mb={2} />
+      <Number
+        label="Number"
+        value={state}
+        error
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
+      <Number
+        label="Number"
+        value={state}
+        warning
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
+      <Number
+        label="Number"
+        value={state}
+        info
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
     </>
   );
 };
@@ -104,30 +144,40 @@ Validation.parameters = {
 };
 
 export const NewValidation = () => {
+  const [state, setState] = useState("123456");
   return (
     <CarbonProvider validationRedesignOptIn>
       <Number
         label="Number"
-        value="123456"
+        value={state}
         error="Error Message"
         inputHint="Hint text"
         mb={2}
-      />
-      <Number label="Number" value="123456" warning="Warning Message" mb={2} />
-      <Number
-        validationMessagePositionTop={false}
-        label="Number"
-        value="123456"
-        error="Error Message"
-        inputHint="Hint text"
-        mb={2}
+        onChange={(e) => setState(e.target.value)}
       />
       <Number
-        validationMessagePositionTop={false}
         label="Number"
-        value="123456"
+        value={state}
         warning="Warning Message"
         mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
+      <Number
+        validationMessagePositionTop={false}
+        label="Number"
+        value={state}
+        error="Error Message"
+        inputHint="Hint text"
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
+      />
+      <Number
+        validationMessagePositionTop={false}
+        label="Number"
+        value={state}
+        warning="Warning Message"
+        mb={2}
+        onChange={(e) => setState(e.target.value)}
       />
     </CarbonProvider>
   );
@@ -139,7 +189,15 @@ NewValidation.parameters = {
 };
 
 export const AutoFocus = () => {
-  return <Number label="Number" value="123456" autoFocus />;
+  const [state, setState] = useState("123456");
+  return (
+    <Number
+      label="Number"
+      value={state}
+      autoFocus
+      onChange={(e) => setState(e.target.value)}
+    />
+  );
 };
 AutoFocus.storyName = "Auto Focus";
 AutoFocus.parameters = {

--- a/src/components/number/number.component.tsx
+++ b/src/components/number/number.component.tsx
@@ -1,6 +1,5 @@
 import React, { useRef } from "react";
 import Textbox, { TextboxProps } from "../textbox";
-import Logger from "../../__internal__/utils/logger";
 import {
   ALIGN_DEFAULT,
   LABEL_VALIDATION_DEFAULT,
@@ -9,11 +8,9 @@ import {
 } from "../textbox/textbox.component";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 
-let deprecateUncontrolledWarnTriggered = false;
-
 export interface NumberProps extends Omit<TextboxProps, "value"> {
   /** Value passed to the input */
-  value?: string;
+  value: string;
 }
 
 function isValidNumber(value: string) {
@@ -40,15 +37,8 @@ export const Number = React.forwardRef(
     const selectionStart = useRef<null | number>(null);
     const selectionEnd = useRef<null | number>(null);
 
-    if (!deprecateUncontrolledWarnTriggered && !onChange) {
-      deprecateUncontrolledWarnTriggered = true;
-      Logger.deprecate(
-        "Uncontrolled behaviour in `Number` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-      );
-    }
-
     const handleOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      if (isValidNumber(event.target.value) && onChange) {
+      if (isValidNumber(event.target.value)) {
         onChange(event);
       } else {
         event.target.value = value || "";

--- a/src/components/number/number.stories.tsx
+++ b/src/components/number/number.stories.tsx
@@ -32,6 +32,10 @@ Default.storyName = "Default";
 
 export const Sizes: Story = () => {
   const sizes: NumberProps["size"][] = ["small", "medium", "large"];
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
 
   return (
     <>
@@ -39,7 +43,8 @@ export const Sizes: Story = () => {
         <Number
           key={`Number - ${size}`}
           label={`Number - ${size}`}
-          value="123456"
+          value={state}
+          onChange={setValue}
           size={size}
           mb={2}
         />
@@ -50,23 +55,41 @@ export const Sizes: Story = () => {
 Sizes.storyName = "Sizes";
 
 export const Disabled: Story = () => {
-  return <Number label="Number" value="123456" disabled />;
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Number label="Number" value={state} onChange={setValue} disabled />;
 };
 Disabled.storyName = "Disabled";
 
 export const ReadOnly: Story = () => {
-  return <Number label="Number" value="123456" readOnly />;
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Number label="Number" value={state} onChange={setValue} readOnly />;
 };
 ReadOnly.storyName = "Read Only";
 
 export const WithLabelInline: Story = () => {
-  return <Number label="Number" value="123456" labelInline />;
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number label="Number" value={state} onChange={setValue} labelInline />
+  );
 };
 WithLabelInline.storyName = "With Label Inline";
 WithLabelInline.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithLabelAlign: Story = () => {
   const alignments: NumberProps["align"][] = ["right", "left"];
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
 
   return (
     <>
@@ -74,7 +97,8 @@ export const WithLabelAlign: Story = () => {
         <Number
           label="Number"
           labelInline
-          value="123456"
+          value={state}
+          onChange={setValue}
           inputWidth={50}
           key={alignment}
           labelAlign={alignment}
@@ -86,25 +110,53 @@ export const WithLabelAlign: Story = () => {
 WithLabelAlign.storyName = "With Label Align";
 
 export const WithCustomMaxWidth: Story = () => {
-  return <Number label="Number" value="123456" maxWidth="50%" />;
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number label="Number" value={state} onChange={setValue} maxWidth="50%" />
+  );
 };
 WithCustomMaxWidth.storyName = "With Custom Max Width";
 
 export const WithFieldHelp: Story = () => {
-  return <Number label="Number" value="123456" fieldHelp="Help" />;
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number label="Number" value={state} onChange={setValue} fieldHelp="Help" />
+  );
 };
 WithFieldHelp.storyName = "With Field Help";
 
-export const WithInputHint: Story = () => (
-  <Number label="Number" value="123456" inputHint="Hint text (optional)." />
-);
-WithInputHint.storyName = "With Input Hint";
-
-export const WithLabelHelp: Story = () => {
+export const WithInputHint: Story = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
   return (
     <Number
       label="Number"
-      value="123456"
+      value={state}
+      onChange={setValue}
+      inputHint="Hint text (optional)."
+    />
+  );
+};
+WithInputHint.storyName = "With Input Hint";
+
+export const WithLabelHelp: Story = () => {
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Number
+      label="Number"
+      value={state}
+      onChange={setValue}
       labelHelp="Help"
       helpAriaLabel="Help"
     />
@@ -113,6 +165,10 @@ export const WithLabelHelp: Story = () => {
 WithLabelHelp.storyName = "With Label Help";
 
 export const Required: Story = () => {
-  return <Number label="Number" value="123456" required />;
+  const [state, setState] = useState("123456");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Number label="Number" value={state} onChange={setValue} required />;
 };
 Required.storyName = "Required";

--- a/src/components/number/number.test.tsx
+++ b/src/components/number/number.test.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Number from ".";
-import Logger from "../../__internal__/utils/logger";
 
 jest.mock("../../__internal__/utils/logger");
 
@@ -15,13 +14,13 @@ const ControlledNumber = () => {
 };
 
 test("renders a textbox with provided label", () => {
-  render(<Number label="foo" />);
+  render(<Number label="foo" value="" onChange={jest.fn} />);
 
   expect(screen.getByRole("textbox", { name: "foo" })).toBeVisible();
 });
 
 test("renders a textbox with provided value", () => {
-  render(<Number value="123" />);
+  render(<Number value="123" onChange={jest.fn} />);
 
   expect(screen.getByRole("textbox")).toHaveValue("123");
 });
@@ -29,7 +28,7 @@ test("renders a textbox with provided value", () => {
 test("calls onChange when valid characters are provided", async () => {
   const user = userEvent.setup();
   const onChange = jest.fn();
-  render(<Number onChange={onChange} />);
+  render(<Number onChange={onChange} value="" />);
 
   await user.type(screen.getByRole("textbox"), "123");
 
@@ -39,7 +38,7 @@ test("calls onChange when valid characters are provided", async () => {
 test("does not call onChange when invalid characters are provided", async () => {
   const user = userEvent.setup();
   const onChange = jest.fn();
-  render(<Number onChange={onChange} />);
+  render(<Number onChange={onChange} value="" />);
 
   await user.tab();
   await user.keyboard("abc");
@@ -50,7 +49,7 @@ test("does not call onChange when invalid characters are provided", async () => 
 test("calls onKeyDown when a key is pressed", async () => {
   const user = userEvent.setup();
   const onKeyDown = jest.fn();
-  render(<Number onKeyDown={onKeyDown} />);
+  render(<Number onKeyDown={onKeyDown} onChange={jest.fn} value="" />);
 
   await user.tab();
   await user.keyboard("1");
@@ -101,47 +100,47 @@ test("maintains the user's cursor position when an invalid character is provided
   expect(textbox.selectionEnd).toBe(0);
 });
 
-test("logs a deprecation warning when uncontrolled", () => {
-  const loggerSpy = jest.spyOn(Logger, "deprecate");
-  render(<Number />);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "Uncontrolled behaviour in `Number` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
-});
-
 test("renders a required textbox when `required` prop is true", () => {
-  render(<Number required />);
+  render(<Number required onChange={jest.fn} value="" />);
 
   expect(screen.getByRole("textbox")).toBeRequired();
 });
 
 test("renders a disabled textbox when `disabled` prop is true", () => {
-  render(<Number disabled />);
+  render(<Number disabled onChange={jest.fn} value="" />);
 
   expect(screen.getByRole("textbox")).toBeDisabled();
 });
 
 test("renders with `ref` when passed as an object", () => {
   const ref = { current: null };
-  render(<Number ref={ref}>foo</Number>);
+  render(
+    <Number ref={ref} onChange={jest.fn} value="">
+      foo
+    </Number>,
+  );
 
   expect(ref.current).toBe(screen.getByRole("textbox"));
 });
 
 test("renders with `ref` when passed as a callback", () => {
   const ref = jest.fn();
-  render(<Number ref={ref}>foo</Number>);
+  render(
+    <Number ref={ref} onChange={jest.fn} value="">
+      foo
+    </Number>,
+  );
 
   expect(ref).toHaveBeenCalledWith(screen.getByRole("textbox"));
 });
 
 test("sets `ref` to empty after unmount", () => {
   const ref = { current: null };
-  const { unmount } = render(<Number ref={ref}>foo</Number>);
+  const { unmount } = render(
+    <Number ref={ref} onChange={jest.fn} value="">
+      foo
+    </Number>,
+  );
 
   expect(ref.current).toBe(screen.getByRole("textbox"));
 

--- a/src/components/numeral-date/components.test-pw.tsx
+++ b/src/components/numeral-date/components.test-pw.tsx
@@ -2,15 +2,30 @@ import React from "react";
 import NumeralDate, { NumeralDateProps } from ".";
 
 export const NumeralDateComponent = (props: Partial<NumeralDateProps>) => {
-  return <NumeralDate label="Default" {...props} />;
+  return (
+    <NumeralDate
+      value={{ dd: "01", mm: "01", yyyy: "2001" }}
+      label="Default"
+      onChange={() => {}}
+      {...props}
+    />
+  );
 };
 
-export const NumeralDateControlled = (props: Partial<NumeralDateProps>) => {
-  const [value, setValue] = React.useState<NumeralDateProps["value"]>({
-    dd: "",
-    mm: "",
-    yyyy: "",
-  });
+interface NumeralDateControlledProps extends Partial<NumeralDateProps> {
+  initialValue?: NumeralDateProps["value"];
+}
+
+export const NumeralDateControlled = (
+  props: Partial<NumeralDateControlledProps>,
+) => {
+  const [value, setValue] = React.useState<NumeralDateProps["value"]>(
+    props.initialValue ?? {
+      dd: "",
+      mm: "",
+      yyyy: "",
+    },
+  );
 
   return (
     <NumeralDate

--- a/src/components/numeral-date/numeral-date-test.stories.tsx
+++ b/src/components/numeral-date/numeral-date-test.stories.tsx
@@ -13,6 +13,7 @@ export default {
     chromatic: {
       disableSnapshot: true,
     },
+    themeProvider: { chromatic: { theme: "sage" } },
     controls: {
       exclude: [
         "value",
@@ -70,13 +71,13 @@ export const Default = (args: NumeralDateProps) => {
   return (
     <Box>
       <NumeralDate
-        onChange={handleChange}
         label="Numeral date"
         onBlur={handleBlur}
-        value={dateValue}
         name="numeralDate_name"
         id="numeralDate_id"
         {...args}
+        onChange={handleChange}
+        value={dateValue}
       />
     </Box>
   );
@@ -87,6 +88,21 @@ Default.args = {
 };
 
 export const Validations = (args: NumeralDateProps) => {
+  const dateDefault = {
+    dd: "",
+    mm: "",
+    yyyy: "",
+  };
+  const [value, setValue] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value2, setValue2] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value3, setValue3] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value4, setValue4] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value5, setValue5] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value6, setValue6] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value7, setValue7] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value8, setValue8] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value9, setValue9] = useState<NumeralDateProps["value"]>(dateDefault);
+
   return (
     <>
       <NumeralDate
@@ -94,20 +110,33 @@ export const Validations = (args: NumeralDateProps) => {
         error="Error Message"
         mb={2}
         {...args}
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
       />
       <NumeralDate
         label="Numeral date"
         warning="Warning Message"
         mb={2}
         {...args}
+        value={value2}
+        onChange={(ev) => setValue2(ev.target.value)}
       />
-      <NumeralDate label="Numeral date" info="Info Message" mb={2} {...args} />
+      <NumeralDate
+        label="Numeral date"
+        info="Info Message"
+        mb={2}
+        {...args}
+        value={value3}
+        onChange={(ev) => setValue3(ev.target.value)}
+      />
       <NumeralDate
         label="Numeral date"
         error="Error Message"
         validationOnLabel
         mb={2}
         {...args}
+        value={value4}
+        onChange={(ev) => setValue4(ev.target.value)}
       />
       <NumeralDate
         label="Numeral date"
@@ -115,6 +144,8 @@ export const Validations = (args: NumeralDateProps) => {
         validationOnLabel
         mb={2}
         {...args}
+        value={value5}
+        onChange={(ev) => setValue5(ev.target.value)}
       />
       <NumeralDate
         label="Numeral date"
@@ -122,10 +153,33 @@ export const Validations = (args: NumeralDateProps) => {
         validationOnLabel
         mb={2}
         {...args}
+        value={value6}
+        onChange={(ev) => setValue6(ev.target.value)}
       />
-      <NumeralDate label="Numeral date" error mb={2} {...args} />
-      <NumeralDate label="Numeral date" warning mb={2} {...args} />
-      <NumeralDate label="Numeral date" info mb={2} {...args} />
+      <NumeralDate
+        label="Numeral date"
+        error
+        mb={2}
+        {...args}
+        value={value7}
+        onChange={(ev) => setValue7(ev.target.value)}
+      />
+      <NumeralDate
+        label="Numeral date"
+        warning
+        mb={2}
+        {...args}
+        value={value8}
+        onChange={(ev) => setValue8(ev.target.value)}
+      />
+      <NumeralDate
+        label="Numeral date"
+        info
+        mb={2}
+        {...args}
+        value={value9}
+        onChange={(ev) => setValue9(ev.target.value)}
+      />
     </>
   );
 };
@@ -136,6 +190,16 @@ Validations.parameters = {
 };
 
 export const NewValidations = (args: NumeralDateProps) => {
+  const dateDefault = {
+    dd: "",
+    mm: "",
+    yyyy: "",
+  };
+  const [value, setValue] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value2, setValue2] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value3, setValue3] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value4, setValue4] = useState<NumeralDateProps["value"]>(dateDefault);
+
   return (
     <CarbonProvider validationRedesignOptIn>
       <NumeralDate
@@ -144,12 +208,16 @@ export const NewValidations = (args: NumeralDateProps) => {
         labelHelp="Hint text"
         mb={2}
         {...args}
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
       />
       <NumeralDate
         label="Numeral date"
         warning="Warning Message"
         mb={2}
         {...args}
+        value={value2}
+        onChange={(ev) => setValue2(ev.target.value)}
       />
       <NumeralDate
         validationMessagePositionTop={false}
@@ -158,12 +226,16 @@ export const NewValidations = (args: NumeralDateProps) => {
         labelHelp="Hint text"
         mb={2}
         {...args}
+        value={value3}
+        onChange={(ev) => setValue3(ev.target.value)}
       />
       <NumeralDate
         validationMessagePositionTop={false}
         label="Numeral date"
         warning="Warning Message"
         {...args}
+        value={value4}
+        onChange={(ev) => setValue4(ev.target.value)}
       />
     </CarbonProvider>
   );
@@ -176,9 +248,24 @@ NewValidations.parameters = {
 };
 
 export const InForm = () => {
+  const [dateValue, setDateValue] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
+  const handleChange: NumeralDateProps["onChange"] = (event) => {
+    setDateValue(event.target.value);
+    action("change")(event.target.value);
+  };
+
   return (
     <form>
-      <NumeralDate dateFormat={["dd", "mm", "yyyy"]} label="Label" />
+      <NumeralDate
+        dateFormat={["dd", "mm", "yyyy"]}
+        label="Label"
+        value={dateValue}
+        onChange={handleChange}
+      />
       <br />
       <button type="submit">Submit</button>
     </form>
@@ -188,6 +275,18 @@ export const InForm = () => {
 InForm.storyName = "In form";
 
 export const LabelAlign = ({ ...args }) => {
+  const defaultDate = { dd: "", mm: "", yyyy: "" };
+  const [dateValue, setDateValue] =
+    useState<NumeralDateProps["value"]>(defaultDate);
+  const [dateValue2, setDateValue2] =
+    useState<NumeralDateProps["value"]>(defaultDate);
+  const [dateValue3, setDateValue3] =
+    useState<NumeralDateProps["value"]>(defaultDate);
+  const [dateValue4, setDateValue4] =
+    useState<NumeralDateProps["value"]>(defaultDate);
+  const [dateValue5, setDateValue5] =
+    useState<NumeralDateProps["value"]>(defaultDate);
+
   return (
     <Box ml={2}>
       <CarbonProvider validationRedesignOptIn>
@@ -196,6 +295,8 @@ export const LabelAlign = ({ ...args }) => {
           label="labelAlign left"
           labelHelp="labelHelp"
           {...args}
+          value={dateValue}
+          onChange={(event) => setDateValue(event.target.value)}
         />
         <NumeralDate
           mb={2}
@@ -203,6 +304,8 @@ export const LabelAlign = ({ ...args }) => {
           labelHelp="labelHelp"
           labelAlign="right"
           {...args}
+          value={dateValue2}
+          onChange={(event) => setDateValue2(event.target.value)}
         />
       </CarbonProvider>
       <NumeralDate
@@ -211,6 +314,8 @@ export const LabelAlign = ({ ...args }) => {
         labelAlign="right"
         fieldLabelsAlign="right"
         {...args}
+        value={dateValue3}
+        onChange={(event) => setDateValue3(event.target.value)}
       />
       <NumeralDate
         mb={2}
@@ -219,12 +324,16 @@ export const LabelAlign = ({ ...args }) => {
         labelInline
         labelWidth={30}
         {...args}
+        value={dateValue4}
+        onChange={(event) => setDateValue4(event.target.value)}
       />
       <NumeralDate
         label="inline labelAlign right"
         labelInline
         labelWidth={30}
         {...args}
+        value={dateValue5}
+        onChange={(event) => setDateValue5(event.target.value)}
       />
     </Box>
   );
@@ -239,11 +348,50 @@ LabelAlign.parameters = {
 };
 
 export const InlineLabelsSizes = ({ ...args }) => {
+  const [dateValue, setDateValue] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
+
+  const [dateValue2, setDateValue2] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
+
+  const [dateValue3, setDateValue3] = useState<NumeralDateProps["value"]>({
+    dd: "",
+    mm: "",
+    yyyy: "",
+  });
+
   return (
     <Box ml={2}>
-      <NumeralDate mb={2} label="inline small" size="small" {...args} />
-      <NumeralDate mb={2} label="inline medium" size="medium" {...args} />
-      <NumeralDate mb={2} label="inline large" size="large" {...args} />
+      <NumeralDate
+        mb={2}
+        label="inline small"
+        size="small"
+        {...args}
+        value={dateValue}
+        onChange={(event) => setDateValue(event.target.value)}
+      />
+      <NumeralDate
+        mb={2}
+        label="inline medium"
+        size="medium"
+        {...args}
+        value={dateValue2}
+        onChange={(event) => setDateValue2(event.target.value)}
+      />
+      <NumeralDate
+        mb={2}
+        label="inline large"
+        size="large"
+        {...args}
+        value={dateValue3}
+        onChange={(event) => setDateValue3(event.target.value)}
+      />
     </Box>
   );
 };

--- a/src/components/numeral-date/numeral-date.mdx
+++ b/src/components/numeral-date/numeral-date.mdx
@@ -34,21 +34,17 @@ import NumeralDate, { NumeralDateProps } from "carbon-react/lib/components/numer
 
 ### With Input Hint
 
-**Note:** The `labelHelp` prop will only render as hint text when the `validationRedesignOptIn` feature flag on an ancestor [CarbonProvider](../?path=/docs/carbon-provider--docs) is *true*, 
+**Note:** The `labelHelp` prop will only render as hint text when the `validationRedesignOptIn` feature flag on an ancestor [CarbonProvider](../?path=/docs/carbon-provider--docs) is *true*,
 otherwise it will render as a Help tooltip (see the [With labelHelp (legacy)](#with-labelhelp-legacy) example).
 
 <Canvas of={NumeralDateStories.WithInputHint} />
-
-### Controlled
-
-<Canvas of={NumeralDateStories.Controlled} />
 
 ### Allowed date formats
 
 <Canvas of={NumeralDateStories.AllowedDateFormats} />
 
 ### Validating date values
-`NumeralDate` has both error and warning states, which can be set via the `error` and `warning` props respectively. However, `NumeralDate` also has a built-in feature to validate date values automatically, so you don't have to recreate this logic yourself. 
+`NumeralDate` has both error and warning states, which can be set via the `error` and `warning` props respectively. However, `NumeralDate` also has a built-in feature to validate date values automatically, so you don't have to recreate this logic yourself.
 This can be enabled via the `enableInternalError` and `enableInternalWarning` props. The rendered messages are displayed alongside the messages defined with the regular `error` and `warning` props.
 
 This in-built validation feature uses translation keys for the invalid date messages, so you can modify them to suit your localisation needs. The keys are `numeralDate.validation.day`, `numeralDate.validation.month`, and `numeralDate.validation.year`.
@@ -83,7 +79,7 @@ It is possible to focus the `NumeralDate` component programmatically by passing 
 
 ### With labelInline (legacy)
 
-Use the `labelInline` prop to display the label on the same horizontal row as the input. You can adjust its appearance using the `labelWidth` and 
+Use the `labelInline` prop to display the label on the same horizontal row as the input. You can adjust its appearance using the `labelWidth` and
 `labelAlign` props to control the width and text alignment of the label and the `inputWidth` prop to control the width of the input.
 
 **Note:** This is a legacy feature and will only render if the `validationRedesignOptIn` feature flag on an ancestor [CarbonProvider](../?path=/docs/carbon-provider--docs) is *false*.

--- a/src/components/numeral-date/numeral-date.pw.tsx
+++ b/src/components/numeral-date/numeral-date.pw.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { test, expect } from "../../../playwright/helpers/base-test";
 
-import NumeralDate, { NumeralDateProps } from ".";
+import { NumeralDateProps } from ".";
 import {
   NumeralDateComponent,
   NumeralDateControlled,
@@ -242,26 +242,13 @@ test.describe("NumeralDate component", () => {
     mount,
     page,
   }) => {
-    await mount(<NumeralDateComponent />);
+    await mount(<NumeralDateControlled />);
 
     const inputValue = "15";
     const input = numeralDateInput(page, 0);
     await input.fill(inputValue);
 
     await expect(input).toHaveValue(inputValue);
-  });
-
-  test("should render NumeralDate with defaultValue prop", async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <NumeralDate defaultValue={{ dd: "10", mm: "12", yyyy: "2022" }} />,
-    );
-
-    await expect(numeralDateInput(page, 0)).toHaveValue("10");
-    await expect(numeralDateInput(page, 1)).toHaveValue("12");
-    await expect(numeralDateInput(page, 2)).toHaveValue("2022");
   });
 
   (
@@ -275,7 +262,7 @@ test.describe("NumeralDate component", () => {
       mount,
       page,
     }) => {
-      await mount(<NumeralDateComponent enableInternalError />);
+      await mount(<NumeralDateControlled enableInternalError />);
 
       const errorInput = "55";
 
@@ -297,9 +284,9 @@ test.describe("NumeralDate component", () => {
       page,
     }) => {
       await mount(
-        <NumeralDateComponent
+        <NumeralDateControlled
           enableInternalError
-          value={{ dd: "", mm: month, yyyy: year }}
+          initialValue={{ dd: "", mm: month, yyyy: year }}
         />,
       );
 
@@ -321,9 +308,9 @@ test.describe("NumeralDate component", () => {
       page,
     }) => {
       await mount(
-        <NumeralDateComponent
+        <NumeralDateControlled
           enableInternalWarning
-          value={{ dd: "", mm: month, yyyy: year }}
+          initialValue={{ dd: "", mm: month, yyyy: year }}
         />,
       );
 
@@ -345,9 +332,9 @@ test.describe("NumeralDate component", () => {
       page,
     }) => {
       await mount<HooksConfig>(
-        <NumeralDateComponent
+        <NumeralDateControlled
           enableInternalError
-          value={{ dd: "", mm: month, yyyy: year }}
+          initialValue={{ dd: "", mm: month, yyyy: year }}
         />,
         { hooksConfig: { validationRedesignOptIn: true } },
       );
@@ -367,9 +354,9 @@ test.describe("NumeralDate component", () => {
       page,
     }) => {
       await mount<HooksConfig>(
-        <NumeralDateComponent
+        <NumeralDateControlled
           enableInternalWarning
-          value={{ dd: "", mm: month, yyyy: year }}
+          initialValue={{ dd: "", mm: month, yyyy: year }}
         />,
         { hooksConfig: { validationRedesignOptIn: true } },
       );
@@ -394,7 +381,7 @@ test.describe("NumeralDate component", () => {
       mount,
       page,
     }) => {
-      await mount(<NumeralDateComponent enableInternalWarning />);
+      await mount(<NumeralDateControlled enableInternalWarning />);
 
       const warningInput = "55";
 

--- a/src/components/numeral-date/numeral-date.stories.tsx
+++ b/src/components/numeral-date/numeral-date.stories.tsx
@@ -17,15 +17,24 @@ const meta: Meta<typeof NumeralDate> = {
   argTypes: {
     ...styledSystemProps,
   },
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof NumeralDate>;
 
 export const Default: Story = () => {
+  const [value, setValue] = useState<NumeralDateProps["value"]>({
+    dd: "01",
+    mm: "02",
+    yyyy: "2020",
+  });
   return (
     <NumeralDate
-      defaultValue={{ dd: "01", mm: "02", yyyy: "2020" }}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
       label="Default"
     />
   );
@@ -33,15 +42,6 @@ export const Default: Story = () => {
 Default.storyName = "Default";
 
 export const WithInputHint: Story = () => {
-  return (
-    <CarbonProvider validationRedesignOptIn>
-      <NumeralDate label="With label help" labelHelp="Label help" />
-    </CarbonProvider>
-  );
-};
-WithInputHint.storyName = "With Input Hint";
-
-export const Controlled: Story = () => {
   const [value, setValue] = useState<NumeralDateProps["value"]>({
     dd: "",
     mm: "",
@@ -49,32 +49,74 @@ export const Controlled: Story = () => {
   });
 
   return (
-    <NumeralDate
-      onChange={(e) => setValue(e.target.value)}
-      label="Default"
-      value={value}
-    />
+    <CarbonProvider validationRedesignOptIn>
+      <NumeralDate
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        label="With label help"
+        labelHelp="Label help"
+      />
+    </CarbonProvider>
   );
 };
-Controlled.storyName = "Controlled";
+WithInputHint.storyName = "With Input Hint";
 
 export const AllowedDateFormats: Story = () => {
+  const dateDefault = {
+    dd: "",
+    mm: "",
+    yyyy: "",
+  };
+  const [value, setValue] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value2, setValue2] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value3, setValue3] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value4, setValue4] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value5, setValue5] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value6, setValue6] = useState<NumeralDateProps["value"]>(dateDefault);
+
   return (
     <>
-      <NumeralDate label="DD/MM/YYYY - default" mb={2} />
+      <NumeralDate
+        label="DD/MM/YYYY - default"
+        mb={2}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
       <NumeralDate
         label="MM/DD/YYYY"
         dateFormat={["mm", "dd", "yyyy"]}
         mb={2}
+        value={value2}
+        onChange={(e) => setValue2(e.target.value)}
       />
       <NumeralDate
         label="YYYY/MM/DD"
         dateFormat={["yyyy", "mm", "dd"]}
         mb={2}
+        value={value3}
+        onChange={(e) => setValue3(e.target.value)}
       />
-      <NumeralDate label="DD/MM" dateFormat={["dd", "mm"]} mb={2} />
-      <NumeralDate label="MM/DD" dateFormat={["mm", "dd"]} mb={2} />
-      <NumeralDate label="MM/YYYY" dateFormat={["mm", "yyyy"]} mb={2} />
+      <NumeralDate
+        label="DD/MM"
+        dateFormat={["dd", "mm"]}
+        mb={2}
+        value={value4}
+        onChange={(e) => setValue4(e.target.value)}
+      />
+      <NumeralDate
+        label="MM/DD"
+        dateFormat={["mm", "dd"]}
+        mb={2}
+        value={value5}
+        onChange={(e) => setValue5(e.target.value)}
+      />
+      <NumeralDate
+        label="MM/YYYY"
+        dateFormat={["mm", "yyyy"]}
+        mb={2}
+        value={value6}
+        onChange={(e) => setValue6(e.target.value)}
+      />
     </>
   );
 };
@@ -224,6 +266,15 @@ export const WithFieldHelp: Story = () => {
 WithFieldHelp.storyName = "With Field Help";
 
 export const Size: Story = () => {
+  const dateDefault = {
+    dd: "",
+    mm: "",
+    yyyy: "",
+  };
+  const [value, setValue] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value2, setValue2] = useState<NumeralDateProps["value"]>(dateDefault);
+  const [value3, setValue3] = useState<NumeralDateProps["value"]>(dateDefault);
+
   return (
     <>
       <NumeralDate
@@ -231,17 +282,23 @@ export const Size: Story = () => {
         dateFormat={["dd", "mm", "yyyy"]}
         size="small"
         mb={2}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
       />
       <NumeralDate
         label="Date of Birth"
         dateFormat={["dd", "mm", "yyyy"]}
         size="medium"
         mb={2}
+        value={value2}
+        onChange={(e) => setValue2(e.target.value)}
       />
       <NumeralDate
         label="Date of Birth"
         dateFormat={["dd", "mm", "yyyy"]}
         size="large"
+        value={value3}
+        onChange={(e) => setValue3(e.target.value)}
       />
     </>
   );

--- a/src/components/password/components.test-pw.tsx
+++ b/src/components/password/components.test-pw.tsx
@@ -6,7 +6,10 @@ import CarbonProvider from "../carbon-provider/carbon-provider.component";
 export const SIZES = ["small", "medium", "large"] as const;
 export const VALIDATIONS = ["error", "warning", "info"] as const;
 
-export const PasswordComponent = ({ onChange, ...props }: PasswordProps) => {
+export const PasswordComponent = ({
+  onChange,
+  ...props
+}: Omit<PasswordProps, "value">) => {
   const [state, setState] = useState("test");
   const setValue = (ev: React.ChangeEvent<HTMLInputElement>) => {
     setState(ev.target.value);
@@ -31,6 +34,7 @@ export const PasswordValidationsAsAStringWithTooltipDefault = () => {
             {...{ [validationType]: "Message" }}
             mb={2}
             tooltipPosition="bottom"
+            onChange={() => {}}
           />
         </div>
       ))}
@@ -48,6 +52,7 @@ export const PasswordValidationsAsABoolean = () => {
             value="Password"
             {...{ [validationType]: true }}
             mb={2}
+            onChange={() => {}}
           />
           <Password
             label="Password - readOnly"
@@ -55,6 +60,7 @@ export const PasswordValidationsAsABoolean = () => {
             readOnly
             {...{ [validationType]: true }}
             mb={2}
+            onChange={() => {}}
           />
         </div>
       ))}
@@ -72,6 +78,7 @@ export const PasswordValidationsAsAString = () => {
             value="Password"
             {...{ [validationType]: "Message" }}
             mb={2}
+            onChange={() => {}}
           />
           <Password
             label="Password - readOnly"
@@ -79,6 +86,7 @@ export const PasswordValidationsAsAString = () => {
             readOnly
             {...{ [validationType]: "Message" }}
             mb={2}
+            onChange={() => {}}
           />
         </div>
       ))}
@@ -97,6 +105,7 @@ export const PasswordValidationsAsAStringWithTooltipCustom = () => {
             {...{ [validationType]: "Message" }}
             mb={2}
             tooltipPosition="bottom"
+            onChange={() => {}}
           />
         </div>
       ))}
@@ -115,6 +124,7 @@ export const PasswordValidationsAsAStringDisplayedOnLabel = () => {
             validationOnLabel
             {...{ [validationType]: "Message" }}
             mb={2}
+            onChange={() => {}}
           />
           <Password
             label="Password - readOnly"
@@ -123,6 +133,7 @@ export const PasswordValidationsAsAStringDisplayedOnLabel = () => {
             readOnly
             {...{ [validationType]: "Message" }}
             mb={2}
+            onChange={() => {}}
           />
         </div>
       ))}
@@ -136,11 +147,12 @@ export const PasswordNewDesignsValidation = () => {
       <CarbonProvider validationRedesignOptIn>
         {(["error", "warning"] as const).map((validationType) =>
           SIZES.map((size) => (
-            <div style={{ width: "296px" }} key={`${validationType}-${size}`}>
+            <Box width="296px" key={`${validationType}-${size}`}>
               <Password
                 m={4}
                 label={`${size} - ${validationType}`}
-                defaultValue="Password"
+                value="Password"
+                onChange={() => {}}
                 labelHelp="Hint text (optional)"
                 size={size}
                 {...{ [validationType]: "Message" }}
@@ -148,13 +160,14 @@ export const PasswordNewDesignsValidation = () => {
               <Password
                 m={4}
                 label={`readOnly - ${size} - ${validationType}`}
-                defaultValue="Password"
+                value="Password"
+                onChange={() => {}}
                 size={size}
                 labelHelp="Hint text (optional)"
                 readOnly
                 {...{ [validationType]: "Message" }}
               />
-            </div>
+            </Box>
           )),
         )}
       </CarbonProvider>

--- a/src/components/password/password-test.stories.tsx
+++ b/src/components/password/password-test.stories.tsx
@@ -93,7 +93,7 @@ export const Default = (props: PasswordProps) => {
   };
 
   return (
-    <Password label="Password" value={state} onChange={setValue} {...props} />
+    <Password label="Password" {...props} value={state} onChange={setValue} />
   );
 };
 

--- a/src/components/password/password.pw.tsx
+++ b/src/components/password/password.pw.tsx
@@ -38,13 +38,13 @@ test.describe("Prop checks for Password component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
 
     await expect(passwordInput(page)).toHaveAttribute("type", "password");
   });
 
   test("should render with 'forceObscurity' prop", async ({ mount, page }) => {
-    await mount(<PasswordComponent forceObscurity />);
+    await mount(<PasswordComponent forceObscurity onChange={() => {}} />);
 
     await expect(passwordInput(page)).toHaveAttribute("type", "password");
   });
@@ -53,14 +53,14 @@ test.describe("Prop checks for Password component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
 
     await buttonMinorComponent(page).click();
     await expect(passwordInput(page)).toHaveAttribute("type", "text");
   });
 
   test("should render with autoComplete 'off'", async ({ mount, page }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
 
     await expect(passwordInput(page)).toHaveAttribute("autoComplete", "off");
   });
@@ -71,7 +71,7 @@ test.describe("Disabled checks", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent disabled />);
+    await mount(<PasswordComponent disabled onChange={() => {}} />);
 
     await expect(passwordInput(page)).toBeDisabled();
   });
@@ -80,7 +80,7 @@ test.describe("Disabled checks", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent disabled />);
+    await mount(<PasswordComponent disabled onChange={() => {}} />);
 
     await expect(buttonMinorComponent(page)).toBeDisabled();
   });
@@ -89,7 +89,7 @@ test.describe("Disabled checks", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent forceObscurity />);
+    await mount(<PasswordComponent forceObscurity onChange={() => {}} />);
 
     await expect(buttonMinorComponent(page)).toBeDisabled();
   });
@@ -101,7 +101,7 @@ test.describe("Prop checks for ButtonMinor component", () => {
     page,
   }) => {
     const id = "foo";
-    await mount(<PasswordComponent id={id} />);
+    await mount(<PasswordComponent id={id} onChange={() => {}} />);
 
     await expect(buttonMinorComponent(page)).toHaveAttribute(
       "aria-controls",
@@ -113,7 +113,7 @@ test.describe("Prop checks for ButtonMinor component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
 
     await expect(icon(page)).toHaveAttribute("type", "view");
   });
@@ -122,7 +122,7 @@ test.describe("Prop checks for ButtonMinor component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
 
     await icon(page).click();
     await expect(icon(page)).toHaveAttribute("type", "hide");
@@ -132,7 +132,7 @@ test.describe("Prop checks for ButtonMinor component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
 
     await expect(icon(page)).toHaveCSS("margin-right", "8px");
   });
@@ -141,7 +141,7 @@ test.describe("Prop checks for ButtonMinor component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
 
     await expect(buttonMinorComponent(page)).toHaveCSS("min-height", "32px");
   });
@@ -150,7 +150,7 @@ test.describe("Prop checks for ButtonMinor component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
 
     await expect(buttonMinorComponent(page)).toHaveText("Show");
   });
@@ -159,7 +159,7 @@ test.describe("Prop checks for ButtonMinor component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
 
     await buttonMinorComponent(page).click();
     await expect(buttonMinorComponent(page)).toHaveText("Hide");
@@ -169,7 +169,7 @@ test.describe("Prop checks for ButtonMinor component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
 
     await expect(buttonMinorComponent(page)).toHaveAttribute(
       "aria-label",
@@ -181,7 +181,7 @@ test.describe("Prop checks for ButtonMinor component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
 
     await buttonMinorComponent(page).click();
 
@@ -195,7 +195,7 @@ test.describe("Prop checks for ButtonMinor component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
 
     await expect(buttonMinorComponent(page)).toBeVisible();
     await expect(buttonMinorComponent(page)).toHaveCSS(
@@ -223,7 +223,7 @@ test.describe("Prop checks for ButtonMinor component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
     await buttonMinorComponent(page).hover();
 
     await expect(buttonMinorComponent(page)).toBeVisible();
@@ -252,7 +252,7 @@ test.describe("Prop checks for ButtonMinor component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
 
     await expect(icon(page)).toBeVisible();
     await expect(icon(page)).toHaveCSS("color", colorsUtilityMajor300);
@@ -268,7 +268,7 @@ test.describe("Prop checks for ButtonMinor component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
     await buttonMinorComponent(page).hover();
 
     await expect(icon(page)).toBeVisible();
@@ -287,7 +287,7 @@ test.describe("aria-live region checks", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
 
     const hiddenStatus = page.getByRole("status");
     await expect(hiddenStatus).toHaveText("Your password is currently hidden.");
@@ -297,7 +297,7 @@ test.describe("aria-live region checks", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
     await buttonMinorComponent(page).click();
 
     const hiddenStatus = page.getByRole("status");
@@ -310,7 +310,7 @@ test.describe("aria-live region checks", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
     const hiddenStatus = page.getByRole("status");
 
     await expect(hiddenStatus).toBeVisible();
@@ -339,7 +339,7 @@ test.describe("Prop checks for rendered Textbox", () => {
       mount,
       page,
     }) => {
-      await mount(<PasswordComponent size={size} />);
+      await mount(<PasswordComponent size={size} onChange={() => {}} />);
 
       await expect(password(page)).toHaveCSS("min-height", height);
 
@@ -358,7 +358,9 @@ test.describe("Prop checks for rendered Textbox", () => {
       mount,
       page,
     }) => {
-      await mount(<PasswordComponent label={specificValue} />);
+      await mount(
+        <PasswordComponent label={specificValue} onChange={() => {}} />,
+      );
 
       const label = getDataElementByValue(page, "label");
       await expect(label).toHaveText(specificValue);
@@ -370,7 +372,9 @@ test.describe("Prop checks for rendered Textbox", () => {
       mount,
       page,
     }) => {
-      await mount(<PasswordComponent fieldHelp={specificValue} />);
+      await mount(
+        <PasswordComponent fieldHelp={specificValue} onChange={() => {}} />,
+      );
 
       await expect(fieldHelpPreview(page)).toHaveText(specificValue);
     });
@@ -381,7 +385,9 @@ test.describe("Prop checks for rendered Textbox", () => {
       mount,
       page,
     }) => {
-      await mount(<PasswordComponent labelHelp={specificValue} />);
+      await mount(
+        <PasswordComponent labelHelp={specificValue} onChange={() => {}} />,
+      );
 
       await getDataElementByValue(page, "question").hover();
       await expect(tooltipPreview(page)).toHaveText(specificValue);
@@ -389,19 +395,19 @@ test.describe("Prop checks for rendered Textbox", () => {
   });
 
   test("should render with an input icon", async ({ mount, page }) => {
-    await mount(<PasswordComponent inputIcon="add" />);
+    await mount(<PasswordComponent inputIcon="add" onChange={() => {}} />);
 
     await expect(getDataElementByValue(page, "add")).toBeVisible();
   });
 
   test("should render with required prop", async ({ mount, page }) => {
-    await mount(<PasswordComponent required />);
+    await mount(<PasswordComponent required onChange={() => {}} />);
 
     await verifyRequiredAsteriskForLabel(page);
   });
 
   test("should render with autofocus prop", async ({ mount, page }) => {
-    await mount(<PasswordComponent autoFocus />);
+    await mount(<PasswordComponent autoFocus onChange={() => {}} />);
 
     await expect(passwordInput(page)).toBeFocused();
   });
@@ -416,7 +422,13 @@ test.describe("Prop checks for rendered Textbox", () => {
       mount,
       page,
     }) => {
-      await mount(<PasswordComponent labelInline labelAlign={labelAlign} />);
+      await mount(
+        <PasswordComponent
+          labelInline
+          labelAlign={labelAlign}
+          onChange={() => {}}
+        />,
+      );
 
       const labelParent = getDataElementByValue(page, "label").locator("..");
       await expect(labelParent).toHaveCSS("-webkit-box-pack", cssValue);
@@ -428,7 +440,9 @@ test.describe("Prop checks for rendered Textbox", () => {
       mount,
       page,
     }) => {
-      await mount(<PasswordComponent maxWidth={maxWidth} />);
+      await mount(
+        <PasswordComponent maxWidth={maxWidth} onChange={() => {}} />,
+      );
 
       const passwordParent = password(page).locator("..");
       await expect(passwordParent).toHaveCSS("max-width", maxWidth);
@@ -439,7 +453,7 @@ test.describe("Prop checks for rendered Textbox", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
 
     const passwordParent = password(page).locator("..");
     await expect(passwordParent).toHaveCSS("max-width", "100%");
@@ -451,7 +465,7 @@ test.describe("Accessibility tests for Password component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent />);
+    await mount(<PasswordComponent onChange={() => {}} />);
     await checkAccessibility(page);
   });
 
@@ -459,7 +473,7 @@ test.describe("Accessibility tests for Password component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent autoFocus />);
+    await mount(<PasswordComponent autoFocus onChange={() => {}} />);
     await checkAccessibility(page);
   });
 
@@ -467,7 +481,7 @@ test.describe("Accessibility tests for Password component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent characterLimit={5} />);
+    await mount(<PasswordComponent characterLimit={5} onChange={() => {}} />);
     await checkAccessibility(page);
   });
 
@@ -475,7 +489,7 @@ test.describe("Accessibility tests for Password component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent disabled />);
+    await mount(<PasswordComponent disabled onChange={() => {}} />);
     await checkAccessibility(page);
   });
 
@@ -483,7 +497,7 @@ test.describe("Accessibility tests for Password component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent forceObscurity />);
+    await mount(<PasswordComponent forceObscurity onChange={() => {}} />);
     await checkAccessibility(page);
   });
 
@@ -491,7 +505,7 @@ test.describe("Accessibility tests for Password component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent inputHint="foo" />);
+    await mount(<PasswordComponent inputHint="foo" onChange={() => {}} />);
     await checkAccessibility(page);
   });
 
@@ -499,7 +513,7 @@ test.describe("Accessibility tests for Password component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent m={4} />);
+    await mount(<PasswordComponent m={4} onChange={() => {}} />);
     await checkAccessibility(page);
   });
 
@@ -555,7 +569,7 @@ test.describe("Accessibility tests for Password component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent prefix="foo" />);
+    await mount(<PasswordComponent prefix="foo" onChange={() => {}} />);
     await checkAccessibility(page);
   });
 
@@ -563,7 +577,7 @@ test.describe("Accessibility tests for Password component", () => {
     mount,
     page,
   }) => {
-    await mount(<PasswordComponent readOnly />);
+    await mount(<PasswordComponent readOnly onChange={() => {}} />);
     await checkAccessibility(page);
   });
 });
@@ -572,6 +586,6 @@ test("should have the expected border radius styling", async ({
   mount,
   page,
 }) => {
-  await mount(<PasswordComponent />);
+  await mount(<PasswordComponent onChange={() => {}} />);
   await expect(passwordInput(page)).toHaveCSS("border-radius", "4px");
 });

--- a/src/components/password/password.test.tsx
+++ b/src/components/password/password.test.tsx
@@ -10,7 +10,7 @@ jest.mock("../../__internal__/utils/helpers/guid");
 (guid as jest.MockedFunction<typeof guid>).mockImplementation(() => mockedGuid);
 
 test("should render a text input with type 'password'", () => {
-  render(<Password label="password" />);
+  render(<Password label="password" value="" onChange={() => {}} />);
 
   const passwordInput = screen.getByLabelText("password");
   expect(passwordInput).toBeVisible();
@@ -18,7 +18,7 @@ test("should render a text input with type 'password'", () => {
 });
 
 test("should render a `Show password` button", () => {
-  render(<Password />);
+  render(<Password value="" onChange={() => {}} />);
 
   const showPasswordButton = screen.getByRole("button", {
     name: "Show password",
@@ -27,7 +27,7 @@ test("should render a `Show password` button", () => {
 });
 
 test("should change the text input type from 'password' to 'text' when the `Show password` button is clicked", async () => {
-  render(<Password label="password" />);
+  render(<Password label="password" value="" onChange={() => {}} />);
 
   const user = userEvent.setup();
   const showPasswordButton = screen.getByRole("button", {
@@ -40,14 +40,14 @@ test("should change the text input type from 'password' to 'text' when the `Show
 });
 
 test("should render the aria-live region with hidden announcement text", () => {
-  render(<Password />);
+  render(<Password value="" onChange={() => {}} />);
 
   const liveRegion = screen.getByRole("status");
   expect(liveRegion).toHaveTextContent("Your password is currently hidden.");
 });
 
 test("should change the aria-live region announcement text from hidden to shown when the `Show password` button is clicked", async () => {
-  render(<Password />);
+  render(<Password value="" onChange={() => {}} />);
 
   const user = userEvent.setup();
   const showPasswordButton = screen.getByRole("button", {
@@ -62,7 +62,7 @@ test("should change the aria-live region announcement text from hidden to shown 
 });
 
 test("should render the aria-live region as visually hidden but available in the accessibility tree", () => {
-  render(<Password />);
+  render(<Password value="" onChange={() => {}} />);
 
   const liveRegion = screen.getByRole("status");
   expect(liveRegion).toBeInTheDocument();
@@ -78,56 +78,66 @@ test("should render the aria-live region as visually hidden but available in the
 });
 
 test("should render the text input with 'autoComplete' attribute set to 'off'", () => {
-  render(<Password label="password" />);
+  render(<Password label="password" value="" onChange={() => {}} />);
 
   const passwordInput = screen.getByLabelText("password");
   expect(passwordInput).toHaveAttribute("autocomplete", "off");
 });
 
 test("should render the text input as disabled when the `disabled` prop is `true`", () => {
-  render(<Password label="password" disabled />);
+  render(<Password label="password" disabled value="" onChange={() => {}} />);
 
   const passwordInput = screen.getByLabelText("password");
   expect(passwordInput).toBeDisabled();
 });
 
 test("should render the text input with type 'password' when the `forceObscurity` prop is `true`", () => {
-  render(<Password label="password" forceObscurity />);
+  render(
+    <Password label="password" forceObscurity value="" onChange={() => {}} />,
+  );
 
   const passwordInput = screen.getByLabelText("password");
   expect(passwordInput).toHaveAttribute("type", "password");
 });
 
 test("should set the text input's 'id' attribute to the passed `id` prop value", () => {
-  render(<Password label="password" id="1973" />);
+  render(<Password label="password" id="1973" value="" onChange={() => {}} />);
 
   const passwordInput = screen.getByLabelText("password");
   expect(passwordInput).toHaveAttribute("id", "1973");
 });
 
 test("should generate the text input's 'id' attribute via a guid when the `id` prop is not passed", () => {
-  render(<Password label="password" />);
+  render(<Password label="password" value="" onChange={() => {}} />);
 
   const passwordInput = screen.getByLabelText("password");
   expect(passwordInput).toHaveAttribute("id", mockedGuid);
 });
 
 test("should render with provided data- attributes", () => {
-  render(<Password label="password" data-role="bar" data-element="baz" />);
+  render(
+    <Password
+      label="password"
+      data-role="bar"
+      data-element="baz"
+      value=""
+      onChange={() => {}}
+    />,
+  );
 
   expect(screen.getByTestId("bar")).toHaveAttribute("data-element", "baz");
 });
 
 describe("Show/Hide password Button", () => {
   test("should render the `Show password` button icon with type 'view' initially", () => {
-    render(<Password />);
+    render(<Password value="" onChange={() => {}} />);
 
     const icon = screen.getByTestId("icon");
     expect(icon).toHaveAttribute("type", "view");
   });
 
   test("should change the icon type from 'view' to 'hide' when clicked", async () => {
-    render(<Password />);
+    render(<Password value="" onChange={() => {}} />);
 
     const user = userEvent.setup();
     const showPasswordButton = screen.getByRole("button", {
@@ -140,7 +150,7 @@ describe("Show/Hide password Button", () => {
   });
 
   test("should render the `Show Password` button with text 'Show' initially", () => {
-    render(<Password />);
+    render(<Password value="" onChange={() => {}} />);
 
     const showPasswordButton = screen.getByRole("button", {
       name: "Show password",
@@ -149,7 +159,7 @@ describe("Show/Hide password Button", () => {
   });
 
   test("should change the text from 'Show' to 'Hide' when clicked", async () => {
-    render(<Password />);
+    render(<Password value="" onChange={() => {}} />);
 
     const user = userEvent.setup();
     const showPasswordButton = screen.getByRole("button", {
@@ -161,7 +171,7 @@ describe("Show/Hide password Button", () => {
   });
 
   test("should render the `Show password` button with an 'aria-label' of 'Show password' initially", () => {
-    render(<Password />);
+    render(<Password value="" onChange={() => {}} />);
 
     const showPasswordButton = screen.getByRole("button", {
       name: "Show password",
@@ -170,7 +180,7 @@ describe("Show/Hide password Button", () => {
   });
 
   test("should change the 'aria-label' from 'Show password' to 'Hide password' when clicked", async () => {
-    render(<Password />);
+    render(<Password value="" onChange={() => {}} />);
 
     const user = userEvent.setup();
     const showPasswordButton = screen.getByRole("button", {
@@ -182,7 +192,7 @@ describe("Show/Hide password Button", () => {
   });
 
   test("should render the `Show password` button with 'aria-controls' attribute set to the input's 'id'", () => {
-    render(<Password id="1973" />);
+    render(<Password id="1973" value="" onChange={() => {}} />);
 
     const showPasswordButton = screen.getByRole("button", {
       name: "Show password",
@@ -191,7 +201,7 @@ describe("Show/Hide password Button", () => {
   });
 
   test("should render the `Show password` button as disabled when the `disabled` prop is `true`", () => {
-    render(<Password disabled />);
+    render(<Password disabled value="" onChange={() => {}} />);
 
     const showPasswordButton = screen.getByRole("button", {
       name: "Show password",
@@ -200,7 +210,7 @@ describe("Show/Hide password Button", () => {
   });
 
   test("should render the `Show password` button as disabled when the `forceObscurity` prop is `true`", () => {
-    render(<Password forceObscurity />);
+    render(<Password forceObscurity value="" onChange={() => {}} />);
 
     const showPasswordButton = screen.getByRole("button", {
       name: "Show password",

--- a/src/components/popover-container/components.test-pw.tsx
+++ b/src/components/popover-container/components.test-pw.tsx
@@ -53,6 +53,8 @@ export const PopoverContainerComponentCoverButton = (
 };
 
 export const PopoverContainerWithSelect = () => {
+  const [value, setValue] = useState("");
+
   return (
     <Box height="100">
       <PopoverContainer
@@ -60,7 +62,11 @@ export const PopoverContainerWithSelect = () => {
         openButtonAriaLabel="open"
         title="select example"
       >
-        <Select label="my select">
+        <Select
+          label="my select"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        >
           <Option value="red" text="red" />
           <Option value="green" text="green" />
           <Option value="blue" text="blue" />
@@ -162,6 +168,8 @@ export const PopoverContainerFocusOrder = (
 
 export const WithRadioButtons = () => {
   const [open1, setOpen1] = useState(false);
+  const [value, setValue] = useState("1");
+
   return (
     <Box padding="25px" display="inline-flex">
       <PopoverContainer
@@ -177,7 +185,11 @@ export const WithRadioButtons = () => {
         p={0}
       >
         <Box display="flex" justifyContent="space-between" p={2}>
-          <RadioButtonGroup name="bar">
+          <RadioButtonGroup
+            name="bar"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+          >
             <RadioButton value="1" label="radio 1" />
             <RadioButton value="2" label="radio 2" />
           </RadioButtonGroup>

--- a/src/components/popover-container/popover-container-test.stories.tsx
+++ b/src/components/popover-container/popover-container-test.stories.tsx
@@ -68,7 +68,7 @@ export const WithSelect = () => {
         openButtonAriaLabel="open"
         title="select example"
       >
-        <Select label="my select">
+        <Select label="my select" value="red" onChange={() => {}}>
           <Option value="red" text="red" />
           <Option value="green" text="green" />
           <Option value="blue" text="blue" />
@@ -203,10 +203,11 @@ export const InsideMenuWithOpenButton = () => {
           <MenuItem>
             <Search
               key="business-search"
-              defaultValue=""
               variant="dark"
               placeholder="Search all businesses"
               searchWidth="100%"
+              value=""
+              onChange={() => {}}
             />
           </MenuItem>
           <MenuItem href="#">Submenu Item Two</MenuItem>
@@ -255,7 +256,8 @@ export const InsideMenuWithPrimaryOpenButton = () => {
           <MenuItem>
             <Search
               key="business-search"
-              defaultValue=""
+              value=""
+              onChange={() => {}}
               variant="dark"
               placeholder="Search all businesses"
               searchWidth="100%"
@@ -492,7 +494,7 @@ export const WithRadioButtons = () => {
         p={0}
       >
         <Box display="flex" justifyContent="space-between" p={2}>
-          <RadioButtonGroup name="bar">
+          <RadioButtonGroup name="bar" value="1" onChange={() => {}}>
             <RadioButton value="1" label="radio 1" />
             <RadioButton value="2" label="radio 2" />
           </RadioButtonGroup>
@@ -554,7 +556,11 @@ export const WithDateRange = () => {
         </FlatTableHead>
         <FlatTableBody>
           <FlatTableRow>
-            <FlatTableCheckbox ariaLabelledBy="ft-row-1-cell-1 ft-row-1-cell-2 ft-row-1-cell-3" />
+            <FlatTableCheckbox
+              ariaLabelledBy="ft-row-1-cell-1 ft-row-1-cell-2 ft-row-1-cell-3"
+              checked
+              onChange={() => {}}
+            />
             <FlatTableRowHeader id="ft-row-1-cell-1">
               John Doe
             </FlatTableRowHeader>
@@ -562,7 +568,11 @@ export const WithDateRange = () => {
             <FlatTableCell id="ft-row-1-cell-3">Single</FlatTableCell>
           </FlatTableRow>
           <FlatTableRow>
-            <FlatTableCheckbox ariaLabelledBy="ft-row-2-cell-1 ft-row-2-cell-2 ft-row-2-cell-3" />
+            <FlatTableCheckbox
+              ariaLabelledBy="ft-row-2-cell-1 ft-row-2-cell-2 ft-row-2-cell-3"
+              checked
+              onChange={() => {}}
+            />
             <FlatTableRowHeader id="ft-row-2-cell-1">
               Jane Doe
             </FlatTableRowHeader>

--- a/src/components/popover-container/popover-container.stories.tsx
+++ b/src/components/popover-container/popover-container.stories.tsx
@@ -278,7 +278,14 @@ export const Complex: Story = () => {
           <Button ml={2}>Compact</Button>
         </Box>
         <Box mt="4px" mb="4px">
-          <Select name="simple" id="simple" label="color" labelInline>
+          <Select
+            name="simple"
+            id="simple"
+            label="color"
+            labelInline
+            value=""
+            onChange={() => {}}
+          >
             <Option text="Amber" value="1" />
             <Option text="Black" value="2" />
             <Option text="Blue" value="3" />
@@ -294,16 +301,36 @@ export const Complex: Story = () => {
         </Box>
         <DraggableContainer>
           <DraggableItem key="1" id={1}>
-            <Checkbox name="one" label="Draggable Label One" />
+            <Checkbox
+              name="one"
+              label="Draggable Label One"
+              checked
+              onChange={() => {}}
+            />
           </DraggableItem>
           <DraggableItem key="2" id={2}>
-            <Checkbox name="two" label="Draggable Label Two" />
+            <Checkbox
+              name="two"
+              label="Draggable Label Two"
+              checked
+              onChange={() => {}}
+            />
           </DraggableItem>
           <DraggableItem key="3" id={3}>
-            <Checkbox name="three" label="Draggable Label Three" />
+            <Checkbox
+              name="three"
+              label="Draggable Label Three"
+              checked
+              onChange={() => {}}
+            />
           </DraggableItem>
           <DraggableItem key="4" id={4}>
-            <Checkbox name="four" label="Draggable Label Four" />
+            <Checkbox
+              name="four"
+              label="Draggable Label Four"
+              checked
+              onChange={() => {}}
+            />
           </DraggableItem>
         </DraggableContainer>
       </PopoverContainer>
@@ -477,12 +504,12 @@ export const FocusButton = () => {
         stickyFooter
       >
         <Box m={2}>
-          <Textbox label="Textbox" onChange={() => {}} />
-          <Textbox label="Textbox" onChange={() => {}} />
-          <Textbox label="Textbox" onChange={() => {}} />
-          <Textbox label="Textbox" onChange={() => {}} />
-          <Textbox label="Textbox" onChange={() => {}} />
-          <Textbox label="Textbox" onChange={() => {}} />
+          <Textbox label="Textbox" onChange={() => {}} value="" />
+          <Textbox label="Textbox" onChange={() => {}} value="" />
+          <Textbox label="Textbox" onChange={() => {}} value="" />
+          <Textbox label="Textbox" onChange={() => {}} value="" />
+          <Textbox label="Textbox" onChange={() => {}} value="" />
+          <Textbox label="Textbox" onChange={() => {}} value="" />
         </Box>
       </Form>
     </PopoverContainer>

--- a/src/components/popover-container/popover-container.test.tsx
+++ b/src/components/popover-container/popover-container.test.tsx
@@ -599,7 +599,13 @@ describe("closing the popup", () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     render(
       <PopoverContainer onClose={() => {}}>
-        <Select name="colour" id="colour" label="Select colour">
+        <Select
+          name="colour"
+          id="colour"
+          label="Select colour"
+          value="1"
+          onChange={() => {}}
+        >
           <Option text="Amber" value="1" />
           <Option text="Black" value="2" />
         </Select>
@@ -653,7 +659,7 @@ test("when content is navigated via keyboard, the next focusable item should be 
           </Button>
         )}
       >
-        <RadioButtonGroup name="bar">
+        <RadioButtonGroup name="bar" value="1" onChange={() => {}}>
           <RadioButton value="1" label="radio 1" />
           <RadioButton value="2" label="radio 2" />
         </RadioButtonGroup>
@@ -687,7 +693,7 @@ test("when the popover is opened and shift tab key is pressed, the open button s
           </Button>
         )}
       >
-        <RadioButtonGroup name="bar">
+        <RadioButtonGroup name="bar" value="1" onChange={() => {}}>
           <RadioButton value="1" label="radio 1" />
           <RadioButton value="2" label="radio 2" />
         </RadioButtonGroup>

--- a/src/components/radio-button/components.test-pw.tsx
+++ b/src/components/radio-button/components.test-pw.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import Box from "../box";
 import { RadioButtonGroup, RadioButton } from ".";
@@ -6,106 +6,138 @@ import { RadioButtonGroupProps } from "./radio-button-group/radio-button-group.c
 import { RadioButtonProps } from "./radio-button.component";
 import Typography from "../typography";
 
-export const Required = () => (
-  <RadioButtonGroup name="required" legend="Radio group legend" required>
-    <RadioButton id="radio-1" value="radio1" label="Radio Option 1" />
-    <RadioButton id="radio-2" value="radio2" label="Radio Option 2" />
-    <RadioButton id="radio-3" value="radio3" label="Radio Option 3" />
-  </RadioButtonGroup>
-);
+export const Required = () => {
+  const [value, setValue] = useState("radio1");
+  return (
+    <RadioButtonGroup
+      name="required"
+      legend="Radio group legend"
+      required
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
+      <RadioButton id="radio-1" value="radio1" label="Radio Option 1" />
+      <RadioButton id="radio-2" value="radio2" label="Radio Option 2" />
+      <RadioButton id="radio-3" value="radio3" label="Radio Option 3" />
+    </RadioButtonGroup>
+  );
+};
 
-export const WithValidationsOnButtons = () => (
-  <RadioButtonGroup
-    name="validations-on-buttons-group"
-    legend="Radio group legend"
-  >
-    <RadioButton
-      id="validations-on-buttons-radio-1"
-      value="radio1"
-      label="Radio Option 1"
-      error="message"
-      fieldHelp="Some help text for this input."
-    />
-    <RadioButton
-      id="validations-on-buttons-radio-2"
-      value="radio2"
-      label="Radio Option 2"
-      warning="message"
-    />
-    <RadioButton
-      id="validations-on-buttons-radio-3"
-      value="radio3"
-      label="Radio Option 3"
-      info="message"
-    />
-  </RadioButtonGroup>
-);
+export const WithValidationsOnButtons = () => {
+  const [value, setValue] = useState("radio1");
+  return (
+    <RadioButtonGroup
+      name="validations-on-buttons-group"
+      legend="Radio group legend"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
+      <RadioButton
+        id="validations-on-buttons-radio-1"
+        value="radio1"
+        label="Radio Option 1"
+        error="message"
+        fieldHelp="Some help text for this input."
+      />
+      <RadioButton
+        id="validations-on-buttons-radio-2"
+        value="radio2"
+        label="Radio Option 2"
+        warning="message"
+      />
+      <RadioButton
+        id="validations-on-buttons-radio-3"
+        value="radio3"
+        label="Radio Option 3"
+        info="message"
+      />
+    </RadioButtonGroup>
+  );
+};
 
-export const WithValidationsOnRadioGroup = () => (
-  <RadioButtonGroup
-    name="validations-on-group"
-    legend="Radio group legend"
-    error="Error message"
-  >
-    <RadioButton
-      id="validations-on-group-radio-1"
-      value="radio1"
-      label="Radio Option 1"
-    />
-    <RadioButton
-      id="validations-on-group-radio-2"
-      value="radio2"
-      label="Radio Option 2"
-    />
-    <RadioButton
-      id="validations-on-group-radio-3"
-      value="radio3"
-      label="Radio Option 3"
-    />
-  </RadioButtonGroup>
-);
+export const WithValidationsOnRadioGroup = () => {
+  const [value, setValue] = useState("radio1");
+  return (
+    <RadioButtonGroup
+      name="validations-on-group"
+      legend="Radio group legend"
+      error="Error message"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
+      <RadioButton
+        id="validations-on-group-radio-1"
+        value="radio1"
+        label="Radio Option 1"
+      />
+      <RadioButton
+        id="validations-on-group-radio-2"
+        value="radio2"
+        label="Radio Option 2"
+      />
+      <RadioButton
+        id="validations-on-group-radio-3"
+        value="radio3"
+        label="Radio Option 3"
+      />
+    </RadioButtonGroup>
+  );
+};
 
-export const WithTooltipPosition = () => (
-  <RadioButtonGroup name="tooltip-position" legend="Radio group legend">
-    <RadioButton
-      id="radio-1"
-      value="radio1"
-      label="Radio Option 1"
-      error="message"
-      tooltipPosition="right"
-    />
-  </RadioButtonGroup>
-);
+export const WithTooltipPosition = () => {
+  const [value, setValue] = useState("radio1");
+  return (
+    <RadioButtonGroup
+      name="tooltip-position"
+      legend="Radio group legend"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
+      <RadioButton
+        id="radio-1"
+        value="radio1"
+        label="Radio Option 1"
+        error="message"
+        tooltipPosition="right"
+      />
+    </RadioButtonGroup>
+  );
+};
 
-export const WithTooltipPositionOnRadioGroup = () => (
-  <RadioButtonGroup
-    name="validations-on-group-group-tooltip-position-override"
-    legend="Radio group legend"
-    error="Error message"
-    tooltipPosition="top"
-  >
-    <RadioButton
-      id="validations-on-group-radio-1-tooltip-position-override"
-      value="radio1"
-      label="Radio Option 1"
-    />
-    <RadioButton
-      id="validations-on-group-radio-2-tooltip-position-override"
-      value="radio2"
-      label="Radio Option 2"
-    />
-    <RadioButton
-      id="validations-on-group-radio-3-tooltip-position-override"
-      value="radio3"
-      label="Radio Option 3"
-    />
-  </RadioButtonGroup>
-);
+export const WithTooltipPositionOnRadioGroup = () => {
+  const [value, setValue] = useState("radio1");
+  return (
+    <RadioButtonGroup
+      name="validations-on-group-group-tooltip-position-override"
+      legend="Radio group legend"
+      error="Error message"
+      tooltipPosition="top"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
+      <RadioButton
+        id="validations-on-group-radio-1-tooltip-position-override"
+        value="radio1"
+        label="Radio Option 1"
+      />
+      <RadioButton
+        id="validations-on-group-radio-2-tooltip-position-override"
+        value="radio2"
+        label="Radio Option 2"
+      />
+      <RadioButton
+        id="validations-on-group-radio-3-tooltip-position-override"
+        value="radio3"
+        label="Radio Option 3"
+      />
+    </RadioButtonGroup>
+  );
+};
 
 const radioContainerWidth = 400;
 
 export const RadioButtonComponent = (props: Partial<RadioButtonProps>) => {
-  const [isChecked, setIsChecked] = React.useState(false);
+  const [isChecked, setIsChecked] = useState(false);
   return (
     <Box mt="64px" ml="64px" width={radioContainerWidth}>
       <RadioButton
@@ -124,11 +156,14 @@ export const RadioButtonGroupComponent = ({
   children,
   ...props
 }: Partial<RadioButtonGroupProps>) => {
+  const [value, setValue] = useState("radio1");
   return (
     <Box mt="64px" ml="64px">
       <RadioButtonGroup
         name="radiobuttongroup"
         legend="Radio group legend"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
         {...props}
       >
         <RadioButton id="radio-1" value="radio1" label="Yes" />
@@ -142,8 +177,13 @@ export const RadioButtonGroupComponent = ({
 };
 
 export const Default = () => {
+  const [value, setValue] = useState("radio1");
   return (
-    <RadioButtonGroup name="legend-and-labels-group">
+    <RadioButtonGroup
+      name="legend-and-labels-group"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
       <RadioButton id="radio-1" value="radio1" label="Radio Option 1" />
       <RadioButton id="radio-2" value="radio2" label="Radio Option 2" />
       <RadioButton id="radio-3" value="radio3" label="Radio Option 3" />
@@ -152,10 +192,13 @@ export const Default = () => {
 };
 
 export const WithLegendAndLabels = () => {
+  const [value, setValue] = useState("radio1");
   return (
     <RadioButtonGroup
       name="legend-and-labels-group"
       legend="Radio group legend"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
     >
       <RadioButton
         id="radio-1"
@@ -180,8 +223,11 @@ export const WithLegendAndLabels = () => {
 };
 
 export const WithInlineLegend = () => {
+  const [value, setValue] = useState("radio1");
   return (
     <RadioButtonGroup
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
       name="inline-legend-group"
       legend="Radio group legend"
       legendInline
@@ -195,8 +241,11 @@ export const WithInlineLegend = () => {
 };
 
 export const WithLeftMargin = () => {
+  const [value, setValue] = useState("radio1");
   return (
     <RadioButtonGroup
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
       name="left-margin-group"
       legend="Radio group legend"
       ml="20%"
@@ -221,6 +270,7 @@ export const WithLeftMargin = () => {
 };
 
 export const EnableAdaptiveBehaviour = () => {
+  const [value, setValue] = useState("radio1");
   return (
     <RadioButtonGroup
       name="enable-adaptive-behaviour-group"
@@ -228,6 +278,8 @@ export const EnableAdaptiveBehaviour = () => {
       ml="20%"
       adaptiveLegendBreakpoint={960}
       adaptiveSpacingBreakpoint={960}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
     >
       <RadioButton
         id="enable-adaptive-behaviour-radio-1"
@@ -251,11 +303,14 @@ export const EnableAdaptiveBehaviour = () => {
 EnableAdaptiveBehaviour.parameters = { chromatic: { disableSnapshot: true } };
 
 export const DifferentLabelSpacing = () => {
+  const [value, setValue] = useState("radio1");
   return (
     <RadioButtonGroup
       name="different-label-spacing-group"
       legend="Radio group legend"
       labelSpacing={2}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
     >
       <RadioButton
         id="different-label-spacing-radio-1"
@@ -277,8 +332,15 @@ export const DifferentLabelSpacing = () => {
 };
 
 export const InlineRadioButtons = () => {
+  const [value, setValue] = useState("radio1");
   return (
-    <RadioButtonGroup name="inline-group" legend="Radio group legend" inline>
+    <RadioButtonGroup
+      name="inline-group"
+      legend="Radio group legend"
+      inline
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
       <RadioButton id="inline-radio-1" value="radio1" label="Radio Option 1" />
       <RadioButton id="inline-radio-2" value="radio2" label="Radio Option 2" />
       <RadioButton id="inline-radio-3" value="radio3" label="Radio Option 3" />
@@ -287,8 +349,14 @@ export const InlineRadioButtons = () => {
 };
 
 export const ReverseRadioButtons = () => {
+  const [value, setValue] = useState("radio1");
   return (
-    <RadioButtonGroup name="reverse-group" legend="Radio group legend">
+    <RadioButtonGroup
+      name="reverse-group"
+      legend="Radio group legend"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
       <RadioButton
         id="reverse-radio-1"
         value="radio1"
@@ -312,8 +380,14 @@ export const ReverseRadioButtons = () => {
 };
 
 export const DisableRadioButtons = () => {
+  const [value, setValue] = useState("radio1");
   return (
-    <RadioButtonGroup name="disable-group" legend="Radio group legend">
+    <RadioButtonGroup
+      name="disable-group"
+      legend="Radio group legend"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
       <RadioButton
         id="disable-radio-1"
         value="radio1"
@@ -337,8 +411,14 @@ export const DisableRadioButtons = () => {
 };
 
 export const WithFieldHelp = () => {
+  const [value, setValue] = useState("radio1");
   return (
-    <RadioButtonGroup name="field-help-group" legend="Radio group legend">
+    <RadioButtonGroup
+      name="field-help-group"
+      legend="Radio group legend"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
       <RadioButton
         id="field-help-radio-1"
         value="radio1"
@@ -362,8 +442,14 @@ export const WithFieldHelp = () => {
 };
 
 export const WithLargeRadioButtons = () => {
+  const [value, setValue] = useState("radio1");
   return (
-    <RadioButtonGroup name="large-group" legend="Radio group legend">
+    <RadioButtonGroup
+      name="large-group"
+      legend="Radio group legend"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
       <RadioButton
         id="large-radio-1"
         value="radio1"
@@ -390,10 +476,13 @@ export const WithLargeRadioButtons = () => {
 };
 
 export const WithCustomStyledLabels = () => {
+  const [value, setValue] = useState("radio1");
   return (
     <RadioButtonGroup
       name="custom-styled-label-group"
       legend="Radio group legend"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
     >
       <RadioButton
         id="custom-styled-label-radio-1"

--- a/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
+++ b/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
@@ -10,7 +10,6 @@ import useIsAboveBreakpoint from "../../../hooks/__internal__/useIsAboveBreakpoi
 import { filterStyledSystemMarginProps } from "../../../style/utils";
 import { TooltipProvider } from "../../../__internal__/tooltip-provider";
 import { ValidationProps } from "../../../__internal__/validations";
-import Logger from "../../../__internal__/utils/logger";
 import NewValidationContext from "../../carbon-provider/__internal__/new-validation.context";
 import ValidationMessage from "../../../__internal__/validation-message/validation-message.component";
 import Box from "../../box";
@@ -18,8 +17,6 @@ import guid from "../../../__internal__/utils/helpers/guid";
 import useInputAccessibility from "../../../hooks/__internal__/useInputAccessibility";
 import ErrorBorder from "../../textbox/textbox.style";
 import HintText from "../../../__internal__/hint-text";
-
-let deprecateUncontrolledWarnTriggered = false;
 
 export interface RadioButtonGroupProps
   extends ValidationProps,
@@ -60,11 +57,11 @@ export interface RadioButtonGroupProps
   /** Callback fired when each RadioButton is blurred */
   onBlur?: (ev: React.FocusEvent<HTMLInputElement>) => void;
   /** Callback fired when the user selects a RadioButton */
-  onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   /** Flag to configure component as mandatory */
   required?: boolean;
   /** value of the selected RadioButton */
-  value?: string;
+  value: string;
   /** [Legacy] Overrides the default tooltip position */
   tooltipPosition?: "top" | "bottom" | "left" | "right";
   /** Render the ValidationMessage above the RadioButton inputs when validationRedesignOptIn flag is set */
@@ -100,13 +97,6 @@ export const RadioButtonGroup = ({
   const internalId = useRef(guid());
   const uniqueId = id || internalId.current;
   const inputHintId = legendHelp ? `${uniqueId}-hint` : undefined;
-
-  if (!deprecateUncontrolledWarnTriggered && !onChange) {
-    deprecateUncontrolledWarnTriggered = true;
-    Logger.deprecate(
-      "Uncontrolled behaviour in `Radio Button` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-    );
-  }
 
   const marginProps = filterStyledSystemMarginProps(rest);
 

--- a/src/components/radio-button/radio-button-group/radio-button-group.test.tsx
+++ b/src/components/radio-button/radio-button-group/radio-button-group.test.tsx
@@ -3,30 +3,11 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { RadioButton, RadioButtonGroup } from "..";
 import CarbonProvider from "../../carbon-provider";
-import Logger from "../../../__internal__/utils/logger";
 import { mockMatchMedia } from "../../../__spec_helper__/__internal__/test-utils";
-
-test("logs a deprecation warning for uncontrolled behaviour", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-  render(
-    <RadioButtonGroup name="group">
-      <RadioButton value="radio1" label="Radio Button 1" />
-    </RadioButtonGroup>,
-  );
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "Uncontrolled behaviour in `Radio Button` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
-});
 
 test("renders with provided `RadioButton` children", () => {
   render(
-    <RadioButtonGroup name="group" onChange={() => {}}>
+    <RadioButtonGroup name="group" onChange={() => {}} value="radio1">
       <RadioButton value="radio1" label="Radio Button 1" />
     </RadioButtonGroup>,
   );
@@ -38,7 +19,7 @@ test("renders with provided `RadioButton` children", () => {
 
 test("renders with RadioButton and non-`RadioButton` children when passed as an array", () => {
   render(
-    <RadioButtonGroup name="group" onChange={() => {}}>
+    <RadioButtonGroup name="group" onChange={() => {}} value="radio1">
       {[
         <RadioButton key="radio1" value="radio1" label="Radio Button 1" />,
         null,
@@ -60,6 +41,7 @@ test("renders with provided data- attributes", () => {
       data-role="bar"
       data-element="baz"
       onChange={() => {}}
+      value="radio1"
     >
       <RadioButton value="radio1" label="Radio Button 1" />
     </RadioButtonGroup>,
@@ -77,6 +59,7 @@ test("renders fieldset with provided `legend`", () => {
       name="group"
       legend="Radio Group Legend"
       onChange={() => {}}
+      value="radio1"
     >
       <RadioButton value="radio1" label="Radio Button 1" />
     </RadioButtonGroup>,
@@ -106,12 +89,13 @@ test("calls `onChange` when a `RadioButton` child is checked", async () => {
   const user = userEvent.setup();
   const onChange = jest.fn();
   render(
-    <RadioButtonGroup name="group" onChange={onChange}>
+    <RadioButtonGroup name="group" onChange={onChange} value="">
       <RadioButton value="radio1" label="Radio Button 1" />
+      <RadioButton value="radio2" label="Radio Button 2" />
     </RadioButtonGroup>,
   );
 
-  const radioButton = screen.getByRole("radio");
+  const radioButton = screen.getAllByRole("radio")[0];
 
   await user.click(radioButton);
 
@@ -122,7 +106,12 @@ test("calls `onBlur` when a `RadioButton` child is blurred", async () => {
   const user = userEvent.setup();
   const onBlur = jest.fn();
   render(
-    <RadioButtonGroup name="group" onChange={() => {}} onBlur={onBlur}>
+    <RadioButtonGroup
+      name="group"
+      onChange={() => {}}
+      onBlur={onBlur}
+      value="radio1"
+    >
       <RadioButton value="radio1" label="Radio Button 1" />
     </RadioButtonGroup>,
   );
@@ -135,7 +124,7 @@ test("calls `onBlur` when a `RadioButton` child is blurred", async () => {
 
 test("renders required `RadioButton` children when `required` prop is true", () => {
   render(
-    <RadioButtonGroup name="group" required onChange={() => {}}>
+    <RadioButtonGroup name="group" required onChange={() => {}} value="radio1">
       <RadioButton value="radio1" label="Radio Button 1" />
     </RadioButtonGroup>,
   );
@@ -153,6 +142,7 @@ test("renders with inline legend when screen is larger than `adaptiveLegendBreak
       legend="Radio Group Legend"
       adaptiveLegendBreakpoint={450}
       onChange={() => {}}
+      value="radio1"
     >
       <RadioButton value="radio1" label="Radio Button 1" />
     </RadioButtonGroup>,
@@ -171,6 +161,7 @@ test("renders with legend on top when screen is smaller than `adaptiveLegendBrea
       legend="Radio Group Legend"
       adaptiveLegendBreakpoint={450}
       onChange={() => {}}
+      value="radio1"
     >
       <RadioButton value="radio1" label="Radio Button 1" />
     </RadioButtonGroup>,
@@ -189,6 +180,7 @@ test("renders with provided margin-left when screen is larger than `adaptiveSpac
       ml="20%"
       adaptiveSpacingBreakpoint={450}
       onChange={() => {}}
+      value="radio1"
     >
       <RadioButton value="radio1" label="Radio Button 1" />
     </RadioButtonGroup>,
@@ -207,6 +199,7 @@ test("does not render with provided margin-left when screen is smaller than `ada
       ml="20%"
       adaptiveSpacingBreakpoint={450}
       onChange={() => {}}
+      value="radio1"
     >
       <RadioButton value="radio1" label="Radio Button 1" />
     </RadioButtonGroup>,
@@ -226,6 +219,7 @@ describe("when `validationRedesignOptIn` flag is true", () => {
           legend="legend"
           error="Error message"
           onChange={() => {}}
+          value="radio1"
         >
           <RadioButton value="radio1" label="Radio Button 1" />
         </RadioButtonGroup>
@@ -246,6 +240,7 @@ describe("when `validationRedesignOptIn` flag is true", () => {
           legend="legend"
           warning="Warning message"
           onChange={() => {}}
+          value="radio1"
         >
           <RadioButton value="radio1" label="Radio Button 1" />
         </RadioButtonGroup>
@@ -266,6 +261,7 @@ describe("when `validationRedesignOptIn` flag is true", () => {
           legend="legend"
           legendHelp="Hint message"
           onChange={() => {}}
+          value="radio1"
         >
           <RadioButton value="radio1" label="Radio Button 1" />
         </RadioButtonGroup>
@@ -291,6 +287,7 @@ describe("when `validationRedesignOptIn` flag is true", () => {
           error="Error message"
           inline
           onChange={() => {}}
+          value="radio1"
         >
           <RadioButton value="radio1" label="Radio Button 1" />
         </RadioButtonGroup>
@@ -307,7 +304,7 @@ describe("when `validationRedesignOptIn` flag is true", () => {
   it("renders with RadioButton and non-`RadioButton` children when passed as an array", () => {
     render(
       <CarbonProvider validationRedesignOptIn>
-        <RadioButtonGroup name="group" onChange={() => {}}>
+        <RadioButtonGroup name="group" onChange={() => {}} value="radio1">
           {[
             <RadioButton key="radio1" value="radio1" label="Radio Button 1" />,
             null,
@@ -333,6 +330,7 @@ describe("when `validationRedesignOptIn` flag is true", () => {
           error="Error message"
           onChange={() => {}}
           validationMessagePositionTop={false}
+          value="radio1"
         >
           <RadioButton value="radio1" label="Radio Button 1" />
         </RadioButtonGroup>
@@ -357,6 +355,7 @@ describe("when `validationRedesignOptIn` flag is true", () => {
           warning="Warning message"
           onChange={() => {}}
           validationMessagePositionTop={false}
+          value="radio1"
         >
           <RadioButton value="radio1" label="Radio Button 1" />
         </RadioButtonGroup>

--- a/src/components/radio-button/radio-button-test.stories.tsx
+++ b/src/components/radio-button/radio-button-test.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { RadioButtonGroup, RadioButton } from ".";
 import { RadioButtonGroupProps } from "./radio-button-group/radio-button-group.component";
 import CarbonProvider from "../carbon-provider";
@@ -13,6 +13,7 @@ export default {
     chromatic: {
       disableSnapshot: true,
     },
+    themeProvider: { chromatic: { theme: "sage" } },
   },
   argTypes: {
     labelSpacing: {
@@ -30,64 +31,78 @@ export default {
   },
 };
 
-export const WithLabelHelp = ({ ...args }) => (
-  <RadioButtonGroup name="labelHelp" legend="Radio group legend">
-    <RadioButton
-      id="radio-1"
-      value="radio1"
-      label="Radio Option 1"
-      labelHelp="Radio 1"
-      {...args}
-    />
-    <RadioButton
-      id="radio-2"
-      value="radio2"
-      label="Radio Option 2"
-      labelHelp="Radio 2"
-      {...args}
-    />
-    <RadioButton
-      id="radio-3"
-      value="radio3"
-      label="Radio Option 3"
-      labelHelp="Radio 3"
-      {...args}
-    />
-  </RadioButtonGroup>
-);
+export const WithLabelHelp = ({ ...args }) => {
+  const [value, setValue] = useState("");
+
+  return (
+    <RadioButtonGroup
+      name="labelHelp"
+      legend="Radio group legend"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
+      <RadioButton
+        id="radio-1"
+        value="radio1"
+        label="Radio Option 1"
+        labelHelp="Radio 1"
+        {...args}
+      />
+      <RadioButton
+        id="radio-2"
+        value="radio2"
+        label="Radio Option 2"
+        labelHelp="Radio 2"
+        {...args}
+      />
+      <RadioButton
+        id="radio-3"
+        value="radio3"
+        label="Radio Option 3"
+        labelHelp="Radio 3"
+        {...args}
+      />
+    </RadioButtonGroup>
+  );
+};
 WithLabelHelp.storyName = "With labelHelp";
 WithLabelHelp.parameters = {
   chromatic: { disableSnapshot: false },
   themeProvider: { chromatic: { theme: "sage" } },
 };
 
-export const WithValidationsOnButtons = ({ ...args }) => (
-  <RadioButtonGroup
-    name="validations-on-buttons-group"
-    onChange={() => {}}
-    {...args}
-  >
-    <RadioButton
-      id="validations-on-buttons-radio-1"
-      value="radio1"
-      label="Radio Option 1"
-      error="message"
-      fieldHelp="Some help text for this input."
-    />
-    <RadioButton
-      id="validations-on-buttons-radio-2"
-      value="radio2"
-      label="Radio Option 2"
-      warning="message"
-    />
-    <RadioButton
-      id="validations-on-buttons-radio-3"
-      value="radio3"
-      label="Radio Option 3"
-      info="message"
-    />
-  </RadioButtonGroup>
-);
+export const WithValidationsOnButtons = ({ ...args }) => {
+  const [value, setValue] = useState("");
+
+  return (
+    <RadioButtonGroup
+      name="validations-on-buttons-group"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      {...args}
+    >
+      <RadioButton
+        id="validations-on-buttons-radio-1"
+        value="radio1"
+        label="Radio Option 1"
+        error="message"
+        fieldHelp="Some help text for this input."
+      />
+      <RadioButton
+        id="validations-on-buttons-radio-2"
+        value="radio2"
+        label="Radio Option 2"
+        warning="message"
+      />
+      <RadioButton
+        id="validations-on-buttons-radio-3"
+        value="radio3"
+        label="Radio Option 3"
+        info="message"
+      />
+    </RadioButtonGroup>
+  );
+};
 WithValidationsOnButtons.storyName = "Validations on RadioButton";
 WithValidationsOnButtons.args = {
   legend: "Radio group legend",
@@ -100,81 +115,90 @@ WithValidationsOnButtons.parameters = {
   themeProvider: { chromatic: { theme: "sage" } },
 };
 
-export const WithValidationsOnRadioGroup = ({ ...args }) => (
-  <>
-    <RadioButtonGroup
-      name="validations-on-group"
-      onChange={() => {}}
-      error="Error message"
-      mb={2}
-      {...args}
-    >
-      <RadioButton
-        id="validations-on-group-radio-1"
-        value="radio1"
-        label="Radio Option 1"
-      />
-      <RadioButton
-        id="validations-on-group-radio-2"
-        value="radio2"
-        label="Radio Option 2"
-      />
-      <RadioButton
-        id="validations-on-group-radio-3"
-        value="radio3"
-        label="Radio Option 3"
-      />
-    </RadioButtonGroup>
+export const WithValidationsOnRadioGroup = ({ ...args }) => {
+  const [errorValue, setErrorValue] = useState("");
+  const [warningValue, setWarningValue] = useState("");
+  const [infoValue, setInfoValue] = useState("");
 
-    <RadioButtonGroup
-      name="validations-on-group"
-      onChange={() => {}}
-      warning="Warning message"
-      mb={2}
-      {...args}
-    >
-      <RadioButton
-        id="validations-on-group-radio-1"
-        value="radio1"
-        label="Radio Option 1"
-      />
-      <RadioButton
-        id="validations-on-group-radio-2"
-        value="radio2"
-        label="Radio Option 2"
-      />
-      <RadioButton
-        id="validations-on-group-radio-3"
-        value="radio3"
-        label="Radio Option 3"
-      />
-    </RadioButtonGroup>
+  return (
+    <>
+      <RadioButtonGroup
+        name="error-validations-on-group"
+        value={errorValue}
+        onChange={(e) => setErrorValue(e.target.value)}
+        error="Error message"
+        mb={2}
+        {...args}
+      >
+        <RadioButton
+          id="error-validations-on-group-radio-1"
+          value="error-validations-on-group-radio-1"
+          label="Error Radio Option 1"
+        />
+        <RadioButton
+          id="error-validations-on-group-radio-2"
+          value="error-validations-on-group-radio-2"
+          label="Error Radio Option 2"
+        />
+        <RadioButton
+          id="error-validations-on-group-radio-3"
+          value="error-validations-on-group-radio-3"
+          label="Error Radio Option 3"
+        />
+      </RadioButtonGroup>
 
-    <RadioButtonGroup
-      name="validations-on-group"
-      onChange={() => {}}
-      info="Info message"
-      mb={2}
-      {...args}
-    >
-      <RadioButton
-        id="validations-on-group-radio-1"
-        value="radio1"
-        label="Radio Option 1"
-      />
-      <RadioButton
-        id="validations-on-group-radio-2"
-        value="radio2"
-        label="Radio Option 2"
-      />
-      <RadioButton
-        id="validations-on-group-radio-3"
-        value="radio3"
-        label="Radio Option 3"
-      />
-    </RadioButtonGroup>
-  </>
-);
+      <RadioButtonGroup
+        name="warning-validations-on-group"
+        value={warningValue}
+        onChange={(e) => setWarningValue(e.target.value)}
+        warning="Warning message"
+        mb={2}
+        {...args}
+      >
+        <RadioButton
+          id="warning-validations-on-group-radio-1"
+          value="warning-validations-on-group-radio-1"
+          label="Warning Radio Option 1"
+        />
+        <RadioButton
+          id="warning-validations-on-group-radio-2"
+          value="warning-validations-on-group-radio-2"
+          label="Warning Radio Option 2"
+        />
+        <RadioButton
+          id="warning-validations-on-group-radio-3"
+          value="warning-validations-on-group-radio-3"
+          label="Warning Radio Option 3"
+        />
+      </RadioButtonGroup>
+
+      <RadioButtonGroup
+        name="info-validations-on-group"
+        value={infoValue}
+        onChange={(e) => setInfoValue(e.target.value)}
+        info="Info message"
+        mb={2}
+        {...args}
+      >
+        <RadioButton
+          id="info-validations-on-group-radio-1"
+          value="info-validations-on-group-radio-1"
+          label="Info Radio Option 1"
+        />
+        <RadioButton
+          id="info-validations-on-group-radio-2"
+          value="info-validations-on-group-radio-2"
+          label="Info Radio Option 2"
+        />
+        <RadioButton
+          id="info-validations-on-group-radio-3"
+          value="info-validations-on-group-radio-3"
+          label="Info Radio Option 3"
+        />
+      </RadioButtonGroup>
+    </>
+  );
+};
 WithValidationsOnRadioGroup.storyName = "Validations on RadioButtonGroup";
 WithValidationsOnRadioGroup.args = {
   legend: "Radio group legend",
@@ -189,34 +213,59 @@ WithValidationsOnRadioGroup.parameters = {
 };
 
 export const NewValidation = ({ ...props }: Partial<RadioButtonGroupProps>) => {
+  const [errorValueTop, setErrorValueTop] = useState("");
+  const [errorValue, setErrorValue] = useState("");
+  const [warningValueTop, setWarningValueTop] = useState("");
+  const [warningValue, setWarningValue] = useState("");
+
   return (
     <CarbonProvider validationRedesignOptIn>
       <RadioButtonGroup
-        name="radio-button-group-error"
+        name="radio-button-group-error-top"
         error="Error Message"
         mb={2}
+        value={errorValueTop}
+        onChange={(e) => setErrorValueTop(e.target.value)}
         {...props}
       >
-        <RadioButton id="radio-1" value="radio1" label="Yes" />
-        <RadioButton id="radio-2" value="radio2" label="No" />
         <RadioButton
-          id="radio-3"
-          value="radio3"
+          id="error-top-radio-1"
+          value="error-top-radio-1"
+          label="Yes"
+        />
+        <RadioButton
+          id="error-top-radio-2"
+          value="error-top-radio-2"
+          label="No"
+        />
+        <RadioButton
+          id="error-top-radio-3"
+          value="error-top-radio-3"
           label="Maybe"
           fieldHelp="fieldHelp text"
         />
       </RadioButtonGroup>
       <RadioButtonGroup
-        name="radio-button-group-warning"
+        name="radio-button-group-warning-top"
         warning="Warning Message"
         mb={2}
+        value={warningValueTop}
+        onChange={(e) => setWarningValueTop(e.target.value)}
         {...props}
       >
-        <RadioButton id="radio-1" value="radio1" label="Yes" />
-        <RadioButton id="radio-2" value="radio2" label="No" />
         <RadioButton
-          id="radio-3"
-          value="radio3"
+          id="warning-top-radio-1"
+          value="warning-top-radio-1"
+          label="Yes"
+        />
+        <RadioButton
+          id="warning-top-radio-2"
+          value="warning-top-radio-2"
+          label="No"
+        />
+        <RadioButton
+          id="warning-top-radio-3"
+          value="warning-top-radio-3"
           label="Maybe"
           fieldHelp="fieldHelp text"
         />
@@ -226,13 +275,15 @@ export const NewValidation = ({ ...props }: Partial<RadioButtonGroupProps>) => {
         name="radio-button-group-error-bottom"
         error="Error Message"
         mb={2}
+        value={errorValue}
+        onChange={(e) => setErrorValue(e.target.value)}
         {...props}
       >
-        <RadioButton id="radio-1" value="radio1" label="Yes" />
-        <RadioButton id="radio-2" value="radio2" label="No" />
+        <RadioButton id="error-radio-1" value="error-radio-1" label="Yes" />
+        <RadioButton id="error-radio-2" value="error-radio-2" label="No" />
         <RadioButton
-          id="radio-3"
-          value="radio3"
+          id="error-radio-3"
+          value="error-radio-3"
           label="Maybe"
           fieldHelp="fieldHelp text"
         />
@@ -241,13 +292,15 @@ export const NewValidation = ({ ...props }: Partial<RadioButtonGroupProps>) => {
         validationMessagePositionTop={false}
         name="radio-button-group-warning-bottom"
         warning="Warning Message"
+        value={warningValue}
+        onChange={(e) => setWarningValue(e.target.value)}
         {...props}
       >
-        <RadioButton id="radio-1" value="radio1" label="Yes" />
-        <RadioButton id="radio-2" value="radio2" label="No" />
+        <RadioButton id="warning-radio-1" value="warning-radio-1" label="Yes" />
+        <RadioButton id="warning-radio-2" value="warning-radio-2" label="No" />
         <RadioButton
-          id="radio-3"
-          value="radio3"
+          id="warning-radio-3"
+          value="warning-radio-3"
           label="Maybe"
           fieldHelp="fieldHelp text"
         />
@@ -271,53 +324,101 @@ NewValidation.parameters = {
 export const NewValidationInline = ({
   ...props
 }: Partial<RadioButtonGroupProps>) => {
+  const [errorValueTop, setErrorValueTop] = useState("");
+  const [errorValue, setErrorValue] = useState("");
+  const [warningValueTop, setWarningValueTop] = useState("");
+  const [warningValue, setWarningValue] = useState("");
+
   return (
     <CarbonProvider validationRedesignOptIn>
       <RadioButtonGroup
-        name="radio-button-group-error"
+        name="radio-button-group-error-top"
         error="Error Message"
-        inline
         mb={2}
+        inline
+        value={errorValueTop}
+        onChange={(e) => setErrorValueTop(e.target.value)}
         {...props}
       >
-        <RadioButton id="radio-1" value="radio1" label="Yes" />
-        <RadioButton id="radio-2" value="radio2" label="No" />
-        <RadioButton id="radio-3" value="radio3" label="Maybe" />
+        <RadioButton
+          id="error-top-radio-1"
+          value="error-top-radio-1"
+          label="Yes"
+        />
+        <RadioButton
+          id="error-top-radio-2"
+          value="error-top-radio-2"
+          label="No"
+        />
+        <RadioButton
+          id="error-top-radio-3"
+          value="error-top-radio-3"
+          label="Maybe"
+          fieldHelp="fieldHelp text"
+        />
       </RadioButtonGroup>
       <RadioButtonGroup
-        name="radio-button-group-warning"
+        name="radio-button-group-warning-top"
         warning="Warning Message"
-        inline
         mb={2}
+        inline
+        value={warningValueTop}
+        onChange={(e) => setWarningValueTop(e.target.value)}
         {...props}
       >
-        <RadioButton id="radio-1" value="radio1" label="Yes" />
-        <RadioButton id="radio-2" value="radio2" label="No" />
-        <RadioButton id="radio-3" value="radio3" label="Maybe" />
+        <RadioButton
+          id="warning-top-radio-1"
+          value="warning-top-radio-1"
+          label="Yes"
+        />
+        <RadioButton
+          id="warning-top-radio-2"
+          value="warning-top-radio-2"
+          label="No"
+        />
+        <RadioButton
+          id="warning-top-radio-3"
+          value="warning-top-radio-3"
+          label="Maybe"
+          fieldHelp="fieldHelp text"
+        />
       </RadioButtonGroup>
       <RadioButtonGroup
         validationMessagePositionTop={false}
         name="radio-button-group-error-bottom"
         error="Error Message"
-        inline
         mb={2}
+        inline
+        value={errorValue}
+        onChange={(e) => setErrorValue(e.target.value)}
         {...props}
       >
-        <RadioButton id="radio-1" value="radio1" label="Yes" />
-        <RadioButton id="radio-2" value="radio2" label="No" />
-        <RadioButton id="radio-3" value="radio3" label="Maybe" />
+        <RadioButton id="error-radio-1" value="error-radio-1" label="Yes" />
+        <RadioButton id="error-radio-2" value="error-radio-2" label="No" />
+        <RadioButton
+          id="error-radio-3"
+          value="error-radio-3"
+          label="Maybe"
+          fieldHelp="fieldHelp text"
+        />
       </RadioButtonGroup>
       <RadioButtonGroup
         validationMessagePositionTop={false}
         name="radio-button-group-warning-bottom"
         warning="Warning Message"
         inline
-        mb={2}
+        value={warningValue}
+        onChange={(e) => setWarningValue(e.target.value)}
         {...props}
       >
-        <RadioButton id="radio-1" value="radio1" label="Yes" />
-        <RadioButton id="radio-2" value="radio2" label="No" />
-        <RadioButton id="radio-3" value="radio3" label="Maybe" />
+        <RadioButton id="warning-radio-1" value="warning-radio-1" label="Yes" />
+        <RadioButton id="warning-radio-2" value="warning-radio-2" label="No" />
+        <RadioButton
+          id="warning-radio-3"
+          value="warning-radio-3"
+          label="Maybe"
+          fieldHelp="fieldHelp text"
+        />
       </RadioButtonGroup>
     </CarbonProvider>
   );
@@ -328,6 +429,7 @@ NewValidationInline.args = {
   legendHelp: "Legend help text",
   legendAlign: "left",
   required: true,
+  inline: true,
 };
 NewValidationInline.parameters = {
   chromatic: { disableSnapshot: false },
@@ -337,33 +439,40 @@ NewValidationInline.parameters = {
 export const WithLegendAlignment = ({
   ...props
 }: Partial<RadioButtonGroupProps>) => {
+  const [valueLeft, setValueLeft] = useState("");
+  const [valueRight, setValueRight] = useState("");
+
   return (
     <CarbonProvider validationRedesignOptIn>
       <RadioButtonGroup
         name="radio-button-group-left"
+        value={valueLeft}
+        onChange={(e) => setValueLeft(e.target.value)}
         {...props}
         legendAlign="left"
         mb={2}
       >
-        <RadioButton id="radio-1-left" value="radio1" label="Yes" />
-        <RadioButton id="radio-2-left" value="radio2" label="No" />
+        <RadioButton id="radio-1-left" value="radio1-left" label="Yes" />
+        <RadioButton id="radio-2-left" value="radio2-left" label="No" />
         <RadioButton
           id="radio-3-left"
-          value="radio3"
+          value="radio3-left"
           label="RadioButton with a longer label"
           fieldHelp="fieldHelp text"
         />
       </RadioButtonGroup>
       <RadioButtonGroup
         name="radio-button-group-right"
+        value={valueRight}
+        onChange={(e) => setValueRight(e.target.value)}
         {...props}
         legendAlign="right"
       >
-        <RadioButton id="radio-1-right" value="radio1" label="Yes" />
-        <RadioButton id="radio-2-right" value="radio2" label="No" />
+        <RadioButton id="radio-1-right" value="radio1-right" label="Yes" />
+        <RadioButton id="radio-2-right" value="radio2-right" label="No" />
         <RadioButton
           id="radio-3-right"
-          value="radio3"
+          value="radio3-right"
           label="RadioButton with a longer label"
           fieldHelp="fieldHelp text"
         />
@@ -386,6 +495,7 @@ WithLegendAlignment.parameters = {
 };
 
 export const HiddenInlineRadioButtons = () => {
+  const [value, setValue] = useState("");
   const [isCheckboxChecked, setIsCheckboxChecked] = React.useState(false);
   const [isSwitchChecked, setIsSwitchChecked] = React.useState(false);
 
@@ -395,7 +505,12 @@ export const HiddenInlineRadioButtons = () => {
         <Box position="sticky" height="300px" top="0%" bg="black" />
         <Box height="1200px">
           <Box m={2}>
-            <RadioButtonGroup legend="Radio Buttons" name="radio-buttons">
+            <RadioButtonGroup
+              legend="Radio Buttons"
+              name="radio-buttons"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+            >
               <RadioButton id="first" value="1" label="first" size="large" />
               <RadioButton id="second" value="2" label="second" size="large" />
             </RadioButtonGroup>

--- a/src/components/radio-button/radio-button.stories.tsx
+++ b/src/components/radio-button/radio-button.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import generateStyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
@@ -17,14 +17,23 @@ const meta: Meta<typeof RadioButton> = {
   argTypes: {
     ...styledSystemProps,
   },
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof RadioButton>;
 
 export const Default: Story = () => {
+  const [value, setValue] = useState("");
+
   return (
-    <RadioButtonGroup name="legend-and-labels-group">
+    <RadioButtonGroup
+      name="legend-and-labels-group"
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
+    >
       <RadioButton id="radio-1" value="radio1" label="Radio Option 1" />
       <RadioButton id="radio-2" value="radio2" label="Radio Option 2" />
       <RadioButton id="radio-3" value="radio3" label="Radio Option 3" />
@@ -34,7 +43,7 @@ export const Default: Story = () => {
 Default.storyName = "Default";
 
 export const WithLegendAndLabels: Story = () => {
-  const [value, setValue] = React.useState("radio1");
+  const [value, setValue] = React.useState("");
   return (
     <RadioButtonGroup
       name="legend-and-labels-group"
@@ -51,12 +60,15 @@ export const WithLegendAndLabels: Story = () => {
 WithLegendAndLabels.storyName = "With Legend";
 
 export const WithLegendHelp: Story = () => {
+  const [value, setValue] = useState("");
   return (
     <CarbonProvider validationRedesignOptIn>
       <RadioButtonGroup
         name="input-hint-group"
         legend="With legendHelp"
         legendHelp="Legend Help"
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
       >
         <RadioButton id="radio-1" value="radio1" label="Radio Option 1" />
         <RadioButton id="radio-2" value="radio2" label="Radio Option 2" />
@@ -68,12 +80,15 @@ export const WithLegendHelp: Story = () => {
 WithLegendHelp.storyName = "With Legend Help";
 
 export const WithInlineLegend: Story = () => {
+  const [value, setValue] = useState("");
   return (
     <RadioButtonGroup
       name="inline-legend-group"
       legend="Radio group legend"
       legendInline
       legendWidth={10}
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
     >
       <RadioButton id="radio-1" value="radio1" label="Radio Option 1" />
       <RadioButton id="radio-2" value="radio2" label="Radio Option 2" />
@@ -84,6 +99,7 @@ export const WithInlineLegend: Story = () => {
 WithInlineLegend.storyName = "With Inline Legend";
 
 export const EnableAdaptiveBehaviour: Story = () => {
+  const [value, setValue] = useState("");
   return (
     <RadioButtonGroup
       name="enable-adaptive-behaviour-group"
@@ -91,6 +107,8 @@ export const EnableAdaptiveBehaviour: Story = () => {
       ml="20%"
       adaptiveLegendBreakpoint={960}
       adaptiveSpacingBreakpoint={960}
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
     >
       <RadioButton
         id="enable-adaptive-behaviour-radio-1"
@@ -114,11 +132,14 @@ EnableAdaptiveBehaviour.storyName = "Enable Adaptive Behaviour";
 EnableAdaptiveBehaviour.parameters = { chromatic: { disableSnapshot: true } };
 
 export const DifferentLabelSpacing: Story = () => {
+  const [value, setValue] = useState("");
   return (
     <RadioButtonGroup
       name="different-label-spacing-group"
       legend="Radio group legend"
       labelSpacing={2}
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
     >
       <RadioButton
         id="different-label-spacing-radio-1"
@@ -141,8 +162,15 @@ export const DifferentLabelSpacing: Story = () => {
 DifferentLabelSpacing.storyName = "Label Spacing";
 
 export const InlineRadioButtons: Story = () => {
+  const [value, setValue] = useState("");
   return (
-    <RadioButtonGroup name="inline-group" legend="Radio group legend" inline>
+    <RadioButtonGroup
+      name="inline-group"
+      legend="Radio group legend"
+      inline
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
+    >
       <RadioButton id="inline-radio-1" value="radio1" label="Radio Option 1" />
       <RadioButton id="inline-radio-2" value="radio2" label="Radio Option 2" />
       <RadioButton id="inline-radio-3" value="radio3" label="Radio Option 3" />
@@ -152,8 +180,14 @@ export const InlineRadioButtons: Story = () => {
 InlineRadioButtons.storyName = "Inline Radio Buttons";
 
 export const ReverseRadioButtons: Story = () => {
+  const [value, setValue] = useState("");
   return (
-    <RadioButtonGroup name="reverse-group" legend="Radio group legend">
+    <RadioButtonGroup
+      name="reverse-group"
+      legend="Radio group legend"
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
+    >
       <RadioButton
         id="reverse-radio-1"
         value="radio1"
@@ -178,8 +212,14 @@ export const ReverseRadioButtons: Story = () => {
 ReverseRadioButtons.storyName = "Reverse Radio Buttons";
 
 export const DisableRadioButtons: Story = () => {
+  const [value, setValue] = useState("");
   return (
-    <RadioButtonGroup name="disable-group" legend="Radio group legend">
+    <RadioButtonGroup
+      name="disable-group"
+      legend="Radio group legend"
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
+    >
       <RadioButton
         id="disable-radio-1"
         value="radio1"
@@ -204,8 +244,14 @@ export const DisableRadioButtons: Story = () => {
 DisableRadioButtons.storyName = "Disable Radio Buttons";
 
 export const WithFieldHelp: Story = () => {
+  const [value, setValue] = useState("");
   return (
-    <RadioButtonGroup name="field-help-group" legend="Radio group legend">
+    <RadioButtonGroup
+      name="field-help-group"
+      legend="Radio group legend"
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
+    >
       <RadioButton
         id="field-help-radio-1"
         value="radio1"
@@ -230,8 +276,14 @@ export const WithFieldHelp: Story = () => {
 WithFieldHelp.storyName = "With Field Help";
 
 export const WithLargeRadioButtons: Story = () => {
+  const [value, setValue] = useState("");
   return (
-    <RadioButtonGroup name="large-group" legend="Radio group legend">
+    <RadioButtonGroup
+      name="large-group"
+      legend="Radio group legend"
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
+    >
       <RadioButton
         id="large-radio-1"
         value="radio1"
@@ -259,10 +311,13 @@ export const WithLargeRadioButtons: Story = () => {
 WithLargeRadioButtons.storyName = "With Large Radio Buttons";
 
 export const WithCustomStyledLabels: Story = () => {
+  const [value, setValue] = useState("");
   return (
     <RadioButtonGroup
       name="custom-styled-label-group"
       legend="Radio group legend"
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
     >
       <RadioButton
         id="custom-styled-label-radio-1"
@@ -302,11 +357,20 @@ export const WithCustomStyledLabels: Story = () => {
 };
 WithCustomStyledLabels.storyName = "With Custom Styled Labels";
 
-export const Required: Story = () => (
-  <RadioButtonGroup name="radio-group-required" required legend="Required">
-    <RadioButton id="radio-1" value="radio1" label="Radio Option 1" />
-    <RadioButton id="radio-2" value="radio2" label="Radio Option 2" />
-    <RadioButton id="radio-3" value="radio3" label="Radio Option 3" />
-  </RadioButtonGroup>
-);
+export const Required: Story = () => {
+  const [value, setValue] = useState("");
+  return (
+    <RadioButtonGroup
+      name="radio-group-required"
+      required
+      legend="Required"
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
+    >
+      <RadioButton id="radio-1" value="radio1" label="Radio Option 1" />
+      <RadioButton id="radio-2" value="radio2" label="Radio Option 2" />
+      <RadioButton id="radio-3" value="radio3" label="Radio Option 3" />
+    </RadioButtonGroup>
+  );
+};
 Required.storyName = "Required";

--- a/src/components/search/components.test-pw.tsx
+++ b/src/components/search/components.test-pw.tsx
@@ -2,20 +2,23 @@ import React from "react";
 import Search, { SearchProps } from ".";
 import Box from "../box";
 
-// eslint-disable-next-line import/prefer-default-export
-export const SearchComponent = (props: SearchProps) => {
-  const [value, setValue] = React.useState("");
+export const SearchComponent = (
+  props: Partial<SearchProps> & { value?: string },
+) => {
+  const [internalValue, setInternalValue] = React.useState(props.value ?? "");
   return (
     <Search
       placeholder="Search..."
-      onChange={(e) => setValue(e.target.value)}
-      value={value}
+      onChange={(e) => setInternalValue(e.target.value)}
+      value={internalValue}
       {...props}
     />
   );
 };
 
-export const SearchComponentLightBackground = (props: SearchProps) => {
+export const SearchComponentLightBackground = (
+  props: Omit<SearchProps, "onChange" | "value">,
+) => {
   const [value, setValue] = React.useState("");
   return (
     <Box width="700px" height="108px" bg="#FFFFFF">
@@ -30,7 +33,9 @@ export const SearchComponentLightBackground = (props: SearchProps) => {
   );
 };
 
-export const SearchComponentDarkBackground = (props: SearchProps) => {
+export const SearchComponentDarkBackground = (
+  props: Omit<SearchProps, "onChange" | "value">,
+) => {
   const [value, setValue] = React.useState("");
   return (
     <Box width="700px" height="108px" bg="#003349">

--- a/src/components/search/search-test.stories.tsx
+++ b/src/components/search/search-test.stories.tsx
@@ -11,6 +11,7 @@ export default {
     chromatic: {
       disableSnapshot: true,
     },
+    themeProvider: { chromatic: { theme: "sage" } },
   },
   argTypes: {
     variant: {
@@ -103,15 +104,57 @@ export const FilterOnClear = () => {
 FilterOnClear.storyName = "Filter on clear";
 
 export const Validation = () => {
+  const [state, setState] = useState("");
+  const [state2, setState2] = useState("");
+  const [state3, setState3] = useState("");
+  const [state4, setState4] = useState("");
+  const [state5, setState5] = useState("");
+  const [state6, setState6] = useState("");
+
   return (
     <>
-      <Search defaultValue="" searchButton error="Error Message" mb={2} />
-      <Search defaultValue="" searchButton warning="Warning Message" mb={2} />
-      <Search defaultValue="" searchButton info="Info Message" mb={2} />
+      <Search
+        onChange={(ev) => setState(ev.target.value)}
+        value={state}
+        searchButton
+        error="Error Message"
+        mb={2}
+      />
+      <Search
+        onChange={(ev) => setState2(ev.target.value)}
+        value={state2}
+        searchButton
+        warning="Warning Message"
+        mb={2}
+      />
+      <Search
+        onChange={(ev) => setState3(ev.target.value)}
+        value={state3}
+        searchButton
+        info="Info Message"
+        mb={2}
+      />
 
-      <Search defaultValue="" searchButton error mb={2} />
-      <Search defaultValue="" searchButton warning mb={2} />
-      <Search defaultValue="" searchButton info />
+      <Search
+        onChange={(ev) => setState4(ev.target.value)}
+        value={state4}
+        searchButton
+        error
+        mb={2}
+      />
+      <Search
+        onChange={(ev) => setState5(ev.target.value)}
+        value={state5}
+        searchButton
+        warning
+        mb={2}
+      />
+      <Search
+        onChange={(ev) => setState6(ev.target.value)}
+        value={state6}
+        searchButton
+        info
+      />
     </>
   );
 };

--- a/src/components/search/search.mdx
+++ b/src/components/search/search.mdx
@@ -37,13 +37,9 @@ import Search from "carbon-react/lib/components/search";
 
 <Canvas of={SearchStories.Default} />
 
-### Controlled
-
-<Canvas of={SearchStories.Controlled} />
-
 ### With Search Button
 
-You can pass the `searchButton` prop to render a search button. 
+You can pass the `searchButton` prop to render a search button.
 This will render a button with the text "Search" and an aria-label of "search button".
 To override the the default aria-label, you can pass a string value to the `searchButtonAriaLabel` prop.
 
@@ -54,7 +50,7 @@ You can override the text of the search button by passing a string value to the 
 
 <Canvas of={SearchStories.WithSearchButtonPropTextOverride} />
 
-Or, by using the locale provider to override the button's text via the `searchButtonText` translation key. 
+Or, by using the locale provider to override the button's text via the `searchButtonText` translation key.
 Please note that the `searchButton` prop will take precedence over the locale value.
 
 <Canvas of={SearchStories.WithSearchButtonLocaleOverride} />
@@ -79,7 +75,7 @@ The search component can be styled to render on dark backgrounds by passing the 
 
 ### Trigger actions on clear
 
-It is possible to trigger actions such as filtering the search results when the cross icon is clicked. 
+It is possible to trigger actions such as filtering the search results when the cross icon is clicked.
 When the `triggerOnClear` prop is set to `true`, the `onClick` callback will be called when the cross icon is clicked.
 
 <Canvas of={SearchStories.TriggerOnClear} />

--- a/src/components/search/search.pw.tsx
+++ b/src/components/search/search.pw.tsx
@@ -23,7 +23,7 @@ import {
   SearchComponentDarkBackground,
   SearchComponentLightBackground,
 } from "./components.test-pw";
-import Search, { SearchProps } from "./search.component";
+import { SearchProps } from "./search.component";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 const testDataStandard = CHARACTERS.STANDARD;
@@ -91,20 +91,6 @@ test.describe("Prop tests for Search component", () => {
     });
   });
 
-  test("should render Search with defaultValue prop", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<Search defaultValue={testDataStandard} />);
-
-    const searchDefaultInputElement = searchDefaultInput(page);
-
-    await expect(searchDefaultInputElement).toHaveAttribute(
-      "value",
-      testDataStandard,
-    );
-  });
-
   test("should render Search with value prop", async ({ mount, page }) => {
     await mount(<SearchComponent value={testDataStandard} />);
 
@@ -169,12 +155,7 @@ test.describe("Prop tests for Search component", () => {
       mount,
       page,
     }) => {
-      await mount(
-        <Search
-          searchButton={searchButtonBool}
-          defaultValue={testDataStandard}
-        />,
-      );
+      await mount(<SearchComponent searchButton={searchButtonBool} />);
 
       const searchFindIconElement = searchIcon(page);
 
@@ -190,7 +171,7 @@ test.describe("Prop tests for Search component", () => {
     mount,
     page,
   }) => {
-    await mount(<Search searchButton="foo" defaultValue={testDataStandard} />);
+    await mount(<SearchComponent searchButton="foo" />);
 
     await expect(page.getByText("foo")).toBeVisible();
   });
@@ -278,14 +259,9 @@ test.describe("Prop tests for Search component", () => {
   }) => {
     await mount(
       <Box width="700px" height="108px">
-        <div
-          style={{
-            padding: "32px",
-            backgroundColor: "#003349",
-          }}
-        >
+        <Box p={4} backgroundColor="#003349">
           <SearchComponent variant={variant} />
-        </div>
+        </Box>
       </Box>,
     );
 
@@ -310,14 +286,9 @@ test.describe("Prop tests for Search component", () => {
   }) => {
     await mount(
       <Box width="700px" height="108px">
-        <div
-          style={{
-            padding: "32px",
-            backgroundColor: "#003349",
-          }}
-        >
+        <Box p={4} backgroundColor="#003349">
           <SearchComponent variant={variant} />
-        </div>
+        </Box>
       </Box>,
     );
 
@@ -409,7 +380,7 @@ test("should have the expected border radius styling when search button enabled"
   mount,
   page,
 }) => {
-  await mount(<SearchComponent searchButton value="foo" />);
+  await mount(<SearchComponent searchButton />);
 
   const searchDefaultInputElementParent =
     searchDefaultInput(page).locator("..");
@@ -513,11 +484,10 @@ test.describe("Event tests for Search component", () => {
   }) => {
     let callbackCount = 0;
     await mount(
-      <Search
+      <SearchComponent
         onClick={() => {
           callbackCount += 1;
         }}
-        defaultValue={testDataStandard}
         searchButton
       />,
     );
@@ -618,15 +588,6 @@ test.describe("Accessibility tests for Search", () => {
 
       await checkAccessibility(page);
     });
-  });
-
-  test("should check accessibility with defaultValue prop", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<Search defaultValue={testDataStandard} />);
-
-    await checkAccessibility(page);
   });
 
   test("should check accessibility with value prop", async ({

--- a/src/components/search/search.stories.tsx
+++ b/src/components/search/search.stories.tsx
@@ -4,7 +4,6 @@ import { Meta, StoryObj } from "@storybook/react";
 import generateStyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
 import Box from "../box";
-import Button from "../button";
 import Search from ".";
 import I18nProvider from "../i18n-provider/i18n-provider.component";
 
@@ -24,36 +23,24 @@ export default meta;
 type Story = StoryObj<typeof Search>;
 
 export const Default: Story = () => {
-  return <Search placeholder="Search..." defaultValue="" />;
+  const [value, setValue] = useState("");
+  return (
+    <Search
+      placeholder="Search..."
+      onChange={(e) => setValue(e.target.value)}
+      value={value}
+    />
+  );
 };
 Default.storyName = "Default";
 
-export const Controlled: Story = () => {
-  const [value, setValue] = useState("");
-  return (
-    <>
-      <Button onClick={() => setValue("")}>Clear value</Button>
-      <Button onClick={() => setValue("test value")} ml={2}>
-        Set value
-      </Button>
-      <Search
-        id="test"
-        name="test"
-        placeholder="Search..."
-        onChange={(e) => setValue(e.target.value)}
-        value={value}
-        mt={2}
-      />
-    </>
-  );
-};
-Controlled.storyName = "Controlled";
-
 export const WithSearchButton: Story = () => {
+  const [value, setValue] = useState("Here is some text");
   return (
     <Box m={1}>
       <Search
-        defaultValue="Here is some text"
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
         searchButton
         searchButtonAriaLabel="search button aria label"
       />
@@ -63,9 +50,14 @@ export const WithSearchButton: Story = () => {
 WithSearchButton.storyName = "With Search Button";
 
 export const WithSearchButtonPropTextOverride: Story = () => {
+  const [value, setValue] = useState("Here is some text");
   return (
     <Box m={1}>
-      <Search defaultValue="Here is some text" searchButton="Find" />
+      <Search
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+        searchButton="Find"
+      />
     </Box>
   );
 };
@@ -73,10 +65,15 @@ WithSearchButtonPropTextOverride.storyName =
   "With Search Button text override via prop";
 
 export const WithSearchButtonLocaleOverride: Story = () => {
+  const [value, setValue] = useState("Here is some text");
   return (
     <Box m={1}>
       <I18nProvider locale={{ search: { searchButtonText: () => "Find" } }}>
-        <Search defaultValue="Here is some text" searchButton />
+        <Search
+          onChange={(e) => setValue(e.target.value)}
+          value={value}
+          searchButton
+        />
       </I18nProvider>
     </Box>
   );
@@ -85,26 +82,48 @@ WithSearchButtonLocaleOverride.storyName =
   "With Search Button text override via locale";
 
 export const CustomWidth: Story = () => {
-  return <Search placeholder="Search..." defaultValue="" searchWidth="375px" />;
+  const [value, setValue] = useState("");
+  return (
+    <Search
+      placeholder="Search..."
+      onChange={(e) => setValue(e.target.value)}
+      value={value}
+      searchWidth="375px"
+    />
+  );
 };
 CustomWidth.storyName = "Custom Width";
 
 export const WithCustomMaxWidth: Story = () => {
+  const [value, setValue] = useState("Here is some text");
   return (
     <Box m={1}>
-      <Search defaultValue="Here is some text" searchButton maxWidth="50%" />
+      <Search
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+        searchButton
+        maxWidth="50%"
+      />
     </Box>
   );
 };
 WithCustomMaxWidth.storyName = "Custom Max Width";
 
 export const WithAltStyling: Story = () => {
+  const [value, setValue] = useState("Here is some text");
   return (
     <Box width="700px" height="108px" p={4} backgroundColor="#000000">
-      <Search placeholder="Search..." defaultValue="" variant="dark" mb={2} />
       <Search
         placeholder="Search..."
-        defaultValue="Here is some text"
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+        variant="dark"
+        mb={2}
+      />
+      <Search
+        placeholder="Search..."
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
         searchButton
         variant="dark"
       />

--- a/src/components/select/__internal__/select-textbox/select-textbox.component.tsx
+++ b/src/components/select/__internal__/select-textbox/select-textbox.component.tsx
@@ -87,6 +87,8 @@ export interface SelectTextboxProps extends FormInputPropTypes {
   transparent?: boolean;
   /** @private @ignore */
   activeDescendantId?: string;
+  /** Specify a callback triggered on change */
+  onChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 const SelectTextbox = React.forwardRef(
@@ -113,6 +115,7 @@ const SelectTextbox = React.forwardRef(
       transparent = false,
       activeDescendantId,
       onKeyDown,
+      onChange,
       ...restProps
     }: SelectTextboxProps,
     ref: React.ForwardedRef<HTMLInputElement>,
@@ -175,15 +178,16 @@ const SelectTextbox = React.forwardRef(
           inputIcon="dropdown"
           autoComplete="off"
           size={size}
-          // prevent uncontrolled warning being fired
-          onChange={() => {}}
           formattedValue={formattedValue}
-          value={
-            hasStringValue ? (selectedValue as string | string[]) : undefined
-          }
           placeholder={hasTextCursor ? placeholder : undefined}
           {...inputAriaAttributes}
           {...textboxProps}
+          // prevent uncontrolled warning being fired
+          onChange={onChange}
+          // ensure value is properly controlled
+          value={
+            hasStringValue ? (selectedValue as string | string[]) : undefined
+          }
           my={0} // prevents any form spacing being applied
         >
           {!hasTextCursor && (

--- a/src/components/select/__internal__/select-textbox/select-textbox.test.tsx
+++ b/src/components/select/__internal__/select-textbox/select-textbox.test.tsx
@@ -2,10 +2,24 @@ import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import SelectTextbox from ".";
+import SelectTextbox, { SelectTextboxProps } from ".";
+
+const ControlledSelectTextbox = (
+  props: Omit<SelectTextboxProps, "onChange" | "value">,
+) => {
+  const [value, setValue] = React.useState("");
+  return (
+    <SelectTextbox
+      label="Select Colour"
+      {...props}
+      onChange={(e) => setValue(e.target.value)}
+      value={value}
+    />
+  );
+};
 
 test("renders as a combobox", () => {
-  render(<SelectTextbox label="Select Colour" />);
+  render(<ControlledSelectTextbox label="Select Colour" />);
 
   expect(
     screen.getByRole("combobox", { name: /Select Colour/i }),
@@ -13,7 +27,7 @@ test("renders as a combobox", () => {
 });
 
 test("renders as a readonly textbox if readOnly prop is true", () => {
-  render(<SelectTextbox label="Select Colour" readOnly />);
+  render(<ControlledSelectTextbox label="Select Colour" readOnly />);
 
   const input = screen.getByRole("textbox", { name: /Select Colour/i });
   expect(input).toBeVisible();
@@ -21,7 +35,7 @@ test("renders as a readonly textbox if readOnly prop is true", () => {
 });
 
 test("renders as a disabled combobox if disabled prop is true", () => {
-  render(<SelectTextbox label="Select Colour" disabled />);
+  render(<ControlledSelectTextbox label="Select Colour" disabled />);
 
   const input = screen.getByRole("combobox", { name: /Select Colour/i });
   expect(input).toBeVisible();
@@ -29,7 +43,7 @@ test("renders as a disabled combobox if disabled prop is true", () => {
 });
 
 test("combobox has correct accessible name when ariaLabel prop is provided", () => {
-  render(<SelectTextbox ariaLabel="Label" />);
+  render(<ControlledSelectTextbox ariaLabel="Label" />);
 
   expect(screen.getByRole("combobox")).toHaveAccessibleName("Label");
 });
@@ -38,7 +52,7 @@ test("combobox has correct accessible name when ariaLabelledBy prop is provided"
   render(
     <>
       <h3 id="label">Label</h3>
-      <SelectTextbox ariaLabelledby="label" />
+      <ControlledSelectTextbox ariaLabelledby="label" />
     </>,
   );
 
@@ -49,7 +63,7 @@ test("combobox has correct accessible name when accessibilityLabelId prop is pro
   render(
     <>
       <h3 id="label">Label</h3>
-      <SelectTextbox accessibilityLabelId="label" />
+      <ControlledSelectTextbox accessibilityLabelId="label" />
     </>,
   );
 
@@ -57,14 +71,14 @@ test("combobox has correct accessible name when accessibilityLabelId prop is pro
 });
 
 test("renders dropdown icon", () => {
-  render(<SelectTextbox />);
+  render(<ControlledSelectTextbox />);
 
   expect(screen.getByTestId("icon")).toHaveAttribute("type", "dropdown");
 });
 
 test("calls onFocus callback when combobox is focused", () => {
   const onFocus = jest.fn();
-  render(<SelectTextbox label="Textbox" onFocus={onFocus} />);
+  render(<ControlledSelectTextbox label="Textbox" onFocus={onFocus} />);
 
   act(() => {
     screen.getByRole("combobox", { name: "Textbox" }).focus();
@@ -75,7 +89,9 @@ test("calls onFocus callback when combobox is focused", () => {
 
 test("does not call onFocus callback when combobox is disabled", () => {
   const onFocus = jest.fn();
-  render(<SelectTextbox label="Textbox" onFocus={onFocus} disabled />);
+  render(
+    <ControlledSelectTextbox label="Textbox" onFocus={onFocus} disabled />,
+  );
 
   screen.getByRole("combobox", { name: "Textbox" }).focus();
 
@@ -84,7 +100,7 @@ test("does not call onFocus callback when combobox is disabled", () => {
 
 test("calls onBlur callback when combobox is blurred", () => {
   const onBlur = jest.fn();
-  render(<SelectTextbox label="Textbox" onBlur={onBlur} />);
+  render(<ControlledSelectTextbox label="Textbox" onBlur={onBlur} />);
 
   const combobox = screen.getByRole("combobox", { name: "Textbox" });
   act(() => {
@@ -96,7 +112,7 @@ test("calls onBlur callback when combobox is blurred", () => {
 });
 
 test("combobox has placeholder text when it has no value and hasTextCursor prop is true", () => {
-  render(<SelectTextbox hasTextCursor />);
+  render(<ControlledSelectTextbox hasTextCursor />);
 
   expect(screen.getByRole("combobox")).toHaveAttribute(
     "placeholder",
@@ -105,14 +121,16 @@ test("combobox has placeholder text when it has no value and hasTextCursor prop 
 });
 
 test("combobox has custom placeholder text when it has no value, hasTextCursor prop is true and a custom placeholder is provided", () => {
-  render(<SelectTextbox hasTextCursor placeholder="foobar" />);
+  render(<ControlledSelectTextbox hasTextCursor placeholder="foobar" />);
 
   expect(screen.getByRole("combobox")).toHaveAttribute("placeholder", "foobar");
 });
 
 test("does not call onFocus callback when textbox is read only", () => {
   const onFocus = jest.fn();
-  render(<SelectTextbox label="Textbox" onFocus={onFocus} readOnly />);
+  render(
+    <ControlledSelectTextbox label="Textbox" onFocus={onFocus} readOnly />,
+  );
 
   act(() => {
     screen.getByRole("textbox", { name: "Textbox" }).focus();
@@ -124,7 +142,7 @@ test("does not call onFocus callback when textbox is read only", () => {
 describe("when hasTextCursor prop is false", () => {
   it("renders formattedValue in an overlay instead of the combobox", () => {
     render(
-      <SelectTextbox
+      <ControlledSelectTextbox
         label="Textbox"
         formattedValue="foo"
         hasTextCursor={false}
@@ -138,14 +156,16 @@ describe("when hasTextCursor prop is false", () => {
   });
 
   it("displays the placeholder text in an overlay when the combobox has no value", () => {
-    render(<SelectTextbox placeholder="foobaz" hasTextCursor={false} />);
+    render(
+      <ControlledSelectTextbox placeholder="foobaz" hasTextCursor={false} />,
+    );
 
     expect(screen.getByRole("combobox")).not.toHaveTextContent("foobaz");
     expect(screen.getByText("foobaz")).toBeVisible();
   });
 
   it("renders combobox without autocomplete", () => {
-    render(<SelectTextbox label="Textbox" />);
+    render(<ControlledSelectTextbox label="Textbox" />);
 
     const combobox = screen.getByRole("combobox", { name: "Textbox" });
     expect(combobox).toHaveAttribute("autocomplete", "off");
@@ -153,7 +173,10 @@ describe("when hasTextCursor prop is false", () => {
 
   it("hides the combobox overlay from assistive technologies", () => {
     render(
-      <SelectTextbox formattedValue="You can't see me" hasTextCursor={false} />,
+      <ControlledSelectTextbox
+        formattedValue="You can't see me"
+        hasTextCursor={false}
+      />,
     );
 
     expect(screen.getByTestId("select-text")).toHaveAttribute(
@@ -166,7 +189,11 @@ describe("when hasTextCursor prop is false", () => {
     const onClick = jest.fn();
     const user = userEvent.setup();
     render(
-      <SelectTextbox label="Textbox" onClick={onClick} hasTextCursor={false} />,
+      <ControlledSelectTextbox
+        label="Textbox"
+        onClick={onClick}
+        hasTextCursor={false}
+      />,
     );
 
     await user.click(screen.getByText("Please Select..."));
@@ -175,7 +202,9 @@ describe("when hasTextCursor prop is false", () => {
   });
 
   it("truncates the displayed text of the selected option with ellipsis", () => {
-    render(<SelectTextbox formattedValue="foo" hasTextCursor={false} />);
+    render(
+      <ControlledSelectTextbox formattedValue="foo" hasTextCursor={false} />,
+    );
 
     expect(screen.getByText("foo")).toHaveStyle({
       whiteSpace: "nowrap",
@@ -186,7 +215,11 @@ describe("when hasTextCursor prop is false", () => {
 
   it("applies correct styles when disabled", () => {
     render(
-      <SelectTextbox disabled formattedValue="foo" hasTextCursor={false} />,
+      <ControlledSelectTextbox
+        disabled
+        formattedValue="foo"
+        hasTextCursor={false}
+      />,
     );
 
     expect(screen.getByTestId("select-text")).toHaveStyle({
@@ -198,7 +231,11 @@ describe("when hasTextCursor prop is false", () => {
 
   it("applies correct styles when read-only", () => {
     render(
-      <SelectTextbox readOnly formattedValue="foo" hasTextCursor={false} />,
+      <ControlledSelectTextbox
+        readOnly
+        formattedValue="foo"
+        hasTextCursor={false}
+      />,
     );
 
     expect(screen.getByTestId("select-text")).toHaveStyle({
@@ -210,7 +247,11 @@ describe("when hasTextCursor prop is false", () => {
 
   it("applies correct styles when transparent", () => {
     render(
-      <SelectTextbox transparent formattedValue="foo" hasTextCursor={false} />,
+      <ControlledSelectTextbox
+        transparent
+        formattedValue="foo"
+        hasTextCursor={false}
+      />,
     );
 
     expect(screen.getByTestId("select-text")).toHaveStyle({

--- a/src/components/select/filterable-select-interaction.stories.tsx
+++ b/src/components/select/filterable-select-interaction.stories.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/test";
 
-import { FilterableSelect, Option } from "../select";
+import { FilterableSelect, FilterableSelectProps, Option } from "../select";
 import Box from "../box";
 import Button from "../button";
 
@@ -19,22 +19,35 @@ export default {
   },
 };
 
+const ControlledFilterableSelect = (
+  props: Omit<FilterableSelectProps, "children" | "onChange" | "value">,
+) => {
+  const [value, setValue] = React.useState<string>("");
+  return (
+    <FilterableSelect
+      {...props}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
+    </FilterableSelect>
+  );
+};
+
 export const OpenFromIconClick: Story = {
   render: () => (
     <Box height={220}>
-      <FilterableSelect name="simple" id="simple" label="color">
-        <Option text="Amber" value="1" />
-        <Option text="Black" value="2" />
-        <Option text="Blue" value="3" />
-        <Option text="Brown" value="4" />
-        <Option text="Green" value="5" />
-        <Option text="Orange" value="6" />
-        <Option text="Pink" value="7" />
-        <Option text="Purple" value="8" />
-        <Option text="Red" value="9" />
-        <Option text="White" value="10" />
-        <Option text="Yellow" value="11" />
-      </FilterableSelect>
+      <ControlledFilterableSelect name="simple" id="simple" label="color" />
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -59,19 +72,7 @@ OpenFromIconClick.storyName = "Open From Icon";
 export const HighlightItem: Story = {
   render: () => (
     <Box height={220}>
-      <FilterableSelect name="simple" id="simple" label="color">
-        <Option text="Amber" value="1" />
-        <Option text="Black" value="2" />
-        <Option text="Blue" value="3" />
-        <Option text="Brown" value="4" />
-        <Option text="Green" value="5" />
-        <Option text="Orange" value="6" />
-        <Option text="Pink" value="7" />
-        <Option text="Purple" value="8" />
-        <Option text="Red" value="9" />
-        <Option text="White" value="10" />
-        <Option text="Yellow" value="11" />
-      </FilterableSelect>
+      <ControlledFilterableSelect name="simple" id="simple" label="color" />
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -99,19 +100,7 @@ HighlightItem.storyName = "Highlight Item";
 export const PartialFilterItem: Story = {
   render: () => (
     <Box height={220}>
-      <FilterableSelect name="simple" id="simple" label="color">
-        <Option text="Amber" value="1" />
-        <Option text="Black" value="2" />
-        <Option text="Blue" value="3" />
-        <Option text="Brown" value="4" />
-        <Option text="Green" value="5" />
-        <Option text="Orange" value="6" />
-        <Option text="Pink" value="7" />
-        <Option text="Purple" value="8" />
-        <Option text="Red" value="9" />
-        <Option text="White" value="10" />
-        <Option text="Yellow" value="11" />
-      </FilterableSelect>
+      <ControlledFilterableSelect name="simple" id="simple" label="color" />
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -139,9 +128,7 @@ PartialFilterItem.storyName = "Partial Filter Item";
 export const HoverItem: Story = {
   render: () => (
     <Box height={220}>
-      <FilterableSelect name="simple" id="simple" label="color">
-        <Option text="Amber" value="1" />
-      </FilterableSelect>
+      <ControlledFilterableSelect name="simple" id="simple" label="color" />
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -175,9 +162,7 @@ HoverItem.storyName = "Hover Item";
 export const HoverHighlightedItem: Story = {
   render: () => (
     <Box height={220}>
-      <FilterableSelect name="simple" id="simple" label="color">
-        <Option text="Amber" value="1" />
-      </FilterableSelect>
+      <ControlledFilterableSelect name="simple" id="simple" label="color" />
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -213,9 +198,7 @@ HoverHighlightedItem.storyName = "Hover Highlighted Item";
 export const NoResults: Story = {
   render: () => (
     <Box height={220}>
-      <FilterableSelect name="simple" id="simple" label="color">
-        <Option text="Amber" value="1" />
-      </FilterableSelect>
+      <ControlledFilterableSelect name="simple" id="simple" label="color" />
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -243,7 +226,7 @@ NoResults.storyName = "No Results";
 export const WithActionButton: Story = {
   render: () => (
     <Box height={220}>
-      <FilterableSelect
+      <ControlledFilterableSelect
         name="simple"
         id="simple"
         label="color"
@@ -253,9 +236,7 @@ export const WithActionButton: Story = {
           </Button>
         }
         onListAction={() => {}}
-      >
-        <Option text="Amber" value="1" />
-      </FilterableSelect>
+      />
     </Box>
   ),
   play: async ({ canvasElement }) => {

--- a/src/components/select/filterable-select/components.test-pw.tsx
+++ b/src/components/select/filterable-select/components.test-pw.tsx
@@ -86,10 +86,15 @@ export const FilterableSelectObjectAsValueComponent = (
 export const FilterableSelectMultiColumnsComponent = (
   props: Partial<FilterableSelectProps>,
 ) => {
+  const [value, setValue] = useState("2");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
   return (
     <FilterableSelect
       multiColumn
-      defaultValue="2"
+      value={value}
+      onChange={onChangeHandler}
       {...props}
       tableHeader={
         <tr>
@@ -138,10 +143,15 @@ export const FilterableSelectMultiColumnsComponent = (
 export const FilterableSelectMultiColumnsNestedComponent = (
   props: Partial<FilterableSelectProps>,
 ) => {
+  const [value, setValue] = useState("2");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
   return (
     <FilterableSelect
       multiColumn
-      defaultValue="2"
+      value={value}
+      onChange={onChangeHandler}
       {...props}
       tableHeader={
         <tr>
@@ -240,32 +250,45 @@ export const FilterableSelectWithActionButtonComponent = () => {
   );
 };
 
-export const WithVirtualScrolling = () => (
-  <FilterableSelect
-    name="virtualised"
-    id="virtualised"
-    label="choose an option"
-    labelInline
-    enableVirtualScroll
-    virtualScrollOverscan={10}
-  >
-    {Array(10000)
-      .fill(undefined)
-      .map((_, index) => (
-        <Option
-          key={`option-${index + 1}`}
-          value={`${index}`}
-          text={`Option ${index + 1}.`}
-        />
-      ))}
-  </FilterableSelect>
-);
+export const WithVirtualScrolling = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+  return (
+    <FilterableSelect
+      name="virtualised"
+      id="virtualised"
+      label="choose an option"
+      labelInline
+      enableVirtualScroll
+      virtualScrollOverscan={10}
+      value={value}
+      onChange={onChangeHandler}
+    >
+      {Array(10000)
+        .fill(undefined)
+        .map((_, index) => (
+          <Option
+            key={`option-${index + 1}`}
+            value={`${index}`}
+            text={`Option ${index + 1}.`}
+          />
+        ))}
+    </FilterableSelect>
+  );
+};
 
 export const FilterableSelectNestedInDialog = ({
   openOnFocus = false,
   autofocus = false,
 }) => {
   const [isOpen, setIsOpen] = useState(true);
+  const [value, setValue] = useState("");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   return (
     <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
       <FilterableSelect
@@ -273,6 +296,8 @@ export const FilterableSelectNestedInDialog = ({
         autoFocus={autofocus}
         name="testSelect"
         id="testSelect"
+        value={value}
+        onChange={onChangeHandler}
       >
         <Option value="opt1" text="red" />
         <Option value="opt2" text="green" />

--- a/src/components/select/filterable-select/filterable-select-test.stories.tsx
+++ b/src/components/select/filterable-select/filterable-select-test.stories.tsx
@@ -6,6 +6,7 @@ import Dialog from "../../dialog";
 import Button from "../../button";
 import Typography from "../../typography";
 import CarbonProvider from "../../carbon-provider";
+import useMultiInput from "../../../hooks/use-multi-input";
 
 export default {
   component: FilterableSelect,
@@ -108,36 +109,44 @@ export const Default = (props: Partial<FilterableSelectProps>) => {
 Default.storyName = "Default";
 
 export const Validation = () => {
+  const { state, setValue } = useMultiInput();
+
   return (
     <>
       <FilterableSelect
-        name="filterable"
-        id="filterable"
+        name="filterable-error"
+        id="filterable-error"
         label="Filterable Select"
         error="Error Message"
         mb={2}
+        value={state["filterable-error"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </FilterableSelect>
       <FilterableSelect
-        name="filterable"
-        id="filterable"
+        name="filterable-warning"
+        id="filterable-warning"
         label="Filterable Select"
         warning="Warning Message"
         mb={2}
+        value={state["filterable-warning"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </FilterableSelect>
       <FilterableSelect
-        name="filterable"
-        id="filterable"
+        name="filterable-info"
+        id="filterable-info"
         label="Filterable Select"
         info="Info Message"
         mb={2}
+        value={state["filterable-info"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -145,36 +154,42 @@ export const Validation = () => {
       </FilterableSelect>
 
       <FilterableSelect
-        name="filterable"
-        id="filterable"
+        name="filterable-error-vol"
+        id="filterable-error"
         label="Filterable Select"
         error="Error Message"
         validationOnLabel
         mb={2}
+        value={state["filterable-error-vol"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </FilterableSelect>
       <FilterableSelect
-        name="filterable"
-        id="filterable"
+        name="filterable-warning-vol"
+        id="filterable-warning-vol"
         label="Filterable Select"
         warning="Warning Message"
         validationOnLabel
         mb={2}
+        value={state["filterable-warning-vol"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </FilterableSelect>
       <FilterableSelect
-        name="filterable"
-        id="filterable"
+        name="filterable-info-vol"
+        id="filterable-info-vol"
         label="Filterable Select"
         info="Info Message"
         validationOnLabel
         mb={2}
+        value={state["filterable-info-vol"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -182,33 +197,39 @@ export const Validation = () => {
       </FilterableSelect>
 
       <FilterableSelect
-        name="filterable"
-        id="filterable"
+        name="filterable-error-bool"
+        id="filterable-error-bool"
         label="Filterable Select"
         error
         mb={2}
+        value={state["filterable-error-bool"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </FilterableSelect>
       <FilterableSelect
-        name="filterable"
-        id="filterable"
+        name="filterable-warning-bool"
+        id="filterable-warning-bool"
         label="Filterable Select"
         warning
         mb={2}
+        value={state["filterable-warning-bool"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </FilterableSelect>
       <FilterableSelect
-        name="filterable"
-        id="filterable"
+        name="filterable-info-bool"
+        id="filterable-info-bool"
         label="Filterable Select"
         info
         mb={2}
+        value={state["filterable-info-bool"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -224,25 +245,31 @@ Validation.parameters = {
 };
 
 export const NewValidation = () => {
+  const { state, setValue } = useMultiInput();
+
   return (
     <CarbonProvider validationRedesignOptIn>
       <FilterableSelect
-        name="filterable"
-        id="filterable"
+        name="filterable1"
+        id="filterable1"
         label="Filterable Select"
         error="Error Message"
         mb={2}
+        value={state["filterable1"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </FilterableSelect>
       <FilterableSelect
-        name="filterable"
-        id="filterable"
+        name="filterable2"
+        id="filterable2"
         label="Filterable Select"
         warning="Warning Message"
         mb={2}
+        value={state["filterable2"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -250,11 +277,13 @@ export const NewValidation = () => {
       </FilterableSelect>
       <FilterableSelect
         validationMessagePositionTop={false}
-        name="filterable"
-        id="filterable"
+        name="filterable3"
+        id="filterable3"
         label="Filterable Select"
         error="Error Message"
         mb={2}
+        value={state["filterable3"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -262,11 +291,13 @@ export const NewValidation = () => {
       </FilterableSelect>
       <FilterableSelect
         validationMessagePositionTop={false}
-        name="filterable"
-        id="filterable"
+        name="filterable4"
+        id="filterable4"
         label="Filterable Select"
         warning="Warning Message"
         mb={2}
+        value={state["filterable4"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -507,10 +538,16 @@ export const FilterableSelectObjectAsValueComponent = (
 export const FilterableSelectMultiColumnsComponent = (
   props: Partial<FilterableSelectProps>,
 ) => {
+  const [value, setValue] = useState("2");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
   return (
     <FilterableSelect
       multiColumn
-      defaultValue="2"
+      value={value}
+      onChange={onChangeHandler}
       {...props}
       tableHeader={
         <tr>
@@ -559,11 +596,17 @@ export const FilterableSelectMultiColumnsComponent = (
 export const FilterableSelectMultiColumnsNestedComponent = (
   args: Partial<FilterableSelectProps>,
 ) => {
+  const [value, setValue] = useState("2");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
   return (
     <FilterableSelect
       {...args}
       multiColumn
-      defaultValue="2"
+      value={value}
+      onChange={onChangeHandler}
       tableHeader={
         <tr>
           <th>Name</th>
@@ -721,32 +764,47 @@ export const FilterableSelectListActionEventComponent = (
   );
 };
 
-export const FilterableSelectWithManyOptionsAndVirtualScrolling = () => (
-  <FilterableSelect
-    name="virtualised"
-    id="virtualised"
-    label="choose an option"
-    labelInline
-    enableVirtualScroll
-    virtualScrollOverscan={10}
-  >
-    {Array(10000)
-      .fill(undefined)
-      .map((_, index) => (
-        <Option
-          key={`option-${index + 1}`}
-          value={`${index}`}
-          text={`Option ${index + 1}.`}
-        />
-      ))}
-  </FilterableSelect>
-);
+export const FilterableSelectWithManyOptionsAndVirtualScrolling = () => {
+  const [value, setValue] = useState("");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  return (
+    <FilterableSelect
+      name="virtualised"
+      id="virtualised"
+      label="choose an option"
+      labelInline
+      enableVirtualScroll
+      virtualScrollOverscan={10}
+      value={value}
+      onChange={onChangeHandler}
+    >
+      {Array(10000)
+        .fill(undefined)
+        .map((_, index) => (
+          <Option
+            key={`option-${index + 1}`}
+            value={`${index}`}
+            text={`Option ${index + 1}.`}
+          />
+        ))}
+    </FilterableSelect>
+  );
+};
 
 export const FilterableSelectNestedInDialog = ({
   openOnFocus = false,
   autofocus = false,
 }) => {
   const [isOpen, setIsOpen] = useState(true);
+  const [value, setValue] = useState("");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
   return (
     <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
       <FilterableSelect
@@ -754,6 +812,8 @@ export const FilterableSelectNestedInDialog = ({
         autoFocus={autofocus}
         name="testSelect"
         id="testSelect"
+        value={value}
+        onChange={onChangeHandler}
       >
         <Option value="opt1" text="red" />
         <Option value="opt2" text="green" />
@@ -798,7 +858,7 @@ export const OnChangeWithDeleteStory = () => {
   return (
     <>
       <div>Value: {value}</div>
-      <FilterableSelect label="test" onChange={onChange}>
+      <FilterableSelect label="test" onChange={onChange} value={value}>
         <Option text="item0" value="0" />
         <Option text="item1" value="1" />
         <Option text="item2" value="2" />
@@ -807,23 +867,26 @@ export const OnChangeWithDeleteStory = () => {
   );
 };
 
-export const SingleOption = () => (
-  <FilterableSelect
-    name="simple"
-    id="simple"
-    label="color"
-    labelInline
-    onOpen={action("onOpen")}
-    onChange={action("onChange")}
-    onClick={action("onClick")}
-    onFilterChange={action("onFilterChange")}
-    onFocus={action("onFocus")}
-    onBlur={action("onBlur")}
-    onKeyDown={action("onKeyDown")}
-  >
-    <Option text="Amber" value="1" />
-  </FilterableSelect>
-);
+export const SingleOption = () => {
+  return (
+    <FilterableSelect
+      name="simple"
+      id="simple"
+      label="color"
+      labelInline
+      onOpen={action("onOpen")}
+      onChange={action("onChange")}
+      onClick={action("onClick")}
+      onFilterChange={action("onFilterChange")}
+      onFocus={action("onFocus")}
+      onBlur={action("onBlur")}
+      onKeyDown={action("onKeyDown")}
+      value={""}
+    >
+      <Option text="Amber" value="1" />
+    </FilterableSelect>
+  );
+};
 
 SingleOption.storyName = "Single Option";
 
@@ -853,36 +916,76 @@ export const FilterableSelectWithTruncatedText = () => {
   );
 };
 
-export const AriaDescribedByExample = () => (
-  <>
+export const AriaDescribedByExample = () => {
+  const [value, setValue] = useState("1");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  return (
+    <>
+      <FilterableSelect
+        name="simple"
+        id="simple"
+        label="color"
+        aria-describedby="combo-box-description"
+        labelInline
+        onOpen={action("onOpen")}
+        onChange={onChangeHandler}
+        onClick={action("onClick")}
+        onFilterChange={action("onFilterChange")}
+        onFocus={action("onFocus")}
+        onBlur={action("onBlur")}
+        onKeyDown={action("onKeyDown")}
+        value={value}
+      >
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+        <Option text="Brown" value="4" />
+        <Option text="Green" value="5" />
+        <Option text="Orange" value="6" />
+        <Option text="Pink" value="7" />
+        <Option text="Purple" value="8" />
+        <Option text="Red" value="9" />
+        <Option text="White" value="10" />
+        <Option text="Yellow" value="11" />
+      </FilterableSelect>
+      <Typography my={5} id="combo-box-description">
+        This is a description of the select textbox
+      </Typography>
+    </>
+  );
+};
+
+export const FilterableSelectWithStateAndObjects = ({
+  label,
+  ...props
+}: Partial<FilterableSelectProps>) => {
+  const optionListValues = [
+    { id: "Black", value: 1, text: "Black" },
+    { id: "Blue", value: 2, text: "Blue" },
+  ];
+
+  const [value, setValue] = useState<Record<string, unknown>>(
+    optionListValues[1],
+  );
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value as unknown as Record<string, unknown>);
+  }
+
+  return (
     <FilterableSelect
-      name="simple"
-      id="simple"
-      label="color"
-      aria-describedby="combo-box-description"
-      labelInline
-      onOpen={action("onOpen")}
-      onChange={action("onChange")}
-      onClick={action("onClick")}
-      onFilterChange={action("onFilterChange")}
-      onFocus={action("onFocus")}
-      onBlur={action("onBlur")}
-      onKeyDown={action("onKeyDown")}
+      label={label}
+      value={value}
+      onChange={onChangeHandler}
+      {...props}
     >
-      <Option text="Amber" value="1" />
-      <Option text="Black" value="2" />
-      <Option text="Blue" value="3" />
-      <Option text="Brown" value="4" />
-      <Option text="Green" value="5" />
-      <Option text="Orange" value="6" />
-      <Option text="Pink" value="7" />
-      <Option text="Purple" value="8" />
-      <Option text="Red" value="9" />
-      <Option text="White" value="10" />
-      <Option text="Yellow" value="11" />
+      {optionListValues.map((option) => (
+        <Option key={option.id} text={option.text} value={option} />
+      ))}
     </FilterableSelect>
-    <Typography my={5} id="combo-box-description">
-      This is a description of the select textbox
-    </Typography>
-  </>
-);
+  );
+};

--- a/src/components/select/filterable-select/filterable-select.mdx
+++ b/src/components/select/filterable-select/filterable-select.mdx
@@ -57,10 +57,6 @@ will have the same width as the input.
 
 <Canvas of={FilterableSelectStories.ListWidth}/>
 
-### Controlled Usage
-
-<Canvas of={FilterableSelectStories.Controlled} />
-
 ### Open on focus
 
 <Canvas of={FilterableSelectStories.OpenOnFocus} />
@@ -155,7 +151,7 @@ This component supports input validation, see our [Validations](../?path=/docs/d
 
 ## Testing with React Testing Library (RTL)
 
-Testing with RTL is supported for the `FilterableSelect` component, please consult the [Testing with RTL](../?path=/docs/select--docs#testing-with-react-testing-library-rtl) 
+Testing with RTL is supported for the `FilterableSelect` component, please consult the [Testing with RTL](../?path=/docs/select--docs#testing-with-react-testing-library-rtl)
 section in `SimpleSelect` for more information.
 
 ## Props

--- a/src/components/select/filterable-select/filterable-select.pw.tsx
+++ b/src/components/select/filterable-select/filterable-select.pw.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import FilterableSelect, { FilterableSelectProps } from ".";
-import Option from "../option";
+import { FilterableSelectProps } from ".";
 import { test, expect } from "../../../../playwright/helpers/base-test";
 import {
   FilterableSelectComponent,
@@ -566,15 +565,7 @@ test.describe("FilterableSelect component", () => {
     page,
   }) => {
     const { update } = await mount(
-      <FilterableSelect label="Colour">
-        <Option text="Amber" value="Amber" />
-        <Option text="Black" value="Black" />
-        <Option text="Cyan" value="Cyan" />
-        <Option text="Dark Blue" value="Dark Blue" />
-        <Option text="Emerald" value="Emerald" />
-        <Option text="Fuchsia" value="Fuchsia" />
-        <Option text="Gold" value="Gold" />
-      </FilterableSelect>,
+      <FilterableSelectComponent label="Colour" />,
     );
 
     const input = page.getByRole("combobox");
@@ -591,21 +582,9 @@ test.describe("FilterableSelect component", () => {
       (element) => element.scrollTop,
     );
 
-    await update(
-      <FilterableSelect label="Colour">
-        <Option text="Amber" value="Amber" />
-        <Option text="Black" value="Black" />
-        <Option text="Cyan" value="Cyan" />
-        <Option text="Dark Blue" value="Dark Blue" />
-        <Option text="Emerald" value="Emerald" />
-        <Option text="Fuchsia" value="Fuchsia" />
-        <Option text="Gold" value="Gold" />
-        <Option text="Hot Pink" value="Hot Pink" />
-        <Option text="Indigo" value="Indigo" />
-      </FilterableSelect>,
-    );
+    await update(<FilterableSelectComponent label="Colour" />);
 
-    await expect(page.getByRole("option")).toHaveCount(9);
+    await expect(page.getByRole("option")).toHaveCount(11);
 
     // check that the scroll position hasn't changed
     const newScrollPosition = await dropdownList.evaluate(

--- a/src/components/select/filterable-select/filterable-select.stories.tsx
+++ b/src/components/select/filterable-select/filterable-select.stories.tsx
@@ -33,9 +33,20 @@ export default meta;
 type Story = StoryObj<typeof FilterableSelect>;
 
 export const Default: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   return (
     <Box height={220}>
-      <FilterableSelect name="simple" id="simple" label="color">
+      <FilterableSelect
+        name="simple"
+        id="simple"
+        label="color"
+        value={value}
+        onChange={onChangeHandler}
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
@@ -97,6 +108,10 @@ ListPlacement.storyName = "List Placement";
 ListPlacement.parameters = { chromatic: { disableSnapshot: true } };
 
 export const ListHeight: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
   return (
     <Box height={500}>
       <FilterableSelect
@@ -104,6 +119,8 @@ export const ListHeight: Story = () => {
         name="list height"
         id="list-height"
         label="List height"
+        value={value}
+        onChange={onChangeHandler}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -149,45 +166,11 @@ export const ListWidth: Story = () => {
 ListWidth.storyName = "List Width";
 ListWidth.parameters = { chromatic: { disableSnapshot: true } };
 
-export const Controlled: Story = () => {
+export const OpenOnFocus: Story = () => {
   const [value, setValue] = useState("");
   function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
     setValue(event.target.value);
   }
-  function clearValue() {
-    setValue("");
-  }
-  return (
-    <Box height={300}>
-      <Button onClick={clearValue} mb={2}>
-        clear
-      </Button>
-      <FilterableSelect
-        id="controlled"
-        name="controlled"
-        label="color"
-        value={value}
-        onChange={onChangeHandler}
-      >
-        <Option text="Amber" value="1" />
-        <Option text="Black" value="2" />
-        <Option text="Blue" value="3" />
-        <Option text="Brown" value="4" />
-        <Option text="Green" value="5" />
-        <Option text="Orange" value="6" />
-        <Option text="Pink" value="7" />
-        <Option text="Purple" value="8" />
-        <Option text="Red" value="9" />
-        <Option text="White" value="10" />
-        <Option text="Yellow" value="11" />
-      </FilterableSelect>
-    </Box>
-  );
-};
-Controlled.storyName = "Controlled";
-Controlled.parameters = { chromatic: { disableSnapshot: true } };
-
-export const OpenOnFocus: Story = () => {
   return (
     <Box height={250}>
       <FilterableSelect
@@ -195,6 +178,8 @@ export const OpenOnFocus: Story = () => {
         id="openOnFocus"
         label="color"
         openOnFocus
+        value={value}
+        onChange={onChangeHandler}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -215,13 +200,18 @@ OpenOnFocus.storyName = "Open on Focus";
 OpenOnFocus.parameters = { chromatic: { disableSnapshot: true } };
 
 export const Disabled: Story = () => {
+  const [value, setValue] = useState("3");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
   return (
     <FilterableSelect
       aria-label="disabled"
       name="disabled"
       id="disabled"
-      defaultValue="3"
       disabled
+      value={value}
+      onChange={onChangeHandler}
     >
       <Option text="Amber" value="1" />
       <Option text="Black" value="2" />
@@ -240,13 +230,18 @@ export const Disabled: Story = () => {
 Disabled.storyName = "Disabled";
 
 export const Readonly: Story = () => {
+  const [value, setValue] = useState("4");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
   return (
     <FilterableSelect
       aria-label="readonly"
       name="readonly"
       id="readonly"
-      defaultValue="4"
       readOnly
+      value={value}
+      onChange={onChangeHandler}
     >
       <Option text="Amber" value="1" />
       <Option text="Black" value="2" />
@@ -265,13 +260,18 @@ export const Readonly: Story = () => {
 Readonly.storyName = "Read Only";
 
 export const WithMultipleColumns: Story = () => {
+  const [value, setValue] = useState("4");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
   return (
     <Box height={250}>
       <FilterableSelect
         name="withMultipleColumns"
         id="withMultipleColumns"
         label="clients"
-        defaultValue="4"
+        value={value}
+        onChange={onChangeHandler}
         multiColumn
         tableHeader={
           <tr>
@@ -314,13 +314,19 @@ WithMultipleColumns.storyName = "With Multiple Columns";
 WithMultipleColumns.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithMultipleColumnsAndNested: Story = () => {
+  const [value, setValue] = useState("2");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   return (
     <Box height={300}>
       <FilterableSelect
         name="withMultipleColumns"
         id="withMultipleColumns"
         label="clients"
-        defaultValue="2"
+        value={value}
+        onChange={onChangeHandler}
         multiColumn
         openOnFocus
         tableHeader={
@@ -571,9 +577,21 @@ WithInfiniteScroll.storyName = "With Infinite Scroll";
 WithInfiniteScroll.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithCustomMaxWidth: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   return (
     <Box height={250}>
-      <FilterableSelect name="simple" id="simple" label="color" maxWidth="50%">
+      <FilterableSelect
+        name="simple"
+        id="simple"
+        label="color"
+        maxWidth="50%"
+        value={value}
+        onChange={onChangeHandler}
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
@@ -592,6 +610,10 @@ export const WithCustomMaxWidth: Story = () => {
 WithCustomMaxWidth.storyName = "With Custom Max Width";
 
 export const Required: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
   return (
     <Box height={250}>
       <FilterableSelect
@@ -599,6 +621,8 @@ export const Required: Story = () => {
         id="required-select"
         label="Foreground Color"
         required
+        value={value}
+        onChange={onChangeHandler}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -667,6 +691,10 @@ WithObjectAsValue.storyName = "With Object as Value";
 WithObjectAsValue.parameters = { chromatic: { disableSnapshot: true } };
 
 export const Virtualised: Story = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
   const colors = [
     "Amber",
     "Black",
@@ -698,6 +726,8 @@ export const Virtualised: Story = () => {
         labelInline
         enableVirtualScroll
         virtualScrollOverscan={20}
+        value={value}
+        onChange={onChangeHandler}
       >
         {options}
       </FilterableSelect>
@@ -806,6 +836,7 @@ export const CustomFilterAndOptionStyle: Story = () => {
             </Box>
           )
         }
+        value={selectedColor ?? ""}
       >
         {data.map(({ text, color }) => (
           <Option text={text} value={color} key={color}>

--- a/src/components/select/multi-select/components.test-pw.tsx
+++ b/src/components/select/multi-select/components.test-pw.tsx
@@ -47,8 +47,24 @@ export const MultiSelectComponent = (props: Partial<MultiSelectProps>) => {
 export const MultiSelectDefaultValueComponent = (
   props: Partial<MultiSelectProps>,
 ) => {
+  const [values, setValues] = useState<string[]>(() => {
+    if (props.value) {
+      return props.value as string[];
+    }
+    return ["1", "2"];
+  });
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValues(event.target.value as unknown as string[]);
+  }
+
   return (
-    <MultiSelect label="color" labelInline {...props}>
+    <MultiSelect
+      label="color"
+      labelInline
+      {...props}
+      value={values}
+      onChange={onChangeHandler}
+    >
       <Option text="Amber" value="1" />
       <Option text="Black" value="2" />
       <Option text="Blue" value="3" />
@@ -72,11 +88,7 @@ export const MultiSelectLongPillComponent = (
     setValue(event.target.value as unknown as string[]);
   }
   return (
-    <div
-      style={{
-        maxWidth: "200px",
-      }}
-    >
+    <Box maxWidth="200px">
       <MultiSelect
         label="color"
         labelInline
@@ -96,7 +108,7 @@ export const MultiSelectLongPillComponent = (
         <Option text="White" value="10" />
         <Option text="Yellow" value="11" />
       </MultiSelect>
-    </div>
+    </Box>
   );
 };
 
@@ -141,10 +153,16 @@ export const MultiSelectObjectAsValueComponent = (
 export const MultiSelectMultiColumnsComponent = (
   props: Partial<MultiSelectProps>,
 ) => {
+  const [values, setValues] = useState<string[]>(["2"]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValues(event.target.value as unknown as string[]);
+  }
+
   return (
     <MultiSelect
       multiColumn
-      defaultValue={["2"]}
+      value={values}
+      onChange={onChangeHandler}
       {...props}
       tableHeader={
         <tr>
@@ -226,8 +244,18 @@ export const MultiSelectMaxOptionsComponent = (
 export const MultiSelectCustomColorComponent = (
   props: Partial<MultiSelectProps>,
 ) => {
+  const [values, setValues] = useState<string[]>(["1", "3"]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValues(event.target.value as unknown as string[]);
+  }
   return (
-    <MultiSelect label="color" labelInline defaultValue={["1", "3"]} {...props}>
+    <MultiSelect
+      label="color"
+      labelInline
+      value={values}
+      onChange={onChangeHandler}
+      {...props}
+    >
       <Option text="Amber" value="1" borderColor="#FFBF00" fill />
       <Option text="Black" value="2" borderColor="blackOpacity65" fill />
       <Option text="Blue" value="3" borderColor="productBlue" />
@@ -243,32 +271,45 @@ export const MultiSelectCustomColorComponent = (
   );
 };
 
-export const WithVirtualScrolling = () => (
-  <MultiSelect
-    name="virtualised"
-    id="virtualised"
-    label="choose an option"
-    labelInline
-    enableVirtualScroll
-    virtualScrollOverscan={10}
-  >
-    {Array(10000)
-      .fill(undefined)
-      .map((_, index) => (
-        <Option
-          key={`option-${index + 1}`}
-          value={`${index}`}
-          text={`Option ${index + 1}.`}
-        />
-      ))}
-  </MultiSelect>
-);
+export const WithVirtualScrolling = () => {
+  const [values, setValues] = useState<string[]>(["1", "2"]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValues(event.target.value as unknown as string[]);
+  }
+  return (
+    <MultiSelect
+      name="virtualised"
+      id="virtualised"
+      label="choose an option"
+      labelInline
+      enableVirtualScroll
+      virtualScrollOverscan={10}
+      value={values}
+      onChange={onChangeHandler}
+    >
+      {Array(10000)
+        .fill(undefined)
+        .map((_, index) => (
+          <Option
+            key={`option-${index + 1}`}
+            value={`${index}`}
+            text={`Option ${index + 1}.`}
+          />
+        ))}
+    </MultiSelect>
+  );
+};
 
 export const MultiSelectNestedInDialog = ({
   openOnFocus = false,
   autofocus = false,
 }) => {
   const [isOpen, setIsOpen] = useState(true);
+  const [values, setValues] = useState<string[]>(["1", "2"]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValues(event.target.value as unknown as string[]);
+  }
+
   return (
     <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
       <MultiSelect
@@ -276,6 +317,9 @@ export const MultiSelectNestedInDialog = ({
         autoFocus={autofocus}
         name="testSelect"
         id="testSelect"
+        label="Select a color"
+        value={values}
+        onChange={onChangeHandler}
       >
         <Option value="opt1" text="red" />
         <Option value="opt2" text="green" />
@@ -420,14 +464,22 @@ const optionListValues = [
   },
 ];
 
-export const OptionsWithSameName = () => (
-  <MultiSelect
-    name="multi-options-with-same-name"
-    id="multi-options-with-same-name"
-    label="multi options with same name"
-  >
-    {optionListValues.map((option) => (
-      <Option key={option.id} text={option.text} value={option} />
-    ))}
-  </MultiSelect>
-);
+export const OptionsWithSameName = () => {
+  const [values, setValues] = useState<string[]>(["1", "2"]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValues(event.target.value as unknown as string[]);
+  }
+  return (
+    <MultiSelect
+      name="multi-options-with-same-name"
+      id="multi-options-with-same-name"
+      label="multi options with same name"
+      value={values}
+      onChange={onChangeHandler}
+    >
+      {optionListValues.map((option) => (
+        <Option key={option.id} text={option.text} value={option} />
+      ))}
+    </MultiSelect>
+  );
+};

--- a/src/components/select/multi-select/multi-select-interaction.stories.tsx
+++ b/src/components/select/multi-select/multi-select-interaction.stories.tsx
@@ -2,7 +2,13 @@ import { StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/test";
 import React from "react";
 
-import { MultiSelect, Option, OptionRow, OptionGroupHeader } from "..";
+import {
+  MultiSelect,
+  Option,
+  OptionRow,
+  OptionGroupHeader,
+  MultiSelectProps,
+} from "..";
 import Box from "../../box";
 
 import { allowInteractions } from "../../../../.storybook/interaction-toggle/reduced-motion";
@@ -18,17 +24,54 @@ export default {
   },
 };
 
+interface ControlledMultiSelectProps
+  extends Omit<MultiSelectProps, "onChange" | "value" | "children"> {
+  children?: React.ReactNode;
+  value?: string[];
+}
+
+const ControlledMultiSelect = (props: ControlledMultiSelectProps) => {
+  const [value, setValue] = React.useState<string[]>(props.value || []);
+  return (
+    <MultiSelect
+      {...props}
+      value={value}
+      onChange={(e) => setValue(e.target.value as unknown as string[])}
+    >
+      <Option text="Amber" value="1" />
+      <Option text="Black" value="2" />
+      <Option text="Blue" value="3" />
+      <Option text="Brown" value="4" />
+      <Option text="Green" value="5" />
+      <Option text="Orange" value="6" />
+      <Option text="Pink" value="7" />
+      <Option text="Purple" value="8" />
+      <Option text="Red" value="9" />
+      <Option text="White" value="10" />
+      <Option text="Yellow" value="11" />
+    </MultiSelect>
+  );
+};
+
+const ControlledMultiSelectWithOptions = (
+  props: ControlledMultiSelectProps,
+) => {
+  const [value, setValue] = React.useState<string[]>(props.value || []);
+  return (
+    <MultiSelect
+      {...props}
+      value={value}
+      onChange={(e) => setValue(e.target.value as unknown as string[])}
+    >
+      {props.children}
+    </MultiSelect>
+  );
+};
+
 export const HighlightedItem: Story = {
   render: () => (
     <Box height={250}>
-      <MultiSelect name="multi" id="multi" label="Color">
-        <Option text="Amber" value="1" />
-        <Option text="Black" value="2" />
-        <Option text="Blue" value="3" />
-        <Option text="Brown" value="4" />
-        <Option text="Green" value="5" />
-        <Option text="Orange" value="6" />
-      </MultiSelect>
+      <ControlledMultiSelect name="multi" id="multi" label="Color" />
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -57,14 +100,7 @@ HighlightedItem.storyName = "Highlighted Item";
 export const HoverItem: Story = {
   render: () => (
     <Box height={250}>
-      <MultiSelect name="multi" id="multi" label="Color">
-        <Option text="Amber" value="1" />
-        <Option text="Black" value="2" />
-        <Option text="Blue" value="3" />
-        <Option text="Brown" value="4" />
-        <Option text="Green" value="5" />
-        <Option text="Orange" value="6" />
-      </MultiSelect>
+      <ControlledMultiSelect name="multi" id="multi" label="Color" />
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -98,12 +134,12 @@ HoverItem.parameters = {
 export const MultiColumnList: Story = {
   render: () => (
     <Box height={250}>
-      <MultiSelect
+      <ControlledMultiSelectWithOptions
         name="multi"
         id="multi"
         label="Color"
         multiColumn
-        defaultValue={["1", "2"]}
+        value={["1", "2"]}
         tableHeader={
           <tr>
             <th>Name</th>
@@ -137,7 +173,7 @@ export const MultiColumnList: Story = {
           <td>Zoe</td>
           <td>Astronaut</td>
         </OptionRow>
-      </MultiSelect>
+      </ControlledMultiSelectWithOptions>
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -167,11 +203,11 @@ MultiColumnList.parameters = {
 export const GroupedOptions: Story = {
   render: () => (
     <Box height={250}>
-      <MultiSelect
+      <ControlledMultiSelectWithOptions
         name="multi"
         id="multi"
         label="Color"
-        defaultValue={["1", "2"]}
+        value={["1", "2"]}
       >
         <OptionGroupHeader
           id="groupHeader1"
@@ -189,7 +225,7 @@ export const GroupedOptions: Story = {
         <Option text="Brown" value="4" />
         <Option text="Green" value="5" />
         <Option text="Orange" value="6" />
-      </MultiSelect>
+      </ControlledMultiSelectWithOptions>
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -219,11 +255,11 @@ GroupedOptions.parameters = {
 export const WithCustomColoredPills: Story = {
   render: () => (
     <Box height={250}>
-      <MultiSelect
+      <ControlledMultiSelectWithOptions
         name="multi"
         id="multi"
         label="Color"
-        defaultValue={["1", "2", "3", "4", "5", "6"]}
+        value={["1", "2", "3", "4", "5", "6"]}
       >
         <Option text="Amber" value="1" borderColor="#FFBF00" fill />
         <Option text="Black" value="2" borderColor="blackOpacity65" fill />
@@ -231,7 +267,7 @@ export const WithCustomColoredPills: Story = {
         <Option text="Brown" value="4" borderColor="brown" fill />
         <Option text="Green" value="5" borderColor="productGreen" />
         <Option text="Orange" value="6" borderColor="orange" />
-      </MultiSelect>
+      </ControlledMultiSelectWithOptions>
     </Box>
   ),
   play: async ({ canvasElement }) => {

--- a/src/components/select/multi-select/multi-select-test.stories.tsx
+++ b/src/components/select/multi-select/multi-select-test.stories.tsx
@@ -3,10 +3,11 @@ import { MultiSelect, Option, MultiSelectProps } from "..";
 import partialAction from "../../../../.storybook/utils/partial-action";
 import OptionRow from "../option-row/option-row.component";
 import Button from "../../button/button.component";
-import Dialog from "../../dialog";
+
 import Box from "../../box";
 import CarbonProvider from "../../carbon-provider/carbon-provider.component";
 import Typography from "../../typography";
+import Dialog from "../../dialog";
 
 export default {
   component: MultiSelect,
@@ -110,6 +111,16 @@ export const Default = (props: Partial<MultiSelectProps>) => {
 Default.storyName = "Default";
 
 export const Validation = () => {
+  const [values, setValues] = useState<string[]>([]);
+  const [values2, setValues2] = useState<string[]>([]);
+  const [values3, setValues3] = useState<string[]>([]);
+  const [values4, setValues4] = useState<string[]>([]);
+  const [values5, setValues5] = useState<string[]>([]);
+  const [values6, setValues6] = useState<string[]>([]);
+  const [values7, setValues7] = useState<string[]>([]);
+  const [values8, setValues8] = useState<string[]>([]);
+  const [values9, setValues9] = useState<string[]>([]);
+
   return (
     <>
       <MultiSelect
@@ -117,6 +128,10 @@ export const Validation = () => {
         id="multi"
         label="MultiSelect"
         error="Error Message"
+        value={values}
+        onChange={(event) =>
+          setValues(event.target.value as unknown as string[])
+        }
       >
         <Option value="1" text="One" />
         <Option value="2" text="Two" />
@@ -127,6 +142,10 @@ export const Validation = () => {
         id="multi"
         label="MultiSelect"
         warning="Warning Message"
+        value={values2}
+        onChange={(event) =>
+          setValues2(event.target.value as unknown as string[])
+        }
       >
         <Option value="1" text="One" />
         <Option value="2" text="Two" />
@@ -137,6 +156,10 @@ export const Validation = () => {
         id="multi"
         label="MultiSelect"
         info="Info Message"
+        value={values3}
+        onChange={(event) =>
+          setValues3(event.target.value as unknown as string[])
+        }
       >
         <Option value="1" text="One" />
         <Option value="2" text="Two" />
@@ -149,6 +172,10 @@ export const Validation = () => {
         label="MultiSelect"
         error="Error Message"
         validationOnLabel
+        value={values4}
+        onChange={(event) =>
+          setValues4(event.target.value as unknown as string[])
+        }
       >
         <Option value="1" text="One" />
         <Option value="2" text="Two" />
@@ -160,6 +187,10 @@ export const Validation = () => {
         label="MultiSelect"
         warning="Warning Message"
         validationOnLabel
+        value={values5}
+        onChange={(event) =>
+          setValues5(event.target.value as unknown as string[])
+        }
       >
         <Option value="1" text="One" />
         <Option value="2" text="Two" />
@@ -171,23 +202,54 @@ export const Validation = () => {
         label="MultiSelect"
         info="Info Message"
         validationOnLabel
+        value={values6}
+        onChange={(event) =>
+          setValues6(event.target.value as unknown as string[])
+        }
       >
         <Option value="1" text="One" />
         <Option value="2" text="Two" />
         <Option value="3" text="Three" />
       </MultiSelect>
 
-      <MultiSelect name="multi" id="multi" label="MultiSelect" error>
+      <MultiSelect
+        name="multi"
+        id="multi"
+        label="MultiSelect"
+        error
+        value={values7}
+        onChange={(event) =>
+          setValues7(event.target.value as unknown as string[])
+        }
+      >
         <Option value="1" text="One" />
         <Option value="2" text="Two" />
         <Option value="3" text="Three" />
       </MultiSelect>
-      <MultiSelect name="multi" id="multi" label="MultiSelect" warning>
+      <MultiSelect
+        name="multi"
+        id="multi"
+        label="MultiSelect"
+        warning
+        value={values8}
+        onChange={(event) =>
+          setValues8(event.target.value as unknown as string[])
+        }
+      >
         <Option value="1" text="One" />
         <Option value="2" text="Two" />
         <Option value="3" text="Three" />
       </MultiSelect>
-      <MultiSelect name="multi" id="multi" label="MultiSelect" info>
+      <MultiSelect
+        name="multi"
+        id="multi"
+        label="MultiSelect"
+        info
+        value={values9}
+        onChange={(event) =>
+          setValues9(event.target.value as unknown as string[])
+        }
+      >
         <Option value="1" text="One" />
         <Option value="2" text="Two" />
         <Option value="3" text="Three" />
@@ -202,6 +264,11 @@ Validation.parameters = {
 };
 
 export const NewValidation = () => {
+  const [values, setValues] = useState<string[]>([]);
+  const [values2, setValues2] = useState<string[]>([]);
+  const [values3, setValues3] = useState<string[]>([]);
+  const [values4, setValues4] = useState<string[]>([]);
+
   return (
     <CarbonProvider validationRedesignOptIn>
       <MultiSelect
@@ -210,6 +277,10 @@ export const NewValidation = () => {
         label="MultiSelect"
         error="Error Message"
         mb={2}
+        value={values}
+        onChange={(event) =>
+          setValues(event.target.value as unknown as string[])
+        }
       >
         <Option value="1" text="One" />
         <Option value="2" text="Two" />
@@ -221,6 +292,10 @@ export const NewValidation = () => {
         label="MultiSelect"
         warning="Warning Message"
         mb={2}
+        value={values2}
+        onChange={(event) =>
+          setValues2(event.target.value as unknown as string[])
+        }
       >
         <Option value="1" text="One" />
         <Option value="2" text="Two" />
@@ -233,6 +308,10 @@ export const NewValidation = () => {
         label="MultiSelect"
         error="Error Message"
         mb={2}
+        value={values3}
+        onChange={(event) =>
+          setValues3(event.target.value as unknown as string[])
+        }
       >
         <Option value="1" text="One" />
         <Option value="2" text="Two" />
@@ -245,6 +324,10 @@ export const NewValidation = () => {
         label="MultiSelect"
         warning="Warning Message"
         mb={2}
+        value={values4}
+        onChange={(event) =>
+          setValues4(event.target.value as unknown as string[])
+        }
       >
         <Option value="1" text="One" />
         <Option value="2" text="Two" />
@@ -268,11 +351,7 @@ export const MultiSelectLongPillComponent = (
   }
 
   return (
-    <div
-      style={{
-        maxWidth: "200px",
-      }}
-    >
+    <Box maxWidth="200px">
       <MultiSelect
         label="color"
         labelInline
@@ -292,7 +371,7 @@ export const MultiSelectLongPillComponent = (
         <Option text="White" value="10" />
         <Option text="Yellow" value="11" />
       </MultiSelect>
-    </div>
+    </Box>
   );
 };
 
@@ -516,10 +595,15 @@ export const MultiSelectObjectAsValueComponent = (
 export const MultiSelectMultiColumnsComponent = (
   props: Partial<MultiSelectProps>,
 ) => {
+  const [values, setValues] = useState<string[]>(["2"]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValues(event.target.value as unknown as string[]);
+  }
   return (
     <MultiSelect
       multiColumn
-      defaultValue={["2"]}
+      value={values}
+      onChange={onChangeHandler}
       {...props}
       tableHeader={
         <tr>
@@ -633,8 +717,18 @@ export const MultiSelectOnFilterChangeEventComponent = ({
 export const MultiSelectCustomColorComponent = (
   props: Partial<MultiSelectProps>,
 ) => {
+  const [values, setValues] = useState<string[]>(["1", "3"]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValues(event.target.value as unknown as string[]);
+  }
   return (
-    <MultiSelect label="color" labelInline defaultValue={["1", "3"]} {...props}>
+    <MultiSelect
+      label="color"
+      labelInline
+      value={values}
+      onChange={onChangeHandler}
+      {...props}
+    >
       <Option text="Amber" value="1" borderColor="#FFBF00" fill />
       <Option text="Black" value="2" borderColor="blackOpacity65" fill />
       <Option text="Blue" value="3" borderColor="productBlue" />
@@ -650,31 +744,44 @@ export const MultiSelectCustomColorComponent = (
   );
 };
 
-export const MultiSelectWithManyOptionsAndVirtualScrolling = () => (
-  <MultiSelect
-    name="virtualised"
-    id="virtualised"
-    label="choose an option"
-    labelInline
-    enableVirtualScroll
-    virtualScrollOverscan={10}
-  >
-    {Array(10000)
-      .fill(undefined)
-      .map((_, index) => (
-        <Option
-          key={`option-${index + 1}`}
-          value={`${index}`}
-          text={`Option ${index + 1}.`}
-        />
-      ))}
-  </MultiSelect>
-);
+export const MultiSelectWithManyOptionsAndVirtualScrolling = () => {
+  const [values, setValues] = useState<string[]>(["1", "2"]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValues(event.target.value as unknown as string[]);
+  }
+
+  return (
+    <MultiSelect
+      name="virtualised"
+      id="virtualised"
+      label="choose an option"
+      labelInline
+      enableVirtualScroll
+      virtualScrollOverscan={10}
+      value={values}
+      onChange={onChangeHandler}
+    >
+      {Array(10000)
+        .fill(undefined)
+        .map((_, index) => (
+          <Option
+            key={`option-${index + 1}`}
+            value={`${index}`}
+            text={`Option ${index + 1}.`}
+          />
+        ))}
+    </MultiSelect>
+  );
+};
 
 export const MultiSelectNestedInDialog = ({
   openOnFocus = false,
   autofocus = false,
 }) => {
+  const [values, setValues] = useState<string[]>(["1", "2"]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValues(event.target.value as unknown as string[]);
+  }
   const [isOpen, setIsOpen] = useState(true);
   return (
     <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
@@ -683,6 +790,8 @@ export const MultiSelectNestedInDialog = ({
         autoFocus={autofocus}
         name="testSelect"
         id="testSelect"
+        value={values}
+        onChange={onChangeHandler}
       >
         <Option value="opt1" text="red" />
         <Option value="opt2" text="green" />
@@ -809,11 +918,17 @@ const optionListValues = [
 ];
 
 export const OptionsWithSameName = () => {
+  const [values, setValues] = useState<string[]>([]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValues(event.target.value as unknown as string[]);
+  }
   return (
     <MultiSelect
       name="multi-options-with-same-name"
       id="multi-options-with-same-name"
       label="multi options with same name"
+      value={values}
+      onChange={onChangeHandler}
     >
       {optionListValues.map((option) => (
         <Option key={option.id} text={option.text} value={option} />

--- a/src/components/select/multi-select/multi-select.component.tsx
+++ b/src/components/select/multi-select/multi-select.component.tsx
@@ -5,8 +5,6 @@ import React, {
   useCallback,
   useMemo,
 } from "react";
-import invariant from "invariant";
-
 import {
   filterOutStyledSystemSpacingProps,
   filterStyledSystemMarginProps,
@@ -29,12 +27,9 @@ import Pill, { PillProps } from "../../pill";
 import isExpectedOption from "../__internal__/utils/is-expected-option";
 import isExpectedValue from "../__internal__/utils/is-expected-value";
 import isNavigationKey from "../__internal__/utils/is-navigation-key";
-import Logger from "../../../__internal__/utils/logger";
 import useStableCallback from "../../../hooks/__internal__/useStableCallback";
 import useInputAccessibility from "../../../hooks/__internal__/useInputAccessibility/useInputAccessibility";
 import { CustomSelectChangeEvent } from "../simple-select";
-
-let deprecateUncontrolledWarnTriggered = false;
 
 const FilterableSelectList = withFilter(SelectList);
 
@@ -48,8 +43,6 @@ export interface MultiSelectProps
   size?: "small" | "medium" | "large";
   /** Child components (such as Option or OptionRow) for the SelectList */
   children: React.ReactNode;
-  /** The default selected value(s), when the component is operating in uncontrolled mode */
-  defaultValue?: string[] | Record<string, unknown>[];
   /** If true the loader animation is displayed in the option list */
   isLoading?: boolean;
   /** When true component will work in multi column mode.
@@ -70,8 +63,8 @@ export interface MultiSelectProps
    * Works only in multiColumn mode
    */
   tableHeader?: React.ReactNode;
-  /** The selected value(s), when the component is operating in controlled mode */
-  value?: string[] | Record<string, unknown>[];
+  /** The selected value(s) */
+  value: string[] | Record<string, unknown>[];
   /** [Legacy] Overrides the default tooltip position */
   tooltipPosition?: "top" | "bottom" | "left" | "right";
   /** Maximum list height - defaults to 180 */
@@ -90,7 +83,7 @@ export interface MultiSelectProps
    * Only used if the `enableVirtualScroll` prop is set. */
   virtualScrollOverscan?: number;
   /** Specify a callback triggered on change */
-  onChange?: (
+  onChange: (
     ev: CustomSelectChangeEvent | React.ChangeEvent<HTMLInputElement>,
   ) => void;
   /** Override the default width of the list element. Number passed is converted into pixel value */
@@ -103,7 +96,6 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
       "aria-label": ariaLabel,
       "aria-labelledby": ariaLabelledby,
       value,
-      defaultValue,
       id,
       label,
       name,
@@ -150,13 +142,9 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
     const isMouseDownReported = useRef(false);
     const isMouseDownOnInput = useRef(false);
     const isOpenedByFocus = useRef(false);
-    const isControlled = useRef(value !== undefined);
     const [textboxRef, setTextboxRef] = useState<HTMLInputElement>();
     const [isOpen, setOpenState] = useState(false);
     const [textValue, setTextValue] = useState("");
-    const [selectedValue, setSelectedValue] = useState<
-      (string | Record<string, unknown>)[]
-    >(value || defaultValue || []);
     const [highlightedValue, setHighlightedValue] = useState<
       string | Record<string, unknown>
     >("");
@@ -168,18 +156,6 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
       label,
     });
     const focusTimer = useRef<null | ReturnType<typeof setTimeout>>(null);
-
-    const actualValue = isControlled.current ? value : selectedValue;
-
-    const componentIsUncontrolled =
-      !isControlled || (!onChange && defaultValue);
-
-    if (!deprecateUncontrolledWarnTriggered && componentIsUncontrolled) {
-      deprecateUncontrolledWarnTriggered = true;
-      Logger.deprecate(
-        "Uncontrolled behaviour in `Multi Select` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-      );
-    }
 
     const setOpen = useCallback(() => {
       setOpenState((isAlreadyOpen) => {
@@ -210,8 +186,7 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
       [name, id],
     );
 
-    /* generic value update function which can be used for both controlled and uncontrolled
-     * components, both with and without onChange.
+    /* generic value update function
      * It accepts a function to update the value, which is assumed to be have no side effects and therefore
      * be safe to run more than once if needed. */
     const updateValue = useCallback(
@@ -222,19 +197,14 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
         selectionConfirmed?: boolean,
       ) => {
         const newValue = updateFunction(
-          actualValue as (string | Record<string, unknown>)[],
+          value as (string | Record<string, unknown>)[],
         );
         // only call onChange if an option has been selected or deselected
-        if (newValue.length !== actualValue?.length) {
-          onChange?.(createCustomEvent(newValue, selectionConfirmed));
-        }
-
-        // no need to update selectedValue if the component is controlled: onChange should take care of updating the value
-        if (!isControlled.current) {
-          setSelectedValue(updateFunction);
+        if (newValue.length !== value?.length) {
+          onChange(createCustomEvent(newValue, selectionConfirmed));
         }
       },
-      [createCustomEvent, onChange, actualValue],
+      [createCustomEvent, onChange, value],
     );
 
     function findElementWithMatchingText(
@@ -317,10 +287,10 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
     );
 
     const accessibilityLabel = useMemo(() => {
-      return actualValue && actualValue.length
+      return value && value.length
         ? React.Children.map(children, (child) => {
             return React.isValidElement(child) &&
-              actualValue.includes(child.props.value)
+              value.includes(child.props.value)
               ? child.props.text
               : false;
           })
@@ -329,7 +299,7 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
               return acc ? `${acc}, ${item}` : item;
             }, "")
         : null;
-    }, [children, actualValue]);
+    }, [children, value]);
 
     const handleGlobalClick = useCallback(
       (event: MouseEvent) => {
@@ -363,11 +333,11 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
       const canDelete = !disabled && !readOnly;
       let matchingOptionValue: string;
 
-      if (!actualValue?.length) {
+      if (!value?.length) {
         return "";
       }
 
-      return actualValue.map((singleValue, index) => {
+      return value.map((singleValue, index) => {
         const matchingOption = React.Children.toArray(children).find(
           (child) =>
             React.isValidElement(child) && isExpectedOption(child, singleValue),
@@ -412,36 +382,18 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
         );
       });
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [children, disabled, readOnly, actualValue]);
-
-    useEffect(() => {
-      const modeSwitchedMessage =
-        "Input elements should not switch from uncontrolled to controlled (or vice versa). " +
-        "Decide between using a controlled or uncontrolled input element for the lifetime of the component";
-      const onChangeMissingMessage =
-        "onChange prop required when using a controlled input element";
-
-      invariant(
-        isControlled.current === (value !== undefined),
-        modeSwitchedMessage,
-      );
-      invariant(
-        !isControlled.current || (isControlled.current && onChange),
-        onChangeMissingMessage,
-      );
-    }, [value, onChange]);
+    }, [children, disabled, readOnly, value]);
 
     // removes placeholder when a value is present
     useEffect(() => {
       const hasValue = value?.length;
-      const hasSelectedValue = actualValue?.length;
 
-      if (hasValue || hasSelectedValue) {
+      if (hasValue) {
         setPlaceholderOverride(" ");
       } else {
         setPlaceholderOverride(placeholder);
       }
-    }, [value, actualValue, placeholder]);
+    }, [value, placeholder]);
 
     useEffect(() => {
       const clickEvent = "click";
@@ -606,8 +558,7 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
         setTextValue("");
 
         const isAlreadySelected =
-          actualValue?.findIndex((val) => isExpectedValue(val, newValue)) !==
-          -1;
+          value?.findIndex((val) => isExpectedValue(val, newValue)) !== -1;
 
         textboxRef?.focus();
         isMouseDownReported.current = false;
@@ -620,7 +571,7 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
           return [...previousValue, newValue];
         }, selectionConfirmed);
       },
-      [textboxRef, actualValue, updateValue],
+      [textboxRef, value, updateValue],
     );
 
     const onSelectListClose = useCallback(() => {
@@ -654,7 +605,7 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
         placeholder: placeholderOverride,
         leftChildren: mapValuesToPills,
         formattedValue: textValue,
-        selectedValue: actualValue,
+        selectedValue: value,
         onClick: handleTextboxClick,
         onMouseDown: handleTextboxMouseDown,
         onFocus: handleTextboxFocus,
@@ -703,7 +654,7 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
         listPlacement={listWidth !== undefined ? placement : listPlacement}
         listMaxHeight={listMaxHeight}
         flipEnabled={flipEnabled}
-        multiselectValues={actualValue}
+        multiselectValues={value}
         isOpen={isOpen}
         enableVirtualScroll={enableVirtualScroll}
         virtualScrollOverscan={virtualScrollOverscan}
@@ -745,6 +696,7 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
             hasTextCursor
             isOpen={isOpen}
             labelId={labelId}
+            value={getTextboxProps().formattedValue}
             {...getTextboxProps()}
           />
         </div>

--- a/src/components/select/multi-select/multi-select.mdx
+++ b/src/components/select/multi-select/multi-select.mdx
@@ -56,10 +56,6 @@ will have the same width as the input.
 
 <Canvas of={MultiSelectStories.ListWidth} />
 
-### Controlled Usage
-
-<Canvas of={MultiSelectStories.Controlled} />
-
 ### Open on focus
 
 <Canvas of={MultiSelectStories.OpenOnFocus} />
@@ -140,7 +136,7 @@ This component supports input validation, see our [Validations](../?path=/docs/d
 
 ## Testing with React Testing Library (RTL)
 
-Testing with RTL is supported for the `MultiSelect` component, please consult the [Testing with RTL](../?path=/docs/select--docs#testing-with-react-testing-library-rtl) 
+Testing with RTL is supported for the `MultiSelect` component, please consult the [Testing with RTL](../?path=/docs/select--docs#testing-with-react-testing-library-rtl)
 section in `SimpleSelect` for more information.
 
 ## Props

--- a/src/components/select/multi-select/multi-select.pw.tsx
+++ b/src/components/select/multi-select/multi-select.pw.tsx
@@ -624,7 +624,7 @@ test.describe("MultiSelect component", () => {
     page,
   }) => {
     const { update } = await mount(
-      <MultiSelect label="Colour">
+      <MultiSelect label="Colour" onChange={() => {}} value={["Amber"]}>
         <Option text="Amber" value="Amber" />
         <Option text="Black" value="Black" />
         <Option text="Cyan" value="Cyan" />
@@ -650,7 +650,7 @@ test.describe("MultiSelect component", () => {
     );
 
     await update(
-      <MultiSelect label="Colour">
+      <MultiSelect label="Colour" onChange={() => {}} value={["Amber"]}>
         <Option text="Amber" value="Amber" />
         <Option text="Black" value="Black" />
         <Option text="Cyan" value="Cyan" />
@@ -888,25 +888,11 @@ test.describe("MultiSelect component", () => {
     ).toBeVisible();
   });
 
-  [
-    ["3", "Blue"],
-    ["7", "Pink"],
-  ].forEach(([value, option]) => {
-    test(`should set defaultValue prop to ${value} and show option pill ${option} preselected`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<MultiSelectDefaultValueComponent defaultValue={[value]} />);
-
-      await expect(multiSelectPill(page)).toHaveAttribute("title", option);
-    });
-  });
-
   test("should have no pill option preselected if defaultValue prop is not set", async ({
     mount,
     page,
   }) => {
-    await mount(<MultiSelectDefaultValueComponent />);
+    await mount(<MultiSelectDefaultValueComponent value={[]} />);
 
     await expect(multiSelectPill(page)).toHaveCount(0);
   });
@@ -945,7 +931,10 @@ test.describe("MultiSelect component", () => {
     page,
   }) => {
     await mount(
-      <MultiSelectDefaultValueComponent defaultValue={defaultValue} />,
+      <MultiSelectDefaultValueComponent
+        onChange={() => {}}
+        value={defaultValue}
+      />,
     );
 
     await expect(multiSelectPill(page)).toHaveAttribute("title", "White");
@@ -963,7 +952,10 @@ test.describe("MultiSelect component", () => {
     page,
   }) => {
     await mount(
-      <MultiSelectDefaultValueComponent defaultValue={defaultValue} />,
+      <MultiSelectDefaultValueComponent
+        onChange={() => {}}
+        value={defaultValue}
+      />,
     );
 
     const pillElement = multiSelectPill(page);
@@ -977,7 +969,10 @@ test.describe("MultiSelect component", () => {
     page,
   }) => {
     await mount(
-      <MultiSelectDefaultValueComponent defaultValue={defaultValue} />,
+      <MultiSelectDefaultValueComponent
+        onChange={() => {}}
+        value={defaultValue}
+      />,
     );
 
     const pillElement = multiSelectPill(page);
@@ -1809,16 +1804,6 @@ test.describe("Accessibility tests for MultiSelect component", () => {
 
     await dropdownButton(page).click();
     await checkAccessibility(page, undefined, "scrollable-region-focusable");
-  });
-
-  ["3", "7"].forEach((value) => {
-    test(`should pass accessibility tests with defaultValue prop set to ${value}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<MultiSelectDefaultValueComponent defaultValue={[value]} />);
-      await checkAccessibility(page);
-    });
   });
 
   test("should pass accessibility tests with custom coloured pills", async ({

--- a/src/components/select/multi-select/multi-select.stories.tsx
+++ b/src/components/select/multi-select/multi-select.stories.tsx
@@ -17,15 +17,29 @@ const meta: Meta<typeof MultiSelect> = {
   argTypes: {
     ...styledSystemProps,
   },
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof MultiSelect>;
 
 export const Default: Story = () => {
+  const [value, setValue] = useState<string[]>([]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value as unknown as string[]);
+  }
+
   return (
     <Box height={220}>
-      <MultiSelect name="simple" id="simple" label="color">
+      <MultiSelect
+        name="simple"
+        id="simple"
+        label="color"
+        value={value}
+        onChange={onChangeHandler}
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
@@ -91,6 +105,11 @@ ListPlacement.storyName = "List Placement";
 ListPlacement.parameters = { chromatic: { disableSnapshot: true } };
 
 export const ListHeight: Story = () => {
+  const [value, setValue] = useState<string[]>([]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value as unknown as string[]);
+  }
+
   return (
     <Box height={500}>
       <MultiSelect
@@ -98,6 +117,8 @@ export const ListHeight: Story = () => {
         name="list height"
         id="list-height"
         label="List height"
+        value={value}
+        onChange={onChangeHandler}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -185,6 +206,10 @@ Controlled.storyName = "Controlled";
 Controlled.parameters = { chromatic: { disableSnapshot: true } };
 
 export const OpenOnFocus: Story = () => {
+  const [value, setValue] = useState<string[]>([]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value as unknown as string[]);
+  }
   return (
     <Box height={250}>
       <MultiSelect
@@ -192,6 +217,8 @@ export const OpenOnFocus: Story = () => {
         id="openOnFocus"
         openOnFocus
         label="color"
+        value={value}
+        onChange={onChangeHandler}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -212,12 +239,17 @@ OpenOnFocus.storyName = "Open on Focus";
 OpenOnFocus.parameters = { chromatic: { disableSnapshot: true } };
 
 export const Disabled: Story = () => {
+  const [value, setValue] = useState<string[]>(["1", "3"]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value as unknown as string[]);
+  }
   return (
     <MultiSelect
       aria-label="disabled"
       name="disabled"
       id="select-disabled"
-      defaultValue={["1", "3"]}
+      value={value}
+      onChange={onChangeHandler}
       disabled
     >
       <Option text="Amber" value="1" />
@@ -237,12 +269,17 @@ export const Disabled: Story = () => {
 Disabled.storyName = "Disabled";
 
 export const Readonly: Story = () => {
+  const [value, setValue] = useState<string[]>(["1", "3"]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value as unknown as string[]);
+  }
   return (
     <MultiSelect
       aria-label="readonly"
       name="readonly"
       id="readonly"
-      defaultValue={["1", "3"]}
+      value={value}
+      onChange={onChangeHandler}
       readOnly
     >
       <Option text="Amber" value="1" />
@@ -262,6 +299,11 @@ export const Readonly: Story = () => {
 Readonly.storyName = "Read Only";
 
 export const WithMultipleColumns: Story = () => {
+  const [value, setValue] = useState<string[]>([]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value as unknown as string[]);
+  }
+
   return (
     <Box height={250}>
       <MultiSelect
@@ -276,6 +318,8 @@ export const WithMultipleColumns: Story = () => {
           </tr>
         }
         label="With multiple columns"
+        value={value}
+        onChange={onChangeHandler}
       >
         <OptionRow id="1" value="1" text="John Doe">
           <td>John</td>
@@ -310,6 +354,11 @@ WithMultipleColumns.storyName = "With Multiple Columns";
 WithMultipleColumns.parameters = { chromatic: { disableSnapshot: true } };
 
 export const Required: Story = () => {
+  const [value, setValue] = useState<string[]>([]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value as unknown as string[]);
+  }
+
   return (
     <Box height={250}>
       <MultiSelect
@@ -317,6 +366,8 @@ export const Required: Story = () => {
         id="required-select"
         label="Foreground Color"
         required
+        value={value}
+        onChange={onChangeHandler}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -437,13 +488,19 @@ WithIsLoadingProp.storyName = "With isLoading prop";
 WithIsLoadingProp.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithCustomColoredPills: Story = () => {
+  const [value, setValue] = useState<string[]>(["1", "3"]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value as unknown as string[]);
+  }
+
   return (
     <Box height={250}>
       <MultiSelect
         name="simple"
         id="simple"
         label="color"
-        defaultValue={["1", "3"]}
+        value={value}
+        onChange={onChangeHandler}
       >
         <Option text="Amber" value="1" borderColor="#FFBF00" fill />
         <Option text="Black" value="2" borderColor="blackOpacity65" fill />
@@ -553,9 +610,21 @@ WithInfiniteScroll.storyName = "With infinite scroll";
 WithInfiniteScroll.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithCustomMaxWidth: Story = () => {
+  const [value, setValue] = useState<string[]>([]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value as unknown as string[]);
+  }
+
   return (
     <Box height={250}>
-      <MultiSelect name="simple" id="simple" maxWidth="50%" label="color">
+      <MultiSelect
+        name="simple"
+        id="simple"
+        maxWidth="50%"
+        label="color"
+        value={value}
+        onChange={onChangeHandler}
+      >
         <Option text="Amber" value="1" borderColor="#FFBF00" fill />
         <Option text="Black" value="2" borderColor="blackOpacity65" fill />
         <Option text="Blue" value="3" borderColor="productBlue" />
@@ -574,6 +643,11 @@ export const WithCustomMaxWidth: Story = () => {
 WithCustomMaxWidth.storyName = "With Custom Max Width";
 
 export const PillsWithLongText: Story = () => {
+  const [value, setValue] = useState<string[]>(["1"]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value as unknown as string[]);
+  }
+
   return (
     <Box height={250} maxWidth="200px">
       <MultiSelect
@@ -581,7 +655,8 @@ export const PillsWithLongText: Story = () => {
         id="long-pill-text-wrapped"
         label="long pill text wrapped"
         wrapPillText
-        defaultValue={["1"]}
+        value={value}
+        onChange={onChangeHandler}
       >
         <Option text="Amber is the colour" value="1" />
         <Option text="Black is the colour" value="2" />
@@ -617,6 +692,11 @@ export const Virtualised: Story = () => {
         text={`${colors[index % colors.length]} - option ${index + 1}`}
       />
     ));
+  const [value, setValue] = useState<string[]>([]);
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value as unknown as string[]);
+  }
+
   return (
     <Box height={220}>
       <MultiSelect
@@ -626,6 +706,8 @@ export const Virtualised: Story = () => {
         labelInline
         enableVirtualScroll
         virtualScrollOverscan={20}
+        value={value}
+        onChange={onChangeHandler}
       >
         {options}
       </MultiSelect>

--- a/src/components/select/simple-select/components.test-pw.tsx
+++ b/src/components/select/simple-select/components.test-pw.tsx
@@ -4,6 +4,9 @@ import Content from "../../../components/content";
 import {
   CustomSelectChangeEvent,
   Select as SimpleSelect,
+  Select,
+  Option,
+  SimpleSelectProps,
 } from "../../../../src/components/select";
 import OptionRow from "../option-row/option-row.component";
 import OptionGroupHeader from "../option-group-header/option-group-header.component";
@@ -11,13 +14,13 @@ import Box from "../../box";
 import Icon from "../../icon";
 import Dialog from "../../dialog";
 import Button from "../../button";
-import { Select, Option, SimpleSelectProps } from "..";
 
 export const SimpleSelectComponent = (props: Partial<SimpleSelectProps>) => {
   const [value, setValue] = useState("");
   function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
     setValue(event.target.value);
   }
+
   return (
     <SimpleSelect
       label="simple select"
@@ -86,12 +89,19 @@ export const SimpleSelectObjectAsValueComponent = (
 export const SimpleSelectMultipleColumnsComponent = (
   props: Partial<SimpleSelectProps>,
 ) => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   return (
     <SimpleSelect
       name="withMultipleColumns"
       id="withMultipleColumns"
       label="Clients"
       multiColumn
+      value={value}
+      onChange={onChangeHandler}
       {...props}
       tableHeader={
         <tr>
@@ -140,11 +150,17 @@ export const SimpleSelectMultipleColumnsComponent = (
 export const SimpleSelectCustomOptionChildrenComponent = (
   props: Partial<SimpleSelectProps>,
 ) => {
+  const [value, setValue] = useState("4");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   return (
     <SimpleSelect
       name="customOptionChildren"
       id="customOptionChildren"
-      defaultValue="4"
+      value={value}
+      onChange={onChangeHandler}
       label="Pick your favourite color"
       {...props}
     >
@@ -171,8 +187,19 @@ export const SimpleSelectCustomOptionChildrenComponent = (
 export const SimpleSelectGroupComponent = (
   props: Partial<SimpleSelectProps>,
 ) => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   return (
-    <SimpleSelect name="optGroups" id="optGroups" {...props}>
+    <SimpleSelect
+      name="optGroups"
+      id="optGroups"
+      value={value}
+      onChange={onChangeHandler}
+      {...props}
+    >
       <OptionGroupHeader
         id="groupHeader1"
         label="Group one"
@@ -197,45 +224,72 @@ export const SimpleSelectGroupComponent = (
   );
 };
 
-export const SimpleSelectWithLongWrappingTextComponent = () => (
-  <Box width={400}>
-    <SimpleSelect name="simple" id="simple" label="label" labelInline>
-      <Option
-        text="Like a lot of intelligent animals, most crows are quite social. 
+export const SimpleSelectWithLongWrappingTextComponent = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  return (
+    <Box width={400}>
+      <SimpleSelect
+        name="simple"
+        id="simple"
+        label="label"
+        labelInline
+        value={value}
+        onChange={onChangeHandler}
+      >
+        <Option
+          text="Like a lot of intelligent animals, most crows are quite social.
         For instance, American crows spend most of the year living in pairs or small family groups.
         During the winter months, they will congregate with hundreds or even thousands of their peers to sleep together at night."
-        value="1"
-      />
-    </SimpleSelect>
-  </Box>
-);
-
-export const WithVirtualScrolling = () => (
-  <SimpleSelect
-    name="Virtualised"
-    id="Virtualised"
-    onChange={() => {}}
-    label="Choose an option"
-    enableVirtualScroll
-    virtualScrollOverscan={1}
-  >
-    {Array(20)
-      .fill(undefined)
-      .map((_, index) => (
-        <Option
-          key={`Option-${index + 1}`}
-          value={index.toString()}
-          text={`Option ${index + 1}`}
+          value="1"
         />
-      ))}
-  </SimpleSelect>
-);
+      </SimpleSelect>
+    </Box>
+  );
+};
+
+export const WithVirtualScrolling = () => {
+  const [value, setValue] = useState("");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  return (
+    <SimpleSelect
+      name="Virtualised"
+      id="Virtualised"
+      value={value}
+      onChange={onChangeHandler}
+      label="Choose an option"
+      enableVirtualScroll
+      virtualScrollOverscan={1}
+    >
+      {Array(20)
+        .fill(undefined)
+        .map((_, index) => (
+          <Option
+            key={`Option-${index + 1}`}
+            value={index.toString()}
+            text={`Option ${index + 1}`}
+          />
+        ))}
+    </SimpleSelect>
+  );
+};
 
 export const SimpleSelectNestedInDialog = ({
   openOnFocus = false,
   autofocus = false,
 }) => {
   const [isOpen, setIsOpen] = useState(true);
+  const [value, setValue] = useState("");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   return (
     <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
       <SimpleSelect
@@ -244,6 +298,8 @@ export const SimpleSelectNestedInDialog = ({
         name="testSelect"
         id="testSelect"
         label="choose an option"
+        value={value}
+        onChange={onChangeHandler}
       >
         <Option value="opt1" text="red" />
         <Option value="opt2" text="green" />
@@ -272,9 +328,18 @@ export const SelectWithOptionGroupHeader = () => {
       content: "content",
     },
   ];
+  const [value, setValue] = useState("");
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   return (
     <Box p={10}>
-      <Select placeholder="Scroll does not reach the last option">
+      <Select
+        placeholder="Scroll does not reach the last option"
+        value={value}
+        onChange={onChangeHandler}
+      >
         <OptionGroupHeader label="Scroll does not reach the last option" />
         {reportGroup.map(({ id, title, content }) => {
           return (

--- a/src/components/select/simple-select/simple-select-interaction.stories.tsx
+++ b/src/components/select/simple-select/simple-select-interaction.stories.tsx
@@ -1,8 +1,11 @@
 import { StoryObj } from "@storybook/react";
 import { userEvent, screen, within } from "@storybook/test";
-import React from "react";
+import React, { useState } from "react";
 
-import SimpleSelect from "./simple-select.component";
+import SimpleSelect, {
+  CustomSelectChangeEvent,
+  SimpleSelectProps,
+} from "./simple-select.component";
 import { Select, Option, OptionRow } from "..";
 import OptionGroupHeader from "../option-group-header/option-group-header.component";
 
@@ -17,6 +20,38 @@ import userInteractionPause from "../../../../.storybook/utils/user-interaction-
 
 type Story = StoryObj<typeof SimpleSelect>;
 
+type InteractiveComponentProps = Omit<
+  SimpleSelectProps,
+  "onChange" | "value"
+> & {
+  children: React.ReactNode;
+  onChange: (
+    ev: CustomSelectChangeEvent | React.ChangeEvent<HTMLInputElement>,
+  ) => void;
+  value?: string;
+};
+
+const InteractiveComponent = ({
+  children,
+  onChange,
+  value = "",
+  ...props
+}: InteractiveComponentProps) => {
+  const [internalValue, setValue] = useState(value);
+  return (
+    <SimpleSelect
+      onChange={(event) => {
+        setValue(event.target.value);
+        onChange(event);
+      }}
+      value={internalValue}
+      {...props}
+    >
+      {children}
+    </SimpleSelect>
+  );
+};
+
 export default {
   title: "Select/Interactions",
   parameters: {
@@ -27,7 +62,12 @@ export default {
 export const OpenList: Story = {
   render: () => (
     <Box height={250}>
-      <Select name="simple" id="simple" label="Color">
+      <InteractiveComponent
+        onChange={() => {}}
+        name="simple"
+        id="simple"
+        label="Color"
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
@@ -39,7 +79,7 @@ export const OpenList: Story = {
         <Option text="Red" value="9" />
         <Option text="White" value="10" />
         <Option text="Yellow" value="11" />
-      </Select>
+      </InteractiveComponent>
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -65,11 +105,12 @@ export const OpenComplexList: Story = {
   render: () => (
     <Box height={250}>
       <Select
+        onChange={() => {}}
+        value="2"
         name="complex"
         id="complex"
         label="Employee"
         multiColumn
-        defaultValue="2"
         enableVirtualScroll
         tableHeader={
           <tr>
@@ -118,7 +159,12 @@ OpenComplexList.storyName = "Open Complex List";
 export const HighlightedItem: Story = {
   render: () => (
     <Box height={250}>
-      <Select name="simple" id="simple" label="Color">
+      <InteractiveComponent
+        onChange={() => {}}
+        name="simple"
+        id="simple"
+        label="Color"
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
@@ -130,7 +176,7 @@ export const HighlightedItem: Story = {
         <Option text="Red" value="9" />
         <Option text="White" value="10" />
         <Option text="Yellow" value="11" />
-      </Select>
+      </InteractiveComponent>
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -163,7 +209,12 @@ HighlightedItem.storyName = "Highlighted Item";
 export const SelectedItemHover: Story = {
   render: () => (
     <Box height={250}>
-      <Select name="simple" id="simple" label="Color">
+      <InteractiveComponent
+        onChange={() => {}}
+        name="simple"
+        id="simple"
+        label="Color"
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
@@ -175,7 +226,7 @@ export const SelectedItemHover: Story = {
         <Option text="Red" value="9" />
         <Option text="White" value="10" />
         <Option text="Yellow" value="11" />
-      </Select>
+      </InteractiveComponent>
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -215,7 +266,12 @@ SelectedItemHover.parameters = {
 export const NonSelectedItemHover: Story = {
   render: () => (
     <Box height={250}>
-      <Select name="simple" id="simple" label="Color">
+      <InteractiveComponent
+        onChange={() => {}}
+        name="simple"
+        id="simple"
+        label="Color"
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
@@ -227,7 +283,7 @@ export const NonSelectedItemHover: Story = {
         <Option text="Red" value="9" />
         <Option text="White" value="10" />
         <Option text="Yellow" value="11" />
-      </Select>
+      </InteractiveComponent>
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -267,7 +323,13 @@ NonSelectedItemHover.parameters = {
 export const FocusTransparent: Story = {
   render: () => (
     <Box height={250}>
-      <Select name="simple" id="simple" label="Color" transparent>
+      <InteractiveComponent
+        onChange={() => {}}
+        name="simple"
+        id="simple"
+        label="Color"
+        transparent
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
@@ -279,7 +341,7 @@ export const FocusTransparent: Story = {
         <Option text="Red" value="9" />
         <Option text="White" value="10" />
         <Option text="Yellow" value="11" />
-      </Select>
+      </InteractiveComponent>
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -308,7 +370,13 @@ FocusTransparent.storyName = "Transparent Focus";
 export const FocusTransparentWithSelection: Story = {
   render: () => (
     <Box height={250}>
-      <Select name="simple" id="simple" label="Color" transparent>
+      <InteractiveComponent
+        onChange={() => {}}
+        name="simple"
+        id="simple"
+        label="Color"
+        transparent
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
@@ -320,7 +388,7 @@ export const FocusTransparentWithSelection: Story = {
         <Option text="Red" value="9" />
         <Option text="White" value="10" />
         <Option text="Yellow" value="11" />
-      </Select>
+      </InteractiveComponent>
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -356,7 +424,12 @@ FocusTransparentWithSelection.storyName = "Transparent Focus With Selection";
 export const OptionGroupHeaders: Story = {
   render: () => (
     <Box height={250}>
-      <SimpleSelect name="simple" id="simple" label="Color">
+      <InteractiveComponent
+        onChange={() => {}}
+        name="simple"
+        id="simple"
+        label="Color"
+      >
         <OptionGroupHeader
           id="groupHeader1"
           label="Group one"
@@ -378,7 +451,7 @@ export const OptionGroupHeaders: Story = {
         <Option text="Red" value="9" />
         <Option text="White" value="10" />
         <Option text="Yellow" value="11" />
-      </SimpleSelect>
+      </InteractiveComponent>
     </Box>
   ),
   play: async ({ canvasElement }) => {
@@ -469,12 +542,16 @@ export const NestedInDialog: Story = {
   render: () => (
     <Box height={250}>
       <Dialog open onCancel={() => {}} title="Dialog">
-        <SimpleSelect name="testSelect" id="testSelect">
+        <InteractiveComponent
+          onChange={() => {}}
+          name="testSelect"
+          id="testSelect"
+        >
           <Option value="opt1" text="red" />
           <Option value="opt2" text="green" />
           <Option value="opt3" text="blue" />
           <Option value="opt4" text="black" />
-        </SimpleSelect>
+        </InteractiveComponent>
         <Typography>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla in
           ornare neque. Maecenas pellentesque et erat tincidunt mollis. Etiam

--- a/src/components/select/simple-select/simple-select-test.stories.tsx
+++ b/src/components/select/simple-select/simple-select-test.stories.tsx
@@ -1,14 +1,19 @@
 import React, { useState, useRef } from "react";
 import Typography from "../../../components/typography";
 import Content from "../../../components/content";
-import { Select as SimpleSelect } from "../../../../src/components/select";
+import {
+  Select as SimpleSelect,
+  Select,
+  Option,
+  SimpleSelectProps,
+} from "../../../../src/components/select";
 import OptionRow from "../option-row/option-row.component";
 import OptionGroupHeader from "../option-group-header/option-group-header.component";
 import Box from "../../box";
 import Icon from "../../icon";
 import Dialog from "../../dialog";
-import { Select, Option, SimpleSelectProps } from "..";
 import CarbonProvider from "../../carbon-provider";
+import useMultiInput from "../../../hooks/use-multi-input";
 
 export default {
   component: Select,
@@ -80,9 +85,9 @@ export const Default = (args: SimpleSelectProps) => {
   return (
     <SimpleSelect
       label="simple select"
+      {...args}
       value={value}
       onChange={onChangeHandler}
-      {...args}
     >
       <Option text="Amber" value="1" />
       <Option text="Black" value="2" />
@@ -104,36 +109,44 @@ export const Default = (args: SimpleSelectProps) => {
 Default.storyName = "Default";
 
 export const Validation = () => {
+  const { state, setValue } = useMultiInput();
+
   return (
     <>
       <Select
-        name="simple"
-        id="simple"
+        name="simple-error"
+        id="simple-error"
         label="Simple Select"
         error="Error message"
         mb={2}
+        value={state["simple-error"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </Select>
       <Select
-        name="simple"
-        id="simple"
+        name="simple-warning"
+        id="simple-warning"
         label="Simple Select"
         warning="Warning message"
         mb={2}
+        value={state["simple-warning"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </Select>
       <Select
-        name="simple"
-        id="simple"
+        name="simple-info"
+        id="simple-info"
         label="Simple Select"
         info="Info message"
         mb={2}
+        value={state["simple-info"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -141,53 +154,83 @@ export const Validation = () => {
       </Select>
 
       <Select
-        name="simple"
-        id="simple"
+        name="simple-error-vol"
+        id="simple-error-vol"
         label="Simple Select"
         error="Error message"
         validationOnLabel
         mb={2}
+        value={state["simple-error-vol"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </Select>
       <Select
-        name="simple"
-        id="simple"
+        name="simple-warning-vol"
+        id="simple-warning-vol"
         label="Simple Select"
         warning="Warning message"
         validationOnLabel
         mb={2}
+        value={state["simple-warning-vol"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </Select>
       <Select
-        name="simple"
-        id="simple"
+        name="simple-info-vol"
+        id="simple-info-vol"
         label="Simple Select"
         info="Info message"
         validationOnLabel
         mb={2}
+        value={state["simple-info-vol"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </Select>
 
-      <Select name="simple" id="simple" label="Simple Select" error mb={2}>
+      <Select
+        name="simple-error-bool"
+        id="simple-error-bool"
+        label="Simple Select"
+        error
+        mb={2}
+        value={state["simple-error-bool"] || ""}
+        onChange={setValue}
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </Select>
-      <Select name="simple" id="simple" label="Simple Select" warning mb={2}>
+      <Select
+        name="simple-warning-bool"
+        id="simple-warning-bool"
+        label="Simple Select"
+        warning
+        mb={2}
+        value={state["simple-warning-bool"] || ""}
+        onChange={setValue}
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </Select>
-      <Select name="simple" id="simple" label="Simple Select" info mb={2}>
+      <Select
+        name="simple-info-bool"
+        id="simple-info-bool"
+        label="Simple Select"
+        info
+        mb={2}
+        value={state["simple-info-bool"] || ""}
+        onChange={setValue}
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
@@ -202,26 +245,32 @@ Validation.parameters = {
 };
 
 export const NewValidation = () => {
+  const { state, setValue } = useMultiInput();
+
   return (
     <CarbonProvider validationRedesignOptIn>
       <Select
-        name="simple"
-        id="simple"
+        name="simple-error"
+        id="simple-error"
         label="Simple Select"
         error="Error message"
         inputHint="Hint text"
         mb={2}
+        value={state["simple-error"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </Select>
       <Select
-        name="simple"
-        id="simple"
+        name="simple-warning"
+        id="simple-warning"
         label="Simple Select"
         warning="Warning message"
         mb={2}
+        value={state["simple-warning"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -229,12 +278,14 @@ export const NewValidation = () => {
       </Select>
       <Select
         validationMessagePositionTop={false}
-        name="simple"
-        id="simple"
+        name="simple-error-bottom"
+        id="simple-error-bottom"
         label="Simple Select"
         error="Error message"
         inputHint="Hint text"
         mb={2}
+        value={state["simple-error-bottom"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -242,11 +293,13 @@ export const NewValidation = () => {
       </Select>
       <Select
         validationMessagePositionTop={false}
-        name="simple"
-        id="simple"
+        name="simple-warning-bottom"
+        id="simple-warning-bottom"
         label="Simple Select"
         warning="Warning message"
         mb={2}
+        value={state["simple-warning-bottom"] || ""}
+        onChange={setValue}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -273,6 +326,12 @@ export const DelayedReposition = () => {
   const onOpen = () => {
     setDisplayContent(!displayContent);
   };
+  const [value, setValue] = useState("");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   return (
     <Dialog size="medium" open title="Title">
       <Box
@@ -288,6 +347,8 @@ export const DelayedReposition = () => {
             name="noTimeOut"
             id="noTimeOut"
             onOpen={onOpen}
+            value={value}
+            onChange={onChangeHandler}
           >
             <Option text="Amber" value="1" />
             <Option text="Black" value="2" />
@@ -300,6 +361,8 @@ export const DelayedReposition = () => {
             name="timeOut"
             id="timeOut"
             onOpen={onOpenWithTimeOut}
+            value={value}
+            onChange={onChangeHandler}
           >
             <Option text="Amber" value="1" />
             <Option text="Black" value="2" />
@@ -501,12 +564,19 @@ export const SimpleSelectObjectAsValueComponent = (
 export const SimpleSelectMultipleColumnsComponent = (
   props: Partial<SimpleSelectProps>,
 ) => {
+  const [value, setValue] = useState("2");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   return (
     <SimpleSelect
       name="withMultipleColumns"
       id="withMultipleColumns"
       multiColumn
-      defaultValue="2"
+      value={value}
+      onChange={onChangeHandler}
       {...props}
       tableHeader={
         <tr>
@@ -555,11 +625,18 @@ export const SimpleSelectMultipleColumnsComponent = (
 export const SimpleSelectCustomOptionChildrenComponent = (
   props: Partial<SimpleSelectProps>,
 ) => {
+  const [value, setValue] = useState("4");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   return (
     <SimpleSelect
       name="customOptionChildren"
       id="customOptionChildren"
-      defaultValue="4"
+      value={value}
+      onChange={onChangeHandler}
       label="Pick your favourite color"
       {...props}
     >
@@ -586,8 +663,20 @@ export const SimpleSelectCustomOptionChildrenComponent = (
 export const SimpleSelectGroupComponent = (
   props: Partial<SimpleSelectProps>,
 ) => {
+  const [value, setValue] = useState("");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   return (
-    <SimpleSelect name="optGroups" id="optGroups" {...props}>
+    <SimpleSelect
+      name="optGroups"
+      id="optGroups"
+      {...props}
+      value={value}
+      onChange={onChangeHandler}
+    >
       <OptionGroupHeader
         id="groupHeader1"
         label="Group one"
@@ -649,45 +738,76 @@ export const SimpleSelectEventsComponent = ({
   );
 };
 
-export const SimpleSelectWithLongWrappingTextComponent = () => (
-  <Box width={400}>
-    <SimpleSelect name="simple" id="simple" label="label" labelInline>
-      <Option
-        text="Like a lot of intelligent animals, most crows are quite social. 
+export const SimpleSelectWithLongWrappingTextComponent = () => {
+  const [value, setValue] = useState("");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  return (
+    <Box width={400}>
+      <SimpleSelect
+        name="simple"
+        id="simple"
+        label="label"
+        labelInline
+        value={value}
+        onChange={onChangeHandler}
+      >
+        <Option
+          text="Like a lot of intelligent animals, most crows are quite social.
         For instance, American crows spend most of the year living in pairs or small family groups.
         During the winter months, they will congregate with hundreds or even thousands of their peers to sleep together at night."
-        value="1"
-      />
-    </SimpleSelect>
-  </Box>
-);
-
-export const SimpleSelectWithManyOptionsAndVirtualScrolling = () => (
-  <SimpleSelect
-    name="virtualised"
-    id="virtualised"
-    label="choose an option"
-    labelInline
-    enableVirtualScroll
-    virtualScrollOverscan={10}
-  >
-    {Array(10000)
-      .fill(undefined)
-      .map((_, index) => (
-        <Option
-          key={`option-${index + 1}`}
-          value={`${index}`}
-          text={`Option ${index + 1}.`}
+          value="1"
         />
-      ))}
-  </SimpleSelect>
-);
+      </SimpleSelect>
+    </Box>
+  );
+};
+
+export const SimpleSelectWithManyOptionsAndVirtualScrolling = () => {
+  const [value, setValue] = useState("");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
+  return (
+    <SimpleSelect
+      name="virtualised"
+      id="virtualised"
+      label="choose an option"
+      labelInline
+      enableVirtualScroll
+      virtualScrollOverscan={10}
+      value={value}
+      onChange={onChangeHandler}
+    >
+      {Array(10000)
+        .fill(undefined)
+        .map((_, index) => (
+          <Option
+            key={`option-${index + 1}`}
+            value={`${index}`}
+            text={`Option ${index + 1}.`}
+          />
+        ))}
+    </SimpleSelect>
+  );
+};
 
 export const SimpleSelectNestedInDialog = ({
   openOnFocus = false,
   autofocus = false,
 }) => {
   const [isOpen, setIsOpen] = useState(true);
+  const [value, setValue] = useState("");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   return (
     <Dialog open={isOpen} onCancel={() => setIsOpen(false)} title="Dialog">
       <SimpleSelect
@@ -695,6 +815,8 @@ export const SimpleSelectNestedInDialog = ({
         autoFocus={autofocus}
         name="testSelect"
         id="testSelect"
+        value={value}
+        onChange={onChangeHandler}
       >
         <Option value="opt1" text="red" />
         <Option value="opt2" text="green" />
@@ -706,6 +828,12 @@ export const SimpleSelectNestedInDialog = ({
 };
 
 export const SelectWithOptionGroupHeader = () => {
+  const [value, setValue] = useState("");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   const reportGroup = [
     { id: 1, title: "There are 2 more options", content: "content" },
     { id: 2, title: "There is 1 more below", content: "content" },
@@ -715,9 +843,14 @@ export const SelectWithOptionGroupHeader = () => {
       content: "content",
     },
   ];
+
   return (
     <Box p={10}>
-      <Select placeholder="Scroll does not reach the last option">
+      <Select
+        placeholder="Scroll does not reach the last option"
+        value={value}
+        onChange={onChangeHandler}
+      >
         <OptionGroupHeader label="Scroll does not reach the last option" />
         {reportGroup.map(({ id, title, content }) => {
           return (
@@ -839,6 +972,12 @@ export const ComplexCustomChildren = () => {
 };
 
 export const SimpleSelectWithAriaDescribedby = () => {
+  const [value, setValue] = useState("");
+
+  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
+    setValue(event.target.value);
+  }
+
   return (
     <Box m={3} width={300}>
       <Select
@@ -847,6 +986,8 @@ export const SimpleSelectWithAriaDescribedby = () => {
         label="color"
         aria-label="color"
         aria-describedby="combo-box-description"
+        value={value}
+        onChange={onChangeHandler}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />

--- a/src/components/select/simple-select/simple-select.mdx
+++ b/src/components/select/simple-select/simple-select.mdx
@@ -75,10 +75,6 @@ The `size` prop can be used to set the size of the select input. The default val
 
 <Canvas of={SimpleSelectStories.Sizes} />
 
-### Controlled usage
-
-<Canvas of={SimpleSelectStories.Controlled} />
-
 ### With object as value
 
 Option values could be passed as objects, useful when custom data is associated with an option.
@@ -128,8 +124,8 @@ This prop will be called every time a user scrolls to the bottom of the list.
 
 ### Custom Option content
 
-The `Option` component accepts any valid React node as children, which allows for custom content to be rendered inside the option. 
-The `text` value will be used as the displayed value in the input field when selected. You can also use the `leftChildren` prop to render a node to the left of the option text. 
+The `Option` component accepts any valid React node as children, which allows for custom content to be rendered inside the option.
+The `text` value will be used as the displayed value in the input field when selected. You can also use the `leftChildren` prop to render a node to the left of the option text.
 
 <Canvas of={SimpleSelectStories.CustomOptionChildren} />
 

--- a/src/components/select/simple-select/simple-select.pw.tsx
+++ b/src/components/select/simple-select/simple-select.pw.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import SimpleSelect, { SimpleSelectProps } from ".";
+import { SimpleSelectProps } from ".";
 import Option from "../option";
 import { test, expect } from "../../../../playwright/helpers/base-test";
 import {
@@ -479,7 +479,7 @@ test.describe("SimpleSelect component", () => {
     page,
   }) => {
     const { update } = await mount(
-      <SimpleSelect label="Colour">
+      <SimpleSelectComponent label="Colour">
         <Option text="Amber" value="Amber" />
         <Option text="Black" value="Black" />
         <Option text="Cyan" value="Cyan" />
@@ -487,7 +487,7 @@ test.describe("SimpleSelect component", () => {
         <Option text="Emerald" value="Emerald" />
         <Option text="Fuchsia" value="Fuchsia" />
         <Option text="Gold" value="Gold" />
-      </SimpleSelect>,
+      </SimpleSelectComponent>,
     );
 
     const dropdownIcon = page.getByTestId("input-icon-toggle");
@@ -504,7 +504,7 @@ test.describe("SimpleSelect component", () => {
     );
 
     await update(
-      <SimpleSelect label="Colour">
+      <SimpleSelectComponent label="Colour">
         <Option text="Amber" value="Amber" />
         <Option text="Black" value="Black" />
         <Option text="Cyan" value="Cyan" />
@@ -514,10 +514,10 @@ test.describe("SimpleSelect component", () => {
         <Option text="Gold" value="Gold" />
         <Option text="Hot Pink" value="Hot Pink" />
         <Option text="Indigo" value="Indigo" />
-      </SimpleSelect>,
+      </SimpleSelectComponent>,
     );
 
-    await expect(page.getByRole("option")).toHaveCount(9);
+    await expect(page.getByRole("option")).toHaveCount(11);
 
     // check that the scroll position hasn't changed
     const newScrollPosition = await dropdownList.evaluate(
@@ -629,7 +629,7 @@ test.describe("SimpleSelect component", () => {
     mount,
     page,
   }) => {
-    await mount(<SimpleSelectMultipleColumnsComponent defaultValue="2" />);
+    await mount(<SimpleSelectMultipleColumnsComponent value="2" />);
 
     const columns = 3;
     await selectText(page).click();

--- a/src/components/select/simple-select/simple-select.stories.tsx
+++ b/src/components/select/simple-select/simple-select.stories.tsx
@@ -32,9 +32,16 @@ export default meta;
 type Story = StoryObj<typeof SimpleSelect>;
 
 export const Default: Story = () => {
+  const [value, setValue] = useState("");
   return (
     <Box height={250}>
-      <Select name="simple" id="simple" label="Color">
+      <Select
+        name="simple"
+        id="simple"
+        label="Color"
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
@@ -53,6 +60,8 @@ export const Default: Story = () => {
 Default.storyName = "Default";
 
 export const Required: Story = () => {
+  const [value, setValue] = useState("");
+
   return (
     <Box height={250}>
       <Select
@@ -60,6 +69,8 @@ export const Required: Story = () => {
         id="required-select"
         label="Foreground Color"
         required
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -122,6 +133,7 @@ ListPlacement.storyName = "List Placement";
 ListPlacement.parameters = { chromatic: { disableSnapshot: true } };
 
 export const ListHeight: Story = () => {
+  const [value, setValue] = useState("");
   return (
     <Box height={500}>
       <Select
@@ -129,6 +141,8 @@ export const ListHeight: Story = () => {
         name="list height"
         id="list-height"
         label="List height"
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -174,6 +188,9 @@ ListWidth.storyName = "List Width";
 ListWidth.parameters = { chromatic: { disableSnapshot: true } };
 
 export const Sizes: Story = () => {
+  const [value, setValue] = useState("");
+  const [value2, setValue2] = useState("");
+  const [value3, setValue3] = useState("");
   return (
     <Box height={350}>
       <Select
@@ -182,6 +199,8 @@ export const Sizes: Story = () => {
         label="Small"
         size="small"
         mb={2}
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -193,12 +212,21 @@ export const Sizes: Story = () => {
         label="Medium"
         size="medium"
         mb={2}
+        value={value2}
+        onChange={(ev) => setValue2(ev.target.value)}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
       </Select>
-      <Select name="size-large" id="size-large" label="Large" size="large">
+      <Select
+        name="size-large"
+        id="size-large"
+        label="Large"
+        size="large"
+        value={value3}
+        onChange={(ev) => setValue3(ev.target.value)}
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
@@ -207,44 +235,6 @@ export const Sizes: Story = () => {
   );
 };
 Sizes.storyName = "Sizes";
-
-export const Controlled: Story = () => {
-  const [value, setValue] = useState("");
-  function onChangeHandler(event: React.ChangeEvent<HTMLInputElement>) {
-    setValue(event.target.value);
-  }
-  function clearValue() {
-    setValue("");
-  }
-  return (
-    <Box height={300}>
-      <Button onClick={clearValue} mb={2}>
-        clear
-      </Button>
-      <Select
-        id="controlled"
-        name="controlled"
-        value={value}
-        onChange={onChangeHandler}
-        label="color"
-      >
-        <Option text="Amber" value="1" />
-        <Option text="Black" value="2" />
-        <Option text="Blue" value="3" />
-        <Option text="Brown" value="4" />
-        <Option text="Green" value="5" />
-        <Option text="Orange" value="6" />
-        <Option text="Pink" value="7" />
-        <Option text="Purple" value="8" />
-        <Option text="Red" value="9" />
-        <Option text="White" value="10" />
-        <Option text="Yellow" value="11" />
-      </Select>
-    </Box>
-  );
-};
-Controlled.storyName = "Controlled";
-Controlled.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithObjectAsValue: Story = () => {
   const optionListValues = [
@@ -296,9 +286,17 @@ WithObjectAsValue.storyName = "With Object as Value";
 WithObjectAsValue.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithCustomMaxWidth: Story = () => {
+  const [value, setValue] = useState("");
   return (
     <Box height={250}>
-      <Select name="simple" id="simple" label="color" maxWidth="100%">
+      <Select
+        name="simple"
+        id="simple"
+        label="color"
+        maxWidth="100%"
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
@@ -455,9 +453,17 @@ WithInfiniteScroll.storyName = "With infinite scroll";
 WithInfiniteScroll.parameters = { chromatic: { disableSnapshot: true } };
 
 export const OpenOnFocus: Story = () => {
+  const [value, setValue] = useState("");
   return (
     <Box height={250}>
-      <Select name="openOnFocus" id="openOnFocus" openOnFocus label="color">
+      <Select
+        name="openOnFocus"
+        id="openOnFocus"
+        openOnFocus
+        label="color"
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
+      >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
         <Option text="Blue" value="3" />
@@ -477,13 +483,15 @@ OpenOnFocus.storyName = "Open on Focus";
 OpenOnFocus.parameters = { chromatic: { disableSnapshot: true } };
 
 export const Disabled: Story = () => {
+  const [value, setValue] = useState("3");
   return (
     <Select
       aria-label="disabled"
       name="disabled"
       id="disabled"
-      defaultValue="3"
       disabled
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
     >
       <Option text="Amber" value="1" />
       <Option text="Black" value="2" />
@@ -502,13 +510,15 @@ export const Disabled: Story = () => {
 Disabled.storyName = "Disabled";
 
 export const Readonly: Story = () => {
+  const [value, setValue] = useState("4");
   return (
     <Select
       aria-label="readonly"
       name="readonly"
       id="readonly"
-      defaultValue="4"
       readOnly
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
     >
       <Option text="Amber" value="1" />
       <Option text="Black" value="2" />
@@ -527,6 +537,7 @@ export const Readonly: Story = () => {
 Readonly.storyName = "Readonly";
 
 export const Transparent: Story = () => {
+  const [value, setValue] = useState("");
   return (
     <Box height={250} width={200}>
       <Select
@@ -535,6 +546,8 @@ export const Transparent: Story = () => {
         placeholder="Please select a colour"
         transparent
         label="Choose a colour"
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -554,15 +567,17 @@ export const Transparent: Story = () => {
 Transparent.storyName = "Transparent";
 
 export const TransparentDisabled: Story = () => {
+  const [value, setValue] = useState("4");
   return (
     <Box height={250} width={150}>
       <Select
         name="transparent"
         id="transparent"
-        defaultValue="4"
         transparent
         label="Choose a colour"
         disabled
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -638,13 +653,13 @@ CustomOptionChildren.storyName = "Custom Option Children";
 CustomOptionChildren.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithMultipleColumns: Story = () => {
+  const [value, setValue] = useState("2");
   return (
     <Box height={250}>
       <Select
         name="withMultipleColumns"
         id="withMultipleColumns"
         multiColumn
-        defaultValue="2"
         tableHeader={
           <tr>
             <th>Name</th>
@@ -653,6 +668,8 @@ export const WithMultipleColumns: Story = () => {
           </tr>
         }
         label="With multiple columns"
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
       >
         <OptionRow id="1" value="1" text="John Doe">
           <td>John</td>
@@ -687,9 +704,16 @@ WithMultipleColumns.storyName = "With Multiple Columns";
 WithMultipleColumns.parameters = { chromatic: { disableSnapshot: true } };
 
 export const OptionGroups: Story = () => {
+  const [value, setValue] = useState("");
   return (
     <Box height={250}>
-      <Select name="optGroups" id="optGroups" label="color">
+      <Select
+        name="optGroups"
+        id="optGroups"
+        label="color"
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
+      >
         <OptionGroupHeader label="Group one" icon="individual" />
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -712,9 +736,16 @@ OptionGroups.storyName = "Option Groups";
 OptionGroups.parameters = { chromatic: { disableSnapshot: true } };
 
 export const OptionGroupsWithComposedChildren: Story = () => {
+  const [value, setValue] = useState("");
   return (
     <Box height={250}>
-      <Select name="optGroups" id="optGroups" label="color">
+      <Select
+        name="optGroups"
+        id="optGroups"
+        label="color"
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
+      >
         <OptionGroupHeader>
           <Icon type="individual" /> <h4>Group One Composed</h4>
         </OptionGroupHeader>
@@ -746,14 +777,16 @@ OptionGroupsWithComposedChildren.parameters = {
 };
 
 export const EnablingAdaptiveBehaviour: Story = () => {
+  const [value, setValue] = useState("4");
   return (
     <Box height={220}>
       <Select
         name="adaptive"
         id="adaptive"
         label="color"
-        defaultValue="4"
         adaptiveLabelBreakpoint={960}
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
       >
         <Option text="Amber" value="1" />
         <Option text="Black" value="2" />
@@ -774,6 +807,7 @@ EnablingAdaptiveBehaviour.storyName = "Enabling Adaptive Behaviour";
 EnablingAdaptiveBehaviour.parameters = { chromatic: { disableSnapshot: true } };
 
 export const Virtualised: Story = () => {
+  const [value, setValue] = useState("");
   return (
     <Box height={220}>
       <Select
@@ -783,6 +817,8 @@ export const Virtualised: Story = () => {
         labelInline
         enableVirtualScroll
         virtualScrollOverscan={20}
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
       >
         {Array(10000)
           .fill(undefined)
@@ -800,6 +836,7 @@ export const Virtualised: Story = () => {
 Virtualised.storyName = "Virtualised";
 
 export const WithMultipleColumnsAndVirtualisation: Story = () => {
+  const [value, setValue] = useState("2");
   return (
     <Box height={250}>
       <Select
@@ -807,7 +844,8 @@ export const WithMultipleColumnsAndVirtualisation: Story = () => {
         id="withMultipleColumnsAndVirtualisation"
         label="choose an option"
         multiColumn
-        defaultValue="2"
+        value={value}
+        onChange={(ev) => setValue(ev.target.value)}
         enableVirtualScroll
         tableHeader={
           <tr>
@@ -844,6 +882,7 @@ WithMultipleColumnsAndVirtualisation.parameters = {
 
 export const SelectionConfirmedStory: Story = () => {
   const [selectionConfirmed, setSelectionConfirmed] = useState(false);
+  const [value, setValue] = useState("");
   return (
     <Box height={280}>
       <Typography variant="strong">
@@ -855,8 +894,10 @@ export const SelectionConfirmedStory: Story = () => {
         )}
       </Typography>
       <Select
+        value={value}
         onChange={(ev: CustomSelectChangeEvent) => {
           setSelectionConfirmed(!!ev.selectionConfirmed);
+          setValue(ev.target.value);
         }}
         name="selection confirmed"
         id="selection confirmed"

--- a/src/components/sidebar/components.test-pw.tsx
+++ b/src/components/sidebar/components.test-pw.tsx
@@ -204,6 +204,8 @@ export const SidebarComponentWithSubHeading = (
 };
 
 export const SidebarBackgroundScrollTestComponent = () => {
+  const [value, setValue] = useState("");
+
   return (
     <Box height="2000px" position="relative">
       <Box
@@ -215,7 +217,13 @@ export const SidebarBackgroundScrollTestComponent = () => {
         I should not be scrolled into view
       </Box>
       <Sidebar open onCancel={() => {}}>
-        <Textbox label="textbox" />
+        <Textbox
+          label="textbox"
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+          }}
+        />
       </Sidebar>
     </Box>
   );
@@ -224,6 +232,8 @@ export const SidebarBackgroundScrollTestComponent = () => {
 export const SidebarBackgroundScrollWithOtherFocusableContainers = () => {
   const toast1Ref = useRef(null);
   const toast2Ref = useRef(null);
+  const [value, setValue] = useState("");
+
   return (
     <Box height="2000px" position="relative">
       <Box
@@ -239,7 +249,13 @@ export const SidebarBackgroundScrollWithOtherFocusableContainers = () => {
         onCancel={() => {}}
         focusableContainers={[toast1Ref, toast2Ref]}
       >
-        <Textbox label="textbox" />
+        <Textbox
+          label="textbox"
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+          }}
+        />
       </Sidebar>
       <Toast open onDismiss={() => {}} ref={toast1Ref} targetPortalId="stacked">
         Toast message 1
@@ -256,6 +272,9 @@ export const SidebarComponentFocusable = (props: Partial<SidebarProps>) => {
   const [isToastOpen, setIsToastOpen] = React.useState(false);
   const toastRef = React.useRef(null);
   const CUSTOM_SELECTOR = "button, .focusable-container input";
+  const [value, setValue] = useState("");
+  const [value2, setValue2] = useState("");
+
   return (
     <>
       <Sidebar
@@ -267,10 +286,20 @@ export const SidebarComponentFocusable = (props: Partial<SidebarProps>) => {
         {...props}
       >
         <Box className="focusable-container">
-          <Textbox label="First Name" />
+          <Textbox
+            label="First Name"
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+            }}
+          />
         </Box>
         <Box>
-          <Textbox label="Surname" />
+          <Textbox
+            label="Surname"
+            value={value2}
+            onChange={(e) => setValue2(e.target.value)}
+          />
         </Box>
         <Box className="focusable-container">
           <Button

--- a/src/components/sidebar/sidebar-test.stories.tsx
+++ b/src/components/sidebar/sidebar-test.stories.tsx
@@ -144,13 +144,13 @@ export const WithStickyForm: StoryObj<typeof Sidebar> = {
         stickyFooter
         onSubmit={(ev) => ev.preventDefault()}
       >
-        <Textbox label="Textbox" />
-        <Textbox label="Textbox" />
-        <Textbox label="Textbox" />
-        <Textbox label="Textbox" />
-        <Textbox label="Textbox" />
-        <Textbox label="Textbox" />
-        <Textbox label="Textbox" />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
       </Form>
     </Sidebar>
   ),
@@ -170,13 +170,13 @@ export const WithForm: StoryObj<typeof Sidebar> = {
         saveButton={<Button buttonType="primary">Save</Button>}
         onSubmit={(ev) => ev.preventDefault()}
       >
-        <Textbox label="Textbox" />
-        <Textbox label="Textbox" />
-        <Textbox label="Textbox" />
-        <Textbox label="Textbox" />
-        <Textbox label="Textbox" />
-        <Textbox label="Textbox" />
-        <Textbox label="Textbox" />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
+        <Textbox label="Textbox" value="" onChange={() => {}} />
       </Form>
     </Sidebar>
   ),

--- a/src/components/sidebar/sidebar.stories.tsx
+++ b/src/components/sidebar/sidebar.stories.tsx
@@ -378,9 +378,9 @@ export const OtherFocusableContainers: Story = () => {
           <Typography>
             This is an example of a dialog with a Form as content
           </Typography>
-          <Textbox label="First Name" />
-          <Textbox label="Middle Name" />
-          <Textbox label="Surname" />
+          <Textbox label="First Name" value="" onChange={() => {}} />
+          <Textbox label="Middle Name" onChange={() => {}} value="" />
+          <Textbox label="Surname" onChange={() => {}} value="" />
           <Button onClick={() => setIsToast1Open(true)}>
             Show first toast
           </Button>
@@ -512,7 +512,7 @@ export const TopModalOverride: Story = () => {
         title="Confirm"
         onConfirm={() => {}}
       >
-        <Textbox label="Confirm textbox" />
+        <Textbox label="Confirm textbox" value="" onChange={() => {}} />
       </Confirm>
       <Sidebar
         open={isOpenSidebar && isOpenAll}
@@ -520,14 +520,14 @@ export const TopModalOverride: Story = () => {
         header="sidebar"
         topModalOverride
       >
-        <Textbox label="Sidebar textbox" />
+        <Textbox label="Sidebar textbox" value="" onChange={() => {}} />
       </Sidebar>
       <Dialog
         open={isOpenDialog && isOpenAll}
         onCancel={() => setIsOpenDialog(false)}
         title="Dialog"
       >
-        <Textbox label="Dialog textbox" />
+        <Textbox label="Dialog textbox" value="" onChange={() => {}} />
       </Dialog>
     </>
   );

--- a/src/components/simple-color-picker/simple-color-picker.component.tsx
+++ b/src/components/simple-color-picker/simple-color-picker.component.tsx
@@ -21,9 +21,6 @@ import ValidationIcon from "../../__internal__/validations/validation-icon.compo
 import { InputGroupContext } from "../../__internal__/input-behaviour";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import { ValidationProps } from "../../__internal__/validations";
-import Logger from "../../__internal__/utils/logger";
-
-let deprecateUncontrolledWarnTriggered = false;
 
 export interface SimpleColorPickerProps
   extends ValidationProps,
@@ -40,7 +37,7 @@ export interface SimpleColorPickerProps
   /** The name to apply to the input. */
   name: string;
   /** Prop for `onChange` events */
-  onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   /** Prop for `onKeyDown` events */
   onKeyDown?: (ev: React.KeyboardEvent<HTMLInputElement>) => void;
   /** Prop for `onBlur` events */
@@ -50,7 +47,7 @@ export interface SimpleColorPickerProps
   /** When true, validation icon will be placed on legend instead of being placed by the input */
   validationOnLegend?: boolean;
   /** The currently selected color. */
-  value?: string;
+  value: string;
 }
 
 export interface SimpleColorPickerRef {
@@ -269,13 +266,6 @@ export const SimpleColorPicker = React.forwardRef<
     warning,
     info,
   };
-
-  if (!deprecateUncontrolledWarnTriggered && !onChange) {
-    deprecateUncontrolledWarnTriggered = true;
-    Logger.deprecate(
-      "Uncontrolled behaviour in `Simple Color Picker` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-    );
-  }
 
   return (
     <Fieldset

--- a/src/components/simple-color-picker/simple-color-picker.test.tsx
+++ b/src/components/simple-color-picker/simple-color-picker.test.tsx
@@ -3,7 +3,6 @@ import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SimpleColor, SimpleColorPicker } from ".";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
-import Logger from "../../__internal__/utils/logger";
 
 jest.mock("../../__internal__/utils/logger");
 
@@ -15,21 +14,15 @@ afterAll(() => {
   jest.useRealTimers();
 });
 
-test("should display deprecation warning once when rendered as uncontrolled", () => {
-  const loggerSpy = jest.spyOn(Logger, "deprecate");
-  render(<SimpleColorPicker legend="uncontrolled" name="uncontrolled" />);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "Uncontrolled behaviour in `Simple Color Picker` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockClear();
-});
-
 testStyledSystemMargin(
   (props) => (
-    <SimpleColorPicker legend="SimpleColorPicker Legend" name="test" {...props}>
+    <SimpleColorPicker
+      legend="SimpleColorPicker Legend"
+      name="test"
+      value="transparent"
+      onChange={jest.fn}
+      {...props}
+    >
       <SimpleColor id="foo" key="bar" value="#00A376" defaultChecked />
     </SimpleColorPicker>
   ),
@@ -43,6 +36,8 @@ test("renders with provided data- attributes", () => {
       name="test"
       data-role="bar"
       data-element="baz"
+      value="transparent"
+      onChange={jest.fn}
     >
       <SimpleColor value="#00A376" />
     </SimpleColorPicker>,
@@ -64,6 +59,8 @@ test("the `onKeyDown` callback prop is called when the user presses a key", asyn
       onKeyDown={onKeyDown}
       legend="SimpleColorPicker Legend"
       name="test"
+      value="#00A376"
+      onChange={jest.fn}
     >
       <SimpleColor value="#00A376" />
       <SimpleColor value="#0073C1" />
@@ -81,7 +78,12 @@ test("the `onKeyDown` callback prop is called when the user presses a key", asyn
 
 test("when the `defaultChecked` prop is set on one of the `SimpleColor` children, the corresponding input is checked", () => {
   render(
-    <SimpleColorPicker legend="SimpleColorPicker Legend" name="test">
+    <SimpleColorPicker
+      legend="SimpleColorPicker Legend"
+      name="test"
+      value="#0073C1"
+      onChange={jest.fn}
+    >
       <SimpleColor value="#00A376" />
       <SimpleColor value="#0073C1" defaultChecked />
       <SimpleColor value="#582C83" />
@@ -103,6 +105,8 @@ test("the `data-down` attribute is set to `false` for colors on the bottom row, 
       childWidth="40"
       legend="SimpleColorPicker Legend"
       name="test"
+      value="#00A376"
+      onChange={jest.fn}
     >
       <SimpleColor value="#00A376" />
       <SimpleColor value="#0073C1" />
@@ -129,6 +133,7 @@ test("pressing the left arrow key when focused on the first color changes select
       onChange={onChange}
       legend="SimpleColorPicker Legend"
       name="test"
+      value="#00A376"
     >
       <SimpleColor value="#00A376" />
       <SimpleColor value="#0073C1" />
@@ -154,34 +159,7 @@ test("pressing the right arrow key changes selection to the next color", async (
   const onChange = jest.fn();
   render(
     <SimpleColorPicker
-      onChange={onChange}
-      legend="SimpleColorPicker Legend"
-      name="test"
-    >
-      <SimpleColor value="#00A376" />
-      <SimpleColor value="#0073C1" />
-      <SimpleColor value="#582C83" />
-    </SimpleColorPicker>,
-  );
-  act(() => {
-    screen.getAllByRole("radio")[1].focus();
-  });
-  await user.keyboard("{ArrowRight}");
-
-  expect(onChange).toHaveBeenCalledTimes(1);
-  expect(onChange).toHaveBeenCalledWith(
-    expect.objectContaining({
-      target: expect.objectContaining({ value: "#582C83" }),
-    }),
-  );
-  expect(screen.getAllByRole("radio")[2]).toHaveFocus();
-});
-
-test("pressing the right arrow key when focused on the last color changes selection to the first color", async () => {
-  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-  const onChange = jest.fn();
-  render(
-    <SimpleColorPicker
+      value=""
       onChange={onChange}
       legend="SimpleColorPicker Legend"
       name="test"
@@ -205,11 +183,42 @@ test("pressing the right arrow key when focused on the last color changes select
   expect(screen.getAllByRole("radio")[0]).toHaveFocus();
 });
 
+// coverage
+test("pressing the right arrow key when the middle colour is focused changes selection to the next color", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  const onChange = jest.fn();
+  render(
+    <SimpleColorPicker
+      value=""
+      onChange={onChange}
+      legend="SimpleColorPicker Legend"
+      name="test"
+    >
+      <SimpleColor value="#00A376" />
+      <SimpleColor value="#0073C1" />
+      <SimpleColor value="#582C83" />
+    </SimpleColorPicker>,
+  );
+  act(() => {
+    screen.getAllByRole("radio")[1].focus();
+  });
+  await user.keyboard("{ArrowRight}");
+
+  expect(onChange).toHaveBeenCalledTimes(1);
+  expect(onChange).toHaveBeenCalledWith(
+    expect.objectContaining({
+      target: expect.objectContaining({ value: "#582C83" }),
+    }),
+  );
+  expect(screen.getAllByRole("radio")[2]).toHaveFocus();
+});
+
 test("when the input has multiple rows, pressing the up arrow key changes selection to the color immediately above", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
   const onChange = jest.fn();
   render(
     <SimpleColorPicker
+      value=""
       onChange={onChange}
       maxWidth="100"
       childWidth="100"
@@ -245,6 +254,7 @@ test("when focus is already on the top row, pressing the up arrow key does not c
       childWidth="40"
       legend="SimpleColorPicker Legend"
       name="test"
+      value="#00A376"
     >
       <SimpleColor value="#00A376" />
       <SimpleColor value="#0073C1" />
@@ -270,6 +280,7 @@ test("when the input has multiple rows, pressing the down arrow key changes sele
       childWidth="100"
       legend="SimpleColorPicker Legend"
       name="test"
+      value=""
     >
       <SimpleColor value="#00A376" />
       <SimpleColor value="#0073C1" />
@@ -300,6 +311,7 @@ test("when focus is already on the bottom row, pressing the down arrow key does 
       childWidth="40"
       legend="SimpleColorPicker Legend"
       name="test"
+      value="#00A376"
     >
       <SimpleColor value="#00A376" />
       <SimpleColor value="#0073C1" />
@@ -324,6 +336,7 @@ test("focus is not changed if a non-arrow key is pressed", async () => {
       onChange={onChange}
       legend="SimpleColorPicker Legend"
       name="test"
+      value="#00A376"
     >
       <SimpleColor value="#00A376" />
       <SimpleColor value="#0073C1" />
@@ -347,6 +360,8 @@ test("the `onBlur` callback prop should not be called if focus moves from one co
       onBlur={onBlur}
       legend="SimpleColorPicker Legend"
       name="test"
+      value="#00A376"
+      onChange={jest.fn}
     >
       <SimpleColor value="#00A376" />
       <SimpleColor value="#0073C1" />
@@ -370,6 +385,8 @@ test("the `onBlur` callback prop should not be called if the currently-focused c
       onBlur={onBlur}
       legend="SimpleColorPicker Legend"
       name="test"
+      value="#00A376"
+      onChange={jest.fn}
     >
       <SimpleColor value="#00A376" />
       <SimpleColor value="#0073C1" />
@@ -392,6 +409,8 @@ test("the `onBlur` callback prop should be called if an input is blurred by clic
       onBlur={onBlur}
       legend="SimpleColorPicker Legend"
       name="test"
+      value="#00A376"
+      onChange={jest.fn}
     >
       <SimpleColor value="#00A376" />
       <SimpleColor value="#0073C1" />
@@ -419,7 +438,12 @@ test("validates the incorrect children prop", () => {
 
   expect(() => {
     render(
-      <SimpleColorPicker name="test" legend="SimpleColorPicker Legend">
+      <SimpleColorPicker
+        name="test"
+        legend="SimpleColorPicker Legend"
+        value="#00A376"
+        onChange={jest.fn}
+      >
         <p>Invalid children</p>
         <p>Invalid children</p>
       </SimpleColorPicker>,
@@ -446,6 +470,8 @@ test("returns a list of inputs in the ref", () => {
         ref={simpleColorPickerData}
         legend="SimpleColorPicker Legend"
         name="test"
+        value="#00A376"
+        onChange={jest.fn}
       >
         <SimpleColor value="#00A376" />
         <SimpleColor value="#0073C1" />
@@ -466,7 +492,13 @@ test("returns a list of inputs in the ref", () => {
 
 test("the `required` prop is passed to the inputs", () => {
   render(
-    <SimpleColorPicker required legend="SimpleColorPicker Legend" name="test">
+    <SimpleColorPicker
+      required
+      legend="SimpleColorPicker Legend"
+      name="test"
+      value="#00A376"
+      onChange={jest.fn}
+    >
       <SimpleColor value="#00A376" />
       <SimpleColor value="#0073C1" />
       <SimpleColor value="#582C83" />
@@ -481,7 +513,12 @@ test("the `required` prop is passed to the inputs", () => {
 test("empty children are accepted without error", () => {
   expect(() => {
     render(
-      <SimpleColorPicker name="test" legend="SimpleColorPicker Legend">
+      <SimpleColorPicker
+        name="test"
+        legend="SimpleColorPicker Legend"
+        value="#00A376"
+        onChange={jest.fn}
+      >
         {null}
         {false}
         {undefined}
@@ -500,6 +537,8 @@ test.each(["error", "warning", "info"])(
         validationOnLegend
         legend="SimpleColorPicker Legend"
         name="test"
+        value="#00A376"
+        onChange={jest.fn}
       />,
     );
 
@@ -508,3 +547,22 @@ test.each(["error", "warning", "info"])(
     ).toBeVisible();
   },
 );
+
+// coverage for transparent sample
+test("renders a transparent color sample when value is 'transparent'", () => {
+  render(
+    <SimpleColorPicker
+      legend="SimpleColorPicker Legend"
+      name="test"
+      data-role="bar"
+      data-element="baz"
+      value="transparent"
+      onChange={jest.fn}
+    >
+      <SimpleColor value="transparent" aria-label="transparent" />
+      <SimpleColor value="#00A376" />
+    </SimpleColorPicker>,
+  );
+
+  expect(screen.getByRole("radio", { name: "transparent" })).toBeChecked();
+});

--- a/src/components/simple-color-picker/simple-color/simple-color.component.tsx
+++ b/src/components/simple-color-picker/simple-color/simple-color.component.tsx
@@ -10,6 +10,8 @@ import {
 } from "./simple-color.style";
 
 export interface SimpleColorProps {
+  /** the value of the label to pass to screen reader software */
+  "aria-label"?: string;
   /** the value of the color that is represented by this SimpleColor */
   value: string;
   /** the input name */
@@ -46,8 +48,8 @@ export const SimpleColor = React.forwardRef<HTMLInputElement, SimpleColorProps>(
       name,
       checked = false,
       id,
-      defaultChecked,
       className,
+      "aria-label": ariaLabel,
       ...rest
     } = props;
 
@@ -64,12 +66,12 @@ export const SimpleColor = React.forwardRef<HTMLInputElement, SimpleColorProps>(
           onMouseDown={onMouseDown}
           checked={checked}
           name={name}
+          aria-label={ariaLabel}
           type="radio"
           role="radio"
           value={value}
           ref={ref}
           id={inputId}
-          defaultChecked={defaultChecked}
           {...rest}
         />
         <StyledColorSampleBox color={value}>

--- a/src/components/step-flow/step-flow.stories.tsx
+++ b/src/components/step-flow/step-flow.stories.tsx
@@ -235,7 +235,7 @@ export const ExampleImplementation: Story = () => {
             This is an example of a Dialog with a Form as content, with a Step
             Flow to help users complete tasks in a specific order.
           </Typography>
-          <Textarea label="Textarea label" />
+          <Textarea label="Textarea label" value="" onChange={() => {}} />
         </Form>
       </Dialog>
     </>
@@ -310,7 +310,7 @@ export const ExampleImplementationWithTitleNode: Story = () => {
             This is an example of a Dialog with a Form as content, with a Step
             Flow to help users complete tasks in a specific order.
           </Typography>
-          <Textarea label="Textarea label" />
+          <Textarea label="Textarea label" onChange={() => {}} value="" />
         </Form>
       </Dialog>
     </>

--- a/src/components/switch/__internal__/switch-slider-panel.test.tsx
+++ b/src/components/switch/__internal__/switch-slider-panel.test.tsx
@@ -22,7 +22,7 @@ afterAll(() => {
 });
 
 test("when `loading` is true, the correct Loader styles are applied", () => {
-  render(<Switch onChange={() => {}} loading />);
+  render(<Switch onChange={() => {}} loading checked />);
 
   const loaderElement = screen.getByTestId("switch-slider-loader");
 
@@ -34,7 +34,7 @@ test("when `loading` is true, the correct Loader styles are applied", () => {
 });
 
 test("when `loading` is true, applies the correct LoaderSquare styles", async () => {
-  render(<Switch onChange={() => {}} loading />);
+  render(<Switch onChange={() => {}} loading checked />);
 
   const loaderSquares = screen.getAllByTestId("loader-square");
 
@@ -44,7 +44,7 @@ test("when `loading` is true, applies the correct LoaderSquare styles", async ()
 });
 
 test("when `loading` is true and Switch `size` is large, the correct LoaderSquare styles are applied", async () => {
-  render(<Switch onChange={() => {}} size="large" loading />);
+  render(<Switch onChange={() => {}} size="large" loading checked />);
 
   const loaderSquares = screen.getAllByTestId("loader-square");
 
@@ -55,7 +55,7 @@ test("when `loading` is true and Switch `size` is large, the correct LoaderSquar
 
 describe("when the theme is set to sageTheme", () => {
   it("applies the correct base styles", () => {
-    render(<Switch onChange={() => {}} />);
+    render(<Switch onChange={() => {}} checked />);
 
     const switchPanel = screen.getByTestId("slider-panel");
 
@@ -65,7 +65,7 @@ describe("when the theme is set to sageTheme", () => {
   });
 
   it("applies the correct off panel styles", () => {
-    render(<Switch onChange={() => {}} />);
+    render(<Switch onChange={() => {}} checked />);
 
     const switchPanel = screen.getByTestId("slider-panel");
 
@@ -81,7 +81,7 @@ describe("when the theme is set to sageTheme", () => {
 
 // coverage
 test("renders with normal styles when `isDarkBackground` is false", () => {
-  render(<Switch onChange={() => {}} isDarkBackground={false} />);
+  render(<Switch onChange={() => {}} isDarkBackground={false} checked />);
 
   const switchPanel = screen.getByTestId("slider-panel");
 
@@ -90,7 +90,7 @@ test("renders with normal styles when `isDarkBackground` is false", () => {
 
 // coverage
 test("renders with dark background styles when `isDarkBackground` is true", () => {
-  render(<Switch onChange={() => {}} isDarkBackground />);
+  render(<Switch onChange={() => {}} isDarkBackground checked />);
 
   const switchPanel = screen.getByTestId("slider-panel");
 

--- a/src/components/switch/components.test-pw.tsx
+++ b/src/components/switch/components.test-pw.tsx
@@ -20,7 +20,7 @@ export const SwitchComponent = (props: Partial<SwitchProps>) => {
 };
 
 export const SwitchComponentValidations = (props: Partial<SwitchProps>) => {
-  const [, setIsChecked] = React.useState(false);
+  const [isChecked, setIsChecked] = React.useState(false);
   return (
     <Box>
       {["error", "warning", "info"].map((type) => (
@@ -31,6 +31,7 @@ export const SwitchComponentValidations = (props: Partial<SwitchProps>) => {
           label={`Example switch (${type})`}
           name={`switch-${type}`}
           onChange={() => setIsChecked((state) => !state)}
+          checked={isChecked}
           {...props}
         />
       ))}
@@ -39,22 +40,29 @@ export const SwitchComponentValidations = (props: Partial<SwitchProps>) => {
 };
 
 export const WithMargin = () => {
+  const [isChecked, setIsChecked] = React.useState(false);
   return (
     <>
       <Switch
         label="With labelHelp"
         labelHelp="This text provides more information for the label."
         m={2}
+        onChange={() => setIsChecked((state) => !state)}
+        checked={isChecked}
       />
       <Switch
         label="With labelHelp"
         labelHelp="This text provides more information for the label."
         m={4}
+        onChange={() => setIsChecked((state) => !state)}
+        checked={isChecked}
       />
       <Switch
         label="With labelHelp"
         labelHelp="This text provides more information for the label."
         m="9px"
+        onChange={() => setIsChecked((state) => !state)}
+        checked={isChecked}
       />
     </>
   );

--- a/src/components/switch/switch-test.stories.tsx
+++ b/src/components/switch/switch-test.stories.tsx
@@ -5,6 +5,7 @@ import I18nProvider from "../i18n-provider/i18n-provider.component";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 import Switch, { SwitchProps } from "./switch.component";
 import Box from "../box/box.component";
+import { useMultiInputBoolean } from "../../hooks/use-multi-input/use-multi-input";
 
 const meta: Meta<typeof Switch> = {
   title: "Switch/Test",
@@ -65,19 +66,87 @@ Default.args = {
 };
 
 export const Validation: Story = ({ ...args }: Partial<SwitchProps>) => {
+  const { state, setValue } = useMultiInputBoolean();
+
   return (
     <>
-      <Switch error="Error Message" mb={2} {...args} />
-      <Switch warning="Warning Message" mb={2} {...args} />
-      <Switch info="Info Message" mb={2} {...args} />
+      <Switch
+        error="Error Message"
+        mb={2}
+        name="switch-error"
+        checked={state["switch-error"] || false}
+        onChange={setValue}
+        {...args}
+      />
+      <Switch
+        warning="Warning Message"
+        mb={2}
+        name="switch-warning"
+        checked={state["switch-warning"] || false}
+        onChange={setValue}
+        {...args}
+      />
+      <Switch
+        info="Info Message"
+        mb={2}
+        name="switch-info"
+        checked={state["switch-info"] || false}
+        onChange={setValue}
+        {...args}
+      />
 
-      <Switch error="Error Message" validationOnLabel mb={2} {...args} />
-      <Switch warning="Warning Message" validationOnLabel mb={2} {...args} />
-      <Switch info="Info Message" validationOnLabel mb={2} {...args} />
+      <Switch
+        error="Error Message"
+        validationOnLabel
+        mb={2}
+        name="switch-error-vol"
+        checked={state["switch-error-vol"] || false}
+        onChange={setValue}
+        {...args}
+      />
+      <Switch
+        warning="Warning Message"
+        validationOnLabel
+        mb={2}
+        name="switch-warning-vol"
+        checked={state["switch-warning-vol"] || false}
+        onChange={setValue}
+        {...args}
+      />
+      <Switch
+        info="Info Message"
+        validationOnLabel
+        mb={2}
+        name="switch-info-vol"
+        checked={state["switch-info-vol"] || false}
+        onChange={setValue}
+        {...args}
+      />
 
-      <Switch error mb={2} {...args} />
-      <Switch warning mb={2} {...args} />
-      <Switch info mb={2} {...args} />
+      <Switch
+        error
+        mb={2}
+        name="switch-error-bool"
+        checked={state["switch-error-bool"] || false}
+        onChange={setValue}
+        {...args}
+      />
+      <Switch
+        warning
+        mb={2}
+        name="switch-warning-bool"
+        checked={state["switch-warning-bool"] || false}
+        onChange={setValue}
+        {...args}
+      />
+      <Switch
+        info
+        mb={2}
+        name="switch-info-bool"
+        checked={state["switch-info-bool"] || false}
+        onChange={setValue}
+        {...args}
+      />
     </>
   );
 };
@@ -91,20 +160,42 @@ Validation.parameters = {
 };
 
 export const NewValidation: Story = ({ ...args }: Partial<SwitchProps>) => {
+  const { state, setValue } = useMultiInputBoolean();
+
   return (
     <CarbonProvider validationRedesignOptIn>
-      <Switch error="Error Message (Fix is required)" mb={2} {...args} />
-      <Switch warning="Warning Message" mb={2} {...args} />
       <Switch
-        validationMessagePositionTop={false}
         error="Error Message (Fix is required)"
         mb={2}
+        name="switch-error"
+        checked={state["switch-error"] || false}
+        onChange={setValue}
+        {...args}
+      />
+      <Switch
+        warning="Warning Message (Fix is optional)"
+        mb={2}
+        name="switch-warning"
+        checked={state["switch-warning"] || false}
+        onChange={setValue}
         {...args}
       />
       <Switch
         validationMessagePositionTop={false}
-        warning="Warning Message"
+        error="Error Message (Fix is required)"
         mb={2}
+        name="switch-error-bottom"
+        checked={state["switch-error-bottom"] || false}
+        onChange={setValue}
+        {...args}
+      />
+      <Switch
+        validationMessagePositionTop={false}
+        warning="Warning Message (Fix is optional)"
+        mb={2}
+        name="switch-warn-bottom"
+        checked={state["switch-warn-bottom"] || false}
+        onChange={setValue}
         {...args}
       />
     </CarbonProvider>
@@ -124,50 +215,89 @@ NewValidation.parameters = {
 export const NewValidationInline: Story = ({
   ...args
 }: Partial<SwitchProps>) => {
+  const { state, setValue } = useMultiInputBoolean();
+
   return (
     <CarbonProvider validationRedesignOptIn>
       <Box maxWidth="400px" backgroundColor="#f5f5f5" p={2}>
-        <Switch {...args} />
-        <Switch labelHelp="Hint text" mt={2} {...args} />
-        <Switch labelHelp="Hint text" fieldHelp="fieldHelp" mt={2} {...args} />
         <Switch
-          labelHelp="Really long hint text that should wrap to the next line if it gets too long because labelWidth is set to 50%"
+          labelInline
+          mb={2}
+          name="switch-il"
+          checked={state["switch-il"] || false}
+          onChange={setValue}
+          {...args}
+        />
+        <Switch
+          labelInline
+          labelHelp="Hint text"
+          mb={2}
+          name="switch-il-hint"
+          checked={state["switch-il-hint"] || false}
+          onChange={setValue}
+          {...args}
+        />
+        <Switch
+          labelInline
+          labelHelp="Hint text"
           fieldHelp="fieldHelp"
+          name="switch-il-field"
+          checked={state["switch-il-field"] || false}
+          onChange={setValue}
+          {...args}
+        />
+        <Switch
+          label="Label"
+          labelInline
           labelWidth={50}
+          labelHelp="Really long hint text that should wrap to the next line if it gets too long because labelWidth is set to 50%"
+          fieldHelp="field help"
           mt={2}
-          {...args}
+          name="switch-il-long-help"
+          checked={state["switch-il-long-help"] || false}
+          onChange={setValue}
         />
+
         <Switch
           labelHelp="Hint text"
           error="Error Message (Fix is required)"
-          mt={2}
-          {...args}
-        />
-        <Switch
-          warning="Warning Message"
-          fieldHelp="fieldHelp"
+          labelInline
           my={2}
+          name="switch-il-hint-error"
+          checked={state["switch-il-hint-error"] || false}
+          onChange={setValue}
+          {...args}
+        />
+        <Switch
+          warning="Warning Message (Fix is optional)"
+          labelInline
+          fieldHelp="fieldHelp"
+          mb={2}
+          name="switch-il-field-warn"
+          checked={state["switch-il-field-warn"] || false}
+          onChange={setValue}
           {...args}
         />
         <Switch
           labelHelp="Hint text"
           error="Error Message (Fix is required)"
-          validationMessagePositionTop={false}
-          mt={2}
-          {...args}
-        />
-        <Switch
-          warning="Warning Message"
-          fieldHelp="fieldHelp"
+          labelInline
           validationMessagePositionTop={false}
           my={2}
+          name="switch-il-help-error-bot"
+          checked={state["switch-il-help-error-bot"] || false}
+          onChange={setValue}
           {...args}
         />
         <Switch
-          reverse={false}
-          labelHelp="Hint text"
-          error="Error Message (Fix is required)"
-          mt={2}
+          warning="Warning Message (Fix is optional)"
+          labelInline
+          fieldHelp="fieldHelp"
+          validationMessagePositionTop={false}
+          mb={2}
+          name="switch-il-field-warn-bot"
+          checked={state["switch-il-field-warn-bot"] || false}
+          onChange={setValue}
           {...args}
         />
       </Box>
@@ -184,19 +314,22 @@ NewValidationInline.parameters = {
   themeProvider: { chromatic: { theme: "sage" } },
 };
 
-export const WithLongTextStrings = () => (
-  <I18nProvider
-    locale={{
-      locale: () => "fake-locale",
-      switch: {
-        on: () => "Absolutely",
-        off: () => "Regrettably",
-      },
-    }}
-  >
-    <Switch />
-  </I18nProvider>
-);
+export const WithLongTextStrings = () => {
+  const [state, setState] = useState(false);
+  return (
+    <I18nProvider
+      locale={{
+        locale: () => "fake-locale",
+        switch: {
+          on: () => "Absolutely",
+          off: () => "Regrettably",
+        },
+      }}
+    >
+      <Switch checked={state} onChange={(e) => setState(e.target.checked)} />
+    </I18nProvider>
+  );
+};
 
 WithLongTextStrings.storyName = "Long text strings";
 WithLongTextStrings.parameters = {
@@ -206,6 +339,7 @@ WithLongTextStrings.parameters = {
 };
 
 export const WithMargin = ({ ...args }: Partial<SwitchProps>) => {
+  const [state, setState] = useState(false);
   return (
     <CarbonProvider validationRedesignOptIn>
       <Box
@@ -221,7 +355,8 @@ export const WithMargin = ({ ...args }: Partial<SwitchProps>) => {
             label="Some text"
             labelInline
             reverse={args.reverse}
-            defaultChecked
+            checked={state}
+            onChange={(e) => setState(e.target.checked)}
           />
         </Box>
       </Box>
@@ -242,6 +377,9 @@ WithMargin.args = {
 
 export const WithLoading = () => {
   const [isLoading, setIsLoading] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
+  const [isChecked2, setIsChecked2] = useState(false);
+  const [isChecked3, setIsChecked3] = useState(false);
   const [isLoadingValidation, setIsLoadingValidation] = useState(false);
   const [isLoadingNewValidation, setIsLoadingNewValidation] = useState(false);
   const [count, setCount] = useState(5);
@@ -302,7 +440,9 @@ export const WithLoading = () => {
           onChange={() => {
             setIsLoading(true);
             setCount(5);
+            setIsChecked((state) => !state);
           }}
+          checked={isChecked}
         />
       </Box>
 
@@ -315,7 +455,9 @@ export const WithLoading = () => {
           onChange={() => {
             setIsLoadingValidation(true);
             setCount(5);
+            setIsChecked2((state) => !state);
           }}
+          checked={isChecked2}
         />
       </Box>
 
@@ -328,7 +470,9 @@ export const WithLoading = () => {
             onChange={() => {
               setIsLoadingNewValidation(true);
               setCount(5);
+              setIsChecked3((state) => !state);
             }}
+            checked={isChecked3}
           />
         </CarbonProvider>
       </Box>
@@ -343,6 +487,7 @@ export const WithLoading = () => {
 WithLoading.storyName = "With Loading";
 
 export const LabelHelpAndFieldHelp = () => {
+  const { state, setValue } = useMultiInputBoolean();
   return (
     <>
       <Switch
@@ -350,6 +495,9 @@ export const LabelHelpAndFieldHelp = () => {
         labelInline
         labelHelp="labelHelp"
         fieldHelp="This text provides help for the input."
+        name="switch1"
+        checked={state["switch1"] || false}
+        onChange={setValue}
       />
       <Switch
         label="With inline fieldHelp and labelHelp"
@@ -358,6 +506,9 @@ export const LabelHelpAndFieldHelp = () => {
         fieldHelp="This text provides help for the input."
         fieldHelpInline
         mt={2}
+        name="switch2"
+        checked={state["switch2"] || false}
+        onChange={setValue}
       />
       <Switch
         label="With inline fieldHelp and labelHelp not reversed"
@@ -367,6 +518,9 @@ export const LabelHelpAndFieldHelp = () => {
         fieldHelpInline
         reverse={false}
         mt={2}
+        name="switch3"
+        checked={state["switch3"] || false}
+        onChange={setValue}
       />
     </>
   );

--- a/src/components/switch/switch.component.tsx
+++ b/src/components/switch/switch.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useContext, useRef } from "react";
+import React, { useContext, useRef } from "react";
 import { MarginProps } from "styled-system";
 
 import Box from "../box";
@@ -9,7 +9,6 @@ import { TagProps } from "../../__internal__/utils/helpers/tags";
 import Label from "../../__internal__/label";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import NewValidationContext from "../carbon-provider/__internal__/new-validation.context";
-import Logger from "../../__internal__/utils/logger";
 import ValidationMessage from "../../__internal__/validation-message/validation-message.component";
 import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint";
 import StyledSwitch, { ErrorBorder } from "./switch.style";
@@ -19,13 +18,11 @@ import HintText from "../../__internal__/hint-text";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 
 export interface SwitchProps
-  extends CommonCheckableInputProps,
+  extends Omit<CommonCheckableInputProps, "defaultChecked">,
     MarginProps,
     TagProps {
   /** Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set */
   adaptiveLabelBreakpoint?: number;
-  /** Set the default value of the Switch if component is meant to be used as uncontrolled */
-  defaultChecked?: boolean;
   /** When true label is inline */
   labelInline?: boolean;
   /** Triggers loading animation */
@@ -44,9 +41,11 @@ export interface SwitchProps
   validationMessagePositionTop?: boolean;
   /** Label width, as a percentage, when labelInline is true */
   labelWidth?: number;
+  /** OnChange event handler */
+  onChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
+  /** Checked state of the input */
+  checked: boolean;
 }
-
-let deprecateUncontrolledWarnTriggered = false;
 
 export const Switch = React.forwardRef(
   (
@@ -59,7 +58,6 @@ export const Switch = React.forwardRef(
       onFocus,
       value,
       checked,
-      defaultChecked,
       disabled,
       loading,
       reverse = true,
@@ -86,35 +84,11 @@ export const Switch = React.forwardRef(
     }: SwitchProps,
     ref: React.ForwardedRef<HTMLInputElement>,
   ) => {
-    const isControlled = checked !== undefined;
     const { validationRedesignOptIn } = useContext(NewValidationContext);
 
     const labelId = useRef(`${guid()}-label`);
     const inputHintId = useRef(`${guid()}-hint`);
     const validationMessageId = useRef(`${guid()}-message`);
-
-    const [checkedInternal, setCheckedInternal] = useState(
-      defaultChecked || false,
-    );
-
-    if (!deprecateUncontrolledWarnTriggered && !onChange) {
-      deprecateUncontrolledWarnTriggered = true;
-      Logger.deprecate(
-        "Uncontrolled behaviour in `Switch` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-      );
-    }
-
-    const onChangeInternal = useCallback(
-      (e: React.ChangeEvent<HTMLInputElement>) => {
-        if (loading) {
-          e.preventDefault();
-        } else {
-          setCheckedInternal(e.target.checked);
-          onChange?.(e);
-        }
-      },
-      [setCheckedInternal, onChange, loading],
-    );
 
     const largeScreen = useIsAboveBreakpoint(adaptiveLabelBreakpoint);
     let shouldLabelBeInline: boolean | undefined = labelInline;
@@ -133,7 +107,7 @@ export const Switch = React.forwardRef(
       "data-component": "switch",
       "data-role": dataRole,
       "data-element": dataElement,
-      checked: isControlled ? checked : checkedInternal,
+      checked,
       isDarkBackground,
       fieldHelpInline,
       labelInline: shouldLabelBeInline,
@@ -144,7 +118,7 @@ export const Switch = React.forwardRef(
     };
 
     const switchSliderProps = {
-      checked: isControlled ? checked : checkedInternal,
+      checked,
       disabled,
       loading,
       isDarkBackground,
@@ -163,7 +137,7 @@ export const Switch = React.forwardRef(
       info,
       disabled,
       loading,
-      checked: isControlled ? checked : checkedInternal,
+      checked,
       label,
       labelHelp,
       labelWidth,
@@ -173,7 +147,7 @@ export const Switch = React.forwardRef(
       onBlur,
       isDarkBackground,
       onFocus,
-      onChange: isControlled ? onChange : onChangeInternal,
+      onChange,
       id,
       name,
       value,
@@ -193,7 +167,7 @@ export const Switch = React.forwardRef(
       "data-component": "switch",
       "data-role": dataRole,
       "data-element": dataElement,
-      checked: isControlled ? checked : checkedInternal,
+      checked,
       labelInline: shouldLabelBeInline,
       isDarkBackground,
       size,
@@ -203,7 +177,7 @@ export const Switch = React.forwardRef(
     };
 
     const switchSliderPropsForNewValidation = {
-      checked: isControlled ? checked : checkedInternal,
+      checked,
       disabled,
       loading,
       isDarkBackground,
@@ -219,11 +193,11 @@ export const Switch = React.forwardRef(
       warning,
       disabled,
       loading,
-      checked: isControlled ? checked : checkedInternal,
+      checked,
       onBlur,
       isDarkBackground,
       onFocus,
-      onChange: isControlled ? onChange : onChangeInternal,
+      onChange,
       id,
       name,
       value,

--- a/src/components/switch/switch.pw.tsx
+++ b/src/components/switch/switch.pw.tsx
@@ -495,7 +495,12 @@ test.describe("Prop tests for Switch component", () => {
       page,
     }) => {
       await mount(
-        <Switch label="Label" name="switch-name" defaultChecked={boolVal} />,
+        <Switch
+          label="Label"
+          name="switch-name"
+          checked={boolVal}
+          onChange={() => {}}
+        />,
       );
 
       if (boolVal) {
@@ -922,7 +927,12 @@ test.describe("Accessibility tests", () => {
       page,
     }) => {
       await mount(
-        <Switch label="Label" name="switch-name" defaultChecked={boolVal} />,
+        <Switch
+          label="Label"
+          name="switch-name"
+          checked={boolVal}
+          onChange={() => {}}
+        />,
       );
 
       await checkAccessibility(page);

--- a/src/components/switch/switch.stories.tsx
+++ b/src/components/switch/switch.stories.tsx
@@ -5,6 +5,7 @@ import generateStyledSystemProps from "../../../.storybook/utils/styled-system-p
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 import Box from "../box";
 import Switch from ".";
+import { useMultiInputBoolean } from "../../hooks/use-multi-input/use-multi-input";
 
 const styledSystemProps = generateStyledSystemProps({
   margin: true,
@@ -15,6 +16,9 @@ const meta: Meta<typeof Switch> = {
   component: Switch,
   argTypes: {
     ...styledSystemProps,
+  },
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
   },
 };
 
@@ -51,20 +55,47 @@ export const WithInputHint: Story = () => {
 WithInputHint.storyName = "With Input Hint";
 
 export const Sizes: Story = () => {
+  const { state, setValue } = useMultiInputBoolean();
+
   return (
     <>
-      <Switch label="small" name="switch-small" size="small" mb={2} />
-      <Switch label="large" name="switch-large" size="large" />
+      <Switch
+        label="small"
+        name="switch-small"
+        size="small"
+        mb={2}
+        checked={state["switch-small"] || false}
+        onChange={setValue}
+      />
+      <Switch
+        label="large"
+        name="switch-large"
+        size="large"
+        checked={state["switch-large"] || false}
+        onChange={setValue}
+      />
     </>
   );
 };
 Sizes.storyName = "Sizes";
 
 export const Disabled: Story = () => {
+  const [isChecked, setIsChecked] = useState(false);
   return (
     <>
-      <Switch label="Disabled switch" disabled />
-      <Switch label="Disabled switch" disabled checked mt={2} />
+      <Switch
+        label="Disabled switch"
+        disabled
+        checked={isChecked}
+        onChange={(e) => setIsChecked(e.target.checked)}
+      />
+      <Switch
+        label="Disabled switch"
+        disabled
+        checked={!isChecked}
+        onChange={(e) => setIsChecked(e.target.checked)}
+        mt={2}
+      />
     </>
   );
 };
@@ -99,25 +130,74 @@ export const Reversed: Story = () => {
 Reversed.storyName = "Reversed";
 
 export const Loading: Story = () => {
+  const [state1, setState1] = useState(true);
+  const [state2, setState2] = useState(false);
+  const [state3, setState3] = useState(true);
+  const [state4, setState4] = useState(false);
+
   return (
     <>
-      <Switch checked label="small on" size="small" loading mb={2} />
-      <Switch label="small off" size="small" loading mb={2} />
-      <Switch checked label="large on" size="large" loading mb={2} />
-      <Switch label="large off" size="large" loading mb={2} />
+      <Switch
+        label="small on"
+        size="small"
+        loading
+        mb={2}
+        name="small-on-loader"
+        checked={state1}
+        onChange={(ev) => setState1(ev.target.checked)}
+      />
+      <Switch
+        label="small off"
+        size="small"
+        loading
+        mb={2}
+        name="small-off-loader"
+        checked={state2}
+        onChange={(ev) => setState2(ev.target.checked)}
+      />
+      <Switch
+        name="large-on-loader"
+        checked={state3}
+        onChange={(ev) => setState3(ev.target.checked)}
+        label="large on"
+        size="large"
+        loading
+        mb={2}
+      />
+      <Switch
+        label="large off"
+        size="large"
+        name="large-off-loader"
+        checked={state4}
+        onChange={(ev) => setState4(ev.target.checked)}
+        loading
+        mb={2}
+      />
     </>
   );
 };
 Loading.storyName = "Loading";
 
 export const WithLabelInline: Story = () => {
+  const { state, setValue } = useMultiInputBoolean();
+
   return (
     <>
-      <Switch label="With labelInline" labelInline mb={2} />
+      <Switch
+        label="With labelInline"
+        labelInline
+        mb={2}
+        name="with-label-inline"
+        checked={state["with-label-inline"] || false}
+        onChange={setValue}
+      />
       <Switch
         label="With labelInline and reversed"
         labelInline
         reverse={false}
+        name="with-label-inline-rev"
+        checked={state["with-label-inline-rev"] || false}
+        onChange={setValue}
       />
     </>
   );
@@ -125,11 +205,15 @@ export const WithLabelInline: Story = () => {
 WithLabelInline.storyName = "With labelInline";
 
 export const WithFieldHelp: Story = () => {
+  const [isChecked, setIsChecked] = useState(false);
+  const [isChecked2, setIsChecked2] = useState(false);
   return (
     <>
       <Switch
         label="With fieldHelp"
         fieldHelp="This text provides help for the input."
+        checked={isChecked}
+        onChange={(e) => setIsChecked(e.target.checked)}
       />
       <Switch
         label="With inline fieldHelp"
@@ -137,6 +221,8 @@ export const WithFieldHelp: Story = () => {
         fieldHelp="This text provides help for the input."
         fieldHelpInline
         mt={2}
+        checked={isChecked2}
+        onChange={(e) => setIsChecked2(e.target.checked)}
       />
     </>
   );
@@ -159,6 +245,9 @@ export const WithLabelHelp: Story = () => {
 WithLabelHelp.storyName = "With labelHelp";
 
 export const WithDarkBackground: Story = () => {
+  const [isChecked, setIsChecked] = useState(false);
+  const [isChecked2, setIsChecked2] = useState(false);
+
   return (
     <Box m={2} padding={3} backgroundColor="#000000">
       <CarbonProvider validationRedesignOptIn>
@@ -167,6 +256,8 @@ export const WithDarkBackground: Story = () => {
           isDarkBackground
           mb="2"
           fieldHelp="Field help text"
+          checked={isChecked}
+          onChange={(e) => setIsChecked(e.target.checked)}
         />
         <Switch
           label="Example Switch"
@@ -174,6 +265,8 @@ export const WithDarkBackground: Story = () => {
           error="Error message"
           fieldHelp="Field help text"
           isDarkBackground
+          checked={isChecked2}
+          onChange={(e) => setIsChecked2(e.target.checked)}
         />
       </CarbonProvider>
     </Box>

--- a/src/components/switch/switch.test.tsx
+++ b/src/components/switch/switch.test.tsx
@@ -1,80 +1,48 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import Switch from "./switch.component";
-import Logger from "../../__internal__/utils/logger";
+
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
 import I18nProvider from "../../components/i18n-provider";
 import CarbonProvider from "../../components/carbon-provider";
 
 jest.mock("../../__internal__/utils/helpers/guid");
 
-test("should display deprecation warning once", () => {
-  const loggerSpy = jest
-    .spyOn(Logger, "deprecate")
-    .mockImplementation(() => {});
-
-  render(<Switch name="my-switch" defaultValue="test" />);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "Uncontrolled behaviour in `Switch` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
-});
-
 testStyledSystemMargin(
-  (props) => <Switch data-role="switch-wrapper" {...props} />,
+  (props) => (
+    <Switch
+      data-role="switch-wrapper"
+      checked={false}
+      onChange={() => {}}
+      {...props}
+    />
+  ),
   () => screen.getByTestId("switch-wrapper"),
 );
 
 test("accepts ref as a ref object", () => {
   const ref = { current: null };
-  render(<Switch ref={ref} />);
+  render(<Switch ref={ref} checked={false} onChange={() => {}} />);
 
   expect(ref.current).toBe(screen.getByRole("switch"));
 });
 
 test("accepts ref as a ref callback", () => {
   const ref = jest.fn();
-  render(<Switch ref={ref} />);
+  render(<Switch ref={ref} checked={false} onChange={() => {}} />);
 
   expect(ref).toHaveBeenCalledWith(screen.getByRole("switch"));
 });
 
 test("sets ref to empty after unmounting", () => {
   const ref = { current: null };
-  const { unmount } = render(<Switch ref={ref} />);
+  const { unmount } = render(
+    <Switch ref={ref} checked={false} onChange={() => {}} />,
+  );
 
   unmount();
 
   expect(ref.current).toBe(null);
-});
-
-test("when component is uncontrolled, it sets proper default internal state", () => {
-  render(<Switch name="my-switch" defaultValue="test" defaultChecked />);
-
-  expect(screen.getByRole("switch")).toBeChecked();
-});
-
-test("when component is uncontrolled, it changes internal state and passes event to the provided onChange prop when change is triggered", async () => {
-  const user = userEvent.setup({ delay: null });
-  const onChangeMock = jest.fn();
-
-  render(<Switch onChange={onChangeMock} />);
-
-  const switchElement = screen.getByRole("switch");
-  await user.click(switchElement);
-
-  expect(onChangeMock).toHaveBeenCalledWith(
-    expect.objectContaining({
-      target: expect.objectContaining({
-        checked: true,
-      }),
-    }),
-  );
-  expect(switchElement).toBeChecked();
 });
 
 test("when component is controlled, it passes checked value to the Switch", () => {
@@ -113,7 +81,14 @@ test("has default a translation for off", () => {
 
 // required for styling coverage
 test("when `reverse` is false, the correct Label component styles are applied", () => {
-  render(<Switch reverse={false} label="label" />);
+  render(
+    <Switch
+      reverse={false}
+      label="label"
+      checked={false}
+      onChange={() => {}}
+    />,
+  );
 
   const labelContainer = screen.getByTestId("label-container");
 
@@ -121,7 +96,14 @@ test("when `reverse` is false, the correct Label component styles are applied", 
 });
 
 test("when `reverse` is true, the correct Label component styles are applied", () => {
-  render(<Switch reverse={false} label="label" />);
+  render(
+    <Switch
+      reverse={false}
+      label="label"
+      checked={false}
+      onChange={() => {}}
+    />,
+  );
 
   const labelContainer = screen.getByTestId("label-container");
 
@@ -135,6 +117,8 @@ test("when `reverse` is false and `fieldHelpInline` is true, the correct FieldHe
       fieldHelp="This text provides help"
       fieldHelpInline
       label="label"
+      checked={false}
+      onChange={() => {}}
     />,
   );
 
@@ -151,6 +135,8 @@ test("when `labelInline` is true, fieldHelpInline is false and `reverse` is fals
       fieldHelpInline={false}
       labelInline
       reverse={false}
+      checked={false}
+      onChange={() => {}}
     />,
   );
   const fieldHelp = screen.getByText("This text provides help");
@@ -164,6 +150,8 @@ test("when `fieldHelpInline` is true, the correct FieldHelp component styles are
       fieldHelpInline
       fieldHelp="This text provides help"
       label="label"
+      checked={false}
+      onChange={() => {}}
     />,
   );
 
@@ -173,7 +161,9 @@ test("when `fieldHelpInline` is true, the correct FieldHelp component styles are
 });
 
 test("when `labelInline` is true, the correct Label component styles are applied", () => {
-  render(<Switch label="label" labelInline />);
+  render(
+    <Switch label="label" labelInline checked={false} onChange={() => {}} />,
+  );
 
   const labelContainer = screen.getByTestId("label-container");
 
@@ -187,6 +177,8 @@ test("when `fieldHelpInline` is true and `labelInline` is true, the correct Chec
       fieldHelp="This text provides help"
       fieldHelpInline
       labelInline
+      checked={false}
+      onChange={() => {}}
     />,
   );
 
@@ -202,6 +194,8 @@ test("when `fieldHelpInline` true and `labelInline` true, the correct Label comp
       fieldHelp="This text provides help"
       fieldHelpInline
       labelInline
+      checked={false}
+      onChange={() => {}}
     />,
   );
 
@@ -217,6 +211,8 @@ test("when `fieldHelpInline` true and `labelInline` true, the correct FieldHelp 
       fieldHelp="This text provides help"
       fieldHelpInline
       labelInline
+      checked={false}
+      onChange={() => {}}
     />,
   );
 
@@ -226,13 +222,13 @@ test("when `fieldHelpInline` true and `labelInline` true, the correct FieldHelp 
 });
 
 test("when `size` is large, the correct CheckableInput component styles are applied", () => {
-  render(<Switch size="large" />);
+  render(<Switch size="large" checked={false} onChange={() => {}} />);
 
   expect(screen.getByRole("switch")).toHaveStyle("height: 44px");
 });
 
 test("when `size` is large, the correct SwitchSlider component styles are applied", () => {
-  render(<Switch size="large" />);
+  render(<Switch size="large" checked={false} onChange={() => {}} />);
 
   const switchSlider = screen.getByTestId("slider");
 
@@ -240,7 +236,15 @@ test("when `size` is large, the correct SwitchSlider component styles are applie
 });
 
 test("when `size` is large and `labelInline` is true, the correct Label component styles are applied", () => {
-  render(<Switch size="large" labelInline label="label" />);
+  render(
+    <Switch
+      size="large"
+      labelInline
+      label="label"
+      checked={false}
+      onChange={() => {}}
+    />,
+  );
 
   const labelContainer = screen.getByTestId("label-container");
 
@@ -259,6 +263,8 @@ test("when `size` is large and `reverse` is false, the correct FieldHelp compone
       label="label"
       reverse={false}
       fieldHelp="this is field help"
+      checked={false}
+      onChange={() => {}}
     />,
   );
 
@@ -269,19 +275,43 @@ test("when `size` is large and `reverse` is false, the correct FieldHelp compone
 
 test("the `error` prop should not throw an error if `loading` is true", () => {
   expect(() => {
-    render(<Switch id="mock-input" loading error />);
+    render(
+      <Switch
+        id="mock-input"
+        loading
+        error
+        checked={false}
+        onChange={() => {}}
+      />,
+    );
   }).not.toThrow();
 });
 
 test("the `warning` prop should not throw an error if `loading` is true", () => {
   expect(() => {
-    render(<Switch id="mock-input" loading warning />);
+    render(
+      <Switch
+        id="mock-input"
+        loading
+        warning
+        checked={false}
+        onChange={() => {}}
+      />,
+    );
   }).not.toThrow();
 });
 
 test("the `info` prop should not throw an error if `loading` is true", () => {
   expect(() => {
-    render(<Switch id="mock-input" loading info />);
+    render(
+      <Switch
+        id="mock-input"
+        loading
+        info
+        checked={false}
+        onChange={() => {}}
+      />,
+    );
   }).not.toThrow();
 });
 
@@ -294,6 +324,8 @@ test.each(["error", "warning"])(
           label="label"
           validationMessagePositionTop={false}
           {...{ [validationType]: "This is a validation message" }}
+          checked={false}
+          onChange={() => {}}
         />
       </CarbonProvider>,
     );
@@ -305,7 +337,15 @@ test.each(["error", "warning"])(
 );
 
 test("`helpAriaLabel` prop should set the aria-label on the Help component", () => {
-  render(<Switch label="foo" labelHelp="fooHelp" helpAriaLabel="text" />);
+  render(
+    <Switch
+      label="foo"
+      labelHelp="fooHelp"
+      helpAriaLabel="text"
+      checked={false}
+      onChange={() => {}}
+    />,
+  );
 
   const help = screen.getByRole("button");
 
@@ -314,7 +354,7 @@ test("`helpAriaLabel` prop should set the aria-label on the Help component", () 
 
 // Required for coverage
 test("the correct border colour is applied when `error` validation is true", () => {
-  render(<Switch error />);
+  render(<Switch error checked={false} onChange={() => {}} />);
 
   const switchSlider = screen.getByTestId("slider");
 
@@ -325,7 +365,7 @@ test("the correct border colour is applied when `error` validation is true", () 
 
 // Required for coverage
 test("the correct border colour is applied when `warning` validation is true", () => {
-  render(<Switch warning />);
+  render(<Switch warning checked={false} onChange={() => {}} />);
 
   const switchSlider = screen.getByTestId("slider");
 
@@ -338,7 +378,7 @@ test("the correct border colour is applied when `warning` validation is true", (
 test("the correct background colour is applied to the `ErrorBorder` element when `error` validation is a string", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch error="this is an error" />
+      <Switch error="this is an error" checked={false} onChange={() => {}} />
     </CarbonProvider>,
   );
 
@@ -353,7 +393,7 @@ test("the correct background colour is applied to the `ErrorBorder` element when
 test("the correct background colour is applied to the `ErrorBorder` element when `warning` validation is a string", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch warning="this is a warning" />
+      <Switch warning="this is a warning" checked={false} onChange={() => {}} />
     </CarbonProvider>,
   );
 
@@ -368,7 +408,13 @@ test("the correct background colour is applied to the `ErrorBorder` element when
 test("renders `labelHelp` as hint text when `validationRedesignOptIn` flag is true", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch label="foo" labelHelp="hint text" warning="this is a warning" />
+      <Switch
+        label="foo"
+        labelHelp="hint text"
+        warning="this is a warning"
+        checked={false}
+        onChange={() => {}}
+      />
     </CarbonProvider>,
   );
 
@@ -378,7 +424,13 @@ test("renders `labelHelp` as hint text when `validationRedesignOptIn` flag is tr
 test("should render with correct accessible name and description when `validationRedesignOptIn` flag is true", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch label="foo" labelHelp="hint text" error="this is an error" />
+      <Switch
+        label="foo"
+        labelHelp="hint text"
+        error="this is an error"
+        checked={false}
+        onChange={() => {}}
+      />
     </CarbonProvider>,
   );
 
@@ -421,7 +473,7 @@ test("the expected translations are correctly applied for off", () => {
         },
       }}
     >
-      <Switch onChange={() => {}} />
+      <Switch checked={false} onChange={() => {}} />
     </I18nProvider>,
   );
 
@@ -434,7 +486,7 @@ test("the expected translations are correctly applied for off", () => {
 test("renders with normal styles when `isDarkBackground` is false", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch isDarkBackground={false} />
+      <Switch isDarkBackground={false} checked={false} onChange={() => {}} />
     </CarbonProvider>,
   );
 
@@ -449,7 +501,7 @@ test("renders with normal styles when `isDarkBackground` is false", () => {
 test("renders with dark background styles when `isDarkBackground` is true", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch isDarkBackground />
+      <Switch isDarkBackground checked={false} onChange={() => {}} />
     </CarbonProvider>,
   );
 
@@ -462,7 +514,7 @@ test("renders with dark background styles when `isDarkBackground` is true", () =
 test("renders correctly with inputWidth set to numerical value of between 0 and 1", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch inputWidth={0.5} />
+      <Switch inputWidth={0.5} checked={false} onChange={() => {}} />
     </CarbonProvider>,
   );
 
@@ -475,7 +527,7 @@ test("renders correctly with inputWidth set to numerical value of between 0 and 
 test("renders correctly with labelInline and new validation", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch labelInline />
+      <Switch labelInline checked={false} onChange={() => {}} />
     </CarbonProvider>,
   );
 
@@ -488,7 +540,7 @@ test("renders correctly with labelInline and new validation", () => {
 test("renders correctly with reverse flag set under erroneous state and new validation", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch reverse error="error" />
+      <Switch reverse error="error" checked={false} onChange={() => {}} />
     </CarbonProvider>,
   );
 
@@ -501,7 +553,12 @@ test("renders correctly with reverse flag set under erroneous state and new vali
 test("renders correctly with no reverse flag set under erroneous state and new validation", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch reverse={false} error="error" />
+      <Switch
+        reverse={false}
+        error="error"
+        checked={false}
+        onChange={() => {}}
+      />
     </CarbonProvider>,
   );
 
@@ -514,7 +571,7 @@ test("renders correctly with no reverse flag set under erroneous state and new v
 test("renders correctly with reverse flag not set and new validation", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch reverse={false} />
+      <Switch reverse={false} checked={false} onChange={() => {}} />
     </CarbonProvider>,
   );
 
@@ -527,7 +584,12 @@ test("renders correctly with reverse flag not set and new validation", () => {
 test("renders correctly with hint text and dark background in new validation", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch labelHelp="hint text" isDarkBackground />
+      <Switch
+        labelHelp="hint text"
+        isDarkBackground
+        checked={false}
+        onChange={() => {}}
+      />
     </CarbonProvider>,
   );
 
@@ -540,7 +602,7 @@ test("renders correctly with hint text and dark background in new validation", (
 test("renders correctly with hint text in new validation", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch labelHelp="hint text" />
+      <Switch labelHelp="hint text" checked={false} onChange={() => {}} />
     </CarbonProvider>,
   );
 
@@ -553,7 +615,12 @@ test("renders correctly with hint text in new validation", () => {
 test("renders correctly with inline label and field help in new validation", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch labelInline fieldHelp="Field help" />
+      <Switch
+        labelInline
+        fieldHelp="Field help"
+        checked={false}
+        onChange={() => {}}
+      />
     </CarbonProvider>,
   );
 
@@ -566,7 +633,13 @@ test("renders correctly with inline label and field help in new validation", () 
 test("renders correctly with inline label, dark background and field help in new validation", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch labelInline fieldHelp="Field help" isDarkBackground />
+      <Switch
+        labelInline
+        fieldHelp="Field help"
+        isDarkBackground
+        checked={false}
+        onChange={() => {}}
+      />
     </CarbonProvider>,
   );
 
@@ -584,6 +657,8 @@ test("renders correctly with inline label, dark background, error and field help
         fieldHelp="Field help"
         error="error"
         isDarkBackground
+        checked={false}
+        onChange={() => {}}
       />
     </CarbonProvider>,
   );
@@ -602,6 +677,8 @@ test("renders with the correct error colour when `isDarkBackground` is false", (
         fieldHelp="Field help"
         error="error"
         isDarkBackground={false}
+        checked={false}
+        onChange={() => {}}
       />
     </CarbonProvider>,
   );
@@ -620,6 +697,8 @@ test("renders with the correct error colour when `isDarkBackground` is true", ()
         fieldHelp="Field help"
         error="error"
         isDarkBackground
+        checked={false}
+        onChange={() => {}}
       />
     </CarbonProvider>,
   );
@@ -633,7 +712,12 @@ test("renders with the correct error colour when `isDarkBackground` is true", ()
 test("renders correctly with inline label and hint text in new validation", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch labelInline labelHelp="Field help" />
+      <Switch
+        labelInline
+        labelHelp="Field help"
+        checked={false}
+        onChange={() => {}}
+      />
     </CarbonProvider>,
   );
 
@@ -646,7 +730,13 @@ test("renders correctly with inline label and hint text in new validation", () =
 test("renders correctly with inline label and hint text in new validation when reversed", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch labelInline labelHelp="Field help" reverse={false} />
+      <Switch
+        labelInline
+        labelHelp="Field help"
+        reverse={false}
+        checked={false}
+        onChange={() => {}}
+      />
     </CarbonProvider>,
   );
 
@@ -658,7 +748,13 @@ test("renders correctly with inline label and hint text in new validation when r
 test("when `labelInline` is true and `reverse` is false no margin left is applied to the input-wrapper", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch label="label" labelInline reverse={false} />
+      <Switch
+        label="label"
+        labelInline
+        reverse={false}
+        checked={false}
+        onChange={() => {}}
+      />
     </CarbonProvider>,
   );
 
@@ -669,7 +765,13 @@ test("when `labelInline` is true and `reverse` is false no margin left is applie
 test("when `labelInline` is true and `reverse` is true no margin right is applied to the input-wrapper", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch label="label" labelInline reverse />
+      <Switch
+        label="label"
+        labelInline
+        reverse
+        checked={false}
+        onChange={() => {}}
+      />
     </CarbonProvider>,
   );
 
@@ -680,22 +782,16 @@ test("when `labelInline` is true and `reverse` is true no margin right is applie
 test("when `labelInline` is true, the provided `labelWidth` is applied to the label-wrapper", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Switch label="label" labelInline labelWidth={50} />
+      <Switch
+        label="label"
+        labelInline
+        labelWidth={50}
+        onChange={jest.fn}
+        checked
+      />
     </CarbonProvider>,
   );
 
   const labelWrapper = screen.getByTestId("label-wrapper");
   expect(labelWrapper).toHaveStyle("width: 50%");
-});
-
-test("when component is uncontrolled and loading, it doesn't change internal state and the provided onChange is not called", async () => {
-  const user = userEvent.setup({ delay: null });
-  const onChangeMock = jest.fn();
-
-  render(<Switch onChange={onChangeMock} loading />);
-
-  const switchElement = screen.getByRole("switch");
-  await user.click(switchElement);
-
-  expect(onChangeMock).not.toHaveBeenCalled();
 });

--- a/src/components/tabs/components.test-pw.tsx
+++ b/src/components/tabs/components.test-pw.tsx
@@ -128,6 +128,7 @@ export const TabsComponentValidations = (props: Partial<TabsProps>) => {
           label="Add error"
           error={errors.two}
           onChange={() => setErrors({ ...errors, two: !errors.two })}
+          checked={errors.two}
         />
         <Checkbox
           label="Add warning"
@@ -154,11 +155,13 @@ export const TabsComponentValidations = (props: Partial<TabsProps>) => {
           label="Add error"
           error={errors.three}
           onChange={() => setErrors({ ...errors, three: !errors.three })}
+          checked={errors.three}
         />
         <Checkbox
           label="Add warning"
           warning={warnings.three}
           onChange={() => setWarnings({ ...warnings, three: !warnings.three })}
+          checked={warnings.three}
         />
         <Checkbox
           label="Add info"
@@ -331,6 +334,7 @@ export const WithAdditionalTitleSiblings = () => {
             label="Add error"
             error={errors.two}
             onChange={() => setErrors({ ...errors, two: !errors.two })}
+            checked={errors.two}
           />
         </Tab>
         <Tab
@@ -352,6 +356,7 @@ export const WithAdditionalTitleSiblings = () => {
             label="Add error"
             error={errors.three}
             onChange={() => setErrors({ ...errors, three: !errors.three })}
+            checked={errors.three}
           />
         </Tab>
       </Tabs>
@@ -402,6 +407,7 @@ export const WithAdditionalTitleSiblingsSizeLarge = () => {
           <Checkbox
             label="Add error"
             error={errors.two}
+            checked={errors.two}
             onChange={() => setErrors({ ...errors, two: !errors.two })}
           />
         </Tab>
@@ -423,6 +429,7 @@ export const WithAdditionalTitleSiblingsSizeLarge = () => {
           <Checkbox
             label="Add error"
             error={errors.three}
+            checked={errors.three}
             onChange={() => setErrors({ ...errors, three: !errors.three })}
           />
         </Tab>
@@ -466,6 +473,7 @@ export const WithCustomLayout = () => {
         >
           <Checkbox
             label="Add error"
+            checked={errors.one}
             error={errors.one}
             onChange={() => setErrors({ ...errors, one: !errors.one })}
           />
@@ -496,6 +504,7 @@ export const WithCustomLayout = () => {
         >
           <Checkbox
             label="Add error"
+            checked={errors.two}
             error={errors.two}
             onChange={() => setErrors({ ...errors, two: !errors.two })}
           />
@@ -526,6 +535,7 @@ export const WithCustomLayout = () => {
         >
           <Checkbox
             label="Add error"
+            checked={errors.three}
             error={errors.three}
             onChange={() => setErrors({ ...errors, three: !errors.three })}
           />

--- a/src/components/tabs/tab/tab.component.tsx
+++ b/src/components/tabs/tab/tab.component.tsx
@@ -69,9 +69,7 @@ export const Tab = ({
   href,
   // title is destructured purely to NOT spread it as part of rest to the underlying HTML element.
   // Both this and titleProps are used as part of child.props inside Tabs component
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   title,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   titleProps,
   ...rest
 }: TabProps) => {

--- a/src/components/tabs/tab/tab.test.tsx
+++ b/src/components/tabs/tab/tab.test.tsx
@@ -106,7 +106,7 @@ test("calls the `updateErrors` function prop when an error is present in a child
   const updateErrors = jest.fn();
   render(
     <Tab tabId="foo" updateErrors={updateErrors}>
-      <Textbox onChange={() => {}} id="bar" error />
+      <Textbox onChange={() => {}} id="bar" error value="" />
     </Tab>,
   );
 
@@ -117,7 +117,7 @@ test("calls the `updateWarnings` function prop when a warning is present in a ch
   const updateWarnings = jest.fn();
   render(
     <Tab tabId="foo" updateWarnings={updateWarnings}>
-      <Textbox onChange={() => {}} id="bar" warning />
+      <Textbox onChange={() => {}} id="bar" warning value="" />
     </Tab>,
   );
 

--- a/src/components/tabs/tabs-test.stories.tsx
+++ b/src/components/tabs/tabs-test.stories.tsx
@@ -123,7 +123,7 @@ export const ValidationPositionTop = () => {
   return (
     <Tabs position="top">
       <Tab errorMessage="Error Message" tabId="tab-1" title="Tab 1" key="tab-1">
-        <Textbox label="textbox" error />
+        <Textbox label="textbox" error onChange={() => {}} value="" />
       </Tab>
       <Tab
         warningMessage="Warning Message"
@@ -131,10 +131,10 @@ export const ValidationPositionTop = () => {
         title="Tab 2"
         key="tab-2"
       >
-        <Textbox label="textbox" warning />
+        <Textbox label="textbox" warning onChange={() => {}} value="" />
       </Tab>
       <Tab infoMessage="Info Message" tabId="tab-3" title="Tab 3" key="tab-3">
-        <Textbox label="textbox" info />
+        <Textbox label="textbox" info onChange={() => {}} value="" />
       </Tab>
     </Tabs>
   );
@@ -149,7 +149,7 @@ export const ValidationPositionLeft = () => {
   return (
     <Tabs position="left">
       <Tab errorMessage="Error Message" tabId="tab-1" title="Tab 1" key="tab-1">
-        <Textbox label="textbox" error />
+        <Textbox label="textbox" error onChange={() => {}} value="" />
       </Tab>
       <Tab
         warningMessage="Warning Message"
@@ -157,10 +157,10 @@ export const ValidationPositionLeft = () => {
         title="Tab 2"
         key="tab-2"
       >
-        <Textbox label="textbox" warning />
+        <Textbox label="textbox" warning onChange={() => {}} value="" />
       </Tab>
       <Tab infoMessage="Info Message" tabId="tab-3" title="Tab 3" key="tab-3">
-        <Textbox label="textbox" info />
+        <Textbox label="textbox" info onChange={() => {}} value="" />
       </Tab>
     </Tabs>
   );
@@ -181,7 +181,13 @@ export const NewValidationPositionTop = () => {
           title="Tab 1"
           key="tab-1"
         >
-          <Textbox label="textbox" error="Error Message" m={2} />
+          <Textbox
+            label="textbox"
+            error="Error Message"
+            m={2}
+            onChange={() => {}}
+            value=""
+          />
         </Tab>
         <Tab
           warningMessage="Tab Warning Message"
@@ -189,7 +195,13 @@ export const NewValidationPositionTop = () => {
           title="Tab 2"
           key="tab-2"
         >
-          <Textbox label="textbox" warning="Warning Message" m={2} />
+          <Textbox
+            label="textbox"
+            warning="Warning Message"
+            m={2}
+            onChange={() => {}}
+            value=""
+          />
         </Tab>
       </Tabs>
     </CarbonProvider>
@@ -211,7 +223,13 @@ export const NewValidationPositionLeft = () => {
           title="Tab 1"
           key="tab-1"
         >
-          <Textbox label="textbox" error="Error Message" m={2} />
+          <Textbox
+            label="textbox"
+            error="Error Message"
+            m={2}
+            onChange={() => {}}
+            value=""
+          />
         </Tab>
         <Tab
           warningMessage="Tab Warning Message"
@@ -219,7 +237,13 @@ export const NewValidationPositionLeft = () => {
           title="Tab 2"
           key="tab-2"
         >
-          <Textbox label="textbox" warning="Warning Message" m={2} />
+          <Textbox
+            label="textbox"
+            warning="Warning Message"
+            m={2}
+            onChange={() => {}}
+            value=""
+          />
         </Tab>
       </Tabs>
     </CarbonProvider>
@@ -272,6 +296,7 @@ export const WithAdditionalTitleSiblingsRedesign = () => {
             <Checkbox
               label="Add error"
               error={errors.two}
+              checked={errors.two}
               onChange={() => setErrors({ ...errors, two: !errors.two })}
               m={2}
             />
@@ -292,6 +317,7 @@ export const WithAdditionalTitleSiblingsRedesign = () => {
             <Checkbox
               label="Add error"
               error={errors.three}
+              checked={errors.three}
               onChange={() => setErrors({ ...errors, three: !errors.three })}
               m={2}
             />

--- a/src/components/tabs/tabs.stories.tsx
+++ b/src/components/tabs/tabs.stories.tsx
@@ -1076,7 +1076,13 @@ export const WithValidationState = () => {
           title="Tab 1"
           key="tab-1"
         >
-          <Textbox label="Textbox" error="Error Message" m={2} />
+          <Textbox
+            label="Textbox"
+            error="Error Message"
+            m={2}
+            onChange={() => {}}
+            value=""
+          />
         </Tab>
         <Tab
           warningMessage="Tab Warning Message"
@@ -1084,7 +1090,13 @@ export const WithValidationState = () => {
           title="Tab 2"
           key="tab-2"
         >
-          <Textbox label="Textbox" warning="Warning Message" m={2} />
+          <Textbox
+            label="Textbox"
+            warning="Warning Message"
+            m={2}
+            onChange={() => {}}
+            value=""
+          />
         </Tab>
       </Tabs>
     </CarbonProvider>

--- a/src/components/tabs/tabs.test.tsx
+++ b/src/components/tabs/tabs.test.tsx
@@ -66,8 +66,9 @@ test("should not throw an error when rendered with NumeralDate as a child", () =
             label="As string"
             tooltipPosition="top"
             value={{ dd: "01", mm: "01", yyyy: "0001" }}
+            onChange={() => {}}
           />
-          <Textbox error="error" onChange={() => {}} />
+          <Textbox error="error" onChange={() => {}} value="" />
         </Tab>
       </Tabs>,
     );
@@ -146,7 +147,7 @@ test.each(["error", "warning", "info"] as const)(
           warningMessage="warning"
           infoMessage="info"
         >
-          <Textbox onChange={() => {}} {...{ [validation]: true }} />
+          <Textbox onChange={() => {}} value="" {...{ [validation]: true }} />
         </Tab>
         <Tab
           title="Tab Title 2"
@@ -155,7 +156,7 @@ test.each(["error", "warning", "info"] as const)(
           warningMessage="warning"
           infoMessage="info"
         >
-          <Textbox onChange={() => {}} {...{ [validation]: true }} />
+          <Textbox onChange={() => {}} value="" {...{ [validation]: true }} />
         </Tab>
       </Tabs>,
     );
@@ -735,7 +736,7 @@ test("when there is no validation issue in a tab, no validation icon is displaye
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox onChange={() => {}} />
+        <Textbox onChange={() => {}} value="" />
       </Tab>
       <Tab
         tabId="tab-2"
@@ -744,7 +745,7 @@ test("when there is no validation issue in a tab, no validation icon is displaye
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox onChange={() => {}} />
+        <Textbox onChange={() => {}} value="" />
       </Tab>
     </Tabs>,
   );
@@ -791,7 +792,7 @@ test("when there is an error in a tab, an error icon is displayed in the corresp
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox onChange={() => {}} />
+        <Textbox onChange={() => {}} value="" />
       </Tab>
       <Tab
         tabId="tab-2"
@@ -800,7 +801,7 @@ test("when there is an error in a tab, an error icon is displayed in the corresp
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox error onChange={() => {}} />
+        <Textbox error onChange={() => {}} value="" />
       </Tab>
     </Tabs>,
   );
@@ -847,7 +848,7 @@ test("when errors and warnings are both present in a tab, only the error icon is
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox onChange={() => {}} />
+        <Textbox onChange={() => {}} value="" />
       </Tab>
       <Tab
         tabId="tab-2"
@@ -856,8 +857,8 @@ test("when errors and warnings are both present in a tab, only the error icon is
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox error onChange={() => {}} />
-        <Textbox warning onChange={() => {}} />
+        <Textbox error onChange={() => {}} value="" />
+        <Textbox warning onChange={() => {}} value="" />
       </Tab>
     </Tabs>,
   );
@@ -901,11 +902,11 @@ test("error and warning icons are displayed correctly when the new validation fl
       <Tabs selectedTabId="tab-1">
         <Tab tabId="tab-1" title="Tab 1" errorMessage="error">
           Content for tab 1
-          <Textbox error onChange={() => {}} />
+          <Textbox error onChange={() => {}} value="" />
         </Tab>
         <Tab tabId="tab-2" title="Tab 2" warningMessage="warning">
           Content for tab 2
-          <Textbox warning onChange={() => {}} />
+          <Textbox warning onChange={() => {}} value="" />
         </Tab>
       </Tabs>
     </CarbonProvider>,
@@ -943,11 +944,11 @@ test("error and warning icons are displayed correctly when the new validation fl
       <Tabs selectedTabId="tab-1" position="left">
         <Tab tabId="tab-1" title="Tab 1" errorMessage="error">
           Content for tab 1
-          <Textbox error onChange={() => {}} />
+          <Textbox error onChange={() => {}} value="" />
         </Tab>
         <Tab tabId="tab-2" title="Tab 2" warningMessage="warning">
           Content for tab 2
-          <Textbox warning onChange={() => {}} />
+          <Textbox warning onChange={() => {}} value="" />
         </Tab>
       </Tabs>
     </CarbonProvider>,
@@ -988,7 +989,7 @@ test("when errors, warnings and infos are all present in a tab, only the error i
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox onChange={() => {}} />
+        <Textbox onChange={() => {}} value="" />
       </Tab>
       <Tab
         tabId="tab-2"
@@ -997,9 +998,9 @@ test("when errors, warnings and infos are all present in a tab, only the error i
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox error onChange={() => {}} />
-        <Textbox warning onChange={() => {}} />
-        <Textbox info onChange={() => {}} />
+        <Textbox error onChange={() => {}} value="" />
+        <Textbox warning onChange={() => {}} value="" />
+        <Textbox info onChange={() => {}} value="" />
       </Tab>
     </Tabs>,
   );
@@ -1046,7 +1047,7 @@ test("when a tab has warnings and no errors, a warning icon is displayed in the 
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox onChange={() => {}} />
+        <Textbox onChange={() => {}} value="" />
       </Tab>
       <Tab
         tabId="tab-2"
@@ -1055,7 +1056,7 @@ test("when a tab has warnings and no errors, a warning icon is displayed in the 
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox warning onChange={() => {}} />
+        <Textbox warning onChange={() => {}} value="" />
       </Tab>
     </Tabs>,
   );
@@ -1102,7 +1103,7 @@ test("when a tab has info and no errors or warnings, an info icon is displayed i
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox onChange={() => {}} />
+        <Textbox onChange={() => {}} value="" />
       </Tab>
       <Tab
         tabId="tab-2"
@@ -1111,7 +1112,7 @@ test("when a tab has info and no errors or warnings, an info icon is displayed i
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox info onChange={() => {}} />
+        <Textbox info onChange={() => {}} value="" />
       </Tab>
     </Tabs>,
   );
@@ -1162,7 +1163,7 @@ test("an error icon is displayed in the corresponding tab title when specified b
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox error onChange={() => {}} />
+        <Textbox error onChange={() => {}} value="" />
       </Tab>
       <Tab
         tabId="tab-2"
@@ -1171,7 +1172,7 @@ test("an error icon is displayed in the corresponding tab title when specified b
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox onChange={() => {}} />
+        <Textbox onChange={() => {}} value="" />
       </Tab>
     </Tabs>,
   );
@@ -1224,7 +1225,7 @@ test("a warning icon is displayed in the corresponding tab title when specified 
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox warning onChange={() => {}} />
+        <Textbox warning onChange={() => {}} value="" />
       </Tab>
       <Tab
         tabId="tab-2"
@@ -1233,7 +1234,7 @@ test("a warning icon is displayed in the corresponding tab title when specified 
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox onChange={() => {}} />
+        <Textbox onChange={() => {}} value="" />
       </Tab>
     </Tabs>,
   );
@@ -1286,7 +1287,7 @@ test("an info icon is displayed in the corresponding tab title when specified by
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox info onChange={() => {}} />
+        <Textbox info onChange={() => {}} value="" />
       </Tab>
       <Tab
         tabId="tab-2"
@@ -1295,7 +1296,7 @@ test("an info icon is displayed in the corresponding tab title when specified by
         warningMessage="warning"
         infoMessage="info"
       >
-        <Textbox onChange={() => {}} />
+        <Textbox onChange={() => {}} value="" />
       </Tab>
     </Tabs>,
   );
@@ -1465,14 +1466,17 @@ test.each(["error", "warning", "info"])(
         <Tab tabId="1" title="Test">
           <Textbox
             onChange={() => {}}
+            value=""
             {...{ [validation]: "first validation message" }}
           />
           <Textbox
             onChange={() => {}}
+            value=""
             {...{ [validation]: "second validation message" }}
           />
           <Textbox
             onChange={() => {}}
+            value=""
             {...{ [validation]: "third validation message" }}
           />
         </Tab>
@@ -1499,11 +1503,13 @@ test.each(["error", "warning", "info"])(
         <Tab tabId="1" title="Test">
           <Textbox
             onChange={() => {}}
+            value=""
             {...{ [validation]: "first validation message" }}
           />
-          <Textbox onChange={() => {}} {...{ [validation]: true }} />
+          <Textbox onChange={() => {}} value="" {...{ [validation]: true }} />
           <Textbox
             onChange={() => {}}
+            value=""
             {...{ [validation]: "third validation message" }}
           />
         </Tab>
@@ -1530,6 +1536,7 @@ test.each(["error", "warning", "info"])(
         <Tab tabId="1" title="Test">
           <Textbox
             onChange={() => {}}
+            value=""
             {...{ [validation]: "first validation message" }}
           />
         </Tab>
@@ -1558,9 +1565,9 @@ test.each(["error", "warning", "info"])(
           title="Test"
           {...{ [`${validation}Message`]: "a single message" }}
         >
-          <Textbox onChange={() => {}} {...{ [validation]: true }} />
-          <Textbox onChange={() => {}} {...{ [validation]: true }} />
-          <Textbox onChange={() => {}} {...{ [validation]: true }} />
+          <Textbox onChange={() => {}} value="" {...{ [validation]: true }} />
+          <Textbox onChange={() => {}} value="" {...{ [validation]: true }} />
+          <Textbox onChange={() => {}} value="" {...{ [validation]: true }} />
         </Tab>
       </Tabs>,
     );
@@ -1587,14 +1594,17 @@ test.each(["error", "warning", "info"])(
         >
           <Textbox
             onChange={() => {}}
+            value=""
             {...{ [validation]: "first validation message" }}
           />
           <Textbox
             onChange={() => {}}
+            value=""
             {...{ [validation]: "second validation message" }}
           />
           <Textbox
             onChange={() => {}}
+            value=""
             {...{ [validation]: "third validation message" }}
           />
         </Tab>

--- a/src/components/text-editor/text-editor-test.stories.tsx
+++ b/src/components/text-editor/text-editor-test.stories.tsx
@@ -64,9 +64,20 @@ export const NewValidation: Story = () => {
 NewValidation.storyName = "New Validation";
 
 export const MultipleInputs: Story = () => {
+  const [state, setState] = useState("");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
   return (
     <CarbonProvider validationRedesignOptIn>
-      <Textbox mb={2} label="Textbox" inputHint="Hint Text" error="error" />
+      <Textbox
+        mb={2}
+        label="Textbox"
+        inputHint="Hint Text"
+        error="error"
+        onChange={setValue}
+        value={state}
+      />
       <TextEditor
         namespace="storybook-witherror"
         labelText="Text Editor"
@@ -75,7 +86,13 @@ export const MultipleInputs: Story = () => {
         characterLimit={100}
         mb={2}
       />
-      <Textbox mb={2} label="Textbox" inputHint="Hint Text" />
+      <Textbox
+        mb={2}
+        label="Textbox"
+        inputHint="Hint Text"
+        onChange={setValue}
+        value={state}
+      />
       <TextEditor
         namespace="storybook"
         labelText="Text Editor"

--- a/src/components/textarea/components.test-pw.tsx
+++ b/src/components/textarea/components.test-pw.tsx
@@ -14,7 +14,7 @@ export const Default = ({
   characterLimit,
   fieldHelp,
   ...args
-}: TextareaTestProps) => {
+}: Omit<TextareaTestProps, "value" | "onChange">) => {
   const [state, setState] = useState("");
   const handleChange = ({
     target: { value },
@@ -70,10 +70,21 @@ export const InScrollableContainer = () => {
 };
 
 export const DisabledExample = () => {
-  return <Textarea label="Textarea" disabled />;
+  const [value, setValue] = useState("");
+
+  return (
+    <Textarea
+      label="Textarea"
+      disabled
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 
 export const LabelAlignExample = () => {
+  const [value, setValue] = useState("");
+
   return (
     <>
       {(["right", "left"] as const).map((alignment) => (
@@ -83,6 +94,8 @@ export const LabelAlignExample = () => {
           inputWidth={50}
           key={alignment}
           labelAlign={alignment}
+          value={value}
+          onChange={({ target }) => setValue(target.value)}
         />
       ))}
     </>
@@ -90,11 +103,29 @@ export const LabelAlignExample = () => {
 };
 
 export const ReadOnlyExample = () => {
-  return <Textarea label="Textarea" readOnly />;
+  const [value, setValue] = useState("");
+
+  return (
+    <Textarea
+      label="Textarea"
+      readOnly
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 
 export const AutoFocusExample = () => {
-  return <Textarea label="Textarea" autoFocus />;
+  const [value, setValue] = useState("");
+
+  return (
+    <Textarea
+      label="Textarea"
+      autoFocus
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 
 export const ExpandableExample = () => {
@@ -143,36 +174,102 @@ export const CharacterLimitExampleWithButton = () => {
 };
 
 export const LabelInlineExample = () => {
-  return <Textarea label="Textarea" labelInline />;
+  const [value, setValue] = useState("");
+
+  return (
+    <Textarea
+      label="Textarea"
+      labelInline
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 
 export const CustomWidthExample = () => {
+  const [value, setValue] = useState("");
+
   return (
-    <Textarea label="Textarea" labelInline labelWidth={50} inputWidth={50} />
+    <Textarea
+      label="Textarea"
+      labelInline
+      labelWidth={50}
+      inputWidth={50}
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
   );
 };
 
 export const FieldHelpExample = () => {
-  return <Textarea label="Textarea" fieldHelp="Help" />;
+  const [value, setValue] = useState("");
+
+  return (
+    <Textarea
+      label="Textarea"
+      fieldHelp="Help"
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 
 export const MaxWidthExample = () => {
-  return <Textarea label="Textarea" maxWidth="70%" />;
+  const [value, setValue] = useState("");
+
+  return (
+    <Textarea
+      label="Textarea"
+      maxWidth="70%"
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 
 export const InputHintExample = () => {
-  return <Textarea label="Textarea" inputHint="Hint text (optional)." />;
+  const [value, setValue] = useState("");
+
+  return (
+    <Textarea
+      label="Textarea"
+      inputHint="Hint text (optional)."
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 
 export const LabelHelpExample = () => {
-  return <Textarea label="Textarea" labelHelp="Help" helpAriaLabel="Help" />;
+  const [value, setValue] = useState("");
+
+  return (
+    <Textarea
+      label="Textarea"
+      labelHelp="Help"
+      helpAriaLabel="Help"
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 
 export const RequiredExample = () => {
-  return <Textarea label="Textarea" required />;
+  const [value, setValue] = useState("");
+
+  return (
+    <Textarea
+      label="Textarea"
+      required
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 
 export const ValidationStringExample = () => {
+  const [value, setValue] = useState("");
+
   return (
     <>
       {["error", "warning", "info"].map((validationType) => (
@@ -181,12 +278,16 @@ export const ValidationStringExample = () => {
             label="Textarea"
             {...{ [validationType]: "Message" }}
             mb={2}
+            value={value}
+            onChange={({ target }) => setValue(target.value)}
           />
           <Textarea
             label="Textarea - readOnly"
             readOnly
             {...{ [validationType]: "Message" }}
             mb={2}
+            value={value}
+            onChange={({ target }) => setValue(target.value)}
           />
         </Box>
       ))}
@@ -195,6 +296,8 @@ export const ValidationStringExample = () => {
 };
 
 export const ValidationStringPositionExample = () => {
+  const [value, setValue] = useState("");
+
   return (
     <>
       {["error", "warning", "info"].map((validationType) => (
@@ -204,6 +307,8 @@ export const ValidationStringPositionExample = () => {
             {...{ [validationType]: "Message" }}
             mb={2}
             tooltipPosition="bottom"
+            value={value}
+            onChange={({ target }) => setValue(target.value)}
           />
         </Box>
       ))}
@@ -212,6 +317,8 @@ export const ValidationStringPositionExample = () => {
 };
 
 export const ValidationLabelExample = () => {
+  const [value, setValue] = useState("");
+
   return (
     <>
       {["error", "warning", "info"].map((validationType) => (
@@ -221,6 +328,8 @@ export const ValidationLabelExample = () => {
             validationOnLabel
             {...{ [validationType]: "Message" }}
             mb={2}
+            value={value}
+            onChange={({ target }) => setValue(target.value)}
           />
           <Textarea
             label="Textarea - readOnly"
@@ -228,6 +337,8 @@ export const ValidationLabelExample = () => {
             readOnly
             {...{ [validationType]: "Message" }}
             mb={2}
+            value={value}
+            onChange={({ target }) => setValue(target.value)}
           />
         </Box>
       ))}
@@ -236,6 +347,8 @@ export const ValidationLabelExample = () => {
 };
 
 export const ValidationLabelPositionExample = () => {
+  const [value, setValue] = useState("");
+
   return (
     <>
       {["error", "warning", "info"].map((validationType) => (
@@ -246,6 +359,8 @@ export const ValidationLabelPositionExample = () => {
             {...{ [validationType]: "Message" }}
             mb={2}
             tooltipPosition="top"
+            value={value}
+            onChange={({ target }) => setValue(target.value)}
           />
         </Box>
       ))}
@@ -254,6 +369,8 @@ export const ValidationLabelPositionExample = () => {
 };
 
 export const NewDesignValidationExample = () => {
+  const [value, setValue] = useState("");
+
   return (
     <CarbonProvider validationRedesignOptIn>
       {["error", "warning"].map((validationType) => (
@@ -263,6 +380,8 @@ export const NewDesignValidationExample = () => {
             inputHint="Hint text (optional)."
             {...{ [validationType]: "Message" }}
             m={4}
+            value={value}
+            onChange={({ target }) => setValue(target.value)}
           />
           <Textarea
             label={`readOnly - ${validationType}`}
@@ -270,6 +389,8 @@ export const NewDesignValidationExample = () => {
             readOnly
             {...{ [validationType]: "Message" }}
             m={4}
+            value={value}
+            onChange={({ target }) => setValue(target.value)}
           />
         </Box>
       ))}
@@ -278,16 +399,26 @@ export const NewDesignValidationExample = () => {
 };
 
 export const ValidationBooleanExample = () => {
+  const [value, setValue] = useState("");
+
   return (
     <>
       {["error", "warning", "info"].map((validationType) => (
         <Box key={`${validationType}-boolean-component`}>
-          <Textarea label="Textarea" {...{ [validationType]: true }} mb={2} />
+          <Textarea
+            label="Textarea"
+            {...{ [validationType]: true }}
+            mb={2}
+            value={value}
+            onChange={({ target }) => setValue(target.value)}
+          />
           <Textarea
             label="Textarea - readOnly"
             readOnly
             {...{ [validationType]: true }}
             mb={2}
+            value={value}
+            onChange={({ target }) => setValue(target.value)}
           />
         </Box>
       ))}

--- a/src/components/textarea/textarea-test.stories.tsx
+++ b/src/components/textarea/textarea-test.stories.tsx
@@ -7,6 +7,7 @@ import Box from "../box";
 import Button from "../button";
 import isChromatic from "../../../.storybook/isChromatic";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
+import useMultiInput from "../../hooks/use-multi-input";
 
 interface TextareaTestProps extends TextareaProps {
   labelHelp?: string;
@@ -167,29 +168,86 @@ export const Default = ({
 Default.storyName = "Default";
 
 export const Validation = () => {
+  const { state, setValue } = useMultiInput();
   return (
     <>
-      <Textarea label="Textarea" error="Error Message" mb={2} />
-      <Textarea label="Textarea" warning="Warning Message" mb={2} />
-      <Textarea label="Textarea" info="Info Message" mb={2} />
+      <Textarea
+        label="Textarea"
+        error="Error Message"
+        mb={2}
+        name="ta-error"
+        value={state["ta-error"] || ""}
+        onChange={setValue}
+      />
+      <Textarea
+        label="Textarea"
+        warning="Warning Message"
+        mb={2}
+        name="ta-warning"
+        value={state["ta-warning"] || ""}
+        onChange={setValue}
+      />
+      <Textarea
+        label="Textarea"
+        info="Info Message"
+        mb={2}
+        name="ta-info"
+        value={state["ta-info"] || ""}
+        onChange={setValue}
+      />
 
       <Textarea
         label="Textarea"
         error="Error Message"
         validationOnLabel
         mb={2}
+        name="ta-error-vol"
+        value={state["ta-error-vol"] || ""}
+        onChange={setValue}
       />
       <Textarea
         label="Textarea"
         warning="Warning Message"
         validationOnLabel
         mb={2}
+        name="ta-warn-vol"
+        value={state["ta-warn-vol"] || ""}
+        onChange={setValue}
       />
-      <Textarea label="Textarea" info="Info Message" validationOnLabel mb={2} />
+      <Textarea
+        label="Textarea"
+        info="Info Message"
+        validationOnLabel
+        mb={2}
+        name="ta-info-vol"
+        value={state["ta-info-vol"] || ""}
+        onChange={setValue}
+      />
 
-      <Textarea label="Textarea" error mb={2} />
-      <Textarea label="Textarea" warning mb={2} />
-      <Textarea label="Textarea" info mb={2} />
+      <Textarea
+        label="Textarea"
+        error
+        mb={2}
+        name="ta-error-bool"
+        value={state["ta-error-bool"] || ""}
+        onChange={setValue}
+      />
+      <Textarea
+        label="Textarea"
+        warning
+        mb={2}
+        name="ta-warn-bool"
+        value={state["ta-warn-bool"] || ""}
+        onChange={setValue}
+      />
+      <Textarea
+        label="Textarea"
+        info
+        mb={2}
+        name="ta-info-bool"
+        value={state["ta-info-bool"] || ""}
+        onChange={setValue}
+      />
     </>
   );
 };
@@ -200,20 +258,42 @@ Validation.parameters = {
 };
 
 export const NewValidation = () => {
+  const { state, setValue } = useMultiInput();
+
   return (
     <CarbonProvider validationRedesignOptIn>
-      <Textarea label="Textarea" error="Error Message" mb={2} />
-      <Textarea label="Textarea" warning="Warning Message" mb={2} />
+      <Textarea
+        label="Textarea"
+        error="Error Message"
+        mb={2}
+        name="ta-error"
+        value={state["ta-error"] || ""}
+        onChange={setValue}
+      />
+      <Textarea
+        label="Textarea"
+        warning="Warning Message"
+        mb={2}
+        name="ta-warn"
+        value={state["ta-warn"] || ""}
+        onChange={setValue}
+      />
       <Textarea
         validationMessagePositionTop={false}
         label="Textarea"
         error="Error Message"
         mb={2}
+        name="ta-error-bottom"
+        value={state["ta-error-bottom"] || ""}
+        onChange={setValue}
       />
       <Textarea
         validationMessagePositionTop={false}
         label="Textarea"
         warning="Warning Message"
+        name="ta-warn-bottom"
+        value={state["ta-warn-bottom"] || ""}
+        onChange={setValue}
       />
     </CarbonProvider>
   );
@@ -317,6 +397,8 @@ WithExpandableAndRows.parameters = {
 };
 
 export const LabelAlign: StoryType = () => {
+  const { state, setValue } = useMultiInput();
+
   return (
     <CarbonProvider validationRedesignOptIn>
       {["left", "right"].map((labelAlign) => (
@@ -326,6 +408,9 @@ export const LabelAlign: StoryType = () => {
           inputHint="help text"
           labelAlign={labelAlign as TextareaProps["labelAlign"]}
           mb={2}
+          name={`ta-${labelAlign}`}
+          value={state[`ta-${labelAlign}`] || ""}
+          onChange={setValue}
         />
       ))}
     </CarbonProvider>
@@ -338,7 +423,16 @@ LabelAlign.parameters = {
 };
 
 export const AutoFocusStory = () => {
-  return <Textarea label="Textarea" autoFocus />;
+  const [value, setValue] = useState("");
+
+  return (
+    <Textarea
+      label="Textarea"
+      autoFocus
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
 };
 AutoFocusStory.storyName = "Auto Focus";
 AutoFocusStory.parameters = {

--- a/src/components/textarea/textarea.component.tsx
+++ b/src/components/textarea/textarea.component.tsx
@@ -101,11 +101,16 @@ export interface TextareaProps
   /** Name of the input */
   name?: string;
   /** Callback fired when the user types in the Textarea */
-  onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   /** Placeholder text for the component */
   placeholder?: string;
   /** Adds readOnly property */
   readOnly?: boolean;
+  /**
+   * [Legacy] Flag to configure component as optional.
+   * @deprecated If the value of this component is not required, use the `required` prop and set it to false instead.
+   */
+  isOptional?: boolean;
   /** The number of visible text lines for the control. When set, this determines the height of the textarea, and the minHeight property is ignored. */
   rows?: number;
   /** [Legacy] Overrides the default tooltip position */
@@ -113,7 +118,7 @@ export interface TextareaProps
   /** [Legacy] When true, validation icon will be placed on label instead of being placed on the input */
   validationOnLabel?: boolean;
   /** The value of the Textbox */
-  value?: string;
+  value: string;
   /**
    * Indicate that warning has occurred.
    * Pass string to display icon, tooltip and orange border.
@@ -130,7 +135,7 @@ export interface TextareaProps
   validationMessagePositionTop?: boolean;
 }
 
-let deprecateUncontrolledWarnTriggered = false;
+let deprecateOptionalWarnTriggered = false;
 let warnBorderRadiusArrayTooLarge = false;
 
 export const Textarea = React.forwardRef(
@@ -175,12 +180,19 @@ export const Textarea = React.forwardRef(
       borderRadius,
       hideBorders = false,
       required,
+      isOptional,
       minHeight = DEFAULT_MIN_HEIGHT,
       validationMessagePositionTop = true,
       ...rest
     }: TextareaProps,
     ref: React.ForwardedRef<HTMLTextAreaElement>,
   ) => {
+    if (!deprecateOptionalWarnTriggered && isOptional) {
+      deprecateOptionalWarnTriggered = true;
+      Logger.deprecate(
+        "`isOptional` is deprecated in TextArea and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+      );
+    }
     const { validationRedesignOptIn } = useContext(NewValidationContext);
 
     const labelInlineWithNewValidation = validationRedesignOptIn
@@ -230,13 +242,6 @@ export const Textarea = React.forwardRef(
       if (characterLimit) setCharacterCountAriaLive("off");
       onBlur?.(ev);
     };
-
-    if (!deprecateUncontrolledWarnTriggered && !onChange) {
-      deprecateUncontrolledWarnTriggered = true;
-      Logger.deprecate(
-        "Uncontrolled behaviour in `Textarea` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-      );
-    }
 
     if (
       Array.isArray(borderRadius) &&

--- a/src/components/textarea/textarea.stories.tsx
+++ b/src/components/textarea/textarea.stories.tsx
@@ -6,6 +6,7 @@ import generateStyledSystemProps from "../../../.storybook/utils/styled-system-p
 import I18nProvider from "../i18n-provider";
 
 import Textarea from ".";
+import useMultiInput from "../../hooks/use-multi-input";
 
 const styledSystemProps = generateStyledSystemProps({
   margin: true,
@@ -32,11 +33,21 @@ export const DefaultStory: Story = () => {
 DefaultStory.storyName = "Default";
 
 export const DisabledStory: Story = () => {
-  return <Textarea label="Textarea" disabled />;
+  const [value, setValue] = useState("");
+  return (
+    <Textarea
+      label="Textarea"
+      disabled
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 DisabledStory.storyName = "Disabled";
 
 export const LabelAlignStory: Story = () => {
+  const { state, setValue } = useMultiInput();
+
   return (
     <>
       {(["right", "left"] as const).map((alignment) => (
@@ -47,6 +58,9 @@ export const LabelAlignStory: Story = () => {
           key={alignment}
           labelAlign={alignment}
           mb={2}
+          name={`ta-${alignment}`}
+          value={state[`ta-${alignment}`] || ""}
+          onChange={setValue}
         />
       ))}
     </>
@@ -55,7 +69,15 @@ export const LabelAlignStory: Story = () => {
 LabelAlignStory.storyName = "Label Align";
 
 export const ReadOnlyStory: Story = () => {
-  return <Textarea label="Textarea" readOnly />;
+  const [value, setValue] = useState("");
+  return (
+    <Textarea
+      label="Textarea"
+      readOnly
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 ReadOnlyStory.storyName = "Read Only";
 
@@ -121,41 +143,111 @@ export const TranslationsCharacterLimitStory: Story = () => {
 TranslationsCharacterLimitStory.storyName = "Translations Character Limit";
 
 export const LabelInlineStory: Story = () => {
-  return <Textarea label="Textarea" labelInline />;
+  const [value, setValue] = useState("");
+  return (
+    <Textarea
+      label="Textarea"
+      labelInline
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 LabelInlineStory.storyName = "Label Inline";
 
 export const CustomWidthStory: Story = () => {
+  const [value, setValue] = useState("");
   return (
-    <Textarea label="Textarea" labelInline labelWidth={50} inputWidth={50} />
+    <Textarea
+      label="Textarea"
+      labelInline
+      labelWidth={50}
+      inputWidth={50}
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
   );
 };
 CustomWidthStory.storyName = "Custom Width";
 
 export const FieldHelpStory: Story = () => {
-  return <Textarea label="Textarea" fieldHelp="Help" />;
+  const [value, setValue] = useState("");
+  return (
+    <Textarea
+      label="Textarea"
+      fieldHelp="Help"
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 FieldHelpStory.storyName = "Field Help";
 
 export const MaxWidthStory: Story = () => {
-  return <Textarea label="Textarea" maxWidth="70%" />;
+  const [value, setValue] = useState("");
+  return (
+    <Textarea
+      label="Textarea"
+      maxWidth="70%"
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 MaxWidthStory.storyName = "Max Width";
 
 export const InputHintStory: Story = () => {
-  return <Textarea label="Textarea" inputHint="Hint text (optional)." />;
+  const [value, setValue] = useState("");
+  return (
+    <Textarea
+      label="Textarea"
+      inputHint="Hint text (optional)."
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 InputHintStory.storyName = "Input Hint";
 
 export const LabelHelpStory: Story = () => {
-  return <Textarea label="Textarea" labelHelp="Help" helpAriaLabel="Help" />;
+  const [value, setValue] = useState("");
+  return (
+    <Textarea
+      label="Textarea"
+      labelHelp="Help"
+      helpAriaLabel="Help"
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 LabelHelpStory.storyName = "Label Help";
 
 export const RequiredStory: Story = () => {
-  return <Textarea label="Textarea" required />;
+  const [value, setValue] = useState("");
+  return (
+    <Textarea
+      label="Textarea"
+      required
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
 };
 RequiredStory.storyName = "Required";
+
+export const IsOptionalStory: Story = () => {
+  const [value, setValue] = useState("");
+  return (
+    <Textarea
+      label="Textarea"
+      isOptional
+      value={value}
+      onChange={({ target }) => setValue(target.value)}
+    />
+  );
+};
+IsOptionalStory.storyName = "isOptional";
 
 export const BorderRadiusStory: Story = () => {
   const [stateOne, setStateOne] = useState("");

--- a/src/components/textbox/components.test-pw.tsx
+++ b/src/components/textbox/components.test-pw.tsx
@@ -19,6 +19,10 @@ export const TextboxComponent = (props: Partial<TextboxProps>) => {
 
 export const TextboxComponentRef = () => {
   const ref = useRef<HTMLInputElement | null>(null);
+  const [state, setState] = useState("");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
 
   return (
     <Box margin="0 25px">
@@ -29,7 +33,7 @@ export const TextboxComponentRef = () => {
       >
         Focus Textbox
       </Button>
-      <Textbox ref={ref} />
+      <Textbox ref={ref} value={state} onChange={setValue} />
     </Box>
   );
 };
@@ -65,68 +69,145 @@ export const TextboxComponentWithPositionedChildren = () => {
 };
 
 export const TextboxValidationsAsAStringWithTooltipDefault = () => {
+  const [errorState, setErrorState] = useState("Textbox");
+  const [warningState, setWarningState] = useState("Textbox");
+  const [infoState, setInfoState] = useState("Textbox");
+  const setValue = (
+    { target }: React.ChangeEvent<HTMLInputElement>,
+    size: string,
+  ) => {
+    if (size === "error") setErrorState(target.value);
+    else if (size === "warning") setWarningState(target.value);
+    else if (size === "info") setInfoState(target.value);
+  };
+
   return (
     <Box>
-      {VALIDATIONS.map((validationType) => (
-        <div key={`${validationType}-string-label`}>
-          <Textbox
-            label="Textbox"
-            value="Textbox"
-            validationOnLabel
-            {...{ [validationType]: "Message" }}
-            mb={2}
-            tooltipPosition="bottom"
-          />
-        </div>
-      ))}
+      <div key={`error-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={errorState}
+          onChange={(e) => setValue(e, "error")}
+          validationOnLabel
+          error="Message"
+          mb={2}
+          tooltipPosition="bottom"
+        />
+      </div>
+      <div key={`warning-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={warningState}
+          onChange={(e) => setValue(e, "warning")}
+          validationOnLabel
+          warning="Message"
+          mb={2}
+          tooltipPosition="bottom"
+        />
+      </div>
+      <div key={`info-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={infoState}
+          onChange={(e) => setValue(e, "info")}
+          validationOnLabel
+          info="Message"
+          mb={2}
+          tooltipPosition="bottom"
+        />
+      </div>
     </Box>
   );
 };
 
 export const TextboxValidationsAsABoolean = () => {
+  const [errorState, setErrorState] = useState("Textbox");
+  const [warningState, setWarningState] = useState("Textbox");
+  const [infoState, setInfoState] = useState("Textbox");
+  const setValue = (
+    { target }: React.ChangeEvent<HTMLInputElement>,
+    size: string,
+  ) => {
+    if (size === "error") setErrorState(target.value);
+    else if (size === "warning") setWarningState(target.value);
+    else if (size === "info") setInfoState(target.value);
+  };
+
   return (
     <Box>
-      {VALIDATIONS.map((validationType) => (
-        <div key={`${validationType}-boolean-component`}>
-          <Textbox
-            label="Textbox"
-            value="Textbox"
-            {...{ [validationType]: true }}
-            mb={2}
-          />
-          <Textbox
-            label="Textbox - readOnly"
-            value="Textbox"
-            readOnly
-            {...{ [validationType]: true }}
-            mb={2}
-          />
-        </div>
-      ))}
+      <div key={`error-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={errorState}
+          onChange={(e) => setValue(e, "error")}
+          error
+          mb={2}
+        />
+      </div>
+      <div key={`warning-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={warningState}
+          onChange={(e) => setValue(e, "warning")}
+          warning
+          mb={2}
+        />
+      </div>
+      <div key={`info-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={infoState}
+          onChange={(e) => setValue(e, "info")}
+          info
+          mb={2}
+        />
+      </div>
     </Box>
   );
 };
 
 export const TextboxValidationsAsAString = () => {
+  const [errorState, setErrorState] = useState("Textbox");
+  const [warningState, setWarningState] = useState("Textbox");
+  const [infoState, setInfoState] = useState("Textbox");
+  const setValue = (
+    { target }: React.ChangeEvent<HTMLInputElement>,
+    size: string,
+  ) => {
+    if (size === "error") setErrorState(target.value);
+    else if (size === "warning") setWarningState(target.value);
+    else if (size === "info") setInfoState(target.value);
+  };
+
   return (
     <Box>
-      {VALIDATIONS.map((validationType) => (
-        <div key={`${validationType}-string-component`}>
-          <Textbox
-            label="Textbox"
-            value="Textbox"
-            {...{ [validationType]: "Message" }}
-            mb={2}
-          />
-          <Textbox
-            label="Textbox - readOnly"
-            value="Textbox"
-            readOnly
-            {...{ [validationType]: "Message" }}
-            mb={2}
-          />
-        </div>
-      ))}
+      <div key={`error-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={errorState}
+          onChange={(e) => setValue(e, "error")}
+          error
+          mb={2}
+        />
+      </div>
+      <div key={`warning-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={warningState}
+          onChange={(e) => setValue(e, "warning")}
+          warning
+          mb={2}
+        />
+      </div>
+      <div key={`info-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={infoState}
+          onChange={(e) => setValue(e, "info")}
+          info
+          mb={2}
+        />
+      </div>
     </Box>
   );
 };
@@ -142,6 +223,7 @@ export const TextboxNewValidationsAsAStringOnGreyBackground = () => {
               value="Textbox"
               {...{ [validationType]: "Message" }}
               mb={2}
+              onChange={() => {}}
             />
             <Textbox
               label="Textbox - readOnly"
@@ -149,6 +231,7 @@ export const TextboxNewValidationsAsAStringOnGreyBackground = () => {
               readOnly
               {...{ [validationType]: "Message" }}
               mb={2}
+              onChange={() => {}}
             />
           </div>
         ))}
@@ -158,60 +241,151 @@ export const TextboxNewValidationsAsAStringOnGreyBackground = () => {
 };
 
 export const TextboxValidationsAsAStringWithTooltipCustom = () => {
+  const [errorState, setErrorState] = useState("Textbox");
+  const [warningState, setWarningState] = useState("Textbox");
+  const [infoState, setInfoState] = useState("Textbox");
+  const setValue = (
+    { target }: React.ChangeEvent<HTMLInputElement>,
+    size: string,
+  ) => {
+    if (size === "error") setErrorState(target.value);
+    else if (size === "warning") setWarningState(target.value);
+    else if (size === "info") setInfoState(target.value);
+  };
+
   return (
     <Box>
-      {VALIDATIONS.map((validationType) => (
-        <div key={`${validationType}-string-component`}>
-          <Textbox
-            label="Textbox"
-            value="Textbox"
-            {...{ [validationType]: "Message" }}
-            mb={2}
-            tooltipPosition="bottom"
-          />
-        </div>
-      ))}
+      <div key={`error-string-component`}>
+        <Textbox
+          label="Textbox"
+          error="Message"
+          value={errorState}
+          onChange={(e) => setValue(e, "error")}
+          mb={2}
+          tooltipPosition="bottom"
+        />
+      </div>
+
+      <div key={`warning-string-component`}>
+        <Textbox
+          label="Textbox"
+          warning="Message"
+          value={warningState}
+          onChange={(e) => setValue(e, "error")}
+          mb={2}
+          tooltipPosition="bottom"
+        />
+      </div>
+
+      <div key={`info-string-component`}>
+        <Textbox
+          label="Textbox"
+          info="Message"
+          value={infoState}
+          onChange={(e) => setValue(e, "info")}
+          mb={2}
+          tooltipPosition="bottom"
+        />
+      </div>
     </Box>
   );
 };
 
 export const TextboxValidationsAsAStringDisplayedOnLabel = () => {
+  const [errorState, setErrorState] = useState("Textbox");
+  const [warningState, setWarningState] = useState("Textbox");
+  const [infoState, setInfoState] = useState("Textbox");
+  const setValue = (
+    { target }: React.ChangeEvent<HTMLInputElement>,
+    size: string,
+  ) => {
+    if (size === "error") setErrorState(target.value);
+    else if (size === "warning") setWarningState(target.value);
+    else if (size === "info") setInfoState(target.value);
+  };
+
   return (
     <Box>
-      {VALIDATIONS.map((validationType) => (
-        <div key={`${validationType}-string-label`}>
-          <Textbox
-            label="Textbox"
-            value="Textbox"
-            validationOnLabel
-            {...{ [validationType]: "Message" }}
-            mb={2}
-          />
-          <Textbox
-            label="Textbox - readOnly"
-            value="Textbox"
-            validationOnLabel
-            readOnly
-            {...{ [validationType]: "Message" }}
-            mb={2}
-          />
-        </div>
-      ))}
+      <div key={`error-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={errorState}
+          onChange={(e) => setValue(e, "error")}
+          validationOnLabel
+          error="Message"
+          mb={2}
+        />
+        <Textbox
+          label="Textbox - readOnly"
+          value={errorState}
+          onChange={(e) => setValue(e, "error")}
+          validationOnLabel
+          readOnly
+          error="Message"
+          mb={2}
+        />
+      </div>
+
+      <div key={`warning-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={warningState}
+          onChange={(e) => setValue(e, "warning")}
+          validationOnLabel
+          warning="Message"
+          mb={2}
+        />
+        <Textbox
+          label="Textbox - readOnly"
+          value={warningState}
+          onChange={(e) => setValue(e, "warning")}
+          validationOnLabel
+          readOnly
+          warning="Message"
+          mb={2}
+        />
+      </div>
+
+      <div key={`info-string-label`}>
+        <Textbox
+          label="Textbox"
+          value={infoState}
+          onChange={(e) => setValue(e, "info")}
+          validationOnLabel
+          info="Message"
+          mb={2}
+        />
+        <Textbox
+          label="Textbox - readOnly"
+          value={infoState}
+          onChange={(e) => setValue(e, "info")}
+          validationOnLabel
+          readOnly
+          info="Message"
+          mb={2}
+        />
+      </div>
     </Box>
   );
 };
 
 export const TextboxNewDesignsValidation = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
   return (
     <Box>
       <CarbonProvider validationRedesignOptIn>
         {(["error", "warning"] as const).map((validationType) =>
           SIZES.map((size) => (
-            <div style={{ width: "296px" }} key={`${validationType}-${size}`}>
+            <Box width="296px" key={`${validationType}-${size}`}>
               <Textbox
                 m={4}
                 label={`${size} - ${validationType}`}
-                defaultValue="Textbox"
+                value={state}
+                onChange={setValue}
                 labelHelp="Hint text (optional)"
                 size={size}
                 {...{ [validationType]: "Message" }}
@@ -219,13 +393,14 @@ export const TextboxNewDesignsValidation = () => {
               <Textbox
                 m={4}
                 label={`readOnly - ${size} - ${validationType}`}
-                defaultValue="Textbox"
+                value={state}
+                onChange={setValue}
                 size={size}
                 labelHelp="Hint text (optional)"
                 readOnly
                 {...{ [validationType]: "Message" }}
               />
-            </div>
+            </Box>
           )),
         )}
       </CarbonProvider>

--- a/src/components/textbox/textbox-test.stories.tsx
+++ b/src/components/textbox/textbox-test.stories.tsx
@@ -9,10 +9,12 @@ import {
   getCommonTextboxArgs,
   getCommonTextboxArgsWithSpecialCharacters,
 } from "./utils";
+import useMultiInput from "../../hooks/use-multi-input";
 
 export default {
   title: "Textbox/Test",
   parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
     info: { disable: true },
     chromatic: {
       disableSnapshot: true,
@@ -45,19 +47,78 @@ Default.argTypes = commonTextboxArgTypes();
 Default.args = getCommonTextboxArgs();
 
 export const Validation = () => {
+  const { state, setValue } = useMultiInput();
+
   return (
     <>
-      <Textbox label="Textbox" error="Error Message" />
-      <Textbox label="Textbox" warning="Warning Message" />
-      <Textbox label="Textbox" info="Info Message" />
+      <Textbox
+        name="textbox1"
+        label="Textbox"
+        error="Error Message"
+        value={state["textbox1"] || ""}
+        onChange={setValue}
+      />
+      <Textbox
+        name="textbox2"
+        label="Textbox"
+        warning="Warning Message"
+        value={state["textbox2"] || ""}
+        onChange={setValue}
+      />
+      <Textbox
+        name="textbox3"
+        label="Textbox"
+        info="Info Message"
+        value={state["textbox3"] || ""}
+        onChange={setValue}
+      />
 
-      <Textbox label="Textbox" error="Error Message" validationOnLabel />
-      <Textbox label="Textbox" warning="Warning Message" validationOnLabel />
-      <Textbox label="Textbox" info="Info Message" validationOnLabel />
+      <Textbox
+        name="textbox4"
+        label="Textbox"
+        error="Error Message"
+        validationOnLabel
+        value={state["textbox4"] || ""}
+        onChange={setValue}
+      />
+      <Textbox
+        name="textbox5"
+        label="Textbox"
+        warning="Warning Message"
+        validationOnLabel
+        value={state["textbox5"] || ""}
+        onChange={setValue}
+      />
+      <Textbox
+        name="textbox6"
+        label="Textbox"
+        info="Info Message"
+        validationOnLabel
+        value={state["textbox6"] || ""}
+        onChange={setValue}
+      />
 
-      <Textbox label="Textbox" error />
-      <Textbox label="Textbox" warning />
-      <Textbox label="Textbox" info />
+      <Textbox
+        name="textbox7"
+        label="Textbox"
+        error
+        value={state["textbox7"] || ""}
+        onChange={setValue}
+      />
+      <Textbox
+        name="textbox8"
+        label="Textbox"
+        warning
+        value={state["textbox8"] || ""}
+        onChange={setValue}
+      />
+      <Textbox
+        name="textbox9"
+        label="Textbox"
+        info
+        value={state["textbox9"] || ""}
+        onChange={setValue}
+      />
     </>
   );
 };
@@ -68,19 +129,39 @@ Validation.parameters = {
 };
 
 export const NewValidation = () => {
+  const { state, setValue } = useMultiInput();
+
   return (
     <CarbonProvider validationRedesignOptIn>
-      <Textbox label="Textbox" error="Error Message" />
-      <Textbox label="Textbox" warning="Warning Message" />
       <Textbox
+        name="textbox1"
+        label="Textbox"
+        error="Error Message"
+        value={state["textbox1"] || ""}
+        onChange={setValue}
+      />
+      <Textbox
+        name="textbox2"
+        label="Textbox"
+        warning="Warning Message"
+        value={state["textbox2"] || ""}
+        onChange={setValue}
+      />
+      <Textbox
+        name="textbox3"
         validationMessagePositionTop={false}
         label="Textbox"
         error="Error Message"
+        value={state["textbox3"] || ""}
+        onChange={setValue}
       />
       <Textbox
+        name="textbox4"
         validationMessagePositionTop={false}
         label="Textbox"
         warning="Warning Message"
+        value={state["textbox4"] || ""}
+        onChange={setValue}
       />
     </CarbonProvider>
   );
@@ -92,16 +173,21 @@ NewValidation.parameters = {
 };
 
 export const PrefixWithSizes = () => {
+  const { state, setValue } = useMultiInput();
+
   return (
     <>
       {["small", "medium", "large"].map((size) => (
         <Textbox
           key={`Textbox - ${size}`}
           label={`Textbox - ${size}`}
-          defaultValue="Textbox"
+          value={state[size] || ""}
+          onChange={setValue}
           prefix="prefix"
+          name={size}
           size={size as TextboxProps["size"]}
           mb={2}
+          placeholder="Textbox"
         />
       ))}
     </>
@@ -120,6 +206,8 @@ export const LabelAndHintTextAlign = () => {
     { inline: true, align: "right", error: "Error message" },
     { inline: true, align: "right", error: undefined },
   ];
+  const { state, setValue } = useMultiInput();
+
   return (
     <Box>
       <h1>Old Validation</h1>
@@ -127,7 +215,11 @@ export const LabelAndHintTextAlign = () => {
         {variants.map(({ inline, align, error: e }) => (
           <Textbox
             label={`${inline ? "Inline" : "Stacked"} - ${align}${e ? " with Error" : ""}`}
-            value="Textbox"
+            value={
+              state[`old-${inline}-${align}-${e ? "error" : "no-error"}`] || ""
+            }
+            name={`old-${inline}-${align}-${e ? "error" : "no-error"}`}
+            onChange={setValue}
             inputWidth={50}
             key={`${inline ? "inline" : "stacked"}-${align}-old-${e ? "error" : "no-error"}`}
             labelAlign={align as TextboxProps["labelAlign"]}
@@ -144,7 +236,12 @@ export const LabelAndHintTextAlign = () => {
           {variants.map(({ inline, align, error: e }) => (
             <Textbox
               label={`${inline ? "Inline" : "Stacked"} - ${align}${e ? " with Error" : ""}`}
-              value="Textbox"
+              value={
+                state[`new-${inline}-${align}-${e ? "error" : "no-error"}`] ||
+                ""
+              }
+              name={`new-${inline}-${align}-${e ? "error" : "no-error"}`}
+              onChange={setValue}
               inputWidth={50}
               key={`${inline ? "inline" : "stacked"}-${align}-new-${e ? "error" : "no-error"}`}
               labelAlign={align as TextboxProps["labelAlign"]}
@@ -165,9 +262,13 @@ LabelAndHintTextAlign.parameters = {
 };
 
 export const AutoFocus = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
   return (
     <Box>
-      <Textbox label="Textbox" value="Textbox" autoFocus />
+      <Textbox label="Textbox" value={state} onChange={setValue} autoFocus />
     </Box>
   );
 };

--- a/src/components/textbox/textbox.component.tsx
+++ b/src/components/textbox/textbox.component.tsx
@@ -19,7 +19,6 @@ import { ValidationProps } from "../../__internal__/validations";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import NewValidationContext from "../carbon-provider/__internal__/new-validation.context";
 import NumeralDateContext from "../numeral-date/__internal__/numeral-date.context";
-import Logger from "../../__internal__/utils/logger";
 import useCharacterCount from "../../hooks/useCharacterCount";
 import useUniqueId from "../../hooks/__internal__/useUniqueId";
 import guid from "../../__internal__/utils/helpers/guid";
@@ -95,7 +94,7 @@ export interface CommonTextboxProps
   /** [Legacy] Label width as a percentage when label is inline. */
   labelWidth?: number;
   /** Specify a callback triggered on change */
-  onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
   /** Deferred callback to be called after the onChange event */
   onChangeDeferred?: () => void;
   /** Specify a callback triggered on click */
@@ -128,7 +127,7 @@ export interface CommonTextboxProps
   validationMessagePositionTop?: boolean;
 }
 
-export interface TextboxProps extends CommonTextboxProps {
+export interface TextboxProps extends Omit<CommonTextboxProps, "defaultValue"> {
   /** Content to be rendered next to the input */
   children?: React.ReactNode;
   /** Container for DatePicker or SelectList components */
@@ -136,8 +135,6 @@ export interface TextboxProps extends CommonTextboxProps {
   /** Character limit of the textarea */
   characterLimit?: number;
 }
-
-let deprecateUncontrolledWarnTriggered = false;
 
 export const Textbox = React.forwardRef(
   (
@@ -229,13 +226,6 @@ export const Textbox = React.forwardRef(
     const { disableErrorBorder } = useContext(NumeralDateContext);
     const computeLabelPropValues = <T,>(prop: T): undefined | T =>
       validationRedesignOptIn ? undefined : prop;
-
-    if (!deprecateUncontrolledWarnTriggered && !onChange) {
-      deprecateUncontrolledWarnTriggered = true;
-      Logger.deprecate(
-        "Uncontrolled behaviour in `Textbox` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-      );
-    }
 
     const { labelId, validationId, fieldHelpId, ariaDescribedBy } =
       useInputAccessibility({
@@ -426,7 +416,5 @@ export const Textbox = React.forwardRef(
     );
   },
 );
-
-Textbox.displayName = "Textbox";
 
 export default Textbox;

--- a/src/components/textbox/textbox.stories.tsx
+++ b/src/components/textbox/textbox.stories.tsx
@@ -14,6 +14,9 @@ const styledSystemProps = generateStyledSystemProps({
 const meta: Meta<typeof Textbox> = {
   title: "Textbox",
   component: Textbox,
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
+  },
   argTypes: {
     ...styledSystemProps,
   },
@@ -22,14 +25,19 @@ const meta: Meta<typeof Textbox> = {
 export default meta;
 type Story = StoryObj<typeof Textbox>;
 
-const SIZES = ["small", "medium", "large"] as const;
-
 export const Default: Story = () => {
-  const [state, setState] = useState("Textbox");
+  const [state, setState] = useState("");
   const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
     setState(target.value);
   };
-  return <Textbox label="Textbox" value={state} onChange={setValue} />;
+  return (
+    <Textbox
+      label="Textbox"
+      value={state}
+      onChange={setValue}
+      placeholder="Textbox"
+    />
+  );
 };
 Default.storyName = "Default";
 
@@ -102,17 +110,48 @@ export const Prefix: Story = () => {
 Prefix.storyName = "Prefix";
 
 export const Sizes: Story = () => {
+  const [smallState, setSmallState] = useState("");
+  const [mediumState, setMediumState] = useState("");
+  const [largeState, setLargeState] = useState("");
+  const setValue = (
+    { target }: React.ChangeEvent<HTMLInputElement>,
+    size: string,
+  ) => {
+    if (size === "small") setSmallState(target.value);
+    else if (size === "medium") setMediumState(target.value);
+    else if (size === "large") setLargeState(target.value);
+  };
   return (
     <Box>
-      {SIZES.map((size) => (
-        <Textbox
-          key={`Textbox - ${size}`}
-          label={`Textbox - ${size}`}
-          defaultValue="Textbox"
-          size={size}
-          mb={2}
-        />
-      ))}
+      <Textbox
+        key={`Textbox - small`}
+        label={`Textbox - small`}
+        value={smallState}
+        size={"small"}
+        mb={2}
+        onChange={(e) => setValue(e, "small")}
+        placeholder="Textbox"
+      />
+
+      <Textbox
+        key={`Textbox - medium`}
+        label={`Textbox - medium`}
+        value={mediumState}
+        size={"medium"}
+        mb={2}
+        onChange={(e) => setValue(e, "medium")}
+        placeholder="Textbox"
+      />
+
+      <Textbox
+        key={`Textbox - large`}
+        label={`Textbox - large`}
+        value={largeState}
+        size={"large"}
+        mb={2}
+        onChange={(e) => setValue(e, "large")}
+        placeholder="Textbox"
+      />
     </Box>
   );
 };
@@ -128,26 +167,60 @@ export const Margins: Story = () => {
 Margins.storyName = "Margins";
 
 export const Disabled: Story = () => {
-  return <Textbox label="Textbox" value="Textbox" disabled />;
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Textbox label="Textbox" disabled value={state} onChange={setValue} />;
 };
 Disabled.storyName = "Disabled";
 
 export const ReadOnly: Story = () => {
-  return <Textbox label="Textbox" value="Textbox" readOnly />;
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Textbox
+      label="Textbox"
+      readOnly
+      value={state}
+      onChange={setValue}
+      placeholder="Textbox"
+    />
+  );
 };
 ReadOnly.storyName = "Read Only";
 
 export const WithLabelInline: Story = () => {
-  return <Textbox label="Textbox" value="Textbox" labelInline />;
+  const [state, setState] = useState("");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return (
+    <Textbox
+      label="Textbox"
+      labelInline
+      value={state}
+      onChange={setValue}
+      placeholder="Textbox"
+    />
+  );
 };
 WithLabelInline.storyName = "With Label Inline";
 WithLabelInline.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithCustomLabelWidthAndInputWidth: Story = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
   return (
     <Textbox
       label="Textbox"
-      value="Textbox"
+      value={state}
+      onChange={setValue}
       labelInline
       labelWidth={50}
       inputWidth={50}
@@ -158,20 +231,45 @@ WithCustomLabelWidthAndInputWidth.storyName =
   "With Custom Label Width And Input Width";
 
 export const WithCustomMaxWidth: Story = () => {
-  return <Textbox label="Textbox" value="Textbox" maxWidth="50%" />;
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Textbox label="Textbox" value={state} onChange={setValue} maxWidth="50%" />
+  );
 };
 WithCustomMaxWidth.storyName = "With Custom Max Width";
 
 export const WithFieldHelp: Story = () => {
-  return <Textbox label="Textbox" value="Textbox" fieldHelp="Help" />;
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
+  return (
+    <Textbox
+      label="Textbox"
+      value={state}
+      onChange={setValue}
+      fieldHelp="Help"
+    />
+  );
 };
 WithFieldHelp.storyName = "With Field Help";
 
 export const WithInputHint: Story = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+
   return (
     <Textbox
       label="Textbox"
-      value="Textbox"
+      value={state}
+      onChange={setValue}
       inputHint="Hint text (optional)."
     />
   );
@@ -179,10 +277,15 @@ export const WithInputHint: Story = () => {
 WithInputHint.storyName = "With Input Hint";
 
 export const WithLabelHelp: Story = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
   return (
     <Textbox
       label="Textbox"
-      value="Textbox"
+      value={state}
+      onChange={setValue}
       labelHelp="Help"
       helpAriaLabel="Help"
     />
@@ -191,17 +294,35 @@ export const WithLabelHelp: Story = () => {
 WithLabelHelp.storyName = "With Label Help";
 
 export const Required: Story = () => {
-  return <Textbox label="Textbox" value="Textbox" required />;
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Textbox label="Textbox" value={state} onChange={setValue} required />;
 };
 Required.storyName = "Required";
 
+export const IsOptional: Story = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
+  return <Textbox label="Textbox" value={state} onChange={setValue} />;
+};
+IsOptional.storyName = "IsOptional";
+
 export const LabelAlign: Story = () => {
+  const [state, setState] = useState("Textbox");
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setState(target.value);
+  };
   return (
     <Box>
       {(["right", "left"] as const).map((alignment) => (
         <Textbox
           label="Textbox"
-          value="Textbox"
+          value={state}
+          onChange={setValue}
           labelInline
           inputWidth={50}
           key={alignment}

--- a/src/components/textbox/textbox.test.tsx
+++ b/src/components/textbox/textbox.test.tsx
@@ -35,18 +35,15 @@ afterAll(() => {
   loggerSpy.mockClear();
 });
 
-test("should display deprecation warning once when rendered as uncontrolled", () => {
-  render(<Textbox name="my-textbox" defaultValue="test" />);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "Uncontrolled behaviour in `Textbox` is deprecated and support will soon be removed. Please make sure all your inputs are controlled.",
-  );
-
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-});
-
 testStyledSystemMargin(
-  (props) => <Textbox data-role="textbox-wrapper" {...props} />,
+  (props) => (
+    <Textbox
+      data-role="textbox-wrapper"
+      value="foo"
+      onChange={() => {}}
+      {...props}
+    />
+  ),
   () => screen.getByTestId("textbox-wrapper"),
   { modifier: "&&&" },
 );
@@ -55,7 +52,13 @@ describe(`when the characterLimit prop is passed`, () => {
   it.each([2, 3, 4])("renders a character counter", (characterLimit) => {
     const valueString = "foo";
     const limitMinusValue = characterLimit - valueString.length >= 0;
-    render(<Textbox value={valueString} characterLimit={characterLimit} />);
+    render(
+      <Textbox
+        value={valueString}
+        onChange={() => {}}
+        characterLimit={characterLimit}
+      />,
+    );
     const underCharacters =
       characterLimit - valueString.length === 1 ? "character" : "characters";
     const overCharacters =
@@ -76,7 +79,7 @@ describe(`when the characterLimit prop is passed`, () => {
   });
 
   it("should render a visually hidden hint with id generated via guid", () => {
-    render(<Textbox value="foo" characterLimit={73} />);
+    render(<Textbox value="foo" onChange={() => {}} characterLimit={73} />);
     expect(
       screen.getByText("You can enter up to 73 characters", {
         selector: '[data-element="visually-hidden-hint"]',
@@ -85,7 +88,7 @@ describe(`when the characterLimit prop is passed`, () => {
   });
 
   it("should reference the visually hidden hint id in the input's aria-describedby", () => {
-    render(<Textbox value="foo" characterLimit={73} />);
+    render(<Textbox value="foo" onChange={() => {}} characterLimit={73} />);
     expect(screen.getByRole("textbox")).toHaveAttribute(
       "aria-describedby",
       mockedGuid,
@@ -93,7 +96,9 @@ describe(`when the characterLimit prop is passed`, () => {
   });
 
   it("renders a counter with an over limit warning", () => {
-    render(<Textbox value="test string" characterLimit={10} />);
+    render(
+      <Textbox value="test string" onChange={() => {}} characterLimit={10} />,
+    );
 
     expect(
       screen.getByText("1 character too many", {
@@ -105,21 +110,23 @@ describe(`when the characterLimit prop is passed`, () => {
 
 test("accepts ref as a ref object", () => {
   const ref = { current: null };
-  render(<Textbox ref={ref} />);
+  render(<Textbox value="foo" onChange={() => {}} ref={ref} />);
 
   expect(ref.current).toBe(screen.getByRole("textbox"));
 });
 
 test("accepts ref as a ref callback", () => {
   const ref = jest.fn();
-  render(<Textbox ref={ref} />);
+  render(<Textbox value="foo" onChange={() => {}} ref={ref} />);
 
   expect(ref).toHaveBeenCalledWith(screen.getByRole("textbox"));
 });
 
 test("sets ref to empty after unmount", () => {
   const ref = { current: null };
-  const { unmount } = render(<Textbox ref={ref} />);
+  const { unmount } = render(
+    <Textbox value="foo" onChange={() => {}} ref={ref} />,
+  );
 
   unmount();
 
@@ -142,7 +149,7 @@ test.each([
 ] as const)(
   "styles the input appropriately when an icon is present inside",
   (props: Partial<TextboxProps>) => {
-    render(<Textbox value="test string" {...props} />);
+    render(<Textbox value="test string" onChange={() => {}} {...props} />);
     expect(screen.getByRole("presentation")).toHaveStyleRule(
       "padding-right",
       "0",
@@ -159,6 +166,7 @@ test("supports a separate onClick handler passing for the icon", async () => {
   render(
     <Textbox
       value="foobar"
+      onChange={() => {}}
       inputIcon="search"
       onClick={onClick}
       iconOnClick={iconOnClick}
@@ -182,7 +190,9 @@ test.each([
 ] as EnterKeyHintTypes[])(
   "'enterKeyHint' is correctly passed to the input when prop value is %s",
   (keyHints) => {
-    render(<Textbox value="foobar" enterKeyHint={keyHints} />);
+    render(
+      <Textbox value="foobar" onChange={() => {}} enterKeyHint={keyHints} />,
+    );
 
     expect(screen.getByRole("textbox")).toHaveAttribute(
       "enterkeyhint",
@@ -201,6 +211,7 @@ test.each(["disabled", "readOnly"])(
     render(
       <Textbox
         value="foobar"
+        onChange={() => {}}
         inputIcon="search"
         onClick={onClick}
         iconOnClick={iconOnClick}
@@ -225,6 +236,7 @@ test.each(["disabled", "readOnly"])(
     render(
       <Textbox
         value="foobar"
+        onChange={() => {}}
         inputIcon="search"
         onMouseDown={onMouseDown}
         iconOnMouseDown={iconOnMouseDown}
@@ -248,6 +260,7 @@ test.each(["disabled", "readOnly"])(
     render(
       <Textbox
         value="foobar"
+        onChange={() => {}}
         inputIcon="search"
         onClick={onClick}
         disabled={propName === "disabled"}
@@ -270,6 +283,7 @@ test.each(["disabled", "readOnly"])(
     render(
       <Textbox
         value="foobar"
+        onChange={() => {}}
         inputIcon="search"
         onMouseDown={onMouseDown}
         disabled={propName === "disabled"}
@@ -286,7 +300,14 @@ test.each(["disabled", "readOnly"])(
 test.each(validationTypes)(
   "when %s prop passed as string render proper validation icon by the input",
   (type) => {
-    render(<Textbox label="Label" {...{ [type]: "Message" }} />);
+    render(
+      <Textbox
+        label="Label"
+        value="foo"
+        onChange={() => {}}
+        {...{ [type]: "Message" }}
+      />,
+    );
     const inputPresentationContainer = screen.getByRole("presentation");
     const validationIcon = screen.getByTestId(`icon-${type}`);
     expect(inputPresentationContainer).toContainElement(validationIcon);
@@ -298,7 +319,13 @@ test.each(validationTypes)(
   as true render proper validation icon on the label`,
   (type) => {
     render(
-      <Textbox label="Label" {...{ [type]: "Message" }} validationOnLabel />,
+      <Textbox
+        label="Label"
+        value="foo"
+        onChange={() => {}}
+        {...{ [type]: "Message" }}
+        validationOnLabel
+      />,
     );
     const labelContainer = screen.getByTestId("label-container");
     const validationIcon = screen.getByTestId(`icon-${type}`);
@@ -321,6 +348,8 @@ test.each([
     render(
       <Textbox
         label="Label"
+        value="foo"
+        onChange={() => {}}
         error="Message"
         validationOnLabel={onLabel}
         tooltipPosition={tooltipPosition}
@@ -338,7 +367,7 @@ test.each([
 describe("when the prefix prop is set", () => {
   it("renders a StyledPrefix with this prop value", () => {
     const prefixValue = "bar";
-    render(<Textbox value="foo" prefix={prefixValue} />);
+    render(<Textbox value="foo" onChange={() => {}} prefix={prefixValue} />);
     expect(screen.getByText(prefixValue)).toHaveAttribute(
       "data-element",
       "textbox-prefix",
@@ -347,7 +376,14 @@ describe("when the prefix prop is set", () => {
 
   it("renders with 'flex-direction' as 'row' when the align prop is 'right'", () => {
     const prefixValue = "bar";
-    render(<Textbox value="foo" prefix={prefixValue} align="right" />);
+    render(
+      <Textbox
+        value="foo"
+        onChange={() => {}}
+        prefix={prefixValue}
+        align="right"
+      />,
+    );
     expect(screen.getByRole("presentation")).toHaveStyle({
       flexDirection: "row",
     });
@@ -355,12 +391,12 @@ describe("when the prefix prop is set", () => {
 });
 
 test("the required prop is passed to the input", () => {
-  render(<Textbox value="foo" label="Required" required />);
+  render(<Textbox value="foo" onChange={() => {}} label="Required" required />);
   expect(screen.getByRole("textbox")).toBeRequired();
 });
 
 test("when the required prop is set, the label includes the 'required' asterisk", () => {
-  render(<Textbox value="foo" label="Required" required />);
+  render(<Textbox value="foo" onChange={() => {}} label="Required" required />);
   expect(screen.getByText("Required")).toHaveStyleRule("content", '"*"', {
     modifier: "::after",
   });
@@ -368,7 +404,13 @@ test("when the required prop is set, the label includes the 'required' asterisk"
 
 test("renders the positionChildren prop before the input", () => {
   const Component = () => <div>positionedChildren content</div>;
-  render(<Textbox positionedChildren={<Component />} />);
+  render(
+    <Textbox
+      value="foo"
+      onChange={() => {}}
+      positionedChildren={<Component />}
+    />,
+  );
   const positionChildren = screen.getByText("positionedChildren content");
   const input = screen.getByRole("textbox");
   expect(positionChildren.compareDocumentPosition(input)).toEqual(
@@ -381,6 +423,7 @@ test("passes the helpAriaLabel prop down to the help component", () => {
   render(
     <Textbox
       value=""
+      onChange={() => {}}
       label="label"
       labelHelp="some help"
       helpAriaLabel={text}
@@ -394,7 +437,7 @@ test("sets the accessible label to the provided aria-labelledby", () => {
   const Component = () => (
     <>
       <p id="test">label</p>
-      <Textbox aria-labelledby="test" />
+      <Textbox aria-labelledby="test" value="foo" onChange={() => {}} />
     </>
   );
   render(<Component />);
@@ -406,7 +449,12 @@ test("appends the provided `aria-describedby` to the accessible description", ()
   const Component = () => (
     <>
       <p id="test">description</p>
-      <Textbox inputHint="hint text" aria-describedby="test" />
+      <Textbox
+        inputHint="hint text"
+        aria-describedby="test"
+        value="foo"
+        onChange={() => {}}
+      />
     </>
   );
   render(<Component />);
@@ -419,7 +467,15 @@ test("appends the provided `aria-describedby` to the accessible description", ()
 test.each(validationTypes)(
   'when id is present, %s prop is set as a string and the input is focused, the id of the validation tooltip is added to "aria-describedby" in the input',
   async (validationType) => {
-    render(<Textbox label="bar" id="foo" {...{ [validationType]: "test" }} />);
+    render(
+      <Textbox
+        label="bar"
+        id="foo"
+        {...{ [validationType]: "test" }}
+        value="foo"
+        onChange={() => {}}
+      />,
+    );
     const input = screen.getByRole("textbox");
     act(() => {
       input.focus();
@@ -436,7 +492,14 @@ test.each(validationTypes)(
 test.each(validationTypes)(
   "when id is not present, %s prop is set as a string and the input is focused, the id of the validation tooltip is added to 'aria-describedby' in the input",
   async (validationType) => {
-    render(<Textbox label="bar" {...{ [validationType]: "test" }} />);
+    render(
+      <Textbox
+        label="bar"
+        value="foo"
+        onChange={() => {}}
+        {...{ [validationType]: "test" }}
+      />,
+    );
     const input = screen.getByRole("textbox");
     act(() => {
       input.focus();
@@ -454,7 +517,15 @@ test.each(validationTypes)(
 );
 
 test("when id and fieldHelp are both present, the id of the field help is added to 'aria-describedby' in the input", () => {
-  render(<Textbox id="foo" label="bar" fieldHelp="baz" />);
+  render(
+    <Textbox
+      id="foo"
+      label="bar"
+      fieldHelp="baz"
+      value="foo"
+      onChange={() => {}}
+    />,
+  );
 
   expect(screen.getByText("baz")).toHaveAttribute("id", "foo-field-help");
   expect(screen.getByRole("textbox")).toHaveAttribute(
@@ -464,7 +535,9 @@ test("when id and fieldHelp are both present, the id of the field help is added 
 });
 
 test("when fieldHelp is present and id is not present, the id of the field help is added to 'aria-describedby' in the input", () => {
-  render(<Textbox label="bar" fieldHelp="baz" />);
+  render(
+    <Textbox label="bar" fieldHelp="baz" value="foo" onChange={() => {}} />,
+  );
 
   expect(screen.getByText("baz")).toHaveAttribute(
     "id",
@@ -482,6 +555,8 @@ test.each(validationTypes)(
     render(
       <Textbox
         label="bar"
+        value="foo"
+        onChange={() => {}}
         id="foo"
         fieldHelp="baz"
         {...{ [validationType]: "test" }}
@@ -508,7 +583,13 @@ test.each(validationTypes)(
   'when id is not present, %s prop is set as a string, fieldHelp is present and the input is focused, the ids of both the validation tooltip are added to "aria-describedby" in the input',
   async (validationType) => {
     render(
-      <Textbox label="bar" fieldHelp="baz" {...{ [validationType]: "test" }} />,
+      <Textbox
+        label="bar"
+        value="foo"
+        onChange={() => {}}
+        fieldHelp="baz"
+        {...{ [validationType]: "test" }}
+      />,
     );
     const input = screen.getByRole("textbox");
     act(() => {
@@ -533,7 +614,12 @@ test.each(validationTypes)(
 test("describes the input with the inputHint and error message when validationMessagePositionTop is true", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Textbox inputHint="input hint" error="validation message" />
+      <Textbox
+        inputHint="input hint"
+        value="foo"
+        onChange={() => {}}
+        error="validation message"
+      />
     </CarbonProvider>,
   );
 
@@ -545,7 +631,12 @@ test("describes the input with the inputHint and error message when validationMe
 test("describes the input with the inputHint and warning when validationMessagePositionTop is true", () => {
   render(
     <CarbonProvider validationRedesignOptIn>
-      <Textbox inputHint="input hint" warning="validation message" />
+      <Textbox
+        inputHint="input hint"
+        value="foo"
+        onChange={() => {}}
+        warning="validation message"
+      />
     </CarbonProvider>,
   );
 
@@ -559,6 +650,8 @@ test("describes the input with the inputHint and error message when validationMe
     <CarbonProvider validationRedesignOptIn>
       <Textbox
         inputHint="input hint"
+        value="foo"
+        onChange={() => {}}
         error="validation message"
         validationMessagePositionTop={false}
       />
@@ -574,6 +667,8 @@ test("describes the input with the inputHint and warning when validationMessageP
   render(
     <CarbonProvider validationRedesignOptIn>
       <Textbox
+        value="foo"
+        onChange={() => {}}
         inputHint="input hint"
         warning="validation message"
         validationMessagePositionTop={false}
@@ -587,7 +682,15 @@ test("describes the input with the inputHint and warning when validationMessageP
 });
 
 test("renders validation tooltip with provided 'tooltipId' prop", async () => {
-  render(<Textbox label="bar" error="baz" tooltipId="foo" />);
+  render(
+    <Textbox
+      label="bar"
+      error="baz"
+      value="foo"
+      onChange={() => {}}
+      tooltipId="foo"
+    />,
+  );
 
   const input = screen.getByRole("textbox");
   act(() => {
@@ -600,12 +703,12 @@ test("renders validation tooltip with provided 'tooltipId' prop", async () => {
 
 describe("when inputHint prop is present", () => {
   it("renders the hint", () => {
-    render(<Textbox value="test string" inputHint="foo" />);
+    render(<Textbox value="test string" onChange={() => {}} inputHint="foo" />);
     expect(screen.getByText("foo")).toBeInTheDocument();
   });
 
   it("assigns the input hint a guid as id and references it in the aria-describedby of the input", () => {
-    render(<Textbox value="test string" inputHint="bar" />);
+    render(<Textbox value="test string" onChange={() => {}} inputHint="bar" />);
     expect(screen.getByText("bar")).toHaveAttribute("id", mockedGuid);
     expect(screen.getByRole("textbox")).toHaveAttribute(
       "aria-describedby",
@@ -616,7 +719,13 @@ describe("when inputHint prop is present", () => {
   it("uses the inputHint prop instead of labelHelp when both are passed", () => {
     render(
       <CarbonProvider validationRedesignOptIn>
-        <Textbox labelHelp="labelHelp" inputHint="inputHint" error="foo" />
+        <Textbox
+          labelHelp="labelHelp"
+          inputHint="inputHint"
+          error="foo"
+          value="foo"
+          onChange={() => {}}
+        />
       </CarbonProvider>,
     );
     expect(screen.getByText("inputHint")).toBeInTheDocument();
@@ -634,7 +743,12 @@ describe("when rendered with new validations", () => {
 
   it('adds the id of the validation text to "aria-describedby" in the input', () => {
     const mockId = "foo";
-    renderWithNewValidations({ id: mockId, error: "bar" });
+    renderWithNewValidations({
+      id: mockId,
+      error: "bar",
+      value: "foo",
+      onChange: jest.fn(),
+    });
 
     expect(screen.getByText("bar")).toHaveAttribute(
       "id",
@@ -654,6 +768,8 @@ describe("when rendered with new validations", () => {
       labelWidth: 100,
       labelSpacing: 1,
       reverse: true,
+      value: "foo",
+      onChange: jest.fn(),
     });
     const labelContainer = screen.getByTestId("label-container");
     expect(labelContainer).toHaveStyle({ width: undefined });
@@ -663,7 +779,11 @@ describe("when rendered with new validations", () => {
   });
 
   it("renders the hint text with the correct styling when the labelHelp prop is passed", () => {
-    renderWithNewValidations({ labelHelp: "help" });
+    renderWithNewValidations({
+      labelHelp: "help",
+      value: "foo",
+      onChange: jest.fn(),
+    });
     const hintText = screen.getByText("help");
     expect(hintText).toBeInTheDocument();
     expect(hintText).toHaveStyleRule("color", "var(--colorsUtilityYin055)");
@@ -674,7 +794,7 @@ describe("when rendered with new validations", () => {
 });
 
 test("renders with the expected border radius styling", () => {
-  render(<Textbox />);
+  render(<Textbox value="foo" onChange={() => {}} />);
   expect(screen.getByRole("textbox")).toHaveStyleRule(
     "border-radius",
     "var(--borderRadius050)",

--- a/src/components/time/time-test.stories.tsx
+++ b/src/components/time/time-test.stories.tsx
@@ -293,10 +293,12 @@ export const WithValueModifiers: Story = () => {
         <Textbox
           label="Hours"
           onChange={(e) => setTextboxHours(e.target.value)}
+          value={textboxHours}
         />
         <Textbox
           label="Minutes"
           onChange={(e) => setTextboxMinutes(e.target.value)}
+          value={textboxHours}
         />
         <Button
           onClick={() =>

--- a/src/components/tooltip/tooltip.config.ts
+++ b/src/components/tooltip/tooltip.config.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/prefer-default-export
 export const TOOLTIP_POSITIONS = ["bottom", "left", "right", "top"];
 
 export type TooltipPositions = "top" | "bottom" | "left" | "right";

--- a/src/components/vertical-menu/components.test-pw.tsx
+++ b/src/components/vertical-menu/components.test-pw.tsx
@@ -100,7 +100,6 @@ export const VerticalMenuDefaultComponent = (
 };
 
 export const VerticalMenuItemCustom = ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   component,
   ...props
 }: Partial<VerticalMenuItemProps>) => {
@@ -137,7 +136,6 @@ export const VerticalMenuItemCustom = ({
 };
 
 export const VerticalMenuItemCustomHref = ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   component,
   ...props
 }: Partial<VerticalMenuItemProps>) => {

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-divider/responsive-vertical-menu-divider.stories.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu-divider/responsive-vertical-menu-divider.stories.tsx
@@ -1,11 +1,12 @@
-import { Meta, StoryObj } from "@storybook/react";
+import { ArgTypes, Meta, StoryObj } from "@storybook/react";
+import { MarginProps } from "styled-system";
 
 import { ResponsiveVerticalMenuDivider } from "./responsive-vertical-menu-divider.component";
 import generateStyledSystemProps from "../../../../../.storybook/utils/styled-system-props";
 
 const styledSystemProps = generateStyledSystemProps({
   margin: true,
-});
+}) as Partial<ArgTypes<MarginProps>>;
 
 const meta: Meta<typeof ResponsiveVerticalMenuDivider> = {
   title: "ResponsiveVerticalMenuDivider",

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.pw.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.pw.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import React from "react";
 import { test, expect } from "../../../../playwright/helpers/base-test";
 

--- a/src/components/vertical-menu/vertical-menu.pw.tsx
+++ b/src/components/vertical-menu/vertical-menu.pw.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-await-in-loop */
 import React from "react";
 import { test, expect } from "../../../playwright/helpers/base-test";
 import {

--- a/src/hooks/use-multi-input/index.ts
+++ b/src/hooks/use-multi-input/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./use-multi-input";

--- a/src/hooks/use-multi-input/use-multi-input.tsx
+++ b/src/hooks/use-multi-input/use-multi-input.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+
+type FormState = { [key: string]: string };
+type FormStateBoolean = { [key: string]: boolean };
+
+export function useMultiInput(initialState: FormState = {}) {
+  const [state, setState] = useState<FormState>(initialState);
+
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = target;
+    setState((prev) => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const reset = () => setState(initialState);
+
+  return {
+    state,
+    setValue,
+    reset,
+    setState,
+  };
+}
+
+export function useMultiInputBoolean(initialState: FormStateBoolean = {}) {
+  const [state, setState] = useState<FormStateBoolean>(initialState);
+
+  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, checked } = target;
+    setState((prev) => ({
+      ...prev,
+      [name]: checked,
+    }));
+  };
+
+  const reset = () => setState(initialState);
+
+  return {
+    state,
+    setValue,
+    reset,
+    setState,
+  };
+}
+
+export default useMultiInput;

--- a/src/hooks/useCharacterCount/useCharacterCount.tsx
+++ b/src/hooks/useCharacterCount/useCharacterCount.tsx
@@ -4,7 +4,7 @@ import guid from "../../__internal__/utils/helpers/guid";
 import useDebounce from "../__internal__/useDebounce";
 
 const useCharacterCount = (
-  value = "",
+  value: string,
   characterLimit?: number,
   characterCountAriaLive?: "off" | "polite",
 ): [JSX.Element | null, string | undefined] => {

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -9,9 +9,8 @@ const assertCorrectColorMix = (
   Object.keys(colorConfig).forEach((color) => {
     const match = color.match(/([a-z]+)([\d]{0,2})/i);
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const func = match![1];
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+
     const weight = Number(match![2]);
 
     expect(paletteObject[func](weight)).toEqual(`#${colorConfig[color]}`);
@@ -60,7 +59,6 @@ describe("style", () => {
       palette = generatePalette(config);
     });
 
-    // eslint-disable-next-line jest/expect-expect
     it("produces the correct color mix", () => {
       assertCorrectColorMix(colorConfig, palette);
     });

--- a/src/style/themes/none/none.test.ts
+++ b/src/style/themes/none/none.test.ts
@@ -30,7 +30,6 @@ const assertIsSubset = (
 };
 
 describe("noneTheme", () => {
-  // eslint-disable-next-line jest/expect-expect
   it("contains the base theme", () => {
     assertIsSubset(baseTheme, noneTheme);
   });

--- a/src/style/utils/color.test.ts
+++ b/src/style/utils/color.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jest/expect-expect */
 import color from "./color";
 import { baseTheme } from "../themes";
 


### PR DESCRIPTION
Removes uncontrolled input support from the following components: 

- [x] Textbox
- [x] Decimal
- [x] Number
- [x] SimpleSelect
- [x] Filterable Select
- [x] MultiSelect
- [x] GroupedCharacter
- [x] NumeralDate
- [x] Search
- [x] Checkbox
- [x] RadioButton
- [x] Switch
- [x] SimpleColorPicker
- [x] AdvancedColorPicker
- [x] ButtonToggle
- [x] Password
- [x] TextArea

BREAKING CHANGE: Component props designed to support uncontrolled usage e.g. defaultValue have been removed, and all value and onChange props are now required.


```javascript
import React, { useState } from 'react';
import Textbox from 'carbon-react/lib/components/textbox;

const CustomTextbox = (args) => {
  const [value, setValue] = useState("");
  return <Textbox value={value} onChange={e => setValue(e.target.value)} />;
}
```

### Proposed behaviour

Remove support for uncontrolled usage from the components listed above.

### Current behaviour

Our input-based components support uncontrolled usage

### Checklist

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ]  Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

