### PR TITLE
fix(link): enable focus on Safari

### DIFF
--- a/src/components/link/link.test.tsx
+++ b/src/components/link/link.test.tsx
@@ -750,3 +750,50 @@ test("logs a deprecation warning when tooltip props are used", async () => {
 
   loggerSpy.mockRestore();
 });
+
+describe("ref forwarding", () => {
+  test("accepts ref as a ref object", () => {
+    const mockRef = { current: null };
+    render(
+      <Link href="#" ref={mockRef}>
+        bar
+      </Link>,
+    );
+    const link = screen.getByRole("link");
+    expect(mockRef.current).toBe(link);
+  });
+
+  test("accepts ref as a ref callback", () => {
+    const mockRef = jest.fn();
+    render(
+      <Link href="#" ref={mockRef}>
+        bar
+      </Link>,
+    );
+    const link = screen.getByRole("link");
+    expect(mockRef).toHaveBeenCalledWith(link);
+  });
+
+  test("sets ref to null after unmount", () => {
+    const mockRef = { current: null };
+    const { unmount } = render(
+      <Link href="#" ref={mockRef}>
+        bar
+      </Link>,
+    );
+    unmount();
+    expect(mockRef.current).toBe(null);
+  });
+
+  test("calls ref callback with null on unmount", () => {
+    const mockRef = jest.fn();
+    const { unmount } = render(
+      <Link href="#" ref={mockRef}>
+        bar
+      </Link>,
+    );
+    mockRef.mockClear();
+    unmount();
+    expect(mockRef).toHaveBeenCalledWith(null);
+  });
+});


### PR DESCRIPTION
### Proposed behaviour

Enable focus on Safari for Link component

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour
Focus is disabled on Safari 
<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
