### PR TITLE
fix(flat-table): optimise component to reduce re-renders

### DIFF
--- a/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.component.tsx
+++ b/src/components/flat-table/flat-table-checkbox/flat-table-checkbox.component.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useRef } from "react";
+import React, { useCallback, useContext, useRef } from "react";
 import StyledFlatTableCheckbox from "./flat-table-checkbox.style";
 import { Checkbox } from "../../checkbox";
 import Events from "../../../__internal__/utils/helpers/events/events";
@@ -46,16 +46,22 @@ export const FlatTableCheckbox = ({
 
   const dataElement = `flat-table-checkbox-${as === "td" ? "cell" : "header"}`;
 
-  const handleClick = (event: React.MouseEvent<HTMLInputElement>) => {
-    event.stopPropagation();
-    onClick?.(event);
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (!Events.isDownKey(event) && !Events.isUpKey(event)) {
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLInputElement>) => {
       event.stopPropagation();
-    }
-  };
+      onClick?.(event);
+    },
+    [onClick],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (!Events.isDownKey(event) && !Events.isUpKey(event)) {
+        event.stopPropagation();
+      }
+    },
+    [],
+  );
 
   return (
     <StyledFlatTableCheckbox

--- a/src/components/flat-table/flat-table-test.stories.tsx
+++ b/src/components/flat-table/flat-table-test.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { action } from "@storybook/addon-actions";
 import {
   FlatTable,
@@ -8,6 +8,7 @@ import {
   FlatTableHeader,
   FlatTableRowHeader,
   FlatTableCell,
+  FlatTableCheckbox,
   FlatTableProps,
   FlatTableRowProps,
   FlatTableHeaderProps,
@@ -1364,6 +1365,99 @@ export const ExtendedColumnSorting = (args: FlatTableProps) => {
               <FlatTableCell key={name}>{row[name]}</FlatTableCell>
             ))}
           </FlatTableRow>
+        ))}
+      </FlatTableBody>
+    </FlatTable>
+  );
+};
+
+const data = Array.from({ length: 300 }, (_, index) => ({
+  id: index + 1,
+  name: `Item ${index + 1}`,
+  value: Math.floor(Math.random() * 1000),
+  status: index % 2 === 0 ? "Active" : "Inactive",
+}));
+
+const MemoizedRow = React.memo(
+  ({
+    rowId,
+    row,
+    isChecked,
+    onSelect,
+  }: {
+    rowId: string;
+    row: (typeof data)[number];
+    isChecked: boolean;
+    onSelect: (id: string) => void;
+  }) => {
+    return (
+      <FlatTableRow>
+        <FlatTableCheckbox
+          checked={isChecked}
+          onChange={() => onSelect(rowId)}
+          ariaLabelledBy={`row-${row.id}-id row-${row.id}-name row-${row.id}-value row-${row.id}-status`}
+        />
+        <FlatTableCell id={`row-${row.id}-id`}>{row.id}</FlatTableCell>
+        <FlatTableCell id={`row-${row.id}-name`}>{row.name}</FlatTableCell>
+        <FlatTableCell id={`row-${row.id}-value`}>{row.value}</FlatTableCell>
+        <FlatTableCell id={`row-${row.id}-status`}>{row.status}</FlatTableCell>
+      </FlatTableRow>
+    );
+  },
+);
+
+export const WithSelectableRows = () => {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const isChecked = (id: string) => selectedIds.has(id);
+
+  const handleSelectAll = useCallback(() => {
+    setSelectedIds((prev) => {
+      if (prev.size === data.length) {
+        return new Set();
+      } else {
+        return new Set(data.map((row) => row.id.toString()));
+      }
+    });
+  }, []);
+
+  const handleRowSelect = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(id)) {
+        newSet.delete(id);
+      } else {
+        newSet.add(id);
+      }
+      return newSet;
+    });
+  }, []);
+
+  return (
+    <FlatTable colorTheme="light" width="100%">
+      <FlatTableHead>
+        <FlatTableRow>
+          <FlatTableCheckbox
+            as="th"
+            checked={selectedIds.size === data.length}
+            onChange={handleSelectAll}
+            ariaLabelledBy="header-id header-name header-value header-status"
+          />
+          <FlatTableHeader id="header-id">ID</FlatTableHeader>
+          <FlatTableHeader id="header-name">Name</FlatTableHeader>
+          <FlatTableHeader id="header-value">Value</FlatTableHeader>
+          <FlatTableHeader id="header-status">Status</FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+      <FlatTableBody>
+        {data.map((row) => (
+          <MemoizedRow
+            key={row.id}
+            rowId={row.id.toString()}
+            row={row}
+            onSelect={handleRowSelect}
+            isChecked={isChecked(row.id.toString())}
+          />
         ))}
       </FlatTableBody>
     </FlatTable>


### PR DESCRIPTION
fix #7657

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Removes `children` from `useLayoutEffect`, memoization of context value and event handlers also added.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
No memoization of event handlers or context, layout effect has `children` in deps array

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Storybook added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Best way to test optimisation is to run React devtools profiler over the new test story and compare it with doing the same thing on the version in [master](https://stackblitz.com/edit/parsium-carbon-starter-qgpdj4yx?file=src%2FApp.tsx).

Clicking checkboxes in the stackblitz/master version will cause the whole table to re-render, in the proposed changes you should only see the rows with the clicked checkboxes re-render the rest of the table should not

Worth doing a brush test of the rest as well to ensure anything not caught buy testing or regression has crept into the component with these changes