### PR TITLE
feat(text-editor): update mentions to allow fuzzy searching

### DIFF
--- a/src/components/text-editor/__internal__/__ui__/Mentions/mentions.style.ts
+++ b/src/components/text-editor/__internal__/__ui__/Mentions/mentions.style.ts
@@ -72,6 +72,7 @@ export const MentionsListItem = styled.li`
     align-items: center;
     font-size: 14px;
     margin-top: -1px;
+    white-space: pre;
   }
 
   div[data-component="portrait"] {

--- a/src/components/text-editor/__internal__/__ui__/Mentions/mentions.test.tsx
+++ b/src/components/text-editor/__internal__/__ui__/Mentions/mentions.test.tsx
@@ -1,10 +1,50 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import React from "react";
 import { checkForAtSignMentions, getPossibleQueryMatch } from "./helpers";
 import MentionsTypeaheadMenuItem from "./mentions-typeahead-menu-item.component";
 import MentionTypeaheadOption from "./mention-typeahead-option.class";
+import MentionsPlugin from "./mentions.component";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { LexicalTypeaheadMenuPlugin } from "@lexical/react/LexicalTypeaheadMenuPlugin";
+import { $createMentionNode } from "../../__nodes__/mention.node";
+import { $createTextNode, $isTextNode } from "lexical";
 
-describe("checkForAtSignMentions", () => {
+// Mock the Lexical hooks and components
+jest.mock("@lexical/react/LexicalComposerContext", () => ({
+  useLexicalComposerContext: jest.fn(),
+}));
+
+jest.mock("lexical", () => ({
+  ...jest.requireActual("lexical"),
+  $createTextNode: jest.fn(),
+  $isTextNode: jest.fn(),
+  TextNode: jest.fn(),
+}));
+
+jest.mock("../../__nodes__/mention.node", () => ({
+  $createMentionNode: jest.fn(),
+  $isMentionNode: jest.fn(),
+}));
+
+jest.mock("@lexical/react/LexicalTypeaheadMenuPlugin", () => ({
+  LexicalTypeaheadMenuPlugin: jest.fn(() => null),
+  MenuOption: class {
+    key: string;
+    constructor(key: string) {
+      this.key = key;
+    }
+  },
+}));
+
+jest.mock("../../../../../hooks/__internal__/useLocale", () => () => ({
+  textEditor: {
+    mentions: {
+      listAriaLabel: () => "Mentions list",
+    },
+  },
+}));
+
+describe("when checkForAtSignMentions function is called", () => {
   it("returns null for plain text", () => {
     expect(checkForAtSignMentions("hello world", 1)).toBeNull();
   });
@@ -28,7 +68,7 @@ describe("checkForAtSignMentions", () => {
   });
 });
 
-describe("getPossibleQueryMatch", () => {
+describe("when getPossibleQueryMatch function is called", () => {
   it("requires at least 1 character", () => {
     expect(getPossibleQueryMatch("@")).toBeNull();
   });
@@ -43,7 +83,7 @@ describe("getPossibleQueryMatch", () => {
   });
 });
 
-describe("MentionsTypeaheadMenuItem", () => {
+describe("when MentionsTypeaheadMenuItem component is rendered", () => {
   it("renders correctly when not selected", () => {
     render(
       <MentionsTypeaheadMenuItem
@@ -74,5 +114,147 @@ describe("MentionsTypeaheadMenuItem", () => {
     expect(screen.getByRole("option", { name: "Alice" })).toHaveClass(
       "selected",
     );
+  });
+});
+
+describe("MentionsPlugin", () => {
+  const mockEditor = {
+    registerCommand: jest.fn(() => jest.fn()),
+    update: jest.fn((callback) => callback()),
+  };
+
+  beforeEach(() => {
+    (useLexicalComposerContext as jest.Mock).mockReturnValue([mockEditor]);
+    (LexicalTypeaheadMenuPlugin as jest.Mock).mockClear();
+    ($createTextNode as jest.Mock).mockClear();
+    ($isTextNode as unknown as jest.Mock).mockClear();
+    ($createMentionNode as jest.Mock).mockClear();
+  });
+
+  const searchOptions = [
+    { id: "1", name: "Will Seabrook" },
+    { id: "2", name: "John Doe" },
+    { id: "3", name: "Jane Smith" },
+  ];
+
+  it("filters options using fuzzy search (includes) instead of startsWith", async () => {
+    render(<MentionsPlugin namespace="test" searchOptions={searchOptions} />);
+
+    // Get the props passed to the mocked LexicalTypeaheadMenuPlugin
+    const { calls } = (LexicalTypeaheadMenuPlugin as jest.Mock).mock;
+    const lastCall = calls[calls.length - 1];
+    const [props] = lastCall;
+
+    // Simulate typing "Seabrook" (surname)
+    const { onQueryChange } = props;
+
+    act(() => {
+      onQueryChange("Seabrook");
+    });
+
+    // Check the new props passed to LexicalTypeaheadMenuPlugin
+    await waitFor(() => {
+      const { calls: updatedCalls } = (LexicalTypeaheadMenuPlugin as jest.Mock)
+        .mock;
+      const [updatedProps] = updatedCalls[updatedCalls.length - 1];
+
+      expect(updatedProps.options).toHaveLength(1);
+    });
+
+    const { calls: updatedCalls } = (LexicalTypeaheadMenuPlugin as jest.Mock)
+      .mock;
+    const [updatedProps] = updatedCalls[updatedCalls.length - 1];
+    expect(updatedProps.options[0].name).toBe("Will Seabrook");
+  });
+
+  it("filters options case-insensitively", async () => {
+    render(<MentionsPlugin namespace="test" searchOptions={searchOptions} />);
+
+    const { calls } = (LexicalTypeaheadMenuPlugin as jest.Mock).mock;
+    const [props] = calls[calls.length - 1];
+    const { onQueryChange } = props;
+
+    act(() => {
+      onQueryChange("seabrook");
+    });
+
+    await waitFor(() => {
+      const { calls: updatedCalls } = (LexicalTypeaheadMenuPlugin as jest.Mock)
+        .mock;
+      const [updatedProps] = updatedCalls[updatedCalls.length - 1];
+
+      expect(updatedProps.options).toHaveLength(1);
+    });
+
+    const { calls: updatedCalls } = (LexicalTypeaheadMenuPlugin as jest.Mock)
+      .mock;
+    const [updatedProps] = updatedCalls[updatedCalls.length - 1];
+    expect(updatedProps.options[0].name).toBe("Will Seabrook");
+  });
+
+  describe("onSelectOption", () => {
+    it("inserts a space after mention if next sibling is not a space", () => {
+      const mockMentionNode = {
+        getNextSibling: jest.fn().mockReturnValue(null),
+        insertAfter: jest.fn(),
+      };
+      ($createMentionNode as jest.Mock).mockReturnValue(mockMentionNode);
+
+      const mockSpaceNode = { select: jest.fn() };
+      ($createTextNode as jest.Mock).mockReturnValue(mockSpaceNode);
+
+      const closeMenu = jest.fn();
+      const nodeToReplace = { replace: jest.fn() };
+      const option = new MentionTypeaheadOption("1", "Will Seabrook", "WS");
+
+      render(<MentionsPlugin namespace="test" searchOptions={searchOptions} />);
+
+      const { calls } = (LexicalTypeaheadMenuPlugin as jest.Mock).mock;
+      const [props] = calls[calls.length - 1];
+      const { onSelectOption } = props;
+
+      act(() => {
+        onSelectOption(option, nodeToReplace, closeMenu);
+      });
+
+      expect(nodeToReplace.replace).toHaveBeenCalledWith(mockMentionNode);
+      expect($createTextNode).toHaveBeenCalledWith(" ");
+      expect(mockMentionNode.insertAfter).toHaveBeenCalledWith(mockSpaceNode);
+      expect(mockSpaceNode.select).toHaveBeenCalled();
+      expect(closeMenu).toHaveBeenCalled();
+    });
+
+    it("moves selection if next sibling starts with a space", () => {
+      const mockNextSibling = {
+        getTextContent: jest.fn().mockReturnValue(" existing text"),
+        select: jest.fn(),
+      };
+      const mockMentionNode = {
+        getNextSibling: jest.fn().mockReturnValue(mockNextSibling),
+        insertAfter: jest.fn(),
+      };
+      ($createMentionNode as jest.Mock).mockReturnValue(mockMentionNode);
+      ($isTextNode as unknown as jest.Mock).mockReturnValue(true);
+
+      const closeMenu = jest.fn();
+      const nodeToReplace = { replace: jest.fn() };
+      const option = new MentionTypeaheadOption("1", "Will Seabrook", "WS");
+
+      render(<MentionsPlugin namespace="test" searchOptions={searchOptions} />);
+
+      const { calls } = (LexicalTypeaheadMenuPlugin as jest.Mock).mock;
+      const [props] = calls[calls.length - 1];
+      const { onSelectOption } = props;
+
+      act(() => {
+        onSelectOption(option, nodeToReplace, closeMenu);
+      });
+
+      expect(nodeToReplace.replace).toHaveBeenCalledWith(mockMentionNode);
+      expect($createTextNode).not.toHaveBeenCalled();
+      expect(mockMentionNode.insertAfter).not.toHaveBeenCalled();
+      expect(mockNextSibling.select).toHaveBeenCalledWith(1, 1);
+      expect(closeMenu).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/text-editor/text-editor.component.tsx
+++ b/src/components/text-editor/text-editor.component.tsx
@@ -362,7 +362,7 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
                       <ClickableLinkPlugin newTab />
                       <AutoLinkerPlugin />
                       <StyledSpanEnterPlugin />
-                      {customPlugins}
+                      {React.Children.toArray(customPlugins)}
                     </StyledTextEditor>
                   </>
                 )}

--- a/src/components/text-editor/text-editor.pw.tsx
+++ b/src/components/text-editor/text-editor.pw.tsx
@@ -1492,7 +1492,7 @@ test.describe("Mentions", () => {
 
     let mentionList = page.locator("ul[data-role='mention-list']");
     await expect(mentionList).toBeVisible();
-    expect(await mentionList.locator("li").count()).toBe(2);
+    expect(await mentionList.locator("li").count()).toBe(4);
 
     await page.keyboard.press("Backspace");
     await expect(mentionList).toBeHidden();


### PR DESCRIPTION
### Proposed behaviour

- Add fuzzy search functionality to the mentions plugin

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

- The mentions plugin does not allow you to search anything other than from left to right

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required

#### QA

- [x] Tested in provided StackBlitz sandbox/Storybook
- [x] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
