### PR TITLE
build(lint): enable recommended rules for playwright

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -346,6 +346,7 @@ export default defineConfig([
     },
   },
   {
+    ...playwright.configs["flat/recommended"],
     files: ["**/*.pw.ts*", "**/*.test-pw.ts*", "playwright/**/*.ts*"],
     plugins: {
       playwright: fixupPluginRules(playwright),
@@ -362,6 +363,24 @@ export default defineConfig([
       },
     },
     rules: {
+      ...playwright.configs["flat/recommended"].rules,
+      "playwright/expect-expect": [
+        "error",
+        {
+          assertFunctionNames: [
+            "checkAccessibility",
+            "checkCSSOutline",
+            "checkGoldenOutline",
+            "containsClass",
+            "assertCssValueIsApproximately",
+            "verifyRequiredAsterisk",
+            "verifyRequiredAsteriskForLabel",
+            "verifyRequiredAsteriskForLegend",
+            "checkElementBorderColours",
+            "checkNewFocusStyling",
+          ],
+        },
+      ],
       "playwright/no-commented-out-tests": "error",
       "playwright/no-focused-test": "error",
       "playwright/no-skipped-test": "warn",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -271,6 +271,7 @@ export default defineConfig([
           allow: ["arrowFunctions"],
         },
       ],
+      "@typescript-eslint/no-non-null-assertion": "error",
       "@typescript-eslint/no-unused-vars": [
         "error",
         {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test-update": "jest --config=./jest.config.ts --updateSnapshot",
     "test-storybook": "test-storybook --url http://127.0.0.1:9001",
     "format": "prettier --write './{src,playwright}/**/*.{js,jsx,ts,tsx}'",
-    "lint": "eslint ./src ./playwright",
+    "lint": "eslint ./src ./playwright --max-warnings=636 --report-unused-disable-directives",
     "precompile": "npm run type-check && npm run build",
     "prepublishOnly": "npm run precompile",
     "build-storybook": "dotenvx run -- storybook build -c .storybook",

--- a/playwright/support/helper.ts
+++ b/playwright/support/helper.ts
@@ -237,7 +237,7 @@ const verifyRequiredAsterisk = async (locator: Locator) => {
   const contentValue = await locator.evaluate((el) =>
     window.getComputedStyle(el, "after").getPropertyValue("content"),
   );
-  await expect(contentValue).toBe('"*"');
+  expect(contentValue).toBe('"*"');
 };
 
 export const verifyRequiredAsteriskForLabel = (
@@ -348,4 +348,17 @@ export const waitForElementFocus = async (page: Page, locator: Locator) => {
     (element) => document.activeElement === element,
     focusedElement,
   );
+};
+
+export const checkNewFocusStyling = async (locator: Locator) => {
+  const shadowValue = await locator.evaluate((el) =>
+    window.getComputedStyle(el, "after").getPropertyValue("box-shadow"),
+  );
+  const outlineValue = await locator.evaluate((el) =>
+    window.getComputedStyle(el, "after").getPropertyValue("outline"),
+  );
+  expect(shadowValue).toBe(
+    `rgba(0, 0, 0, 0.9) 0px 0px 0px 3px inset, rgb(255, 188, 25) 0px 0px 0px 6px inset`,
+  );
+  expect(outlineValue).toBe(`rgba(0, 0, 0, 0) solid 3px`);
 };

--- a/src/components/action-popover/action-popover-test.stories.tsx
+++ b/src/components/action-popover/action-popover-test.stories.tsx
@@ -979,6 +979,7 @@ export const ActionPopoverSubmenuClick: Story = {
   play: async ({ canvasElement }) => {
     // This is required due to a known issue with the canvasElement not being the parent of the component when a Portal is used.
     // https://github.com/storybookjs/storybook/issues/26963
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const canvas = within(canvasElement.parentElement!);
     const actionPopoverButtons = canvas.getAllByRole("button");
     await userEvent.click(actionPopoverButtons[0]);

--- a/src/components/action-popover/action-popover.pw.tsx
+++ b/src/components/action-popover/action-popover.pw.tsx
@@ -93,7 +93,7 @@ test("should close opened submenu by keyboard event when another submenu is open
 
   await expect(emailSubmenuItem).toBeVisible();
 
-  await expect(businessSubmenuItem).not.toBeVisible();
+  await expect(businessSubmenuItem).toBeHidden();
 });
 
 test("should close opened submenu by keyboard event when another submenu is opened by hover event", async ({
@@ -127,7 +127,7 @@ test("should close opened submenu by keyboard event when another submenu is open
 
   await expect(emailSubmenuItem).toBeVisible();
 
-  await expect(businessSubmenuItem).not.toBeVisible();
+  await expect(businessSubmenuItem).toBeHidden();
 });
 
 test.describe("check functionality for ActionPopover component", () => {
@@ -298,7 +298,7 @@ test.describe("check functionality for ActionPopover component", () => {
     const focusedElement = page.locator("*:focus");
     await focusedElement.press("Tab");
     const actionPopoverElement = actionPopover(page).first();
-    await expect(actionPopoverElement).not.toBeVisible();
+    await expect(actionPopoverElement).toBeHidden();
   });
 
   // TODO: Skipped due to flaky focus behaviour. To review in FE-6428
@@ -309,7 +309,7 @@ test.describe("check functionality for ActionPopover component", () => {
     const focusedElement = page.locator("*:focus");
     await focusedElement.press("Shift+Tab");
     const actionPopoverElement = actionPopover(page).first();
-    await expect(actionPopoverElement).not.toBeVisible();
+    await expect(actionPopoverElement).toBeHidden();
   });
 
   // TODO: Skipped due to flaky focus behaviour. To review in FE-6428
@@ -320,7 +320,7 @@ test.describe("check functionality for ActionPopover component", () => {
     const focusedElement = page.locator("*:focus");
     await focusedElement.press("Escape");
     const actionPopoverElement = actionPopover(page).first();
-    await expect(actionPopoverElement).not.toBeVisible();
+    await expect(actionPopoverElement).toBeHidden();
   });
 
   // TODO: Skipped due to flaky focus behaviour. To review in FE-6428
@@ -335,7 +335,7 @@ test.describe("check functionality for ActionPopover component", () => {
     await focusedElement.press("ArrowDown");
     await focusedElement.press("Escape");
     const actionPopoverElement = actionPopover(page).first();
-    await expect(actionPopoverElement).not.toBeVisible();
+    await expect(actionPopoverElement).toBeHidden();
   });
 
   // TODO: Skipped due to flaky focus behaviour. To review in FE-6428
@@ -354,7 +354,7 @@ test.describe("check functionality for ActionPopover component", () => {
     await focusedElement.press("ArrowLeft");
     await page.locator("*:focus").press("Escape");
     const actionPopoverElement = actionPopover(page).first();
-    await expect(actionPopoverElement).not.toBeVisible();
+    await expect(actionPopoverElement).toBeHidden();
   });
 
   test("should close by clicking outside of the component", async ({
@@ -366,7 +366,7 @@ test.describe("check functionality for ActionPopover component", () => {
     await actionPopoverButtonElement.click();
     await page.locator("body").click();
     const actionPopoverElement = actionPopover(page).first();
-    await expect(actionPopoverElement).not.toBeVisible();
+    await expect(actionPopoverElement).toBeHidden();
   });
 
   test("should close by clicking onto Open icon", async ({ mount, page }) => {
@@ -374,7 +374,7 @@ test.describe("check functionality for ActionPopover component", () => {
     const actionPopoverButtonElement = actionPopoverButton(page).nth(0);
     await actionPopoverButtonElement.dblclick();
     const actionPopoverElement = actionPopover(page).first();
-    await expect(actionPopoverElement).not.toBeVisible();
+    await expect(actionPopoverElement).toBeHidden();
   });
 
   (
@@ -471,7 +471,7 @@ test.describe("check functionality for ActionPopover component", () => {
       const submenuItem = getDataElementByValue(page, "submenu1").nth(position);
       await submenuItem.press("Enter");
       const actionPopoverElement = actionPopover(page).first();
-      await expect(actionPopoverElement).not.toBeVisible();
+      await expect(actionPopoverElement).toBeHidden();
     });
   });
 
@@ -499,7 +499,7 @@ test.describe("check functionality for ActionPopover component", () => {
       }
       await focusedElement.press("ArrowRight");
       const submenu = actionPopoverSubmenuByIndex(page, 1);
-      await expect(submenu).not.toBeVisible();
+      await expect(submenu).toBeHidden();
     });
   });
 
@@ -527,7 +527,7 @@ test.describe("check functionality for ActionPopover component", () => {
       }
       await focusedElement.press("Escape");
       const actionPopoverElement = actionPopover(page).first();
-      await expect(actionPopoverElement).not.toBeVisible();
+      await expect(actionPopoverElement).toBeHidden();
     });
   });
 
@@ -550,7 +550,7 @@ test.describe("check functionality for ActionPopover component", () => {
       }
       await focusedElement.click();
       const actionPopoverElement = actionPopover(page).first();
-      await expect(actionPopoverElement).not.toBeVisible();
+      await expect(actionPopoverElement).toBeHidden();
     });
   });
 
@@ -1286,7 +1286,7 @@ test.describe("rounded-corners", () => {
 // there is an issue with asserting token values for this test
 test("has the expected styling when focused", async ({ mount, page }) => {
   await mount(<ActionPopoverCustom />);
-  const actionPopoverButtonElement = await actionPopoverButton(page).nth(0);
+  const actionPopoverButtonElement = actionPopoverButton(page).nth(0);
   await actionPopoverButtonElement.focus();
   await expect(actionPopoverButtonElement).toHaveCSS(
     "box-shadow",
@@ -1538,13 +1538,13 @@ test.describe("when nested inside a Dialog component", () => {
     await page.keyboard.press("Escape");
 
     const actionPopoverElement = actionPopover(page);
-    await expect(actionPopoverElement).not.toBeVisible();
+    await expect(actionPopoverElement).toBeHidden();
 
     const dialogElement = dialog(page);
     await expect(dialogElement).toBeVisible();
 
     await page.keyboard.press("Escape");
 
-    await expect(dialogElement).not.toBeVisible();
+    await expect(dialogElement).toBeHidden();
   });
 });

--- a/src/components/adaptive-sidebar/adaptive-sidebar.pw.tsx
+++ b/src/components/adaptive-sidebar/adaptive-sidebar.pw.tsx
@@ -99,14 +99,14 @@ test.describe("Component properties", () => {
     const openButton = page.getByRole("button").filter({ hasText: "Open" });
     const sidebar = page.getByRole("dialog");
     await expect(openButton).not.toBeFocused();
-    await expect(sidebar).not.toBeVisible();
+    await expect(sidebar).toBeHidden();
 
     await openButton.click();
     await expect(sidebar).toBeVisible();
     const closeButton = page.getByRole("button").filter({ hasText: "Close" });
     await closeButton.click();
     await expect(openButton).not.toBeFocused();
-    await expect(sidebar).not.toBeVisible();
+    await expect(sidebar).toBeHidden();
   });
 
   test("should render the AdaptiveSidebar component as a modal when at mobile resolution", async ({

--- a/src/components/advanced-color-picker/advanced-color-picker.pw.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.pw.tsx
@@ -46,14 +46,14 @@ test("when AdvancedColorPicker is opened and then closed, with the `restoreFocus
   const initialCell = advancedColorPickerCell(page);
   const dialog = page.getByRole("dialog");
   await expect(initialCell).not.toBeFocused();
-  await expect(dialog).not.toBeVisible();
+  await expect(dialog).toBeHidden();
 
   await initialCell.click();
   await expect(dialog).toBeVisible();
   const closeButton = page.getByLabel("Close");
   await closeButton.click();
   await expect(initialCell).not.toBeFocused();
-  await expect(dialog).not.toBeVisible();
+  await expect(dialog).toBeHidden();
 });
 
 test.describe("should render AdvancedColorPicker component and check functionality", () => {
@@ -113,7 +113,7 @@ test.describe("should render AdvancedColorPicker component and check functionali
 
       const picker = simpleColorPickerInput(page, 7);
       await picker.press(key);
-      await expect(simpleColorPickerComponent(page)).not.toBeVisible();
+      await expect(simpleColorPickerComponent(page)).toBeHidden();
     });
   });
 
@@ -287,7 +287,7 @@ test.describe("should render AdvancedColorPicker component and check props", () 
       if (bool) {
         await expect(advancedColorPickerParent(page)).toBeVisible();
       } else {
-        await expect(advancedColorPickerParent(page)).not.toBeVisible();
+        await expect(advancedColorPickerParent(page)).toBeHidden();
       }
     });
   });

--- a/src/components/alert/alert.pw.tsx
+++ b/src/components/alert/alert.pw.tsx
@@ -29,18 +29,12 @@ test.describe("should render Alert component", () => {
   specialCharacters.forEach((text) => {
     test(`with ${text} as a title`, async ({ mount, page }) => {
       await mount(<AlertComponent title={text} />);
-
-      const title = alertTitle(page);
-      const titleText = await title.textContent();
-      expect(titleText).toEqual(text);
+      await expect(alertTitle(page)).toHaveText(text);
     });
 
     test(`with ${text} as a subtitle`, async ({ mount, page }) => {
       await mount(<AlertComponent subtitle={text} />);
-
-      const subtitle = alertSubtitle(page);
-      const alertSubtitleText = await subtitle.textContent();
-      expect(alertSubtitleText).toEqual(text);
+      await expect(alertSubtitle(page)).toHaveText(text);
     });
 
     test(`with ${text} as children`, async ({ mount, page }) => {

--- a/src/components/badge/badge.pw.tsx
+++ b/src/components/badge/badge.pw.tsx
@@ -53,7 +53,7 @@ test.describe("should render Badge component", () => {
       page,
     }) => {
       await mount(<BadgeComponent counter={countInput} />);
-      await expect(badgeCounter(page)).not.toBeVisible();
+      await expect(badgeCounter(page)).toBeHidden();
     });
   });
 

--- a/src/components/batch-selection/batch-selection.pw.tsx
+++ b/src/components/batch-selection/batch-selection.pw.tsx
@@ -51,7 +51,7 @@ test.describe("check BatchSelection component properties", () => {
     await mount(<BatchSelectionComponent hidden />);
     const batchSelection = batchSelectionComponent(page);
     await expect(batchSelection).toHaveAttribute("hidden", /.*/);
-    await expect(batchSelection).not.toBeVisible();
+    await expect(batchSelection).toBeHidden();
   });
 
   test("should check disabled BatchSelection", async ({ mount, page }) => {

--- a/src/components/breadcrumbs/breadcrumbs.pw.tsx
+++ b/src/components/breadcrumbs/breadcrumbs.pw.tsx
@@ -14,7 +14,7 @@ import {
 import { checkAccessibility } from "../../../playwright/support/helper";
 import { CHARACTERS } from "../../../playwright/support/constants";
 
-test.describe("should render Breadcrumbs component", async () => {
+test.describe("should render Breadcrumbs component", () => {
   test("should check Breadcrumbs children is set visible", async ({
     mount,
     page,
@@ -232,7 +232,7 @@ test("when Crumb's isCurrent prop is true, Crumb divider should not exist", asyn
   );
 });
 
-test.describe("Accessibility tests for Breadcrumbs component", async () => {
+test.describe("Accessibility tests for Breadcrumbs component", () => {
   test("should pass accessibility tests for Breadcrumbs default story", async ({
     mount,
     page,

--- a/src/components/button-bar/button-bar.pw.tsx
+++ b/src/components/button-bar/button-bar.pw.tsx
@@ -75,7 +75,7 @@ test.describe("check props for Button-Bar component", () => {
   });
 });
 
-test.describe("accessibility tests", async () => {
+test.describe("accessibility tests", () => {
   [BUTTON_BAR_SIZES[0], BUTTON_BAR_SIZES[1], BUTTON_BAR_SIZES[2]].forEach(
     (size) => {
       test(`should check accessibility for ${size} size for a Button-Bar`, async ({
@@ -130,7 +130,7 @@ test("should verify ButtonBar with wrapped components can be navigated using key
   await expect(buttonAtIndex(1)).not.toBeFocused();
 });
 
-test.describe("when custom Button wrapper components are used as children in ButtonBar", async () => {
+test.describe("when custom Button wrapper components are used as children in ButtonBar", () => {
   test("Button size is small when the size prop is set to small and passed to ButtonBar", async ({
     mount,
     page,
@@ -186,7 +186,7 @@ test.describe("when custom Button wrapper components are used as children in But
   });
 });
 
-test.describe("renders with ButtonMinor children", async () => {
+test.describe("renders with ButtonMinor children", () => {
   const indexes = [0, 1, 2];
 
   test.beforeEach(async ({ mount }) => {
@@ -229,7 +229,7 @@ test.describe("renders with ButtonMinor children", async () => {
   });
 });
 
-test.describe("renders with IconButton children", async () => {
+test.describe("renders with IconButton children", () => {
   test("should render IconButton with correct styles on hover", async ({
     mount,
     page,

--- a/src/components/button/button.pw.tsx
+++ b/src/components/button/button.pw.tsx
@@ -166,15 +166,15 @@ test.describe("Button component", () => {
   test("should check Button is enabled", async ({ mount, page }) => {
     await mount(<ButtonDifferentTypes />);
 
-    await expect(page.getByText("Primary")).not.toBeDisabled();
+    await expect(page.getByText("Primary")).toBeEnabled();
 
-    await expect(page.getByText("Secondary")).not.toBeDisabled();
+    await expect(page.getByText("Secondary")).toBeEnabled();
 
-    await expect(page.getByText("Tertiary")).not.toBeDisabled();
+    await expect(page.getByText("Tertiary")).toBeEnabled();
 
-    await expect(page.getByText("Gradient white")).not.toBeDisabled();
+    await expect(page.getByText("Gradient white")).toBeEnabled();
 
-    await expect(page.getByText("Gradient grey")).not.toBeDisabled();
+    await expect(page.getByText("Gradient grey")).toBeEnabled();
   });
 });
 

--- a/src/components/carbon-provider/carbon-provider.pw.tsx
+++ b/src/components/carbon-provider/carbon-provider.pw.tsx
@@ -41,7 +41,7 @@ const commonColorsOnHover = ["rgb(0, 99, 0)", "rgb(0, 103, 56)"];
 const loaderBarColors = ["rgb(179, 224, 179)", "rgb(179, 217, 200)"];
 
 buildTestArray(commonColors).forEach(([theme, color]) => {
-  test.describe(`Carbon Provider`, async () => {
+  test.describe(`Carbon Provider`, () => {
     test(`Button component should render with ${theme} theme and verify theme color`, async ({
       mount,
       page,

--- a/src/components/confirm/confirm.pw.tsx
+++ b/src/components/confirm/confirm.pw.tsx
@@ -462,9 +462,9 @@ test.describe("should render Confirm component", () => {
 
       const dialog = page.getByRole("alertdialog");
       if (boolVal) {
-        await expect(dialog).toBeAttached;
+        await expect(dialog).toBeAttached();
       } else {
-        await expect(dialog).not.toBeAttached;
+        await expect(dialog).not.toBeAttached();
       }
     });
   });

--- a/src/components/date-range/date-range-interactions.stories.tsx
+++ b/src/components/date-range/date-range-interactions.stories.tsx
@@ -339,21 +339,14 @@ export const ValidationDateRange: Story = {
     const canvas = within(canvasElement);
     const portal = within(document.body);
 
-    const errorIcon = canvasElement.querySelector(
-      '[data-role="icon-error"]',
-    ) as HTMLElement | null;
-    const warningIcon = canvasElement.querySelector(
-      '[data-role="icon-warning"]',
-    ) as HTMLElement | null;
+    const errorIcon = canvas.getByTestId("icon-error");
+    const warningIcon = canvas.getByTestId("icon-warning");
 
-    expect(errorIcon).not.toBeNull();
-    expect(warningIcon).not.toBeNull();
-
-    await userEvent.hover(errorIcon!);
+    await userEvent.hover(errorIcon);
     expect(await portal.findByText(/required/i)).toBeInTheDocument();
 
-    await userEvent.unhover(errorIcon!);
-    await userEvent.hover(warningIcon!);
+    await userEvent.unhover(errorIcon);
+    await userEvent.hover(warningIcon);
     expect(await portal.findByText(/end warning/i)).toBeInTheDocument();
 
     const startInput = canvas.getByRole("textbox", { name: /start/i });

--- a/src/components/date-range/date-range.pw.tsx
+++ b/src/components/date-range/date-range.pw.tsx
@@ -489,7 +489,7 @@ test.describe("Functionality tests for DateRange component", () => {
 
     await page.keyboard.press("Tab");
 
-    await expect(popoverContainer).not.toBeVisible();
+    await expect(popoverContainer).toBeHidden();
     await expect(popoverButton).toBeFocused();
   });
 });

--- a/src/components/date/date.pw.tsx
+++ b/src/components/date/date.pw.tsx
@@ -153,7 +153,7 @@ test.describe("Functionality tests", () => {
     await inputParent.click();
 
     const wrapper = dayPickerWrapper(page);
-    await expect(wrapper).not.toBeVisible();
+    await expect(wrapper).toBeHidden();
   });
 
   test(`should not close dayPicker after double click on input`, async ({

--- a/src/components/detail/detail.pw.tsx
+++ b/src/components/detail/detail.pw.tsx
@@ -42,8 +42,8 @@ test("should set Detail icon on preview to chevron_up", async ({
   await mount(<Detail icon="chevron_up" />);
 
   await expect(icon(page)).toHaveAttribute("type", "chevron_up");
-  const isVisible = await icon(page).isVisible();
-  expect(isVisible).toBeTruthy();
+  const isVisible = icon(page);
+  await expect(isVisible).toBeVisible();
 });
 
 test.describe("Accessibility tests for Detail component", () => {

--- a/src/components/dialog/dialog.pw.tsx
+++ b/src/components/dialog/dialog.pw.tsx
@@ -139,7 +139,7 @@ test.describe("Dialog component", () => {
         const backgroundUILocatorElement = backgroundUILocator(page);
 
         if (enableBackgroundUIValue) {
-          await expect(backgroundUILocatorElement).not.toBeVisible();
+          await expect(backgroundUILocatorElement).toBeHidden();
         } else {
           await expect(backgroundUILocatorElement).toBeVisible();
         }
@@ -152,7 +152,7 @@ test.describe("Dialog component", () => {
     }) => {
       await mount(<DialogComponent showCloseIcon={false} />);
 
-      await expect(page.getByLabel("Close")).not.toBeVisible();
+      await expect(page.getByLabel("Close")).toBeHidden();
     });
 
     test("when showCloseIcon prop is true, clicking close icon closes Dialog", async ({
@@ -166,7 +166,7 @@ test.describe("Dialog component", () => {
 
       await page.getByLabel("Close").click();
 
-      await expect(dialog).not.toBeVisible();
+      await expect(dialog).toBeHidden();
     });
 
     test("pressing the Escape key closes Dialog", async ({ mount, page }) => {
@@ -177,7 +177,7 @@ test.describe("Dialog component", () => {
 
       await dialog.press("Escape");
 
-      await expect(dialog).not.toBeVisible();
+      await expect(dialog).toBeHidden();
     });
 
     test("when disableEscKey prop is passed, pressing the Escape key does not close Dialog", async ({
@@ -308,14 +308,14 @@ test.describe("Dialog component", () => {
         .filter({ hasText: "Open Dialog" });
       const dialog = page.getByRole("dialog");
       await expect(button).not.toBeFocused();
-      await expect(dialog).not.toBeVisible();
+      await expect(dialog).toBeHidden();
 
       await button.click();
       await expect(dialog).toBeVisible();
       const closeButton = page.getByLabel("Close");
       await closeButton.click();
       await expect(button).toBeFocused();
-      await expect(dialog).not.toBeVisible();
+      await expect(dialog).toBeHidden();
     });
 
     test("when Dialog is open on render, then closed, opened and then closed again, the call to action element should be focused", async ({
@@ -333,7 +333,7 @@ test.describe("Dialog component", () => {
         .getByRole("button")
         .filter({ hasText: "Open Dialog" });
       await expect(button).not.toBeFocused();
-      await expect(dialog).not.toBeVisible();
+      await expect(dialog).toBeHidden();
 
       await button.click();
       await expect(dialog).toBeVisible();
@@ -352,7 +352,7 @@ test.describe("Dialog component", () => {
         .filter({ hasText: "Open First Dialog" });
       const firstDialog = page.getByRole("dialog").first();
       await expect(firstButton).not.toBeFocused();
-      await expect(firstDialog).not.toBeVisible();
+      await expect(firstDialog).toBeHidden();
 
       await firstButton.click();
       await expect(firstDialog).toBeVisible();
@@ -384,14 +384,14 @@ test.describe("Dialog component", () => {
         .filter({ hasText: "Open Dialog" });
       const dialog = page.getByRole("dialog");
       await expect(button).not.toBeFocused();
-      await expect(dialog).not.toBeVisible();
+      await expect(dialog).toBeHidden();
 
       await button.click();
       await expect(dialog).toBeVisible();
       const closeButton = page.getByLabel("Close");
       await closeButton.click();
       await expect(button).not.toBeFocused();
-      await expect(dialog).not.toBeVisible();
+      await expect(dialog).toBeHidden();
     });
 
     test("when disableAutoFocus prop is passed, the first focusable element should not be focused", async ({
@@ -945,10 +945,10 @@ test.describe("Fullscreen Dialog component", () => {
 
       const closeIcon = getDataElementByValue(page, "close").first();
       const dialogFullScreen = page.getByRole("dialog");
-      await expect(closeIcon).toBeAttached;
-      await expect(dialogFullScreen).toBeAttached;
+      await expect(closeIcon).toBeAttached();
+      await expect(dialogFullScreen).toBeAttached();
       await closeIcon.click();
-      await expect(dialogFullScreen).not.toBeAttached;
+      await expect(dialogFullScreen).not.toBeAttached();
     });
 
     specialCharacters.forEach((title) => {
@@ -1004,9 +1004,9 @@ test.describe("Fullscreen Dialog component", () => {
       await mount(<FullScreenDialogComponent disableEscKey />);
 
       const dialogFullScreen = page.getByRole("dialog");
-      await expect(dialogFullScreen).toBeAttached;
+      await expect(dialogFullScreen).toBeVisible();
       await page.keyboard.press("Escape");
-      await expect(dialogFullScreen).not.toBeAttached;
+      await expect(dialogFullScreen).toBeVisible();
     });
 
     test("should close after pressing Escape button", async ({
@@ -1016,9 +1016,9 @@ test.describe("Fullscreen Dialog component", () => {
       await mount(<FullScreenDialogComponent />);
 
       const dialogFullScreen = page.getByRole("dialog");
-      await expect(dialogFullScreen).toBeAttached;
+      await expect(dialogFullScreen).toBeVisible();
       await page.keyboard.press("Escape");
-      await expect(dialogFullScreen).not.toBeAttached;
+      await expect(dialogFullScreen).toBeHidden();
     });
 
     test("should allow to close nested `Dialog` and then the main, full-screen `Dialog` window", async ({
@@ -1205,7 +1205,7 @@ test.describe("Fullscreen Dialog component", () => {
         .filter({ hasText: "Open Dialog Full Screen" });
       const dialogFullScreen = page.getByRole("dialog");
       await expect(button).not.toBeFocused();
-      await expect(dialogFullScreen).not.toBeVisible();
+      await expect(dialogFullScreen).toBeHidden();
 
       await button.click();
       await dialogFullScreen.waitFor();
@@ -1213,7 +1213,7 @@ test.describe("Fullscreen Dialog component", () => {
       const closeButton = page.getByLabel("Close");
       await closeButton.click();
 
-      await expect(dialogFullScreen).not.toBeVisible();
+      await expect(dialogFullScreen).toBeHidden();
       await expect(button).toBeFocused();
     });
 
@@ -1232,7 +1232,7 @@ test.describe("Fullscreen Dialog component", () => {
         .getByRole("button")
         .filter({ hasText: "Open Dialog Full Screen" });
       await expect(button).not.toBeFocused();
-      await expect(dialogFullScreen).not.toBeVisible();
+      await expect(dialogFullScreen).toBeHidden();
 
       await button.click();
       await expect(dialogFullScreen).toBeVisible();
@@ -1251,7 +1251,7 @@ test.describe("Fullscreen Dialog component", () => {
         .filter({ hasText: "Open Main Dialog" });
       const firstDialog = page.getByRole("dialog").first();
       await expect(firstButton).not.toBeFocused();
-      await expect(firstDialog).not.toBeVisible();
+      await expect(firstDialog).toBeHidden();
 
       await firstButton.click();
       await expect(firstDialog).toBeVisible();
@@ -1285,14 +1285,14 @@ test.describe("Fullscreen Dialog component", () => {
         .filter({ hasText: "Open Dialog Full Screen" });
       const dialogFullScreen = page.getByRole("dialog");
       await expect(button).not.toBeFocused();
-      await expect(dialogFullScreen).not.toBeVisible();
+      await expect(dialogFullScreen).toBeHidden();
 
       await button.click();
       await expect(dialogFullScreen).toBeVisible();
       const closeButton = page.getByLabel("Close");
       await closeButton.click();
       await expect(button).not.toBeFocused();
-      await expect(dialogFullScreen).not.toBeVisible();
+      await expect(dialogFullScreen).toBeHidden();
     });
 
     test("should render component with autofocus disabled", async ({

--- a/src/components/drawer/drawer.pw.tsx
+++ b/src/components/drawer/drawer.pw.tsx
@@ -84,9 +84,9 @@ test.describe("check props for Drawer component", () => {
         await expect(sidebarInnerElementTwo).toBeVisible();
         await expect(sidebarInnerElementThree).toBeVisible();
       } else {
-        await expect(sidebarInnerElementOne).not.toBeVisible();
-        await expect(sidebarInnerElementTwo).not.toBeVisible();
-        await expect(sidebarInnerElementThree).not.toBeVisible();
+        await expect(sidebarInnerElementOne).toBeHidden();
+        await expect(sidebarInnerElementTwo).toBeHidden();
+        await expect(sidebarInnerElementThree).toBeHidden();
       }
     });
   });
@@ -117,7 +117,7 @@ test.describe("check props for Drawer component", () => {
 
     const sidebarInnerElement = drawerSidebarContentInnerElement(page, 0);
     await expect(sidebarInnerElement).toHaveText("link a");
-    await expect(sidebarInnerElement).not.toBeVisible();
+    await expect(sidebarInnerElement).toBeHidden();
   });
 
   test("should render component opened when the expanded prop is true", async ({

--- a/src/components/fieldset/fieldset.pw.tsx
+++ b/src/components/fieldset/fieldset.pw.tsx
@@ -27,7 +27,7 @@ test.describe("should render Fieldset component", () => {
   test(`should verify preview is not displayed`, async ({ mount, page }) => {
     await mount(<FieldsetComponent legend="" />);
 
-    await expect(getDataElementByValue(page, "legend")).not.toBeVisible();
+    await expect(getDataElementByValue(page, "legend")).toBeHidden();
   });
 
   ["error", "warning", "info"].forEach((type) => {

--- a/src/components/flat-table/flat-table.pw.tsx
+++ b/src/components/flat-table/flat-table.pw.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import type { Locator } from "@playwright/test";
 import { test, expect } from "../../../playwright/helpers/base-test";
 import { FlatTableCheckboxProps } from ".";
 import {
@@ -84,6 +83,7 @@ import {
   getStyle,
   waitForAnimationEnd,
   continuePressingTAB,
+  checkNewFocusStyling,
 } from "../../../playwright/support/helper";
 
 const sizes = [
@@ -134,19 +134,6 @@ const vlightGrey = "rgb(230, 235, 237)";
 const green = "rgb(177, 211, 69)";
 const blue = "rgb(0, 0, 255)";
 const lightBlue = "rgb(51, 92, 220)";
-
-const checkNewFocusStyling = async (locator: Locator) => {
-  const shadowValue = await locator.evaluate((el) =>
-    window.getComputedStyle(el, "after").getPropertyValue("box-shadow"),
-  );
-  const outlineValue = await locator.evaluate((el) =>
-    window.getComputedStyle(el, "after").getPropertyValue("outline"),
-  );
-  expect(shadowValue).toBe(
-    `rgba(0, 0, 0, 0.9) 0px 0px 0px 3px inset, rgb(255, 188, 25) 0px 0px 0px 6px inset`,
-  );
-  expect(outlineValue).toBe(`rgba(0, 0, 0, 0) solid 3px`);
-};
 
 const indexes = (length: number, start = 0) =>
   Array.from({ length: length - start }).map((_, index) => index + start);

--- a/src/components/help/help.pw.tsx
+++ b/src/components/help/help.pw.tsx
@@ -105,7 +105,7 @@ test.describe("Testing Help component properties", () => {
       if (boolVal === true) {
         await expect(tooltip).toBeVisible();
       } else {
-        await expect(tooltip).not.toBeVisible();
+        await expect(tooltip).toBeHidden();
       }
     });
   });

--- a/src/components/icon/icon-unicodes.js
+++ b/src/components/icon/icon-unicodes.js
@@ -295,10 +295,6 @@ const legacyNames = {
   analysis: statusSymbols.chart_line,
   graph: statusSymbols.chart_line,
   basket: batchActions.cart,
-  // `tsc` emits an invalid .d.ts file if we're using normal property access (.delete):
-  // it tries to use `delete` as an identifier, but `delete` is a reserved keyword.
-  // By using ["delete"] instead, tsc generates a different - valid - .d.ts file
-  // See also: https://github.com/microsoft/TypeScript/issues/53111
   bin: batchActions["delete"],
   bulk_destroy: batchActions["delete"],
   caret_down: actions.dropdown,

--- a/src/components/icon/icon.pw.tsx
+++ b/src/components/icon/icon.pw.tsx
@@ -97,7 +97,7 @@ test.describe("should check Icon component properties", () => {
   }) => {
     await mount(<IconTooltipComponent tooltipVisible={false} />);
     const tooltip = getDataElementByValue(page, "tooltip");
-    await expect(tooltip).not.toBeVisible();
+    await expect(tooltip).toBeHidden();
   });
 
   colorData.forEach(([tooltipBgColor]) => {

--- a/src/components/loader-spinner/loader-spinner.pw.tsx
+++ b/src/components/loader-spinner/loader-spinner.pw.tsx
@@ -161,7 +161,7 @@ test.describe("Prop checks for Loader Spinner component", () => {
   }) => {
     await mount(<LoaderSpinnerComponent showSpinnerLabel={false} />);
 
-    await expect(loaderSpinnerVisibleLabel(page)).not.toBeVisible();
+    await expect(loaderSpinnerVisibleLabel(page)).toBeHidden();
   });
 
   test("when 'showSpinnerLabel' is `false` a visually hidden alternative label is rendered", async ({

--- a/src/components/loader/loader.pw.tsx
+++ b/src/components/loader/loader.pw.tsx
@@ -170,7 +170,7 @@ test.describe("check props for Loader component test", () => {
     });
   });
 
-  test.describe("Accessibility tests for Loader component", async () => {
+  test.describe("Accessibility tests for Loader component", () => {
     test("should pass accessibility tests for Loader default story", async ({
       mount,
       page,

--- a/src/components/menu/menu.pw.tsx
+++ b/src/components/menu/menu.pw.tsx
@@ -1007,7 +1007,7 @@ test.describe("Prop tests for Menu component", () => {
 
     const item = page.getByRole("button").filter({ hasText: "Menu" });
     await expect(item).not.toBeFocused();
-    await expect(fullscreen).not.toBeVisible();
+    await expect(fullscreen).toBeHidden();
 
     await item.click();
     await waitForAnimationEnd(fullscreen);
@@ -1126,9 +1126,9 @@ test.describe("Prop tests for Menu Fullscreen component", () => {
     const closeIcon = closeIconButton(page).first();
     await closeIcon.click();
     const fullScreenMenu1 = fullscreenMenu(page, 0).locator("span");
-    await expect(fullScreenMenu1).not.toBeVisible();
+    await expect(fullScreenMenu1).toBeHidden();
     const fullScreenMenu2 = fullscreenMenu(page, 1).locator("ul").first();
-    await expect(fullScreenMenu2).not.toBeVisible();
+    await expect(fullScreenMenu2).toBeHidden();
     const thisMenu = menu(page).first();
     await expect(thisMenu).toBeVisible();
   });
@@ -1342,7 +1342,7 @@ test.describe("Prop tests for Menu Fullscreen component", () => {
       if (boolVal) {
         await expect(fullScreenMenu).toBeVisible();
       } else {
-        await expect(fullScreenMenu).not.toBeVisible();
+        await expect(fullScreenMenu).toBeHidden();
       }
     });
   });

--- a/src/components/message/message.pw.tsx
+++ b/src/components/message/message.pw.tsx
@@ -49,7 +49,7 @@ test.describe("Tests for Message component properties", () => {
     page,
   }) => {
     await mount(<MessageComponent open={false} />);
-    await expect(messagePreview(page)).not.toBeVisible();
+    await expect(messagePreview(page)).toBeHidden();
   });
 
   test(`should focus component when open is true and component has a ref`, async ({
@@ -85,7 +85,7 @@ test.describe("Tests for Message component properties", () => {
     page,
   }) => {
     await mount(<MessageComponent showCloseIcon={false} />);
-    await expect(page.getByRole("button", { name: "Close" })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Close" })).toBeHidden();
   });
 
   testData.forEach((ariaLabel) => {

--- a/src/components/multi-action-button/multi-action-button.pw.tsx
+++ b/src/components/multi-action-button/multi-action-button.pw.tsx
@@ -300,8 +300,8 @@ test.describe("Functional tests", () => {
     await expect(listButton1).toBeFocused();
     await page.keyboard.press("Shift+Tab");
     await expect(actionButton).toBeFocused();
-    await expect(listButton1).not.toBeVisible();
-    await expect(listButton2).not.toBeVisible();
+    await expect(listButton1).toBeHidden();
+    await expect(listButton2).toBeHidden();
   });
 
   test(`should verify pressing ArrowDown key does not loop focus to top`, async ({
@@ -354,9 +354,9 @@ test.describe("Functional tests", () => {
       name: "Multi Action Button 2",
     });
     await expect(actionButton2).toBeFocused();
-    await expect(listButton1).not.toBeVisible();
-    await expect(listButton2).not.toBeVisible();
-    await expect(listButton3).not.toBeVisible();
+    await expect(listButton1).toBeHidden();
+    await expect(listButton2).toBeHidden();
+    await expect(listButton3).toBeHidden();
   });
 
   test(`should verify that pressing metaKey + ArrowUp moves focus to first child button`, async ({
@@ -510,7 +510,7 @@ test.describe("Functional tests", () => {
     const additionalButtons = page.getByRole("list");
     await expect(additionalButtons).toBeVisible();
     await page.keyboard.press("Escape");
-    await expect(additionalButtons).not.toBeVisible();
+    await expect(additionalButtons).toBeHidden();
   });
 
   test(`should verify that clicking one of the child buttons closes MultiActionButton`, async ({
@@ -530,7 +530,7 @@ test.describe("Functional tests", () => {
     const listButton3 = page.getByRole("button", { name: "Short" });
     await listButton3.click();
 
-    await expect(additionalButtons).not.toBeVisible();
+    await expect(additionalButtons).toBeHidden();
   });
 });
 
@@ -571,8 +571,8 @@ test.describe("Functional tests with child buttons wrapped in a custom component
     await expect(listButton1).toBeFocused();
     await page.keyboard.press("Shift+Tab");
     await expect(actionButton).toBeFocused();
-    await expect(listButton1).not.toBeVisible();
-    await expect(listButton2).not.toBeVisible();
+    await expect(listButton1).toBeHidden();
+    await expect(listButton2).toBeHidden();
   });
 
   test(`should verify pressing ArrowDown key does not loop focus to top`, async ({
@@ -625,9 +625,9 @@ test.describe("Functional tests with child buttons wrapped in a custom component
       name: "Multi Action Button 2",
     });
     await expect(actionButton2).toBeFocused();
-    await expect(listButton1).not.toBeVisible();
-    await expect(listButton2).not.toBeVisible();
-    await expect(listButton3).not.toBeVisible();
+    await expect(listButton1).toBeHidden();
+    await expect(listButton2).toBeHidden();
+    await expect(listButton3).toBeHidden();
   });
 
   test(`should verify that pressing metaKey + ArrowUp moves focus to first child button`, async ({
@@ -763,7 +763,7 @@ test.describe("Functional tests with child buttons wrapped in a custom component
     const additionalButtons = page.getByRole("list");
     await expect(additionalButtons).toBeVisible();
     await page.keyboard.press("Escape");
-    await expect(additionalButtons).not.toBeVisible();
+    await expect(additionalButtons).toBeHidden();
   });
 
   test(`should verify that clicking one of the child buttons closes MultiActionButton`, async ({
@@ -783,7 +783,7 @@ test.describe("Functional tests with child buttons wrapped in a custom component
     const listButton3 = page.getByRole("button", { name: "Button 3" });
     await listButton3.click();
 
-    await expect(additionalButtons).not.toBeVisible();
+    await expect(additionalButtons).toBeHidden();
   });
 });
 

--- a/src/components/navigation-bar/navigation-bar.pw.tsx
+++ b/src/components/navigation-bar/navigation-bar.pw.tsx
@@ -72,25 +72,30 @@ test.describe("Test props for NavigationBar component", () => {
     });
   });
 
-  ([true, false] as NavigationBarProps["isLoading"][]).forEach((boolean) => {
-    test(`should render with isLoading prop set to ${boolean}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <NavigationBarComponent isLoading={boolean}>
-          {testData}
-        </NavigationBarComponent>,
-      );
+  test("does not render content when isLoading prop is true", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <NavigationBarComponent isLoading>{testData}</NavigationBarComponent>,
+    );
 
-      const navigation = page.locator(`[data-component="navigation-bar"]`);
+    const navigationBar = page.getByRole("navigation");
+    await expect(navigationBar).not.toHaveText(testData);
+  });
 
-      if (boolean) {
-        await expect(navigation).not.toBeAttached;
-      } else {
-        await expect(navigation).toBeVisible();
-      }
-    });
+  test("renders content when isLoading prop is false", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <NavigationBarComponent isLoading={false}>
+        {testData}
+      </NavigationBarComponent>,
+    );
+
+    const navigationBar = page.getByRole("navigation");
+    await expect(navigationBar).toHaveText(testData);
   });
 
   (["fixed", "sticky"] as const).forEach((position) => {

--- a/src/components/numeral-date/numeral-date.pw.tsx
+++ b/src/components/numeral-date/numeral-date.pw.tsx
@@ -427,7 +427,7 @@ test.describe("NumeralDate component", () => {
 
     await expect(numeralDateInput(page, 0)).toHaveAccessibleName("Day");
     await expect(numeralDateInput(page, 1)).toHaveAccessibleName("Month");
-    await expect(numeralDateInput(page, 2)).not.toBeVisible();
+    await expect(numeralDateInput(page, 2)).toBeHidden();
   });
 
   test('should render NumeralDate with `["mm", "dd"]` dateFormat prop', async ({
@@ -438,7 +438,7 @@ test.describe("NumeralDate component", () => {
 
     await expect(numeralDateInput(page, 0)).toHaveAccessibleName("Month");
     await expect(numeralDateInput(page, 1)).toHaveAccessibleName("Day");
-    await expect(numeralDateInput(page, 2)).not.toBeVisible();
+    await expect(numeralDateInput(page, 2)).toBeHidden();
   });
 
   test('should render NumeralDate with `["mm", "yyyy"]` dateFormat prop', async ({
@@ -449,7 +449,7 @@ test.describe("NumeralDate component", () => {
 
     await expect(numeralDateInput(page, 0)).toHaveAccessibleName("Month");
     await expect(numeralDateInput(page, 1)).toHaveAccessibleName("Year");
-    await expect(numeralDateInput(page, 2)).not.toBeVisible();
+    await expect(numeralDateInput(page, 2)).toBeHidden();
   });
 
   (
@@ -626,7 +626,7 @@ test.describe("NumeralDate component", () => {
       await checkAccessibility(page);
     });
 
-    test("should pass accessibility tests for NumeralDateControlled component ", async ({
+    test("should pass accessibility tests for NumeralDateControlled component", async ({
       mount,
       page,
     }) => {

--- a/src/components/pager/pager.pw.tsx
+++ b/src/components/pager/pager.pw.tsx
@@ -216,7 +216,7 @@ test.describe("Prop tests", () => {
       if (showTotal) {
         await expect(pagerSummary(page)).toBeVisible();
       } else {
-        await expect(pagerSummary(page)).not.toBeVisible();
+        await expect(pagerSummary(page)).toBeHidden();
       }
     });
   });
@@ -265,7 +265,7 @@ test.describe("Prop tests", () => {
       if (showCount) {
         await expect(currentPageSection(page).first()).toBeVisible();
       } else {
-        await expect(currentPageSection(page)).not.toBeVisible();
+        await expect(currentPageSection(page)).toBeHidden();
       }
     });
   });
@@ -314,8 +314,8 @@ test.describe("Prop tests", () => {
       );
 
       if (hideElements) {
-        await expect(firstArrow(page)).not.toBeVisible();
-        await expect(previousArrow(page)).not.toBeVisible();
+        await expect(firstArrow(page)).toBeHidden();
+        await expect(previousArrow(page)).toBeHidden();
       } else {
         await expect(firstArrow(page)).toBeVisible();
         await expect(previousArrow(page)).toBeVisible();
@@ -333,8 +333,8 @@ test.describe("Prop tests", () => {
       );
 
       if (hideElements) {
-        await expect(nextArrow(page)).not.toBeVisible();
-        await expect(lastArrow(page)).not.toBeVisible();
+        await expect(nextArrow(page)).toBeHidden();
+        await expect(lastArrow(page)).toBeHidden();
       } else {
         await expect(nextArrow(page)).toBeVisible();
         await expect(lastArrow(page)).toBeVisible();

--- a/src/components/pod/pod.pw.tsx
+++ b/src/components/pod/pod.pw.tsx
@@ -351,7 +351,7 @@ test.describe("when onEdit prop is passed", () => {
       </Pod>,
     );
 
-    await expect(podEdit(page)).not.toBeVisible();
+    await expect(podEdit(page)).toBeHidden();
 
     await podContent(page).click();
     await expect(podEdit(page)).toBeVisible();
@@ -367,7 +367,7 @@ test.describe("when onEdit prop is passed", () => {
       </Pod>,
     );
 
-    await expect(podEdit(page)).not.toBeVisible();
+    await expect(podEdit(page)).toBeHidden();
     await podBlock(page).hover();
 
     await expect(podEdit(page)).toBeVisible();
@@ -383,7 +383,7 @@ test.describe("when onEdit prop is passed", () => {
       </Pod>,
     );
 
-    await expect(podEdit(page)).not.toBeVisible();
+    await expect(podEdit(page)).toBeHidden();
 
     await podBlock(page).focus();
     await expect(podEdit(page)).toBeVisible();
@@ -484,7 +484,7 @@ test.describe("when onUndo and softDelete props are passed", () => {
       if (boolVal) {
         await expect(podUndo(page)).toBeVisible();
       } else {
-        await expect(podUndo(page)).not.toBeVisible();
+        await expect(podUndo(page)).toBeHidden();
       }
     });
   });

--- a/src/components/popover-container/popover-container.pw.tsx
+++ b/src/components/popover-container/popover-container.pw.tsx
@@ -177,7 +177,7 @@ test.describe("Check props of Popover Container component", () => {
 
     const popoverContainerContentElement = popoverContainerContent(page);
 
-    await expect(popoverContainerContentElement).not.toBeVisible();
+    await expect(popoverContainerContentElement).toBeHidden();
   });
 
   test("should render with renderCloseComponent", async ({ mount, page }) => {
@@ -303,7 +303,7 @@ test.describe("Check props of Popover Container component", () => {
     await expect(childButton).toBeFocused();
     await childButton.press("Tab");
     await expect(siblingButton).toBeFocused();
-    await expect(container).not.toBeVisible();
+    await expect(container).toBeHidden();
   });
 
   test("should focus the open button element when user back tabs and first element in the container is focused", async ({
@@ -320,7 +320,7 @@ test.describe("Check props of Popover Container component", () => {
     await expect(closeButton).toBeFocused();
     await closeButton.press("Shift+Tab");
     await expect(openButton).toBeFocused();
-    await expect(container).not.toBeVisible();
+    await expect(container).toBeHidden();
   });
 
   test("should trap focus when user is tabbing and the container covers the trigger button", async ({
@@ -404,7 +404,7 @@ test.describe("Check props of Popover Container component", () => {
     await page.keyboard.press("Tab"); // focus on close icon
     await page.keyboard.press("Tab"); // focus outside of container and on to additional button
 
-    await expect(container).not.toBeVisible();
+    await expect(container).toBeHidden();
     await expect(additionalButton).toBeFocused();
   });
 

--- a/src/components/portrait/portrait.pw.tsx
+++ b/src/components/portrait/portrait.pw.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { test, expect } from "../../../playwright/helpers/base-test";
-import { getDataElementByValue } from "../../../playwright/components";
+import { getDataElementByValue, icon } from "../../../playwright/components";
 import {
   portraitImage,
   portraitInitials,
   portraitPreview,
 } from "../../../playwright/components/portrait/index";
-import { icon } from "../../../playwright/components/index";
 import {
   CHARACTERS,
   COLOR,
@@ -299,7 +298,7 @@ test.describe("Prop checks for Portrait component", () => {
         await expect(tooltip).toBeVisible();
         await expect(tooltip).toHaveText("foo");
       } else {
-        await expect(tooltip).not.toBeVisible();
+        await expect(tooltip).toBeHidden();
       }
     });
   });

--- a/src/components/preview/preview.pw.tsx
+++ b/src/components/preview/preview.pw.tsx
@@ -69,7 +69,7 @@ test.describe("check Preview component properties", () => {
       if (bool) {
         await expect(previewComponent(page)).toBeVisible();
       } else {
-        await expect(previewComponent(page)).not.toBeVisible();
+        await expect(previewComponent(page)).toBeHidden();
       }
     });
   });

--- a/src/components/radio-button/radio-button.pw.tsx
+++ b/src/components/radio-button/radio-button.pw.tsx
@@ -124,7 +124,7 @@ test.describe("should render RadioButton component", () => {
       if (booleanValue) {
         await expect(radiobuttonElement).toBeDisabled();
       } else {
-        await expect(radiobuttonElement).not.toBeDisabled();
+        await expect(radiobuttonElement).toBeEnabled();
       }
     });
   });

--- a/src/components/select/filterable-select/filterable-select.pw.tsx
+++ b/src/components/select/filterable-select/filterable-select.pw.tsx
@@ -245,7 +245,7 @@ test.describe("FilterableSelect component", () => {
 
     await expect(commonDataElementInputPreview(page)).not.toBeEditable();
     await selectInput(page).click();
-    await expect(selectListWrapper(page)).not.toBeVisible();
+    await expect(selectListWrapper(page)).toBeHidden();
   });
 
   test("should render icon with read only style", async ({ mount, page }) => {
@@ -414,7 +414,7 @@ test.describe("FilterableSelect component", () => {
     await inputElement.focus();
     await expect(inputElement).toBeFocused();
     await expect(inputElement).toHaveAttribute("aria-expanded", "false");
-    await expect(selectListWrapper(page)).not.toBeVisible();
+    await expect(selectListWrapper(page)).toBeHidden();
   });
 
   test("should open the list with mouse click on input", async ({
@@ -449,7 +449,7 @@ test.describe("FilterableSelect component", () => {
     await expect(selectListWrapperElement).toBeVisible();
     await selectInputElement.press("Tab");
     await expect(selectInputElement).toHaveAttribute("aria-expanded", "false");
-    await expect(selectListWrapperElement).not.toBeVisible();
+    await expect(selectListWrapperElement).toBeHidden();
   });
 
   test("should close the list with the Esc key", async ({ mount, page }) => {
@@ -460,7 +460,7 @@ test.describe("FilterableSelect component", () => {
     await expect(selectListWrapperElement).toBeVisible();
     await commonDataElementInputPreview(page).press("Escape");
     await expect(selectInput(page)).toHaveAttribute("aria-expanded", "false");
-    await expect(selectListWrapperElement).not.toBeVisible();
+    await expect(selectListWrapperElement).toBeHidden();
   });
 
   test("should close the list by clicking out of the component", async ({
@@ -474,7 +474,7 @@ test.describe("FilterableSelect component", () => {
     await expect(selectListWrapperElement).toBeVisible();
     await page.locator("body").click({ position: { x: 0, y: 0 } });
     await expect(selectInput(page)).toHaveAttribute("aria-expanded", "false");
-    await expect(selectListWrapperElement).not.toBeVisible();
+    await expect(selectListWrapperElement).toBeHidden();
   });
 
   keyToTrigger.forEach((key) => {
@@ -498,7 +498,7 @@ test.describe("FilterableSelect component", () => {
 
     await commonDataElementInputPreview(page).focus();
     await selectInput(page).press("Enter");
-    await expect(selectListWrapper(page)).not.toBeVisible();
+    await expect(selectListWrapper(page)).toBeHidden();
   });
 
   ["Amber", "Yellow"].forEach((option) => {
@@ -512,7 +512,7 @@ test.describe("FilterableSelect component", () => {
       await selectOptionByText(page, option).click();
       await expect(getDataElementByValue(page, "input")).toHaveValue(option);
       await expect(selectInput(page)).toHaveAttribute("aria-expanded", "false");
-      await expect(selectListWrapper(page)).not.toBeVisible();
+      await expect(selectListWrapper(page)).toBeHidden();
     });
   });
 
@@ -607,7 +607,7 @@ test.describe("FilterableSelect component", () => {
     await selectOptionByText(page, option).click();
     await expect(getDataElementByValue(page, "input")).toHaveValue(option);
     await expect(selectInput(page)).toHaveAttribute("aria-expanded", "false");
-    await expect(wrapperElement).not.toBeVisible();
+    await expect(wrapperElement).toBeHidden();
     await buttonElement.click();
     await expect(wrapperElement.locator("li")).toHaveCount(count);
   });
@@ -634,7 +634,7 @@ test.describe("FilterableSelect component", () => {
     await expect(selectInput(page)).toHaveAttribute("aria-expanded", "true");
     await expect(wrapperElement).toBeVisible();
     await selectOption(page, positionOfElement("first")).click();
-    await expect(wrapperElement).not.toBeVisible();
+    await expect(wrapperElement).toBeHidden();
   });
 
   test("should open list when openOnFocus set, user selects an option via enter key and then input is blurred then focused again", async ({
@@ -651,7 +651,7 @@ test.describe("FilterableSelect component", () => {
     await expect(wrapperElement).toBeVisible();
     await selectInputElement.press("ArrowDown");
     await selectInputElement.press("Enter");
-    await expect(wrapperElement).not.toBeVisible();
+    await expect(wrapperElement).toBeHidden();
     await inputElement.blur();
     await inputElement.focus();
     await expect(wrapperElement).toBeVisible();
@@ -912,7 +912,7 @@ test.describe("FilterableSelect component", () => {
     await expect(headerElements).toHaveCount(columns);
     const assertions = [];
     for (let i = 0; i < columns; i++) {
-      assertions.push(expect(headerElements.nth(i)).toBeVisible());
+      assertions.push(await expect(headerElements.nth(i)).toBeVisible());
     }
     await Promise.all(assertions);
     await expect(
@@ -932,14 +932,14 @@ test.describe("FilterableSelect component", () => {
     await expect(headerElements).toHaveCount(columns);
     const headerAssertions = [];
     for (let i = 0; i < columns; i++) {
-      headerAssertions.push(expect(headerElements.nth(i)).toBeVisible());
+      headerAssertions.push(await expect(headerElements.nth(i)).toBeVisible());
     }
     await Promise.all(headerAssertions);
     const bodyElements = multiColumnsSelectListBody(page);
     await expect(bodyElements).toHaveCount(columns);
     const bodyAssertions = [];
     for (let i = 0; i < columns; i++) {
-      bodyAssertions.push(expect(bodyElements.nth(i)).toBeVisible());
+      bodyAssertions.push(await expect(bodyElements.nth(i)).toBeVisible());
     }
     await Promise.all(bodyAssertions);
     const addElementButtonElement = filterableSelectAddElementButton(page);
@@ -1299,10 +1299,10 @@ test.describe("When nested inside of a Dialog component", () => {
     const inputElement = commonDataElementInputPreview(page);
     const dialogElement = dialogWithRole(page, "dialog");
     await inputElement.press("Escape");
-    await expect(selectList(page)).not.toBeVisible();
+    await expect(selectList(page)).toBeHidden();
     await expect(dialogElement).toBeVisible();
     await inputElement.press("Escape");
-    await expect(dialogElement).not.toBeVisible();
+    await expect(dialogElement).toBeHidden();
   });
 
   test("should not refocus the select textbox when closing it by clicking outside", async ({
@@ -1313,7 +1313,7 @@ test.describe("When nested inside of a Dialog component", () => {
 
     await dropdownButton(page).click();
     await dialogWithRole(page, "dialog").click();
-    await expect(selectList(page)).not.toBeVisible();
+    await expect(selectList(page)).toBeHidden();
     await expect(commonDataElementInputPreview(page)).not.toBeFocused();
   });
 
@@ -1344,7 +1344,7 @@ test.describe("Selection confirmed", () => {
     await selectOptionByText(page, "Five").click();
     await expect(
       page.locator('[data-element="confirmed-selection-1"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-5"]'),
     ).toBeVisible();
@@ -1352,7 +1352,7 @@ test.describe("Selection confirmed", () => {
     await selectOptionByText(page, "Seven").click();
     await expect(
       page.locator('[data-element="confirmed-selection-5"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-7"]'),
     ).toBeVisible();
@@ -1379,7 +1379,7 @@ test.describe("Selection confirmed", () => {
     await inputElement.press("Enter");
     await expect(
       page.locator('[data-element="confirmed-selection-1"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-3"]'),
     ).toBeVisible();
@@ -1389,7 +1389,7 @@ test.describe("Selection confirmed", () => {
     await inputElement.press("Enter");
     await expect(
       page.locator('[data-element="confirmed-selection-3"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-5"]'),
     ).toBeVisible();
@@ -1398,7 +1398,7 @@ test.describe("Selection confirmed", () => {
     await inputElement.press("Enter");
     await expect(
       page.locator('[data-element="confirmed-selection-5"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-6"]'),
     ).toBeVisible();
@@ -1425,7 +1425,7 @@ test.describe("Selection confirmed", () => {
     await inputElement.press("Enter");
     await expect(
       page.locator('[data-element="confirmed-selection-9"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-7"]'),
     ).toBeVisible();
@@ -1435,7 +1435,7 @@ test.describe("Selection confirmed", () => {
     await inputElement.press("Enter");
     await expect(
       page.locator('[data-element="confirmed-selection-7"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-5"]'),
     ).toBeVisible();
@@ -1444,7 +1444,7 @@ test.describe("Selection confirmed", () => {
     await inputElement.press("Enter");
     await expect(
       page.locator('[data-element="confirmed-selection-5"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-4"]'),
     ).toBeVisible();
@@ -1461,7 +1461,7 @@ test.describe("Selection confirmed", () => {
     await inputElement.fill("th");
     await expect(
       page.locator('[data-element="confirmed-selection-3"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await inputElement.press("Enter");
     await expect(
       page.locator('[data-element="confirmed-selection-3"]'),
@@ -1511,7 +1511,7 @@ test("should not select a disabled option when a filter is typed", async ({
   await inputElement.press("Enter");
   await expect(
     page.locator('[data-element="confirmed-selection-2"]'),
-  ).not.toBeVisible();
+  ).toBeHidden();
   await inputElement.press("ArrowDown");
   await inputElement.press("Enter");
   await expect(

--- a/src/components/select/multi-select/multi-select.pw.tsx
+++ b/src/components/select/multi-select/multi-select.pw.tsx
@@ -227,7 +227,7 @@ test.describe("MultiSelect component", () => {
 
     await expect(commonDataElementInputPreview(page)).not.toBeEditable();
     await selectInput(page).click();
-    await expect(selectListWrapper(page)).not.toBeVisible();
+    await expect(selectListWrapper(page)).toBeHidden();
   });
 
   test("should render icon with read only style", async ({ mount, page }) => {
@@ -394,7 +394,7 @@ test.describe("MultiSelect component", () => {
     await inputElement.focus();
     await expect(inputElement).toBeFocused();
     await expect(inputElement).toHaveAttribute("aria-expanded", "false");
-    await expect(selectListWrapper(page)).not.toBeVisible();
+    await expect(selectListWrapper(page)).toBeHidden();
   });
 
   test("should open the list with mouse click on input", async ({
@@ -429,7 +429,7 @@ test.describe("MultiSelect component", () => {
     await dropdownButton(page).click();
     await expect(selectListWrapper(page)).toBeVisible();
     await dropdownButton(page).click();
-    await expect(selectListWrapper(page)).not.toBeVisible();
+    await expect(selectListWrapper(page)).toBeHidden();
   });
 
   test("should close the list with the Tab key", async ({ mount, page }) => {
@@ -441,7 +441,7 @@ test.describe("MultiSelect component", () => {
     await expect(selectListWrapperElement).toBeVisible();
     await selectInputElement.press("Tab");
     await expect(selectInputElement).toHaveAttribute("aria-expanded", "false");
-    await expect(selectListWrapperElement).not.toBeVisible();
+    await expect(selectListWrapperElement).toBeHidden();
   });
 
   test("should close the list with the Esc key", async ({ mount, page }) => {
@@ -452,7 +452,7 @@ test.describe("MultiSelect component", () => {
     await expect(selectListWrapperElement).toBeVisible();
     await commonDataElementInputPreview(page).press("Escape");
     await expect(selectInput(page)).toHaveAttribute("aria-expanded", "false");
-    await expect(selectListWrapperElement).not.toBeVisible();
+    await expect(selectListWrapperElement).toBeHidden();
   });
 
   test("should close the list by clicking out of the component", async ({
@@ -466,7 +466,7 @@ test.describe("MultiSelect component", () => {
     await expect(selectListWrapperElement).toBeVisible();
     await page.locator("body").click({ position: { x: 0, y: 0 } });
     await expect(selectInput(page)).toHaveAttribute("aria-expanded", "false");
-    await expect(selectListWrapperElement).not.toBeVisible();
+    await expect(selectListWrapperElement).toBeHidden();
   });
 
   [keyToTrigger[0], keyToTrigger[1], keyToTrigger[4], keyToTrigger[5]].forEach(
@@ -492,7 +492,7 @@ test.describe("MultiSelect component", () => {
 
     await commonDataElementInputPreview(page).focus();
     await selectInput(page).press("Enter");
-    await expect(selectListWrapper(page)).not.toBeVisible();
+    await expect(selectListWrapper(page)).toBeHidden();
   });
 
   ["Amber", "Yellow"].forEach((option) => {
@@ -880,7 +880,7 @@ test.describe("MultiSelect component", () => {
     await expect(headerElements).toHaveCount(columns);
     const assertions = [];
     for (let i = 0; i < columns; i++) {
-      assertions.push(expect(headerElements.nth(i)).toBeVisible());
+      assertions.push(await expect(headerElements.nth(i)).toBeVisible());
     }
     await Promise.all(assertions);
     await expect(
@@ -1280,10 +1280,10 @@ test.describe("When nested inside of a Dialog component", () => {
     const inputElement = commonDataElementInputPreview(page);
     const dialogElement = dialogWithRole(page, "dialog");
     await inputElement.press("Escape");
-    await expect(selectList(page)).not.toBeVisible();
+    await expect(selectList(page)).toBeHidden();
     await expect(dialogElement).toBeVisible();
     await inputElement.press("Escape");
-    await expect(dialogElement).not.toBeVisible();
+    await expect(dialogElement).toBeHidden();
   });
 
   test("should not refocus the select textbox when closing it by clicking outside", async ({
@@ -1294,7 +1294,7 @@ test.describe("When nested inside of a Dialog component", () => {
 
     await dropdownButton(page).click();
     await dialogWithRole(page, "dialog").click();
-    await expect(selectList(page)).not.toBeVisible();
+    await expect(selectList(page)).toBeHidden();
     await expect(commonDataElementInputPreview(page)).not.toBeFocused();
   });
 
@@ -1488,10 +1488,10 @@ test("should not add an empty Pill when filter text does not match option text",
   await mount(<MultiSelectComponent />);
 
   const pillElement = multiSelectPill(page);
-  await expect(pillElement).not.toBeVisible();
+  await expect(pillElement).toBeHidden();
   await commonDataElementInputPreview(page).fill("abc");
   await selectInput(page).press("Enter");
-  await expect(pillElement).not.toBeVisible();
+  await expect(pillElement).toBeHidden();
 });
 
 test("should not select a disabled option when a filter is typed", async ({
@@ -1506,7 +1506,7 @@ test("should not select a disabled option when a filter is typed", async ({
   await inputElement.press("Enter");
   await expect(
     page.locator('[data-element="confirmed-selection-2"]'),
-  ).not.toBeVisible();
+  ).toBeHidden();
   await inputElement.press("ArrowDown");
   await inputElement.press("Enter");
   await expect(

--- a/src/components/select/simple-select/simple-select.pw.tsx
+++ b/src/components/select/simple-select/simple-select.pw.tsx
@@ -189,7 +189,7 @@ test.describe("SimpleSelect component", () => {
     await selectText(page).click();
     await expect(commonDataElementInputPreview(page)).not.toBeEditable();
     await expect(selectText(page)).toHaveAttribute("aria-hidden", "true");
-    await expect(selectListWrapper(page)).not.toBeVisible();
+    await expect(selectListWrapper(page)).toBeHidden();
   });
 
   test("should render icon with read only style", async ({ mount, page }) => {
@@ -380,7 +380,7 @@ test.describe("SimpleSelect component", () => {
     await expect(selectListWrapperElement).toBeVisible();
     await selectInputElement.press("Tab");
     await expect(selectInputElement).toHaveAttribute("aria-expanded", "false");
-    await expect(selectListWrapperElement).not.toBeVisible();
+    await expect(selectListWrapperElement).toBeHidden();
   });
 
   test("should close the list with the Esc key", async ({ mount, page }) => {
@@ -391,7 +391,7 @@ test.describe("SimpleSelect component", () => {
     await expect(selectListWrapperElement).toBeVisible();
     await commonDataElementInputPreview(page).press("Escape");
     await expect(selectInput(page)).toHaveAttribute("aria-expanded", "false");
-    await expect(selectListWrapperElement).not.toBeVisible();
+    await expect(selectListWrapperElement).toBeHidden();
   });
 
   test("should close the list by clicking out of the component", async ({
@@ -405,7 +405,7 @@ test.describe("SimpleSelect component", () => {
     await expect(selectListWrapperElement).toBeVisible();
     await page.locator("body").click();
     await expect(selectInput(page)).toHaveAttribute("aria-expanded", "false");
-    await expect(selectListWrapperElement).not.toBeVisible();
+    await expect(selectListWrapperElement).toBeHidden();
   });
 
   keyToTrigger.forEach((key) => {
@@ -432,7 +432,7 @@ test.describe("SimpleSelect component", () => {
       await selectOptionByText(page, option).click();
       await expect(getDataElementByValue(page, "input")).toHaveValue(option);
       await expect(selectInput(page)).toHaveAttribute("aria-expanded", "false");
-      await expect(selectListWrapper(page)).not.toBeVisible();
+      await expect(selectListWrapper(page)).toBeHidden();
     });
   });
 
@@ -638,14 +638,14 @@ test.describe("SimpleSelect component", () => {
     await expect(headerElements).toHaveCount(columns);
     const headerAssertions = [];
     for (let i = 0; i < columns; i++) {
-      headerAssertions.push(expect(headerElements.nth(i)).toBeVisible());
+      headerAssertions.push(await expect(headerElements.nth(i)).toBeVisible());
     }
     await Promise.all(headerAssertions);
     const bodyElements = multiColumnsSelectListBody(page);
     await expect(bodyElements).toHaveCount(columns);
     const bodyAssertions = [];
     for (let i = 0; i < columns; i++) {
-      bodyAssertions.push(expect(bodyElements.nth(i)).toBeVisible());
+      bodyAssertions.push(await expect(bodyElements.nth(i)).toBeVisible());
     }
     await Promise.all(bodyAssertions);
     await expect(multiColumnsSelectListRow(page)).toHaveCSS(
@@ -1231,7 +1231,7 @@ test.describe("Check virtual scrolling", () => {
     });
     await selectOptionByText(page, "Yellow").click();
 
-    await expect(selectOptionByText(page, "Yellow")).not.toBeVisible();
+    await expect(selectOptionByText(page, "Yellow")).toBeHidden();
 
     await selectText(page).click();
     await expect(selectOptionByText(page, "Yellow")).toBeInViewport({
@@ -1285,10 +1285,10 @@ test.describe("When nested inside of a Dialog component", () => {
     const inputElement = commonDataElementInputPreview(page);
     const dialogElement = dialogWithRole(page, "dialog");
     await inputElement.press("Escape");
-    await expect(selectList(page)).not.toBeVisible();
+    await expect(selectList(page)).toBeHidden();
     await expect(dialogElement).toBeVisible();
     await inputElement.press("Escape");
-    await expect(dialogElement).not.toBeVisible();
+    await expect(dialogElement).toBeHidden();
   });
 
   test("should not refocus the select textbox when closing it by clicking outside", async ({
@@ -1299,7 +1299,7 @@ test.describe("When nested inside of a Dialog component", () => {
 
     await selectText(page).click();
     await dialogWithRole(page, "dialog").click();
-    await expect(selectList(page)).not.toBeVisible();
+    await expect(selectList(page)).toBeHidden();
     await expect(commonDataElementInputPreview(page)).not.toBeFocused();
   });
 
@@ -1313,7 +1313,7 @@ test.describe("When nested inside of a Dialog component", () => {
     await expect(selectList(page)).toBeVisible();
   });
 
-  test("should be able to focus the last item in the select list when the select list has an OptionGroupHeader ", async ({
+  test("should be able to focus the last item in the select list when the select list has an OptionGroupHeader", async ({
     mount,
     page,
   }) => {
@@ -1343,7 +1343,7 @@ test.describe("Selection confirmed", () => {
     await selectOptionByText(page, "Five").click();
     await expect(
       page.locator('[data-element="confirmed-selection-1"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-5"]'),
     ).toBeVisible();
@@ -1351,7 +1351,7 @@ test.describe("Selection confirmed", () => {
     await selectOptionByText(page, "Seven").click();
     await expect(
       page.locator('[data-element="confirmed-selection-5"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-7"]'),
     ).toBeVisible();
@@ -1378,7 +1378,7 @@ test.describe("Selection confirmed", () => {
     await inputElement.press("Enter");
     await expect(
       page.locator('[data-element="confirmed-selection-1"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-3"]'),
     ).toBeVisible();
@@ -1388,7 +1388,7 @@ test.describe("Selection confirmed", () => {
     await inputElement.press("Enter");
     await expect(
       page.locator('[data-element="confirmed-selection-3"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-5"]'),
     ).toBeVisible();
@@ -1397,7 +1397,7 @@ test.describe("Selection confirmed", () => {
     await inputElement.press("Enter");
     await expect(
       page.locator('[data-element="confirmed-selection-5"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-6"]'),
     ).toBeVisible();
@@ -1424,7 +1424,7 @@ test.describe("Selection confirmed", () => {
     await inputElement.press("Enter");
     await expect(
       page.locator('[data-element="confirmed-selection-9"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-7"]'),
     ).toBeVisible();
@@ -1434,7 +1434,7 @@ test.describe("Selection confirmed", () => {
     await inputElement.press("Enter");
     await expect(
       page.locator('[data-element="confirmed-selection-7"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-5"]'),
     ).toBeVisible();
@@ -1443,7 +1443,7 @@ test.describe("Selection confirmed", () => {
     await inputElement.press("Enter");
     await expect(
       page.locator('[data-element="confirmed-selection-5"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await expect(
       page.locator('[data-element="confirmed-selection-4"]'),
     ).toBeVisible();
@@ -1460,7 +1460,7 @@ test.describe("Selection confirmed", () => {
     await inputElement.type("t");
     await expect(
       page.locator('[data-element="confirmed-selection-2"]'),
-    ).not.toBeVisible();
+    ).toBeHidden();
     await inputElement.press("Enter");
     await expect(
       page.locator('[data-element="confirmed-selection-2"]'),

--- a/src/components/sidebar/sidebar.pw.tsx
+++ b/src/components/sidebar/sidebar.pw.tsx
@@ -48,7 +48,7 @@ test.describe("Prop tests for Sidebar component", () => {
       const backgroundUILocatorElement = backgroundUILocator(page);
 
       if (enableBackgroundUIValue) {
-        await expect(backgroundUILocatorElement).not.toBeVisible();
+        await expect(backgroundUILocatorElement).toBeHidden();
       } else {
         await expect(backgroundUILocatorElement).toBeVisible();
       }
@@ -207,7 +207,7 @@ test.describe("Prop tests for Sidebar component", () => {
 
     const toastElement = getComponent(page, "toast");
 
-    await expect(toastElement).not.toBeVisible();
+    await expect(toastElement).toBeHidden();
 
     const openToastElement = getDataElementByValue(page, "open-toast");
     await openToastElement.click();
@@ -219,7 +219,7 @@ test.describe("Prop tests for Sidebar component", () => {
       .getByLabel("Close");
     await toastElementCloseButton.click();
 
-    await expect(toastElement).not.toBeVisible();
+    await expect(toastElement).toBeHidden();
   });
 
   test("should render component with first input and button as focusableSelectors", async ({
@@ -254,7 +254,7 @@ test.describe("Prop tests for Sidebar component", () => {
 
     const toastElement = getComponent(page, "toast");
 
-    await expect(toastElement).not.toBeVisible();
+    await expect(toastElement).toBeHidden();
 
     const openToastElement = getDataElementByValue(page, "open-toast");
     await openToastElement.click();
@@ -276,14 +276,14 @@ test.describe("Prop tests for Sidebar component", () => {
     const button = page.getByRole("button").filter({ hasText: "Open sidebar" });
     const sidebar = sidebarPreview(page);
     await expect(button).not.toBeFocused();
-    await expect(sidebar).not.toBeVisible();
+    await expect(sidebar).toBeHidden();
 
     await button.click();
     await expect(sidebar).toBeVisible();
     const closeButton = page.getByLabel("Close");
     await closeButton.click();
     await expect(button).toBeFocused();
-    await expect(sidebar).not.toBeVisible();
+    await expect(sidebar).toBeHidden();
   });
 
   test("when Sidebar is open on render, then closed, opened and then closed again, the call to action element should be focused", async ({
@@ -299,7 +299,7 @@ test.describe("Prop tests for Sidebar component", () => {
 
     const button = page.getByRole("button").filter({ hasText: "Open sidebar" });
     await expect(button).not.toBeFocused();
-    await expect(sidebar).not.toBeVisible();
+    await expect(sidebar).toBeHidden();
 
     await button.click();
     await expect(sidebar).toBeVisible();
@@ -318,7 +318,7 @@ test.describe("Prop tests for Sidebar component", () => {
       .filter({ hasText: "Open First Sidebar" });
     const firstSidebar = sidebarPreview(page).first();
     await expect(firstButton).not.toBeFocused();
-    await expect(firstSidebar).not.toBeVisible();
+    await expect(firstSidebar).toBeHidden();
 
     await firstButton.click();
     await expect(firstSidebar).toBeVisible();
@@ -348,14 +348,14 @@ test.describe("Prop tests for Sidebar component", () => {
     const button = page.getByRole("button").filter({ hasText: "Open sidebar" });
     const sidebar = sidebarPreview(page);
     await expect(button).not.toBeFocused();
-    await expect(sidebar).not.toBeVisible();
+    await expect(sidebar).toBeHidden();
 
     await button.click();
     await expect(sidebar).toBeVisible();
     const closeButton = page.getByLabel("Close");
     await closeButton.click();
     await expect(button).not.toBeFocused();
-    await expect(sidebar).not.toBeVisible();
+    await expect(sidebar).toBeHidden();
   });
 
   test("should call onCancel callback when a click event is triggered", async ({
@@ -398,7 +398,7 @@ test.describe("Prop tests for Sidebar component", () => {
     const focusedElement = page.locator("*:focus");
     await focusedElement.press("Enter");
 
-    await expect(sidebarPreviewElement).not.toBeVisible();
+    await expect(sidebarPreviewElement).toBeHidden();
 
     await bodyElement.press("Tab");
     const DialogCloseIconButton = getComponent(page, "dialog").locator(

--- a/src/components/simple-color-picker/simple-color-picker.pw.tsx
+++ b/src/components/simple-color-picker/simple-color-picker.pw.tsx
@@ -342,7 +342,7 @@ test.describe("Check functionality for SimpleColorPicker component", () => {
 
       await expect(
         simpleColorPickerComponent(page).locator(`[data-element="${type}"]`),
-      ).not.toBeVisible();
+      ).toBeHidden();
       await expect(
         simpleColorDiv(page, 0).locator("..").locator(".."),
       ).toHaveCSS("outline-color", color);

--- a/src/components/step-sequence/step-sequence.pw.tsx
+++ b/src/components/step-sequence/step-sequence.pw.tsx
@@ -164,7 +164,7 @@ test.describe("Testing StepSequence component properties", () => {
       await mount(<StepSequenceItemCustom status={status} hideIndicator />);
       const expectedLabelChild =
         stepSequenceDataComponentItem(page).locator(ICON);
-      await expect(expectedLabelChild).not.toBeVisible();
+      await expect(expectedLabelChild).toBeHidden();
       await expect(stepSequenceDataComponentItem(page)).toHaveCSS(
         "color",
         color,

--- a/src/components/switch/switch.pw.tsx
+++ b/src/components/switch/switch.pw.tsx
@@ -92,13 +92,13 @@ test.describe("Prop tests for Switch component", () => {
       await mount(<SwitchComponent loading={boolVal} />);
 
       if (boolVal) {
-        await expect(switchInput(page)).not.toBeDisabled();
+        await expect(switchInput(page)).toBeEnabled();
 
         await expect(
           getDataRoleByValue(page, "switch-slider-loader"),
         ).toBeVisible();
       } else {
-        await expect(switchInput(page)).not.toBeDisabled();
+        await expect(switchInput(page)).toBeEnabled();
       }
     });
   });
@@ -154,9 +154,9 @@ test.describe("Prop tests for Switch component", () => {
 
         await expect(switchLabel(page)).toBeDisabled();
       } else {
-        await expect(switchInput(page)).not.toBeDisabled();
+        await expect(switchInput(page)).toBeEnabled();
 
-        await expect(switchLabel(page)).not.toBeDisabled();
+        await expect(switchLabel(page)).toBeEnabled();
       }
     });
   });

--- a/src/components/tabs/tabs.pw.tsx
+++ b/src/components/tabs/tabs.pw.tsx
@@ -356,7 +356,7 @@ test.describe("Tabs component", () => {
       await expect(icon).toBeVisible();
 
       await getDataElementByValue(page, "foo-button").click();
-      await expect(icon).not.toBeVisible();
+      await expect(icon).toBeHidden();
     });
   });
 
@@ -366,7 +366,7 @@ test.describe("Tabs component", () => {
   }) => {
     await mount(<TabsValidationOverride />);
 
-    await expect(tabById(page, 1).locator(ICON)).not.toBeVisible();
+    await expect(tabById(page, 1).locator(ICON)).toBeHidden();
     await expect(page.getByText("Tab 1", { exact: true })).toHaveCSS(
       "outline-color",
       "rgba(0, 0, 0, 0.9)",
@@ -526,7 +526,7 @@ test.describe("Tabs component", () => {
       await checkAccessibility(page);
     });
 
-    test("should pass accessibility tests when position is left and size is large ", async ({
+    test("should pass accessibility tests when position is left and size is large", async ({
       mount,
       page,
     }) => {
@@ -708,7 +708,7 @@ test.describe("Tabs component", () => {
     await page.getByRole("button").click();
 
     await expect(page.getByText("Content for tab 2")).toBeVisible();
-    await expect(page.getByText("Content for tab 1")).not.toBeVisible();
+    await expect(page.getByText("Content for tab 1")).toBeHidden();
   });
 
   test("navigation buttons only appear when there are preceding or succeeding tab titles out of view", async ({

--- a/src/components/text-editor/text-editor.pw.tsx
+++ b/src/components/text-editor/text-editor.pw.tsx
@@ -121,10 +121,10 @@ test.describe("Prop tests", () => {
     test(`value of 0`, async ({ mount, page }) => {
       await mount(<TextEditorDefaultComponent characterLimit={0} />);
 
-      const displayedLimit = await page
-        .locator("div[data-role='pw-rte-character-limit']")
-        .isVisible();
-      expect(displayedLimit).toBe(false);
+      const displayedLimit = page.locator(
+        "div[data-role='pw-rte-character-limit']",
+      );
+      await expect(displayedLimit).toBeHidden();
     });
 
     [
@@ -136,10 +136,10 @@ test.describe("Prop tests", () => {
         await mount(
           <TextEditorDefaultComponent characterLimit={characterLimit} />,
         );
-        let displayedLimit = await page
-          .locator("div[data-role='pw-rte-character-limit']")
-          .textContent();
-        expect(displayedLimit).toBe(`${text} characters remaining`);
+        let displayedLimit = page.locator(
+          "div[data-role='pw-rte-character-limit']",
+        );
+        await expect(displayedLimit).toHaveText(`${text} characters remaining`);
 
         const stringToType = "a".repeat(characterLimit);
 
@@ -153,20 +153,20 @@ test.describe("Prop tests", () => {
         // eslint-disable-next-line playwright/no-wait-for-timeout
         await page.waitForTimeout(3000);
 
-        displayedLimit = await page
-          .locator("div[data-role='pw-rte-character-limit']")
-          .textContent();
-        expect(displayedLimit).toBe(`0 characters remaining`);
+        displayedLimit = page.locator(
+          "div[data-role='pw-rte-character-limit']",
+        );
+        await expect(displayedLimit).toHaveText(`0 characters remaining`);
 
         await textbox.fill(`${stringToType}1`);
 
         // eslint-disable-next-line playwright/no-wait-for-timeout
         await page.waitForTimeout(3000);
 
-        displayedLimit = await page
-          .locator("div[data-role='pw-rte-character-limit']")
-          .textContent();
-        expect(displayedLimit).toBe(`0 characters remaining`);
+        displayedLimit = page.locator(
+          "div[data-role='pw-rte-character-limit']",
+        );
+        await expect(displayedLimit).toHaveText(`0 characters remaining`);
 
         const displayedWarning = page.getByTestId("pw-rte-validation-message");
         await expect(displayedWarning).toHaveText(
@@ -458,10 +458,8 @@ test.describe("Prop tests", () => {
   test.describe("inputHint", () => {
     test(`value of 'hint'`, async ({ mount, page }) => {
       await mount(<TextEditorDefaultComponent inputHint="hint" />);
-      const hint = await page
-        .locator(`div[data-role='hint-text']`)
-        .textContent();
-      expect(hint).toBe("hint");
+      const hint = page.locator(`div[data-role='hint-text']`);
+      await expect(hint).toHaveText("hint");
     });
 
     test(`value not provided`, async ({ mount, page }) => {
@@ -475,10 +473,8 @@ test.describe("Prop tests", () => {
     [{ value: "Text Editor" }].forEach(({ value }) => {
       test(`value of ${value}`, async ({ mount, page }) => {
         await mount(<TextEditorDefaultComponent labelText={value} />);
-        const editorLabel = await page
-          .locator("label[data-element='label']")
-          .textContent();
-        expect(editorLabel).toBe(value);
+        const editorLabel = page.locator("label[data-element='label']");
+        await expect(editorLabel).toHaveText(value);
       });
     });
   });
@@ -487,10 +483,10 @@ test.describe("Prop tests", () => {
     [undefined, "Enter text here"].forEach((placeholder) => {
       test(`value of ${placeholder}`, async ({ mount, page }) => {
         await mount(<TextEditorDefaultComponent placeholder={placeholder} />);
-        const displayedPlaceholder = await page
-          .locator("div[data-role='pw-rte-placeholder']")
-          .textContent();
-        expect(displayedPlaceholder).toBe(placeholder || "");
+        const displayedPlaceholder = page.locator(
+          "div[data-role='pw-rte-placeholder']",
+        );
+        await expect(displayedPlaceholder).toHaveText(placeholder || "");
       });
     });
   });
@@ -545,30 +541,32 @@ test.describe("Prop tests", () => {
       await mount(
         <TextEditorDefaultComponent initialValue={preformattedValue} />,
       );
-      const defaultText = await page.locator("p").textContent();
-      expect(defaultText).toBe("Sample text with some formatting applied.");
+      const defaultText = page.locator("p");
+      await expect(defaultText).toHaveText(
+        "Sample text with some formatting applied.",
+      );
 
-      const normalText = await page.locator("p> span").nth(0).textContent();
-      expect(normalText).toBe("Sample text with ");
-      const boldText = await page.locator("p > strong").textContent();
-      expect(boldText).toBe("some formatting");
-      const italicText = await page.locator("p > em").textContent();
-      expect(italicText).toBe("applied");
+      const normalText = page.locator("p> span").nth(0);
+      await expect(normalText).toHaveText("Sample text with ");
+      const boldText = page.locator("p > strong");
+      await expect(boldText).toHaveText("some formatting");
+      const italicText = page.locator("p > em");
+      await expect(italicText).toHaveText("applied");
 
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
       await textbox.click();
       await textbox.pressSequentially(" This is added text", { delay: 100 });
 
-      const updatedText = await page.locator("p").textContent();
-      expect(updatedText).toBe(
+      const updatedText = page.locator("p");
+      await expect(updatedText).toHaveText(
         "Sample text with some formatting applied. This is added text",
       );
 
       await textbox.press("Enter");
       await textbox.pressSequentially("New line text", { delay: 100 });
 
-      const newParagraph = await page.locator("p").nth(1).textContent();
-      expect(newParagraph).toBe("New line text");
+      const newParagraph = page.locator("p").nth(1);
+      await expect(newParagraph).toHaveText("New line text");
     });
   });
 
@@ -599,21 +597,19 @@ test.describe("Prop tests", () => {
       _.dispatchEvent(event);
     }, textToPaste);
 
-    const displayedLimitAfterPastingText = await page
-      .getByTestId("pw-rte-character-limit")
-      .textContent();
-
-    expect(displayedLimitAfterPastingText).toBe(
+    const displayedLimitAfterPastingText = page.getByTestId(
+      "pw-rte-character-limit",
+    );
+    await expect(displayedLimitAfterPastingText).toHaveText(
       `${remainingCharactersAfterPasting} characters remaining`,
     );
 
     await page.keyboard.type(textToType);
 
-    const displayedLimitAfterKeyboardUpdate = await page
-      .getByTestId("pw-rte-character-limit")
-      .textContent();
-
-    expect(displayedLimitAfterKeyboardUpdate).toBe(
+    const displayedLimitAfterKeyboardUpdate = page.getByTestId(
+      "pw-rte-character-limit",
+    );
+    await expect(displayedLimitAfterKeyboardUpdate).toHaveText(
       `${remainingCharsAfterTyping} characters remaining`,
     );
   });
@@ -645,21 +641,19 @@ test.describe("Prop tests", () => {
       _.dispatchEvent(event);
     }, textToPaste);
 
-    const displayedWarningAfterPastingText = await page
-      .getByTestId("pw-rte-validation-message")
-      .textContent();
-
-    expect(displayedWarningAfterPastingText).toBe(
+    const displayedWarningAfterPastingText = page.getByTestId(
+      "pw-rte-validation-message",
+    );
+    await expect(displayedWarningAfterPastingText).toHaveText(
       `You are ${charactersLimit} character(s) over the character limit`,
     );
 
     await page.keyboard.type(textToType);
 
-    const displayedWarningAfterKeyboardUpdate = await page
-      .getByTestId("pw-rte-validation-message")
-      .textContent();
-
-    expect(displayedWarningAfterKeyboardUpdate).toBe(
+    const displayedWarningAfterKeyboardUpdate = page.getByTestId(
+      "pw-rte-validation-message",
+    );
+    await expect(displayedWarningAfterKeyboardUpdate).toHaveText(
       `You are ${charactersLimitAfterTyping} character(s) over the character limit`,
     );
   });
@@ -669,9 +663,7 @@ test.describe("Prop tests", () => {
     page,
   }) => {
     await mount(<TextEditorDefaultComponent m={2} />);
-    const textEditorWrapper = await page.locator(
-      `div[data-component='text-editor']`,
-    );
+    const textEditorWrapper = page.locator(`div[data-component='text-editor']`);
     await expect(textEditorWrapper).toHaveCSS("margin", "16px");
   });
 
@@ -680,9 +672,7 @@ test.describe("Prop tests", () => {
     page,
   }) => {
     await mount(<TextEditorDefaultComponent m="16px" />);
-    const textEditorWrapper = await page.locator(
-      `div[data-component='text-editor']`,
-    );
+    const textEditorWrapper = page.locator(`div[data-component='text-editor']`);
     await expect(textEditorWrapper).toHaveCSS("margin", "16px");
   });
 });
@@ -699,15 +689,17 @@ test.describe("Functionality tests", () => {
           onCancel={() => {}}
         />,
       );
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
       await textbox.click();
       await textbox.pressSequentially(" This is some text", { delay: 100 });
       const cancelButton = page.locator(
         "button[data-role='pw-rte-cancel-button']",
       );
       await cancelButton.click();
-      const displayedText = await textbox.textContent();
-      expect(displayedText).toBe("Sample text with some formatting applied.");
+      const displayedText = textbox;
+      await expect(displayedText).toHaveText(
+        "Sample text with some formatting applied.",
+      );
     });
   });
 
@@ -722,7 +714,7 @@ test.describe("Functionality tests", () => {
           }}
         />,
       );
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
       await textbox.click();
       await textbox.pressSequentially(" This is some text", { delay: 100 });
 
@@ -753,7 +745,7 @@ test.describe("Functionality tests", () => {
           }}
         />,
       );
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
       await textbox.click();
       await textbox.pressSequentially(" This is some text", { delay: 100 });
 
@@ -812,7 +804,7 @@ test.describe("Functionality tests", () => {
           }}
         />,
       );
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
       await textbox.click();
       expect(currentValue).toBe(true);
     });
@@ -832,13 +824,11 @@ test.describe("Functionality tests", () => {
         />,
       );
 
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
       await textbox.click();
       await textbox.pressSequentially("This is some text", { delay: 100 });
 
-      const saveButton = await page.locator(
-        "button[data-role='pw-rte-save-button']",
-      );
+      const saveButton = page.locator("button[data-role='pw-rte-save-button']");
       await saveButton.click();
       expect(_htmlString).not.toBeNull();
       expect(_json).not.toBeNull();
@@ -888,14 +878,12 @@ test.describe("Functionality tests", () => {
       await mount(
         <TextEditorDefaultComponent initialValue={unformattedValue} />,
       );
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
       await textbox.selectText();
-      const boldButton = await page.locator(
-        "button[data-role='pw-rte-bold-button']",
-      );
+      const boldButton = page.locator("button[data-role='pw-rte-bold-button']");
       await boldButton.click();
-      const boldText = await page.locator("strong").textContent();
-      expect(boldText).toBe("This text needs formatting");
+      const boldText = page.locator("strong");
+      await expect(boldText).toHaveText("This text needs formatting");
       await textbox.selectText();
       await boldButton.click();
       expect(await page.locator("strong").count()).toBe(0);
@@ -909,7 +897,7 @@ test.describe("Functionality tests", () => {
         <TextEditorDefaultComponent initialValue={unformattedValue} />,
       );
 
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
 
       expect(await page.locator("strong").count()).toBe(0);
       expect(await page.locator("span[data-lexical-text='true']").count()).toBe(
@@ -918,9 +906,7 @@ test.describe("Functionality tests", () => {
 
       await textbox.click();
 
-      const boldButton = await page.locator(
-        "button[data-role='pw-rte-bold-button']",
-      );
+      const boldButton = page.locator("button[data-role='pw-rte-bold-button']");
 
       await boldButton.click();
       await textbox.click();
@@ -954,14 +940,14 @@ test.describe("Functionality tests", () => {
       await mount(
         <TextEditorDefaultComponent initialValue={unformattedValue} />,
       );
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
       await textbox.selectText();
-      const italicButton = await page.locator(
+      const italicButton = page.locator(
         "button[data-role='pw-rte-italic-button']",
       );
       await italicButton.click();
-      const italicText = await page.locator("em").textContent();
-      expect(italicText).toBe("This text needs formatting");
+      const italicText = page.locator("em");
+      await expect(italicText).toHaveText("This text needs formatting");
       await textbox.selectText();
       await italicButton.click();
       expect(await page.locator("em").count()).toBe(0);
@@ -975,7 +961,7 @@ test.describe("Functionality tests", () => {
         <TextEditorDefaultComponent initialValue={unformattedValue} />,
       );
 
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
 
       expect(await page.locator("em").count()).toBe(0);
       expect(await page.locator("span[data-lexical-text='true']").count()).toBe(
@@ -984,7 +970,7 @@ test.describe("Functionality tests", () => {
 
       await textbox.click();
 
-      const italicButton = await page.locator(
+      const italicButton = page.locator(
         "button[data-role='pw-rte-italic-button']",
       );
 
@@ -1020,14 +1006,14 @@ test.describe("Functionality tests", () => {
       await mount(
         <TextEditorDefaultComponent initialValue={unformattedValue} />,
       );
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
       await textbox.selectText();
-      const orderedListButton = await page.locator(
+      const orderedListButton = page.locator(
         "button[data-role='pw-rte-ordered-list-button']",
       );
       await orderedListButton.click();
-      const orderedList = await page.locator("ol").textContent();
-      expect(orderedList).toBe("This text needs formatting");
+      const orderedList = page.locator("ol");
+      await expect(orderedList).toHaveText("This text needs formatting");
       await orderedListButton.click();
       expect(await page.locator("ol").count()).toBe(0);
     });
@@ -1041,14 +1027,14 @@ test.describe("Functionality tests", () => {
       await mount(
         <TextEditorDefaultComponent initialValue={unformattedValue} />,
       );
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
       await textbox.selectText();
-      const unorderedListButton = await page.locator(
+      const unorderedListButton = page.locator(
         "button[data-role='pw-rte-unordered-list-button']",
       );
       await unorderedListButton.click();
-      const unorderedList = await page.locator("ul").textContent();
-      expect(unorderedList).toBe("This text needs formatting");
+      const unorderedList = page.locator("ul");
+      await expect(unorderedList).toHaveText("This text needs formatting");
       await unorderedListButton.click();
       expect(await page.locator("ul").count()).toBe(0);
     });
@@ -1069,7 +1055,7 @@ test.describe("Events tests", () => {
           }}
         />,
       );
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
       await textbox.click();
       await textbox.fill("https://www.");
       await textbox.press("g");
@@ -1089,7 +1075,7 @@ test.describe("Events tests", () => {
         await mount(
           <TextEditorDefaultComponent initialValue={unformattedValue} />,
         );
-        const textbox = await page.locator("div[role='textbox']");
+        const textbox = page.locator("div[role='textbox']");
         await textbox.selectText();
         await page.keyboard.press("ControlOrMeta+B");
         expect(await page.locator("strong").count()).toBe(1);
@@ -1102,7 +1088,7 @@ test.describe("Events tests", () => {
         page,
       }) => {
         await mount(<TextEditorDefaultComponent />);
-        const textbox = await page.locator("div[role='textbox']");
+        const textbox = page.locator("div[role='textbox']");
         await textbox.click();
         await textbox.pressSequentially("**", { delay: 100 });
         expect(await page.locator("strong").count()).toBe(0);
@@ -1118,7 +1104,7 @@ test.describe("Events tests", () => {
         await mount(
           <TextEditorDefaultComponent initialValue={unformattedValue} />,
         );
-        const textbox = await page.locator("div[role='textbox']");
+        const textbox = page.locator("div[role='textbox']");
         await textbox.selectText();
         await page.keyboard.press("ControlOrMeta+I");
         expect(await page.locator("em").count()).toBe(1);
@@ -1131,7 +1117,7 @@ test.describe("Events tests", () => {
         page,
       }) => {
         await mount(<TextEditorDefaultComponent />);
-        const textbox = await page.locator("div[role='textbox']");
+        const textbox = page.locator("div[role='textbox']");
         await textbox.click();
         await textbox.pressSequentially("*", { delay: 100 });
         expect(await page.locator("em").count()).toBe(0);
@@ -1150,7 +1136,7 @@ test.describe("Events tests", () => {
         await mount(
           <TextEditorDefaultComponent initialValue={unformattedValue} />,
         );
-        const textbox = await page.locator("div[role='textbox']");
+        const textbox = page.locator("div[role='textbox']");
         await textbox.click();
         await textbox.press("Home");
         expect(await page.locator("ul").count()).toBe(0);
@@ -1170,7 +1156,7 @@ test.describe("Events tests", () => {
       await mount(
         <TextEditorDefaultComponent initialValue={unformattedValue} />,
       );
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
       await textbox.click();
       await textbox.press("Home");
       expect(await page.locator("ol").count()).toBe(0);
@@ -1187,7 +1173,7 @@ test.describe("Events tests", () => {
       page,
     }) => {
       await mount(<TextEditorDefaultComponent />);
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
       await textbox.click();
       await textbox.pressSequentially(">", { delay: 100 });
       expect(await page.locator("blockquote").count()).toBe(0);
@@ -1208,7 +1194,7 @@ test.describe("Events tests", () => {
         page,
       }) => {
         await mount(<TextEditorDefaultComponent />);
-        const textbox = await page.locator("div[role='textbox']");
+        const textbox = page.locator("div[role='textbox']");
         await textbox.click();
         expect(await page.locator(tag).count()).toBe(0);
         await textbox.pressSequentially(`${headingChar} `, { delay: 100 });
@@ -1225,7 +1211,7 @@ test.describe("Events tests", () => {
       page,
     }) => {
       await mount(<TextEditorDefaultComponent />);
-      const textbox = await page.locator("div[role='textbox']");
+      const textbox = page.locator("div[role='textbox']");
       await textbox.click();
       await textbox.pressSequentially("[Link text](https://www.sage.com)", {
         delay: 100,
@@ -1251,7 +1237,7 @@ test.describe("Styling tests", () => {
       }) => {
         await mount(<TextEditorDefaultComponent rows={rows} />);
         await expect(
-          await page.locator("div[data-role='pw-rte-editable']"),
+          page.locator("div[data-role='pw-rte-editable']"),
         ).toHaveCSS("min-height", `${expectedHeight}px`);
       });
     });

--- a/src/components/textarea/textarea.pw.tsx
+++ b/src/components/textarea/textarea.pw.tsx
@@ -300,7 +300,7 @@ test.describe("Props tests for Textarea component", () => {
     const visuallyHiddenCharacterCountElement =
       visuallyHiddenCharacterCount(page);
 
-    await expect(visuallyHiddenCharacterCountElement).not.toBeVisible();
+    await expect(visuallyHiddenCharacterCountElement).toBeHidden();
   });
 
   test("visually hidden hint of 5 should be rendered", async ({
@@ -322,7 +322,7 @@ test.describe("Props tests for Textarea component", () => {
 
     const visuallyHiddenHintElement = visuallyHiddenHint(page);
 
-    await expect(visuallyHiddenHintElement).not.toBeVisible();
+    await expect(visuallyHiddenHintElement).toBeHidden();
   });
 
   ["10%", "30%", "50%", "80%", "100%"].forEach((maxWidth) => {

--- a/src/components/tile-select/tile-select.pw.tsx
+++ b/src/components/tile-select/tile-select.pw.tsx
@@ -224,7 +224,7 @@ test.describe("check props for TileSelect component", () => {
       "tile-select-accordion-content",
     ).locator("..");
 
-    await expect(tileSelectAccordionChildren).not.toBeVisible();
+    await expect(tileSelectAccordionChildren).toBeHidden();
   });
 
   test("should check when accordionExpanded set as true", async ({

--- a/src/components/time/time.pw.tsx
+++ b/src/components/time/time.pw.tsx
@@ -437,7 +437,7 @@ test.describe("Time component", () => {
     });
   });
 
-  test.describe("Accessibility tests ", () => {
+  test.describe("Accessibility tests", () => {
     test("should pass for default implementation", async ({ mount, page }) => {
       await mount(
         <TimeComponent

--- a/src/components/toast/toast.pw.tsx
+++ b/src/components/toast/toast.pw.tsx
@@ -47,7 +47,7 @@ test.describe("Toast component", () => {
 
     await page.keyboard.press("Escape");
 
-    await expect(toastComponent(page)).not.toBeVisible();
+    await expect(toastComponent(page)).toBeHidden();
   });
 
   test("should render with focus", async ({ mount, page }) => {
@@ -110,7 +110,7 @@ test.describe("Toast component", () => {
       if (boolVal) {
         await expect(toastComponent(page)).toBeVisible();
       } else {
-        await expect(toastComponent(page)).not.toBeVisible();
+        await expect(toastComponent(page)).toBeHidden();
       }
     });
   });
@@ -121,7 +121,7 @@ test.describe("Toast component", () => {
   }) => {
     await mount(<ToastComponent timeout={1} />);
 
-    await expect(toastComponent(page)).not.toBeVisible();
+    await expect(toastComponent(page)).toBeHidden();
   });
 
   test("should render with targetPortalId prop", async ({ mount, page }) => {
@@ -191,7 +191,7 @@ test.describe("Toast component", () => {
     const closeIconToast = closeIconButton(page).nth(0);
     await closeIconToast.click();
 
-    await expect(toastComponent(page)).not.toBeVisible();
+    await expect(toastComponent(page)).toBeHidden();
   });
 
   test("should render with expected border radius", async ({ mount, page }) => {
@@ -232,7 +232,7 @@ test.describe("check events for Toast component", () => {
     );
     await page.keyboard.press("Escape");
 
-    await expect(page.getByText("Toast")).not.toBeVisible();
+    await expect(page.getByText("Toast")).toBeHidden();
     expect(callbackCount).toBe(1);
   });
 });

--- a/src/components/tooltip/tooltip.pw.tsx
+++ b/src/components/tooltip/tooltip.pw.tsx
@@ -61,7 +61,7 @@ test.describe("Tooltip component", () => {
   }) => {
     await mount(<TooltipComponent isVisible={false} />);
 
-    await expect(getDataElementByValue(page, "tooltip")).not.toBeVisible();
+    await expect(getDataElementByValue(page, "tooltip")).toBeHidden();
   });
 
   (
@@ -308,7 +308,7 @@ test.describe("Tooltip component", () => {
   }) => {
     await mount(<UncontrolledTooltipComponent />);
 
-    await expect(getDataElementByValue(page, "tooltip")).not.toBeVisible();
+    await expect(getDataElementByValue(page, "tooltip")).toBeHidden();
     const buttonElement = page.getByRole("button");
     await buttonElement.hover();
     await expect(getDataElementByValue(page, "tooltip")).toBeVisible();
@@ -320,12 +320,12 @@ test.describe("Tooltip component", () => {
   }) => {
     await mount(<UncontrolledTooltipComponent />);
 
-    await expect(getDataElementByValue(page, "tooltip")).not.toBeVisible();
+    await expect(getDataElementByValue(page, "tooltip")).toBeHidden();
     const buttonElement = page.getByRole("button");
     await buttonElement.hover();
     await expect(getDataElementByValue(page, "tooltip")).toBeVisible();
     await page.mouse.move(100, 100);
-    await expect(getDataElementByValue(page, "tooltip")).not.toBeVisible();
+    await expect(getDataElementByValue(page, "tooltip")).toBeHidden();
   });
 
   test(`should show tooltip when target is focused`, async ({
@@ -334,7 +334,7 @@ test.describe("Tooltip component", () => {
   }) => {
     await mount(<UncontrolledTooltipComponent />);
 
-    await expect(getDataElementByValue(page, "tooltip")).not.toBeVisible();
+    await expect(getDataElementByValue(page, "tooltip")).toBeHidden();
     const buttonElement = page.getByRole("button");
     await buttonElement.focus();
     await expect(getDataElementByValue(page, "tooltip")).toBeVisible();
@@ -346,12 +346,12 @@ test.describe("Tooltip component", () => {
   }) => {
     await mount(<UncontrolledTooltipComponent />);
 
-    await expect(getDataElementByValue(page, "tooltip")).not.toBeVisible();
+    await expect(getDataElementByValue(page, "tooltip")).toBeHidden();
     const buttonElement = page.getByRole("button");
     await buttonElement.focus();
     await expect(getDataElementByValue(page, "tooltip")).toBeVisible();
     await buttonElement.blur();
-    await expect(getDataElementByValue(page, "tooltip")).not.toBeVisible();
+    await expect(getDataElementByValue(page, "tooltip")).toBeHidden();
   });
 
   test(`new tooltip target should still trigger tooltip visibility`, async ({
@@ -365,13 +365,13 @@ test.describe("Tooltip component", () => {
     await buttonElement.hover();
     await expect(getDataElementByValue(page, "tooltip")).toBeVisible();
     await page.mouse.move(100, 100);
-    await expect(getDataElementByValue(page, "tooltip")).not.toBeVisible();
+    await expect(getDataElementByValue(page, "tooltip")).toBeHidden();
     await page.getByText("Change target").click();
     await expect(buttonElement).toHaveText("Secondary target");
     await buttonElement.hover();
     await expect(getDataElementByValue(page, "tooltip")).toBeVisible();
     await page.mouse.move(100, 100);
-    await expect(getDataElementByValue(page, "tooltip")).not.toBeVisible();
+    await expect(getDataElementByValue(page, "tooltip")).toBeHidden();
   });
 
   test(`should have the expected border radius styling`, async ({

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.pw.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.pw.tsx
@@ -37,8 +37,8 @@ test.describe("functional tests", () => {
       );
       await expect(responsiveVerticalMenuLauncher(page)).toBeVisible();
       await responsiveVerticalMenuLauncher(page).click();
-      await expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
-      await expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
+      expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
+      expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
 
       await assertCssValueIsApproximately(
         responsiveVerticalMenuPrimary(page),
@@ -60,8 +60,8 @@ test.describe("functional tests", () => {
 
       await expect(responsiveVerticalMenuLauncher(page)).toBeVisible();
       await responsiveVerticalMenuLauncher(page).click();
-      await expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
-      await expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
+      expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
+      expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
 
       await expect(responsiveVerticalMenuPrimary(page)).toHaveAttribute(
         "height",
@@ -83,12 +83,12 @@ test.describe("functional tests", () => {
 
     await expect(responsiveVerticalMenuLauncher(page)).toBeVisible();
     await responsiveVerticalMenuLauncher(page).click();
-    await expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
-    await expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
+    expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
+    expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
 
-    const iconMenuItem = await page.getByText("Primary Icon");
-    const iconlessMenuItem = await page.getByText("Primary No Icon");
-    const customIconMenuItem = await page.getByText("Primary Custom Icon");
+    const iconMenuItem = page.getByText("Primary Icon");
+    const iconlessMenuItem = page.getByText("Primary No Icon");
+    const customIconMenuItem = page.getByText("Primary Custom Icon");
 
     const clientOffsetIconMenuItem = await iconMenuItem.evaluate((el) => {
       return el.getBoundingClientRect().x;
@@ -108,23 +108,21 @@ test.describe("functional tests", () => {
     // for a marginal difference in the x position of the menu items,
     // as the icon may be slightly different in size/position
     // depending on the browser, icon used, etc..
-    await expect(clientOffsetIconMenuItem).toBeGreaterThanOrEqual(29);
-    await expect(clientOffsetIconMenuItem).toBeLessThanOrEqual(33);
+    expect(clientOffsetIconMenuItem).toBeGreaterThanOrEqual(29);
+    expect(clientOffsetIconMenuItem).toBeLessThanOrEqual(33);
     // expect extra 40px offset for icon
-    await expect(clientOffsetIconlessMenuItem).toBeGreaterThanOrEqual(29);
-    await expect(clientOffsetIconlessMenuItem).toBeLessThanOrEqual(33);
+    expect(clientOffsetIconlessMenuItem).toBeGreaterThanOrEqual(29);
+    expect(clientOffsetIconlessMenuItem).toBeLessThanOrEqual(33);
 
-    await expect(clientOffsetCustomIconMenuItem).toBeGreaterThanOrEqual(29);
-    await expect(clientOffsetCustomIconMenuItem).toBeLessThanOrEqual(33);
+    expect(clientOffsetCustomIconMenuItem).toBeGreaterThanOrEqual(29);
+    expect(clientOffsetCustomIconMenuItem).toBeLessThanOrEqual(33);
 
     await page.locator("[id='secondary-menu-toggle']").click();
-    await expect(responsiveVerticalMenuSecondary(page)).toBeDefined();
+    expect(responsiveVerticalMenuSecondary(page)).toBeDefined();
 
-    const secondaryIconMenuItem = await page.getByText("Secondary Icon");
-    const secondaryIconlessMenuItem = await page.getByText("Secondary No Icon");
-    const secondaryCustomIconMenuItem = await page.getByText(
-      "Secondary Custom Icon",
-    );
+    const secondaryIconMenuItem = page.getByText("Secondary Icon");
+    const secondaryIconlessMenuItem = page.getByText("Secondary No Icon");
+    const secondaryCustomIconMenuItem = page.getByText("Secondary Custom Icon");
 
     const clientOffsetSecondaryIconMenuItem =
       await secondaryIconMenuItem.evaluate((el) => {
@@ -139,30 +137,20 @@ test.describe("functional tests", () => {
         return el.getBoundingClientRect().x;
       });
 
-    await expect(clientOffsetSecondaryIconMenuItem).toBeGreaterThanOrEqual(404);
-    await expect(clientOffsetSecondaryIconMenuItem).toBeLessThanOrEqual(408);
+    expect(clientOffsetSecondaryIconMenuItem).toBeGreaterThanOrEqual(404);
+    expect(clientOffsetSecondaryIconMenuItem).toBeLessThanOrEqual(408);
 
-    await expect(clientOffsetSecondaryIconlessMenuItem).toBeGreaterThanOrEqual(
-      404,
-    );
-    await expect(clientOffsetSecondaryIconlessMenuItem).toBeLessThanOrEqual(
-      408,
-    );
-    await expect(
-      clientOffsetSecondaryCustomIconMenuItem,
-    ).toBeGreaterThanOrEqual(404);
-    await expect(clientOffsetSecondaryCustomIconMenuItem).toBeLessThanOrEqual(
-      408,
-    );
+    expect(clientOffsetSecondaryIconlessMenuItem).toBeGreaterThanOrEqual(404);
+    expect(clientOffsetSecondaryIconlessMenuItem).toBeLessThanOrEqual(408);
+    expect(clientOffsetSecondaryCustomIconMenuItem).toBeGreaterThanOrEqual(404);
+    expect(clientOffsetSecondaryCustomIconMenuItem).toBeLessThanOrEqual(408);
 
     await page.locator("[id='tertiary-menu-toggle']").click();
     await expect(responsiveVerticalMenuNthSecondaryItem(page, 0)).toBeVisible();
 
-    const tertiaryIconMenuItem = await page.getByText("Tertiary Icon");
-    const tertiaryIconlessMenuItem = await page.getByText("Tertiary No Icon");
-    const tertiaryCustomIconMenuItem = await page.getByText(
-      "Tertiary Custom Icon",
-    );
+    const tertiaryIconMenuItem = page.getByText("Tertiary Icon");
+    const tertiaryIconlessMenuItem = page.getByText("Tertiary No Icon");
+    const tertiaryCustomIconMenuItem = page.getByText("Tertiary Custom Icon");
 
     const clientOffsetTertiaryIconMenuItem =
       await tertiaryIconMenuItem.evaluate((el) => {
@@ -177,20 +165,14 @@ test.describe("functional tests", () => {
         return el.getBoundingClientRect().x;
       });
 
-    await expect(clientOffsetTertiaryIconMenuItem).toBeGreaterThanOrEqual(437);
-    await expect(clientOffsetTertiaryIconMenuItem).toBeLessThanOrEqual(441);
+    expect(clientOffsetTertiaryIconMenuItem).toBeGreaterThanOrEqual(437);
+    expect(clientOffsetTertiaryIconMenuItem).toBeLessThanOrEqual(441);
 
-    await expect(clientOffsetTertiaryIconlessMenuItem).toBeGreaterThanOrEqual(
-      437,
-    );
-    await expect(clientOffsetTertiaryIconlessMenuItem).toBeLessThanOrEqual(441);
+    expect(clientOffsetTertiaryIconlessMenuItem).toBeGreaterThanOrEqual(437);
+    expect(clientOffsetTertiaryIconlessMenuItem).toBeLessThanOrEqual(441);
 
-    await expect(clientOffsetTertiaryCustomIconMenuItem).toBeGreaterThanOrEqual(
-      437,
-    );
-    await expect(clientOffsetTertiaryCustomIconMenuItem).toBeLessThanOrEqual(
-      441,
-    );
+    expect(clientOffsetTertiaryCustomIconMenuItem).toBeGreaterThanOrEqual(437);
+    expect(clientOffsetTertiaryCustomIconMenuItem).toBeLessThanOrEqual(441);
   });
 });
 
@@ -373,8 +355,8 @@ test.describe("accessibility tests", () => {
 
     await expect(responsiveVerticalMenuLauncher(page)).toBeVisible();
     await responsiveVerticalMenuLauncher(page).click();
-    await expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
-    await expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
+    expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
+    expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
 
     await checkAccessibility(page);
   });
@@ -387,8 +369,8 @@ test.describe("accessibility tests", () => {
 
     await expect(responsiveVerticalMenuLauncher(page)).toBeVisible();
     await responsiveVerticalMenuLauncher(page).click();
-    await expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
-    await expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
+    expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
+    expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
     await expect(responsiveVerticalMenuNthPrimaryItem(page, 0)).toBeVisible();
 
     await page.locator("[id='primary-menu']").click();
@@ -405,8 +387,8 @@ test.describe("accessibility tests", () => {
 
     await expect(responsiveVerticalMenuLauncher(page)).toBeVisible();
     await responsiveVerticalMenuLauncher(page).click();
-    await expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
-    await expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
+    expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
+    expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
     await expect(responsiveVerticalMenuNthPrimaryItem(page, 0)).toBeVisible();
 
     await page.locator("[id='primary-menu']").click();
@@ -424,8 +406,8 @@ test.describe("accessibility tests", () => {
 
     await expect(responsiveVerticalMenuLauncher(page)).toBeVisible();
     await responsiveVerticalMenuLauncher(page).click();
-    await expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
-    await expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
+    expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
+    expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
 
     await page.locator("[id='primary-menu']").click();
     await page.locator("[id='secondary-menu']").click();

--- a/src/components/vertical-menu/vertical-menu.pw.tsx
+++ b/src/components/vertical-menu/vertical-menu.pw.tsx
@@ -289,7 +289,7 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
 
     await page.keyboard.press("Escape");
 
-    await expect(verticalMenu).not.toBeVisible();
+    await expect(verticalMenu).toBeHidden();
   });
 
   test(`should render Vertical Menu Full Screen with isOpen prop`, async ({
@@ -328,7 +328,7 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
 
     const item = page.getByRole("button").filter({ hasText: "Menu" });
     await expect(item).not.toBeFocused();
-    await expect(verticalMenuFullScreen(page)).not.toBeVisible();
+    await expect(verticalMenuFullScreen(page)).toBeHidden();
 
     await item.click();
     await waitForAnimationEnd(verticalMenuFullScreen(page));
@@ -672,14 +672,5 @@ test.describe("should check the accessibility tests", () => {
     await mount(<VerticalMenuFullScreenCustom isOpen />);
 
     await checkAccessibility(page);
-  });
-});
-
-test.describe("href redirect", () => {
-  // this test must be last in the test suite as the navigation to a new page messes up any later tests
-  test(`should navigate to the children href`, async ({ mount, page }) => {
-    await mount(<VerticalMenuDefaultComponent />);
-
-    await verticalMenuItem(page).nth(1).click();
   });
 });

--- a/src/style/style.test.ts
+++ b/src/style/style.test.ts
@@ -1,108 +1,102 @@
 import config from "./color-config";
 import mix from "./utils/mix";
-import generatePalette, { PaletteFunction } from "./palette";
-
-const assertCorrectColorMix = (
-  colorConfig: Record<string, string>,
-  paletteObject: Record<string, PaletteFunction>,
-) => {
-  Object.keys(colorConfig).forEach((color) => {
-    const match = color.match(/([a-z]+)([\d]{0,2})/i);
-
-    const func = match![1];
-
-    const weight = Number(match![2]);
-
-    expect(paletteObject[func](weight)).toEqual(`#${colorConfig[color]}`);
-  });
-};
+import generatePalette from "./palette";
 
 describe("style", () => {
   const colorConfig: Record<string, string> = {
-    brilliantGreenShade20: "00B000",
-    brilliantGreenTint50: "80EE80",
-    goldTint50: "FFDA80",
-    errorRedShade20: "9F2D3F",
-    genericGreenTint50: "80CC80",
-    genericGreenTint30: "4DB84D",
-    genericGreenShade15: "008200",
-    genericGreenShade35: "006300",
-    genericGreenShade55: "004500",
-    productGreenTint50: "80D1BB",
-    productGreenTint30: "4DBF9F",
-    productGreenShade21: "00815D",
-    productGreenShade41: "006046",
-    productGreenShade61: "00402E",
-    productBlueTint50: "80BBE4",
-    productBlueTint30: "4DA0D9",
-    productBlueShade3: "0073C2",
-    productBlueShade23: "005C9A",
-    productBlueShade43: "004472",
-    amethystTint50: "AC96C1",
-    amethystTint30: "8A6BA8",
-    amethystTint10: "69418F",
-    amethystShade10: "4F2876",
-    amethystShade30: "3E1F5C",
-    slateTint95: "F2F5F6",
-    slateTint90: "E6EBED",
-    slateTint80: "CCD6DB",
-    slateTint60: "99ADB6",
-    slateTint40: "668592",
-    slateTint20: "335C6D",
-    slateShade60: "00141D",
+    brilliantGreenShade20: "#00B000",
+    brilliantGreenTint50: "#80EE80",
+    goldTint50: "#FFDA80",
+    errorRedShade20: "#9F2D3F",
+    genericGreenTint50: "#80CC80",
+    genericGreenTint30: "#4DB84D",
+    genericGreenShade15: "#008200",
+    genericGreenShade35: "#006300",
+    genericGreenShade55: "#004500",
+    productGreenTint50: "#80D1BB",
+    productGreenTint30: "#4DBF9F",
+    productGreenShade21: "#00815D",
+    productGreenShade41: "#006046",
+    productGreenShade61: "#00402E",
+    productBlueTint50: "#80BBE4",
+    productBlueTint30: "#4DA0D9",
+    productBlueShade3: "#0073C2",
+    productBlueShade23: "#005C9A",
+    productBlueShade43: "#004472",
+    amethystTint50: "#AC96C1",
+    amethystTint30: "#8A6BA8",
+    amethystTint10: "#69418F",
+    amethystShade10: "#4F2876",
+    amethystShade30: "#3E1F5C",
+    slateTint95: "#F2F5F6",
+    slateTint90: "#E6EBED",
+    slateTint80: "#CCD6DB",
+    slateTint60: "#99ADB6",
+    slateTint40: "#668592",
+    slateTint20: "#335C6D",
+    slateShade60: "#00141D",
   };
 
-  describe("palette", () => {
-    let palette: Record<string, PaletteFunction>;
+  it("palette produces correct color mix", () => {
+    const palette = generatePalette(config);
 
-    beforeEach(() => {
-      palette = generatePalette(config);
-    });
+    const paletteColors = Object.fromEntries(
+      Object.keys(colorConfig).map((color) => {
+        const match = color.match(/([a-z]+)([\d]{0,2})/i);
 
-    it("produces the correct color mix", () => {
-      assertCorrectColorMix(colorConfig, palette);
-    });
+        if (!match) {
+          throw new Error(`Color name ${color} did not match expected pattern`);
+        }
+
+        const func = match[1];
+        const weight = Number(match[2]);
+
+        return [color, palette[func](weight)];
+      }),
+    );
+
+    expect(paletteColors).toMatchObject(colorConfig);
   });
 
-  describe("mix", () => {
+  describe("mix function", () => {
     it("defaults to a weight of 50", () => {
       expect(mix(config.genericGreen, "FFFFFF")).toEqual(
-        `#${colorConfig.genericGreenTint50}`,
+        colorConfig.genericGreenTint50,
       );
     });
 
     it("accepts colors without a hash symbol", () => {
       expect(mix(config.genericGreen, "FFFFFF")).toEqual(
-        `#${colorConfig.genericGreenTint50}`,
+        colorConfig.genericGreenTint50,
       );
     });
 
     it("accepts colors with a hash symbol", () => {
-      expect(mix(`#${config.genericGreen}`, "#FFFFFF")).toEqual(
-        `#${colorConfig.genericGreenTint50}`,
+      expect(mix(config.genericGreen, "#FFFFFF")).toEqual(
+        colorConfig.genericGreenTint50,
       );
     });
 
     it("accepts three-digit hashes", () => {
       expect(mix(config.genericGreen, "FFF")).toEqual(
-        `#${colorConfig.genericGreenTint50}`,
+        colorConfig.genericGreenTint50,
       );
       expect(mix("FFF", config.genericGreen)).toEqual(
-        `#${colorConfig.genericGreenTint50}`,
+        colorConfig.genericGreenTint50,
       );
     });
 
     it("accepts colors with combinations of with and without hash symbols", () => {
-      expect(mix(`#${config.genericGreen}`, "FFFFFF")).toEqual(
-        `#${colorConfig.genericGreenTint50}`,
+      expect(mix(config.genericGreen, "FFFFFF")).toEqual(
+        colorConfig.genericGreenTint50,
       );
       expect(mix(config.genericGreen, "#FFFFFF")).toEqual(
-        `#${colorConfig.genericGreenTint50}`,
+        colorConfig.genericGreenTint50,
       );
     });
 
     it("returns empty string if no second input color passed", () => {
-      expect(mix(`#${config.genericGreen}`, "")).toEqual("");
+      expect(mix(config.genericGreen, "")).toEqual("");
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour

- Enable the recommended rules from the Playwright ESLint plugin and fix immediate errors.
- Set a maximum threshold on the number of permitted linting warnings.
- Re-enable the linting rule for forbidding null assertion operators in TypeScript.

### Current behaviour

- Our Playwright tests contain several anti-patterns that don't adhere to recommendations from the Playwright community. Enabling the recommended linting rules results in many new errors and warnings.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required
