### PR TITLE
chore(deps): update eslint packages - FE-7502

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,7 +105,7 @@
         "browserslist": "^4.26.3",
         "chromatic": "^6.17.4",
         "conventional-changelog-conventionalcommits": "^8.0.0",
-        "core-js": "^3.33.3",
+        "core-js": "^3.45.1",
         "css-loader": "^6.8.1",
         "dayjs": "^1.11.10",
         "eslint": "^9.36.0",
@@ -10870,9 +10870,9 @@
       "license": "MIT"
     },
     "node_modules/core-js": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.42.0.tgz",
-      "integrity": "sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g==",
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "browserslist": "^4.26.3",
     "chromatic": "^6.17.4",
     "conventional-changelog-conventionalcommits": "^8.0.0",
-    "core-js": "^3.33.3",
+    "core-js": "^3.45.1",
     "css-loader": "^6.8.1",
     "dayjs": "^1.11.10",
     "eslint": "^9.36.0",


### PR DESCRIPTION
### Proposed behaviour

- Update various `eslint` associated packages.
- Update `browserlist` package.
- Remove `classnames` package.
- Update `core-js` package.

### Current behaviour

- Various `eslint` associated packages are using older version. 
- `browserlist` package is on an older version with out of dates browsers being used.
- `classnames` package is installed but not used.
- `core-js` currently on an older version.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

`classnames` was introduced 10 years ago in to the codebase. It appears that we are no longer using it anywhere in the codebase, so I took the decision to remove it.

### Testing instructions

- All CI jobs should pass
- Storybook should work locally
- No new warnings or errors should occur when installing dependancies locally
- Playwright should continue to work locally
- `npm run lint` should continue to work locally
