### PR TITLE
fix(textbox): prevent VO from reading out labels twice when textbox is marked as required

### DIFF
--- a/playwright/support/helper.ts
+++ b/playwright/support/helper.ts
@@ -234,20 +234,23 @@ export function keyCode(type: keyof typeof keys): {
 const verifyRequiredAsterisk = async (locator: Locator) => {
   // use getComputedStyle to read the pseudo selector
   // and read the value of the `content` CSS property
-  const contentValue = await locator.evaluate((el) =>
-    window.getComputedStyle(el, "after").getPropertyValue("content"),
-  );
+  const contentValue = await locator.evaluate((el) => {
+    return window.getComputedStyle(el, "after").getPropertyValue("content");
+  });
   await expect(contentValue).toBe('"*"');
 };
 
-export const verifyRequiredAsteriskForLabel = (
+export const verifyRequiredAsteriskForLabel = async (
   page: Page,
   locator?: Locator,
 ) => {
   if (locator) {
     return verifyRequiredAsterisk(locator);
   }
-  return verifyRequiredAsterisk(label(page));
+
+  const indicatorSpan = label(page).getByTestId("required-indicator");
+  await expect(indicatorSpan).toBeVisible();
+  await expect(indicatorSpan).toHaveText("*");
 };
 
 export const verifyRequiredAsteriskForLegend = (page: Page) =>

--- a/src/__internal__/label/label.component.tsx
+++ b/src/__internal__/label/label.component.tsx
@@ -184,6 +184,11 @@ export const Label = ({
         isDarkBackground={isDarkBackground}
       >
         {children}
+        {isRequired && (
+          <span aria-hidden="true" data-role="required-indicator">
+            *
+          </span>
+        )}
       </StyledLabel>
       {icon()}
     </StyledLabelContainer>

--- a/src/__internal__/label/label.style.ts
+++ b/src/__internal__/label/label.style.ts
@@ -18,16 +18,11 @@ const StyledLabel = styled.label<StyledLabelProps>`
   display: block;
   font-weight: var(--fontWeights500);
 
-  ${({ isRequired }) =>
-    isRequired &&
-    css`
-      ::after {
-        content: "*";
-        color: var(--colorsSemanticNegative500);
-        font-weight: var(--fontWeights500);
-        margin-left: var(--spacing050);
-      }
-    `}
+  span[data-role="required-indicator"] {
+    color: var(--colorsSemanticNegative500);
+    font-weight: var(--fontWeights500);
+    margin-left: var(--spacing050);
+  }
 
   ${({ disabled }) =>
     disabled &&

--- a/src/components/file-input/file-input.test.tsx
+++ b/src/components/file-input/file-input.test.tsx
@@ -125,9 +125,7 @@ describe("rendering with no file uploaded", () => {
   it("renders an asterisk next to label when required prop is passed", () => {
     render(<FileInput label="file input" required onChange={() => {}} />);
 
-    expect(screen.getByText("file input")).toHaveStyleRule("content", '"*"', {
-      modifier: "::after",
-    });
+    expect(screen.getByTestId("required-indicator")).toBeInTheDocument();
   });
 
   it("renders a root container with flex direction column when isVertical prop is true", () => {

--- a/src/components/text-editor/text-editor.pw.tsx
+++ b/src/components/text-editor/text-editor.pw.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { test, expect } from "../../../playwright/helpers/base-test";
 
-import { checkAccessibility } from "../../../playwright/support/helper";
+import {
+  checkAccessibility,
+  verifyRequiredAsteriskForLabel,
+} from "../../../playwright/support/helper";
 
 import TextEditorDefaultComponent, {
   TextEditorWithHeader,
@@ -525,16 +528,10 @@ test.describe("Prop tests", () => {
     });
   });
 
-  test.describe("required", () => {
-    [true, false].forEach((required) => {
-      test(`value of ${required}`, async ({ mount, page }) => {
-        await mount(<TextEditorDefaultComponent required={required} />);
-        const content = await page.evaluate(
-          "window.getComputedStyle(document.getElementById('pw-rte-label'), '::after').getPropertyValue('content')",
-        );
-        expect(content).toBe(required ? '"*"' : "none");
-      });
-    });
+  test("required", async ({ mount, page }) => {
+    await mount(<TextEditorDefaultComponent required />);
+
+    await verifyRequiredAsteriskForLabel(page);
   });
 
   test.describe("value", () => {

--- a/src/components/textbox/textbox.pw.tsx
+++ b/src/components/textbox/textbox.pw.tsx
@@ -4,8 +4,8 @@ import { test, expect } from "../../../playwright/helpers/base-test";
 import {
   getDesignTokensByCssProperty,
   checkAccessibility,
-  verifyRequiredAsteriskForLabel,
   assertCssValueIsApproximately,
+  verifyRequiredAsteriskForLabel,
 } from "../../../playwright/support/helper";
 import {
   fieldHelpPreview,

--- a/src/components/textbox/textbox.test.tsx
+++ b/src/components/textbox/textbox.test.tsx
@@ -397,9 +397,7 @@ test("the required prop is passed to the input", () => {
 
 test("when the required prop is set, the label includes the 'required' asterisk", () => {
   render(<Textbox value="foo" onChange={() => {}} label="Required" required />);
-  expect(screen.getByText("Required")).toHaveStyleRule("content", '"*"', {
-    modifier: "::after",
-  });
+  expect(screen.getByTestId("required-indicator")).toBeInTheDocument();
 });
 
 test("renders the positionChildren prop before the input", () => {


### PR DESCRIPTION
fixes #7510

### Proposed behaviour

Replace the current approach (the `::after` CSS pseudo-selector) with an inline span containing the `*` indicator

### Current behaviour

When textboxes are marked as required, VoiceOver reads the label out twice

### Checklist

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

- Open the `Required` story under `Textbox` in Safari
- Clear the text
- Turn on VO and focus on the textbox
- Observe that no repetition happens.

Note that, as the story is named `textbox--required`, the word `textbox` may appear twice; once for the page title and once for the field label. The crucial thing is that the label is only read once, and the asterisk isn't announced