### PR TITLE
fix(flat-table): ensure focus is only applied when using keyboard navigation - FE-7454

### DIFF
--- a/src/components/flat-table/flat-table.component.tsx
+++ b/src/components/flat-table/flat-table.component.tsx
@@ -84,7 +84,6 @@ export const FlatTable = ({
   const [hasHorizontalScrollbar, setHasHorizontalScrollbar] = useState(false);
   const [firstColRowSpanIndex, setFirstColRowSpanIndex] = useState(-1);
   const [lastColRowSpanIndex, setLastColRowSpanIndex] = useState(-1);
-  const [focused, setFocused] = useState(false);
   const addDefaultHeight = !height && (hasStickyHead || hasStickyFooter);
   const tableStylingProps = {
     caption,
@@ -266,19 +265,12 @@ export const FlatTable = ({
       firstColRowSpanIndex={firstColRowSpanIndex}
       lastColRowSpanIndex={lastColRowSpanIndex}
       onKeyDown={handleKeyDown}
-      isFocused={focused}
       {...rest}
       data-component="flat-table-wrapper"
       title={title}
     >
       <StyledTableContainer
         ref={container}
-        onFocus={() => {
-          if (container.current === document.activeElement) {
-            setFocused(true);
-          }
-        }}
-        onBlur={() => setFocused(false)}
         tabIndex={0}
         overflowX={overflowX}
         width={width}

--- a/src/components/flat-table/flat-table.interaction.stories.tsx
+++ b/src/components/flat-table/flat-table.interaction.stories.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { StoryObj, composeStory } from "@storybook/react";
+import { userEvent, within, expect, waitFor } from "@storybook/test";
+import { allowInteractions } from "../../../.storybook/interaction-toggle/reduced-motion";
+import DefaultDecorator from "../../../.storybook/utils/default-decorator";
+import { FlatTable } from "./flat-table.component";
+import meta, { DefaultStory, Paginated } from "./flat-table.stories";
+
+type Story = StoryObj<typeof FlatTable>;
+
+export default {
+  title: "Flat Table/Interactions",
+  component: FlatTable,
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
+  },
+};
+
+export const FlatTableFocused: Story = {
+  ...DefaultStory,
+  play: async ({ canvasElement }) => {
+    if (!allowInteractions()) return;
+
+    const canvas = within(canvasElement);
+    const focusableTableContainer = canvas.getByTestId("flat-table-container");
+
+    await userEvent.tab();
+
+    await waitFor(() => expect(focusableTableContainer).toHaveFocus());
+  },
+  decorators: [
+    (StoryToRender) => (
+      <DefaultDecorator>
+        <StoryToRender />
+      </DefaultDecorator>
+    ),
+  ],
+};
+
+const composedPaginationStory = composeStory(Paginated, meta);
+
+export const FlatTableWithPagerFocused: Story = {
+  render: composedPaginationStory,
+  play: async ({ canvasElement }) => {
+    if (!allowInteractions()) return;
+
+    const canvas = within(canvasElement);
+    const focusableTableContainer = canvas.getByTestId("flat-table-container");
+
+    await userEvent.tab();
+
+    await waitFor(() => expect(focusableTableContainer).toHaveFocus());
+  },
+  decorators: [
+    (StoryToRender) => (
+      <DefaultDecorator>
+        <StoryToRender />
+      </DefaultDecorator>
+    ),
+  ],
+};

--- a/src/components/flat-table/flat-table.pw.tsx
+++ b/src/components/flat-table/flat-table.pw.tsx
@@ -2371,6 +2371,24 @@ test.describe("Prop tests", () => {
       }
     });
   });
+
+  test(`should apply correct focus styling when wrapper is focused via keyboard`, async ({
+    mount,
+    page,
+  }) => {
+    await mount(<FlatTableComponent />);
+
+    await page.keyboard.press("Tab");
+
+    await expect(flatTableWrapper(page)).toHaveCSS(
+      "box-shadow",
+      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+    );
+    await expect(flatTableWrapper(page)).toHaveCSS(
+      "outline",
+      "rgba(0, 0, 0, 0) solid 3px",
+    );
+  });
 });
 
 test.describe("Accessibility tests", () => {

--- a/src/components/flat-table/flat-table.style.ts
+++ b/src/components/flat-table/flat-table.style.ts
@@ -114,7 +114,6 @@ interface StyledFlatTableWrapperProps
   hasVerticalScrollbar: boolean;
   lastColRowSpanIndex: number;
   firstColRowSpanIndex: number;
-  isFocused: boolean;
   bottomBorderRadius: NonNullable<FlatTableProps["bottomBorderRadius"]>;
 }
 
@@ -145,13 +144,12 @@ const StyledFlatTableWrapper = styled(StyledBox).attrs(
       border-bottom-right-radius: var(--${bottomBorderRadius});
     `}
 
-  ${({ isInSidebar, isFocused }) => css`
+  ${({ isInSidebar }) => css`
     box-sizing: border-box;
 
-    ${isFocused &&
-    css`
+    :has(${StyledTableContainer}:focus-visible) {
       ${addFocusStyling()}
-    `}
+    }
 
     ${isInSidebar ? "min-width: fit-content;" : ""}
   `}

--- a/src/components/flat-table/flat-table.test.tsx
+++ b/src/components/flat-table/flat-table.test.tsx
@@ -51,7 +51,8 @@ testStyledSystemMargin(
 );
 
 describe("when rows are interactive", () => {
-  it("should apply the expected focus styling to the wrapper element when it is focused", () => {
+  it("should apply the expected focus styling to the wrapper element when it is focused", async () => {
+    const user = userEvent.setup();
     render(
       <FlatTable>
         <FlatTableBody>
@@ -66,18 +67,11 @@ describe("when rows are interactive", () => {
         </FlatTableBody>
       </FlatTable>,
     );
-    const tableWrapper = screen.getByRole("region");
     const focusableTableContainer = screen.getByTestId("flat-table-container");
-    act(() => {
-      focusableTableContainer.focus();
-    });
+
+    await user.keyboard("{Tab}");
 
     expect(focusableTableContainer).toHaveFocus();
-    expect(tableWrapper).toHaveStyleRule("outline", "transparent 3px solid");
-    expect(tableWrapper).toHaveStyleRule(
-      "box-shadow",
-      "0px 0px 0px var(--borderWidth300) var(--colorsSemanticFocus500),0px 0px 0px var(--borderWidth600) var(--colorsUtilityYin090)",
-    );
   });
 
   it("should not move focus to first row with `onClick` when down arrow pressed and table wrapper focused", async () => {


### PR DESCRIPTION
fixes #7467

### Proposed behaviour

`Flat-Table` should only be focusable when using keyboard navigation.

### Current behaviour

`Flat-Table` can be focused when using keyboard navigation or clicking with a mouse.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

I have moved one of the unit tests that asserts the styles applied via focusing of the flat table container in to a Playwright test. I have also included an interaction story so that we can capture this via chromatic too. 

### Testing instructions

- Focus styling should only be applied to Flat-Table via keyboard navigation.
- No other functional or styling regressions associated with Flat-Table.
- New Chromatic snapshot should capture what is intended. 
