### PR TITLE
Fe 7470 breadcrumbs focus safari

### DIFF
--- a/src/components/breadcrumbs/breadcrumbs.pw.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.pw.tsx
@@ -166,41 +166,42 @@ test.describe("should render Breadcrumbs component", async () => {
     );
   });
 
-  test("should have correct color when Crumb is current and isDarkBackground is true", async ({
+  test("should have non-interactive cursor when Crumb is current and isDarkBackground is true", async ({
     mount,
     page,
   }) => {
     await mount(<OnDarkBackground />);
+    await page.waitForSelector('[data-component="breadcrumbs"]');
 
-    const currentCrumb = crumbAtIndex(page, 3).locator("a");
-    await expect(currentCrumb).toHaveCSS("color", "rgb(255, 255, 255)");
-    await currentCrumb.hover();
-    await expect(currentCrumb).toHaveCSS("color", "rgb(255, 255, 255)");
-    await expect(currentCrumb).toHaveCSS("cursor", "text");
+    const currentCrumb = crumbAtIndex(page, 3).locator(
+      'span[data-component="crumb"]',
+    );
+
+    await expect(currentCrumb).toBeVisible();
+    await expect(currentCrumb).toHaveAttribute("aria-current", "page");
+    await expect(currentCrumb).toHaveCSS("cursor", "auto");
   });
 
-  [
-    {
-      isCurrent: true,
-      expectedAttribute: "aria-current",
-      expectedValue: "page",
-    },
-    {
-      isCurrent: false,
-      expectedAttribute: "href",
-      expectedValue: "#",
-    },
-  ].forEach(({ isCurrent, expectedAttribute, expectedValue }) => {
-    test(`should check Crumb with isCurrent prop is ${isCurrent}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<DefaultCrumb isCurrent={isCurrent} />);
-      await expect(crumbAtIndex(page, 0).locator("a")).toHaveAttribute(
-        expectedAttribute,
-        expectedValue,
-      );
-    });
+  test("should check Crumb with isCurrent prop is true", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<DefaultCrumb isCurrent={true} />);
+    await expect(crumbAtIndex(page, 0).locator("span")).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  test("should check Crumb with isCurrent prop is false", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<DefaultCrumb isCurrent={false} />);
+    await expect(crumbAtIndex(page, 0).locator("a")).toHaveAttribute(
+      "href",
+      "#",
+    );
   });
 
   test("should check Crumb with href prop set to default val", async ({
@@ -222,13 +223,14 @@ test("when Crumb's isCurrent prop is true, Crumb divider should not exist", asyn
   await mount(<DefaultCrumb isCurrent />);
 
   const crumbElement = crumbAtIndex(page, 0);
-  await expect(crumbElement.locator("a")).toHaveAttribute(
+
+  await expect(crumbElement.locator("span")).toHaveAttribute(
     "aria-current",
     "page",
   );
-  await expect(crumbElement.locator("span").nth(1)).toHaveCSS(
-    "color",
-    "rgba(0, 0, 0, 0.9)",
+
+  await expect(crumbElement.locator('[data-role="crumb-divider"]')).toHaveCount(
+    0,
   );
 });
 

--- a/src/components/breadcrumbs/crumb/crumb.component.tsx
+++ b/src/components/breadcrumbs/crumb/crumb.component.tsx
@@ -24,26 +24,52 @@ export interface CrumbProps
       | "disabled"
     >,
     TagProps {
-  /** This sets the Crumb to current, does not render Link */
   isCurrent?: boolean;
+  onClick?: (
+    ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+  ) => void;
 }
 
-const Crumb = React.forwardRef<HTMLAnchorElement, CrumbProps>(
-  ({ href, isCurrent, children, onClick, ...rest }: CrumbProps, ref) => {
+const Crumb = React.forwardRef<HTMLLIElement, CrumbProps>(
+  ({ href, isCurrent, children, onClick, ...rest }, ref) => {
     const { isDarkBackground } = useBreadcrumbsContext();
 
+    const isSafari = React.useMemo(() => {
+      if (typeof navigator === "undefined") return false;
+      return /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+    }, []);
+
+    const handleClick = React.useCallback(
+      (
+        event: React.MouseEvent<
+          HTMLAnchorElement | HTMLButtonElement,
+          MouseEvent
+        >,
+      ) => {
+        if (!isCurrent && isSafari) {
+          (event.currentTarget as HTMLElement).focus({ preventScroll: true });
+        }
+        onClick?.(event);
+      },
+      [isCurrent, isSafari, onClick],
+    );
+
     return (
-      <li>
+      <li ref={ref}>
         <StyledCrumb
-          ref={ref}
           isCurrent={isCurrent}
           aria-current={isCurrent ? "page" : undefined}
           isDarkBackground={isDarkBackground}
+          data-testid={isCurrent ? "current-crumb" : "link-anchor"}
           {...rest}
           {...tagComponent("crumb", rest)}
           {...(!isCurrent && {
             href,
-            onClick,
+            onClick: handleClick,
+          })}
+          {...(isCurrent && {
+            as: "span",
+            tabIndex: -1,
           })}
         >
           {children}

--- a/src/components/breadcrumbs/crumb/crumb.test.tsx
+++ b/src/components/breadcrumbs/crumb/crumb.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Crumb from "./crumb.component";
 import Logger from "../../../__internal__/utils/logger";
@@ -27,27 +27,26 @@ test("passes href to the anchor element when isCurrent is false", () => {
   );
 
   const link = screen.getByRole("link", { name: "Link text" });
-
   expect(link).toHaveAttribute("href", "foo");
 });
 
-test("does not pass href to the anchor element when isCurrent is true", () => {
+test("does not pass href when isCurrent is true (renders a non-link current crumb)", () => {
   render(
     <Breadcrumbs>
-      <Crumb href="foo" data-role="crumb" isCurrent>
+      <Crumb href="foo" isCurrent>
         Link text
       </Crumb>
     </Breadcrumbs>,
   );
 
-  const anchor = screen.getByTestId("link-anchor");
-
-  expect(anchor).not.toHaveAttribute("href", "foo");
+  const el = screen.getByText("Link text");
+  expect(el).not.toHaveAttribute("href");
 });
 
-test("calls onClick callback when the crumb link is clicked", async () => {
+test("invokes onClick when the crumb link is clicked (not current)", async () => {
   const onClick = jest.fn();
   const user = userEvent.setup();
+
   render(
     <Breadcrumbs>
       <Crumb href="#" onClick={onClick}>
@@ -56,15 +55,14 @@ test("calls onClick callback when the crumb link is clicked", async () => {
     </Breadcrumbs>,
   );
 
-  const link = screen.getByRole("link", { name: "Link text" });
-  await user.click(link);
-
+  await user.click(screen.getByRole("link", { name: "Link text" }));
   expect(onClick).toHaveBeenCalledTimes(1);
 });
 
-test("does not call onClick callback when isCurrent is true", async () => {
+test("does not invoke onClick when isCurrent is true", async () => {
   const onClick = jest.fn();
   const user = userEvent.setup();
+
   render(
     <Breadcrumbs>
       <Crumb href="#" onClick={onClick} isCurrent>
@@ -73,13 +71,14 @@ test("does not call onClick callback when isCurrent is true", async () => {
     </Breadcrumbs>,
   );
 
-  const link = screen.getByText("Link text");
-  await user.click(link);
-
-  expect(onClick).toHaveBeenCalledTimes(0);
+  await user.click(screen.getByText("Link text"));
+  expect(
+    screen.queryByRole("link", { name: "Link text" }),
+  ).not.toBeInTheDocument();
+  expect(onClick).not.toHaveBeenCalled();
 });
 
-test("renders with provided data- attributes", () => {
+test("forwards provided data- attributes", () => {
   render(
     <Breadcrumbs>
       <Crumb href="#" data-element="bar" data-role="baz">
@@ -89,4 +88,112 @@ test("renders with provided data- attributes", () => {
   );
 
   expect(screen.getByTestId("baz")).toHaveAttribute("data-element", "bar");
+});
+
+test("calls focus({ preventScroll: true }) on Safari when not current", async () => {
+  const originalUA = window.navigator.userAgent;
+  Object.defineProperty(window.navigator, "userAgent", {
+    value:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15",
+    configurable: true,
+  });
+
+  const onClick = jest.fn();
+  const user = userEvent.setup();
+
+  render(
+    <Breadcrumbs>
+      <Crumb href="#" onClick={onClick}>
+        Link text
+      </Crumb>
+    </Breadcrumbs>,
+  );
+
+  const link = screen.getByRole("link", { name: "Link text" });
+  const focusSpy = jest.spyOn(link, "focus");
+
+  await user.click(link);
+
+  expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+  expect(onClick).toHaveBeenCalled();
+
+  focusSpy.mockRestore();
+  Object.defineProperty(window.navigator, "userAgent", {
+    value: originalUA,
+    configurable: true,
+  });
+});
+
+test("does not render a link or call onClick on Safari when current", async () => {
+  const originalUA = window.navigator.userAgent;
+  Object.defineProperty(window.navigator, "userAgent", {
+    value:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Safari/605.1.15",
+    configurable: true,
+  });
+
+  const onClick = jest.fn();
+  const user = userEvent.setup();
+
+  render(
+    <Breadcrumbs>
+      <Crumb href="#" onClick={onClick} isCurrent>
+        Link text
+      </Crumb>
+    </Breadcrumbs>,
+  );
+
+  await user.click(screen.getByText("Link text"));
+  expect(
+    screen.queryByRole("link", { name: "Link text" }),
+  ).not.toBeInTheDocument();
+  expect(onClick).not.toHaveBeenCalled();
+
+  Object.defineProperty(window.navigator, "userAgent", {
+    value: originalUA,
+    configurable: true,
+  });
+});
+
+test("adds aria-current='page' on the current crumb", () => {
+  render(
+    <Breadcrumbs>
+      <Crumb href="#" isCurrent>
+        Current Page
+      </Crumb>
+    </Breadcrumbs>,
+  );
+
+  const el = screen.getByText("Current Page");
+  expect(el).toHaveAttribute("aria-current", "page");
+});
+
+test("isSafari returns false when navigator is undefined (no preventScroll focus call)", () => {
+  const originalDesc = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  Object.defineProperty(globalThis, "navigator", {
+    value: undefined,
+    configurable: true,
+  });
+
+  const onClick = jest.fn();
+
+  render(
+    <Breadcrumbs>
+      <Crumb href="#" onClick={onClick}>
+        Link text
+      </Crumb>
+    </Breadcrumbs>,
+  );
+
+  const link = screen.getByRole("link", { name: "Link text" });
+  const focusSpy = jest.spyOn(link, "focus");
+
+  fireEvent.click(link);
+
+  expect(focusSpy).not.toHaveBeenCalledWith({ preventScroll: true });
+  expect(onClick).toHaveBeenCalled();
+
+  if (originalDesc) {
+    Object.defineProperty(globalThis, "navigator", originalDesc);
+  }
 });


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
