### PR TITLE
fix(multi-action-button): allow dialog-mounted mult-action-button options to fire in Safari

### DIFF
--- a/src/components/multi-action-button/multi-action-button-test.stories.tsx
+++ b/src/components/multi-action-button/multi-action-button-test.stories.tsx
@@ -5,16 +5,20 @@ import MultiActionButton, {
 } from "./multi-action-button.component";
 import Button from "../button";
 import Box from "../box";
+import Dialog from "../dialog";
 import {
   MULTI_ACTION_BUTTON_ALIGNMENTS,
   MULTI_ACTION_BUTTON_SIZES,
   MULTI_ACTION_BUTTON_THEMES,
   MULTI_ACTION_BUTTON_POSITIONS,
 } from "./multi-action-button.config";
+import { StoryObj } from "@storybook/react/*";
+
+type Story = StoryObj<typeof MultiActionButton>;
 
 export default {
   title: "Multi Action Button/Test",
-  includeStories: ["MultiActionButtonStory"],
+
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -86,5 +90,56 @@ MultiActionButtonStory.story = {
     subtext: "",
     text: "Multi Action Button",
     position: "left",
+  },
+};
+
+const WithinDialog = () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [normalButtonToggled, setNormalButtonToggled] = React.useState(false);
+  const [dialogButtonToggled, setDialogButtonToggled] = React.useState(false);
+
+  return (
+    <Box display={"flex"} gap="20px" mb="20px" flexDirection={"column"}>
+      <>
+        <div>
+          Result of standard implementation interaction:{" "}
+          {normalButtonToggled ? "on" : "off"}
+        </div>
+        <div>
+          Result of dialog implementation interaction:{" "}
+          {dialogButtonToggled ? "on" : "off"}
+        </div>
+        <MultiActionButton text="Normal Options" buttonType="primary">
+          <Button onClick={() => setNormalButtonToggled((p) => !p)}>
+            Toggle normal state value
+          </Button>
+        </MultiActionButton>
+        <Box maxWidth={300} mt={20} mb={20}>
+          <Button onClick={() => setIsOpen(true)}>Open dialog</Button>
+          <Dialog open={isOpen} onCancel={() => setIsOpen(false)}>
+            <MultiActionButton text="Dialog Options" buttonType="primary">
+              <Button onClick={() => setDialogButtonToggled((p) => !p)}>
+                Toggle dialog state value
+              </Button>
+              <Button
+                onClick={() => alert("A second button which also works.")}
+              >
+                Show alert
+              </Button>
+            </MultiActionButton>
+          </Dialog>
+        </Box>
+      </>
+    </Box>
+  );
+};
+
+export const MultiActionButtonWithinDialog: Story = {
+  render: () => <WithinDialog />,
+};
+MultiActionButtonWithinDialog.story = {
+  name: "within a dialog",
+  parameters: {
+    chromatic: { disableSnapshot: true },
   },
 };

--- a/src/components/multi-action-button/multi-action-button.component.tsx
+++ b/src/components/multi-action-button/multi-action-button.component.tsx
@@ -116,6 +116,11 @@ export const MultiActionButton = forwardRef<
       ...filterOutStyledSystemSpacingProps(rest),
     };
 
+    // Pull ref out so it doesn't get passed to the container
+    // which breaks the component if it is mounted in a Dialog
+    // (but only in Safari)
+    const { ref: _wrapperRef, ...restWrapperProps } = wrapperProps;
+
     const renderAdditionalButtons = () => (
       <Popover
         disableBackgroundUI={isInFlatTable}
@@ -136,7 +141,7 @@ export const MultiActionButton = forwardRef<
       >
         <StyledButtonChildrenContainer
           id={submenuId.current}
-          {...wrapperProps}
+          {...restWrapperProps}
           align={align}
         >
           <SplitButtonContext.Provider value={contextValue}>


### PR DESCRIPTION
fix #7531

### Proposed behaviour

Remove the `ref` value that is returned from the `useChildButtons` hook from the set of wrapper props; it seems it should only ever be used in a `SplitButton` instance.

### Current behaviour

When mounted in a `Dialog`, the options of a `MultiActionButton` do not fire their `onClick` events and the menu closes.

### Checklist

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Use the `WithinDialog` test story under `MultiActionButton` to ensure that button clicks are handled correctly in all browsers