### PR TITLE
chore: add deprecated jsdocs tag to all deprecated public exports

### DIFF
--- a/src/components/alert/alert.component.tsx
+++ b/src/components/alert/alert.component.tsx
@@ -2,6 +2,9 @@ import React from "react";
 
 import Dialog, { DialogProps } from "../dialog";
 
+/**
+ * @deprecated Alert has been deprecated. See the Carbon documentation for migration details.
+ */
 export const Alert = ({
   children,
   size = "extra-small",

--- a/src/components/alert/index.ts
+++ b/src/components/alert/index.ts
@@ -1,2 +1,7 @@
 export { default } from "./alert.component";
-export type { DialogProps as AlertProps } from "../dialog";
+export type {
+  /**
+   * @deprecated `Alert` has been deprecated. See the Carbon documentation for migration details.
+   */
+  DialogProps as AlertProps,
+} from "../dialog";

--- a/src/components/button-bar/button-bar.component.tsx
+++ b/src/components/button-bar/button-bar.component.tsx
@@ -6,6 +6,9 @@ import ButtonBarContext, {
 } from "./__internal__/button-bar.context";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
+/**
+ * @deprecated `ButtonBar` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface ButtonBarProps
   extends ButtonBarContextProps,
     SpaceProps,
@@ -14,6 +17,9 @@ export interface ButtonBarProps
   children: React.ReactNode;
 }
 
+/**
+ * @deprecated `ButtonBar` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const ButtonBar = ({
   children,
   size = "medium",

--- a/src/components/button-minor/button-minor.component.tsx
+++ b/src/components/button-minor/button-minor.component.tsx
@@ -4,11 +4,17 @@ import { ButtonProps } from "../button";
 import ButtonBarContext from "../button-bar/__internal__/button-bar.context";
 import BatchSelectionContext from "../batch-selection/__internal__/batch-selection.context";
 
+/**
+ * @deprecated `ButtonMinor` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface ButtonMinorProps extends ButtonProps {
   /** @private @ignore */
   isInPassword?: boolean;
 }
 
+/**
+ * @deprecated `ButtonMinor` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const ButtonMinor = React.forwardRef<
   HTMLButtonElement,
   ButtonMinorProps

--- a/src/components/confirm/confirm.component.tsx
+++ b/src/components/confirm/confirm.component.tsx
@@ -10,6 +10,9 @@ import Loader from "../loader";
 import useLocale from "../../hooks/__internal__/useLocale";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
+/**
+ * @deprecated `Confirm` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface ConfirmProps
   extends Omit<
     DialogProps,
@@ -63,6 +66,9 @@ export interface ConfirmProps
   onConfirm: (ev: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
+/**
+ * @deprecated See the Carbon documentation for migration details.
+ */
 export const Confirm = ({
   "aria-labelledby": ariaLabelledBy,
   "aria-describedby": ariaDescribedBy,

--- a/src/components/content/content.component.tsx
+++ b/src/components/content/content.component.tsx
@@ -10,6 +10,9 @@ import {
 } from "./content.style";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
+/**
+ * @deprecated `Content` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface ContentProps
   extends StyledContentProps,
     StyledContentTitleProps,
@@ -21,6 +24,9 @@ export interface ContentProps
   title?: React.ReactNode;
 }
 
+/**
+ * @deprecated `Content` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const Content = ({
   variant = "primary",
   children,

--- a/src/components/detail/detail.component.tsx
+++ b/src/components/detail/detail.component.tsx
@@ -12,6 +12,9 @@ import {
   StyledDetailFootnote,
 } from "./detail.style";
 
+/**
+ * @deprecated `Detail` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface DetailProps extends MarginProps, TagProps {
   /**
    * @private
@@ -27,6 +30,9 @@ export interface DetailProps extends MarginProps, TagProps {
   children?: React.ReactNode;
 }
 
+/**
+ * @deprecated `Detail` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const Detail = ({
   className,
   icon,

--- a/src/components/dismissible-box/dismissible-box.component.tsx
+++ b/src/components/dismissible-box/dismissible-box.component.tsx
@@ -11,6 +11,9 @@ import Icon from "../icon";
 import { BoxProps } from "../box";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
+/**
+ * @deprecated `DimissibleBox` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface DismissibleBoxProps
   extends SpaceProps,
     StyledDismissibleBoxProps,
@@ -33,6 +36,9 @@ export interface DismissibleBoxProps
   width?: number | string;
 }
 
+/**
+ * @deprecated `DismissibleBox` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const DismissibleBox = ({
   children,
   closeButtonDataProps,

--- a/src/components/duelling-picklist/duelling-picklist.component.tsx
+++ b/src/components/duelling-picklist/duelling-picklist.component.tsx
@@ -16,6 +16,9 @@ import FocusContext, {
   FocusContextType,
 } from "./__internal__/duelling-picklist.context";
 
+/**
+ * @deprecated `DuellingPicklist` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface DuellingPicklistProps extends MarginProps, TagProps {
   /**
    * Content of the component, should contain two Picklist children
@@ -34,6 +37,9 @@ export interface DuellingPicklistProps extends MarginProps, TagProps {
   rightLabel?: string;
 }
 
+/**
+ * @deprecated `DuellingPicklist` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const DuellingPicklist = ({
   children,
   disabled,

--- a/src/components/duelling-picklist/picklist-divider/picklist-divider.component.tsx
+++ b/src/components/duelling-picklist/picklist-divider/picklist-divider.component.tsx
@@ -3,6 +3,9 @@ import { StyledComponentProps } from "styled-components";
 
 import StyledPicklistDivider from "./picklist-divider.style";
 
+/**
+ * @deprecated `PicklistDivider` has been deprecated. See the Carbon documentation for migration details.
+ */
 export type PicklistDividerProps = StyledComponentProps<
   "div",
   Record<string, unknown>,
@@ -10,6 +13,9 @@ export type PicklistDividerProps = StyledComponentProps<
   ""
 >;
 
+/**
+ * @deprecated `PicklistDivider` has been deprecated. See the Carbon documentation for migration details.
+ */
 const PicklistDivider = (props: PicklistDividerProps) => (
   <StyledPicklistDivider {...props} data-element="picklist-divider" />
 );

--- a/src/components/duelling-picklist/picklist-group/picklist-group.component.tsx
+++ b/src/components/duelling-picklist/picklist-group/picklist-group.component.tsx
@@ -16,6 +16,9 @@ import {
 import FocusContext from "../__internal__/duelling-picklist.context";
 import Events from "../../../__internal__/utils/helpers/events";
 
+/**
+ * @deprecated `PicklistGroup` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface PicklistGroupProps {
   /** Group title */
   title: React.ReactNode;
@@ -33,6 +36,9 @@ export interface PicklistGroupProps {
   isLastGroup?: boolean;
 }
 
+/**
+ * @deprecated `PicklistGroup` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const PicklistGroup = React.forwardRef<
   HTMLButtonElement,
   PicklistGroupProps

--- a/src/components/duelling-picklist/picklist-item/picklist-item.component.tsx
+++ b/src/components/duelling-picklist/picklist-item/picklist-item.component.tsx
@@ -11,6 +11,9 @@ import Events from "../../../__internal__/utils/helpers/events";
 
 type Item = Record<string, unknown> | string | number;
 
+/**
+ * @deprecated `PicklistItem` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface PicklistItemProps {
   /** Item content */
   children: React.ReactNode;
@@ -36,6 +39,9 @@ export interface PicklistItemProps {
   isLastGroup?: boolean;
 }
 
+/**
+ * @deprecated `PicklistItem` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const PicklistItem = React.forwardRef<
   HTMLButtonElement,
   PicklistItemProps

--- a/src/components/duelling-picklist/picklist-placeholder/picklist-placeholder.component.tsx
+++ b/src/components/duelling-picklist/picklist-placeholder/picklist-placeholder.component.tsx
@@ -2,11 +2,17 @@ import React from "react";
 
 import { StyledPicklistPlaceholder } from "../duelling-picklist.style";
 
+/**
+ * @deprecated `PicklistPlaceholder` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface PicklistPlaceholderProps {
   /** Text to be displayed when list is empty */
   text: string;
 }
 
+/**
+ * @deprecated `PicklistPlaceholder` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const PicklistPlaceholder = ({ text }: PicklistPlaceholderProps) => {
   return (
     <StyledPicklistPlaceholder data-element="picklist-placeholder">

--- a/src/components/duelling-picklist/picklist/picklist.component.tsx
+++ b/src/components/duelling-picklist/picklist/picklist.component.tsx
@@ -6,6 +6,9 @@ import FocusContext from "../__internal__/duelling-picklist.context";
 import Events from "../../../__internal__/utils/helpers/events";
 import PicklistGroup from "../picklist-group/picklist-group.component";
 
+/**
+ * @deprecated `Picklist` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface PicklistProps {
   /** List of PicklistItem elements */
   children?: React.ReactNode;
@@ -17,6 +20,9 @@ export interface PicklistProps {
   index?: number;
 }
 
+/**
+ * @deprecated `Picklist` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const Picklist = ({
   disabled,
   children,

--- a/src/components/grid/grid-container/grid-container.component.tsx
+++ b/src/components/grid/grid-container/grid-container.component.tsx
@@ -5,6 +5,9 @@ import tagComponent, {
 } from "../../../__internal__/utils/helpers/tags/tags";
 import StyledGridContainer from "./grid-container.style";
 
+/**
+ * @deprecated `GridContainer` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface GridContainerProps
   extends SpaceProps,
     GridProps,
@@ -14,6 +17,9 @@ export interface GridContainerProps
   children?: React.ReactNode;
 }
 
+/**
+ * @deprecated `GridContainer` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const GridContainer = (props: GridContainerProps) => (
   <StyledGridContainer {...props} {...tagComponent("grid", props)} />
 );

--- a/src/components/grid/grid-item/grid-item.component.tsx
+++ b/src/components/grid/grid-item/grid-item.component.tsx
@@ -4,6 +4,9 @@ import tagComponent, {
 } from "../../../__internal__/utils/helpers/tags/tags";
 import StyledGridItem, { StyledGridItemProps } from "./grid-item.style";
 
+/**
+ * @deprecated `GridItem` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface GridItemProps
   extends StyledGridItemProps,
     React.HTMLAttributes<HTMLDivElement>,
@@ -12,6 +15,9 @@ export interface GridItemProps
   children?: React.ReactNode;
 }
 
+/**
+ * @deprecated `GridItem` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const GridItem = (props: GridItemProps) => {
   const { children, responsiveSettings, ...rest } = props;
   return (

--- a/src/components/grouped-character/grouped-character.component.tsx
+++ b/src/components/grouped-character/grouped-character.component.tsx
@@ -15,6 +15,9 @@ type CustomTarget = {
   value: EventValue;
 };
 
+/**
+ * @deprecated `GroupedCharacter` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface CustomEvent
   extends Omit<React.ChangeEvent<HTMLInputElement>, "target"> {
   target: CustomTarget;
@@ -32,6 +35,9 @@ const buildCustomTarget = (
   };
 };
 
+/**
+ * @deprecated `GroupedCharacter` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface GroupedCharacterProps
   extends Omit<TextboxProps, "onChange" | "onBlur" | "data-component"> {
   /** pattern by which input value should be grouped */
@@ -46,6 +52,9 @@ export interface GroupedCharacterProps
   value: string;
 }
 
+/**
+ * @deprecated `GroupedCharacter` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const GroupedCharacter = React.forwardRef(
   (
     {

--- a/src/components/heading/heading.component.tsx
+++ b/src/components/heading/heading.component.tsx
@@ -20,7 +20,14 @@ import {
 } from "./heading.style";
 import useLocale from "../../hooks/__internal__/useLocale";
 
+/**
+ * @deprecated `Heading` has been deprecated. See the Carbon documentation for migration details.
+ */
 export type HeadingType = "h1" | "h2" | "h3" | "h4" | "h5";
+
+/**
+ * @deprecated `Heading` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface HeadingProps extends MarginProps, TagProps {
   /** Child elements */
   children?: React.ReactNode;
@@ -58,6 +65,9 @@ export interface HeadingProps extends MarginProps, TagProps {
   helpAriaLabel?: string;
 }
 
+/**
+ * @deprecated `Heading` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const Heading = ({
   children,
   backLink,

--- a/src/components/hr/hr.component.tsx
+++ b/src/components/hr/hr.component.tsx
@@ -7,6 +7,9 @@ import useIsAboveBreakpoint from "../../hooks/__internal__/useIsAboveBreakpoint"
 
 import Logger from "../../__internal__/utils/logger";
 
+/**
+ * @deprecated `Hr` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface HrProps extends MarginProps, TagProps {
   /** Set whether the component should be recognised by assistive technologies */
   "aria-hidden"?: "true" | "false";
@@ -21,6 +24,9 @@ export interface HrProps extends MarginProps, TagProps {
 
 let deprecatedWarnTriggered = false;
 
+/**
+ * @deprecated `Hr` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const Hr = ({
   adaptiveMxBreakpoint,
   ml,

--- a/src/components/icon-button/icon-button.component.tsx
+++ b/src/components/icon-button/icon-button.component.tsx
@@ -7,6 +7,9 @@ import { IconProps } from "../icon";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import BatchSelectionContext from "../batch-selection/__internal__/batch-selection.context";
 
+/**
+ * @deprecated `IconButton` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface IconButtonProps extends SpaceProps, TagProps {
   /** Prop to specify the aria-label of the icon-button component */
   "aria-label"?: string;
@@ -28,6 +31,9 @@ export interface IconButtonProps extends SpaceProps, TagProps {
   "data-component"?: string;
 }
 
+/**
+ * @deprecated `IconButton` has been deprecated. See the Carbon documentation for migration details.
+ */
 const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
   (
     {

--- a/src/components/inline-inputs/inline-inputs.component.tsx
+++ b/src/components/inline-inputs/inline-inputs.component.tsx
@@ -21,6 +21,9 @@ type GutterOptions =
   | "large"
   | "extra-large";
 
+/**
+ * @deprecated `InlineInputs` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface InlineInputsProps
   extends MarginProps,
     StyledContentContainerProps,
@@ -61,6 +64,9 @@ const columnWrapper = (children: React.ReactNode, gutter: GutterOptions) => {
   });
 };
 
+/**
+ * @deprecated `InlineInputs` has been deprecated. See the Carbon documentation for migration details.
+ */
 const InlineInputs = ({
   adaptiveLabelBreakpoint,
   label,

--- a/src/components/loader/loader.component.tsx
+++ b/src/components/loader/loader.component.tsx
@@ -13,6 +13,9 @@ import StyledLoaderSquare, {
 } from "./loader-square.style";
 import Typography from "../typography";
 
+/**
+ * @deprecated `Loader` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface LoaderProps
   extends Omit<StyledLoaderSquareProps, "backgroundColor">,
     MarginProps,
@@ -26,6 +29,9 @@ export interface LoaderProps
   loaderLabel?: string;
 }
 
+/**
+ * @deprecated `Loader` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const Loader = ({
   variant = "default",
   size = "medium",

--- a/src/components/number/number.component.tsx
+++ b/src/components/number/number.component.tsx
@@ -8,6 +8,9 @@ import {
 } from "../textbox/textbox.component";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
 
+/**
+ * @deprecated `Number` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface NumberProps extends Omit<TextboxProps, "value"> {
   /** Value passed to the input */
   value: string;
@@ -20,6 +23,9 @@ function isValidNumber(value: string) {
   return result;
 }
 
+/**
+ * @deprecated `Number` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const Number = React.forwardRef(
   (
     {

--- a/src/components/pages/page/page.component.tsx
+++ b/src/components/pages/page/page.component.tsx
@@ -9,6 +9,9 @@ import Box from "../../box";
 import { StyledPage, StyledPageContent } from "./page.style";
 import { filterStyledSystemPaddingProps } from "../../../style/utils";
 
+/**
+ * @deprecated `Page` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface PageProps extends PaddingProps, TagProps {
   /** The title for the page, normally a Heading component. */
   title?: React.ReactNode;
@@ -20,6 +23,9 @@ export interface PageProps extends PaddingProps, TagProps {
   transitionName?: () => string;
 }
 
+/**
+ * @deprecated `Page` has been deprecated. See the Carbon documentation for migration details.
+ */
 const Page = ({ role, title, children, ...rest }: PageProps) => {
   const styledPageNodeRef = useRef(null);
   const { transitionName } = rest;

--- a/src/components/pages/pages.component.tsx
+++ b/src/components/pages/pages.component.tsx
@@ -7,6 +7,9 @@ import Page from "./page";
 import { PagesWrapperStyle, PagesContent } from "./pages.style";
 import type { ThemeObject } from "../../style/themes/theme.types";
 
+/**
+ * @deprecated `Pages` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface PagesProps extends TagProps {
   /** The selected tab on page load */
   initialpageIndex?: number | string;
@@ -24,6 +27,9 @@ const NEXT = "next";
 const PREVIOUS = "previous";
 const TRANSITION_TIME = 500;
 
+/**
+ * @deprecated `Pages` has been deprecated. See the Carbon documentation for migration details.
+ */
 const Pages = ({
   pageIndex: incomingPageIndex,
   initialpageIndex = 0,

--- a/src/components/pod/pod.component.tsx
+++ b/src/components/pod/pod.component.tsx
@@ -21,6 +21,9 @@ import Icon from "../icon";
 import Event from "../../__internal__/utils/helpers/events";
 import { PodAlignment, PodSize, PodVariant } from "./pod.config";
 
+/**
+ * @deprecated `Pod` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface PodProps extends MarginProps, TagProps {
   /** Aligns the title to left, right or center */
   alignTitle?: PodAlignment;
@@ -64,6 +67,9 @@ export interface PodProps extends MarginProps, TagProps {
   internalEditButton?: boolean;
 }
 
+/**
+ * @deprecated `Pod` has been deprecated. See the Carbon documentation for migration details.
+ */
 const Pod = React.forwardRef<HTMLDivElement, PodProps>(
   (
     {

--- a/src/components/settings-row/settings-row.component.tsx
+++ b/src/components/settings-row/settings-row.component.tsx
@@ -12,6 +12,9 @@ import {
   StyledSettingsRowInput,
 } from "./settings-row.style";
 
+/**
+ * @deprecated `SettingsRow` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface SettingsRowProps extends MarginProps, TagProps {
   /**  A title for this group of settings. */
   title?: string;
@@ -31,6 +34,9 @@ export interface SettingsRowProps extends MarginProps, TagProps {
   className?: string;
 }
 
+/**
+ * @deprecated `SettingsRow` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const SettingsRow = ({
   title,
   headingType = "h3",

--- a/src/components/toast/toast.component.tsx
+++ b/src/components/toast/toast.component.tsx
@@ -19,6 +19,9 @@ import useModalManager from "../../hooks/__internal__/useModalManager";
 import guid from "../../__internal__/utils/helpers/guid";
 import Typography from "../typography";
 
+/**
+ * @deprecated `Toast` has been deprecated. See the Carbon documentation for migration details.
+ */
 type ToastVariants =
   | "error"
   | "info"
@@ -28,7 +31,14 @@ type ToastVariants =
   | "neutral"
   | "notification";
 
+/**
+ * @deprecated `Toast` has been deprecated. See the Carbon documentation for migration details.
+ */
 type AlignOptions = "left" | "center" | "right";
+
+/**
+ * @deprecated `Toast` has been deprecated. See the Carbon documentation for migration details.
+ */
 type AlignYOptions = "top" | "center" | "bottom";
 
 interface IconTypes {
@@ -41,6 +51,9 @@ interface IconTypes {
   notice?: "none";
 }
 
+/**
+ * @deprecated `Toast` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface ToastProps extends TagProps {
   /** Sets the horizontal alignment of the component. */
   align?: AlignOptions;
@@ -73,6 +86,9 @@ export interface ToastProps extends TagProps {
   disableAutoFocus?: boolean;
 }
 
+/**
+ * @deprecated `Toast` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
   (
     {

--- a/src/components/tooltip/tooltip.component.tsx
+++ b/src/components/tooltip/tooltip.component.tsx
@@ -40,8 +40,14 @@ function preserveRef<ElementType>(
 
 const TOOLTIP_DELAY = 100;
 
+/**
+ * @deprecated `Tooltip` has been deprecated. See the Carbon documentation for migration details.
+ */
 export type InputSizes = "small" | "medium" | "large";
 
+/**
+ * @deprecated `Tooltip` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface TooltipProps extends TagProps {
   /** The message to be displayed within the tooltip */
   message: React.ReactNode;
@@ -75,6 +81,9 @@ export interface TooltipProps extends TagProps {
   inputSize?: InputSizes;
 }
 
+/**
+ * @deprecated `Tooltip` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const Tooltip = React.forwardRef<HTMLDivElement | null, TooltipProps>(
   (
     {

--- a/src/components/vertical-divider/vertical-divider.component.tsx
+++ b/src/components/vertical-divider/vertical-divider.component.tsx
@@ -5,6 +5,9 @@ import { StyledVerticalWrapper, StyledDivider } from "./vertical-divider.style";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 import Logger from "../../__internal__/utils/logger";
 
+/**
+ * @deprecated `VerticalDivider` has been deprecated. See the Carbon documentation for migration details.
+ */
 type TintRange =
   | 1
   | 2
@@ -107,6 +110,9 @@ type TintRange =
   | 99
   | 100;
 
+/**
+ * @deprecated `VerticalDivider` has been deprecated. See the Carbon documentation for migration details.
+ */
 export interface VerticalDividerProps extends SpaceProps, TagProps {
   /** Shorthand for the height attribute */
   h?: number | string;
@@ -128,6 +134,9 @@ export interface VerticalDividerProps extends SpaceProps, TagProps {
 
 let deprecatedWarnTriggered = false;
 
+/**
+ * @deprecated `VerticalDivider` has been deprecated. See the Carbon documentation for migration details.
+ */
 export const VerticalDivider = ({
   h,
   height,


### PR DESCRIPTION
### Proposed behaviour

For all recently deprecated components, add `@depreacted` jsdocs tag to all of their public exports to reflect their status.

### Current behaviour

Recently deprecated components aren't flagged as deprecated in IDEs.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
