### PR TITLE
feat(tabs): add support for programmatic tab focus

### DIFF
--- a/src/components/tabs/index.ts
+++ b/src/components/tabs/index.ts
@@ -1,3 +1,3 @@
 export { Tabs, Tab } from "./tabs.component";
-export type { TabsProps } from "./tabs.component";
+export type { TabsProps, TabsHandle } from "./tabs.component";
 export type { TabProps } from "./tab";

--- a/src/components/tabs/tabs.component.tsx
+++ b/src/components/tabs/tabs.component.tsx
@@ -10,6 +10,8 @@ import React, {
   Children,
   ReactElement,
   ComponentProps,
+  forwardRef,
+  useImperativeHandle,
 } from "react";
 import { MarginProps } from "styled-system";
 import Tab from "./tab";
@@ -22,6 +24,14 @@ import StyledTabs from "./tabs.style";
 import TabsHeader from "./__internal__/tabs-header";
 import TabTitle from "./__internal__/tab-title";
 import DrawerSidebarContext from "../drawer/__internal__/drawer-sidebar.context";
+
+export type TabsHandle = {
+  /**
+   * Programmatically focus on a specific tab.
+   * @param tabId - The ID of the tab to focus. Must match the `tabId` prop of the target `Tab` component.
+   */
+  focusTab: (tabId: string) => void;
+} | null;
 
 export interface TabsProps extends MarginProps, TagProps {
   /** Prevent rendering of hidden tabs, by default this is set to true and therefore all tabs will be rendered */
@@ -85,393 +95,421 @@ let deprecatedBordersWarningTriggered = false;
 let deprecatedValidationSummaryWarningTriggered = false;
 let deprecateCurrentImplementationWarningTriggered = false;
 
-const Tabs = ({
-  align = "left",
-  children,
-  onTabChange,
-  selectedTabId,
-  renderHiddenTabs = true,
-  position = "top",
-  extendedLine = true,
-  size,
-  borders = "off",
-  variant = "default",
-  validationStatusOverride,
-  headerWidth,
-  showValidationsSummary,
-  ...rest
-}: TabsProps) => {
-  if (!deprecateCurrentImplementationWarningTriggered) {
-    Logger.deprecate(
-      "The current implementation of the `Tabs` component is deprecated and will be changing in a future release.",
-    );
-    deprecateCurrentImplementationWarningTriggered = true;
-  }
-
-  if (
-    !!showValidationsSummary &&
-    !deprecatedValidationSummaryWarningTriggered
-  ) {
-    Logger.deprecate(
-      "The `showValidationsSummary` prop in the `Tabs` component is deprecated and will be removed in a future release.",
-    );
-    deprecatedValidationSummaryWarningTriggered = true;
-  }
-
-  if (align === "right" && !deprecatedRightAlignedTabContentWarningTriggered) {
-    Logger.deprecate(
-      "Support for the `right` value of `align` in the `Tabs` component is deprecated and will be removed in a future release.",
-    );
-    deprecatedRightAlignedTabContentWarningTriggered = true;
-  }
-
-  if (!extendedLine && !deprecatedExtendedLineWarningTriggered) {
-    Logger.deprecate(
-      "The `extendedLine` prop in the `Tabs` component is deprecated and will be removed in a future release.",
-    );
-    deprecatedExtendedLineWarningTriggered = true;
-  }
-
-  if (borders !== "off" && !deprecatedBordersWarningTriggered) {
-    Logger.deprecate(
-      "The `borders` prop in the `Tabs` component is deprecated and will be removed in a future release.",
-    );
-    deprecatedBordersWarningTriggered = true;
-  }
-
-  if (position !== "left" && headerWidth !== undefined) {
-    Logger.error(
-      "Invalid usage of prop headerWidth in Tabs. The headerWidth can be used only if position is set to left",
-    );
-  }
-
-  /** The children nodes converted into an Array */
-  const filteredChildren = useMemo(
-    () => Children.toArray(children).filter((child) => child),
-    [children],
-  ) as ReactElement<ComponentProps<typeof Tab>>[];
-
-  /** Array of the tabIds for the child nodes */
-  const tabIds = useMemo(
-    () => filteredChildren.map((child) => child.props.tabId),
-    [filteredChildren],
-  );
-
-  /** Array of refs to the TabTitle nodes */
-  const tabRefs = useMemo<React.RefObject<HTMLElement>[]>(
-    () =>
-      Array.from({ length: filteredChildren.length }).map(() => createRef()),
-    [filteredChildren.length],
-  );
-
-  const previousSelectedTabId = useRef(selectedTabId);
-  const [selectedTabIdState, setSelectedTabIdState] = useState<
-    string | undefined
-  >(selectedTabId || filteredChildren[0].props.tabId);
-
-  const { isInSidebar } = useContext(DrawerSidebarContext);
-  const [tabsErrors, setTabsErrors] = useState<
-    Record<string, Record<string, undefined | string | boolean>>
-  >({});
-  const [tabsWarnings, setTabsWarnings] = useState<
-    Record<string, Record<string, undefined | string | boolean>>
-  >({});
-  const [tabsInfos, setTabsInfos] = useState<
-    Record<string, Record<string, undefined | string | boolean>>
-  >({});
-
-  const updateErrors = useCallback(
-    (id: string, error: Record<string, undefined | string | boolean>) => {
-      setTabsErrors((state) => ({ ...state, [id]: error }));
+const Tabs = forwardRef<TabsHandle, TabsProps>(
+  (
+    {
+      align = "left",
+      children,
+      onTabChange,
+      selectedTabId,
+      renderHiddenTabs = true,
+      position = "top",
+      extendedLine = true,
+      size,
+      borders = "off",
+      variant = "default",
+      validationStatusOverride,
+      headerWidth,
+      showValidationsSummary,
+      ...rest
     },
-    [],
-  );
-
-  const updateWarnings = useCallback(
-    (id: string, warning: Record<string, undefined | string | boolean>) => {
-      setTabsWarnings((state) => ({ ...state, [id]: warning }));
-    },
-    [],
-  );
-
-  const updateInfos = useCallback(
-    (id: string, info: Record<string, undefined | string | boolean>) => {
-      setTabsInfos((state) => ({ ...state, [id]: info }));
-    },
-    [],
-  );
-
-  /** Returns true/false for if the given tab id is selected. */
-  const isTabSelected = useCallback(
-    (tabId: string) => tabId === selectedTabIdState,
-    [selectedTabIdState],
-  );
-
-  /** Updates the currently visible tab */
-  const updateVisibleTab = useCallback(
-    (tabid: string) => {
-      if (!isTabSelected(tabid)) {
-        setSelectedTabIdState(tabid);
-      }
-      if (onTabChange) {
-        onTabChange(tabid);
-      }
-    },
-    [onTabChange, isTabSelected],
-  );
-
-  const blurPreviousSelectedTab = useCallback(() => {
-    const { current } = previousSelectedTabId;
-    const previousTabIndex = current
-      ? tabIds.indexOf(current)
-      : /* istanbul ignore next */ -1;
-    /* istanbul ignore else */
-    if (previousTabIndex !== -1) {
-      const previousTabRef = tabRefs[previousTabIndex];
-      previousTabRef.current?.blur();
+    ref,
+  ) => {
+    if (!deprecateCurrentImplementationWarningTriggered) {
+      Logger.deprecate(
+        "The current implementation of the `Tabs` component is deprecated and will be changing in a future release.",
+      );
+      deprecateCurrentImplementationWarningTriggered = true;
     }
-  }, [tabIds, tabRefs]);
 
-  useEffect(() => {
-    if (previousSelectedTabId.current !== selectedTabId) {
-      if (selectedTabId !== selectedTabIdState) {
-        setSelectedTabIdState(selectedTabId);
-        blurPreviousSelectedTab();
-      }
-      previousSelectedTabId.current = selectedTabId;
+    if (
+      !!showValidationsSummary &&
+      !deprecatedValidationSummaryWarningTriggered
+    ) {
+      Logger.deprecate(
+        "The `showValidationsSummary` prop in the `Tabs` component is deprecated and will be removed in a future release.",
+      );
+      deprecatedValidationSummaryWarningTriggered = true;
     }
-  }, [
-    blurPreviousSelectedTab,
-    previousSelectedTabId,
-    selectedTabId,
-    selectedTabIdState,
-  ]);
 
-  const createTabClickHandler =
-    (tabId: string) => (ev: React.MouseEvent<HTMLElement>) => {
-      // istanbul ignore if
-      // (code doesn't seem to be ever reached - FE-6835 raised to investigate and hopefully remove this)
-      if (Event.isEventType(ev, "keydown")) {
-        return;
-      }
-
-      updateVisibleTab(tabId);
-    };
-
-  /** Focuses the tab for the reference specified */
-  const focusTab = (ref: React.RefObject<HTMLElement>) => {
-    ref.current?.focus();
-    /* istanbul ignore next */
-    const rect = ref.current?.getBoundingClientRect();
-    /* istanbul ignore next */
-    if (rect) {
-      const isVisible =
-        rect.top >= 0 &&
-        rect.left >= 0 &&
-        rect.bottom <=
-          (window.innerHeight || document.documentElement.clientHeight) &&
-        rect.right <=
-          (window.innerWidth || document.documentElement.clientWidth);
-      if (!isVisible) {
-        ref.current?.scrollIntoView({ behavior: "auto", inline: "center" });
-      }
+    if (
+      align === "right" &&
+      !deprecatedRightAlignedTabContentWarningTriggered
+    ) {
+      Logger.deprecate(
+        "Support for the `right` value of `align` in the `Tabs` component is deprecated and will be removed in a future release.",
+      );
+      deprecatedRightAlignedTabContentWarningTriggered = true;
     }
-  };
 
-  /** Will trigger the tab at the given index. */
-  const goToTab = (event: React.KeyboardEvent<HTMLElement>, index: number) => {
-    event.preventDefault();
-    let newIndex = index;
-
-    if (index < 0) {
-      newIndex = tabIds.length - 1;
-    } else if (index === tabIds.length) {
-      newIndex = 0;
+    if (!extendedLine && !deprecatedExtendedLineWarningTriggered) {
+      Logger.deprecate(
+        "The `extendedLine` prop in the `Tabs` component is deprecated and will be removed in a future release.",
+      );
+      deprecatedExtendedLineWarningTriggered = true;
     }
-    const nextRef = tabRefs[newIndex];
-    focusTab(nextRef);
-  };
 
-  const createTabKeydownHandler =
-    (index: number) => (event: React.KeyboardEvent<HTMLElement>) => {
-      const isTabVertical = isInSidebar || position === "left";
-      const isUp = isTabVertical && Event.isUpKey(event);
-      const isDown = isTabVertical && Event.isDownKey(event);
-      const isLeft = !isTabVertical && Event.isLeftKey(event);
-      const isRight = !isTabVertical && Event.isRightKey(event);
-      if (isUp || isLeft) {
-        goToTab(event, index - 1);
-      } else if (isDown || isRight) {
-        goToTab(event, index + 1);
+    if (borders !== "off" && !deprecatedBordersWarningTriggered) {
+      Logger.deprecate(
+        "The `borders` prop in the `Tabs` component is deprecated and will be removed in a future release.",
+      );
+      deprecatedBordersWarningTriggered = true;
+    }
+
+    if (position !== "left" && headerWidth !== undefined) {
+      Logger.error(
+        "Invalid usage of prop headerWidth in Tabs. The headerWidth can be used only if position is set to left",
+      );
+    }
+
+    /** The children nodes converted into an Array */
+    const filteredChildren = useMemo(
+      () => Children.toArray(children).filter((child) => child),
+      [children],
+    ) as ReactElement<ComponentProps<typeof Tab>>[];
+
+    /** Array of the tabIds for the child nodes */
+    const tabIds = useMemo(
+      () => filteredChildren.map((child) => child.props.tabId),
+      [filteredChildren],
+    );
+
+    /** Array of refs to the TabTitle nodes */
+    const tabRefs = useMemo<React.RefObject<HTMLElement>[]>(
+      () =>
+        Array.from({ length: filteredChildren.length }).map(() => createRef()),
+      [filteredChildren.length],
+    );
+
+    const previousSelectedTabId = useRef(selectedTabId);
+    const [selectedTabIdState, setSelectedTabIdState] = useState<
+      string | undefined
+    >(selectedTabId || filteredChildren[0].props.tabId);
+
+    const { isInSidebar } = useContext(DrawerSidebarContext);
+    const [tabsErrors, setTabsErrors] = useState<
+      Record<string, Record<string, undefined | string | boolean>>
+    >({});
+    const [tabsWarnings, setTabsWarnings] = useState<
+      Record<string, Record<string, undefined | string | boolean>>
+    >({});
+    const [tabsInfos, setTabsInfos] = useState<
+      Record<string, Record<string, undefined | string | boolean>>
+    >({});
+
+    const updateErrors = useCallback(
+      (id: string, error: Record<string, undefined | string | boolean>) => {
+        setTabsErrors((state) => ({ ...state, [id]: error }));
+      },
+      [],
+    );
+
+    const updateWarnings = useCallback(
+      (id: string, warning: Record<string, undefined | string | boolean>) => {
+        setTabsWarnings((state) => ({ ...state, [id]: warning }));
+      },
+      [],
+    );
+
+    const updateInfos = useCallback(
+      (id: string, info: Record<string, undefined | string | boolean>) => {
+        setTabsInfos((state) => ({ ...state, [id]: info }));
+      },
+      [],
+    );
+
+    /** Returns true/false for if the given tab id is selected. */
+    const isTabSelected = useCallback(
+      (tabId: string) => tabId === selectedTabIdState,
+      [selectedTabIdState],
+    );
+
+    /** Updates the currently visible tab */
+    const updateVisibleTab = useCallback(
+      (tabid: string) => {
+        if (!isTabSelected(tabid)) {
+          setSelectedTabIdState(tabid);
+        }
+        if (onTabChange) {
+          onTabChange(tabid);
+        }
+      },
+      [onTabChange, isTabSelected],
+    );
+
+    const blurPreviousSelectedTab = useCallback(() => {
+      const { current } = previousSelectedTabId;
+      const previousTabIndex = current
+        ? tabIds.indexOf(current)
+        : /* istanbul ignore next */ -1;
+      /* istanbul ignore else */
+      if (previousTabIndex !== -1) {
+        const previousTabRef = tabRefs[previousTabIndex];
+        previousTabRef.current?.blur();
       }
-    };
+    }, [tabIds, tabRefs]);
 
-  /** Build the headers for the tab component */
-  const renderTabHeaders = () => {
-    const tabTitles = filteredChildren.map((child, index) => {
-      const {
-        tabId,
-        title,
-        siblings,
-        titlePosition,
-        errorMessage,
-        warningMessage,
-        infoMessage,
-        href,
-        customLayout,
-        titleProps,
-      } = child.props;
-      const refId = `${tabId}-tab`;
-      const errors = tabsErrors[tabId];
-      const warnings = tabsWarnings[tabId];
-      const infos = tabsInfos[tabId];
+    useEffect(() => {
+      if (previousSelectedTabId.current !== selectedTabId) {
+        if (selectedTabId !== selectedTabIdState) {
+          setSelectedTabIdState(selectedTabId);
+          blurPreviousSelectedTab();
+        }
+        previousSelectedTabId.current = selectedTabId;
+      }
+    }, [
+      blurPreviousSelectedTab,
+      previousSelectedTabId,
+      selectedTabId,
+      selectedTabIdState,
+    ]);
 
-      const errorsCount =
-        errors && Object.entries(errors).filter((tab) => tab[1]).length;
-      const warningsCount =
-        warnings && Object.entries(warnings).filter((tab) => tab[1]).length;
-      const infosCount =
-        infos && Object.entries(infos).filter((tab) => tab[1]).length;
-
-      const hasOverride =
-        validationStatusOverride && validationStatusOverride[tabId];
-      const errorOverride =
-        hasOverride && validationStatusOverride[tabId].error;
-      const warningOverride =
-        hasOverride && validationStatusOverride[tabId].warning;
-      const infoOverride = hasOverride && validationStatusOverride[tabId].info;
-      const tabHasError =
-        errorOverride !== undefined ? errorOverride : !!errorsCount;
-      const tabHasWarning =
-        warningOverride !== undefined
-          ? warningOverride
-          : !!warningsCount && !tabHasError;
-      const tabHasInfo =
-        infoOverride !== undefined
-          ? infoOverride
-          : !!infosCount && !tabHasError && !tabHasWarning;
-
-      const getValidationMessage = (
-        message: string | undefined,
-        validations: Record<string, undefined | string | boolean> = {},
-      ): string | undefined => {
-        const summaryOfMessages = Object.values(validations).filter(
-          (value) => value && typeof value === "string",
-        ) as string[];
-
-        if (!showValidationsSummary || !summaryOfMessages.length) {
-          return message;
+    const createTabClickHandler =
+      (tabId: string) => (ev: React.MouseEvent<HTMLElement>) => {
+        // istanbul ignore if
+        // (code doesn't seem to be ever reached - FE-6835 raised to investigate and hopefully remove this)
+        if (Event.isEventType(ev, "keydown")) {
+          return;
         }
 
-        if (summaryOfMessages.length === 1) {
-          return summaryOfMessages[0];
-        }
-
-        return summaryOfMessages.map((value) => `• ${value}`).join("\n");
+        updateVisibleTab(tabId);
       };
 
-      return (
-        <TabTitle
-          {...titleProps}
-          position={isInSidebar ? "left" : position}
-          dataTabId={tabId}
-          id={refId}
-          key={tabId}
-          onClick={createTabClickHandler(tabId)}
-          onKeyDown={createTabKeydownHandler(index)}
-          ref={tabRefs[index]}
-          tabIndex={isTabSelected(tabId) ? 0 : -1}
-          title={title}
-          href={href}
-          isTabSelected={isTabSelected(tabId)}
-          error={tabHasError}
-          warning={tabHasWarning}
-          info={tabHasInfo}
-          size={size || "default"}
-          borders={borders !== "off"}
-          siblings={siblings}
-          titlePosition={titlePosition}
-          errorMessage={getValidationMessage(errorMessage, errors)}
-          warningMessage={getValidationMessage(warningMessage, warnings)}
-          infoMessage={getValidationMessage(infoMessage, infos)}
-          alternateStyling={variant === "alternate"}
-          noLeftBorder={["no left side", "no sides"].includes(borders)}
-          noRightBorder={["no right side", "no sides"].includes(borders)}
-          customLayout={customLayout}
-          isInSidebar={isInSidebar}
-          align={align}
-        />
-      );
-    });
+    /** Focuses the tab for the reference specified */
+    const focusTab = (ref: React.RefObject<HTMLElement>) => {
+      ref.current?.focus();
+      /* istanbul ignore next */
+      const rect = ref.current?.getBoundingClientRect();
+      /* istanbul ignore next */
+      if (rect) {
+        const isVisible =
+          rect.top >= 0 &&
+          rect.left >= 0 &&
+          rect.bottom <=
+            (window.innerHeight || document.documentElement.clientHeight) &&
+          rect.right <=
+            (window.innerWidth || document.documentElement.clientWidth);
+        if (!isVisible) {
+          ref.current?.scrollIntoView({ behavior: "auto", inline: "center" });
+        }
+      }
+    };
 
-    return (
-      <TabsHeader
-        align={align}
-        position={isInSidebar ? "left" : position}
-        role="tablist"
-        extendedLine={extendedLine}
-        noRightBorder={["no right side", "no sides"].includes(borders)}
-        isInSidebar={isInSidebar}
-        size={size || "default"}
-      >
-        {tabTitles}
-      </TabsHeader>
+    /** Will trigger the tab at the given index. */
+    const goToTab = (
+      event: React.KeyboardEvent<HTMLElement>,
+      index: number,
+    ) => {
+      event.preventDefault();
+      let newIndex = index;
+
+      if (index < 0) {
+        newIndex = tabIds.length - 1;
+      } else if (index === tabIds.length) {
+        newIndex = 0;
+      }
+      const nextRef = tabRefs[newIndex];
+      focusTab(nextRef);
+    };
+
+    const createTabKeydownHandler =
+      (index: number) => (event: React.KeyboardEvent<HTMLElement>) => {
+        const isTabVertical = isInSidebar || position === "left";
+        const isUp = isTabVertical && Event.isUpKey(event);
+        const isDown = isTabVertical && Event.isDownKey(event);
+        const isLeft = !isTabVertical && Event.isLeftKey(event);
+        const isRight = !isTabVertical && Event.isRightKey(event);
+        if (isUp || isLeft) {
+          goToTab(event, index - 1);
+        } else if (isDown || isRight) {
+          goToTab(event, index + 1);
+        }
+      };
+
+    useImperativeHandle<TabsHandle, TabsHandle>(
+      ref,
+      () => ({
+        focusTab(tabId) {
+          const tabRef =
+            tabRefs[
+              filteredChildren.findIndex((child) => child.props.tabId === tabId)
+            ];
+          if (tabRef) {
+            focusTab(tabRef);
+          }
+        },
+      }),
+      [filteredChildren, tabRefs],
     );
-  };
 
-  /** Builds all tabs where non selected tabs have class of hidden */
-  const renderTabs = () => {
-    if (isInSidebar) return null;
+    /** Build the headers for the tab component */
+    const renderTabHeaders = () => {
+      const tabTitles = filteredChildren.map((child, index) => {
+        const {
+          tabId,
+          title,
+          siblings,
+          titlePosition,
+          errorMessage,
+          warningMessage,
+          infoMessage,
+          href,
+          customLayout,
+          titleProps,
+        } = child.props;
+        const refId = `${tabId}-tab`;
+        const errors = tabsErrors[tabId];
+        const warnings = tabsWarnings[tabId];
+        const infos = tabsInfos[tabId];
 
-    if (!renderHiddenTabs) {
-      const tab = filteredChildren.find((child) =>
-        isTabSelected(child.props.tabId),
-      );
+        const errorsCount =
+          errors && Object.entries(errors).filter((tab) => tab[1]).length;
+        const warningsCount =
+          warnings && Object.entries(warnings).filter((tab) => tab[1]).length;
+        const infosCount =
+          infos && Object.entries(infos).filter((tab) => tab[1]).length;
+
+        const hasOverride =
+          validationStatusOverride && validationStatusOverride[tabId];
+        const errorOverride =
+          hasOverride && validationStatusOverride[tabId].error;
+        const warningOverride =
+          hasOverride && validationStatusOverride[tabId].warning;
+        const infoOverride =
+          hasOverride && validationStatusOverride[tabId].info;
+        const tabHasError =
+          errorOverride !== undefined ? errorOverride : !!errorsCount;
+        const tabHasWarning =
+          warningOverride !== undefined
+            ? warningOverride
+            : !!warningsCount && !tabHasError;
+        const tabHasInfo =
+          infoOverride !== undefined
+            ? infoOverride
+            : !!infosCount && !tabHasError && !tabHasWarning;
+
+        const getValidationMessage = (
+          message: string | undefined,
+          validations: Record<string, undefined | string | boolean> = {},
+        ): string | undefined => {
+          const summaryOfMessages = Object.values(validations).filter(
+            (value) => value && typeof value === "string",
+          ) as string[];
+
+          if (!showValidationsSummary || !summaryOfMessages.length) {
+            return message;
+          }
+
+          if (summaryOfMessages.length === 1) {
+            return summaryOfMessages[0];
+          }
+
+          return summaryOfMessages.map((value) => `• ${value}`).join("\n");
+        };
+
+        return (
+          <TabTitle
+            {...titleProps}
+            position={isInSidebar ? "left" : position}
+            dataTabId={tabId}
+            id={refId}
+            key={tabId}
+            onClick={createTabClickHandler(tabId)}
+            onKeyDown={createTabKeydownHandler(index)}
+            ref={tabRefs[index]}
+            tabIndex={isTabSelected(tabId) ? 0 : -1}
+            title={title}
+            href={href}
+            isTabSelected={isTabSelected(tabId)}
+            error={tabHasError}
+            warning={tabHasWarning}
+            info={tabHasInfo}
+            size={size || "default"}
+            borders={borders !== "off"}
+            siblings={siblings}
+            titlePosition={titlePosition}
+            errorMessage={getValidationMessage(errorMessage, errors)}
+            warningMessage={getValidationMessage(warningMessage, warnings)}
+            infoMessage={getValidationMessage(infoMessage, infos)}
+            alternateStyling={variant === "alternate"}
+            noLeftBorder={["no left side", "no sides"].includes(borders)}
+            noRightBorder={["no right side", "no sides"].includes(borders)}
+            customLayout={customLayout}
+            isInSidebar={isInSidebar}
+            align={align}
+          />
+        );
+      });
 
       return (
-        tab &&
-        cloneElement(tab, {
-          ...tab.props,
+        <TabsHeader
+          align={align}
+          position={isInSidebar ? "left" : position}
+          role="tablist"
+          extendedLine={extendedLine}
+          noRightBorder={["no right side", "no sides"].includes(borders)}
+          isInSidebar={isInSidebar}
+          size={size || "default"}
+        >
+          {tabTitles}
+        </TabsHeader>
+      );
+    };
+
+    /** Builds all tabs where non selected tabs have class of hidden */
+    const renderTabs = () => {
+      if (isInSidebar) return null;
+
+      if (!renderHiddenTabs) {
+        const tab = filteredChildren.find((child) =>
+          isTabSelected(child.props.tabId),
+        );
+
+        return (
+          tab &&
+          cloneElement(tab, {
+            ...tab.props,
+            role: "tabpanel",
+            position,
+            isTabSelected: isTabSelected(tab.props.tabId),
+            key: `${tab.props.tabId}-tab`,
+            ariaLabelledby: `${tab.props.tabId}-tab`,
+            updateErrors,
+            updateWarnings,
+            updateInfos,
+          })
+        );
+      }
+
+      return filteredChildren.map((child) => {
+        return cloneElement(child, {
+          ...child.props,
           role: "tabpanel",
           position,
-          isTabSelected: isTabSelected(tab.props.tabId),
-          key: `${tab.props.tabId}-tab`,
-          ariaLabelledby: `${tab.props.tabId}-tab`,
+          isTabSelected: isTabSelected(child.props.tabId),
+          key: `${child.props.tabId}-tab`,
+          ariaLabelledby: `${child.props.tabId}-tab`,
           updateErrors,
           updateWarnings,
           updateInfos,
-        })
-      );
-    }
-
-    return filteredChildren.map((child) => {
-      return cloneElement(child, {
-        ...child.props,
-        role: "tabpanel",
-        position,
-        isTabSelected: isTabSelected(child.props.tabId),
-        key: `${child.props.tabId}-tab`,
-        ariaLabelledby: `${child.props.tabId}-tab`,
-        updateErrors,
-        updateWarnings,
-        updateInfos,
+        });
       });
-    });
-  };
+    };
 
-  return (
-    <StyledTabs
-      position={isInSidebar ? "left" : position}
-      data-role="tabs"
-      isInSidebar={isInSidebar}
-      headerWidth={headerWidth}
-      {...rest}
-      {...tagComponent("tabs", rest)}
-    >
-      {renderTabHeaders()}
-      {renderTabs()}
-    </StyledTabs>
-  );
-};
+    return (
+      <StyledTabs
+        position={isInSidebar ? "left" : position}
+        data-role="tabs"
+        isInSidebar={isInSidebar}
+        headerWidth={headerWidth}
+        {...rest}
+        {...tagComponent("tabs", rest)}
+      >
+        {renderTabHeaders()}
+        {renderTabs()}
+      </StyledTabs>
+    );
+  },
+);
 
 export { Tabs, Tab };

--- a/src/components/tabs/tabs.mdx
+++ b/src/components/tabs/tabs.mdx
@@ -53,6 +53,18 @@ The tabs widget also allows you to select a tab on page load. By default this is
 
 <Canvas of={TabsStories.DefaultStory} />
 
+### Focusing a Tab Programmatically
+
+```javascript
+import { TabsHandle } from "carbon-react/lib/components/tabs";
+```
+
+The `TabsHandle` type provides an imperative handle for programmatic control over a desired `Tab`. 
+Using a ref, you can access its `focusTab()` method which accepts a `tabId` parameter.
+Pass the same ID that you've assigned to the `tabId` prop on the `Tab` you want to focus.
+
+<Canvas of={TabsStories.ProgrammaticFocus} />
+
 ### Positioned top and aligned right
 
 <Canvas of={TabsStories.PositionedTopAlignedRight} />

--- a/src/components/tabs/tabs.stories.tsx
+++ b/src/components/tabs/tabs.stories.tsx
@@ -1,11 +1,12 @@
-import React from "react";
+import React, { useRef } from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import generateStyledSystemProps from "../../../.storybook/utils/styled-system-props";
 import Pill from "../pill";
 import Icon from "../icon";
+import Button from "../button";
 import Box from "../box";
-import { Tabs, Tab } from ".";
+import { Tabs, Tab, TabsHandle } from ".";
 import CarbonProvider from "../carbon-provider/carbon-provider.component";
 import Textbox from "../textbox";
 
@@ -83,6 +84,72 @@ export const DefaultStory: Story = () => {
   );
 };
 DefaultStory.storyName = "Default";
+
+export const ProgrammaticFocus: Story = () => {
+  const tabsHandle = useRef<TabsHandle>(null);
+
+  return (
+    <Box p="4px">
+      <Tabs ref={tabsHandle} align="left" position="top">
+        <Tab
+          errorMessage="error"
+          warningMessage="warning"
+          infoMessage="info"
+          tabId="tab-1"
+          title="Tab 1"
+          key="tab-1"
+        >
+          Content for tab 1
+        </Tab>
+        <Tab
+          errorMessage="error"
+          warningMessage="warning"
+          infoMessage="info"
+          tabId="tab-2"
+          title="Tab 2"
+          key="tab-2"
+        >
+          Content for tab 2
+        </Tab>
+        <Tab
+          errorMessage="error"
+          warningMessage="warning"
+          infoMessage="info"
+          tabId="tab-3"
+          title="Tab 3"
+          key="tab-3"
+        >
+          Content for tab 3
+        </Tab>
+        <Tab
+          errorMessage="error"
+          warningMessage="warning"
+          infoMessage="info"
+          tabId="tab-4"
+          title="Tab 4"
+          key="tab-4"
+        >
+          Content for tab 4
+        </Tab>
+        <Tab
+          errorMessage="error"
+          warningMessage="warning"
+          infoMessage="info"
+          tabId="tab-5"
+          title="Tab 5"
+          key="tab-5"
+        >
+          Content for tab 5
+        </Tab>
+      </Tabs>
+      <Button mt={5} onClick={() => tabsHandle.current?.focusTab("tab-4")}>
+        Focus Tab 4
+      </Button>
+    </Box>
+  );
+};
+ProgrammaticFocus.storyName = "Focusing a Tab Programmatically";
+ProgrammaticFocus.parameters = { chromatic: { disableSnapshot: true } };
 
 export const PositionedTopAlignedRight: Story = () => {
   return (

--- a/src/components/tabs/tabs.test.tsx
+++ b/src/components/tabs/tabs.test.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from "react";
 import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Tabs, Tab } from ".";
+import { Tabs, Tab, TabsHandle } from ".";
 import { StyledTabsHeaderWrapper } from "./__internal__/tabs-header/tabs-header.style";
 import StyledTab from "./tab/tab.style";
 import {
   assertLoggerComponentMessage,
   testStyledSystemMargin,
 } from "../../__spec_helper__/__internal__/test-utils";
+import Button from "../button";
 import Drawer from "../drawer";
 import Textbox from "../textbox";
 import NumeralDate from "../numeral-date";
@@ -147,6 +148,74 @@ test("should throw an error if rendered with `headerWidth` prop and `position` p
   );
 
   consoleSpy.mockRestore();
+});
+
+test("calling exposed focusTab method with correct tabId focuses chosen tab", async () => {
+  const user = userEvent.setup();
+  const MockComponent = () => {
+    const tabsHandle = React.useRef<TabsHandle>(null);
+
+    return (
+      <>
+        <Tabs ref={tabsHandle}>
+          <Tab title="Tab Title 1" tabId="uniqueid1">
+            TabContent
+          </Tab>
+        </Tabs>
+        <Button onClick={() => tabsHandle.current?.focusTab("uniqueid1")}>
+          Press me to focus on the only tab
+        </Button>
+      </>
+    );
+  };
+
+  render(<MockComponent />);
+  const button = screen.getByRole("button", {
+    name: "Press me to focus on the only tab",
+  });
+
+  await user.click(button);
+
+  const tab = screen.getByRole("tab", {
+    name: "Tab Title 1",
+  });
+
+  expect(tab).toHaveFocus();
+});
+
+test("exposed focusTab method handles being called with invalid tabId", async () => {
+  const user = userEvent.setup();
+  const MockComponent = () => {
+    const tabsHandle = React.useRef<TabsHandle>(null);
+
+    return (
+      <>
+        <Tabs ref={tabsHandle}>
+          <Tab title="Tab Title 1" tabId="uniqueid1">
+            TabContent
+          </Tab>
+        </Tabs>
+        <Button
+          onClick={() => tabsHandle.current?.focusTab("completely-wrong-id")}
+        >
+          Press me to focus on the only tab
+        </Button>
+      </>
+    );
+  };
+
+  render(<MockComponent />);
+  const button = screen.getByRole("button", {
+    name: "Press me to focus on the only tab",
+  });
+
+  await user.click(button);
+
+  const tab = screen.getByRole("tab", {
+    name: "Tab Title 1",
+  });
+
+  expect(tab).not.toHaveFocus();
 });
 
 test("the `selectedTabId` prop determines which child `Tab` is displayed", () => {


### PR DESCRIPTION
fix #7567

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

adds a `forwardRef` to `Tabs` with a `focusTab` method which provides consumers the means to programmatically focus a specific tab. This can be achieved by utilising the `tabId` parameter and passing the same ID that has been assigned to the `tabId` prop on the `Tab` component which needs focus

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently there is no supported way to programmatically focus a specific `Tab` component via `Tabs`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Feel free to use the new story added "Focusing a Tab Programmatically", this shows how the imperative handle is imported, applied and demonstrates the focus being correctly applied a specific `Tab`.
