### PR TITLE
docs(tabs): restore property descriptions

### DIFF
--- a/src/components/tabs/__next__/tabs.types.ts
+++ b/src/components/tabs/__next__/tabs.types.ts
@@ -41,32 +41,52 @@ export interface TabsContextProps {
 }
 
 export interface TabPanelProps {
+  /** The content to be shown in the tab panel */
   children?: React.ReactNode;
+  /** The ID of the tab panel */
   id: string;
+  /** The ID of the controlling tab */
   tabId: string;
 }
 
 export interface TabListProps {
+  /** The label read out when the tab list gains focus */
   ariaLabel: string;
+  /** The tabs to be shown in the tab list */
   children?: React.ReactNode;
 }
 
 export interface TabProps {
+  /** The tab panel that this tab controls */
   controls: string;
+  /** The ID of the tab */
   id: string;
+  /** The error state of the tab */
   error?: boolean | string;
+  /** The label shown on the tab */
   label: React.ReactNode;
+  /** The item shown to the left of the label */
   leftSlot?: React.ReactNode;
+  /** The item shown to the right of the label */
   rightSlot?: React.ReactNode;
+  /** The warning state of the tab */
   warning?: boolean | string;
-  // DEPRECATED - to be removed when legacy tabs removed
+  /**
+   * The info state of the tab
+   * @deprecated to be removed when legacy `Tabs` and `Tab` are removed
+   * */
   info?: boolean | string;
 }
 
 export interface TabsProps {
+  /** The tab list to be rendered within this set of tabs  */
   children?: React.ReactNode;
+  /** The label associated with this set of tabs, for assistive technologies */
   labelledBy?: string;
+  /** The orientation of the tabs */
   orientation?: "horizontal" | "vertical";
+  /** The pre-selected tab to show e.g when restoring from URL  */
   selectedTabId?: string;
+  /** The size of the tabs to use */
   size?: "medium" | "large";
 }


### PR DESCRIPTION
### Proposed behaviour

Add the descriptions back in

### Current behaviour

The new Tabs documentation is missing descriptions on it's property tables

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required
