### PR TITLE
feat(tabs): updated to use correct new tokens

### DIFF
--- a/src/components/tabs/__next__/tabs-test.stories.tsx
+++ b/src/components/tabs/__next__/tabs-test.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof Tabs> = {
   },
   decorators: [
     (StoryToRender) => (
-      <Box backgroundColor="#ddd" p={3}>
+      <Box backgroundColor="#f4f5f6" p={3}>
         <StoryToRender />
       </Box>
     ),

--- a/src/components/tabs/__next__/tabs.stories.tsx
+++ b/src/components/tabs/__next__/tabs.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta<typeof Tabs> = {
   },
   decorators: [
     (StoryToRender) => (
-      <Box backgroundColor="#ddd" p={3}>
+      <Box backgroundColor="#f4f5f6" p={3}>
         <StoryToRender />
       </Box>
     ),

--- a/src/components/tabs/__next__/tabs.style.ts
+++ b/src/components/tabs/__next__/tabs.style.ts
@@ -61,7 +61,7 @@ export const StyledTabListWrapper = styled.div`
 
 export const Spacer = styled.div`
   align-self: flex-end;
-  background: #8b8b8bff;
+  background: var(--tab-border-active-alt);
   flex-grow: 1;
   height: 2px;
 `;
@@ -76,10 +76,10 @@ export const StyledScrollButton = styled.button<{
   border-radius: 0px;
   border-top-right-radius: 8px;
   border-top-left-radius: 8px;
-  border-color: #8b8b8bff;
+  border-color: var(--tab-border-active-alt);
   background: white;
   border: none;
-  border-bottom: 2px solid #8b8b8bff;
+  border-bottom: 2px solid var(--tab-border-active-alt);
   top: 6px;
   position: relative;
 `;
@@ -92,9 +92,9 @@ export const StyledScrollButtonPlaceholder = styled.div<{
   height: ${({ size }) => (size === "medium" ? "40px" : "48px")};
   width: ${({ size }) => (size === "medium" ? "40px" : "48px")};
   border-radius: 0;
-  border-color: #8b8b8bff;
+  border-color: var(--tab-border-active-alt);
   border: none;
-  border-bottom: 2px solid #8b8b8bff;
+  border-bottom: 2px solid var(--tab-border-active-alt);
   top: 4px;
   position: relative;
 `;
@@ -111,7 +111,7 @@ interface StyledTabProps
 export const StyledTab = styled.button<StyledTabProps>`
   background-color: transparent;
   border: none;
-  border-bottom: 2px solid #8b8b8bff;
+  border-bottom: 2px solid var(--tab-border-active-alt);
 
   border-bottom-left-radius: 0px;
   border-bottom-right-radius: 0px;
@@ -137,7 +137,7 @@ export const StyledTab = styled.button<StyledTabProps>`
   }
 
   :hover {
-    background-color: #00000010;
+    background-color: var(--tab-bg-hover);
     cursor: pointer;
   }
 
@@ -152,7 +152,7 @@ export const StyledTab = styled.button<StyledTabProps>`
     orientation === "horizontal" &&
     css`
       background-color: white;
-      border: 2px solid #8b8b8bff;
+      border: 2px solid var(--tab-border-active-alt);
       border-bottom: none;
 
       padding-top: ${sizes[size].paddingY - 4}px;
@@ -186,7 +186,7 @@ export const StyledTab = styled.button<StyledTabProps>`
     orientation === "vertical"
       ? css`
           border: none;
-          border-right: 2px solid #8b8b8bff;
+          border-right: 2px solid var(--tab-border-active-alt);
 
           border-bottom-left-radius: 8px;
           border-bottom-right-radius: 0px;
@@ -198,7 +198,7 @@ export const StyledTab = styled.button<StyledTabProps>`
           ${activeTab &&
           css`
             background-color: white;
-            border: 2px solid #8b8b8bff;
+            border: 2px solid var(--tab-border-active-alt);
             border-right: none;
 
             padding-top: ${size === "medium"


### PR DESCRIPTION
### Proposed behaviour

The colors in the new tabs are hard coded netrual grey values, we will update this to use the correct new token values.

### Current behaviour

#### Current visual 

<img width="420" height="157" alt="Screenshot 2025-12-05 at 12 35 00" src="https://github.com/user-attachments/assets/5278aa6e-9f71-4ed3-b0b0-e5b61a37dd45" />

Current code example as purely a hex code:

`border-color: #8b8b8bff;`


#### Updated visual 

You can see the updated visual with the design tokens applied. The background is also updated to reflect the most common background they will be used on.

<img width="496" height="163" alt="Screenshot 2025-12-05 at 12 34 45" src="https://github.com/user-attachments/assets/abb903c2-fc11-466d-ba83-ecadfb552681" />

Now you will see tokens applied, e.g

`border-color: var(--tab-border-active-alt);`


### Checklist

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required


### Testing instructions

Simply go to the Tabs story and expect to see the updated visual.
