### PR TITLE
fix(pill): ensure long words do not overflow

### DIFF
--- a/src/components/pill/pill-test.stories.tsx
+++ b/src/components/pill/pill-test.stories.tsx
@@ -145,3 +145,15 @@ export const WithCustomAriaLabels = ({ ...args }: PillProps) => {
     </>
   );
 };
+
+export const LongWordThatWraps = {
+  render: ({ children, ...args }: PillProps) => (
+    <Pill {...args}>{children}</Pill>
+  ),
+  args: {
+    children: "ThisIsAVeryLongWordThatShouldWrap",
+    onDelete: false,
+    wrapText: true,
+    maxWidth: "100px",
+  },
+};

--- a/src/components/pill/pill.pw.tsx
+++ b/src/components/pill/pill.pw.tsx
@@ -258,28 +258,6 @@ test.describe("should render Pill component with props", () => {
       await expect(elementLocator).toHaveCSS("padding", padding);
     });
   });
-
-  (
-    [
-      [true, "break-spaces"],
-      [false, "nowrap"],
-    ] as const
-  ).forEach(([booleanState, cssValue]) => {
-    test(`should render wrapText prop set as ${booleanState}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <Pill maxWidth="44px" wrapText={booleanState}>
-          Wrapped pill
-        </Pill>,
-      );
-
-      const elementLocator = pillPreview(page);
-      await expect(elementLocator).toHaveText("Wrapped pill");
-      await expect(elementLocator).toHaveCSS("white-space", cssValue);
-    });
-  });
 });
 
 test.describe("should check focus outlines and border radius", () => {

--- a/src/components/pill/pill.stories.tsx
+++ b/src/components/pill/pill.stories.tsx
@@ -34,7 +34,7 @@ Default.storyName = "Default";
 export const Wrapped: Story = () => {
   return (
     <Box mb={1}>
-      <Pill maxWidth="55px" wrapText>
+      <Pill maxWidth="65px" wrapText>
         Wrapped pill
       </Pill>
       <Pill ml={1} maxWidth="55px" wrapText>

--- a/src/components/pill/pill.style.ts
+++ b/src/components/pill/pill.style.ts
@@ -97,8 +97,11 @@ const StyledPill = styled.span.attrs(applyBaseTheme)<AllStyledPillProps>`
 
       ${wrapText &&
       css`
-        white-space: break-spaces;
+        overflow-wrap: anywhere;
         hyphens: auto;
+        // disabled auto hyphens in Safari as it doesn't seem to play well with breaking words
+        // soft hyphens can still be added manually
+        -webkit-hyphens: manual;
       `}
 
       color: ${contentColor};

--- a/src/components/pill/pill.test.tsx
+++ b/src/components/pill/pill.test.tsx
@@ -70,7 +70,7 @@ test("should render with expected styles when wrapText is true", () => {
   render(<Pill wrapText>Test Pill</Pill>);
 
   expect(screen.getByText("Test Pill")).toHaveStyle({
-    whiteSpace: "break-spaces",
+    overflowWrap: "anywhere",
     hyphens: "auto",
   });
 });

--- a/src/components/select/multi-select/multi-select-test.stories.tsx
+++ b/src/components/select/multi-select/multi-select-test.stories.tsx
@@ -981,3 +981,29 @@ export const AriaDescribedByExample = () => {
     </>
   );
 };
+
+interface WithPillStoryProps extends Partial<MultiSelectProps> {
+  pillText: string;
+}
+
+export const WithVeryLongPillText = ({
+  pillText,
+  ...args
+}: WithPillStoryProps) => {
+  return (
+    <MultiSelect
+      maxWidth="200px"
+      value={["1"]}
+      onChange={() => {}}
+      name="simple"
+      id="simple"
+      label="color"
+      {...args}
+    >
+      <Option text={pillText} value="1" />
+    </MultiSelect>
+  );
+};
+WithVeryLongPillText.args = {
+  pillText: "Veryveryveryveryveryveryverylongword",
+};


### PR DESCRIPTION

fix #7530

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Long words within `Pill` wrap and do not overflow the container. 

<img width="149" height="104" alt="image" src="https://github.com/user-attachments/assets/5ffb7ffb-7cb0-4361-8116-991bf79683b7" />
<img width="236" height="133" alt="image" src="https://github.com/user-attachments/assets/cf633198-1b61-4e26-a478-afe8ae475e6c" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

`Pill` with a very long word overflows Pill when width is constrained. 

<img width="288" height="42" alt="image" src="https://github.com/user-attachments/assets/77884ea7-f254-438e-9065-c9a2dc34a4ef" />
<img width="311" height="97" alt="image" src="https://github.com/user-attachments/assets/141e34fe-d8b3-4ae1-81b3-7ec879e62098" />


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
