### PR TITLE
chore: add isLarge prop to internal components

### DIFF
--- a/src/__internal__/character-count/character-count.component.tsx
+++ b/src/__internal__/character-count/character-count.component.tsx
@@ -16,6 +16,8 @@ interface CharacterCountProps {
   isDebouncedOverLimit?: boolean;
   isOverLimit: boolean;
   visuallyHiddenHintId?: string;
+  /** Set large font-size */
+  isLarge?: boolean;
 }
 
 const CharacterCount = ({
@@ -26,6 +28,7 @@ const CharacterCount = ({
   isDebouncedOverLimit,
   isOverLimit,
   visuallyHiddenHintId,
+  isLarge,
 }: CharacterCountProps) => {
   const limitMinusValue: number = +limit - +value;
   const valueMinusLimit: number = +value - +limit;
@@ -52,6 +55,7 @@ const CharacterCount = ({
         isOverLimit={isOverLimit}
         data-element="character-count"
         data-role="character-count"
+        isLarge={isLarge}
       >
         {!isOverLimit
           ? l.characterCount.charactersLeft(

--- a/src/__internal__/character-count/character-count.style.ts
+++ b/src/__internal__/character-count/character-count.style.ts
@@ -7,6 +7,7 @@ const StyledCharacterCountWrapper = styled.div``;
 
 const StyledCharacterCount = styled.div.attrs(applyBaseTheme)<{
   isOverLimit: boolean;
+  isLarge?: boolean;
 }>`
   text-align: left;
   font-size: var(--fontSizes100);
@@ -17,6 +18,11 @@ const StyledCharacterCount = styled.div.attrs(applyBaseTheme)<{
       ? "var(--colorsSemanticNegative500)"
       : "var(--colorsUtilityYin055)"};
 
+  ${({ isLarge }) =>
+    isLarge &&
+    css`
+      font-size: var(--fontSizes200);
+    `}
   ${({ isOverLimit }) =>
     isOverLimit &&
     css`

--- a/src/__internal__/character-count/character-count.test.tsx
+++ b/src/__internal__/character-count/character-count.test.tsx
@@ -122,3 +122,13 @@ test("visually hidden hint renders with 'you can enter up to {count} character(s
     "You can enter up to 10 characters",
   );
 });
+
+// coverage
+test("renders with expected styles when `isLarge` is true", () => {
+  render(<CharacterCount isLarge value={5} limit={10} isOverLimit={false} />);
+
+  expect(screen.getByTestId("character-count")).toHaveStyleRule(
+    "font-size",
+    "var(--fontSizes200)",
+  );
+});

--- a/src/__internal__/fieldset/fieldset.component.tsx
+++ b/src/__internal__/fieldset/fieldset.component.tsx
@@ -72,6 +72,8 @@ export interface FieldsetProps extends MarginProps {
   validationMessagePositionTop?: boolean;
   /** Apply new validation styles */
   applyNewValidation?: boolean;
+  /** Set the size of the component */
+  size?: "small" | "medium" | "large";
 }
 
 const Fieldset = ({
@@ -94,6 +96,7 @@ const Fieldset = ({
   validationMessagePositionTop,
   applyNewValidation = false,
   id,
+  size,
   ...rest
 }: FieldsetProps) => {
   const { validationRedesignOptIn } = useContext(NewValidationContext);
@@ -179,6 +182,7 @@ const Fieldset = ({
             warning={warning}
             validationId={validationId}
             validationMessagePositionTop={validationMessagePositionTop}
+            isLarge={size === "large"}
           />
           <ErrorBorder warning={!!(!error && warning)} />
         </>
@@ -204,6 +208,7 @@ const Fieldset = ({
             isDisabled={isDisabled}
             data-element="legend"
             data-role="legend"
+            isLarge={size === "large"}
           >
             {legend}
           </StyledLegend>
@@ -214,6 +219,7 @@ const Fieldset = ({
             id={inputHintId}
             isDisabled={isDisabled}
             align={legendAlignment}
+            isLarge={size === "large"}
           >
             {inputHint}
           </HintText>

--- a/src/__internal__/fieldset/fieldset.style.ts
+++ b/src/__internal__/fieldset/fieldset.style.ts
@@ -26,6 +26,7 @@ export type StyledLegendProps = {
   rightPadding?: 1 | 2;
   isRequired?: boolean;
   isDisabled?: boolean;
+  isLarge?: boolean;
 };
 
 export const StyledLegend = styled.legend<StyledLegendProps>`
@@ -35,6 +36,12 @@ export const StyledLegend = styled.legend<StyledLegendProps>`
   line-height: 24px;
   font-weight: var(--fontWeights500);
   color: var(--colorsUtilityYin090);
+
+  ${({ isLarge }) =>
+    isLarge &&
+    css`
+      font-size: var(--fontSizes200);
+    `}
 
   ${({ isRequired }) =>
     isRequired &&

--- a/src/__internal__/fieldset/fieldset.test.tsx
+++ b/src/__internal__/fieldset/fieldset.test.tsx
@@ -272,4 +272,17 @@ describe("when `applyNewValidation` is provided", () => {
     expect(legend).toHaveStyleRule("color", "var(--colorsUtilityYin030)");
     expect(hint).toHaveStyleRule("color", "var(--colorsUtilityYin030)");
   });
+
+  // coverage
+  test("renders with expected styles when `size` is large", () => {
+    render(
+      <Fieldset applyNewValidation size="large" legend="Legend">
+        <input title="Test" placeholder="Placeholder" />
+      </Fieldset>,
+    );
+
+    const legend = screen.getByTestId("legend");
+
+    expect(legend).toHaveStyleRule("font-size", "var(--fontSizes200)");
+  });
 });

--- a/src/__internal__/hint-text/hint-text.component.tsx
+++ b/src/__internal__/hint-text/hint-text.component.tsx
@@ -24,6 +24,8 @@ export interface HintTextProps {
   marginTop?: string;
   /** Max width for the hint text */
   maxWidth?: string;
+  /** Set large font-size */
+  isLarge?: boolean;
 }
 
 export const HintText = ({
@@ -37,6 +39,7 @@ export const HintText = ({
   marginBottom = "var(--spacing100)",
   marginTop = "var(--spacing000)",
   maxWidth,
+  isLarge,
 }: HintTextProps) => {
   const { validationRedesignOptIn } = useContext(NewValidationContext);
 
@@ -54,6 +57,7 @@ export const HintText = ({
       marginBottom={marginBottom}
       marginTop={marginTop}
       maxWidth={maxWidth}
+      isLarge={isLarge}
     >
       {children}
     </StyledHintText>

--- a/src/__internal__/hint-text/hint-text.style.tsx
+++ b/src/__internal__/hint-text/hint-text.style.tsx
@@ -17,6 +17,12 @@ const StyledHintText = styled.div<HintTextProps>`
   align-items: center;
   font-size: 14px;
 
+  ${({ isLarge }) =>
+    isLarge &&
+    css`
+      font-size: var(--fontSizes200);
+    `}
+
   ${({ align }) => css`
     justify-content: ${align !== "right" ? "flex-start" : "flex-end"};
   `}

--- a/src/__internal__/hint-text/hint-text.test.tsx
+++ b/src/__internal__/hint-text/hint-text.test.tsx
@@ -88,3 +88,13 @@ test("renders correctly with the appropriate top margin", () => {
   expect(screen.getByText("foo")).toBeVisible();
   expect(screen.getByText("foo")).toHaveStyleRule(`margin-top`, "16px");
 });
+
+// coverage
+test("renders with expected styles when `isLarge` is true", () => {
+  render(<HintText isLarge>foo</HintText>);
+
+  expect(screen.getByText("foo")).toHaveStyleRule(
+    "font-size",
+    "var(--fontSizes200)",
+  );
+});

--- a/src/__internal__/label/label.component.tsx
+++ b/src/__internal__/label/label.component.tsx
@@ -88,6 +88,7 @@ export const Label = ({
   width = 30,
   className,
   "aria-label": ariaLabel,
+  isLarge,
 }: LabelProps) => {
   const [isFocused, setFocus] = useState(false);
   const { onMouseEnter, onMouseLeave } = useContext(InputContext);
@@ -182,6 +183,7 @@ export const Label = ({
         as={as}
         aria-label={ariaLabel}
         isDarkBackground={isDarkBackground}
+        isLarge={isLarge}
       >
         {children}
       </StyledLabel>

--- a/src/__internal__/label/label.style.ts
+++ b/src/__internal__/label/label.style.ts
@@ -7,6 +7,8 @@ export interface StyledLabelProps {
   isRequired?: boolean;
   /** Flag to determine whether to use colours for dark backgrounds */
   isDarkBackground?: boolean;
+  /** Set large font-size */
+  isLarge?: boolean;
 }
 
 const StyledLabel = styled.label<StyledLabelProps>`
@@ -17,6 +19,11 @@ const StyledLabel = styled.label<StyledLabelProps>`
   `}
   display: block;
   font-weight: var(--fontWeights500);
+  ${({ isLarge }) =>
+    isLarge &&
+    css`
+      font-size: var(--fontSizes200);
+    `}
 
   ${({ isRequired }) =>
     isRequired &&

--- a/src/__internal__/label/label.test.tsx
+++ b/src/__internal__/label/label.test.tsx
@@ -206,3 +206,13 @@ test("renders with normal styles when `isDarkBackground` is false", () => {
     color: "var(--colorsUtilityYin090)",
   });
 });
+
+// coverage
+test("renders with expected styles when `isLarge` is true", () => {
+  render(<Label isLarge>foo</Label>);
+
+  expect(screen.getByText("foo")).toHaveStyleRule(
+    "font-size",
+    "var(--fontSizes200)",
+  );
+});

--- a/src/__internal__/validation-message/validation-message.component.tsx
+++ b/src/__internal__/validation-message/validation-message.component.tsx
@@ -15,6 +15,8 @@ export interface ValidationMessageProps extends TagProps {
   isDarkBackground?: boolean;
   /** Render the validation message above the input */
   validationMessagePositionTop?: boolean;
+  /** Set large font-size */
+  isLarge?: boolean;
 }
 
 const ValidationMessage = ({
@@ -25,6 +27,7 @@ const ValidationMessage = ({
   "data-element": dataElement,
   "data-role": dataRole = "validation-message",
   validationMessagePositionTop,
+  isLarge,
 }: ValidationMessageProps) => {
   const validation = error || warning;
   const isStringValidation = typeof validation === "string";
@@ -39,6 +42,7 @@ const ValidationMessage = ({
         "data-role": dataRole,
       })}
       validationMessagePositionTop={validationMessagePositionTop}
+      isLarge={isLarge}
     >
       {validation}
     </StyledValidationMessage>

--- a/src/__internal__/validation-message/validation-message.style.ts
+++ b/src/__internal__/validation-message/validation-message.style.ts
@@ -4,16 +4,23 @@ interface StyledValidationMessageProps {
   isWarning?: boolean;
   isDarkBackground?: boolean;
   validationMessagePositionTop?: boolean;
+  isLarge?: boolean;
 }
 
 const StyledValidationMessage = styled.p<StyledValidationMessageProps>`
-  ${({ isWarning, isDarkBackground, validationMessagePositionTop }) => {
+  ${({
+    isWarning,
+    isDarkBackground,
+    validationMessagePositionTop,
+    isLarge,
+  }) => {
     const darkBgColour = isDarkBackground
       ? "var(--colorsSemanticNegative450)"
       : "var(--colorsSemanticNegative500)";
     return css`
       color: ${isWarning ? "var(--tempColorsSemanticCaution600)" : darkBgColour};
       font-weight: ${isWarning ? "normal" : "500"};
+      font-size: ${isLarge ? "var(--fontSizes200)" : "var(--fontSizes100)"};
       margin: 0px;
       margin-${validationMessagePositionTop ? "bottom" : "top"}: 8px;
     `;

--- a/src/__internal__/validation-message/validation-message.test.tsx
+++ b/src/__internal__/validation-message/validation-message.test.tsx
@@ -75,3 +75,13 @@ test("renders with the correct colour when `isDarkBackground` is false", () => {
     color: "var(--colorsSemanticNegative500)",
   });
 });
+
+// coverage
+test("renders with the correct colour when `isLarge` is true", () => {
+  render(<ValidationMessage error="error" isLarge />);
+
+  expect(screen.getByText("error")).toHaveStyleRule(
+    "font-size",
+    "var(--fontSizes200)",
+  );
+});


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Adds `isLarge` prop to internal `Label`, `HintText`, `ValidationMessage`, `CharacterCount` and `Fieldset` components to set 16px font-size for "large" sizes. 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Font-size of `Label`, `HintText`, `ValidationMessage`, `CharacterCount` and `Fieldset` is always 14px.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
