### PR TITLE
docs(divider): fix import typo

### DIFF
--- a/src/components/divider/divider.mdx
+++ b/src/components/divider/divider.mdx
@@ -11,7 +11,6 @@ Provides a vertical or horizontal dividing line to make the adjacent components 
 ## Contents
 
 - [Quick Start](#quick-start)
-
 - [Examples](#examples)
 - [Props](#props)
 
@@ -20,7 +19,7 @@ Provides a vertical or horizontal dividing line to make the adjacent components 
 To use component, import the `Divider` and align it with the other components.
 
 ```javascript
-import Divider from "carbon-react/lib/components/Divider";
+import Divider from "carbon-react/lib/components/divider";
 ```
 
 ## Examples


### PR DESCRIPTION
### Proposed behaviour


### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
