### PR TITLE
fix(vertical-menu): amend h3 to span for childitem

### DIFF
--- a/src/components/vertical-menu/vertical-menu.pw.tsx
+++ b/src/components/vertical-menu/vertical-menu.pw.tsx
@@ -100,7 +100,7 @@ test.describe("should render Vertical Menu component", () => {
     test(`should render with ${title} as title`, async ({ mount, page }) => {
       await mount(<VerticalMenuItemCustom title={title} />);
 
-      await expect(verticalMenuItem(page).locator("h3").first()).toHaveText(
+      await expect(verticalMenuItem(page).locator("span").nth(1)).toHaveText(
         title,
       );
     });
@@ -220,10 +220,10 @@ test.describe("should render Vertical Menu component", () => {
       await mount(<VerticalMenuItemCustom defaultOpen={open} />);
 
       const menuItem1 = verticalMenuItem(page)
-        .locator("h3")
+        .locator("span")
         .filter({ hasText: "ChildItem 1" });
       const menuItem2 = verticalMenuItem(page)
-        .locator("h3")
+        .locator("span")
         .filter({ hasText: "ChildItem 2" });
 
       if (open) {
@@ -443,7 +443,7 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
     await verticalMenuItem(page).nth(2).click();
 
     await expect(
-      verticalMenuItem(page).locator("h3").filter({ hasText: "Active Item" }),
+      verticalMenuItem(page).locator("span").filter({ hasText: "Active Item" }),
     ).toBeVisible();
   });
 
@@ -454,7 +454,7 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
     await verticalMenuItem(page).nth(2).click();
 
     await expect(
-      verticalMenuItem(page).locator("h3").filter({ hasText: "Active Item" }),
+      verticalMenuItem(page).locator("span").filter({ hasText: "Active Item" }),
     ).toBeHidden();
   });
 
@@ -480,14 +480,14 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
       if (action === "expand") {
         await expect(
           verticalMenuItem(page)
-            .locator("h3")
+            .locator("span")
             .filter({ hasText: "Active Item" }),
         ).toBeVisible();
       }
       if (action === "collapse") {
         await expect(
           verticalMenuItem(page)
-            .locator("h3")
+            .locator("span")
             .filter({ hasText: "Active Item" }),
         ).toBeHidden();
       }

--- a/src/components/vertical-menu/vertical-menu.style.ts
+++ b/src/components/vertical-menu/vertical-menu.style.ts
@@ -72,7 +72,7 @@ export const StyledVerticalMenuItem = styled.div.attrs(
   }
 `;
 
-export const StyledTitle = styled.h3`
+export const StyledTitle = styled.span`
   font-weight: 500;
   font-size: 14px;
   line-height: 21px;


### PR DESCRIPTION
fix #7689

### Proposed behaviour
Amend the childitem from a `h3` to a `span` to correct an accessibility issue.
<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour
childitem in Vertical Menu is currently set as an `h3` incorrectly.
<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
Check there are no regressions within the vertical menu component
<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
