### PR TITLE
fix(adaptive-sidebar): modal aria is correct when hidden

### DIFF
--- a/src/components/adaptive-sidebar/adaptive-sidebar.component.tsx
+++ b/src/components/adaptive-sidebar/adaptive-sidebar.component.tsx
@@ -80,18 +80,6 @@ export const AdaptiveSidebar = ({
     }
   }, [open]);
 
-  // Remove inert attribute from elements when sidebar is hidden
-  /* istanbul ignore next */
-  useEffect(() => {
-    if (!hidden || !open) return;
-
-    const inertElements = document.querySelectorAll("[inert]");
-
-    inertElements.forEach((element) => {
-      element.removeAttribute("inert");
-    });
-  }, [hidden, open]);
-
   /* When the adaptive sidebar is conditionally rendered as a modal
    * we need to blur the previously active element to ensure
    * all elements which could be open are closed. */

--- a/src/components/sidebar/sidebar.component.tsx
+++ b/src/components/sidebar/sidebar.component.tsx
@@ -96,6 +96,8 @@ export interface SidebarProps
    * @internal
    * Sets className for component. INTERNAL USE ONLY. */
   className?: string;
+  /** @private @ignore Whether the `Sidebar` is hidden from view when rendered in an `AdaptiveSidebar`. */
+  hidden?: boolean;
 }
 
 export const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
@@ -129,6 +131,7 @@ export const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
       topModalOverride,
       restoreFocusOnClose = true,
       className,
+      hidden,
       ...rest
     }: SidebarProps,
     ref,
@@ -149,7 +152,7 @@ export const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
       [ref],
     );
 
-    const isTopModal = useModalAria(sidebarRef);
+    const isTopModal = useModalAria(sidebarRef, hidden);
 
     const closeIcon = () => {
       if (!onCancel) return null;

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -18,3 +18,9 @@ declare global {
     };
   }
 }
+
+declare module "react" {
+  interface HTMLAttributes {
+    inert?: "" | "true" | string;
+  }
+}

--- a/src/hooks/__internal__/useModalAria/useModalAria.tsx
+++ b/src/hooks/__internal__/useModalAria/useModalAria.tsx
@@ -3,6 +3,7 @@ import TopModalContext from "../../../components/carbon-provider/__internal__/to
 
 export default function useModalAria(
   containerRef: React.RefObject<HTMLDivElement>,
+  hidden?: boolean,
 ) {
   const { topModal } = useContext(TopModalContext);
   const isTopModal = topModal?.contains(containerRef.current);
@@ -14,7 +15,7 @@ export default function useModalAria(
       inert: string | null;
     }[] = [];
     const hideNonTopModalElements = (rootElement: HTMLElement) => {
-      if (rootElement.dataset.notInert === "true") {
+      if (hidden || rootElement.dataset.notInert === "true") {
         // stop recursing, and do nothing, if the container has the "data-not-inert" flag
         return;
       }
@@ -75,7 +76,7 @@ export default function useModalAria(
           element.removeAttribute("data-modal-hidden");
         },
       );
-  }, [topModal, isTopModal]);
+  }, [topModal, isTopModal, hidden]);
 
   return isTopModal;
 }


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Ensures the `useModalAria` hook recognises the hidden functionality in `AdaptiveSidebar` as a valid reason to run the clean-up function. This ensures all relevant attributes previously added are now removed. This aligns hiding the component with the component being closed/unmounted, as there is no perceivable differences between all of these cases for an end user.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, there is an issue where modal aria attributes persist when the `AdaptiveSidebar` is hidden, meaning when it is unhidden the component cannot be interacted with correctly. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

1. Navigate to the `Hidden` story in `AdaptiveSidbar`
2. Expand the browser window to as large a size as possible
3. Open the `AdaptiveSidebar`
4. Hide the `AdaptiveSidebar` via the `SplitButton`
5. Shrink the browser window to as small a size as possible
6. Try and open the `AdaptiveSidebar` in this smaller viewport

Repeating these steps on [master](https://carbon.sage.com/) vs a local reproduction of this PR will show the broken behaviour (master) and the fixed behaviour (local reproduction).