### PR TITLE
docs: i18n improvements 

### DIFF
--- a/docs/i18n.mdx
+++ b/docs/i18n.mdx
@@ -206,45 +206,61 @@ export const PolishPlural = (
 
 ## Where to find translation keys
 
-| Component             | Link to translation keys table                                      |
-|-----------------------|---------------------------------------------------------------------|
-| actions               | [Table](?path=/docs/pod--docs#translation-keys)                     |
-| actionPopover         | [Table](?path=/docs/action-popover--docs#translation-keys)          |
-| advancedColorPicker   | [Table](?path=/docs/advanced-color-picker--docs#translation-keys)   |
-| batchSelection        | [Table](?path=/docs/batch-selection--docs#translation-keys)         |
-| breadcrumbs           | [Table](?path=/docs/breadcrumbs--docs#translation-keys)             |
-| confirm               | [Table](?path=/docs/confirm--docs#translation-keys)                 |
-| characterCount        | [Table](?path=/docs/textarea--docs#translation-keys)                |
-| date                  | [Table](?path=/docs/date-input--docs#translation-keys)              |
-| dialog                | [Table](?path=/docs/dialog--docs#translation-keys)                  |
-| dismissibleBox        | [Table](?path=/docs/dismissible-box--docs#translation-keys)         |
-| errors                | [Table](?path=/docs/form--docs#translation-keys)                    |
-| fileInput             | [Table](?path=/docs/file-input--docs#translation-keys)              |
-| heading               | [Table](?path=/docs/heading--docs#translation-keys)                 |
-| link                  | [Table](?path=/docs/link--docs#translation-keys)                    |
-| loader                | [Table](?path=/docs/loader--docs#translation-keys)                  |
-| loaderSpinner         | [Table](?path=/docs/loader-spinner--docs#translation-keys)          |
-| loaderStar            | [Table](?path=/docs/loader-star--docs#translation-keys)             |
-| menuFullscreen        | [Table](?path=/docs/menu--docs#translation-keys)                    |
-| message               | [Table](?path=/docs/message--docs#translation-keys)                 |
-| numeralDate           | [Table](?path=/docs/numeral-date--docs#translation-keys)            |
-| pager                 | [Table](?path=/docs/pager--docs#translation-keys)                   |
-| password              | [Table](?path=/docs/password--docs#translation-keys)                |
-| pill                  | [Table](?path=/docs/pill--docs#translation-keys)                |
-| progressTracker       | [Table](?path=/docs/progress-tracker--docs#translation-keys)        |
-| pod                   | [Table](?path=/docs/pod--docs#translation-keys)                     |
-| search                | [Table](?path=/docs/search--docs#translation-keys)                  |
-| select                | [Table](?path=/docs/select--docs#translation-keys)                  |
-| sidebar               | [Table](?path=/docs/sidebar--docs#translation-keys)                 |
-| sort                  | [Table](?path=/docs/flat-table--docs#translation-keys)              |
-| splitButton           | [Table](?path=/docs/split-button--docs#translation-keys)            |
-| stepFlow              | [Table](?path=/docs/step-flow--docs#translation-keys)               |
-| switch                | [Table](?path=/docs/switch--docs#translation-keys)                  |
-| textEditor            | [Table](?path=/docs/text-editor--docs#translation-keys)             |
-| tileSelect            | [Table](?path=/docs/tile-select--docs#translation-keys)             |
-| time                  | [Table](?path=/docs/time--docs#translation-keys)                    |
-| toast                 | [Table](?path=/docs/toast--docs#translation-keys)                   |
-| verticalMenuFullScreen| [Table](?path=/docs/menu--docs#translation-keys)                    |
+<table style={{width: '100%', maxWidth: '400px'}} role="table" aria-label="Component translation keys">
+  <thead>
+    <tr>
+      <th scope="col" id="component-header">Component</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr><td headers="component-header">[actionPopover](?path=/docs/action-popover--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[advancedColorPicker](?path=/docs/advanced-color-picker--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[batchSelection](?path=/docs/batch-selection--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[breadcrumbs](?path=/docs/breadcrumbs--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[confirm](?path=/docs/deprecated-confirm--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[date](?path=/docs/date-input--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[dateRange](?path=/docs/date-range--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[decimal](?path=/docs/decimal-input--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[dialog](?path=/docs/dialog--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[dismissibleBox](?path=/docs/deprecated-dismissible-box--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[fileInput](?path=/docs/file-input--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[filterableSelect](?path=/docs/select-filterable--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[flatTable](?path=/docs/flat-table--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[form](?path=/docs/form--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[groupedCharacter](?path=/docs/deprecated-grouped-character--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[heading](?path=/docs/deprecated-heading--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[link](?path=/docs/link--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[loader](?path=/docs/deprecated-loader--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[loaderBar](?path=/docs/loader-bar--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[loaderSpinner](?path=/docs/loader-spinner--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[loaderStar](?path=/docs/loader-star--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[menu](?path=/docs/menu--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[message](?path=/docs/message--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[multiSelect](?path=/docs/select-multiselect--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[number](?path=/docs/deprecated-number-input--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[numeralDate](?path=/docs/numeral-date--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[pager](?path=/docs/pager--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[password](?path=/docs/password--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[pill](?path=/docs/pill--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[pod](?path=/docs/deprecated-pod--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[progressTracker](?path=/docs/progress-tracker--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[responsiveVerticalMenu](?path=/docs/vertical-menu-responsive--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[search](?path=/docs/search--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[sidebar](?path=/docs/sidebar--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[simpleSelect](?path=/docs/select--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[splitButton](?path=/docs/split-button--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[stepFlow](?path=/docs/step-flow--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[switch](?path=/docs/switch--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[textEditor](?path=/docs/text-editor--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[textarea](?path=/docs/textarea--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[textbox](?path=/docs/textbox--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[tileSelect](?path=/docs/tile-select--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[time](?path=/docs/time--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[toast](?path=/docs/deprecated-toast--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[verticalMenu](?path=/docs/vertical-menu--docs#translation-keys)</td></tr>
+    <tr><td headers="component-header">[verticalMenuFullScreen](?path=/docs/vertical-menu--docs#translation-keys)</td></tr>
+  </tbody>
+</table>
 
 ## How to stay updated
 

--- a/src/components/grouped-character/grouped-character.mdx
+++ b/src/components/grouped-character/grouped-character.mdx
@@ -1,4 +1,5 @@
 import { Meta, ArgTypes, Canvas } from "@storybook/blocks";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table"
 
 import * as GroupedCharacterStories from "./grouped-character.stories";
 import DeprecationWarning from "../../../.storybook/utils/deprecation-warning.component"
@@ -97,3 +98,32 @@ This component supports input validation, see our [Validations](../?path=/docs/d
 <ArgTypes of={GroupedCharacterStories} />
 
 **Any other supplied props will be provided to the underlying HTML input element**
+
+<TranslationKeysTable translationData={[
+     {
+      name: "characterCount.tooManyCharacters",
+      description:
+        "The message displayed below the input which will inform" +
+        " users if they have exceeded the set `characterLimit` and how much by." +
+        " This will also be announced to screen readers.",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "characterCount.charactersLeft",
+      description:
+        "The message displayed below the input which will inform" +
+        " users how many characters they have before they reach or exceed the" +
+        " set `characterLimit`. This will also be announced to screen readers.",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "characterCount.visuallyHiddenHint",
+      description:
+        "The message which will be read out to screen reader users, informing them" +
+        " of the set `characterLimit`.",
+      type: "func",
+      returnType: "string",
+    },
+]} />

--- a/src/components/number/number.mdx
+++ b/src/components/number/number.mdx
@@ -1,4 +1,5 @@
 import { Meta, ArgTypes, Canvas } from "@storybook/blocks";
+import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table"
 
 import * as NumberStories from "./number.stories.tsx";
 import DeprecationWarning from "../../../.storybook/utils/deprecation-warning.component"
@@ -89,3 +90,32 @@ Due to the `Textbox` component being used internally by the `Number` component, 
 <ArgTypes of={NumberStories} />
 
 **Any other supplied props will be provided to the underlying HTML input element**
+
+<TranslationKeysTable translationData={[
+     {
+      name: "characterCount.tooManyCharacters",
+      description:
+        "The message displayed below the input which will inform" +
+        " users if they have exceeded the set `characterLimit` and how much by." +
+        " This will also be announced to screen readers.",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "characterCount.charactersLeft",
+      description:
+        "The message displayed below the input which will inform" +
+        " users how many characters they have before they reach or exceed the" +
+        " set `characterLimit`. This will also be announced to screen readers.",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "characterCount.visuallyHiddenHint",
+      description:
+        "The message which will be read out to screen reader users, informing them" +
+        " of the set `characterLimit`.",
+      type: "func",
+      returnType: "string",
+    },
+]} />

--- a/src/components/password/password.mdx
+++ b/src/components/password/password.mdx
@@ -174,5 +174,31 @@ The following keys are available to override the translations for this component
       type: "func",
       returnType: "string",
     },
+         {
+      name: "characterCount.tooManyCharacters",
+      description:
+        "The message displayed below the input which will inform" +
+        " users if they have exceeded the set `characterLimit` and how much by." +
+        " This will also be announced to screen readers.",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "characterCount.charactersLeft",
+      description:
+        "The message displayed below the input which will inform" +
+        " users how many characters they have before they reach or exceed the" +
+        " set `characterLimit`. This will also be announced to screen readers.",
+      type: "func",
+      returnType: "string",
+    },
+    {
+      name: "characterCount.visuallyHiddenHint",
+      description:
+        "The message which will be read out to screen reader users, informing them" +
+        " of the set `characterLimit`.",
+      type: "func",
+      returnType: "string",
+    },
   ]}
 />

--- a/src/components/text-editor/text-editor.mdx
+++ b/src/components/text-editor/text-editor.mdx
@@ -392,6 +392,13 @@ The following keys are available to override the translations for this component
       returnType: "string",
     },
     {
+      name: "TextEditor.toolbarAriaLabel",
+      description:
+        "The text to be read out by screen readers for the toolbar aria-label attribute.",
+      type: "func",
+      returnType: "string",
+    },
+    {
       name: "TextEditor.unorderedListAria",
       description:
         "The text to be read out by screen readers when the Unordered List formatting button is focused.",

--- a/src/components/vertical-menu/vertical-menu.mdx
+++ b/src/components/vertical-menu/vertical-menu.mdx
@@ -102,6 +102,24 @@ to the [i18nProvider](../?path=/docs/documentation-i18n--docs).
 
 <TranslationKeysTable
   translationData={[
+        {
+      name: "verticalMenu.ariaLabels.responsiveMenuLauncher",
+      description: "The text for the responsive menu launcher aria-label attribute",      
+      type: "func",
+      returnType: "string",
+    },
+            {
+      name: "verticalMenu.ariaLabels.responsiveMenuCloseButton",
+      description: "The text for the responsive menu close button aria-label attribute",
+      type: "func",
+      returnType: "string",
+    },
+                {
+      name: "verticalMenu.ariaLabels.responsiveMenuAria",
+      description: "The text for the responsive menu aria-label attribute",
+      type: "func",
+      returnType: "string",
+    },
     {
       name: "verticalMenuFullScreen.ariaLabels.close",
       description: "The text for the close Icon aria-label attribute",


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

i18n docs are now super good  (adds missing translation keys table to respective components, fixes broken links in our i18n keys table and improves accessibility via improved announcements for AT)

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

i18n docs weren't super good 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
