### PR TITLE
feat(select): add new setupSelectMocks util for JSDOM testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@lexical/react": "^0.21.0",
         "@lexical/selection": "^0.21.0",
         "@styled-system/prop-types": "^5.1.5",
-        "@tanstack/react-virtual": "^3.11.2",
+        "@tanstack/react-virtual": "^3.13.12",
         "@types/styled-system": "^5.1.22",
         "chalk": "^4.1.2",
         "crypto-js": "^4.2.0",
@@ -8006,12 +8006,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.13.6",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.6.tgz",
-      "integrity": "sha512-WT7nWs8ximoQ0CDx/ngoFP7HbQF9Q2wQe4nh2NB+u2486eX3nZRE40P9g6ccCVq7ZfTSH5gFOuCoVH5DLNS/aA==",
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.13.6"
+        "@tanstack/virtual-core": "3.13.12"
       },
       "funding": {
         "type": "github",
@@ -8023,9 +8023,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.13.6",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.6.tgz",
-      "integrity": "sha512-cnQUeWnhNP8tJ4WsGcYiX24Gjkc9ALstLbHcBj1t3E7EimN6n6kHH+DPV4PpDnuw00NApQp+ViojMj1GRdwYQg==",
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "@lexical/react": "^0.21.0",
     "@lexical/selection": "^0.21.0",
     "@styled-system/prop-types": "^5.1.5",
-    "@tanstack/react-virtual": "^3.11.2",
+    "@tanstack/react-virtual": "^3.13.12",
     "@types/styled-system": "^5.1.22",
     "chalk": "^4.1.2",
     "crypto-js": "^4.2.0",

--- a/src/components/pager/pager.test.tsx
+++ b/src/components/pager/pager.test.tsx
@@ -5,17 +5,10 @@ import userEvent from "@testing-library/user-event";
 import Pager from "./pager.component";
 import I18nProvider from "../i18n-provider";
 import { frFR } from "../../locales";
-import mockDOMRect from "../../__spec_helper__/mock-dom-rect";
-
-const { getBoundingClientRect } = Element.prototype;
+import { setupSelectMocks } from "../select";
 
 beforeAll(() => {
-  // need to mock getBoundingClientRect so that all options are rendered in the select list in js-dom
-  mockDOMRect(200, 200, "select-list-scrollable-container");
-});
-
-afterAll(() => {
-  Element.prototype.getBoundingClientRect = getBoundingClientRect;
+  setupSelectMocks();
 });
 
 test("the total records number is set to 0 by default", () => {

--- a/src/components/select/__internal__/select-list/select-list.component.tsx
+++ b/src/components/select/__internal__/select-list/select-list.component.tsx
@@ -705,6 +705,7 @@ const SelectList = React.forwardRef(
               ref={listContainerRef}
               maxHeight={listMaxHeight}
               data-component="select-list-scrollable-container"
+              data-element="select-list-scrollable-container"
               data-role="select-list-scrollable-container"
               hasActionButton={!!listActionButton}
             >

--- a/src/components/select/__internal__/select-list/select-list.test.tsx
+++ b/src/components/select/__internal__/select-list/select-list.test.tsx
@@ -8,16 +8,15 @@ import {
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import mockDOMRect from "../../../../__spec_helper__/mock-dom-rect";
 
 import SelectList, { SelectListProps } from "./select-list.component";
 import Option from "../../option";
 import OptionRow from "../../option-row";
+import setupSelectMocks from "../../setup-select-mocks";
 
 beforeEach(() => {
   jest.useFakeTimers();
-  // Mock non-zero dimensions for the scrollable container. To ensure react-virtual renders the list options correctly.
-  mockDOMRect(40, 100, "select-list-scrollable-container");
+  setupSelectMocks();
 });
 
 afterEach(() => {

--- a/src/components/select/filterable-select/filterable-select.mdx
+++ b/src/components/select/filterable-select/filterable-select.mdx
@@ -17,7 +17,7 @@ Filterable Select is a Carbon styled implementation of WAI-ARIA Combobox with In
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Validation states](#validation-states)
-- [Testing with React Testing Library](#testing-with-react-testing-library-rtl)
+- [Testing](#testing)
 - [Props](#props)
 - [Translation keys](#translation-keys)
 
@@ -149,10 +149,27 @@ This allows use-cases like server-side filtering of options, or rich formatting 
 
 This component supports input validation, see our [Validations](../?path=/docs/documentation-validations--docs) documentation page for more information.
 
-## Testing with React Testing Library (RTL)
+## Testing
 
-Testing with RTL is supported for the `FilterableSelect` component, please consult the [Testing with RTL](../?path=/docs/select--docs#testing-with-react-testing-library-rtl)
-section in `SimpleSelect` for more information.
+For testing interactions with `FilterableSelect` as part of a broader user journey, we recommend testing within a browser environment using tools like Playwright or Cypress, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
+
+### JSDOM tests (if required)
+
+If you need to test within JSDOM, we provide a utility function for setting up any required global mocks:
+
+```javascript
+import { setupSelectMocks } from "carbon-react/lib/components/select";
+
+describe("Select tests", () => {
+  beforeAll(() => {
+    setupSelectMocks();
+  });
+
+  test("should render", () => {
+    // your test code here
+  });
+})
+```
 
 ## Props
 

--- a/src/components/select/filterable-select/filterable-select.test.tsx
+++ b/src/components/select/filterable-select/filterable-select.test.tsx
@@ -7,9 +7,9 @@ import {
   Option,
   FilterableSelectProps,
   CustomSelectChangeEvent,
+  setupSelectMocks,
 } from "..";
 import guid from "../../../__internal__/utils/helpers/guid";
-import mockDOMRect from "../../../__spec_helper__/mock-dom-rect";
 
 const mockedGuid = "mocked-guid";
 jest.mock("../../../__internal__/utils/logger");
@@ -17,7 +17,7 @@ jest.mock("../../../__internal__/utils/helpers/guid");
 (guid as jest.MockedFunction<typeof guid>).mockReturnValue(mockedGuid);
 
 beforeAll(() => {
-  mockDOMRect(200, 200, "select-list-scrollable-container");
+  setupSelectMocks();
 });
 
 testStyledSystemMargin(

--- a/src/components/select/index.ts
+++ b/src/components/select/index.ts
@@ -13,3 +13,4 @@ export { default as FilterableSelect } from "./filterable-select";
 export type { FilterableSelectProps } from "./filterable-select";
 export { default as MultiSelect } from "./multi-select";
 export type { MultiSelectProps } from "./multi-select";
+export { default as setupSelectMocks } from "./setup-select-mocks";

--- a/src/components/select/multi-select/multi-select.mdx
+++ b/src/components/select/multi-select/multi-select.mdx
@@ -16,7 +16,7 @@ Select multiple options from the drop-down menu. MultiSelect is a component that
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Validation states](#validation-states)
-- [Testing with React Testing Library](#testing-with-react-testing-library-rtl)
+- [Testing](#testing)
 - [Props](#props)
 - [Translation keys](#translation-keys)
 
@@ -134,10 +134,27 @@ be customised if desired using the `virtualScrollOverscan` prop. Higher values w
 
 This component supports input validation, see our [Validations](../?path=/docs/documentation-validations--docs) documentation page for more information.
 
-## Testing with React Testing Library (RTL)
+## Testing
 
-Testing with RTL is supported for the `MultiSelect` component, please consult the [Testing with RTL](../?path=/docs/select--docs#testing-with-react-testing-library-rtl)
-section in `SimpleSelect` for more information.
+For testing interactions with `MultiSelect` as part of a broader user journey, we recommend testing within a browser environment using tools like Playwright or Cypress, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
+
+### JSDOM tests (if required)
+
+If you need to test within JSDOM, we provide a utility function for setting up any required global mocks:
+
+```javascript
+import { setupSelectMocks } from "carbon-react/lib/components/select";
+
+describe("Select tests", () => {
+  beforeAll(() => {
+    setupSelectMocks();
+  });
+
+  test("should render", () => {
+    // your test code here
+  });
+})
+```
 
 ## Props
 

--- a/src/components/select/multi-select/multi-select.test.tsx
+++ b/src/components/select/multi-select/multi-select.test.tsx
@@ -1,17 +1,15 @@
 import React, { useState } from "react";
 import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import mockDOMRect from "../../../__spec_helper__/mock-dom-rect";
 import { testStyledSystemMargin } from "../../../__spec_helper__/__internal__/test-utils";
 
 import MultiSelect, { MultiSelectProps } from ".";
-import { CustomSelectChangeEvent, Option } from "..";
+import { CustomSelectChangeEvent, Option, setupSelectMocks } from "..";
 
 import Modal from "../../modal";
 
 beforeEach(() => {
-  // Mock non-zero dimensions for the scrollable container in dropdown list. To ensure react-virtual renders options in the dropdown list correctly.
-  mockDOMRect(40, 100, "select-list-scrollable-container");
+  setupSelectMocks();
 });
 
 afterEach(() => {

--- a/src/components/select/setup-select-mocks.ts
+++ b/src/components/select/setup-select-mocks.ts
@@ -1,0 +1,32 @@
+/* istanbul ignore file */
+
+/**
+ * Utility function for setting up global mocks required when testing with `SimpleSelect`, `FilterableSelect` or `MultiSelect` in a non-browser environment like JSDOM.
+ */
+const setupSelectMocks = () => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (process.env.NODE_ENV !== "test") {
+    return;
+  }
+
+  // react-virtual uses offsetHeight when measuring the height of the scrollable container in `SelectList`.
+  // Mock as a non-zero value to ensure it renders the list options on initial render.
+  Object.defineProperties(window.HTMLElement.prototype, {
+    offsetHeight: {
+      get(this: HTMLElement) {
+        return (
+          parseFloat(this.style.height) ||
+          (this.getAttribute("data-element") ===
+          "select-list-scrollable-container"
+            ? 100
+            : 0)
+        );
+      },
+    },
+  });
+};
+
+export default setupSelectMocks;

--- a/src/components/select/simple-select/simple-select.mdx
+++ b/src/components/select/simple-select/simple-select.mdx
@@ -25,7 +25,7 @@ Select one of available options from the drop-down menu. Simple Select is a Carb
 - [Quick Start](#quick-start)
 - [Examples](#examples)
 - [Validation states](#validation-states)
-- [Testing with React Testing Library](#testing-with-react-testing-library-rtl)
+- [Testing](#testing)
 - [Props](#props)
 - [Translation keys](#translation-keys)
 
@@ -200,18 +200,20 @@ for users who rely on assistive technology.
 
 This component supports input validation, see our [Validations](../?path=/docs/documentation-validations--docs) documentation page for more information.
 
-## Testing with React Testing Library (RTL)
+## Testing
 
-If you use [React Testing Library](https://testing-library.com/docs/react-testing-library/intro) in your project, you may need to mock the
-`getBoundingClientRect` method of the `Element` prototype in order to correctly test the `Select` component. You can do this manually in your
-test setup file, or import the `mockDOMRect` method to do it for you.
+For testing interactions with `SimpleSelect` as part of a broader user journey, we recommend testing within a browser environment using tools like Playwright or Cypress, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
+
+### JSDOM tests (if required)
+
+If you need to test within JSDOM, we provide a utility function for setting up any required global mocks:
 
 ```javascript
-import mockDOMRect from "carbon-react/lib/__spec_helper__/mock-dom-rect";
+import { setupSelectMocks } from "carbon-react/lib/components/select";
 
 describe("Select tests", () => {
   beforeAll(() => {
-    mockDOMRect(200, 200, "select-list-scrollable-container");
+    setupSelectMocks();
   });
 
   test("should render", () => {

--- a/src/components/select/simple-select/simple-select.test.tsx
+++ b/src/components/select/simple-select/simple-select.test.tsx
@@ -10,14 +10,13 @@ import userEvent from "@testing-library/user-event";
 import Box from "../../box";
 import Button from "../../button";
 import { testStyledSystemMargin } from "../../../__spec_helper__/__internal__/test-utils";
-import mockDOMRect from "../../../__spec_helper__/mock-dom-rect";
 
 import SimpleSelect, { CustomSelectChangeEvent, SimpleSelectProps } from ".";
 import Option from "../option";
+import setupSelectMocks from "../setup-select-mocks";
 
 beforeEach(() => {
-  // Mock non-zero dimensions for the scrollable container in dropdown list. To ensure react-virtual renders options in the dropdown list correctly.
-  mockDOMRect(40, 100, "select-list-scrollable-container");
+  setupSelectMocks();
 });
 
 afterEach(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -338,6 +338,7 @@ export {
   Option,
   OptionGroupHeader,
   OptionRow,
+  setupSelectMocks,
 } from "./components/select";
 export type {
   CustomSelectChangeEvent,


### PR DESCRIPTION
### Proposed behaviour

- Upgrade `@tanstack/react-virtual` to version 3.13.12
- Introduce public `setupSelectMocks` util - for applying global mocks in JSDOM when testing with the Select components.

### Current behaviour

- Select tests break when `@tanstack/react-virtual` is upgrade to version 3.13.7 or above, due to changes in how the package handles layout measurements

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x]  Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
