### PR TITLE
fix(useInputAccessibility): current validation message is announced - FE-7522

### DIFF
--- a/src/__internal__/checkable-input/checkable-input.test.tsx
+++ b/src/__internal__/checkable-input/checkable-input.test.tsx
@@ -44,7 +44,7 @@ test("renders input with 'aria-describedby' as the id of the validation tooltip 
     input.focus();
   });
 
-  expect(input).toHaveAttribute("aria-describedby", "foo-validation");
+  expect(input).toHaveAttribute("aria-describedby", "foo-validation-1");
 });
 
 test("appends the id of the validation tooltip to the input's 'aria-describedby' when fieldHelp is set and the input is focused", () => {
@@ -67,7 +67,7 @@ test("appends the id of the validation tooltip to the input's 'aria-describedby'
 
   expect(input).toHaveAttribute(
     "aria-describedby",
-    "foo-field-help foo-validation",
+    "foo-field-help foo-validation-1",
   );
 });
 

--- a/src/components/form/form-test.stories.tsx
+++ b/src/components/form/form-test.stories.tsx
@@ -729,3 +729,52 @@ export const WithSetHeight = (args: FormProps) => (
   </Box>
 );
 WithSetHeight.storyName = "With Set Height";
+
+export const DynamicValidations = (args: FormProps) => {
+  const [textboxOneValue, setTextboxOneValue] = useState("");
+  const [textboxOneError, setTextboxOneError] = useState<string | boolean>(
+    false,
+  );
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event?.preventDefault();
+    let hasError = false;
+
+    if (textboxOneValue.trim() === "") {
+      setTextboxOneError("This field is required");
+      hasError = true;
+    } else if (textboxOneValue.length < 3) {
+      setTextboxOneError("Minimum 3 characters required");
+      hasError = true;
+    } else if (textboxOneValue.length > 10) {
+      setTextboxOneError("Maximum 10 characters allowed");
+      hasError = true;
+    } else {
+      setTextboxOneError(false);
+    }
+
+    if (!hasError) {
+      alert("Form submitted successfully!");
+      setTextboxOneValue("");
+    }
+  };
+
+  return (
+    <CarbonProvider validationRedesignOptIn>
+      <Form height="80%" {...args} m={2} onSubmit={handleSubmit}>
+        <Box height="100%">
+          <Textbox
+            required
+            label="Textbox"
+            value={textboxOneValue}
+            onChange={(e) => setTextboxOneValue(e.target.value)}
+            error={textboxOneError}
+          />
+
+          <Button type="submit">Submit</Button>
+        </Box>
+      </Form>
+    </CarbonProvider>
+  );
+};
+DynamicValidations.storyName = "Dynamic validations";

--- a/src/components/textarea/textarea.test.tsx
+++ b/src/components/textarea/textarea.test.tsx
@@ -319,7 +319,7 @@ test.each(["info", "warning", "error"])(
 
 test.each(["info", "warning", "error"])(
   "with id prop not provided, fieldHelp present, %s prop set as a string and the textarea element focused, the fieldHelp and the validation tooltip are combined to provide an accessible description for the textarea element",
-  (validationType) => {
+  async (validationType) => {
     render(
       <MockComponent
         label="bar"

--- a/src/components/textbox/textbox.test.tsx
+++ b/src/components/textbox/textbox.test.tsx
@@ -483,9 +483,9 @@ test.each(validationTypes)(
 
     expect(await screen.findByRole("tooltip")).toHaveAttribute(
       "id",
-      "foo-validation",
+      "foo-validation-1",
     );
-    expect(input).toHaveAttribute("aria-describedby", "foo-validation");
+    expect(input).toHaveAttribute("aria-describedby", "foo-validation-1");
   },
 );
 
@@ -507,11 +507,11 @@ test.each(validationTypes)(
 
     expect(await screen.findByRole("tooltip")).toHaveAttribute(
       "id",
-      `${mockedGuid}-validation`,
+      `${mockedGuid}-validation-1`,
     );
     expect(input).toHaveAttribute(
       "aria-describedby",
-      `${mockedGuid}-validation`,
+      `${mockedGuid}-validation-1`,
     );
   },
 );
@@ -569,12 +569,12 @@ test.each(validationTypes)(
 
     expect(await screen.findByRole("tooltip")).toHaveAttribute(
       "id",
-      "foo-validation",
+      "foo-validation-1",
     );
     expect(screen.getByText("baz")).toHaveAttribute("id", "foo-field-help");
     expect(input).toHaveAttribute(
       "aria-describedby",
-      "foo-field-help foo-validation",
+      "foo-field-help foo-validation-1",
     );
   },
 );
@@ -598,7 +598,7 @@ test.each(validationTypes)(
 
     expect(await screen.findByRole("tooltip")).toHaveAttribute(
       "id",
-      `${mockedGuid}-validation`,
+      `${mockedGuid}-validation-1`,
     );
     expect(screen.getByText("baz")).toHaveAttribute(
       "id",
@@ -606,7 +606,7 @@ test.each(validationTypes)(
     );
     expect(input).toHaveAttribute(
       "aria-describedby",
-      `${mockedGuid}-field-help ${mockedGuid}-validation`,
+      `${mockedGuid}-field-help ${mockedGuid}-validation-1`,
     );
   },
 );
@@ -752,11 +752,11 @@ describe("when rendered with new validations", () => {
 
     expect(screen.getByText("bar")).toHaveAttribute(
       "id",
-      `${mockId}-validation`,
+      `${mockId}-validation-1`,
     );
     expect(screen.getByRole("textbox")).toHaveAttribute(
       "aria-describedby",
-      `${mockId}-validation`,
+      `${mockId}-validation-1`,
     );
   });
 
@@ -790,6 +790,124 @@ describe("when rendered with new validations", () => {
     expect(hintText).toHaveStyleRule("font-size", "14px");
     expect(hintText).toHaveStyleRule("margin-top", "var(--spacing000)");
     expect(hintText).toHaveStyleRule("margin-bottom", "var(--spacing100)");
+  });
+});
+
+describe("when validation message changes", () => {
+  const renderWithNewValidations = (props: TextboxProps) =>
+    render(
+      <CarbonProvider validationRedesignOptIn>
+        <Textbox {...props} />
+      </CarbonProvider>,
+    );
+
+  const newValidationTypes = ["error", "warning"] as const;
+
+  it.each(newValidationTypes)(
+    "updates the %s validation id from validation-1 to validation-2 when the message changes",
+    (validationType) => {
+      const mockId = "foo";
+      const { rerender } = renderWithNewValidations({
+        id: mockId,
+        [validationType]: "first message",
+        value: "foo",
+        onChange: jest.fn(),
+      });
+
+      expect(screen.getByText("first message")).toHaveAttribute(
+        "id",
+        `${mockId}-validation-1`,
+      );
+      expect(screen.getByRole("textbox")).toHaveAttribute(
+        "aria-describedby",
+        `${mockId}-validation-1`,
+      );
+
+      rerender(
+        <CarbonProvider validationRedesignOptIn>
+          <Textbox
+            id={mockId}
+            {...{ [validationType]: "different message" }}
+            value="foo"
+            onChange={jest.fn()}
+          />
+        </CarbonProvider>,
+      );
+
+      expect(screen.getByText("different message")).toHaveAttribute(
+        "id",
+        `${mockId}-validation-2`,
+      );
+      expect(screen.getByRole("textbox")).toHaveAttribute(
+        "aria-describedby",
+        `${mockId}-validation-2`,
+      );
+    },
+  );
+
+  it.each(newValidationTypes)(
+    "keeps the same %s validation id when the message stays the same",
+    (validationType) => {
+      const mockId = "foo";
+      const { rerender } = renderWithNewValidations({
+        id: mockId,
+        [validationType]: "same message",
+        value: "foo",
+        onChange: jest.fn(),
+      });
+
+      expect(screen.getByText("same message")).toHaveAttribute(
+        "id",
+        `${mockId}-validation-1`,
+      );
+
+      rerender(
+        <CarbonProvider validationRedesignOptIn>
+          <Textbox
+            id={mockId}
+            {...{ [validationType]: "same message" }}
+            value="foo"
+            onChange={jest.fn()}
+          />
+        </CarbonProvider>,
+      );
+
+      expect(screen.getByText("same message")).toHaveAttribute(
+        "id",
+        `${mockId}-validation-1`,
+      );
+    },
+  );
+
+  it("updates validation id when switching from error to warning", () => {
+    const mockId = "foo";
+    const { rerender } = renderWithNewValidations({
+      id: mockId,
+      error: "error message",
+      value: "foo",
+      onChange: jest.fn(),
+    });
+
+    expect(screen.getByText("error message")).toHaveAttribute(
+      "id",
+      `${mockId}-validation-1`,
+    );
+
+    rerender(
+      <CarbonProvider validationRedesignOptIn>
+        <Textbox
+          id={mockId}
+          warning="warning message"
+          value="foo"
+          onChange={jest.fn()}
+        />
+      </CarbonProvider>,
+    );
+
+    expect(screen.getByText("warning message")).toHaveAttribute(
+      "id",
+      `${mockId}-validation-2`,
+    );
   });
 });
 

--- a/src/hooks/__internal__/useInputAccessibility/useInputAccessibility.test.ts
+++ b/src/hooks/__internal__/useInputAccessibility/useInputAccessibility.test.ts
@@ -1,3 +1,4 @@
+import { renderHook } from "@testing-library/react";
 import useInputAccessibility from ".";
 
 const id = "test-id";
@@ -8,7 +9,11 @@ const warning = "warning";
 const info = "info";
 
 test("returns all aria related props when all arguments are passed", () => {
-  expect(useInputAccessibility({ id, label, fieldHelp })).toMatchObject({
+  const { result } = renderHook(() =>
+    useInputAccessibility({ id, label, fieldHelp }),
+  );
+
+  expect(result.current).toMatchObject({
     labelId: `${id}-label`,
     validationId: undefined,
     fieldHelpId: `${id}-field-help`,
@@ -17,7 +22,9 @@ test("returns all aria related props when all arguments are passed", () => {
 });
 
 test("returns aria props without labelId when label is not provided", () => {
-  expect(useInputAccessibility({ id, fieldHelp })).toMatchObject({
+  const { result } = renderHook(() => useInputAccessibility({ id, fieldHelp }));
+
+  expect(result.current).toMatchObject({
     labelId: undefined,
     validationId: undefined,
     fieldHelpId: `${id}-field-help`,
@@ -26,51 +33,130 @@ test("returns aria props without labelId when label is not provided", () => {
 });
 
 test("returns ariaDescribedBy with fieldHelp and validationId combined when the fieldHelp is provided and string validation is set, with validationRedesignOptIn set to true", () => {
-  expect(
+  const { result } = renderHook(() =>
     useInputAccessibility({
       id,
       fieldHelp,
       error,
       validationRedesignOptIn: true,
     }),
-  ).toEqual(
+  );
+
+  expect(result.current).toEqual(
     expect.objectContaining({
-      ariaDescribedBy: `${id}-field-help ${id}-validation`,
+      ariaDescribedBy: `${id}-field-help ${id}-validation-1`,
     }),
   );
 });
 
-describe.each([error, info, warning])(
-  "when the id and %s prop is provided",
-  (key) => {
-    it(`returns validationIconId based on that id for ${key}`, () => {
-      expect(useInputAccessibility({ id, [key]: key })).toEqual(
-        expect.objectContaining({
-          validationId: `${id}-validation`,
-        }),
-      );
+describe.each([
+  ["error", error],
+  ["info", info],
+  ["warning", warning],
+])("when the id and %s prop is provided", (keyName, keyValue) => {
+  it(`returns validationIconId based on that id for ${keyName}`, () => {
+    const { result } = renderHook(() =>
+      useInputAccessibility({ id, [keyName]: keyValue }),
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        validationId: `${id}-validation-1`,
+      }),
+    );
+  });
+
+  it(`returns undefined ariaDescribedby prop for ${keyName}`, () => {
+    const { result } = renderHook(() =>
+      useInputAccessibility({ id, [keyName]: keyValue }),
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        ariaDescribedBy: undefined,
+      }),
+    );
+  });
+
+  it(`returns ariaDescribedBy containing validationId based on that id for ${keyName} with validationRedesignOptIn set to true`, () => {
+    const { result } = renderHook(() =>
+      useInputAccessibility({
+        id,
+        [keyName]: keyValue,
+        validationRedesignOptIn: true,
+      }),
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        ariaDescribedBy: `${id}-validation-1`,
+      }),
+    );
+  });
+});
+
+describe("when validation message changes", () => {
+  it("updates validationId from validation-1 to validation-2 when error message changes", () => {
+    const { result, rerender } = renderHook(
+      ({ validationProps }) => useInputAccessibility(validationProps),
+      {
+        initialProps: {
+          validationProps: {
+            id,
+            error: "first error",
+            validationRedesignOptIn: true,
+          },
+        },
+      },
+    );
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        validationId: `${id}-validation-1`,
+        ariaDescribedBy: `${id}-validation-1`,
+      }),
+    );
+
+    rerender({
+      validationProps: {
+        id,
+        error: "different error",
+        validationRedesignOptIn: true,
+      },
     });
 
-    it(`returns undefined ariaDescribedby prop for ${key}`, () => {
-      expect(useInputAccessibility({ id, [key]: key })).toEqual(
-        expect.objectContaining({
-          ariaDescribedBy: undefined,
-        }),
-      );
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        validationId: `${id}-validation-2`,
+        ariaDescribedBy: `${id}-validation-2`,
+      }),
+    );
+  });
+
+  it("keeps the same validationId when the message stays the same", () => {
+    const { result, rerender } = renderHook(
+      ({ validationProps }) => useInputAccessibility(validationProps),
+      {
+        initialProps: {
+          validationProps: {
+            id,
+            error: "first error",
+            validationRedesignOptIn: true,
+          },
+        },
+      },
+    );
+
+    expect(result.current.validationId).toBe(`${id}-validation-1`);
+
+    rerender({
+      validationProps: {
+        id,
+        error: "first error",
+        validationRedesignOptIn: true,
+      },
     });
 
-    it(`returns ariaDescribedBy containing validationId based on that id for ${key} with validationRedesignOptIn set to true`, () => {
-      expect(
-        useInputAccessibility({
-          id,
-          [key]: key,
-          validationRedesignOptIn: true,
-        }),
-      ).toEqual(
-        expect.objectContaining({
-          ariaDescribedBy: `${id}-validation`,
-        }),
-      );
-    });
-  },
-);
+    expect(result.current.validationId).toBe(`${id}-validation-1`);
+  });
+});

--- a/src/hooks/__internal__/useInputAccessibility/useInputAccessibility.ts
+++ b/src/hooks/__internal__/useInputAccessibility/useInputAccessibility.ts
@@ -1,3 +1,6 @@
+import { useEffect, useState } from "react";
+import usePrevious from "../usePrevious";
+
 export default function useInputAccessibility({
   id,
   validationRedesignOptIn,
@@ -22,10 +25,29 @@ export default function useInputAccessibility({
 } {
   const labelId = label ? `${id}-label` : undefined;
 
+  const currentValidationMessage =
+    (typeof error === "string" && error) ||
+    (typeof warning === "string" && warning) ||
+    (typeof info === "string" && info) ||
+    "";
+
+  const [validationCounter, setValidationCounter] = useState(1);
+  const previousMessage = usePrevious(currentValidationMessage);
+
+  useEffect(() => {
+    if (
+      previousMessage !== undefined &&
+      currentValidationMessage &&
+      currentValidationMessage !== previousMessage
+    ) {
+      setValidationCounter((count) => count + 1);
+    }
+  }, [currentValidationMessage, previousMessage]);
+
   const validationId = [error, warning, info].filter(
     (validation) => validation && typeof validation === "string",
   ).length
-    ? `${id}-validation`
+    ? `${id}-validation-${validationCounter}`
     : undefined;
 
   const fieldHelpId = fieldHelp ? `${id}-field-help` : undefined;


### PR DESCRIPTION
We are seeing an accessibility issue in a form where the screen reader (VoiceOver or NVDA) announces the previous error message instead of the current one when the validation state of a field. This fix address the underlying cause of this issue by making sure the aria-describedby is updated if the validation message changes.

fix #7612

### Proposed behaviour

When a validation message is dynamically updated in our input-based components, the new (or current) validation message should be announced. 

### Current behaviour

screen reader (VoiceOver or NVDA) announces the previous error message instead of the current one when the validation state of a field.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context
The commit message is not ideal but we are limited to 72 characters. Ideally I would like to have said "ensure that current validation message is read out by a screenreader when the message is dynamically updated"

### Testing instructions

- There should be no regressions regarding screenreader behaviour with our input-based components. 
- Ensure that the screenreader announces the latest validation message on the example in `Form -> Test -> Dynamic validations`.
