### PR TITLE
build(playwright): export a11y violations/incomplete checks

### DIFF
--- a/playwright/support/helper.ts
+++ b/playwright/support/helper.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
-import { expect } from "@playwright/experimental-ct-react";
+import { expect, test } from "@playwright/experimental-ct-react";
 import { label, legend } from "../components/index";
 
 /**
@@ -63,23 +63,43 @@ export const checkAccessibility = async (
 
   const isCI = process.env.CI === "true";
 
-  if (accessibilityScanResults.incomplete.length > 0 && !isCI) {
-    // Capture the calling stack
-    const { stack } = new Error();
+  if (!isCI) {
+    if (accessibilityScanResults.incomplete.length > 0) {
+      // Capture the calling stack
+      const { stack } = new Error();
 
-    // Parse stack to find the test file name
-    const testFileMatch = stack?.match(/at .*?(\/[^\s]+\.pw\.tsx):(\d+):(\d+)/);
-    const componentName = testFileMatch
-      ? testFileMatch[1].split("/").slice(-2, -1)[0]
-      : "Unknown component";
+      // Parse stack to find the test file name
+      const testFileMatch = stack?.match(
+        /at .*?(\/[^\s]+\.pw\.tsx):(\d+):(\d+)/,
+      );
+      const componentName = testFileMatch
+        ? testFileMatch[1].split("/").slice(-2, -1)[0]
+        : "Unknown component";
 
-    // eslint-disable-next-line no-console
-    console.warn(
-      `\nACCESSIBILITY SCAN INCOMPLETE. Incomplete rules: ${accessibilityScanResults.incomplete.map(
-        (rule) =>
-          `\n\t- ${rule.id}: this is a ${rule.impact} accessibility issue. ${rule.description}`,
-      )}\nPlease check and ensure that the "${componentName}" component meets accessibility criteria manually.\n`,
-    );
+      // eslint-disable-next-line no-console
+      console.warn(
+        `\nACCESSIBILITY SCAN INCOMPLETE. Incomplete rules: ${accessibilityScanResults.incomplete.map(
+          (rule) =>
+            `\n\t- ${rule.id}: this is a ${rule.impact} accessibility issue. ${rule.description}`,
+        )}\nPlease check and ensure that the "${componentName}" component meets accessibility criteria manually.\n`,
+      );
+    }
+  } else {
+    const testInfo = test.info();
+
+    if (accessibilityScanResults.incomplete.length > 0) {
+      await testInfo.attach("accessibility-incomplete.json", {
+        body: JSON.stringify(accessibilityScanResults.incomplete, null, 2),
+        contentType: "application/json",
+      });
+    }
+
+    if (accessibilityScanResults.violations.length > 0) {
+      await testInfo.attach("accessibility-violations.json", {
+        body: JSON.stringify(accessibilityScanResults.violations, null, 2),
+        contentType: "application/json",
+      });
+    }
   }
 
   expect(accessibilityScanResults.violations).toEqual([]);


### PR DESCRIPTION
### Proposed behaviour

Export accessibility violations and/or incomplete checks to the HTML report

### Current behaviour

It is currently only possible to view accessibility violations and/or incomplete checks when running playwright checks locally.

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required
