### PR TITLE
test(anchor-nav): add play functions

### DIFF
--- a/src/components/anchor-navigation/anchor-navigation-interactions.stories.tsx
+++ b/src/components/anchor-navigation/anchor-navigation-interactions.stories.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { StoryObj, StoryFn, composeStory } from "@storybook/react";
+import { userEvent, within, expect, waitFor } from "@storybook/test";
+
+import AnchorNavigation from "./anchor-navigation.component";
+import meta, { DefaultStory } from "./anchor-navigation.stories";
+
+import DefaultDecorator from "../../../.storybook/utils/default-decorator";
+
+type Story = StoryObj<typeof AnchorNavigation>;
+
+export default {
+  title: "Anchor Navigation/Interactions",
+  component: AnchorNavigation,
+  parameters: {
+    info: { disable: true },
+    chromatic: { disableSnapshot: true },
+  },
+};
+
+const RenderFromDefault = composeStory(DefaultStory, meta);
+
+export const NavFocusManagement: Story = {
+  render: RenderFromDefault,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const links = canvas.getAllByRole("link");
+
+    await userEvent.tab();
+    await waitFor(() => expect(links[0]).toHaveFocus());
+
+    await userEvent.tab();
+
+    await waitFor(() => expect(links[1]).toHaveFocus());
+  },
+  decorators: [
+    (StoryToRender: StoryFn) => (
+      <DefaultDecorator>
+        <StoryToRender />
+      </DefaultDecorator>
+    ),
+  ],
+};
+NavFocusManagement.storyName = "Focus Management";
+NavFocusManagement.parameters = {
+  themeProvider: { chromatic: { theme: "sage" } },
+  chromatic: { disableSnapshot: false },
+};
+
+export const ScrollAndFocusInput: Story = {
+  render: RenderFromDefault,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const secondHeading = canvas.getByRole("heading", {
+      name: /^second section$/i,
+    });
+    secondHeading.setAttribute("id", "second-section");
+
+    const secondNavLink =
+      canvas.queryByRole("link", { name: /^second$/i }) ||
+      canvas.getAllByRole("link")[1];
+    secondNavLink.setAttribute("href", "#second-section");
+
+    await userEvent.click(secondNavLink);
+
+    const sectionEl = secondHeading.closest(
+      '[data-carbon-anchornav-ref="true"]',
+    ) as HTMLElement | null;
+    if (!sectionEl) return;
+
+    await waitFor(() => expect(sectionEl).toHaveFocus());
+
+    await userEvent.tab();
+
+    const section = within(sectionEl);
+    const secondInput = section.getByLabelText(/^second section$/i);
+
+    await waitFor(() => expect(secondInput).toBeVisible());
+    await waitFor(() => expect(secondInput).toHaveFocus());
+  },
+  decorators: [
+    (StoryToRender: StoryFn) => (
+      <DefaultDecorator>
+        <StoryToRender />
+      </DefaultDecorator>
+    ),
+  ],
+};


### PR DESCRIPTION
### Proposed behaviour
Add play functions to the Anchor Nav component.
<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour
There are no play functions in this component
<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
