### PR TITLE
fix(menu-item): ensure submenu closes when child item is clicked

### DIFF
--- a/src/components/menu/__internal__/submenu/submenu.component.tsx
+++ b/src/components/menu/__internal__/submenu/submenu.component.tsx
@@ -554,6 +554,7 @@ const Submenu = React.forwardRef<HTMLAnchorElement, SubmenuProps>(
                 blockIndex,
                 updateFocusId: setSubmenuFocusId,
                 submenuHasMaxWidth: !!submenuMaxWidth,
+                closeSubmenu,
               }}
             >
               {children}

--- a/src/components/menu/__internal__/submenu/submenu.context.tsx
+++ b/src/components/menu/__internal__/submenu/submenu.context.tsx
@@ -10,6 +10,7 @@ export interface SubmenuContextProps {
   ) => void;
   blockIndex?: number;
   submenuHasMaxWidth?: boolean;
+  closeSubmenu?: () => void;
 }
 
 const SubmenuContext = React.createContext<SubmenuContextProps>({});

--- a/src/components/menu/component.test-pw.tsx
+++ b/src/components/menu/component.test-pw.tsx
@@ -919,28 +919,6 @@ export const SubmenuMaxWidth = () => (
   </Menu>
 );
 
-export const WithNonInteractiveItem = () => (
-  <Menu>
-    <MenuItem>Non-interactive item</MenuItem>
-  </Menu>
-);
-
-export const WithNonInteractiveSubmenuItem = () => (
-  <Menu>
-    <MenuItem submenu="Submenu">
-      <MenuItem>Non-interactive item</MenuItem>
-    </MenuItem>
-  </Menu>
-);
-
-export const FullscreenWithNonInteractiveItem = () => (
-  <Menu>
-    <MenuFullscreen isOpen onClose={() => {}}>
-      <MenuItem>Non-interactive item</MenuItem>
-    </MenuFullscreen>
-  </Menu>
-);
-
 export const MenuSegmentTitleWithNoMenuItemOutside = () => {
   return (
     <Menu>

--- a/src/components/menu/menu-interaction.stories.tsx
+++ b/src/components/menu/menu-interaction.stories.tsx
@@ -126,8 +126,8 @@ const MenuWithCustomWidth = () => (
         submenu="With maxWidth"
         submenuDirection="left"
       >
+        <MenuItem data-role="hover">Non Interactive Item</MenuItem>
         <MenuItem href="#">Item One</MenuItem>
-        <MenuItem href="#">Item Two</MenuItem>
         <MenuItem href="#">
           This is a longer text string. I will wrap instead of truncating!
         </MenuItem>
@@ -175,6 +175,7 @@ const MenuInNavigationBar = () => (
 const FullScreenWithSegmentTitle = () => (
   <Menu menuType="dark">
     <MenuFullscreen isOpen onClose={() => {}}>
+      <MenuItem data-role="hover">Non Interactive Item</MenuItem>
       <MenuItem data-role="target" href="#">
         Item One
       </MenuItem>
@@ -387,6 +388,7 @@ WithSegmentTitle.parameters = {
   },
 };
 
+// Tests non-interactive item in submenu
 export const WithCustomWidth: Story = {
   render: () => (
     <Box ml="150px" display="flex" flexDirection="row" gap="100px">
@@ -406,7 +408,7 @@ export const WithCustomWidth: Story = {
       name: "With minWidth",
     });
 
-    await userEvent.hover(menuItemMaxWidth);
+    await userEvent.click(menuItemMaxWidth);
     await userEvent.hover(menuItemMinWidth);
     await expect(
       await within(document.body).findByText("Item Three"),
@@ -416,6 +418,13 @@ export const WithCustomWidth: Story = {
         "This is a longer text string. I will wrap instead of truncating!",
       ),
     ).toBeVisible();
+
+    // Ensure focus lands on first focusable menu item
+    await userEvent.tab();
+    const firstItems = within(document.body).getAllByRole("link", {
+      name: "Item One",
+    });
+    await expect(firstItems[0]).toHaveFocus();
   },
   decorators: [
     (StoryToRender) => (
@@ -426,6 +435,12 @@ export const WithCustomWidth: Story = {
   ],
 };
 WithCustomWidth.storyName = "With Custom Width";
+WithCustomWidth.parameters = {
+  pseudo: {
+    hover: "[data-role='hover'] a",
+    rootSelector: "body",
+  },
+};
 
 export const InNavigationBarStory: Story = {
   render: () => <MenuInNavigationBar />,
@@ -450,6 +465,7 @@ export const InNavigationBarStory: Story = {
 };
 InNavigationBarStory.storyName = "In NavigationBar";
 
+// Tests non-interactive item within fullscreen menu
 export const MenuFullScreenWithSegmentTitle: Story = {
   render: () => <FullScreenWithSegmentTitle />,
   play: async () => {
@@ -473,7 +489,7 @@ export const MenuFullScreenWithSegmentTitle: Story = {
 MenuFullScreenWithSegmentTitle.storyName = "MenuFullScreen With Segment Title";
 MenuFullScreenWithSegmentTitle.parameters = {
   pseudo: {
-    hover: "[data-role='target'] button",
+    hover: ["[data-role='target'] button", "[data-role='hover'] a"],
     focus: "[data-role='target'] a",
     rootSelector: "body",
   },

--- a/src/components/menu/menu-item/menu-item.component.tsx
+++ b/src/components/menu/menu-item/menu-item.component.tsx
@@ -198,6 +198,7 @@ export const MenuItem = forwardRef<
       updateFocusId: updateSubmenuFocusId,
       handleKeyDown: handleSubmenuKeyDown,
       submenuHasMaxWidth,
+      closeSubmenu: closeParentSubmenu,
     } = submenuContext;
 
     const focusFromMenu = focusId === menuItemId.current;
@@ -279,10 +280,20 @@ export const MenuItem = forwardRef<
       handleSubmenuKeyDown?.(event);
     };
 
+    const handleClick = (
+      event:
+        | React.MouseEvent<HTMLAnchorElement>
+        | React.MouseEvent<HTMLButtonElement>,
+    ) => {
+      onClick?.(event);
+      closeParentSubmenu?.();
+    };
+
     const elementProps = {
       className: href || onClick ? "carbon-menu-item--has-link" : "",
       href: firstFocusableChild ? undefined : href,
-      onClick: firstFocusableChild ? undefined : onClick,
+      onClick:
+        !firstFocusableChild && (href || onClick) ? handleClick : undefined,
       target,
       rel,
       icon,

--- a/src/components/menu/menu-item/menu-item.test.tsx
+++ b/src/components/menu/menu-item/menu-item.test.tsx
@@ -1163,6 +1163,56 @@ describe("when MenuItem has a submenu", () => {
     expect(onClick).toHaveBeenCalled();
   });
 
+  it("should close the submenu when the user clicks on a link submenu item", async () => {
+    const user = userEvent.setup();
+    render(
+      <Menu>
+        <MenuItem submenu="Menu Item Three">
+          <MenuItem href="#1">Item Submenu One</MenuItem>
+          <MenuItem href="#2">Item Submenu Two</MenuItem>
+        </MenuItem>
+      </Menu>,
+    );
+    const submenuParentItem = screen.getByRole("button", {
+      name: "Menu Item Three",
+    });
+    await user.click(submenuParentItem);
+
+    const submenuItem = screen.getByRole("link", { name: "Item Submenu One" });
+    expect(submenuItem).toBeVisible();
+    await user.click(submenuItem);
+
+    expect(
+      screen.queryByRole("link", { name: "Item Submenu One" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should close the submenu when the user clicks on a button submenu item", async () => {
+    const user = userEvent.setup();
+    render(
+      <Menu>
+        <MenuItem submenu="Menu Item Three">
+          <MenuItem onClick={() => {}}>Item Submenu One</MenuItem>
+          <MenuItem href="#2">Item Submenu Two</MenuItem>
+        </MenuItem>
+      </Menu>,
+    );
+    const submenuParentItem = screen.getByRole("button", {
+      name: "Menu Item Three",
+    });
+    await user.click(submenuParentItem);
+
+    const submenuItem = screen.getByRole("button", {
+      name: "Item Submenu One",
+    });
+    expect(submenuItem).toBeVisible();
+    await user.click(submenuItem);
+
+    expect(
+      screen.queryByRole("button", { name: "Item Submenu One" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("should focus the first item when parent has `href` user presses 'arrowdown' key twice", async () => {
     const user = userEvent.setup();
     render(
@@ -1485,31 +1535,6 @@ describe("when MenuItem has a submenu", () => {
         </Menu>,
       );
     }).not.toThrow();
-  });
-
-  it("should update the focused element when a user clicks a child item", async () => {
-    const user = userEvent.setup();
-    render(
-      <Menu>
-        <MenuItem href="#" submenu="Item One">
-          <MenuItem onClick={() => {}}>Submenu Item One</MenuItem>
-          <MenuItem onClick={() => {}}>Submenu Item Two</MenuItem>
-          <MenuItem onClick={() => {}}>Submenu Item Three</MenuItem>
-        </MenuItem>
-      </Menu>,
-    );
-
-    const parentItem = screen.getByRole("listitem");
-
-    await user.tab();
-    await user.keyboard("{arrowdown}");
-
-    const subitems = within(parentItem).getAllByRole("listitem");
-    const thirdItemButton = within(subitems[2]).getByRole("button");
-
-    await user.click(thirdItemButton);
-
-    expect(thirdItemButton).toHaveFocus();
   });
 
   it("should call the `handleKeyDown` function when one is passed via `submenuContext`", () => {

--- a/src/components/menu/menu.pw.tsx
+++ b/src/components/menu/menu.pw.tsx
@@ -67,9 +67,6 @@ import {
   MenuComponentFullScreenWithLongSubmenuText,
   MenuItemWithPopoverContainerChild,
   SubmenuMaxWidth,
-  WithNonInteractiveItem,
-  WithNonInteractiveSubmenuItem,
-  FullscreenWithNonInteractiveItem,
   MenuSegmentTitleWithNoMenuItemOutside,
 } from "./component.test-pw";
 
@@ -88,64 +85,6 @@ test.describe("Prop tests for Menu component", () => {
     const lastElement = lastSubmenuElement(page, "li");
     await lastElement.scrollIntoViewIfNeeded();
     await expect(lastElement).toBeInViewport();
-  });
-
-  test(`should verify a submenu can be navigated using keyboard tabbing after an item was clicked`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<MenuComponent />);
-
-    const subMenu = submenu(page).first();
-    await subMenu.hover();
-    const menuItemThree = innerMenu(page, 4, span)
-      .filter({ hasText: "Item Submenu Three" })
-      .first();
-    await menuItemThree.click();
-    await expect(menuItemThree).toHaveText("Item Submenu Three");
-    await expect(menuItemThree).toHaveCSS("box-shadow", "none");
-    await page.keyboard.press("Tab");
-    const menuItemFour = innerMenu(page, 5, span)
-      .filter({ hasText: "Item Submenu Four" })
-      .first();
-    await expect(menuItemFour).toHaveText("Item Submenu Four");
-    await expect(menuItemFour).toHaveCSS("box-shadow", "none");
-  });
-
-  test(`should verify a submenu can be navigated using keyboard shift + tabbing after an item was clicked`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<MenuComponent />);
-
-    const subMenu = submenu(page).first();
-    await subMenu.hover();
-    const menuItemThree = innerMenu(page, 4, span).first();
-    await menuItemThree.click();
-    await page.keyboard.press("Shift+Tab");
-    const focusedElement1 = page.locator("*:focus");
-    await expect(focusedElement1).toContainText("Item Submenu Two");
-    await page.keyboard.press("Shift+Tab");
-    const focusedElement2 = page.locator("*:focus");
-    await expect(focusedElement2).toContainText("Item Submenu One");
-  });
-
-  test(`should verify a submenu can be navigated using keyboard up arrow after an item was clicked`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<MenuComponent />);
-
-    const subMenu = submenu(page).first();
-    await subMenu.hover();
-    const menuItemThree = innerMenu(page, 4, span).first();
-    await menuItemThree.click();
-    await page.keyboard.press("ArrowUp");
-    const focusedElement1 = page.locator("*:focus");
-    await expect(focusedElement1).toContainText("Item Submenu Two");
-    await page.keyboard.press("ArrowUp");
-    const focusedElement2 = page.locator("*:focus");
-    await expect(focusedElement2).toContainText("Item Submenu One");
   });
 
   test(`should verify the first submenu item is focused using keyboard tabbing after the parent item was clicked`, async ({
@@ -2401,86 +2340,6 @@ test.describe("Styling, Scrolling & Navigation Bar Tests for Menu Component", ()
     await expect(popoverContainerButton).toHaveCSS(
       "background-color",
       "rgba(0, 0, 0, 0)",
-    );
-  });
-
-  test("a menu item, without a href or onClick prop, does not render with hover styling on hover", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<WithNonInteractiveItem />);
-
-    const item = page
-      .getByRole("listitem")
-      .filter({ hasText: "Non-interactive item" });
-    await item.hover();
-
-    await expect(item.getByTestId("link-anchor")).not.toHaveCSS(
-      "background-color",
-      "rgb(0, 126, 69)",
-    );
-    await expect(item.getByTestId("link-anchor")).not.toHaveCSS(
-      "color",
-      "rgb(255, 255, 255)",
-    );
-    await expect(item.getByTestId("link-anchor")).not.toHaveCSS(
-      "cursor",
-      "pointer",
-    );
-  });
-
-  test("a submenu item, without a href or onClick prop, does not render with hover styling on hover", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<WithNonInteractiveSubmenuItem />);
-
-    const parentItem = page
-      .getByRole("listitem")
-      .filter({ hasText: "Submenu" });
-    await parentItem.getByRole("button").press("Enter");
-
-    const nonInteractiveItem = parentItem
-      .getByRole("listitem")
-      .filter({ hasText: "Non-interactive item" });
-    await nonInteractiveItem.hover();
-
-    await expect(nonInteractiveItem.getByTestId("link-anchor")).not.toHaveCSS(
-      "background-color",
-      "rgb(0, 126, 69)",
-    );
-    await expect(nonInteractiveItem.getByTestId("link-anchor")).not.toHaveCSS(
-      "color",
-      "rgb(255, 255, 255)",
-    );
-    await expect(nonInteractiveItem.getByTestId("link-anchor")).not.toHaveCSS(
-      "cursor",
-      "pointer",
-    );
-  });
-
-  test("an item in a fullscreen menu, which has no href or onClick prop, does not render with hover styling on focus", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<FullscreenWithNonInteractiveItem />);
-
-    const item = page
-      .getByRole("listitem")
-      .filter({ hasText: "Non-interactive item" });
-    await item.hover();
-
-    await expect(item.getByTestId("link-anchor")).not.toHaveCSS(
-      "background-color",
-      "rgb(0, 126, 69)",
-    );
-    await expect(item.getByTestId("link-anchor")).not.toHaveCSS(
-      "color",
-      "rgb(255, 255, 255)",
-    );
-    await expect(item.getByTestId("link-anchor")).not.toHaveCSS(
-      "cursor",
-      "pointer",
     );
   });
 });


### PR DESCRIPTION
fix #6820

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

`MenuItem` submenu closes on click. 
Screen reader users are now pulled out of the submenu and are aware they have been taken to a new page. 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

`MenuItem` submenu remains open on click. 
This also causes issues for screen reader users as they are not aware they have been taken to a new page via a link due to focus remaining on the open submenu.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
