### PR TITLE
fix(multi-action-button): prevent popup closing too early

### DIFF
--- a/src/components/multi-action-button/multi-action-button-test.stories.tsx
+++ b/src/components/multi-action-button/multi-action-button-test.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { action } from "@storybook/addon-actions";
 import MultiActionButton, {
   MultiActionButtonProps,
@@ -11,10 +11,10 @@ import {
   MULTI_ACTION_BUTTON_THEMES,
   MULTI_ACTION_BUTTON_POSITIONS,
 } from "./multi-action-button.config";
+import Dialog from "../dialog";
 
 export default {
   title: "Multi Action Button/Test",
-  includeStories: ["MultiActionButtonStory"],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -86,5 +86,27 @@ MultiActionButtonStory.story = {
     subtext: "",
     text: "Multi Action Button",
     position: "left",
+  },
+};
+
+export const WithinDialog = {
+  render: function WithinDialog() {
+    const [open, setOpen] = useState(false);
+
+    const handleClick = action("onClick");
+
+    return (
+      <>
+        <MultiActionButton text="Multi Action Button" buttonType="primary">
+          <Button onClick={handleClick}>Export file</Button>
+        </MultiActionButton>
+        <Button onClick={() => setOpen(true)}>Open dialog</Button>
+        <Dialog open={open} onCancel={() => setOpen(false)}>
+          <MultiActionButton text="Multi Action Button" buttonType="primary">
+            <Button onClick={handleClick}>Export file</Button>
+          </MultiActionButton>
+        </Dialog>
+      </>
+    );
   },
 };

--- a/src/components/multi-action-button/multi-action-button.test.tsx
+++ b/src/components/multi-action-button/multi-action-button.test.tsx
@@ -120,7 +120,7 @@ test("should open additional buttons when the main button is clicked", async () 
   expect(button).toBeVisible();
 });
 
-test("should close additional buttons when the toggle button is clicked", async () => {
+test("closes additional buttons popup when the toggle button is clicked", async () => {
   const user = userEvent.setup();
   render(
     <MultiActionButton text="Main Button">
@@ -137,7 +137,7 @@ test("should close additional buttons when the toggle button is clicked", async 
   ).not.toBeInTheDocument();
 });
 
-test("should close additional buttons when a child button is clicked", async () => {
+test("closes additional buttons popup when a child button is clicked", async () => {
   const user = userEvent.setup();
   render(
     <MultiActionButton text="Main Button">
@@ -153,7 +153,7 @@ test("should close additional buttons when a child button is clicked", async () 
   ).not.toBeInTheDocument();
 });
 
-test("should close additional buttons when a click occurs outside the component", async () => {
+test("closes additional buttons popup when a click occurs outside the component", async () => {
   const user = userEvent.setup();
   render(
     <MultiActionButton text="Main Button">
@@ -169,7 +169,27 @@ test("should close additional buttons when a click occurs outside the component"
   ).not.toBeInTheDocument();
 });
 
-test("should close additional buttons when a custom adaptive sidebar blur event is dispatched", async () => {
+test("closes additional buttons popup when focus is lost from it", async () => {
+  const user = userEvent.setup();
+  render(
+    <MultiActionButton text="Main Button">
+      <Button>First</Button>
+    </MultiActionButton>,
+  );
+
+  await user.click(screen.getByRole("button", { name: "Main Button" }));
+
+  const childButton = await screen.findByRole("button", { name: "First" });
+  expect(childButton).toBeVisible();
+
+  await user.tab();
+  expect(childButton).toHaveFocus();
+
+  await user.tab({ shift: true });
+  expect(screen.queryByRole("list")).not.toBeInTheDocument();
+});
+
+test("closes additional buttons popup when a custom adaptive sidebar blur event is dispatched", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
@@ -194,6 +214,24 @@ test("should close additional buttons when a custom adaptive sidebar blur event 
   });
 
   expect(button).not.toBeInTheDocument();
+});
+
+test("closes additional buttons popup when Escape key is pressed", async () => {
+  const user = userEvent.setup();
+  render(
+    <MultiActionButton text="Main Button">
+      <Button>First</Button>
+    </MultiActionButton>,
+  );
+
+  await user.click(screen.getByRole("button", { name: "Main Button" }));
+  expect(screen.getByRole("button", { name: "First" })).toBeVisible();
+
+  await user.keyboard("{Escape}");
+
+  expect(
+    screen.queryByRole("button", { name: "First" }),
+  ).not.toBeInTheDocument();
 });
 
 test("should render main button as disabled when 'disabled' prop is true", () => {

--- a/src/components/split-button/split-button.test.tsx
+++ b/src/components/split-button/split-button.test.tsx
@@ -581,7 +581,7 @@ test("should not call the `onClick` handle when main button is clicked whilst di
   expect(onClickMock).not.toHaveBeenCalled();
 });
 
-test("should hide the additional buttons when a click event detected outside the component", async () => {
+test("closes additional buttons popup when a click occurs outside the component", async () => {
   const user = userEvent.setup();
   render(
     <SplitButton text="Main">
@@ -618,7 +618,7 @@ test("should hide the additional buttons when the list is open and 'Enter' key i
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
 });
 
-test("should hide the additional buttons when the list is open and 'Space' key is pressed on the toggle button", async () => {
+test("closes additional buttons popup when 'Space' key is pressed on the toggle button", async () => {
   const user = userEvent.setup();
   render(
     <SplitButton text="Main">
@@ -627,18 +627,18 @@ test("should hide the additional buttons when the list is open and 'Space' key i
   );
 
   const toggle = screen.getByRole("button", { name: "Show more" });
-  toggle.focus();
-  await user.keyboard(" ");
+  await user.click(toggle);
+
   const childButton = await screen.findByRole("button", {
     name: "Single Button",
   });
-
   expect(childButton).toBeVisible();
+
   await user.keyboard(" ");
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
 });
 
-test("should hide the additional buttons when a 'Escape' keydown event detected and focus is within component", async () => {
+test("closes additional buttons popup when Escape is pressed and focus is within the popup", async () => {
   const user = userEvent.setup();
   render(
     <SplitButton text="Main">
@@ -647,19 +647,18 @@ test("should hide the additional buttons when a 'Escape' keydown event detected 
   );
 
   const toggle = screen.getByRole("button", { name: "Show more" });
-  toggle.focus();
-  await user.keyboard("{arrowDown}");
+  await user.click(toggle);
 
   const button1 = await screen.findByRole("button", {
     name: "Single Button",
   });
-
   expect(button1).toBeVisible();
+
   await user.keyboard("{Escape}");
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
 });
 
-test("should hide the additional buttons when a 'Escape' keydown event detected and focus is not within component", async () => {
+test("closes additional buttons popup when Escape is pressed and focus is not within the popup", async () => {
   const user = userEvent.setup();
   render(
     <SplitButton text="Main">
@@ -669,16 +668,17 @@ test("should hide the additional buttons when a 'Escape' keydown event detected 
 
   const toggle = await screen.findByRole("button", { name: "Show more" });
   await user.click(toggle);
+
   const button1 = await screen.findByRole("button", {
     name: "Single Button",
   });
-
   expect(button1).toBeVisible();
+
   await user.keyboard("{Escape}");
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
 });
 
-test("should call the relevant 'onClick' callback and hide the additional buttons when a child button is clicked", async () => {
+test("calls child's onClick callback and closes additional buttons popup when a child button is clicked", async () => {
   const user = userEvent.setup();
   const onClickMock = jest.fn();
   const onClickOnChildMock = jest.fn();
@@ -699,7 +699,7 @@ test("should call the relevant 'onClick' callback and hide the additional button
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
 });
 
-test("should hide the additional buttons when the main button is clicked", async () => {
+test("closes additional buttons popup when the main button is clicked", async () => {
   const user = userEvent.setup();
   render(
     <SplitButton text="Main">
@@ -721,7 +721,7 @@ test("should hide the additional buttons when the main button is clicked", async
   expect(childButton).not.toBeInTheDocument();
 });
 
-test("should hide the additional buttons when the list is open the toggle button is clicked", async () => {
+test("closes additional buttons popup when the toggle button is clicked", async () => {
   const user = userEvent.setup();
   render(
     <SplitButton text="Main">
@@ -742,7 +742,29 @@ test("should hide the additional buttons when the list is open the toggle button
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
 });
 
-test("should hide the additional buttons when the list is open and a custom adaptive sidebar blur event is dispatched", async () => {
+test("closes additional buttons popup when focus is lost from it", async () => {
+  const user = userEvent.setup();
+  render(
+    <SplitButton text="Main">
+      <Button>Single Button</Button>
+    </SplitButton>,
+  );
+
+  await user.click(screen.getByRole("button", { name: "Show more" }));
+
+  const childButton = await screen.findByRole("button", {
+    name: "Single Button",
+  });
+  expect(childButton).toBeVisible();
+
+  await user.tab();
+  expect(childButton).toHaveFocus();
+
+  await user.tab({ shift: true });
+  expect(screen.queryByRole("list")).not.toBeInTheDocument();
+});
+
+test("closes additional buttons popup when a custom adaptive sidebar blur event is dispatched", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
@@ -772,7 +794,7 @@ test("should hide the additional buttons when the list is open and a custom adap
   expect(childButton).not.toBeInTheDocument();
 });
 
-test("should support navigating the additional buttons via down arrow key but stop on last button", async () => {
+test("can navigate through additional buttons via down key presses", async () => {
   const user = userEvent.setup();
   render(
     <SplitButton text="Main">
@@ -783,8 +805,8 @@ test("should support navigating the additional buttons via down arrow key but st
   );
 
   const toggle = screen.getByRole("button", { name: "Show more" });
-  toggle.focus();
-  await user.keyboard("{arrowDown}");
+  await user.click(toggle);
+
   const button1 = await screen.findByRole("button", {
     name: "Extra Button 1",
   });
@@ -805,7 +827,7 @@ test("should support navigating the additional buttons via down arrow key but st
   expect(button3).toHaveFocus();
 });
 
-test("should support navigating the additional buttons via up arrow key but stop on first button", async () => {
+test("can navigate through additional buttons via up key presses but stop on first button", async () => {
   const user = userEvent.setup();
   render(
     <SplitButton text="Main">
@@ -816,7 +838,8 @@ test("should support navigating the additional buttons via up arrow key but stop
   );
 
   const toggle = screen.getByRole("button", { name: "Show more" });
-  toggle.focus();
+  await user.click(toggle);
+
   await user.keyboard("{arrowDown}");
   const button1 = await screen.findByRole("button", {
     name: "Extra Button 1",
@@ -850,8 +873,8 @@ test("focuses last child button when End key is pressed", async () => {
   );
 
   const toggle = screen.getByRole("button", { name: "Show more" });
-  toggle.focus();
-  await user.keyboard("{arrowDown}");
+  await user.click(toggle);
+
   const button1 = await screen.findByRole("button", {
     name: "Extra Button 1",
   });
@@ -992,7 +1015,7 @@ test("focuses first child button when Meta and ArrowUp key are pressed together"
   expect(button1).toHaveFocus();
 });
 
-test("should support navigating the additional buttons via tab key", async () => {
+test("can navigate through additional buttons via tab key presses", async () => {
   const user = userEvent.setup();
   render(
     <SplitButton text="Main">
@@ -1023,7 +1046,7 @@ test("should support navigating the additional buttons via tab key", async () =>
   expect(button3).toHaveFocus();
 });
 
-test("should support navigating the additional buttons via shift+tab key, hide the list when pressed on first button and refocus toggle", async () => {
+test("can navigate through additional buttons via shift+tab key presses, hide the list when pressed on first button and refocus toggle", async () => {
   const user = userEvent.setup();
   render(
     <SplitButton text="Main">

--- a/src/hooks/__internal__/useChildButtons/useChildButtons.tsx
+++ b/src/hooks/__internal__/useChildButtons/useChildButtons.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from "react";
+import React, { useState, useRef, useCallback } from "react";
 import Events from "../../../__internal__/utils/helpers/events";
 import useMenuKeyboardNavigation from "../useMenuKeyboardNavigation";
 
@@ -63,6 +63,11 @@ const useChildButtons = (
     showAdditionalButtons,
   );
 
+  const handleBlur = (ev: React.FocusEvent<HTMLElement>) => {
+    if (ev.currentTarget.contains(ev.relatedTarget)) return;
+    hideButtons();
+  };
+
   const onChildButtonClick =
     (childOnClick?: React.MouseEventHandler<HTMLButtonElement>) =>
     (ev: React.MouseEvent<HTMLButtonElement>) => {
@@ -75,6 +80,7 @@ const useChildButtons = (
     "data-element": "additional-buttons",
     role: "list",
     onKeyDown: handleKeyDown,
+    onBlur: handleBlur,
     minWidth,
     ref: childrenContainer,
   };

--- a/src/hooks/__internal__/useMenuKeyboardNavigation/useMenuKeyboardNavigation.test.tsx
+++ b/src/hooks/__internal__/useMenuKeyboardNavigation/useMenuKeyboardNavigation.test.tsx
@@ -211,18 +211,4 @@ describe("useMenuKeyboardNavigation", () => {
 
     expect(keyDownEvent.defaultPrevented).toBe(true);
   });
-
-  it("calls hide callback when no child button in the menu is focused", () => {
-    const hideCb = jest.fn();
-    render(<MockComponent hideCb={hideCb} />);
-
-    fireEvent.focus(screen.getByRole("button", { name: "Main Button" }));
-
-    fireEvent.focus(screen.getByText(`${childButtonID}-0`));
-
-    fireEvent.focus(
-      screen.getByRole("button", { name: "Next Element in DOM" }),
-    );
-    expect(hideCb).toHaveBeenCalled();
-  });
 });

--- a/src/hooks/__internal__/useMenuKeyboardNavigation/useMenuKeyboardNavigation.ts
+++ b/src/hooks/__internal__/useMenuKeyboardNavigation/useMenuKeyboardNavigation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import Events from "../../../__internal__/utils/helpers/events";
 import useModalManager from "../useModalManager";
 
@@ -82,32 +82,6 @@ export default (
     },
     [getButtonChildren],
   );
-
-  // check if a child button is focused, if not hide the menu
-  const checkFocus = useCallback(() => {
-    const buttonChildren = getButtonChildren();
-
-    if (!buttonChildren) {
-      return;
-    }
-
-    const buttonChildrenFocused = Array.from(buttonChildren).some(
-      (button) => button === document.activeElement,
-    );
-
-    if (!buttonChildrenFocused) {
-      hide();
-    }
-  }, [getButtonChildren, hide]);
-
-  useEffect(() => {
-    document.addEventListener("focusin", checkFocus);
-    window.addEventListener("blur", hide);
-    return () => {
-      document.removeEventListener("focusin", checkFocus);
-      window.removeEventListener("blur", hide);
-    };
-  }, [checkFocus, hide]);
 
   return handleKeyDown;
 };


### PR DESCRIPTION
addresses #7531

### Proposed behaviour

- Observe the popup element itself to detect when it loses focus, and close it if so. Ensures that click events on child buttons fire correctly, regardless of where the component resides on the page.

https://github.com/user-attachments/assets/890ae9c4-903b-4121-8438-bf5edf0fca92

### Current behaviour

- In Safari, when a `MultiActionButton` is within a `Dialog`, clicking a child button inside the popup doesn't fire a click event. This is caused by Safari's event timing combined with our use of window-level blur listeners.

https://github.com/user-attachments/assets/8e9d84ca-dd48-4344-90e1-69b57f8cb046


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

For Safari, Chrome, Edge and Firefox, check the following behaviour within the new "Within Dialog" test story for `MultiActionButton`. Compare behaviour to the original [bug reproduction](https://stackblitz.com/edit/parsium-carbon-starter-mppbdxyi?file=src%2FApp.tsx).

- Clicking child button with mouse fires its `onClick` callback, then closes the popup
- Pressing <kbd>Space</kbd>/<kbd>Enter</kbd> on child button fires its `onClick` callback, then closes the popup
- Tabbing out of popup closes it
- Clicking outside of popup closes it

To detect `onClick` calls within the new story, please check the Storybook Actions panel.