### PR TITLE
fix(dialog,sidebar): background color not defaulting to white

### DIFF
--- a/src/components/dialog/dialog-test.stories.tsx
+++ b/src/components/dialog/dialog-test.stories.tsx
@@ -475,6 +475,32 @@ WithLongTitle.parameters = {
   themeProvider: { chromatic: { theme: "sage" } },
 };
 
+export const WithGreyBackground: StoryType = {
+  render: (args) => {
+    const { children, ...rest } = args;
+    return (
+      <Dialog fullscreen greyBackground {...rest}>
+        {children}
+      </Dialog>
+    );
+  },
+  args: {
+    children:
+      "Lorem, ipsum dolor sit amet consectetur adipisicing elit. Alias labore nostrum quo deserunt repellendus accusamus facilis voluptatem? Dicta illo esse non! Corrupti suscipit reprehenderit ea nesciunt delectus. Non voluptate expedita, repellendus ea vitae dolor nobis aperiam ullam unde ducimus aliquam quidem veniam necessitatibus, suscipit eaque exercitationem aut corrupti, qui ipsa.",
+    open: true,
+    title: "Title",
+    subtitle: "Subtitle",
+    showCloseIcon: true,
+    onCancel: () => {},
+  },
+};
+
+WithGreyBackground.storyName = "Fullscreen: With Grey Background";
+WithGreyBackground.parameters = {
+  chromatic: { disableSnapshot: false },
+  themeProvider: { chromatic: { theme: "sage" } },
+};
+
 export const UsingDialogFullScreenAlias: StoryType = {
   render: (args) => {
     const { children, ...rest } = args;

--- a/src/components/dialog/dialog.style.ts
+++ b/src/components/dialog/dialog.style.ts
@@ -223,7 +223,7 @@ const StyledDialog = styled.div<StyledDialogProps & ContentPaddingInterface>`
   ${({ backgroundColor, dialogHeight, fullscreen, highlightVariant, size }) =>
     fullscreen
       ? css`
-          background-color: var(--colorsUtilityMajor025);
+          background-color: ${backgroundColor};
           height: 100%;
           width: 100%;
         `

--- a/src/components/dialog/dialog.test.tsx
+++ b/src/components/dialog/dialog.test.tsx
@@ -455,6 +455,36 @@ describe("Fullscreen Dialog", () => {
     expect(screen.getByTestId("third-child")).toBeVisible();
   });
 
+  test("renders with white background when fullscreen prop is true and greyBackground prop is false", () => {
+    render(
+      <Dialog fullscreen open>
+        Inner content
+      </Dialog>,
+    );
+
+    const content = screen.getByRole("dialog");
+
+    expect(content).toHaveStyleRule(
+      "background-color",
+      "var(--colorsUtilityYang100)",
+    );
+  });
+
+  test("renders with grey background when fullscreen prop is true and greyBackground prop is true", () => {
+    render(
+      <Dialog fullscreen open greyBackground>
+        Inner content
+      </Dialog>,
+    );
+
+    const content = screen.getByRole("dialog");
+
+    expect(content).toHaveStyleRule(
+      "background-color",
+      "var(--colorsUtilityMajor025)",
+    );
+  });
+
   // test here for coverage only
   test("padding is removed from the content when the `contentPadding` prop is passed", () => {
     render(

--- a/src/components/sidebar/sidebar.style.ts
+++ b/src/components/sidebar/sidebar.style.ts
@@ -21,7 +21,7 @@ const StyledSidebar = styled.div.attrs(applyBaseTheme)<StyledSidebarProps>`
   }
 
   ${({ onCancel, position, size, theme, width }) => css`
-    background: var(--colorsUtilityMajor025);
+    background: var(--colorsUtilityYang100);
     border-radius: 1px;
     bottom: 0;
     position: fixed;

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -330,6 +330,16 @@ test("ensures overflowing content is scrollable", () => {
   expect(sidebarContent).toHaveStyle("overflow-y: auto");
 });
 
+test("ensures correct background color is applied", () => {
+  render(<Sidebar open />);
+
+  const sidebarContent = screen.getByRole("dialog");
+  expect(sidebarContent).toHaveStyleRule(
+    "background",
+    "var(--colorsUtilityYang100)",
+  );
+});
+
 testStyledSystemWidth(
   (props) => (
     <CarbonProvider theme={sageTheme}>


### PR DESCRIPTION
### Proposed behaviour

When the `Dialog` is in full screen, the backgroudn color is white (`var(--colorsUtilityYang100)`). If the prop `greybackground` is set to true the background color changes to grey (`var(--colorsUtilityMajor025)`).

The `Sidebar` component background color has been updated from grey (var(--colorsUtilityMajor025)) to white (var(--colorsUtilityYang100)).

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

When the `Dialog` has full screen set to true the background is hardcoded to grey and there is no way for the user to change this. 
The `Sidebar` component uses by default a grey background.

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
