### PR TITLE
test(test-utils): adds a helper to replace Logger deprecation checks

### DIFF
--- a/src/components/badge/badge.test.tsx
+++ b/src/components/badge/badge.test.tsx
@@ -2,47 +2,32 @@ import React from "react";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Badge from "./badge.component";
-import Logger from "../../__internal__/utils/logger";
+import { assertLoggerComponentMessage } from "../../__spec_helper__/__internal__/test-utils";
 
 jest.mock("../../__internal__/utils/logger");
 
 test("should log a deprecation warning for onClick prop", () => {
-  const loggerSpy = jest.spyOn(Logger, "deprecate");
-  render(<Badge onClick={() => {}} />);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The `onClick` prop in `Badge` is deprecated and will soon be removed.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
-  loggerSpy.mockClear();
+  assertLoggerComponentMessage({
+    component: <Badge onClick={() => {}} />,
+    message:
+      "The `onClick` prop in `Badge` is deprecated and will soon be removed.",
+  });
 });
 
 test("should log a deprecation warning for aria-label prop", () => {
-  const loggerSpy = jest.spyOn(Logger, "deprecate");
-  render(<Badge aria-label="Test label" />);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The `aria-label` prop in `Badge` is deprecated and will soon be removed.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
-  loggerSpy.mockClear();
+  assertLoggerComponentMessage({
+    component: <Badge aria-label="Test label" />,
+    message:
+      "The `aria-label` prop in `Badge` is deprecated and will soon be removed.",
+  });
 });
 
 test("should log a deprecation warning for color prop", () => {
-  const loggerSpy = jest.spyOn(Logger, "deprecate");
-  render(<Badge color="red" />);
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The `color` prop in `Badge` is deprecated and will soon be removed.",
-  );
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  loggerSpy.mockRestore();
-  loggerSpy.mockClear();
+  assertLoggerComponentMessage({
+    component: <Badge color="red" />,
+    message:
+      "The `color` prop in `Badge` is deprecated and will soon be removed.",
+  });
 });
 
 test("should render badge with children", () => {

--- a/src/components/textarea/textarea.test.tsx
+++ b/src/components/textarea/textarea.test.tsx
@@ -3,12 +3,14 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as floatingUi from "@floating-ui/react-dom";
 
-import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
+import {
+  assertLoggerComponentMessage,
+  testStyledSystemMargin,
+} from "../../__spec_helper__/__internal__/test-utils";
 import Textarea, { TextareaProps } from ".";
 import { EnterKeyHintTypes } from "../../__internal__/input";
 import guid from "../../__internal__/utils/helpers/guid";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
-import Logger from "../../__internal__/utils/logger";
 import StyledInput from "../../__internal__/input/input.style";
 
 jest.mock("../../__internal__/utils/logger");
@@ -33,24 +35,11 @@ const MockComponent = (props: CustomType) => {
 };
 
 test("should display deprecation warning once when rendered as optional", () => {
-  const loggerSpy = jest.spyOn(Logger, "deprecate");
-
-  render(
-    <>
-      <MockComponent name="my-textarea" isOptional />
-      <MockComponent name="my-textarea" isOptional />
-    </>,
-  );
-
-  // Ensure the deprecation warning is logged only once
-  expect(loggerSpy).toHaveBeenCalledTimes(1);
-
-  expect(loggerSpy).toHaveBeenNthCalledWith(
-    1,
-    "`isOptional` is deprecated in TextArea and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
-  );
-
-  loggerSpy.mockRestore();
+  assertLoggerComponentMessage({
+    component: <MockComponent name="my-textarea" isOptional />,
+    message:
+      "`isOptional` is deprecated in TextArea and support will soon be removed. If the value of this component is not required, use the `required` prop and set it to false instead.",
+  });
 });
 
 test("should render a textarea element", () => {
@@ -758,25 +747,22 @@ test("renders with the expected custom border radius styling as an array", () =>
 });
 
 test("fires a console warning if more than four border-radius values are passed", () => {
-  const loggerSpy = jest.spyOn(Logger, "warn");
-
-  render(
-    <MockComponent
-      borderRadius={[
-        "borderRadius050",
-        "borderRadius100",
-        "borderRadius200",
-        "borderRadius400",
-        "borderRadius050",
-      ]}
-    />,
-  );
-
-  expect(loggerSpy).toHaveBeenCalledWith(
-    "The `borderRadius` prop in `Textarea` component only supports up to 4 values.",
-  );
-
-  loggerSpy.mockRestore();
+  assertLoggerComponentMessage({
+    component: (
+      <MockComponent
+        borderRadius={[
+          "borderRadius050",
+          "borderRadius100",
+          "borderRadius200",
+          "borderRadius400",
+          "borderRadius050",
+        ]}
+      />
+    ),
+    message:
+      "The `borderRadius` prop in `Textarea` component only supports up to 4 values.",
+    method: "warn",
+  });
 });
 
 test("should render component without borders when hideBorders prop is true", () => {


### PR DESCRIPTION
### Proposed behaviour

Create a new helper util for testing: `assertDeprecationWarning`. This can be used in place of e.g.:

Example:

```ts
test("should log a deprecation warning for onClick prop", () => {
  assertDeprecationWarning({
    component: <Badge onClick={() => {}} />,
    deprecationMessage:
      "The `onClick` prop in `Badge` is deprecated and will soon be removed.",
  });
});
```

The helper also takes a third option, `method`, which can be used to test `Logger.warn` and `Logger.error`. `Logger.deprecate` is used as the default option if this is not set.

### Current behaviour

There are a number of test scenarios that use variations on a similar approach to test that the deprecation warnings from `Logger`, but the implementation is inconsistent.

Example:

```ts
test("should log a deprecation warning for onClick prop", () => {
  const loggerSpy = jest.spyOn(Logger, "deprecate");
  render(<Badge onClick={() => {}} />);

  expect(loggerSpy).toHaveBeenCalledWith(
    "The `onClick` prop in `Badge` is deprecated and will soon be removed.",
  );
  expect(loggerSpy).toHaveBeenCalledTimes(1);

  loggerSpy.mockRestore();
  loggerSpy.mockClear();
});
```

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Run the `Badge` or `TextArea` component unit tests. All tests should pass using the new structure.

**IMPORTANT**: due to the ongoing audit work, the changed unit tests in Badge and TextArea have been done for demonstration purposes only. The work to update the unit tests to use the new helper should be done when the relevant components are updated.