### PR TITLE
fix(flat-table): prevent sorting indicators from impacting text wrapping

### DIFF
--- a/playwright/components/flat-table/index.ts
+++ b/playwright/components/flat-table/index.ts
@@ -40,7 +40,7 @@ export const flatTableBodyRows = (page: Page) =>
 export const flatTableClickableRow = (page: Page, index: number) =>
   page.locator(FLAT_TABLE_COMPONENT).locator("tbody tr").nth(index);
 export const flatTableSortable = (page: Page) =>
-  page.locator(FLAT_TABLE_COMPONENT).locator("thead tr th div [role=button]");
+  page.locator(FLAT_TABLE_COMPONENT).locator("thead tr th button");
 export const flatTableCell = (page: Page, index: number) =>
   page.locator(FLAT_TABLE_CELL).nth(index);
 export const flatTableCheckboxCell = (page: Page, index: number) =>
@@ -73,8 +73,8 @@ export const flatTableCurrentPageInput = (page: Page) =>
 
 export const flatTableRowHeader = (page: Page) =>
   page.locator(FLAT_TABLE_STICKY_ROW);
-export const flatTableHeaderCellsIcon = (page: Page) =>
-  flatTableHeader(page).locator("th > div > div").locator("span");
+export const flatTableHeaderCellsButtonIcon = (page: Page) =>
+  flatTableHeader(page).locator("[data-element='sort-icon']");
 export const flatTableExpandableIcon = (page: Page, index: number) =>
   flatTableCell(page, index).locator(FLAT_TABLE_ICON);
 

--- a/src/components/flat-table/flat-table.pw.tsx
+++ b/src/components/flat-table/flat-table.pw.tsx
@@ -52,7 +52,7 @@ import {
   flatTableBody,
   flatTableCell,
   flatTableCheckboxHeader,
-  flatTableHeaderCellsIcon,
+  flatTableHeaderCellsButtonIcon,
   flatTableExpandableIcon,
   flatTableBodyRows,
   flatTableRowHeader,
@@ -178,20 +178,6 @@ test.describe("Prop tests", () => {
     await mount(<FlatTableComponent />);
 
     await expect(flatTable(page).locator("thead").locator("tr")).toHaveCount(1);
-  });
-
-  test(`should render header with icon nodes as children`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<FlatTableComponent />);
-
-    for await (const i of indexes(4)) {
-      await expect(flatTableHeaderCellsIcon(page).nth(i)).toHaveAttribute(
-        "data-component",
-        "icon",
-      );
-    }
   });
 
   test(`should render with icon node as children`, async ({ mount, page }) => {
@@ -1281,7 +1267,7 @@ test.describe("Prop tests", () => {
       const totalTwo = "1349";
       const totalThree = "849";
       const totalFour = "3840";
-      const headerCellsIcon = flatTableHeaderCellsIcon(page);
+      const headerCellsIcon = flatTableHeaderCellsButtonIcon(page);
       const cell1 = flatTableCell(page, 0);
       const cell2 = flatTableCell(page, 1);
       const cell3 = flatTableCell(page, 2);
@@ -1292,10 +1278,7 @@ test.describe("Prop tests", () => {
       const cell8 = flatTableCell(page, 7);
 
       if (colPosition === "first" && sortOrder === "desc") {
-        await expect(headerCellsIcon).toHaveAttribute(
-          "data-element",
-          "sort_down",
-        );
+        await expect(headerCellsIcon).toHaveAttribute("type", "sort_down");
         await expect(headerCellsIcon).toBeVisible();
         await expect(cell1).toHaveText(valueOne);
         await expect(cell1).toBeVisible();
@@ -1306,10 +1289,7 @@ test.describe("Prop tests", () => {
         await expect(cell7).toHaveText(valueFour);
         await expect(cell7).toBeVisible();
       } else if (colPosition === "first" && sortOrder === "asc") {
-        await expect(headerCellsIcon).toHaveAttribute(
-          "data-element",
-          "sort_up",
-        );
+        await expect(headerCellsIcon).toHaveAttribute("type", "sort_up");
         await expect(headerCellsIcon).toBeVisible();
         await expect(cell1).toHaveText(valueFour);
         await expect(cell1).toBeVisible();
@@ -1320,10 +1300,7 @@ test.describe("Prop tests", () => {
         await expect(cell7).toHaveText(valueOne);
         await expect(cell7).toBeVisible();
       } else if (colPosition === "second" && sortOrder === "desc") {
-        await expect(headerCellsIcon).toHaveAttribute(
-          "data-element",
-          "sort_down",
-        );
+        await expect(headerCellsIcon).toHaveAttribute("type", "sort_down");
         await expect(headerCellsIcon).toBeVisible();
         await expect(cell2).toHaveText(totalFour);
         await expect(cell2).toBeVisible();
@@ -1334,10 +1311,7 @@ test.describe("Prop tests", () => {
         await expect(cell8).toHaveText(totalOne);
         await expect(cell8).toBeVisible();
       } else {
-        await expect(headerCellsIcon).toHaveAttribute(
-          "data-element",
-          "sort_up",
-        );
+        await expect(headerCellsIcon).toHaveAttribute("type", "sort_up");
         await expect(headerCellsIcon).toBeVisible();
         await expect(cell2).toHaveText(totalOne);
         await expect(cell2).toBeVisible();
@@ -1373,7 +1347,7 @@ test.describe("Prop tests", () => {
       const totalTwo = "1349";
       const totalThree = "849";
       const totalFour = "3840";
-      const headerCellsIcon = flatTableHeaderCellsIcon(page);
+      const headerCellsIcon = flatTableHeaderCellsButtonIcon(page);
       const cell1 = flatTableCell(page, 0);
       const cell2 = flatTableCell(page, 1);
       const cell3 = flatTableCell(page, 2);
@@ -1384,10 +1358,7 @@ test.describe("Prop tests", () => {
       const cell8 = flatTableCell(page, 7);
 
       if (colPosition === "first" && sortOrder === "desc") {
-        await expect(headerCellsIcon).toHaveAttribute(
-          "data-element",
-          "sort_down",
-        );
+        await expect(headerCellsIcon).toHaveAttribute("type", "sort_down");
         await expect(headerCellsIcon).toBeVisible();
         await expect(cell1).toHaveText(valueOne);
         await expect(cell1).toBeVisible();
@@ -1398,10 +1369,7 @@ test.describe("Prop tests", () => {
         await expect(cell7).toHaveText(valueFour);
         await expect(cell7).toBeVisible();
       } else if (colPosition === "first" && sortOrder === "asc") {
-        await expect(headerCellsIcon).toHaveAttribute(
-          "data-element",
-          "sort_up",
-        );
+        await expect(headerCellsIcon).toHaveAttribute("type", "sort_up");
         await expect(headerCellsIcon).toBeVisible();
         await expect(cell1).toHaveText(valueFour);
         await expect(cell1).toBeVisible();
@@ -1412,10 +1380,7 @@ test.describe("Prop tests", () => {
         await expect(cell7).toHaveText(valueOne);
         await expect(cell7).toBeVisible();
       } else if (colPosition === "second" && sortOrder === "desc") {
-        await expect(headerCellsIcon).toHaveAttribute(
-          "data-element",
-          "sort_down",
-        );
+        await expect(headerCellsIcon).toHaveAttribute("type", "sort_down");
         await expect(headerCellsIcon).toBeVisible();
         await expect(cell2).toHaveText(totalFour);
         await expect(cell2).toBeVisible();
@@ -1426,10 +1391,7 @@ test.describe("Prop tests", () => {
         await expect(cell8).toHaveText(totalOne);
         await expect(cell8).toBeVisible();
       } else {
-        await expect(headerCellsIcon).toHaveAttribute(
-          "data-element",
-          "sort_up",
-        );
+        await expect(headerCellsIcon).toHaveAttribute("type", "sort_up");
         await expect(headerCellsIcon).toBeVisible();
         await expect(cell2).toHaveText(totalOne);
         await expect(cell2).toBeVisible();
@@ -1465,7 +1427,7 @@ test.describe("Prop tests", () => {
       const totalTwo = "1349";
       const totalThree = "849";
       const totalFour = "3840";
-      const headerCellsIcon = flatTableHeaderCellsIcon(page);
+      const headerCellsIcon = flatTableHeaderCellsButtonIcon(page);
       const cell1 = flatTableCell(page, 0);
       const cell2 = flatTableCell(page, 1);
       const cell3 = flatTableCell(page, 2);
@@ -1476,10 +1438,7 @@ test.describe("Prop tests", () => {
       const cell8 = flatTableCell(page, 7);
 
       if (colPosition === "first" && sortOrder === "desc") {
-        await expect(headerCellsIcon).toHaveAttribute(
-          "data-element",
-          "sort_down",
-        );
+        await expect(headerCellsIcon).toHaveAttribute("type", "sort_down");
         await expect(headerCellsIcon).toBeVisible();
         await expect(cell1).toHaveText(valueOne);
         await expect(cell1).toBeVisible();
@@ -1491,7 +1450,8 @@ test.describe("Prop tests", () => {
         await expect(cell7).toBeVisible();
       } else if (colPosition === "first" && sortOrder === "asc") {
         await expect(headerCellsIcon).toHaveAttribute(
-          "data-element",
+          "type",
+
           "sort_up",
         );
         await expect(headerCellsIcon).toBeVisible();
@@ -1504,10 +1464,7 @@ test.describe("Prop tests", () => {
         await expect(cell7).toHaveText(valueOne);
         await expect(cell7).toBeVisible();
       } else if (colPosition === "second" && sortOrder === "desc") {
-        await expect(headerCellsIcon).toHaveAttribute(
-          "data-element",
-          "sort_down",
-        );
+        await expect(headerCellsIcon).toHaveAttribute("type", "sort_down");
         await expect(headerCellsIcon).toBeVisible();
         await expect(cell2).toHaveText(totalFour);
         await expect(cell2).toBeVisible();
@@ -1518,10 +1475,7 @@ test.describe("Prop tests", () => {
         await expect(cell8).toHaveText(totalOne);
         await expect(cell8).toBeVisible();
       } else {
-        await expect(headerCellsIcon).toHaveAttribute(
-          "data-element",
-          "sort_up",
-        );
+        await expect(headerCellsIcon).toHaveAttribute("type", "sort_up");
         await expect(headerCellsIcon).toBeVisible();
         await expect(cell2).toHaveText(totalOne);
         await expect(cell2).toBeVisible();

--- a/src/components/flat-table/sort/sort.component.tsx
+++ b/src/components/flat-table/sort/sort.component.tsx
@@ -1,11 +1,12 @@
 import React, { useRef } from "react";
-import { TagProps } from "../../../__internal__/utils/helpers/tags";
-import Event from "../../../__internal__/utils/helpers/events";
-import Typography from "../../typography";
-import { StyledSort, StyledSpaceHolder, StyledSortIcon } from "./sort.style";
-import guid from "../../../__internal__/utils/helpers/guid";
-import useLocale from "../../../hooks/__internal__/useLocale";
 import { useStrictFlatTableContext } from "../__internal__/strict-flat-table.context";
+import Typography from "../../typography";
+import Event from "../../../__internal__/utils/helpers/events";
+import guid from "../../../__internal__/utils/helpers/guid";
+import { TagProps } from "../../../__internal__/utils/helpers/tags";
+import useLocale from "../../../hooks/__internal__/useLocale";
+import Icon from "../../icon";
+import StyledSortButton from "./sort.style";
 
 export interface SortProps extends TagProps {
   /** if `asc` it will show `sort_up` icon, if `desc` it will show `sort_down` */
@@ -29,7 +30,9 @@ export const Sort = ({
   const id = useRef(guid());
   const locale = useLocale();
 
-  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+  const onKeyDown = (
+    e: React.KeyboardEvent<HTMLButtonElement | HTMLAnchorElement>,
+  ) => {
     if (Event.isEnterOrSpaceKey(e)) {
       e.preventDefault();
       return onClick?.();
@@ -40,35 +43,34 @@ export const Sort = ({
 
   const { colorTheme } = useStrictFlatTableContext();
 
+  const icon = () =>
+    sortType ? (
+      <Icon
+        data-element="sort-icon"
+        type={sortType === "ascending" ? "sort_up" : "sort_down"}
+      />
+    ) : (
+      <span data-role="sort-placeholder" />
+    );
+
   return (
     <>
       <Typography screenReaderOnly id={id.current}>
         {accessibleName || locale.sort.accessibleName(children, sortType)}
       </Typography>
-      <StyledSort
-        role="button"
-        onKeyDown={onKeyDown}
-        tabIndex={0}
-        onClick={onClick}
-        sortType={sortType}
+
+      <StyledSortButton
         aria-labelledby={id.current}
+        colorTheme={colorTheme}
         data-component="sort"
         data-element={dataElement}
         data-role={dataRole}
+        onClick={onClick}
+        onKeyDown={onKeyDown}
       >
-        {children}
-        {sortType && (
-          <StyledSortIcon
-            type={sortType === "ascending" ? "sort_up" : "sort_down"}
-            iconColor={
-              colorTheme === "dark"
-                ? "--colorsActionMinorYang100"
-                : "--colorActionMinor500"
-            }
-          />
-        )}
-      </StyledSort>
-      {!sortType && <StyledSpaceHolder data-role="sort-placeholder" />}
+        <span>{children}</span>
+        {icon()}
+      </StyledSortButton>
     </>
   );
 };

--- a/src/components/flat-table/sort/sort.style.ts
+++ b/src/components/flat-table/sort/sort.style.ts
@@ -1,43 +1,71 @@
-import styled from "styled-components";
-import Icon from "../../icon";
-import { StyledIconProps } from "../../icon/icon.style";
-import { SortProps } from "./sort.component";
+import styled, { css } from "styled-components";
 import addFocusStyling from "../../../style/utils/add-focus-styling";
-import applyBaseTheme from "../../../style/themes/apply-base-theme";
 
-const StyledSort = styled.div.attrs(applyBaseTheme)<
-  Pick<SortProps, "sortType">
->`
-  display: inline-flex;
-  align-items: center;
-  padding-left: 2px;
-  padding-right: 2px;
-  border-bottom: 1px solid transparent;
-  position: relative;
+const styleConfig = {
+  compact: {
+    fontSize: "13px",
+  },
+  small: {
+    fontSize: "14px",
+  },
+  medium: {
+    fontSize: "14px",
+  },
+  large: {
+    fontSize: "16px",
+  },
+  extraLarge: {
+    fontSize: "16px",
+  },
+};
 
-  :hover {
-    border-bottom: 1px solid;
-    cursor: pointer;
-  }
+const StyledSortButton = styled.button<{
+  colorTheme?: "light" | "transparent-base" | "transparent-white" | "dark";
+  size?: "compact" | "small" | "medium" | "large" | "extraLarge";
+}>`
+  ${({ colorTheme = "light", size = "medium" }) => css`
+    align-items: center;
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    color: ${colorTheme === "dark"
+      ? "var(--colorsUtilityYang100)"
+      : "var(--colorsUtilityYin090)"};
+    display: inline-flex;
+    font-size: ${styleConfig[size].fontSize};
+    font-weight: 500;
+    gap: var(--spacing075);
+    position: relative;
+    text-align: left;
+    word-break: keep-all;
 
-  :focus {
-    ${addFocusStyling()}
-    border-radius: var(--borderRadius025);
-  }
+    span[data-role="sort-placeholder"] {
+      min-width: 24px;
+      :hover {
+        border-bottom: none;
+      }
+    }
+
+    &:hover {
+      span:first-of-type {
+        border-bottom: 1px solid
+          ${colorTheme === "dark"
+            ? "var(--colorsUtilityYang100)"
+            : "var(--colorsUtilityYin090)"};
+      }
+    }
+
+    :focus {
+      ${addFocusStyling()}
+      border-radius: var(--borderRadius025);
+    }
+
+    span[data-component="icon"] {
+      color: ${colorTheme === "dark"
+        ? "var(--colorsActionMinorYang100)"
+        : "var(--colorActionMinor500)"};
+      margin-bottom: 1px;
+    }
+  `}
 `;
-
-const StyledSpaceHolder = styled.div`
-  display: inline-block;
-  width: 22px;
-`;
-
-interface StylesSortIconProps extends StyledIconProps {
-  iconColor?: string;
-}
-
-const StyledSortIcon = styled(Icon)<StylesSortIconProps>`
-  padding-left: var(--spacing075);
-  color: ${({ iconColor }) => `var(${iconColor})`};
-`;
-
-export { StyledSort, StyledSpaceHolder, StyledSortIcon };
+export default StyledSortButton;

--- a/src/components/flat-table/sort/sort.test.tsx
+++ b/src/components/flat-table/sort/sort.test.tsx
@@ -53,7 +53,7 @@ test("should render 'sort_up' Icon if `sortType` is 'ascending'", () => {
     </FlatTable>,
   );
 
-  expect(screen.getByTestId("icon")).toHaveAttribute("data-element", "sort_up");
+  expect(screen.getByTestId("icon")).toHaveAttribute("type", "sort_up");
 });
 
 test("should render 'sort_down' Icon if `sortType` is 'descending'", () => {
@@ -69,10 +69,7 @@ test("should render 'sort_down' Icon if `sortType` is 'descending'", () => {
     </FlatTable>,
   );
 
-  expect(screen.getByTestId("icon")).toHaveAttribute(
-    "data-element",
-    "sort_down",
-  );
+  expect(screen.getByTestId("icon")).toHaveAttribute("type", "sort_down");
 });
 
 test("should render the correct accessible name when the `accessibleName` prop is passed", () => {
@@ -299,9 +296,12 @@ test("should render the expected Icon styling when `colorTheme` is 'dark'", () =
     </FlatTable>,
   );
 
-  expect(screen.getByTestId("icon")).toHaveStyleRule(
+  expect(screen.getByRole("button")).toHaveStyleRule(
     "color",
     "var(--colorsActionMinorYang100)",
+    {
+      modifier: "span[data-component='icon']",
+    },
   );
 });
 
@@ -322,8 +322,11 @@ test.each<FlatTableProps["colorTheme"]>([
     </FlatTable>,
   );
 
-  expect(screen.getByTestId("icon")).toHaveStyleRule(
+  expect(screen.getByRole("button")).toHaveStyleRule(
     "color",
     "var(--colorActionMinor500)",
+    {
+      modifier: "span[data-component='icon']",
+    },
   );
 });


### PR DESCRIPTION
fixes #7586 

### Proposed behaviour

Use the correct semantic element for the sorting buttons, and ensure that the table headers respect the spacing appropriately

### Current behaviour

When using a sortable FlatTable with long header texts, the wrapping behaves oddly as screen size is reduced. The current implementation of `Sort` in `FlatTable` is also built using a clickable `div` as opposed to a button.

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

A test story has been added under `FlatTable`: `Extended Column Sorting` which can be used to test the changes. 
