### PR TITLE
docs(tabs): fix incorrect path to component in documentation

### DIFF
--- a/src/components/tabs/__next__/tabs.mdx
+++ b/src/components/tabs/__next__/tabs.mdx
@@ -35,7 +35,12 @@ sizes should limit the number of tabs used to no more than 5.
 ## Quick Start
 
 ```javascript
-import { Tabs, Tab, TabList, TabPanel } from "carbon-react/lib/components/tabs";
+import {
+  Tabs,
+  Tab,
+  TabList,
+  TabPanel,
+} from "carbon-react/lib/components/tabs/__next__";
 ```
 
 ## Related Components


### PR DESCRIPTION
### Proposed behaviour

Use the correct import path for the new Tabs implementation

### Current behaviour

The import path for the new Tabs implementation is incorrect

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Check that both sets of Tabs documentation (deprecated and main) display the correct usage instructions
