### PR TITLE
docs(welcome): fixes the broken welcome page

### DIFF
--- a/.storybook/welcome-page/components-demo/demo/demo.component.jsx
+++ b/.storybook/welcome-page/components-demo/demo/demo.component.jsx
@@ -18,7 +18,10 @@ import {
 } from "./demo.style";
 
 const Demo = () => {
+  const [textboxValue, setTextboxValue] = useState("");
+  const [selectValue, setSelectValue] = useState("");
   const [numberValue, setNumberValue] = useState("0");
+  const [decimalValue, setDecimalValue] = useState("0");
   const [dateValue, setDateValue] = useState(["01/01/2020", "14/02/2020"]);
   const handleDateChange = ({ target }) => {
     const newValue = [
@@ -68,6 +71,8 @@ const Demo = () => {
                   placeholder="Carbon Textbox"
                   inputIcon="search"
                   aria-label="An example textbox component with spyglass input icon"
+                  value={textboxValue}
+                  onChange={(e) => setTextboxValue(e.target.value)}
                 />
               </StyledComponentWrapper>
               <StyledComponentWrapper styling={{ width: "30%", padding: "1%" }}>
@@ -108,7 +113,8 @@ const Demo = () => {
                 styling={{ width: "95%", padding: "1.5%" }}
               >
                 <Select
-                  defaultValue=""
+                  value={selectValue}
+                  onChange={(e) => setSelectValue(e.target.value)}
                   placeholder="Carbon Select"
                   aria-label="An example select component with two options"
                 >


### PR DESCRIPTION
Some inputs were missing controlled state values. which have now been added

### Proposed behaviour

State has been added for the Search, Decimal and Select components

### Current behaviour

Welcome page doesn't load owing to missing state values

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Open the docs and ensure the Welcome screen loads correctly