### PR TITLE
feat(radio-button, radio-button-group): audit changes

### DIFF
--- a/src/__internal__/checkable-input/__next__/checkable-input.component.tsx
+++ b/src/__internal__/checkable-input/__next__/checkable-input.component.tsx
@@ -142,7 +142,7 @@ const CheckableInput = React.forwardRef(
             <StyledLineContainer size={size}>
               <StyledAccordionLine size={size} />
             </StyledLineContainer>
-            <StyledAccordionContent size={size}>
+            <StyledAccordionContent>
               {conditionalContent}
             </StyledAccordionContent>
           </StyledAccordion>

--- a/src/__internal__/checkable-input/__next__/checkable-input.component.tsx
+++ b/src/__internal__/checkable-input/__next__/checkable-input.component.tsx
@@ -1,0 +1,157 @@
+/**
+ * Checkable Input Component
+ *
+ * Used as a base component for CheckBox and RadioButton components.
+ * Do not add props here that are specific to either CheckBox or RadioButton.
+ * Do not add props to the common interface that are not intended to be in the public interface of both components.
+ * Styles of any children should be handled in their respective component files.
+ */
+
+import React, { useRef, useState, useEffect } from "react";
+import useResizeObserver from "../../../hooks/__internal__/useResizeObserver";
+import {
+  StyledCheckableInput,
+  StyledCheckableInputWrapper,
+  StyledAccordionLine,
+  StyledAccordion,
+  StyledLineContainer,
+  StyledAccordionContent,
+} from "./checkable-input.style";
+import HiddenCheckableInput, {
+  CommonHiddenCheckableInputProps,
+} from "../hidden-checkable-input.component";
+import guid from "../../utils/helpers/guid";
+import { InputBehaviour } from "../../input-behaviour";
+import Label from "../../label/label.component";
+import HintText from "../../hint-text";
+import useMediaQuery from "../../../hooks/useMediaQuery";
+
+// TODO: Remove omitted props from CommonHiddenCheckableInputProps when legacy components are removed
+export interface CommonCheckableInputProps
+  extends Omit<
+    CommonHiddenCheckableInputProps,
+    "validationIconId" | "checked"
+  > {
+  /** Unique identifier for the input. Will use a randomly generated GUID if none is provided. */
+  id?: string;
+  /** Content of the label. */
+  label?: React.ReactNode;
+  /** Additional hint text rendered below the label. */
+  inputHint?: string;
+  /** If true, the component will be disabled. */
+  disabled?: boolean;
+  /** Content to be rendered below the input when checked, cannot be used when inputs are inline. */
+  conditionalContent?: React.ReactNode;
+}
+
+export interface CheckableInputProps extends CommonCheckableInputProps {
+  /** Element to be rendered as the visible input. */
+  children?: React.ReactNode;
+  /** HTML type attribute of the input. */
+  type: string;
+  /** Value passed to the input. */
+  value?: string;
+  /** Checked state of the input. */
+  checked?: boolean;
+  /** Size of the component. */
+  size?: "small" | "medium" | "large";
+}
+
+const CheckableInput = React.forwardRef(
+  (
+    {
+      children,
+      disabled,
+      id: inputId,
+      name,
+      type,
+      value,
+      label,
+      inputHint,
+      checked,
+      conditionalContent,
+      size = "medium",
+      ...props
+    }: CheckableInputProps,
+    ref: React.ForwardedRef<HTMLInputElement>,
+  ) => {
+    const { current: id } = useRef(inputId || guid());
+    const inputHintId = inputHint ? `${id}-hint` : undefined;
+
+    const accordionContainer = useRef<HTMLDivElement>(null);
+    const [contentHeight, setContentHeight] = useState<string | number>(0);
+    const allowMotion = useMediaQuery(
+      "screen and (prefers-reduced-motion: no-preference)",
+    );
+
+    useResizeObserver(accordionContainer, () => {
+      setContentHeight(accordionContainer.current?.scrollHeight as number);
+    });
+
+    useEffect(() => {
+      setContentHeight(accordionContainer.current?.scrollHeight as number);
+    }, [checked]);
+
+    return (
+      <>
+        <StyledCheckableInput disabled={disabled} size={size}>
+          <InputBehaviour>
+            <StyledCheckableInputWrapper>
+              <HiddenCheckableInput
+                id={id}
+                type={type}
+                name={name}
+                value={value}
+                disabled={disabled}
+                checked={checked}
+                ref={ref}
+                ariaDescribedBy={inputHintId}
+                {...props}
+              />
+              {children}
+            </StyledCheckableInputWrapper>
+            {label && (
+              <Label
+                htmlFor={id}
+                disabled={disabled}
+                isLarge={size === "large"}
+              >
+                {label}
+              </Label>
+            )}
+            {inputHint && (
+              <HintText
+                id={inputHintId}
+                marginBottom="0"
+                isDisabled={disabled}
+                isLarge={size === "large"}
+              >
+                {inputHint}
+              </HintText>
+            )}
+          </InputBehaviour>
+        </StyledCheckableInput>
+        {conditionalContent && (
+          <StyledAccordion
+            data-role="conditional-content-accordion"
+            ref={accordionContainer}
+            expanded={checked}
+            contentHeight={contentHeight}
+            allowAnimation={allowMotion}
+          >
+            <StyledLineContainer size={size}>
+              <StyledAccordionLine size={size} />
+            </StyledLineContainer>
+            <StyledAccordionContent size={size}>
+              {conditionalContent}
+            </StyledAccordionContent>
+          </StyledAccordion>
+        )}
+      </>
+    );
+  },
+);
+
+CheckableInput.displayName = "CheckableInput";
+
+export default CheckableInput;

--- a/src/__internal__/checkable-input/__next__/checkable-input.style.tsx
+++ b/src/__internal__/checkable-input/__next__/checkable-input.style.tsx
@@ -1,0 +1,145 @@
+import styled, { css } from "styled-components";
+import { StyledLabelContainer } from "../../label/label.style";
+import HiddenCheckableInputStyle from "../hidden-checkable-input.style";
+import StyledHintText from "../../hint-text/hint-text.style";
+
+interface StyledCheckableProps {
+  size: "small" | "medium" | "large";
+  disabled?: boolean;
+}
+
+export const StyledCheckableInput = styled.div<StyledCheckableProps>`
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-column-gap: var(--global-space-comp-s, 8px);
+  line-height: 150%;
+
+  ${StyledLabelContainer} {
+    padding: 0;
+    margin: 0;
+
+    label {
+      font-weight: 400;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
+  }
+
+  ${StyledHintText} {
+    line-height: 150%;
+    grid-area: 2 / 2;
+  }
+
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      label {
+        color: var(--input-labelset-label-disabled, rgba(0, 0, 0, 0.42));
+      }
+
+      ${HiddenCheckableInputStyle}, label {
+        &:hover,
+        &:focus {
+          outline: none;
+          cursor: not-allowed;
+        }
+      }
+    `}
+`;
+
+export const StyledCheckableInputWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  min-height: 24px;
+`;
+
+interface StyledAccordionProps {
+  expanded?: boolean;
+  contentHeight?: string | number;
+  allowAnimation?: boolean;
+}
+
+export const StyledAccordion = styled.div<StyledAccordionProps>`
+  overflow-y: hidden;
+  visibility: hidden;
+  max-height: 0;
+
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-column-gap: var(--global-space-comp-s, 8px);
+
+  ${({ allowAnimation }) =>
+    allowAnimation &&
+    css`
+      transition: all 0.4s;
+    `}
+
+  ${({ expanded, contentHeight }) => css`
+    ${expanded &&
+    css`
+      visibility: visible;
+      max-height: ${contentHeight}px;
+    `}
+  `}
+`;
+
+const getAccordionSpacing = {
+  small: {
+    top: "var(--global-space-comp-xs, 4px)", // gap between line and input
+    width: "var(--global-size-3xs, 16px)", // width of line container (width of input)
+  },
+  medium: {
+    top: "var(--global-space-comp-s, 8px)",
+    width: "var(--global-size-xs, 24px)",
+  },
+  large: {
+    top: "var(--global-space-comp-m, 12px)",
+    width: "var(--global-size-s, 32px)",
+  },
+};
+
+const contentPadding = "var(--global-space-comp-m, 12px)";
+
+interface StyledAccordionContentProps {
+  size: "small" | "medium" | "large";
+}
+
+export const StyledLineContainer = styled.div<StyledAccordionContentProps>`
+  display: flex;
+  justify-content: center;
+
+  ${({ size }) =>
+    size &&
+    css`
+      width: ${getAccordionSpacing[size].width};
+    `}
+`;
+
+export const StyledAccordionLine = styled.div<StyledAccordionContentProps>`
+  position: absolute;
+  width: 2px;
+  background-color: var(--input-typical-border-alt, rgba(0, 0, 0, 0.3));
+  border-radius: 2px;
+
+  ${({ size }) =>
+    size &&
+    css`
+      top: ${getAccordionSpacing[size].top};
+
+      // Calculate height taking into account top offset and padding of the content
+      height: calc(
+        100% - (${getAccordionSpacing[size].top} + ${contentPadding})
+      );
+    `}
+`;
+
+export const StyledAccordionContent = styled.div<StyledAccordionContentProps>`
+  ${({ size }) =>
+    size &&
+    css`
+      padding: ${contentPadding} 0;
+    `}
+`;

--- a/src/__internal__/checkable-input/__next__/checkable-input.style.tsx
+++ b/src/__internal__/checkable-input/__next__/checkable-input.style.tsx
@@ -136,10 +136,6 @@ export const StyledAccordionLine = styled.div<StyledAccordionContentProps>`
     `}
 `;
 
-export const StyledAccordionContent = styled.div<StyledAccordionContentProps>`
-  ${({ size }) =>
-    size &&
-    css`
-      padding: ${contentPadding} 0;
-    `}
+export const StyledAccordionContent = styled.div`
+  padding: ${contentPadding} 0;
 `;

--- a/src/__internal__/checkable-input/__next__/checkable-input.test.tsx
+++ b/src/__internal__/checkable-input/__next__/checkable-input.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import CommonCheckableInput from "./checkable-input.component";
+import useMediaQuery from "../../../hooks/useMediaQuery";
+
+jest.mock("../../../hooks/useMediaQuery");
+
+test("renders input with provided `type`", () => {
+  render(<CommonCheckableInput type="radio" />);
+
+  expect(screen.getByRole("radio")).toBeInTheDocument();
+});
+
+test("renders with provided children", () => {
+  render(<CommonCheckableInput type="radio">Foo</CommonCheckableInput>);
+
+  expect(screen.getByText("Foo")).toBeVisible();
+});
+
+test("renders input with provided `name`", () => {
+  render(<CommonCheckableInput type="radio" name="test-name" />);
+
+  expect(screen.getByRole("radio")).toHaveAttribute("name", "test-name");
+});
+
+test("renders input with provided `value`", () => {
+  render(<CommonCheckableInput type="radio" value="test-value" />);
+
+  // toHaveValue() does not work with radio or checkbox inputs
+  // eslint-disable-next-line jest-dom/prefer-to-have-value
+  expect(screen.getByRole("radio")).toHaveAttribute("value", "test-value");
+});
+
+test("renders input checked when `checked` prop is true", () => {
+  render(<CommonCheckableInput type="radio" checked onChange={() => {}} />);
+
+  expect(screen.getByRole("radio")).toBeChecked();
+});
+
+test("renders with provided `label`", () => {
+  render(<CommonCheckableInput type="radio" label="Test Label" />);
+
+  expect(screen.getByText("Test Label")).toBeVisible();
+  expect(screen.getByRole("radio")).toHaveAccessibleName("Test Label");
+});
+
+test("renders with provided `inputHint`", () => {
+  render(<CommonCheckableInput type="radio" inputHint="Test Hint Text" />);
+
+  expect(screen.getByText("Test Hint Text")).toBeVisible();
+  expect(screen.getByRole("radio")).toHaveAccessibleDescription(
+    "Test Hint Text",
+  );
+});
+
+test("renders input disabled when `disabled` prop is true", () => {
+  render(<CommonCheckableInput type="radio" disabled />);
+
+  expect(screen.getByRole("radio")).toBeDisabled();
+});
+
+test("displays conditional content when provided and input is checked", () => {
+  render(
+    <CommonCheckableInput
+      type="radio"
+      checked
+      conditionalContent={<div>Conditional Content</div>}
+      onChange={() => {}}
+    />,
+  );
+
+  expect(screen.getByText("Conditional Content")).toBeVisible();
+});
+
+test("does not display conditional content when input is not checked", () => {
+  render(
+    <CommonCheckableInput
+      type="radio"
+      conditionalContent={<div>Conditional Content</div>}
+      onChange={() => {}}
+    />,
+  );
+
+  expect(screen.queryByText("Conditional Content")).not.toBeVisible();
+});
+
+test("applies accordion animation when reduced motion is not preferred", () => {
+  const mockedUseMediaQuery = jest.mocked(useMediaQuery);
+  mockedUseMediaQuery.mockReturnValue(true);
+
+  render(
+    <CommonCheckableInput
+      type="radio"
+      conditionalContent={<div>Conditional Content</div>}
+      onChange={() => {}}
+    />,
+  );
+
+  expect(screen.getByTestId("conditional-content-accordion")).toHaveStyle(
+    "transition: all 0.4s;",
+  );
+});

--- a/src/__internal__/fieldset/__next__/fieldset.component.tsx
+++ b/src/__internal__/fieldset/__next__/fieldset.component.tsx
@@ -1,0 +1,142 @@
+import React, { useRef } from "react";
+import { MarginProps } from "styled-system";
+
+import {
+  StyledFieldset,
+  StyledLegend,
+  StyledFieldsetContentWrapper,
+  StyledFieldsetContent,
+} from "./fieldset.style";
+import ErrorBorder from "../../../components/textbox/textbox.style";
+import ValidationMessage from "../../validation-message";
+import HintText from "../../hint-text";
+import guid from "../../utils/helpers/guid";
+import { filterStyledSystemMarginProps } from "../../../style/utils";
+
+export interface FieldsetProps extends MarginProps {
+  /** Inputs rendered within the fieldset. */
+  children: React.ReactNode;
+  /** Set a name value on the fieldset. */
+  name?: string;
+  /** Set an id value on the fieldset. */
+  id?: string;
+  /** The content for the fieldset legend. */
+  legend?: string;
+  /** Content for an additional hint text below the legend */
+  legendHint?: React.ReactNode;
+  /** Text alignment of legend when inline */
+  legendAlign?: "left" | "right";
+  /** Error message to be displayed when validation fails */
+  error?: string;
+  /** Warning message to be displayed when validation warning occurs */
+  warning?: string;
+  /** If true, an asterisk will be added to the label */
+  isRequired?: boolean;
+  /** Apply disabled styling to the component */
+  isDisabled?: boolean;
+  /** Specifies whether the validation message should be displayed above the input */
+  validationMessagePositionTop?: boolean;
+  /** Set the size of the component */
+  size?: "small" | "medium" | "large";
+  /** When true, children are inline */
+  inline?: boolean;
+}
+
+const Fieldset = ({
+  children,
+  name,
+  id,
+  legend,
+  legendAlign,
+  legendHint,
+  error,
+  warning,
+  isRequired,
+  isDisabled,
+  validationMessagePositionTop,
+  size = "medium",
+  inline = false,
+  ...rest
+}: FieldsetProps) => {
+  const internalId = useRef(guid());
+  const uniqueId = id || internalId.current;
+
+  const legendHintId = legendHint ? `${uniqueId}-hint` : undefined;
+  const validationId = (error || warning) && `${uniqueId}-validation-message`;
+
+  const ariaDescribedBy = [legendHintId, validationId]
+    .filter(Boolean)
+    .join(" ");
+
+  const validationMessage = () => {
+    if (error || warning) {
+      return (
+        <>
+          <ValidationMessage
+            error={error}
+            warning={warning}
+            validationId={validationId}
+            isLarge={size === "large"}
+          />
+          <ErrorBorder warning={!!(!error && warning)} />
+        </>
+      );
+    }
+    return null;
+  };
+
+  return (
+    <StyledFieldset
+      data-component="fieldset"
+      id={uniqueId}
+      name={name}
+      aria-describedby={ariaDescribedBy}
+      validationMessagePositionTop={validationMessagePositionTop}
+      size={size}
+      {...filterStyledSystemMarginProps(rest)}
+      {...rest}
+    >
+      {legend && (
+        <StyledLegend
+          align={legendAlign}
+          isRequired={isRequired}
+          isDisabled={isDisabled}
+          data-element="legend"
+          data-role="legend"
+          isLarge={size === "large"}
+        >
+          {legend}
+        </StyledLegend>
+      )}
+
+      {legendHint && (
+        <HintText
+          id={legendHintId}
+          isDisabled={isDisabled}
+          align={legendAlign}
+          isLarge={size === "large"}
+          marginBottom="0"
+        >
+          {legendHint}
+        </HintText>
+      )}
+
+      <StyledFieldsetContentWrapper
+        validationMessagePositionTop={validationMessagePositionTop}
+        size={size}
+      >
+        {validationMessagePositionTop && validationMessage()}
+        <StyledFieldsetContent
+          data-role="fieldset-content"
+          inline={inline}
+          size={size}
+        >
+          {children}
+        </StyledFieldsetContent>
+        {!validationMessagePositionTop && validationMessage()}
+      </StyledFieldsetContentWrapper>
+    </StyledFieldset>
+  );
+};
+
+export default Fieldset;

--- a/src/__internal__/fieldset/__next__/fieldset.style.tsx
+++ b/src/__internal__/fieldset/__next__/fieldset.style.tsx
@@ -1,0 +1,140 @@
+import styled, { css } from "styled-components";
+import { margin } from "styled-system";
+import applyBaseTheme from "../../../style/themes/apply-base-theme";
+import StyledHintText from "../../hint-text/hint-text.style";
+import StyledValidationMessage from "../../validation-message/validation-message.style";
+
+type StyledFieldsetProps = {
+  validationMessagePositionTop?: boolean;
+  size: "small" | "medium" | "large";
+};
+
+const sizeMap = {
+  small: {
+    contentMargin: "var(--global-space-comp-xs, 4px)",
+    validationMargin: "var(--global-space-comp-xs, 4px)",
+    childrenGap: "var(--global-space-comp-s, 8px)",
+  },
+  medium: {
+    contentMargin: "var(--global-space-comp-s, 8px)",
+    validationMargin: "var(--global-space-comp-s, 8px)",
+    childrenGap: "var(--global-space-comp-m, 12px)",
+  },
+  large: {
+    contentMargin: "var(--global-space-comp-m, 12px)",
+    validationMargin: "var(--global-space-comp-s, 8px)",
+    childrenGap: "var(--global-space-comp-l, 16px)",
+  },
+};
+
+export const StyledFieldset = styled.fieldset.attrs(
+  applyBaseTheme,
+)<StyledFieldsetProps>`
+  margin: 0;
+  margin-bottom: var(--fieldSpacing);
+  ${margin}
+
+  border: none;
+  padding: 0;
+  min-width: 0;
+  min-inline-size: 0;
+  width: fit-content;
+
+  // TODO: Remove once HintText and ValidationMessage have been updated to new designs
+  ${StyledHintText} {
+    line-height: 150%;
+  }
+
+  ${StyledValidationMessage} {
+    ${({ validationMessagePositionTop, size }) => css`
+      line-height: 150%;
+      margin: 0;
+      margin-${validationMessagePositionTop ? "bottom" : "top"}: ${sizeMap[size].validationMargin};
+    `}
+  }
+`;
+
+export type StyledLegendProps = {
+  align?: "left" | "right";
+  isRequired?: boolean;
+  isDisabled?: boolean;
+  isLarge?: boolean;
+};
+
+export const StyledLegend = styled.legend<StyledLegendProps>`
+  display: flex;
+  align-items: center;
+  padding: 0;
+  line-height: 150%;
+  font-weight: 500;
+  font-size: var(--core-fontSize-static-large-step0, 14px);
+  color: var(--input-labelset-label-default, rgba(0, 0, 0, 0.95));
+
+  ${({ isLarge }) =>
+    isLarge &&
+    css`
+      font-size: var(--core-fontSize-static-large-step1, 16px);
+    `}
+
+  ${({ isRequired }) =>
+    isRequired &&
+    css`
+      ::after {
+        content: "*";
+        line-height: 150%;
+        color: var(--input-labelset-label-required, #db004e);
+        font-weight: 500;
+        margin-left: var(--global-space-comp-xs, 4px);
+        position: relative;
+      }
+    `}
+
+  ${({ isDisabled }) =>
+    isDisabled &&
+    css`
+      color: var(--input-labelset-label-disabled, rgba(0, 0, 0, 0.42));
+      ::after {
+        color: var(--input-labelset-label-disabled, rgba(0, 0, 0, 0.42));
+      }
+    `}
+
+  ${({ align }) =>
+    align &&
+    css`
+      text-align: ${align};
+      justify-content: ${align === "right" ? "flex-end" : "flex-start"};
+    `};
+  ${margin}
+`;
+
+export const StyledFieldsetContentWrapper = styled.div<{
+  size: "small" | "medium" | "large";
+  validationMessagePositionTop?: boolean;
+}>`
+  position: relative;
+
+  ${({ size }) => css`
+    margin-top: ${sizeMap[size].contentMargin};
+  `};
+`;
+
+export const StyledFieldsetContent = styled.div<{
+  inline?: boolean;
+  size: "small" | "medium" | "large";
+}>`
+  ${({ inline, size }) => css`
+    display: flex;
+    flex-direction: column;
+    gap: ${sizeMap[size].childrenGap};
+
+    ${inline &&
+    css`
+      flex-direction: row;
+      gap: 12px var(--global-space-comp-l, 16px);
+    `}
+  `};
+`;
+
+export const StyledIconWrapper = styled.div`
+  margin-left: var(--spacing050);
+`;

--- a/src/__internal__/fieldset/__next__/fieldset.style.tsx
+++ b/src/__internal__/fieldset/__next__/fieldset.style.tsx
@@ -104,7 +104,6 @@ export const StyledLegend = styled.legend<StyledLegendProps>`
       text-align: ${align};
       justify-content: ${align === "right" ? "flex-end" : "flex-start"};
     `};
-  ${margin}
 `;
 
 export const StyledFieldsetContentWrapper = styled.div<{
@@ -133,8 +132,4 @@ export const StyledFieldsetContent = styled.div<{
       gap: 12px var(--global-space-comp-l, 16px);
     `}
   `};
-`;
-
-export const StyledIconWrapper = styled.div`
-  margin-left: var(--spacing050);
 `;

--- a/src/__internal__/fieldset/__next__/fieldset.test.tsx
+++ b/src/__internal__/fieldset/__next__/fieldset.test.tsx
@@ -1,0 +1,191 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import Fieldset from "./fieldset.component";
+import { testStyledSystemMargin } from "../../../__spec_helper__/__internal__/test-utils";
+
+test("renders with provided `children`", () => {
+  render(
+    <Fieldset>
+      <input title="Test" placeholder="Placeholder" />
+    </Fieldset>,
+  );
+
+  const input = screen.getByRole("textbox");
+
+  expect(input).toBeVisible();
+});
+
+test("renders with provided `name`", () => {
+  render(
+    <Fieldset name="test-name">
+      <input title="Test" placeholder="Placeholder" />
+    </Fieldset>,
+  );
+
+  const fieldset = screen.getByRole("group");
+
+  expect(fieldset).toHaveAttribute("name", "test-name");
+});
+
+test("renders with provided `id`", () => {
+  render(
+    <Fieldset id="test-id">
+      <input title="Test" placeholder="Placeholder" />
+    </Fieldset>,
+  );
+
+  const fieldset = screen.getByRole("group");
+
+  expect(fieldset).toHaveAttribute("id", "test-id");
+});
+
+test("renders fieldset with provided `legend`", () => {
+  render(
+    <Fieldset legend="Legend">
+      <input title="Test" placeholder="Placeholder" />
+    </Fieldset>,
+  );
+
+  const fieldset = screen.getByRole("group", { name: "Legend" });
+
+  expect(fieldset).toBeVisible();
+});
+
+test("renders with provided `legendHint`", () => {
+  render(
+    <Fieldset legendHint="This is a hint">
+      <input title="Test" placeholder="Placeholder" />
+    </Fieldset>,
+  );
+
+  const hint = screen.getByText("This is a hint");
+
+  expect(hint).toBeVisible();
+  expect(screen.getByRole("group")).toHaveAccessibleDescription(
+    "This is a hint",
+  );
+});
+
+test("renders with provided `error`", () => {
+  render(
+    <Fieldset error="This is an error">
+      <input title="Test" placeholder="Placeholder" />
+    </Fieldset>,
+  );
+
+  const error = screen.getByText("This is an error");
+
+  expect(error).toBeVisible();
+  expect(screen.getByRole("group")).toHaveAccessibleDescription(
+    "This is an error",
+  );
+});
+
+test("renders with provided `warning`", () => {
+  render(
+    <Fieldset warning="This is a warning">
+      <input title="Test" placeholder="Placeholder" />
+    </Fieldset>,
+  );
+
+  const warning = screen.getByText("This is a warning");
+
+  expect(warning).toBeVisible();
+  expect(screen.getByRole("group")).toHaveAccessibleDescription(
+    "This is a warning",
+  );
+});
+
+test("combines `legendHint` and validation message in `aria-describedby` when both are provided", () => {
+  render(
+    <Fieldset legendHint="This is a hint" error="This is an error">
+      <input title="Test" placeholder="Placeholder" />
+    </Fieldset>,
+  );
+
+  const fieldset = screen.getByRole("group");
+  expect(fieldset).toHaveAccessibleDescription(
+    "This is a hint This is an error",
+  );
+});
+
+// coverage
+test("renders with `validationMessagePositionTop` set to true", () => {
+  render(
+    <Fieldset validationMessagePositionTop error="This is an error">
+      <input title="Test" placeholder="Placeholder" />
+    </Fieldset>,
+  );
+
+  const error = screen.getByText("This is an error");
+
+  expect(error).toBeVisible();
+});
+
+// coverage
+test("renders with  expected styles when `size` is set to large", () => {
+  render(
+    <Fieldset legend="Legend" size="large">
+      <input title="Test" placeholder="Placeholder" />
+    </Fieldset>,
+  );
+
+  expect(screen.getByText("Legend")).toHaveStyleRule(
+    "font-size",
+    "var(--core-fontSize-static-large-step1,16px)",
+  );
+});
+
+// coverage
+test("renders with expected styles when `align` is  set to left", () => {
+  render(
+    <Fieldset legend="Legend" legendAlign="left">
+      <input title="Test" placeholder="Placeholder" />
+    </Fieldset>,
+  );
+
+  const legend = screen.getByText("Legend");
+
+  expect(legend).toHaveStyleRule("justify-content", "flex-start");
+  expect(legend).toHaveStyleRule("text-align", "left");
+});
+
+// coverage
+test("renders with expected styles when `align` is  set to right", () => {
+  render(
+    <Fieldset legend="Legend" legendAlign="right">
+      <input title="Test" placeholder="Placeholder" />
+    </Fieldset>,
+  );
+
+  const legend = screen.getByText("Legend");
+
+  expect(legend).toHaveStyleRule("justify-content", "flex-end");
+  expect(legend).toHaveStyleRule("text-align", "right");
+});
+
+// coverage
+test("renders with expected styles when `inline` is true", () => {
+  render(
+    <Fieldset legend="Legend" inline>
+      <input title="Test" placeholder="Placeholder" />
+    </Fieldset>,
+  );
+
+  const content = screen.getByTestId("fieldset-content");
+
+  expect(content).toHaveStyleRule("flex-direction", "row");
+  expect(content).toHaveStyleRule(
+    "gap",
+    "12px var(--global-space-comp-l,16px)",
+  );
+});
+
+testStyledSystemMargin(
+  (props) => (
+    <Fieldset {...props}>
+      <input title="Test" placeholder="Placeholder" />
+    </Fieldset>
+  ),
+  () => screen.getByRole("group"),
+);

--- a/src/components/radio-button/__next__/___internal___/radio-button-group.context.tsx
+++ b/src/components/radio-button/__next__/___internal___/radio-button-group.context.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import createStrictContext from "../../../../__internal__/utils/createStrictContext";
+
+interface RadioButtonGroupContextType {
+  inline?: boolean;
+  error?: boolean;
+  name?: string;
+  onBlur?: (ev: React.FocusEvent<HTMLInputElement>) => void;
+  onChange?: (ev: React.ChangeEvent<HTMLInputElement>) => void;
+  value?: string;
+  size: "small" | "medium" | "large";
+  disabled?: boolean;
+  required?: boolean;
+}
+
+const [RadioButtonGroupProvider, useRadioButtonGroupContext] =
+  createStrictContext<RadioButtonGroupContextType>({
+    name: "RadioButtonGroupContext",
+    errorMessage:
+      "Carbon RadioButtonGroup: Context not found. Have you wrapped your Carbon subcomponents properly? See stack trace for more details.",
+    defaultValue: {
+      size: "medium",
+    },
+  });
+
+export { RadioButtonGroupProvider, useRadioButtonGroupContext };

--- a/src/components/radio-button/__next__/___internal___/radio-button-svg.component.tsx
+++ b/src/components/radio-button/__next__/___internal___/radio-button-svg.component.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import StyledCheckableInputSvgWrapper from "../../../../__internal__/checkable-input/checkable-input-svg-wrapper.style";
+
+const RadioButtonSvg = () => {
+  return (
+    <StyledCheckableInputSvgWrapper>
+      <svg data-role="radio-svg" focusable="false" viewBox="0 0 15 15">
+        <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+          <circle
+            className="radio-button-check"
+            fill="#FFFFFF"
+            cx="7.5"
+            cy="7.5"
+            r="4"
+          />
+        </g>
+      </svg>
+    </StyledCheckableInputSvgWrapper>
+  );
+};
+
+export default React.memo(RadioButtonSvg, () => true);

--- a/src/components/radio-button/__next__/components.test-pw.tsx
+++ b/src/components/radio-button/__next__/components.test-pw.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import { RadioButton, RadioButtonGroup } from ".";
+import Box from "../../box";
+import Textbox from "../../textbox";
+
+export const RadioButtonGroupControlled = ({ ...args }) => {
+  const [value, setValue] = useState("radio1");
+
+  return (
+    <RadioButtonGroup
+      name="radio-group"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      {...args}
+    >
+      <RadioButton id="radio-1" value="radio1" label="Radio Button 1" />
+      <RadioButton id="radio-2" value="radio2" label="Radio Button 2" />
+      <RadioButton id="radio-3" value="radio3" label="Radio Button 3" />
+    </RadioButtonGroup>
+  );
+};
+
+export const RadioButtonControlled = ({ ...args }) => {
+  const [value, setValue] = useState("radio1");
+
+  return (
+    <RadioButtonGroup
+      name="radio-group"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
+      <RadioButton id="radio-1" value="radio1" label="Radio Button" {...args} />
+    </RadioButtonGroup>
+  );
+};
+
+export const RadioButtonWithConditionalContent = ({ ...args }) => {
+  const [value, setValue] = useState("radio1");
+  const [textboxValue, setTextboxValue] = useState("");
+
+  const conditionalContent = (
+    <Box mr={1} width="300px">
+      <Textbox
+        label="Revealed Textbox"
+        value={textboxValue}
+        onChange={(ev) => setTextboxValue(ev.target.value)}
+      />
+    </Box>
+  );
+
+  return (
+    <RadioButtonGroup
+      name="radio-group"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
+      <RadioButton
+        id="radio-1"
+        value="radio1"
+        label="Radio Button 1"
+        conditionalContent={conditionalContent}
+        {...args}
+      />
+      <RadioButton id="radio-2" value="radio2" label="Radio Button 2" />
+      <RadioButton id="radio-3" value="radio3" label="Radio Button 3" />
+    </RadioButtonGroup>
+  );
+};

--- a/src/components/radio-button/__next__/index.ts
+++ b/src/components/radio-button/__next__/index.ts
@@ -1,0 +1,5 @@
+export { RadioButtonGroup } from "./radio-button-group/radio-button-group.component";
+export { RadioButton } from "./radio-button.component";
+
+export type { RadioButtonGroupProps } from "./radio-button-group/radio-button-group.component";
+export type { RadioButtonProps } from "./radio-button.component";

--- a/src/components/radio-button/__next__/radio-button-group/radio-button-group-test.stories.tsx
+++ b/src/components/radio-button/__next__/radio-button-group/radio-button-group-test.stories.tsx
@@ -1,0 +1,299 @@
+import React, { useState } from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import generateStyledSystemProps from "../../../../../.storybook/utils/styled-system-props";
+
+import { RadioButton, RadioButtonGroup, RadioButtonGroupProps } from "..";
+
+import Box from "../../../box";
+import Textbox from "../../../textbox";
+
+const styledSystemProps = generateStyledSystemProps({
+  margin: true,
+});
+
+const meta: Meta<typeof RadioButtonGroup> = {
+  title: "Radio Button/Test",
+  component: RadioButtonGroup,
+  subcomponents: { RadioButton },
+  argTypes: {
+    ...styledSystemProps,
+    error: { control: "text" },
+    warning: { control: "text" },
+  },
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
+    controls: {
+      exclude: ["children", "onBlur", "onChange"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RadioButtonGroup>;
+
+interface RadioButtonGroupComponentProps
+  extends Omit<RadioButtonGroupProps, "value" | "onChange" | "children"> {
+  name: string;
+  id: string;
+}
+
+const RadioButtonGroupComponent = ({
+  name,
+  id,
+  ...args
+}: RadioButtonGroupComponentProps) => {
+  const [value, setValue] = useState("");
+  return (
+    <RadioButtonGroup
+      name={name}
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
+      legendHint="Legend Hint"
+      {...args}
+    >
+      <RadioButton id={`${id}-1`} value={`${id}-1`} label="Radio Option 1" />
+      <RadioButton id={`${id}-2`} value={`${id}-2`} label="Radio Option 2" />
+      <RadioButton
+        id={`${id}-3`}
+        value={`${id}-3`}
+        label="Radio Option 3"
+        inputHint="Input Hint"
+      />
+    </RadioButtonGroup>
+  );
+};
+
+export const Validation = ({ ...args }) => {
+  return (
+    <Box m={2} display="flex" gap={4}>
+      <Box display="flex" flexDirection="column" gap={2}>
+        <RadioButtonGroupComponent
+          id="error-group-small"
+          name="error-group-small"
+          legend="With Error Small"
+          error="Error Message"
+          size="small"
+          required
+          {...args}
+        />
+        <RadioButtonGroupComponent
+          id="warning-group-small"
+          name="warning-group-small"
+          legend="With Warning Small"
+          warning="Warning Message"
+          size="small"
+          {...args}
+        />
+        <RadioButtonGroupComponent
+          id="error-bottom-small-group"
+          name="error-bottom-small-group"
+          legend="With Error at Bottom Small"
+          error="Error Message"
+          validationMessagePositionTop={false}
+          size="small"
+          {...args}
+        />
+        <RadioButtonGroupComponent
+          id="warning-bottom-small-group"
+          name="warning-bottom-small-group"
+          legend="With Warning at Bottom Small"
+          warning="Warning Message"
+          validationMessagePositionTop={false}
+          size="small"
+          {...args}
+        />
+      </Box>
+      <Box display="flex" flexDirection="column" gap={2}>
+        <RadioButtonGroupComponent
+          id="error-group"
+          name="error-group"
+          legend="With Error"
+          error="Error Message"
+          required
+          {...args}
+        />
+        <RadioButtonGroupComponent
+          id="warning-group"
+          name="warning-group"
+          legend="With Warning"
+          warning="Warning Message"
+          {...args}
+        />
+        <RadioButtonGroupComponent
+          id="error-bottom-group"
+          name="error-bottom-group"
+          legend="With Error at Bottom"
+          error="Error Message"
+          validationMessagePositionTop={false}
+          {...args}
+        />
+        <RadioButtonGroupComponent
+          id="warning-bottom-group"
+          name="warning-bottom-group"
+          legend="With Warning at Bottom"
+          warning="Warning Message"
+          validationMessagePositionTop={false}
+          {...args}
+        />
+      </Box>
+      <Box display="flex" flexDirection="column" gap={2}>
+        <RadioButtonGroupComponent
+          id="error-large-group"
+          name="error-large-group"
+          legend="With Error Large"
+          error="Error Message"
+          size="large"
+          required
+          {...args}
+        />
+        <RadioButtonGroupComponent
+          id="warning-large-group"
+          name="warning-large-group"
+          legend="With Warning Large"
+          warning="Warning Message"
+          size="large"
+          {...args}
+        />
+        <RadioButtonGroupComponent
+          id="error-bottom-large-group"
+          name="error-bottom-large-group"
+          legend="With Error at Bottom Large"
+          error="Error Message"
+          validationMessagePositionTop={false}
+          size="large"
+          {...args}
+        />
+        <RadioButtonGroupComponent
+          id="warning-bottom-large-group"
+          name="warning-bottom-large-group"
+          legend="With Warning at Bottom Large"
+          warning="Warning Message"
+          validationMessagePositionTop={false}
+          size="large"
+          {...args}
+        />
+      </Box>
+    </Box>
+  );
+};
+Validation.storyName = "Validation";
+
+export const ValidationInline: Story = {
+  render: (args) => <Validation {...args} />,
+  args: {
+    inline: true,
+  },
+};
+
+export const SizesWithProgressiveDisclosure: Story = ({ ...args }) => {
+  const [valueSmall, setValueSmall] = useState("small1");
+  const [valueMedium, setValueMedium] = useState("medium1");
+  const [valueLarge, setValueLarge] = useState("large1");
+
+  const [textboxValue, setTextboxValue] = useState("");
+
+  const conditionalContent = (
+    <Box mr={1} width="300px">
+      <Textbox
+        label="Revealed Textbox"
+        value={textboxValue}
+        onChange={(ev) => setTextboxValue(ev.target.value)}
+      />
+    </Box>
+  );
+
+  return (
+    <Box m={2} display="flex" flexDirection="column" gap={2}>
+      <RadioButtonGroup
+        name="size-group-small"
+        legend="Small Radio Buttons"
+        value={valueSmall}
+        onChange={(ev) => setValueSmall(ev.target.value)}
+        size="small"
+        {...args}
+      >
+        <RadioButton
+          id="small-radio-1"
+          value="small1"
+          label="Radio Option 1"
+          conditionalContent={conditionalContent}
+        />
+        <RadioButton id="small-radio-2" value="small2" label="Radio Option 2" />
+        <RadioButton id="small-radio-3" value="small3" label="Radio Option 3" />
+      </RadioButtonGroup>
+
+      <RadioButtonGroup
+        name="size-group-medium"
+        legend="Medium Radio Buttons"
+        value={valueMedium}
+        onChange={(ev) => setValueMedium(ev.target.value)}
+        size="medium"
+        {...args}
+      >
+        <RadioButton
+          id="medium-radio-1"
+          value="medium1"
+          label="Radio Option 1"
+          conditionalContent={conditionalContent}
+        />
+        <RadioButton
+          id="medium-radio-2"
+          value="medium2"
+          label="Radio Option 2"
+        />
+        <RadioButton
+          id="medium-radio-3"
+          value="medium3"
+          label="Radio Option 3"
+        />
+      </RadioButtonGroup>
+
+      <RadioButtonGroup
+        name="size-group-large"
+        legend="Large Radio Buttons"
+        value={valueLarge}
+        onChange={(ev) => setValueLarge(ev.target.value)}
+        size="large"
+        {...args}
+      >
+        <RadioButton
+          id="large-radio-1"
+          value="large1"
+          label="Radio Option 1"
+          conditionalContent={conditionalContent}
+        />
+        <RadioButton id="large-radio-2" value="large2" label="Radio Option 2" />
+        <RadioButton id="large-radio-3" value="large3" label="Radio Option 3" />
+      </RadioButtonGroup>
+    </Box>
+  );
+};
+SizesWithProgressiveDisclosure.storyName = "Sizes with Progressive Disclosure";
+SizesWithProgressiveDisclosure.parameters = {
+  chromatic: { delay: 500 },
+};
+
+export const LegendAlignment: Story = ({ ...args }) => {
+  return (
+    <Box m={2} display="flex" flexDirection="column" gap={4}>
+      <RadioButtonGroupComponent
+        id="radio-group-left"
+        name="radio-group-left"
+        legend="Group Left"
+        legendHint="Legend Hint"
+        legendAlign="left"
+        {...args}
+      />
+
+      <RadioButtonGroupComponent
+        id="radio-group-right"
+        name="radio-group-right"
+        legend="Group Right"
+        legendHint="Legend Hint"
+        legendAlign="right"
+        {...args}
+      />
+    </Box>
+  );
+};
+LegendAlignment.storyName = "Legend Alignment";

--- a/src/components/radio-button/__next__/radio-button-group/radio-button-group-test.stories.tsx
+++ b/src/components/radio-button/__next__/radio-button-group/radio-button-group-test.stories.tsx
@@ -18,7 +18,6 @@ const meta: Meta<typeof RadioButtonGroup> = {
   argTypes: {
     ...styledSystemProps,
     error: { control: "text" },
-    warning: { control: "text" },
   },
   parameters: {
     themeProvider: { chromatic: { theme: "sage" } },
@@ -77,27 +76,10 @@ export const Validation = ({ ...args }) => {
           {...args}
         />
         <RadioButtonGroupComponent
-          id="warning-group-small"
-          name="warning-group-small"
-          legend="With Warning Small"
-          warning="Warning Message"
-          size="small"
-          {...args}
-        />
-        <RadioButtonGroupComponent
           id="error-bottom-small-group"
           name="error-bottom-small-group"
           legend="With Error at Bottom Small"
           error="Error Message"
-          validationMessagePositionTop={false}
-          size="small"
-          {...args}
-        />
-        <RadioButtonGroupComponent
-          id="warning-bottom-small-group"
-          name="warning-bottom-small-group"
-          legend="With Warning at Bottom Small"
-          warning="Warning Message"
           validationMessagePositionTop={false}
           size="small"
           {...args}
@@ -113,25 +95,10 @@ export const Validation = ({ ...args }) => {
           {...args}
         />
         <RadioButtonGroupComponent
-          id="warning-group"
-          name="warning-group"
-          legend="With Warning"
-          warning="Warning Message"
-          {...args}
-        />
-        <RadioButtonGroupComponent
           id="error-bottom-group"
           name="error-bottom-group"
           legend="With Error at Bottom"
           error="Error Message"
-          validationMessagePositionTop={false}
-          {...args}
-        />
-        <RadioButtonGroupComponent
-          id="warning-bottom-group"
-          name="warning-bottom-group"
-          legend="With Warning at Bottom"
-          warning="Warning Message"
           validationMessagePositionTop={false}
           {...args}
         />
@@ -147,27 +114,10 @@ export const Validation = ({ ...args }) => {
           {...args}
         />
         <RadioButtonGroupComponent
-          id="warning-large-group"
-          name="warning-large-group"
-          legend="With Warning Large"
-          warning="Warning Message"
-          size="large"
-          {...args}
-        />
-        <RadioButtonGroupComponent
           id="error-bottom-large-group"
           name="error-bottom-large-group"
           legend="With Error at Bottom Large"
           error="Error Message"
-          validationMessagePositionTop={false}
-          size="large"
-          {...args}
-        />
-        <RadioButtonGroupComponent
-          id="warning-bottom-large-group"
-          name="warning-bottom-large-group"
-          legend="With Warning at Bottom Large"
-          warning="Warning Message"
           validationMessagePositionTop={false}
           size="large"
           {...args}

--- a/src/components/radio-button/__next__/radio-button-group/radio-button-group.component.tsx
+++ b/src/components/radio-button/__next__/radio-button-group/radio-button-group.component.tsx
@@ -40,8 +40,6 @@ export interface RadioButtonGroupProps extends MarginProps, TagProps {
   size?: "small" | "medium" | "large";
   /** Error message to be displayed when validation fails. */
   error?: string;
-  /** Warning message to be displayed when validation warning occurs. */
-  warning?: string;
   /** Render the ValidationMessage above the RadioButtonGroup when validationRedesignOptIn flag is set. */
   validationMessagePositionTop?: boolean;
 }
@@ -54,7 +52,6 @@ export const RadioButtonGroup = ({
   legendHint,
   legendAlign,
   error,
-  warning,
   onBlur,
   onChange,
   value,
@@ -77,7 +74,6 @@ export const RadioButtonGroup = ({
       isDisabled={disabled}
       isRequired={required}
       error={error}
-      warning={warning}
       validationMessagePositionTop={validationMessagePositionTop}
       size={size}
       inline={inline}

--- a/src/components/radio-button/__next__/radio-button-group/radio-button-group.component.tsx
+++ b/src/components/radio-button/__next__/radio-button-group/radio-button-group.component.tsx
@@ -1,0 +1,108 @@
+import React, { useRef } from "react";
+import { MarginProps } from "styled-system";
+import tagComponent, {
+  TagProps,
+} from "../../../../__internal__/utils/helpers/tags/tags";
+import Fieldset from "../../../../__internal__/fieldset/__next__/fieldset.component";
+import { filterStyledSystemMarginProps } from "../../../../style/utils";
+import { RadioButtonGroupProvider } from "../___internal___/radio-button-group.context";
+import guid from "../../../../__internal__/utils/helpers/guid";
+
+export interface RadioButtonGroupProps extends MarginProps, TagProps {
+  /**
+   * Unique identifier for the component.
+   * Will use a randomly generated GUID if none is provided.
+   */
+  id?: string;
+  /** The RadioButton objects to be rendered within the group. */
+  children: React.ReactNode;
+  /** When true, RadioButton children are inline. */
+  inline?: boolean;
+  /** The content for the RadioButtonGroup legend. */
+  legend?: string;
+  /** Content for the hint text below the legend. */
+  legendHint?: string;
+  /** Alignment of the legend. */
+  legendAlign?: "left" | "right";
+  /** Specifies the name prop to be applied to each RadioButton in the group. */
+  name: string;
+  /** Value of the selected RadioButton child. */
+  value: string;
+  /** Callback fired when a RadioButton child is blurred. */
+  onBlur?: (ev: React.FocusEvent<HTMLInputElement>) => void;
+  /** Callback fired when a RadioButton child is selected. */
+  onChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
+  /** Flag to disable the RadioButtonGroup. */
+  disabled?: boolean;
+  /** Flag to configure RadioButtonGroup as mandatory. */
+  required?: boolean;
+  /** Size of the RadioButtonGroup. */
+  size?: "small" | "medium" | "large";
+  /** Error message to be displayed when validation fails. */
+  error?: string;
+  /** Warning message to be displayed when validation warning occurs. */
+  warning?: string;
+  /** Render the ValidationMessage above the RadioButtonGroup when validationRedesignOptIn flag is set. */
+  validationMessagePositionTop?: boolean;
+}
+
+export const RadioButtonGroup = ({
+  children,
+  id,
+  name,
+  legend,
+  legendHint,
+  legendAlign,
+  error,
+  warning,
+  onBlur,
+  onChange,
+  value,
+  inline = false,
+  required,
+  validationMessagePositionTop = true,
+  size = "medium",
+  disabled,
+  ...rest
+}: RadioButtonGroupProps) => {
+  const internalId = useRef(guid());
+  const uniqueId = id || internalId.current;
+
+  return (
+    <Fieldset
+      id={uniqueId}
+      legend={legend}
+      legendHint={legendHint}
+      legendAlign={legendAlign}
+      isDisabled={disabled}
+      isRequired={required}
+      error={error}
+      warning={warning}
+      validationMessagePositionTop={validationMessagePositionTop}
+      size={size}
+      inline={inline}
+      {...tagComponent("radio-button-group", rest)}
+      {...filterStyledSystemMarginProps(rest)}
+    >
+      <RadioButtonGroupProvider
+        value={{
+          error: !!error,
+          inline,
+          onBlur,
+          onChange,
+          value,
+          name,
+          size,
+          required,
+          disabled,
+        }}
+      >
+        {children}
+      </RadioButtonGroupProvider>
+    </Fieldset>
+  );
+};
+
+RadioButtonGroup.displayName = "RadioButtonGroup";
+
+export default RadioButtonGroup;

--- a/src/components/radio-button/__next__/radio-button-group/radio-button-group.mdx
+++ b/src/components/radio-button/__next__/radio-button-group/radio-button-group.mdx
@@ -1,0 +1,114 @@
+import { Meta, ArgTypes, Canvas } from "@storybook/blocks";
+
+import * as RadioButtonGroupStories from "./radio-button-group.stories";
+
+<Meta of={RadioButtonGroupStories} />
+
+# Radio Button
+
+<a
+  target="_blank"
+  href="https://zeroheight.com/35ee2cc26/v/latest/p/23d57a-radio-button"
+  style={{ color: "#007E45", fontWeight: "bold", textDecoration: "underline" }}
+  rel="noreferrer"
+>
+  Product Design System component
+</a>
+
+**This documentation page is for the new implementation of `RadioButton` and `RadioButtonGroup`. 
+If you are still using the deprecated implementation, please refer to this <a href="../?path=/docs/deprecated-radio-button--docs">documentation page</a>.**
+
+## Contents
+
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [Validation states](#validation-states)
+- [Props](#props)
+
+## Quick Start
+
+To use these components, import both `RadioButtonGroup` and `RadioButton`, and pass the radio buttons as children of the radio group.
+
+```javascript
+import {
+  RadioButton,
+  RadioButtonGroup,
+} from "carbon-react/lib/components/radio-button/__next__";
+```
+
+## Examples
+
+### Default
+
+<Canvas of={RadioButtonGroupStories.Default} />
+
+### With Legend
+
+A legend can be set for the group of radio buttons by passing the `legend` prop to `RadioButtonGroup` with a string value.
+
+<Canvas of={RadioButtonGroupStories.WithLegend} />
+
+### With Legend Hint
+
+To add a hint below the legend, pass the `legendHint` prop to `RadioButtonGroup` with a string value.
+
+<Canvas of={RadioButtonGroupStories.WithLegendHint} />
+
+### With Input Hint
+
+To add a hint to individual radio buttons, pass the `inputHint` prop to `RadioButton` with a string value.
+
+<Canvas of={RadioButtonGroupStories.WithInputHint} />
+
+### Inline
+
+`RadioButton`s can be displayed inline passing the `inline` prop to `RadioButtonGroup`.
+
+<Canvas of={RadioButtonGroupStories.InlineRadioButtons} />
+
+### Sizes
+
+The size of the `RadioButton`s can be changed with the `size` prop. Available options are `small`, `medium`, and `large`.
+
+<Canvas of={RadioButtonGroupStories.Sizes} />
+
+### Progressive Disclosure
+
+`RadioButton`s can be used to conditionally reveal additional content when selected. 
+This can be achieved by passing the content to the `conditionalContent` prop to `RadioButton`, which accepts any valid ReactNode.
+
+It is recommended that you provide limited amounts of content within conditionally revealed sections, if you need to disclose larger amounts of content, please consider using a different pattern.
+
+**Please Note**: Progressive disclosure is not supported when the `inline` prop is set on `RadioButtonGroup`.
+
+<Canvas of={RadioButtonGroupStories.ProgressiveDisclosure} />
+
+### With Custom Labels
+
+The `label` prop in `RadioButton` accepts a ReactNode, which allows for custom content to be displayed as the label.
+
+<Canvas of={RadioButtonGroupStories.WithCustomLabels} />
+
+### Required
+
+`RadioButtonGroup` can be marked as required by passing the `required` prop.
+
+<Canvas of={RadioButtonGroupStories.Required} />
+
+### Disabled
+
+`RadioButton`s can be disabled using the `disabled` prop either on the `RadioButtonGroup` to disable all radio buttons, or on individual `RadioButton`s to disable them individually.
+
+**Please Note**: Even though Carbon does support disabled radio buttons, their use is not generally recommended by Design System.
+
+<Canvas of={RadioButtonGroupStories.Disabled} />
+
+## Validation States
+
+This component supports input validation, see our [Validations](../?path=/docs/documentation-validations--docs) documentation page for more information.
+
+## Props
+
+**Any other supplied props in `RadioButton` will be provided to the underlying HTML input element**
+
+<ArgTypes of={RadioButtonGroupStories} />

--- a/src/components/radio-button/__next__/radio-button-group/radio-button-group.stories.tsx
+++ b/src/components/radio-button/__next__/radio-button-group/radio-button-group.stories.tsx
@@ -19,7 +19,6 @@ const meta: Meta<typeof RadioButtonGroup> = {
   argTypes: {
     ...styledSystemProps,
     error: { control: "text" },
-    warning: { control: "text" },
   },
   parameters: {
     themeProvider: { chromatic: { theme: "sage" } },

--- a/src/components/radio-button/__next__/radio-button-group/radio-button-group.stories.tsx
+++ b/src/components/radio-button/__next__/radio-button-group/radio-button-group.stories.tsx
@@ -1,0 +1,295 @@
+import React, { useState } from "react";
+import { Meta, StoryObj } from "@storybook/react";
+import generateStyledSystemProps from "../../../../../.storybook/utils/styled-system-props";
+
+import { RadioButton, RadioButtonGroup, RadioButtonGroupProps } from "..";
+
+import Box from "../../../box";
+import Textbox from "../../../textbox";
+import Icon from "../../../icon";
+
+const styledSystemProps = generateStyledSystemProps({
+  margin: true,
+});
+
+const meta: Meta<typeof RadioButtonGroup> = {
+  title: "Radio Button",
+  component: RadioButtonGroup,
+  subcomponents: { RadioButton },
+  argTypes: {
+    ...styledSystemProps,
+    error: { control: "text" },
+    warning: { control: "text" },
+  },
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
+    controls: {
+      exclude: ["children", "onBlur", "onChange", "value", "name"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RadioButtonGroup>;
+
+interface TemplateProps
+  extends Omit<
+    RadioButtonGroupProps,
+    "children" | "value" | "onChange" | "name"
+  > {
+  id?: string;
+}
+
+const ControlledRadioButtonGroup = ({
+  id = "default",
+  ...args
+}: TemplateProps) => {
+  const [value, setValue] = useState("");
+  return (
+    <RadioButtonGroup
+      name={`${id}-group`}
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
+      {...args}
+    >
+      <RadioButton id={`${id}-1`} value="radio1" label="Radio Option 1" />
+      <RadioButton id={`${id}-2`} value="radio2" label="Radio Option 2" />
+      <RadioButton id={`${id}-3`} value="radio3" label="Radio Option 3" />
+    </RadioButtonGroup>
+  );
+};
+
+export const Default: Story = {
+  render: ControlledRadioButtonGroup,
+};
+
+export const WithLegend: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    id: "with-legend",
+    legend: "RadioButtonGroup Legend",
+  },
+};
+
+export const WithLegendHint: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    id: "with-legend-hint",
+    legend: "RadioButtonGroup Legend",
+    legendHint: "Legend Hint",
+  },
+};
+
+export const WithInputHint: Story = ({ ...args }) => {
+  const [value, setValue] = useState("");
+  return (
+    <RadioButtonGroup
+      name="input-hint-group"
+      legend="Radio Button Group Legend"
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
+      {...args}
+    >
+      <RadioButton
+        id="input-hint-radio-1"
+        value="radio1"
+        label="Radio Option 1"
+        inputHint="Input Hint"
+      />
+      <RadioButton
+        id="input-hint-radio-2"
+        value="radio2"
+        label="Radio Option 2"
+        inputHint="Input Hint"
+      />
+      <RadioButton
+        id="input-hint-radio-3"
+        value="radio3"
+        label="Radio Option 3"
+        inputHint="Input Hint"
+      />
+    </RadioButtonGroup>
+  );
+};
+WithInputHint.storyName = "With Input Hint";
+
+export const InlineRadioButtons: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    id: "inline",
+    legend: "RadioButtonGroup Legend",
+    legendHint: "Legend Hint",
+    inline: true,
+  },
+};
+
+export const Sizes: Story = () => {
+  const [valueSmall, setValueSmall] = useState("");
+  const [valueMedium, setValueMedium] = useState("");
+  const [valueLarge, setValueLarge] = useState("");
+
+  return (
+    <Box display="flex" flexDirection="row" justifyContent="space-around">
+      <RadioButtonGroup
+        name="size-group-small"
+        legend="Small Radio Buttons"
+        value={valueSmall}
+        onChange={(ev) => setValueSmall(ev.target.value)}
+        size="small"
+      >
+        <RadioButton id="small-radio-1" value="small1" label="Radio Option 1" />
+        <RadioButton id="small-radio-2" value="small2" label="Radio Option 2" />
+        <RadioButton id="small-radio-3" value="small3" label="Radio Option 3" />
+      </RadioButtonGroup>
+      <RadioButtonGroup
+        name="size-group-medium"
+        legend="Medium Radio Buttons"
+        value={valueMedium}
+        onChange={(ev) => setValueMedium(ev.target.value)}
+        size="medium"
+      >
+        <RadioButton
+          id="medium-radio-1"
+          value="medium1"
+          label="Radio Option 1"
+        />
+        <RadioButton
+          id="medium-radio-2"
+          value="medium2"
+          label="Radio Option 2"
+        />
+        <RadioButton
+          id="medium-radio-3"
+          value="medium3"
+          label="Radio Option 3"
+        />
+      </RadioButtonGroup>
+      <RadioButtonGroup
+        name="size-group-large"
+        legend="Large Radio Buttons"
+        value={valueLarge}
+        onChange={(ev) => setValueLarge(ev.target.value)}
+        size="large"
+      >
+        <RadioButton id="large-radio-1" value="large1" label="Radio Option 1" />
+        <RadioButton id="large-radio-2" value="large2" label="Radio Option 2" />
+        <RadioButton id="large-radio-3" value="large3" label="Radio Option 3" />
+      </RadioButtonGroup>
+    </Box>
+  );
+};
+Sizes.storyName = "Sizes";
+
+export const ProgressiveDisclosure: Story = () => {
+  const [value, setValue] = useState("");
+  const [textboxValue, setTextboxValue] = useState("");
+
+  const conditionalContent = (
+    <Box mr={1} width="300px">
+      <Textbox
+        label="Revealed Textbox"
+        value={textboxValue}
+        onChange={(ev) => setTextboxValue(ev.target.value)}
+      />
+    </Box>
+  );
+
+  return (
+    <RadioButtonGroup
+      legend="Progressive Disclosure"
+      name="progressive-disclosure-group"
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
+    >
+      <RadioButton
+        id="progressive-radio-1"
+        value="radio1"
+        label="Radio Option 1"
+        conditionalContent={conditionalContent}
+      />
+      <RadioButton
+        id="progressive-radio-2"
+        value="radio2"
+        label="Radio Option 2"
+        conditionalContent={conditionalContent}
+      />
+      <RadioButton
+        id="progressive-radio-3"
+        value="radio3"
+        label="Radio Option 3"
+        conditionalContent={conditionalContent}
+      />
+    </RadioButtonGroup>
+  );
+};
+ProgressiveDisclosure.storyName = "Progressive Disclosure";
+ProgressiveDisclosure.parameters = {
+  chromatic: { disableSnapshot: true },
+};
+
+export const WithCustomLabels: Story = () => {
+  const [value, setValue] = useState("");
+  return (
+    <RadioButtonGroup
+      name="custom-styled-label-group"
+      legend="Radio group legend"
+      value={value}
+      onChange={(ev) => setValue(ev.target.value)}
+    >
+      <RadioButton
+        id="custom-styled-label-radio-1"
+        value="radio1"
+        label={
+          <>
+            <Icon type="placeholder" aria-hidden />
+            Radio Button 1
+          </>
+        }
+      />
+      <RadioButton
+        id="custom-styled-label-radio-2"
+        value="radio2"
+        label={
+          <>
+            <Icon type="placeholder" aria-hidden />
+            Radio Button 2
+          </>
+        }
+      />
+      <RadioButton
+        id="custom-styled-label-radio-3"
+        value="radio3"
+        label={
+          <>
+            <Icon type="placeholder" aria-hidden />
+            Radio Button 3
+          </>
+        }
+      />
+    </RadioButtonGroup>
+  );
+};
+WithCustomLabels.storyName = "With Custom Labels";
+
+export const Required: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    id: "required",
+    legend: "RadioButtonGroup Legend",
+    required: true,
+  },
+};
+
+export const Disabled: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    id: "disabled",
+    legend: "RadioButtonGroup Legend",
+    disabled: true,
+  },
+};

--- a/src/components/radio-button/__next__/radio-button-group/radio-button-group.test.tsx
+++ b/src/components/radio-button/__next__/radio-button-group/radio-button-group.test.tsx
@@ -1,7 +1,23 @@
-import React from "react";
+import React, { useState } from "react";
 import { render, screen } from "@testing-library/react";
-
+import userEvent from "@testing-library/user-event";
 import { RadioButton, RadioButtonGroup } from "..";
+
+const ControlledRadioButtonGroup = () => {
+  const [value, setValue] = useState("radio1");
+
+  return (
+    <RadioButtonGroup
+      name="radio-group"
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    >
+      <RadioButton id="radio-1" value="radio1" label="Radio Button 1" />
+      <RadioButton id="radio-2" value="radio2" label="Radio Button 2" />
+      <RadioButton id="radio-3" value="radio3" label="Radio Button 3" />
+    </RadioButtonGroup>
+  );
+};
 
 test("renders with RadioButton children", () => {
   render(
@@ -119,4 +135,20 @@ test("renders RadioButton children as disabled when `disabled` is true", () => {
 
   expect(screen.getByRole("radio", { name: "Radio Button 1" })).toBeDisabled();
   expect(screen.getByRole("radio", { name: "Radio Button 2" })).toBeDisabled();
+});
+
+// coverage
+test("checks RadioButton child when clicked", async () => {
+  const user = userEvent.setup();
+  render(<ControlledRadioButtonGroup />);
+
+  const radio1 = screen.getByRole("radio", { name: "Radio Button 1" });
+  const radio2 = screen.getByRole("radio", { name: "Radio Button 2" });
+  const radio3 = screen.getByRole("radio", { name: "Radio Button 3" });
+
+  await user.click(radio2);
+
+  expect(radio1).not.toBeChecked();
+  expect(radio2).toBeChecked();
+  expect(radio3).not.toBeChecked();
 });

--- a/src/components/radio-button/__next__/radio-button-group/radio-button-group.test.tsx
+++ b/src/components/radio-button/__next__/radio-button-group/radio-button-group.test.tsx
@@ -71,25 +71,6 @@ test("renders with `error` message", () => {
   expect(group).toHaveAccessibleDescription("Error Message");
 });
 
-test("renders with `warning` message", () => {
-  render(
-    <RadioButtonGroup
-      name="radio-group"
-      value=""
-      onChange={() => {}}
-      legend="Radio Group Legend"
-      warning="Warning Message"
-    >
-      <RadioButton value="radio" label="Radio Button" />
-    </RadioButtonGroup>,
-  );
-
-  const group = screen.getByRole("group", { name: "Radio Group Legend" });
-
-  expect(screen.getByText("Warning Message")).toBeVisible();
-  expect(group).toHaveAccessibleDescription("Warning Message");
-});
-
 test("checks the correct RadioButton based on `value`", () => {
   render(
     <RadioButtonGroup name="radio-group" value="radio-2" onChange={() => {}}>

--- a/src/components/radio-button/__next__/radio-button-group/radio-button-group.test.tsx
+++ b/src/components/radio-button/__next__/radio-button-group/radio-button-group.test.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { RadioButton, RadioButtonGroup } from "..";
+
+test("renders with RadioButton children", () => {
+  render(
+    <RadioButtonGroup name="radio-group" value="" onChange={() => {}}>
+      <RadioButton value="radio" label="Radio Button" />
+    </RadioButtonGroup>,
+  );
+
+  expect(
+    screen.getByRole("radio", { name: "Radio Button" }),
+  ).toBeInTheDocument();
+  expect(screen.getByTestId("radio-svg")).toBeVisible();
+});
+
+test("renders with provided `legend`", () => {
+  render(
+    <RadioButtonGroup
+      name="radio-group"
+      value=""
+      onChange={() => {}}
+      legend="Radio Group Legend"
+    >
+      <RadioButton value="radio" label="Radio Button" />
+    </RadioButtonGroup>,
+  );
+
+  expect(
+    screen.getByRole("group", { name: "Radio Group Legend" }),
+  ).toBeVisible();
+});
+
+test("renders with provided `legendHint`", () => {
+  render(
+    <RadioButtonGroup
+      name="radio-group"
+      value=""
+      onChange={() => {}}
+      legend="Radio Group Legend"
+      legendHint="Legend Hint"
+    >
+      <RadioButton value="radio" label="Radio Button" />
+    </RadioButtonGroup>,
+  );
+
+  expect(screen.getByText("Legend Hint")).toBeVisible();
+  expect(
+    screen.getByRole("group", { name: "Radio Group Legend" }),
+  ).toHaveAccessibleDescription("Legend Hint");
+});
+
+test("renders with `error` message", () => {
+  render(
+    <RadioButtonGroup
+      name="radio-group"
+      value=""
+      onChange={() => {}}
+      legend="Radio Group Legend"
+      error="Error Message"
+    >
+      <RadioButton value="radio" label="Radio Button" />
+    </RadioButtonGroup>,
+  );
+
+  const group = screen.getByRole("group", { name: "Radio Group Legend" });
+
+  expect(screen.getByText("Error Message")).toBeVisible();
+  expect(group).toHaveAccessibleDescription("Error Message");
+});
+
+test("renders with `warning` message", () => {
+  render(
+    <RadioButtonGroup
+      name="radio-group"
+      value=""
+      onChange={() => {}}
+      legend="Radio Group Legend"
+      warning="Warning Message"
+    >
+      <RadioButton value="radio" label="Radio Button" />
+    </RadioButtonGroup>,
+  );
+
+  const group = screen.getByRole("group", { name: "Radio Group Legend" });
+
+  expect(screen.getByText("Warning Message")).toBeVisible();
+  expect(group).toHaveAccessibleDescription("Warning Message");
+});
+
+test("checks the correct RadioButton based on `value`", () => {
+  render(
+    <RadioButtonGroup name="radio-group" value="radio-2" onChange={() => {}}>
+      <RadioButton value="radio-1" label="Radio Button 1" />
+      <RadioButton value="radio-2" label="Radio Button 2" />
+    </RadioButtonGroup>,
+  );
+
+  expect(
+    screen.getByRole("radio", { name: "Radio Button 1" }),
+  ).not.toBeChecked();
+  expect(screen.getByRole("radio", { name: "Radio Button 2" })).toBeChecked();
+});
+
+test("renders RadioButton children as requires when `RadioButtonGroup` is required", () => {
+  render(
+    <RadioButtonGroup
+      name="radio-group"
+      value=""
+      onChange={() => {}}
+      legend="Radio Group Legend"
+      required
+    >
+      <RadioButton value="radio-1" label="Radio Button 1" />
+      <RadioButton value="radio-2" label="Radio Button 2" />
+    </RadioButtonGroup>,
+  );
+
+  expect(screen.getByRole("radio", { name: "Radio Button 1" })).toBeRequired();
+  expect(screen.getByRole("radio", { name: "Radio Button 2" })).toBeRequired();
+});
+
+test("renders RadioButton children as disabled when `disabled` is true", () => {
+  render(
+    <RadioButtonGroup
+      name="radio-group"
+      value=""
+      onChange={() => {}}
+      legend="Radio Group Legend"
+      disabled
+    >
+      <RadioButton value="radio-1" label="Radio Button 1" />
+      <RadioButton value="radio-2" label="Radio Button 2" />
+    </RadioButtonGroup>,
+  );
+
+  expect(screen.getByRole("radio", { name: "Radio Button 1" })).toBeDisabled();
+  expect(screen.getByRole("radio", { name: "Radio Button 2" })).toBeDisabled();
+});

--- a/src/components/radio-button/__next__/radio-button.component.tsx
+++ b/src/components/radio-button/__next__/radio-button.component.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import RadioButtonSvg from "../radio-button-svg.component";
+import RadioButtonSvg from "./___internal___/radio-button-svg.component";
 import tagComponent, {
   TagProps,
 } from "../../../__internal__/utils/helpers/tags";

--- a/src/components/radio-button/__next__/radio-button.component.tsx
+++ b/src/components/radio-button/__next__/radio-button.component.tsx
@@ -1,0 +1,111 @@
+import React, { useCallback } from "react";
+import RadioButtonSvg from "../radio-button-svg.component";
+import tagComponent, {
+  TagProps,
+} from "../../../__internal__/utils/helpers/tags";
+
+import CheckableInput, {
+  CommonCheckableInputProps,
+} from "../../../__internal__/checkable-input/__next__/checkable-input.component";
+import RadioButtonStyle from "./radio-button.style";
+import { useRadioButtonGroupContext } from "./___internal___/radio-button-group.context";
+
+export interface RadioButtonProps extends CommonCheckableInputProps, TagProps {
+  /** Callback fired when the RadioButton is clicked. */
+  onClick?: (ev: React.MouseEvent<HTMLInputElement>) => void;
+  /** The value of the RadioButton. */
+  value: string;
+}
+
+export const RadioButton = React.forwardRef<HTMLInputElement, RadioButtonProps>(
+  (
+    {
+      autoFocus,
+      disabled,
+      id,
+      label,
+      inputHint,
+      name,
+      onChange,
+      onBlur,
+      value,
+      conditionalContent,
+      ...props
+    }: RadioButtonProps,
+    ref,
+  ) => {
+    const {
+      error: contextError,
+      inline,
+      onBlur: contextOnBlur,
+      onChange: contextOnChange,
+      value: contextValue,
+      name: contextName,
+      size: contextSize,
+      disabled: contextDisabled,
+      required: contextRequired,
+    } = useRadioButtonGroupContext();
+
+    const isChecked = contextValue === value;
+
+    const handleChange = useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        if (onChange) {
+          onChange(event);
+        }
+
+        /* istanbul ignore else */
+        if (contextOnChange) {
+          contextOnChange(event);
+        }
+      },
+      [onChange, contextOnChange],
+    );
+
+    const handleBlur = useCallback(
+      (event: React.FocusEvent<HTMLInputElement>) => {
+        if (onBlur) {
+          onBlur(event);
+        }
+
+        if (contextOnBlur) {
+          contextOnBlur(event);
+        }
+      },
+      [onBlur, contextOnBlur],
+    );
+
+    return (
+      <RadioButtonStyle
+        size={contextSize}
+        error={contextError}
+        disabled={contextDisabled || disabled}
+        {...tagComponent("radio-button", props)}
+      >
+        <CheckableInput
+          type="radio"
+          id={id}
+          name={name || contextName}
+          value={value}
+          label={label}
+          inputHint={inputHint}
+          disabled={contextDisabled || disabled}
+          required={contextRequired}
+          checked={isChecked}
+          ref={ref}
+          onChange={handleChange}
+          onBlur={handleBlur}
+          size={contextSize}
+          {...(!inline && { conditionalContent })}
+          {...props}
+        >
+          <RadioButtonSvg />
+        </CheckableInput>
+      </RadioButtonStyle>
+    );
+  },
+);
+
+RadioButton.displayName = "RadioButton";
+
+export default RadioButton;

--- a/src/components/radio-button/__next__/radio-button.pw.tsx
+++ b/src/components/radio-button/__next__/radio-button.pw.tsx
@@ -115,19 +115,6 @@ test.describe("Accessibility tests for RadioButton", () => {
     await checkAccessibility(page);
   });
 
-  test("should pass accessibility when `warning` is set", async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <RadioButtonGroupControlled
-        legend="Radio Group Legend"
-        warning="This is a warning"
-      />,
-    );
-    await checkAccessibility(page);
-  });
-
   test("should pass accessibility when `inputHint` is set on RadioButton", async ({
     mount,
     page,

--- a/src/components/radio-button/__next__/radio-button.pw.tsx
+++ b/src/components/radio-button/__next__/radio-button.pw.tsx
@@ -1,0 +1,158 @@
+import React from "react";
+import { test, expect } from "../../../../playwright/helpers/base-test";
+
+import { checkAccessibility } from "../../../../playwright/support/helper";
+
+import {
+  RadioButtonControlled,
+  RadioButtonGroupControlled,
+  RadioButtonWithConditionalContent,
+} from "./components.test-pw";
+
+test("keyboard navigation works correctly in RadioButtonGroup", async ({
+  mount,
+  page,
+}) => {
+  await mount(<RadioButtonGroupControlled />);
+
+  const radio1 = page.getByRole("radio", { name: "Radio Button 1" });
+  const radio2 = page.getByRole("radio", { name: "Radio Button 2" });
+  const radio3 = page.getByRole("radio", { name: "Radio Button 3" });
+
+  await page.keyboard.press("Tab");
+  await expect(radio1).toBeFocused();
+
+  await page.keyboard.press("ArrowDown");
+  await expect(radio2).toBeFocused();
+
+  await page.keyboard.press("ArrowDown");
+  await expect(radio3).toBeFocused();
+
+  await page.keyboard.press("ArrowUp");
+  await expect(radio2).toBeFocused();
+
+  await page.keyboard.press("ArrowUp");
+  await expect(radio1).toBeFocused();
+});
+
+test("clicking on a RadioButton selects it", async ({ mount, page }) => {
+  await mount(<RadioButtonGroupControlled />);
+
+  const radio1 = page.getByRole("radio", { name: "Radio Button 1" });
+  const radio2 = page.getByRole("radio", { name: "Radio Button 2" });
+  const radio3 = page.getByRole("radio", { name: "Radio Button 3" });
+
+  await radio1.click();
+  await expect(radio1).toBeChecked();
+  await expect(radio2).not.toBeChecked();
+  await expect(radio3).not.toBeChecked();
+
+  await radio2.click();
+  await expect(radio1).not.toBeChecked();
+  await expect(radio2).toBeChecked();
+  await expect(radio3).not.toBeChecked();
+
+  await radio3.click();
+  await expect(radio1).not.toBeChecked();
+  await expect(radio2).not.toBeChecked();
+  await expect(radio3).toBeChecked();
+});
+
+test("renders `conditionalContent` when RadioButton is selected and closes when another RadioButton is selected", async ({
+  mount,
+  page,
+}) => {
+  await mount(<RadioButtonWithConditionalContent />);
+
+  await page.getByRole("radio", { name: "Radio Button 1" }).click();
+  await expect(
+    page.getByRole("textbox", { name: "Revealed Textbox" }),
+  ).toBeVisible();
+
+  await page.getByRole("radio", { name: "Radio Button 2" }).click();
+  await expect(
+    page.getByRole("textbox", { name: "Revealed Textbox" }),
+  ).toBeHidden();
+});
+
+test.describe("Accessibility tests for RadioButton", () => {
+  test("should pass accessibility when rendered", async ({ mount, page }) => {
+    await mount(<RadioButtonGroupControlled />);
+    await checkAccessibility(page);
+  });
+
+  test("should pass accessibility when `legend` is set", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<RadioButtonGroupControlled legend="Radio Group Legend" />);
+    await checkAccessibility(page);
+  });
+
+  test("should pass accessibility when `legendHint` is set", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <RadioButtonGroupControlled
+        legend="Radio Group Legend"
+        legendHint="This is a hint"
+      />,
+    );
+    await checkAccessibility(page);
+  });
+
+  test("should pass accessibility when `error` is set", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <RadioButtonGroupControlled
+        legend="Radio Group Legend"
+        error="This is an error"
+      />,
+    );
+    await checkAccessibility(page);
+  });
+
+  test("should pass accessibility when `warning` is set", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <RadioButtonGroupControlled
+        legend="Radio Group Legend"
+        warning="This is a warning"
+      />,
+    );
+    await checkAccessibility(page);
+  });
+
+  test("should pass accessibility when `inputHint` is set on RadioButton", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<RadioButtonControlled inputHint="This is an input hint" />);
+    await checkAccessibility(page);
+  });
+
+  test("should pass accessibility when `conditionalContent` is set on RadioButton", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<RadioButtonWithConditionalContent />);
+
+    await page.getByRole("radio", { name: "Radio Button 1" }).click();
+
+    await expect(
+      page.getByRole("textbox", { name: "Revealed Textbox" }),
+    ).toBeVisible();
+    await checkAccessibility(page);
+
+    await page.getByRole("radio", { name: "Radio Button 2" }).click();
+    await expect(
+      page.getByRole("textbox", { name: "Revealed Textbox" }),
+    ).toBeHidden();
+    await checkAccessibility(page);
+  });
+});

--- a/src/components/radio-button/__next__/radio-button.style.tsx
+++ b/src/components/radio-button/__next__/radio-button.style.tsx
@@ -1,0 +1,100 @@
+import styled, { css } from "styled-components";
+import { margin } from "styled-system";
+import HiddenCheckableInputStyle from "../../../__internal__/checkable-input/hidden-checkable-input.style";
+import StyledCheckableInputSvgWrapper from "../../../__internal__/checkable-input/checkable-input-svg-wrapper.style";
+import applyBaseTheme from "../../../style/themes/apply-base-theme";
+import addFocusStyling from "../../../style/utils/add-focus-styling";
+
+const svgSize = {
+  small: {
+    size: "var(--global-size3xs, 16px)",
+    radius: 5,
+  },
+  medium: {
+    size: "var(--global-size-xs, 24px)",
+    radius: 4.5,
+  },
+  large: {
+    size: "var(--global-size-s, 32px)",
+    radius: 4.285,
+  },
+};
+
+interface RadioButtonStyleProps {
+  disabled?: boolean;
+  size: "small" | "medium" | "large";
+  error?: boolean;
+}
+
+const RadioButtonStyle = styled.div.attrs(
+  applyBaseTheme,
+)<RadioButtonStyleProps>`
+  ${({ disabled, size, error }) => css`
+    ${StyledCheckableInputSvgWrapper}, svg {
+      border-radius: 999px;
+    }
+
+    ${HiddenCheckableInputStyle} {
+      position: absolute;
+      box-sizing: border-box;
+      min-height: var(--global-size-xs, 24px);
+    }
+
+    ${HiddenCheckableInputStyle},
+    ${StyledCheckableInputSvgWrapper},
+    svg {
+      height: ${svgSize[size].size};
+      width: ${svgSize[size].size};
+    }
+
+    svg {
+      box-sizing: border-box;
+      background-color: var(--input-typical-bg-default, #fff);
+      border: 1px solid var(--input-typical-border-default, #7c7c7c);
+      ${!disabled &&
+      css`
+        /* istanbul ignore next */
+        ${error &&
+        `border: 2px solid var(--input-validation-border-error, #DB004E);`}
+      `}
+    }
+
+    circle {
+      r: ${svgSize[size].radius};
+    }
+
+    ${HiddenCheckableInputStyle}:checked + ${StyledCheckableInputSvgWrapper} circle {
+      fill: var(--input-typical-icon-active, #000);
+    }
+
+    ${HiddenCheckableInputStyle}:not([disabled]) {
+      &:focus
+        + ${StyledCheckableInputSvgWrapper},
+        &:hover
+        + ${StyledCheckableInputSvgWrapper} {
+        ${addFocusStyling()}
+      }
+    }
+
+    ${disabled &&
+    css`
+      svg {
+        border: 1px solid
+          var(--input-typical-border-disabled, rgba(0, 0, 0, 0.3));
+        background-color: var(--input-typical-bg-disabled, #eee);
+      }
+
+      circle {
+        fill: var(--input-typical-bg-disabled, #eee);
+      }
+
+      ${HiddenCheckableInputStyle}:checked + ${StyledCheckableInputSvgWrapper} circle {
+        fill: var(--input-typical-icon-disabled, rgba(0, 0, 0, 0.42));
+      }
+    `}
+  `}
+
+  ${margin};
+`;
+
+export default RadioButtonStyle;

--- a/src/components/radio-button/__next__/radio-button.style.tsx
+++ b/src/components/radio-button/__next__/radio-button.style.tsx
@@ -50,7 +50,7 @@ const RadioButtonStyle = styled.div.attrs(
     svg {
       box-sizing: border-box;
       background-color: var(--input-typical-bg-default, #fff);
-      border: 1px solid var(--input-typical-border-default, #7c7c7c);
+      border: 1px solid var(--input-typical-border-default, #668494);
       ${!disabled &&
       css`
         /* istanbul ignore next */

--- a/src/components/radio-button/__next__/radio-button.style.tsx
+++ b/src/components/radio-button/__next__/radio-button.style.tsx
@@ -8,15 +8,15 @@ import addFocusStyling from "../../../style/utils/add-focus-styling";
 const svgSize = {
   small: {
     size: "var(--global-size3xs, 16px)",
-    radius: 5,
+    radius: 4.285,
   },
   medium: {
     size: "var(--global-size-xs, 24px)",
-    radius: 4.5,
+    radius: 4.09,
   },
   large: {
     size: "var(--global-size-s, 32px)",
-    radius: 4.285,
+    radius: 4,
   },
 };
 

--- a/src/components/radio-button/__next__/radio-button.style.tsx
+++ b/src/components/radio-button/__next__/radio-button.style.tsx
@@ -8,15 +8,12 @@ import addFocusStyling from "../../../style/utils/add-focus-styling";
 const svgSize = {
   small: {
     size: "var(--global-size3xs, 16px)",
-    radius: 4.285,
   },
   medium: {
     size: "var(--global-size-xs, 24px)",
-    radius: 4.09,
   },
   large: {
     size: "var(--global-size-s, 32px)",
-    radius: 4,
   },
 };
 
@@ -57,10 +54,6 @@ const RadioButtonStyle = styled.div.attrs(
         ${error &&
         `border: 2px solid var(--input-validation-border-error, #DB004E);`}
       `}
-    }
-
-    circle {
-      r: ${svgSize[size].radius};
     }
 
     ${HiddenCheckableInputStyle}:checked + ${StyledCheckableInputSvgWrapper} circle {

--- a/src/components/radio-button/__next__/radio-button.test.tsx
+++ b/src/components/radio-button/__next__/radio-button.test.tsx
@@ -1,0 +1,195 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RadioButton, RadioButtonGroup } from ".";
+
+test("renders with provided `label`", () => {
+  render(
+    <RadioButtonGroup name="radio-group" value="" onChange={() => {}}>
+      <RadioButton value="radio" label="Radio Button" />
+    </RadioButtonGroup>,
+  );
+
+  expect(
+    screen.getByRole("radio", { name: "Radio Button" }),
+  ).toBeInTheDocument();
+  expect(screen.getByTestId("radio-svg")).toBeVisible();
+  expect(screen.getByText("Radio Button")).toBeVisible();
+});
+
+test("renders with provided `inputHint`", () => {
+  render(
+    <RadioButtonGroup name="radio-group" value="" onChange={() => {}}>
+      <RadioButton value="radio" label="Radio Button" inputHint="Input Hint" />
+    </RadioButtonGroup>,
+  );
+
+  expect(screen.getByText("Input Hint")).toBeVisible();
+  expect(
+    screen.getByRole("radio", { name: "Radio Button" }),
+  ).toHaveAccessibleDescription("Input Hint");
+});
+
+test("calls `onChange` when provided and the radio button is clicked", async () => {
+  const user = userEvent.setup();
+  const onChange = jest.fn();
+  render(
+    <RadioButtonGroup name="radio-group" value="" onChange={() => {}}>
+      <RadioButton value="radio" onChange={onChange} />
+    </RadioButtonGroup>,
+  );
+
+  await user.click(screen.getByRole("radio"));
+
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+
+test("calls `onChange` from context when provided and the radio button is clicked", async () => {
+  const user = userEvent.setup();
+  const onChange = jest.fn();
+  render(
+    <RadioButtonGroup name="radio-group" value="" onChange={onChange}>
+      <RadioButton value="radio" />
+    </RadioButtonGroup>,
+  );
+
+  await user.click(screen.getByRole("radio"));
+
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+
+test("calls `onBlur` when provided and the radio button is blurred", async () => {
+  const user = userEvent.setup();
+  const onBlur = jest.fn();
+  render(
+    <RadioButtonGroup name="radio-group" value="" onChange={() => {}}>
+      <RadioButton value="radio" onBlur={onBlur} />
+    </RadioButtonGroup>,
+  );
+
+  await user.click(screen.getByRole("radio"));
+  await user.tab();
+
+  expect(onBlur).toHaveBeenCalledTimes(1);
+});
+
+test("calls `onBlur` from context when provided and the radio button is blurred", async () => {
+  const user = userEvent.setup();
+  const onBlur = jest.fn();
+  render(
+    <RadioButtonGroup
+      name="radio-group"
+      value=""
+      onBlur={onBlur}
+      onChange={() => {}}
+    >
+      <RadioButton value="radio" />
+    </RadioButtonGroup>,
+  );
+
+  await user.click(screen.getByRole("radio"));
+  await user.tab();
+
+  expect(onBlur).toHaveBeenCalledTimes(1);
+});
+
+test("calls `onClick` when provided and the radio button is clicked", async () => {
+  const user = userEvent.setup();
+  const onClick = jest.fn();
+  render(
+    <RadioButtonGroup name="radio-group" value="" onChange={() => {}}>
+      <RadioButton value="radio" onClick={onClick} />
+    </RadioButtonGroup>,
+  );
+
+  await user.click(screen.getByRole("radio"));
+
+  expect(onClick).toHaveBeenCalledTimes(1);
+});
+
+test("calls `onFocus` when provided and the radio button is focused", async () => {
+  const user = userEvent.setup();
+  const onFocus = jest.fn();
+  render(
+    <RadioButtonGroup name="radio-group" value="" onChange={() => {}}>
+      <RadioButton value="radio" onFocus={onFocus} />
+    </RadioButtonGroup>,
+  );
+
+  await user.click(screen.getByRole("radio"));
+
+  expect(onFocus).toHaveBeenCalledTimes(1);
+});
+
+test("calls `onMouseEnter` when provided and the radio button is hovered", async () => {
+  const user = userEvent.setup();
+  const onMouseEnter = jest.fn();
+  render(
+    <RadioButtonGroup name="radio-group" value="" onChange={() => {}}>
+      <RadioButton value="radio" onMouseEnter={onMouseEnter} />
+    </RadioButtonGroup>,
+  );
+
+  await user.hover(screen.getByRole("radio"));
+
+  expect(onMouseEnter).toHaveBeenCalledTimes(1);
+});
+
+test("calls `onMouseLeave` when provided and the radio button is unhovered", async () => {
+  const user = userEvent.setup();
+  const onMouseLeave = jest.fn();
+  render(
+    <RadioButtonGroup name="radio-group" value="" onChange={() => {}}>
+      <RadioButton value="radio" onMouseLeave={onMouseLeave} />
+    </RadioButtonGroup>,
+  );
+
+  await user.hover(screen.getByRole("radio"));
+  await user.unhover(screen.getByRole("radio"));
+
+  expect(onMouseLeave).toHaveBeenCalledTimes(1);
+});
+
+test("should accept ref as an object", () => {
+  const ref = { current: null };
+  render(
+    <RadioButtonGroup name="radio-group" value="" onChange={() => {}}>
+      <RadioButton value="radio" ref={ref} />
+    </RadioButtonGroup>,
+  );
+
+  expect(ref.current).not.toBeNull();
+});
+
+test("should accept ref as a callback", () => {
+  const ref = jest.fn();
+  render(
+    <RadioButtonGroup name="radio-group" value="" onChange={() => {}}>
+      <RadioButton value="radio" ref={ref} />
+    </RadioButtonGroup>,
+  );
+
+  expect(ref).toHaveBeenCalledTimes(1);
+});
+
+test("should set ref to empty after unmount", () => {
+  const ref = { current: null };
+  const { unmount } = render(
+    <RadioButtonGroup name="radio-group" value="" onChange={() => {}}>
+      <RadioButton value="radio" ref={ref} />
+    </RadioButtonGroup>,
+  );
+
+  unmount();
+  expect(ref.current).toBeNull();
+});
+
+test("renders disabled when `disabled` prop is true", () => {
+  render(
+    <RadioButtonGroup name="radio-group" value="" onChange={() => {}}>
+      <RadioButton value="radio" disabled />
+    </RadioButtonGroup>,
+  );
+
+  expect(screen.getByRole("radio")).toBeDisabled();
+});

--- a/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
+++ b/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
@@ -13,6 +13,9 @@ import { ValidationProps } from "../../../__internal__/validations";
 import NewValidationContext from "../../carbon-provider/__internal__/new-validation.context";
 import guid from "../../../__internal__/utils/helpers/guid";
 
+/**
+ * @deprecated This version of `RadioButtonGroup` is deprecated. See the Carbon documentation for more details.
+ */
 export interface RadioButtonGroupProps
   extends ValidationProps,
     MarginProps,

--- a/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
+++ b/src/components/radio-button/radio-button-group/radio-button-group.component.tsx
@@ -66,6 +66,9 @@ export interface RadioButtonGroupProps
   validationMessagePositionTop?: boolean;
 }
 
+/**
+ * @deprecated This version of `RadioButtonGroup` is deprecated. See the Carbon documentation for more details.
+ */
 export const RadioButtonGroup = ({
   children,
   id,

--- a/src/components/radio-button/radio-button-group/radio-button-group.stories.tsx
+++ b/src/components/radio-button/radio-button-group/radio-button-group.stories.tsx
@@ -12,7 +12,7 @@ const styledSystemProps = generateStyledSystemProps({
 });
 
 const meta: Meta<typeof RadioButtonGroup> = {
-  title: "Radio Button Group",
+  title: "Deprecated/Radio Button Group",
   component: RadioButtonGroup,
   tags: ["hideInSidebar"],
   argTypes: {

--- a/src/components/radio-button/radio-button-test.stories.tsx
+++ b/src/components/radio-button/radio-button-test.stories.tsx
@@ -7,7 +7,7 @@ import Switch from "../switch";
 import Box from "../box";
 
 export default {
-  title: "Radio Button/Test",
+  title: "Deprecated/Radio Button/Test",
   parameters: {
     info: { disable: true },
     chromatic: {

--- a/src/components/radio-button/radio-button.component.tsx
+++ b/src/components/radio-button/radio-button.component.tsx
@@ -14,6 +14,9 @@ interface InternalRadioButtonProps {
   inline?: boolean;
 }
 
+/**
+ * @deprecated This version of `RadioButton` is deprecated. See the Carbon documentation for more details.
+ */
 export interface RadioButtonProps
   extends Omit<CommonCheckableInputProps, "required">,
     MarginProps,

--- a/src/components/radio-button/radio-button.component.tsx
+++ b/src/components/radio-button/radio-button.component.tsx
@@ -31,6 +31,9 @@ export interface RadioButtonProps
   helpAriaLabel?: string;
 }
 
+/**
+ * @deprecated This version of `RadioButton` is deprecated. See the Carbon documentation for more details.
+ */
 export const RadioButton = React.forwardRef<
   HTMLInputElement,
   RadioButtonProps & InternalRadioButtonProps

--- a/src/components/radio-button/radio-button.mdx
+++ b/src/components/radio-button/radio-button.mdx
@@ -2,6 +2,7 @@ import { Meta, ArgTypes, Canvas } from "@storybook/blocks";
 
 import * as RadioButtonGroupStories from "./radio-button-group/radio-button-group.stories";
 import * as RadioButtonStories from "./radio-button.stories";
+import DeprecationWarning from "../../../.storybook/utils/deprecation-warning.component"
 
 <Meta of={RadioButtonStories} />
 
@@ -17,6 +18,12 @@ import * as RadioButtonStories from "./radio-button.stories";
 </a>
 
 Used to provide a group of selectable radio buttons.
+
+<DeprecationWarning>
+This version of `RadioButton` and `RadioButtonGroup` is deprecated and has been replaced by a new version located in the `__next__` directory.
+
+Please see the <a style={{color: "white"}} href="../?path=/docs/radio-button--docs">new documentation page</a> for more information.
+</DeprecationWarning>
 
 ## Contents
 

--- a/src/components/radio-button/radio-button.stories.tsx
+++ b/src/components/radio-button/radio-button.stories.tsx
@@ -12,7 +12,7 @@ const styledSystemProps = generateStyledSystemProps({
 });
 
 const meta: Meta<typeof RadioButton> = {
-  title: "Radio Button",
+  title: "Deprecated/Radio Button",
   component: RadioButton,
   argTypes: {
     ...styledSystemProps,


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Deprecates current version of `RadioButton` and `RadioButtonGroup`.

Adds new version of `RadioButton` and `RadioButtonGroup` with audit changes, located in the `__next__` directory.
To achieve this new versions of internal components of `Fieldset` and `CheckableInput` have also been added. 

`RadioButtonGroup`:
- Replace `legendHelp` with `legendHint`.
- Remove legacy tooltip validation & related props.
- Remove inline legend.
- Add `size` prop with values "small", "medium" and "large".
- Common props to be passed directly through the group component. 
- Update styles.

`RadioButton`:
- Replace `labelHelp` & `fieldHelp` with `inputHint`.
- Remove validation & related props.
- Add progressive disclosure via the `conditionalContent` prop. 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

`RadioButton` and `RadioButtonGroup` are not aligned with the DS. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->