### PR TITLE
feat(responsive-vertical-menu): add programmatic focus support for the responsive vertical menu

### DIFF
--- a/src/components/vertical-menu/responsive-vertical-menu/index.ts
+++ b/src/components/vertical-menu/responsive-vertical-menu/index.ts
@@ -1,7 +1,10 @@
 export { ResponsiveVerticalMenuProvider } from "./responsive-vertical-menu.context";
 
 export { ResponsiveVerticalMenu } from "./responsive-vertical-menu.component";
-export type { ResponsiveVerticalMenuProps } from "./responsive-vertical-menu.component";
+export type {
+  ResponsiveVerticalMenuProps,
+  ResponsiveVerticalMenuHandle,
+} from "./responsive-vertical-menu.component";
 
 export { ResponsiveVerticalMenuItem } from "./responsive-vertical-menu-item";
 export type { ResponsiveVerticalMenuItemProps } from "./responsive-vertical-menu-item";

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.component.tsx
@@ -5,6 +5,8 @@ import React, {
   useLayoutEffect,
   useRef,
   useState,
+  forwardRef,
+  useImperativeHandle,
 } from "react";
 
 import { DepthProvider } from "./__internal__/depth.context";
@@ -47,365 +49,394 @@ export interface ResponsiveVerticalMenuProps extends TagProps {
   launcherButtonDataProps?: TagProps;
 }
 
-const BaseMenu = ({
-  children,
-  height,
-  responsiveBreakpoint = 700,
-  width,
-  launcherButtonDataProps,
-  ...rest
-}: ResponsiveVerticalMenuProps) => {
-  const locale = useLocale();
-  const {
-    active,
-    activeMenuItem,
-    buttonRef,
-    containerRef,
-    menuRef,
-    responsiveMode,
-    top,
-    setActive,
-    setActiveMenuItem,
-    setReducedMotion,
-    setResponsiveMode,
-    setLeft,
-    setTop,
-  } = useResponsiveVerticalMenu();
+export type ResponsiveVerticalMenuHandle = {
+  /** Programmatically focus on the launcher button. */
+  focusLaunchButton: () => void;
+} | null;
 
-  const [childItemCount, setChildItemCount] = useState(0);
-  const largeScreen = useIsAboveBreakpoint(responsiveBreakpoint);
-  const [responsiveWidth, setResponsiveWidth] = useState("100%");
-  const reduceMotion = !useMediaQuery(
-    "screen and (prefers-reduced-motion: no-preference)",
-  );
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  const { current: menu } = menuRef;
-  const { current: button } = buttonRef;
-
-  const measureDimensions = useCallback(() => {
-    // Only calculate the width of the menu if the menu is open in responsive mode
-    if (active && responsiveMode) {
-      // Get the width of the menu container. The ref might not be set yet, hence
-      // the use of `document.querySelector` to find the menu container.
-      const menuContainer =
-        menu ||
-        document.querySelector("[id='responsive-vertical-menu-primary']");
-      /* istanbul ignore else */
-      if (menuContainer) {
-        setResponsiveWidth(`${menuContainer.getBoundingClientRect().width}px`);
-      }
-    }
-
-    if (activeMenuItem && menu) {
-      setLeft(`${menu.getBoundingClientRect().right}px`);
-    } else {
-      setLeft("auto");
-    }
-
-    if (activeMenuItem && button) {
-      setTop(`${button.getBoundingClientRect().bottom}px`);
-    } else {
-      setTop("auto");
-    }
-  }, [active, menu, responsiveMode, activeMenuItem, button]);
-
-  const handleOutsideClick = useCallback(
-    (event: MouseEvent) => {
-      const notInContainer =
-        containerRef.current &&
-        !containerRef.current.contains(event.target as Node);
-
-      if (notInContainer) {
-        setActive(false);
-      }
+const BaseMenu = forwardRef<
+  ResponsiveVerticalMenuHandle,
+  ResponsiveVerticalMenuProps
+>(
+  (
+    {
+      children,
+      height,
+      responsiveBreakpoint = 700,
+      width,
+      launcherButtonDataProps,
+      ...rest
     },
-    [containerRef],
-  );
+    ref,
+  ) => {
+    const locale = useLocale();
+    const {
+      active,
+      activeMenuItem,
+      buttonRef,
+      containerRef,
+      menuRef,
+      responsiveMode,
+      top,
+      setActive,
+      setActiveMenuItem,
+      setReducedMotion,
+      setResponsiveMode,
+      setLeft,
+      setTop,
+    } = useResponsiveVerticalMenu();
 
-  const handleActiveToggle = useCallback(() => {
-    setActive((previous) => !previous);
-    // Make sure the menu is closed when the button is clicked (prevents historic menu items being retained in memory)
-    setActiveMenuItem(null);
-  }, [active, setActive, setActiveMenuItem]);
+    const [childItemCount, setChildItemCount] = useState(0);
+    const largeScreen = useIsAboveBreakpoint(responsiveBreakpoint);
+    const [responsiveWidth, setResponsiveWidth] = useState("100%");
+    const reduceMotion = !useMediaQuery(
+      "screen and (prefers-reduced-motion: no-preference)",
+    );
+    const wrapperRef = useRef<HTMLDivElement>(null);
 
-  useLayoutEffect(() => {
-    measureDimensions();
+    const { current: menu } = menuRef;
+    const { current: button } = buttonRef;
 
-    // Measure dimensions when the window is resized
-    window.addEventListener("resize", measureDimensions);
+    useImperativeHandle<
+      ResponsiveVerticalMenuHandle,
+      ResponsiveVerticalMenuHandle
+    >(
+      ref,
+      () => ({
+        focusLaunchButton() {
+          button?.focus({ preventScroll: true });
+        },
+      }),
+      [button],
+    );
 
-    return () => {
-      window?.removeEventListener("resize", measureDimensions);
-    };
-  }, [active, measureDimensions, menu, responsiveMode]);
-
-  const isResizingRef = useRef(false);
-  const resizeTimeoutRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    const handleResize = () => {
-      isResizingRef.current = true;
-
-      if (resizeTimeoutRef.current !== null) {
-        clearTimeout(resizeTimeoutRef.current);
+    const measureDimensions = useCallback(() => {
+      // Only calculate the width of the menu if the menu is open in responsive mode
+      if (active && responsiveMode) {
+        // Get the width of the menu container. The ref might not be set yet, hence
+        // the use of `document.querySelector` to find the menu container.
+        const menuContainer =
+          menu ||
+          document.querySelector("[id='responsive-vertical-menu-primary']");
+        /* istanbul ignore else */
+        if (menuContainer) {
+          setResponsiveWidth(
+            `${menuContainer.getBoundingClientRect().width}px`,
+          );
+        }
       }
 
-      resizeTimeoutRef.current = window.setTimeout(() => {
-        isResizingRef.current = false;
-      }, 100);
-    };
-
-    window.addEventListener("resize", handleResize);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-      if (resizeTimeoutRef.current !== null) {
-        clearTimeout(resizeTimeoutRef.current);
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    let timeout: NodeJS.Timeout | null = null;
-    const handleBlur = (ev: FocusEvent) => {
-      /* istanbul ignore if */
-      if (!containerRef.current) {
-        return;
+      if (activeMenuItem && menu) {
+        setLeft(`${menu.getBoundingClientRect().right}px`);
+      } else {
+        setLeft("auto");
       }
 
-      if (Events.composedPath(ev).includes(buttonRef.current as EventTarget)) {
-        return;
+      if (activeMenuItem && button) {
+        setTop(`${button.getBoundingClientRect().bottom}px`);
+      } else {
+        setTop("auto");
       }
+    }, [active, menu, responsiveMode, activeMenuItem, button]);
 
-      if (timeout) {
-        clearTimeout(timeout);
-        timeout = null;
-      }
+    const handleOutsideClick = useCallback(
+      (event: MouseEvent) => {
+        const notInContainer =
+          containerRef.current &&
+          !containerRef.current.contains(event.target as Node);
 
-      timeout = setTimeout(() => {
-        if (!containerRef.current?.contains(document.activeElement)) {
+        if (notInContainer) {
           setActive(false);
         }
-      }, 0);
-    };
+      },
+      [containerRef],
+    );
 
-    const handleClose = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        setActive(false);
-      }
-    };
-
-    const currentContainer = containerRef.current;
-
-    if (active && !responsiveMode) {
-      document.addEventListener("keydown", handleClose);
-      window.addEventListener("click", handleOutsideClick);
-      currentContainer?.addEventListener("focusout", handleBlur);
-    }
-
-    return () => {
-      document.removeEventListener("keydown", handleClose);
-      window.removeEventListener("click", handleOutsideClick);
-      currentContainer?.removeEventListener("focusout", handleBlur);
-      if (timeout) clearTimeout(timeout);
-      timeout = null;
-    };
-  }, [
-    active,
-    activeMenuItem,
-    buttonRef,
-    containerRef,
-    handleOutsideClick,
-    responsiveMode,
-  ]);
-
-  useEffect(() => {
-    setReducedMotion?.(reduceMotion);
-    setResponsiveMode?.(!largeScreen);
-  }, [largeScreen, reduceMotion, setReducedMotion, setResponsiveMode]);
-
-  const countChildren = useCallback((currentChildren: React.ReactNode) => {
-    // If there are no children, return 0
-    if (!currentChildren) {
-      return 0;
-    }
-
-    // If the content of children is a single React element, count it and check its children
-    if (React.isValidElement(currentChildren)) {
-      const nodeChildren: number = countChildren(
-        currentChildren.props.children,
-      );
-      return 1 + nodeChildren;
-    }
-
-    // If the content of children is an array of React elements, iterate through them
-    const childrenAsArray = React.Children.toArray(currentChildren);
-
-    /* istanbul ignore else */
-    if (childrenAsArray.length) {
-      const reducedChildren: number = childrenAsArray.reduce(
-        (acc: number, child: React.ReactNode) => {
-          /* istanbul ignore else */
-          if (React.isValidElement(child)) {
-            const total = acc + 1;
-            const childrenCount = countChildren(child.props.children);
-            return total + childrenCount;
-          }
-          return acc;
-        },
-        0,
-      );
-
-      return reducedChildren;
-    }
-    return 0;
-  }, []);
-
-  useEffect(() => {
-    const previousChildCount = childItemCount;
-    const newChildCount = countChildren(children);
-
-    if (previousChildCount !== newChildCount) {
-      setChildItemCount(newChildCount);
+    const handleActiveToggle = useCallback(() => {
+      setActive((previous) => !previous);
+      // Make sure the menu is closed when the button is clicked (prevents historic menu items being retained in memory)
       setActiveMenuItem(null);
-    }
-  }, [childItemCount, children, countChildren, setActiveMenuItem]);
+    }, [active, setActive, setActiveMenuItem]);
 
-  const buttonAriaProps = () => {
-    if (responsiveMode) {
+    useLayoutEffect(() => {
+      measureDimensions();
+
+      // Measure dimensions when the window is resized
+      window.addEventListener("resize", measureDimensions);
+
+      return () => {
+        window?.removeEventListener("resize", measureDimensions);
+      };
+    }, [active, measureDimensions, menu, responsiveMode]);
+
+    const isResizingRef = useRef(false);
+    const resizeTimeoutRef = useRef<number | null>(null);
+
+    useEffect(() => {
+      const handleResize = () => {
+        isResizingRef.current = true;
+
+        if (resizeTimeoutRef.current !== null) {
+          clearTimeout(resizeTimeoutRef.current);
+        }
+
+        resizeTimeoutRef.current = window.setTimeout(() => {
+          isResizingRef.current = false;
+        }, 100);
+      };
+
+      window.addEventListener("resize", handleResize);
+
+      return () => {
+        window.removeEventListener("resize", handleResize);
+        if (resizeTimeoutRef.current !== null) {
+          clearTimeout(resizeTimeoutRef.current);
+        }
+      };
+    }, []);
+
+    useEffect(() => {
+      let timeout: NodeJS.Timeout | null = null;
+      const handleBlur = (ev: FocusEvent) => {
+        /* istanbul ignore if */
+        if (!containerRef.current) {
+          return;
+        }
+
+        if (
+          Events.composedPath(ev).includes(buttonRef.current as EventTarget)
+        ) {
+          return;
+        }
+
+        if (timeout) {
+          clearTimeout(timeout);
+          timeout = null;
+        }
+
+        timeout = setTimeout(() => {
+          if (!containerRef.current?.contains(document.activeElement)) {
+            setActive(false);
+          }
+        }, 0);
+      };
+
+      const handleClose = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          setActive(false);
+        }
+      };
+
+      const currentContainer = containerRef.current;
+
+      if (active && !responsiveMode) {
+        document.addEventListener("keydown", handleClose);
+        window.addEventListener("click", handleOutsideClick);
+        currentContainer?.addEventListener("focusout", handleBlur);
+      }
+
+      return () => {
+        document.removeEventListener("keydown", handleClose);
+        window.removeEventListener("click", handleOutsideClick);
+        currentContainer?.removeEventListener("focusout", handleBlur);
+        if (timeout) clearTimeout(timeout);
+        timeout = null;
+      };
+    }, [
+      active,
+      activeMenuItem,
+      buttonRef,
+      containerRef,
+      handleOutsideClick,
+      responsiveMode,
+    ]);
+
+    useEffect(() => {
+      setReducedMotion?.(reduceMotion);
+      setResponsiveMode?.(!largeScreen);
+    }, [largeScreen, reduceMotion, setReducedMotion, setResponsiveMode]);
+
+    const countChildren = useCallback((currentChildren: React.ReactNode) => {
+      // If there are no children, return 0
+      if (!currentChildren) {
+        return 0;
+      }
+
+      // If the content of children is a single React element, count it and check its children
+      if (React.isValidElement(currentChildren)) {
+        const nodeChildren: number = countChildren(
+          currentChildren.props.children,
+        );
+        return 1 + nodeChildren;
+      }
+
+      // If the content of children is an array of React elements, iterate through them
+      const childrenAsArray = React.Children.toArray(currentChildren);
+
+      /* istanbul ignore else */
+      if (childrenAsArray.length) {
+        const reducedChildren: number = childrenAsArray.reduce(
+          (acc: number, child: React.ReactNode) => {
+            /* istanbul ignore else */
+            if (React.isValidElement(child)) {
+              const total = acc + 1;
+              const childrenCount = countChildren(child.props.children);
+              return total + childrenCount;
+            }
+            return acc;
+          },
+          0,
+        );
+
+        return reducedChildren;
+      }
+      return 0;
+    }, []);
+
+    useEffect(() => {
+      const previousChildCount = childItemCount;
+      const newChildCount = countChildren(children);
+
+      if (previousChildCount !== newChildCount) {
+        setChildItemCount(newChildCount);
+        setActiveMenuItem(null);
+      }
+    }, [childItemCount, children, countChildren, setActiveMenuItem]);
+
+    const buttonAriaProps = () => {
+      if (responsiveMode) {
+        return {
+          "aria-expanded": undefined,
+          "aria-controls": "responsive-vertical-menu-dialog",
+          "aria-label":
+            locale.verticalMenu.ariaLabels?.responsiveMenuLauncher(),
+        };
+      }
       return {
-        "aria-expanded": undefined,
-        "aria-controls": "responsive-vertical-menu-dialog",
+        "aria-expanded": active,
+        "aria-controls": "responsive-vertical-menu-primary",
         "aria-label": locale.verticalMenu.ariaLabels?.responsiveMenuLauncher(),
       };
-    }
-    return {
-      "aria-expanded": active,
-      "aria-controls": "responsive-vertical-menu-primary",
-      "aria-label": locale.verticalMenu.ariaLabels?.responsiveMenuLauncher(),
     };
-  };
 
-  const modalAriaProps = () => {
-    return {
-      role: "dialog" as const,
-      "aria-modal": true,
-      "aria-label": locale.verticalMenu.ariaLabels?.responsiveMenuAria(),
+    const modalAriaProps = () => {
+      return {
+        role: "dialog" as const,
+        "aria-modal": true,
+        "aria-label": locale.verticalMenu.ariaLabels?.responsiveMenuAria(),
+      };
     };
-  };
 
-  return (
-    <div ref={containerRef}>
-      <StyledButton
-        active={active}
-        buttonType="tertiary"
-        iconType="squares_nine"
-        id="responsive-vertical-menu-launcher"
-        onClick={handleActiveToggle}
-        ref={buttonRef}
-        {...tagComponent("responsive-vertical-menu-launcher", {
-          "data-role": "responsive-vertical-menu-launcher",
-          ...launcherButtonDataProps,
-        })}
-        {...buttonAriaProps()}
-      />
-      {responsiveMode ? (
-        <Modal open={active}>
-          <FocusTrap wrapperRef={wrapperRef} isOpen={active}>
-            <ModalContainer
-              ref={wrapperRef}
-              width={responsiveWidth}
-              tabIndex={-1}
-              id="responsive-vertical-menu-dialog"
-              {...modalAriaProps()}
-            >
-              <Box
-                boxSizing="border-box"
-                display="flex"
-                justifyContent="flex-end"
-                width="100%"
-                backgroundColor="var(--colorsGray850)"
-                p={1}
-              >
-                <StyledCloseButton
-                  aria-label={locale.verticalMenu.ariaLabels?.responsiveMenuCloseButton()}
-                  data-component="responsive-vertical-menu-close"
-                  data-role="responsive-vertical-menu-close"
-                  iconType="close"
-                  size="small"
-                  buttonType="tertiary"
-                  onClick={() => {
-                    setActive(false);
-                    setActiveMenuItem(null);
-                  }}
-                />
-              </Box>
-              <StyledResponsiveMenu
-                height={height}
-                id="responsive-vertical-menu-primary"
-                menu="primary"
-                reduceMotion={reduceMotion}
-                ref={menuRef}
-                responsive
+    return (
+      <div ref={containerRef}>
+        <StyledButton
+          active={active}
+          buttonType="tertiary"
+          iconType="squares_nine"
+          id="responsive-vertical-menu-launcher"
+          onClick={handleActiveToggle}
+          ref={buttonRef}
+          {...tagComponent("responsive-vertical-menu-launcher", {
+            "data-role": "responsive-vertical-menu-launcher",
+            ...launcherButtonDataProps,
+          })}
+          {...buttonAriaProps()}
+        />
+        {responsiveMode ? (
+          <Modal open={active}>
+            <FocusTrap wrapperRef={wrapperRef} isOpen={active}>
+              <ModalContainer
+                ref={wrapperRef}
+                width={responsiveWidth}
                 tabIndex={-1}
-                top="48px"
-                width={width}
+                id="responsive-vertical-menu-dialog"
+                {...modalAriaProps()}
               >
-                {children}
-              </StyledResponsiveMenu>
-            </ModalContainer>
-          </FocusTrap>
-        </Modal>
-      ) : (
-        <StyledGlobalVerticalMenuWrapper
-          {...rest}
-          {...tagComponent("responsive-vertical-menu", rest)}
-        >
-          {active && (
-            <>
-              <StyledResponsiveMenu
-                childOpen={!!activeMenuItem}
-                data-component="responsive-vertical-menu-primary"
-                data-role="responsive-vertical-menu-primary"
-                height={height || "100%"}
-                id="responsive-vertical-menu-primary"
-                menu="primary"
-                reduceMotion={reduceMotion}
-                ref={menuRef}
-                responsive={false}
-                tabIndex={-1}
-                top={top}
-                width={width}
-              >
-                {children}
-              </StyledResponsiveMenu>
-            </>
-          )}
-        </StyledGlobalVerticalMenuWrapper>
-      )}
-    </div>
-  );
-};
+                <Box
+                  boxSizing="border-box"
+                  display="flex"
+                  justifyContent="flex-end"
+                  width="100%"
+                  backgroundColor="var(--colorsGray850)"
+                  p={1}
+                >
+                  <StyledCloseButton
+                    aria-label={locale.verticalMenu.ariaLabels?.responsiveMenuCloseButton()}
+                    data-component="responsive-vertical-menu-close"
+                    data-role="responsive-vertical-menu-close"
+                    iconType="close"
+                    size="small"
+                    buttonType="tertiary"
+                    onClick={() => {
+                      setActive(false);
+                      setActiveMenuItem(null);
+                    }}
+                  />
+                </Box>
+                <StyledResponsiveMenu
+                  height={height}
+                  id="responsive-vertical-menu-primary"
+                  menu="primary"
+                  reduceMotion={reduceMotion}
+                  ref={menuRef}
+                  responsive
+                  tabIndex={-1}
+                  top="48px"
+                  width={width}
+                >
+                  {children}
+                </StyledResponsiveMenu>
+              </ModalContainer>
+            </FocusTrap>
+          </Modal>
+        ) : (
+          <StyledGlobalVerticalMenuWrapper
+            {...rest}
+            {...tagComponent("responsive-vertical-menu", rest)}
+          >
+            {active && (
+              <>
+                <StyledResponsiveMenu
+                  childOpen={!!activeMenuItem}
+                  data-component="responsive-vertical-menu-primary"
+                  data-role="responsive-vertical-menu-primary"
+                  height={height || "100%"}
+                  id="responsive-vertical-menu-primary"
+                  menu="primary"
+                  reduceMotion={reduceMotion}
+                  ref={menuRef}
+                  responsive={false}
+                  tabIndex={-1}
+                  top={top}
+                  width={width}
+                >
+                  {children}
+                </StyledResponsiveMenu>
+              </>
+            )}
+          </StyledGlobalVerticalMenuWrapper>
+        )}
+      </div>
+    );
+  },
+);
 
-export const ResponsiveVerticalMenu = ({
-  children,
-  width,
-  height,
-  ...props
-}: ResponsiveVerticalMenuProps) => {
+export const ResponsiveVerticalMenu = forwardRef<
+  ResponsiveVerticalMenuHandle,
+  ResponsiveVerticalMenuProps
+>(({ children, width, height, ...props }, ref) => {
   return (
     <DepthProvider>
       <MenuFocusProvider>
         <ResponsiveVerticalMenuProvider width={width} height={height}>
-          <BaseMenu width={width} height={height} {...props}>
+          <BaseMenu ref={ref} width={width} height={height} {...props}>
             {children}
           </BaseMenu>
         </ResponsiveVerticalMenuProvider>
       </MenuFocusProvider>
     </DepthProvider>
   );
-};
+});
 
 export default ResponsiveVerticalMenu;

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.mdx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.mdx
@@ -151,6 +151,17 @@ For the best experience, these examples should be in Canvas mode.
 
 <Canvas of={ResponsiveVerticalMenuStories.Default} />
 
+### Focusing Launch Button Programmatically
+
+```javascript
+import { ResponsiveVerticalMenuHandle } from "carbon-react/lib/components/responsive-vertical-menu";
+```
+
+The `ResponsiveVerticalMenuHandle` type provides an imperative handle for programmatic control over `ResponsiveVerticalMenu`. 
+Using a `ref`, you can access its `focusLaunchButton()` method to set focus on the launch button as needed.
+
+<Canvas of={ResponsiveVerticalMenuStories.ProgrammaticFocus} />
+
 ### With Divider
 
 <Canvas of={ResponsiveVerticalMenuStories.WithDivider} />

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.stories.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.stories.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import allModes from "../../../../.storybook/modes";
@@ -7,9 +7,11 @@ import isChromatic from "../../../../.storybook/isChromatic";
 import {
   ResponsiveVerticalMenu,
   ResponsiveVerticalMenuDivider,
+  ResponsiveVerticalMenuHandle,
   ResponsiveVerticalMenuItem,
 } from ".";
 import Box from "../../box";
+import Button from "../../button";
 import Icon from "../../icon";
 import GlobalHeader from "../../global-header";
 
@@ -79,6 +81,57 @@ export const Default: Story = () => {
   );
 };
 Default.storyName = "Default";
+
+export const ProgrammaticFocus: Story = () => {
+  const responsiveVerticalMenuHandle =
+    useRef<ResponsiveVerticalMenuHandle>(null);
+
+  return (
+    <>
+      <GlobalHeader>
+        <ResponsiveVerticalMenu
+          ref={responsiveVerticalMenuHandle}
+          height="100%"
+        >
+          <ResponsiveVerticalMenuItem
+            icon="home"
+            id="primary-menu"
+            label="Primary Menu With Children"
+          >
+            <ResponsiveVerticalMenuItem
+              id="secondary-menu"
+              label="Secondary Menu With Children"
+            >
+              <ResponsiveVerticalMenuItem
+                id="tertiary-menu"
+                label="Tertiary Menu"
+              />
+            </ResponsiveVerticalMenuItem>
+            <ResponsiveVerticalMenuItem
+              id="secondary-menu-no-children"
+              label="Secondary Menu Item"
+            />
+          </ResponsiveVerticalMenuItem>
+          <ResponsiveVerticalMenuItem
+            icon="home"
+            id="primary-menu-no-children"
+            label="Primary Menu Item"
+          />
+        </ResponsiveVerticalMenu>
+      </GlobalHeader>
+      <Button
+        mt={5}
+        onClick={() =>
+          responsiveVerticalMenuHandle.current?.focusLaunchButton()
+        }
+      >
+        Focus Launch Button
+      </Button>
+    </>
+  );
+};
+ProgrammaticFocus.storyName = "Focusing Launch Button Programmatically";
+ProgrammaticFocus.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithDivider: Story = () => {
   return (

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.test.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.test.tsx
@@ -7,12 +7,14 @@ import {
   ResponsiveVerticalMenuDivider,
   ResponsiveVerticalMenuItem,
   ResponsiveVerticalMenuProvider,
+  ResponsiveVerticalMenuHandle,
 } from ".";
 import useIsAboveBreakpoint from "../../../hooks/__internal__/useIsAboveBreakpoint";
 import useMediaQuery from "../../../hooks/useMediaQuery";
 import guid from "../../../__internal__/utils/helpers/guid";
 import I18nProvider from "../../../components/i18n-provider";
 import Logger from "../../../__internal__/utils/logger";
+import Button from "../../button";
 
 jest.mock("../../../hooks/__internal__/useIsAboveBreakpoint");
 jest.mock("../../../hooks/useMediaQuery");
@@ -111,6 +113,44 @@ test("renders correctly", async () => {
   expect(screen.getByText("Menu Item 1")).toBeInTheDocument();
   expect(screen.getByText("Menu Item 2")).toBeInTheDocument();
   expect(screen.getByText("Menu Item 3")).toBeInTheDocument();
+});
+
+test("calling exposed focusLaunchButton method focuses launcher button", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  const MockComponent = () => {
+    const responsiveVerticalMenuHandle =
+      React.useRef<ResponsiveVerticalMenuHandle>(null);
+
+    return (
+      <>
+        <ResponsiveVerticalMenu ref={responsiveVerticalMenuHandle}>
+          <ResponsiveVerticalMenuItem id="menu-item-1" label="Menu Item 1" />
+          <ResponsiveVerticalMenuItem id="menu-item-2" label="Menu Item 2" />
+          <ResponsiveVerticalMenuItem id="menu-item-3" label="Menu Item 3" />
+        </ResponsiveVerticalMenu>
+        <Button
+          onClick={() =>
+            responsiveVerticalMenuHandle.current?.focusLaunchButton()
+          }
+        >
+          Press me to refocus on launch button
+        </Button>
+      </>
+    );
+  };
+
+  render(<MockComponent />);
+  const button = screen.getByRole("button", {
+    name: "Press me to refocus on launch button",
+  });
+
+  await user.click(button);
+
+  const launcherButton = screen.getByRole("button", {
+    name: "Product menu launcher",
+  });
+
+  expect(launcherButton).toHaveFocus();
 });
 
 test("throws if children are not wrapped in the provider", async () => {


### PR DESCRIPTION
fix #7574

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

adds a `forwardRef` to the `ResponsiveVerticalMenu` with a `focusLaunchButton` method which provides consumers the means to programmatically focus the launcher button which opens the component

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, there is no clean way to focus the launcher button which opens the component

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Feel free to use the new story added `"Focusing Launch Button Programmatically"`, this shows how the imperative handle is imported, applied and demonstrates the focus being correctly applied to the launcher button.
