### PR TITLE
docs(dialog): document example for scrollable region having keyboard access - FE-6043

### DIFF
--- a/src/components/dialog/dialog.mdx
+++ b/src/components/dialog/dialog.mdx
@@ -147,6 +147,13 @@ Setting the `highlightVariant` prop will add a highlight above the Dialog. Pleas
 
 <Canvas of={DialogStories.HighlightVariant} />
 
+## Accessibility
+
+If your content is scrollable, you will need to ensure that the scrollable region has keyboard access. To do this we recommend
+adding `tabIndex="0"` to the scrollable content container so that keyboard users can access it. An example of this can be seen below:
+
+<Canvas of={DialogStories.WithScrollableContent} />
+
 ## Fullscreen
 
 ## Examples

--- a/src/components/dialog/dialog.stories.tsx
+++ b/src/components/dialog/dialog.stories.tsx
@@ -712,3 +712,40 @@ export const FullScreenDefault: Story = () => {
 };
 FullScreenDefault.storyName = "Fullscreen: Default";
 FullScreenDefault.parameters = { chromatic: { disableSnapshot: true } };
+
+const childrenText = `At vero facilisis interdum sed vitae integer. Ut placerat morbi aenean sagittis nunc non feugiat. Est ac nulla dui tempus ullamcorper in id. Proin elementum vel magna feugiat luctus aliquam tristique ornare. Donec volutpat tempor accumsan est, vel ultrices lectus sed gravida. Mi commodo id dignissim posuere ultricies. Mauris tristique tincidunt sit amet senectus lectus vitae sollicitudin et. Sed fermentum id semper felis convallis tincidunt feugiat.
+Fusce aliquam vel nec justo quisque sagittis habitasse dui. Vel hendrerit proin amet tempus consequat faucibus non. Mi convallis elementum diam suspendisse aliquet augue sed feugiat vestibulum. Risus mauris sem commodo feugiat suspendisse. Lectus scelerisque tincidunt facilisi non pharetra. Integer pulvinar accumsan diam eget. Nullam magna amet viverra luctus duis malesuada morbi. At lacus feugiat proin tortor lacus aliquet in.
+Magna sed sapien risus mauris et aliquam tempus diam. Gravida amet non ornare suspendisse tempor. Tempor mattis aliquet massa imperdiet curabitur integer blandit laoreet. Sed convallis semper bibendum nisi neque aliquet felis imperdiet. Ultrices leo risus cursus est laoreet sociis. Id pretium congue ultricies donec aliquam sodales convallis auctor. Tincidunt viverra sem eleifend viverra id adipiscing eget cursus. Id diam eget tempus arcu.
+`;
+export const WithScrollableContent: Story = {
+  render: function WithScrollableContentExample(args) {
+    const { children, open, ...rest } = args;
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)}>Open Dialog</Button>
+        <Dialog open={isOpen} onCancel={() => setIsOpen(false)} {...rest}>
+          {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+          <div tabIndex={0}>{children}</div>
+        </Dialog>
+      </>
+    );
+  },
+  args: {
+    children: childrenText.repeat(2),
+    title: "Dialog with scrollable content",
+    subtitle: "amet non ornare suspendisse tempor.",
+    height: "200px",
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  decorators: [
+    (Story) => (
+      <Box height="900px" width="100%">
+        <Story />
+      </Box>
+    ),
+  ],
+};


### PR DESCRIPTION
fixes #6164

### Proposed behaviour

Document an example where `Dialog` has scrollable content with a `tabIndex` of `0` to inform consumers of how to avoid the AXE warning `Scrollable region must have keyboard access`.

### Current behaviour

No documentation of how to avoid AXE warning `Scrollable region must have keyboard access`.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

If you see an AXE incomplete violation of `Elements must meet minimum color contrast ratio thresholds` with the newest example, this is a false positive. This is because the element's (div wrapping text) background colour could not be determined because it's partially obscured by another element (dialog). 

### Testing instructions

- Check that new example (`WithScrollableContent`) added to the `Dialog` documentation does not have the AXE warning `Scrollable region must have keyboard access`.
