### PR TITLE
fix(popover-container): ensure onClose is only called when container is an open state

### DIFF
--- a/src/components/popover-container/popover-container-test.stories.tsx
+++ b/src/components/popover-container/popover-container-test.stories.tsx
@@ -717,3 +717,20 @@ WithinGlobalHeader.story = {
     shouldCoverButton: true,
   },
 };
+
+export const OnCloseTest = () => {
+  const [closeCount, setCloseCount] = useState(0);
+  const onClose = () => setCloseCount((count) => count + 1);
+  return (
+    <>
+      <PopoverContainer onClose={onClose}>Content</PopoverContainer>
+      <div>Close count: {closeCount}</div>
+    </>
+  );
+};
+
+OnCloseTest.storyName = "On Close Test";
+OnCloseTest.story = {
+  name: "on-close-test",
+  args: {},
+};

--- a/src/components/popover-container/popover-container.component.tsx
+++ b/src/components/popover-container/popover-container.component.tsx
@@ -285,11 +285,11 @@ export const PopoverContainer = forwardRef<
           },
         );
 
-        if (!eventIsFromSelectInput && Events.isEscKey(ev)) {
+        if (!eventIsFromSelectInput && isOpen && Events.isEscKey(ev)) {
           closePopover(ev);
         }
       },
-      [closePopover],
+      [closePopover, isOpen],
     );
 
     useEffect(() => {

--- a/src/components/popover-container/popover-container.test.tsx
+++ b/src/components/popover-container/popover-container.test.tsx
@@ -558,6 +558,33 @@ describe("closing the popup", () => {
     },
   );
 
+  it("calls onClose when escape key is pressed and popover is open", async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<PopoverContainer onClose={onClose}>Content</PopoverContainer>);
+
+    await user.click(screen.getByRole("button"));
+    await screen.findByRole("dialog");
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not call onClose when escape key is pressed and popover is closed", async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<PopoverContainer onClose={onClose}>Content</PopoverContainer>);
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
   it("calls onClose when content outside of the popup is clicked", async () => {
     const onClose = jest.fn();
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });


### PR DESCRIPTION

fix #7549

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Ensures `onClose` is only called when the container element is in an open state.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
The `onClose` callback is called when use presses escape key but popover is closed

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required
- [x] Storybook added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Test story added for QA