### PR TITLE
fix(submenu): ensure correct focus styling is applied to menu-item

### DIFF
--- a/src/components/menu/__internal__/submenu/submenu.style.ts
+++ b/src/components/menu/__internal__/submenu/submenu.style.ts
@@ -134,28 +134,36 @@ const StyledSubmenu = styled.ul<StyledSubmenuProps>`
       overflow-y: auto;
       ${maxHeight && `max-height: ${maxHeight};`}
 
-      ${StyledMenuItem}:last-child a,
-      ${StyledMenuItem}:last-child button,
-      ${StyledMenuItem}:last-child > span,
-      ${StyledMenuItem}:last-child > div {
-        border-bottom-left-radius: var(--borderRadius100);
-        border-bottom-right-radius: var(--borderRadius100);
+      /* last item in each segment has square corners,
+        except when it is the last menu item in the whole submenu. */
+      & ${StyledSegmentChildren}
+      > ${StyledMenuItem}:last-of-type:not([data-last-visible-menu-item='true']) {
+        a,
+        button,
+        > span,
+        > div {
+          border-bottom-right-radius: var(--borderRadius000);
+          border-bottom-left-radius: var(--borderRadius000);
+
+          :focus {
+            border-bottom-right-radius: var(--borderRadius000);
+            border-bottom-left-radius: var(--borderRadius000);
+          }
+        }
       }
 
-      & ${StyledSegmentChildren} > ${StyledMenuItem}:last-of-type a,
-      ${StyledSegmentChildren} > ${StyledMenuItem}:last-of-type button,
-      ${StyledSegmentChildren} > ${StyledMenuItem}:last-of-type > span,
-      ${StyledSegmentChildren} > ${StyledMenuItem}:last-of-type > div {
-        border-bottom-right-radius: var(--borderRadius000);
-        border-bottom-left-radius: var(--borderRadius000);
+      [data-last-visible-menu-item="true"] {
+        a,
+        button,
+        > span,
+        > div {
+          border-bottom-left-radius: var(--borderRadius100);
+          border-bottom-right-radius: var(--borderRadius100);
 
-        :focus {
-          border-bottom-right-radius: ${applyFocusRadiusStylingToLastItem
-            ? "var(--borderRadius100)"
-            : "var(--borderRadius000)"};
-          border-bottom-left-radius: ${applyFocusRadiusStylingToLastItem
-            ? "var(--borderRadius100)"
-            : "var(--borderRadius000)"};
+          :focus {
+            border-bottom-right-radius: var(--borderRadius100);
+            border-bottom-left-radius: var(--borderRadius100);
+          }
         }
       }
 
@@ -166,7 +174,8 @@ const StyledSubmenu = styled.ul<StyledSubmenuProps>`
             ? "var(--borderRadius100)"
             : "var(--borderRadius000)"};
 
-          ${StyledMenuItem}:last-child ${StyledLink}, ${StyledMenuItem}:last-child a,
+          ${StyledMenuItem}:last-child ${StyledLink},
+          ${StyledMenuItem}:last-child a,
           ${StyledMenuItem}:last-child button {
             border-bottom-right-radius: var(--borderRadius000);
             border-bottom-left-radius: ${applyFocusRadiusStylingToLastItem

--- a/src/components/menu/component.test-pw.tsx
+++ b/src/components/menu/component.test-pw.tsx
@@ -940,3 +940,19 @@ export const FullscreenWithNonInteractiveItem = () => (
     </MenuFullscreen>
   </Menu>
 );
+
+export const MenuSegmentTitleWithNoMenuItemOutside = () => {
+  return (
+    <Menu>
+      <MenuItem submenu="Menu Item">
+        <MenuSegmentTitle text="segment title">
+          <MenuItem href="#">Item Submenu One</MenuItem>
+          <MenuItem href="#">Item Submenu Two</MenuItem>
+        </MenuSegmentTitle>
+        <MenuSegmentTitle variant="alternate" text="alternate title">
+          <MenuItem href="#">Item Submenu Three</MenuItem>
+        </MenuSegmentTitle>
+      </MenuItem>
+    </Menu>
+  );
+};

--- a/src/components/menu/menu-test.stories.tsx
+++ b/src/components/menu/menu-test.stories.tsx
@@ -373,6 +373,15 @@ export const MenuWithTwoSegments = () => {
           </ScrollableBlock>
           <MenuItem href="#">Item Submenu FFS</MenuItem>
         </MenuItem>
+        <MenuItem submenu="Menu Item Five">
+          <MenuSegmentTitle text="segment title">
+            <MenuItem href="#">Item Submenu One</MenuItem>
+            <MenuItem href="#">Item Submenu Two</MenuItem>
+          </MenuSegmentTitle>
+          <MenuSegmentTitle variant="alternate" text="alternate title">
+            <MenuItem href="#">Item Submenu Three</MenuItem>
+          </MenuSegmentTitle>
+        </MenuItem>
       </Menu>
     </Box>
   );

--- a/src/components/menu/menu.pw.tsx
+++ b/src/components/menu/menu.pw.tsx
@@ -70,6 +70,7 @@ import {
   WithNonInteractiveItem,
   WithNonInteractiveSubmenuItem,
   FullscreenWithNonInteractiveItem,
+  MenuSegmentTitleWithNoMenuItemOutside,
 } from "./component.test-pw";
 
 const span = "span";
@@ -2244,6 +2245,20 @@ test.describe("Styling, Scrolling & Navigation Bar Tests for Menu Component", ()
     const scrollableItem = scrollBlock(page).locator("a").last();
 
     await expect(scrollableItem).toHaveCSS("border-radius", "0px 0px 0px 8px");
+  });
+
+  test(`renders last MenuItem in the first segment block with square corners, if there is another segment block after it and no MenuItem after the last segment block in the submenu`, async ({
+    mount,
+    page,
+  }) => {
+    await mount(<MenuSegmentTitleWithNoMenuItemOutside />);
+
+    const subMenu = submenu(page).first();
+    await subMenu.hover();
+    const lastSegmentItem = submenu(page).locator("a").nth(1);
+    await lastSegmentItem.focus();
+
+    await expect(lastSegmentItem).toHaveCSS("border-radius", "0px");
   });
 
   test("should apply the expected styling to the scrollbar when menuType is white", async ({


### PR DESCRIPTION
### Proposed behaviour

Square corner styling should be applied to the last menu-item in a segment if another segment succeeds it and there are no other menu-items outside of the segment blocks.

<img width="258" height="287" alt="Screenshot 2025-11-25 at 14 32 01" src="https://github.com/user-attachments/assets/ad414725-efb3-45b1-8259-74b10e396d56" />

<img width="238" height="280" alt="Screenshot 2025-11-25 at 14 32 11" src="https://github.com/user-attachments/assets/72320951-6845-413f-a37b-1e66f561c2c2" />

### Current behaviour

Rounded corner styling is being applied to the last menu-item in a segment if another segment succeeds it and there are no other menu-items outside of the segment blocks.

<img width="244" height="295" alt="Screenshot 2025-11-25 at 14 33 18" src="https://github.com/user-attachments/assets/b7da66e7-bea3-4eea-ac9f-3cffeb769be9" />

<img width="247" height="307" alt="Screenshot 2025-11-25 at 14 33 25" src="https://github.com/user-attachments/assets/418dd8cd-59f9-4507-8820-7aa10f77afb8" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- No other visual regression with focusing styling with menu-items, segment blocks, scrollable blocks or submenus
- These can be tested using the story `MenuWithTwoSegments` as this has various examples in all the menu-items that should cover most cases. 
