### PR TITLE
test(accordion): refine accordion tests - (FE-7567)

### DIFF
--- a/src/components/accordion/accordion-test.stories.tsx
+++ b/src/components/accordion/accordion-test.stories.tsx
@@ -77,7 +77,7 @@ export const Default = ({ ...args }) => (
   </Accordion>
 );
 
-Default.storyName = "default";
+Default.storyName = "Default";
 
 export const Grouped = ({ ...args }) => (
   <AccordionGroup>
@@ -113,9 +113,9 @@ export const Grouped = ({ ...args }) => (
   </AccordionGroup>
 );
 
-Grouped.storyName = "grouped";
+Grouped.storyName = "Grouped";
 
-export const AccordionWithMultiAction = () => {
+export const WithMultiAction = () => {
   return (
     <Accordion title="Accordion">
       <MultiActionButton text="Multi Action Button">
@@ -136,10 +136,9 @@ export const AccordionWithMultiAction = () => {
   );
 };
 
-AccordionWithMultiAction.storyName =
-  "Accordion with MultiAction and Split Button";
+WithMultiAction.storyName = "With MultiAction and Split Button";
 
-export const AccordionWithDefinitionList = () => {
+export const WithDefinitionList = () => {
   const [isOpen, setOpen] = useState<boolean>(true);
   return (
     <Accordion
@@ -183,9 +182,9 @@ export const AccordionWithDefinitionList = () => {
     </Accordion>
   );
 };
-AccordionWithDefinitionList.storyName = "Accordion With Definition List";
+WithDefinitionList.storyName = "With Definition List";
 
-export const AccordionWithLongSubtitle = () => (
+export const WithLongSubtitle = () => (
   <Accordion
     title="Heading"
     subTitle="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s"
@@ -193,12 +192,12 @@ export const AccordionWithLongSubtitle = () => (
   />
 );
 
-AccordionWithLongSubtitle.storyName = "Accordion With Long Subtitle";
-AccordionWithLongSubtitle.parameters = {
+WithLongSubtitle.storyName = "With Long Subtitle";
+WithLongSubtitle.parameters = {
   chromatic: { disableSnapshot: false },
 };
 
-export const AccordionWithValidations = () => {
+export const WithValidations = () => {
   const [validationKey, setValidationKey] = useState<string>("error");
   const props = useMemo(() => {
     return {
@@ -235,12 +234,9 @@ export const AccordionWithValidations = () => {
     </AccordionGroup>
   );
 };
-AccordionWithValidations.storyName = "Accordion With Validation";
-AccordionWithValidations.parameters = {
-  chromatic: { disableSnapshot: false },
-};
+WithValidations.storyName = "With Validations";
 
-export const WithBoxComponentAndDifferentPaddings = () => {
+export const WithBoxComponentAndCustomPaddings = () => {
   const [isOpen, setOpen] = useState(true);
   return (
     <>
@@ -352,61 +348,29 @@ export const WithBoxComponentAndDifferentPaddings = () => {
     </>
   );
 };
-WithBoxComponentAndDifferentPaddings.storyName =
-  "With Box Component and Different Padding";
-WithBoxComponentAndDifferentPaddings.parameters = {
+WithBoxComponentAndCustomPaddings.storyName =
+  "With Box Component and Custom Paddings";
+WithBoxComponentAndCustomPaddings.parameters = {
   chromatic: { disableSnapshot: false },
 };
 
-export const WithValidationIcon = () => {
-  const [firstAccordionExpanded, setFirstAccordionExpanded] =
-    useState<boolean>(true);
-  const [secondAccordionExpanded, setSecondAccordionExpanded] =
-    useState<boolean>(true);
-  const [thirdAccordionExpanded, setThirdAccordionExpanded] =
-    useState<boolean>(true);
-
-  const toggleFirstAccordion = () => {
-    setFirstAccordionExpanded(!firstAccordionExpanded);
-  };
-  const toggleSecondAccordion = () => {
-    setSecondAccordionExpanded(!secondAccordionExpanded);
-  };
-  const toggleThirdAccordion = () => {
-    setThirdAccordionExpanded(!thirdAccordionExpanded);
-  };
-
+export const IconAlign = () => {
   return (
-    <AccordionGroup>
+    <>
       <Accordion
-        title="First Heading"
-        expanded={firstAccordionExpanded}
-        onChange={toggleFirstAccordion}
-        error="This is an error state"
-      >
-        <Box>Content</Box>
-      </Accordion>
+        title="Heading"
+        subTitle="Icon Left-Aligned"
+        iconAlign="left"
+      />
       <Accordion
-        title="Second Heading"
-        expanded={secondAccordionExpanded}
-        onChange={toggleSecondAccordion}
-        warning="This is a warning state"
-      >
-        <Box>Content</Box>
-      </Accordion>
-      <Accordion
-        title="Third Heading"
-        expanded={thirdAccordionExpanded}
-        onChange={toggleThirdAccordion}
-        info="This is an info state"
-      >
-        <Box>Content</Box>
-      </Accordion>
-    </AccordionGroup>
+        title="Heading"
+        subTitle="Icon Right-Aligned"
+        iconAlign="right"
+      />
+    </>
   );
 };
-WithValidationIcon.storyName = "With Validation Icon";
-WithBoxComponentAndDifferentPaddings.parameters = {
+IconAlign.storyName = "Icon Align";
+IconAlign.parameters = {
   chromatic: { disableSnapshot: false },
-  themeProvider: { chromatic: { theme: "sage" } },
 };

--- a/src/components/accordion/accordion.pw.tsx
+++ b/src/components/accordion/accordion.pw.tsx
@@ -4,68 +4,30 @@ import {
   accordion,
   accordionIcon,
   accordionTitleContainer,
-  accordionTitleContainerByPosition,
   accordionContent,
 } from "../../../playwright/components/accordion";
 import {
-  positionOfElement,
-  getRotationAngle,
-  assertCssValueIsApproximately,
   getStyle,
   checkAccessibility,
 } from "../../../playwright/support/helper";
 import { getDataElementByValue } from "../../../playwright/components";
-import {
-  ACCORDION_ADD_CONTENT,
-  ACCORDION_REMOVE_CONTENT,
-} from "../../../playwright/components/accordion/locators";
 import { SIZE, CHARACTERS } from "../../../playwright/support/constants";
 
 import {
   AccordionComponent,
   AccordionWithIcon,
-  AccordionGroupWithError,
-  AccordionGroupWithWarning,
-  AccordionGroupWithInfo,
-  AccordionGroupComponent,
-  DynamicContent,
   AccordionDefault,
-  AccordionWithBoxAndDifferentPaddings,
-  AccordionGroupDefault,
   AccordionGroupValidation,
   AccordionWithDefinitionList,
   AccordionWithSplit,
 } from "./components.test-pw";
 
 import { additionalButton as splitAdditionalButtons } from "../../../playwright/components/split-button";
-import Typography from "../typography";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
-// TODO: Skipped due to flaky focus behaviour. To review in FE-6428
-test.skip("should have the expected styling when focused", async ({
-  mount,
-  page,
-}) => {
-  await mount(<AccordionComponent />);
-  const elementLocator = accordionTitleContainer(page);
-  const element = await elementLocator;
-  await element.focus();
-  await expect(elementLocator).toHaveCSS(
-    "box-shadow",
-    "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
-  );
-  await expect(elementLocator).toHaveCSS(
-    "outline",
-    "rgba(0, 0, 0, 0) solid 3px",
-  );
-});
-
 test.describe("should render Accordion component", () => {
-  test("should check AccordionRow is expanded using click", async ({
-    mount,
-    page,
-  }) => {
+  test("should expand AccordionRow using click", async ({ mount, page }) => {
     await mount(<AccordionComponent />);
 
     await accordionTitleContainer(page).click();
@@ -83,7 +45,7 @@ test.describe("should render Accordion component", () => {
     await expect(accordionContent(page)).toBeVisible();
   });
 
-  test("should check AccordionRow is expanded using Enter key", async ({
+  test("should expand AccordionRow using Enter key", async ({
     mount,
     page,
   }) => {
@@ -104,7 +66,7 @@ test.describe("should render Accordion component", () => {
     await expect(accordionContent(page)).toBeVisible();
   });
 
-  test("should check Accordion is expanded using Space key and does not trigger scroll", async ({
+  test("should expand Accordion using Space key and does not trigger scroll", async ({
     mount,
     page,
   }) => {
@@ -128,84 +90,7 @@ test.describe("should render Accordion component", () => {
     expect(scrollPosition).toBe(0);
   });
 
-  (["chevron_down", "dropdown", "chevron_down_thick"] as const).forEach(
-    (iconType) => {
-      test(`should set iconType to ${iconType} and transform when Accordion row is closed`, async ({
-        page,
-        mount,
-      }) => {
-        await mount(<AccordionComponent iconType={iconType} />);
-
-        await expect(accordionIcon(page)).toHaveAttribute("type", iconType);
-        await expect(accordionIcon(page)).toBeVisible();
-        const transformValue = await getStyle(accordionIcon(page), "transform");
-        expect(getRotationAngle(transformValue)).toBe(0);
-      });
-    },
-  );
-
-  (["chevron_down", "dropdown", "chevron_down_thick"] as const).forEach(
-    (iconType) => {
-      test(`should set iconType to ${iconType} and transform when Accordion row is open`, async ({
-        page,
-        mount,
-      }) => {
-        await mount(<AccordionComponent iconType={iconType} expanded />);
-
-        await expect(accordionIcon(page)).toHaveAttribute("type", iconType);
-        await expect(accordionIcon(page)).toBeVisible();
-        const transformValue = await getStyle(accordionIcon(page), "transform");
-        expect(getRotationAngle(transformValue)).toBe(180);
-      });
-    },
-  );
-
-  (["left", "right"] as const).forEach((iconAlign) => {
-    test(`should set Accordion iconAlign to ${iconAlign}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<AccordionComponent iconAlign={iconAlign} />);
-
-      const headingContainerLocator = accordionTitleContainerByPosition(
-        page,
-        positionOfElement("first"),
-      );
-
-      await expect(headingContainerLocator.first()).toHaveAttribute(
-        "data-element",
-        "accordion-headings-container",
-      );
-      await expect(headingContainerLocator.first()).toBeVisible();
-
-      if (iconAlign === "right") {
-        // set by default
-        await expect(accordionTitleContainer(page)).toHaveCSS(
-          "justify-content",
-          "space-between",
-        );
-        await expect(accordionTitleContainer(page)).not.toHaveCSS(
-          "flex-direction",
-          "row-reverse",
-        );
-        await expect(headingContainerLocator.first()).toHaveCSS(
-          "margin-right",
-          "0px",
-        );
-      } else {
-        await expect(accordionTitleContainer(page)).toHaveCSS(
-          "flex-direction",
-          "row-reverse",
-        );
-        await expect(headingContainerLocator.last()).toHaveCSS(
-          "margin-right",
-          "16px",
-        );
-      }
-    });
-  });
-
-  test("should verify AccordionRow is expanded by clicking on validation icon", async ({
+  test("should expand AccordionRow by clicking on validation icon", async ({
     mount,
     page,
   }) => {
@@ -286,125 +171,6 @@ test.describe("should render Accordion component", () => {
     });
   });
 
-  [true, false].forEach((state) => {
-    test(`should render Accordion component with default expanded state '${state}'`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<AccordionComponent defaultExpanded={state} />);
-
-      await expect(accordionTitleContainer(page)).toHaveAttribute(
-        "aria-expanded",
-        String(state),
-      );
-      await expect(accordionTitleContainer(page)).toBeVisible();
-    });
-  });
-
-  [true, false].forEach((state) => {
-    test(`should render Accordion component with expanded state '${state}'`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<AccordionComponent expanded={state} />);
-
-      await expect(accordionTitleContainer(page)).toHaveAttribute(
-        "aria-expanded",
-        String(state),
-      );
-      await expect(accordionTitleContainer(page)).toBeVisible();
-    });
-  });
-
-  ["700px", "900px", "1100px", "1300px"].forEach((width) => {
-    test(`should check Accordion width is ${width}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<AccordionComponent width={width} />);
-
-      await assertCssValueIsApproximately(
-        accordion(page),
-        "width",
-        parseInt(width),
-      );
-    });
-  });
-
-  test("should verify Accordion has an error message in the tooltip", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionGroupWithError />);
-
-    await accordionIcon(page).nth(0).click();
-
-    await expect(accordionIcon(page).nth(0)).toHaveAttribute(
-      "data-element",
-      "error",
-    );
-    await expect(accordionIcon(page).nth(0)).toHaveAttribute("type", "error");
-  });
-
-  test("should verify AccordionRow has a warning message in the tooltip", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionGroupWithWarning />);
-
-    await accordionIcon(page).nth(0).click();
-
-    await expect(accordionIcon(page).nth(0)).toHaveAttribute(
-      "data-element",
-      "warning",
-    );
-    await expect(accordionIcon(page).nth(0)).toHaveAttribute("type", "warning");
-  });
-
-  test("should verify AccordionRow has an info message in the tooltip", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionGroupWithInfo />);
-
-    await accordionIcon(page).nth(0).click();
-
-    await expect(accordionIcon(page).nth(0)).toHaveAttribute(
-      "data-element",
-      "info",
-    );
-    await expect(accordionIcon(page).nth(0)).toHaveAttribute("type", "info");
-  });
-
-  test("should verify accordion title changes when accordion is opened", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionComponent title="Closed" openTitle="Open" />);
-
-    await expect(accordionTitleContainer(page)).toContainText("Closed");
-
-    await accordionIcon(page).nth(0).click();
-
-    await expect(accordionTitleContainer(page)).toContainText("Open");
-  });
-
-  test("should verify accordion subtitle does not render when variant is subtle", async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <AccordionComponent
-        title="subtle"
-        variant="subtle"
-        subTitle="subtitle"
-      />,
-    );
-
-    await expect(accordionTitleContainer(page)).toContainText("subtle");
-    await expect(accordionTitleContainer(page)).not.toContainText("subtitle");
-  });
-
   test("should not hide the children container of SplitButton when it opens", async ({
     mount,
     page,
@@ -421,87 +187,8 @@ test.describe("should render Accordion component", () => {
   });
 });
 
-test.describe("should render Accordion Grouped component", () => {
-  test("should move through all grouped accordions using ArrowDown key and check focus", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionGroupComponent />);
-
-    await accordionTitleContainer(page).nth(0).focus();
-    await expect(accordionTitleContainer(page).nth(0)).toHaveCSS(
-      "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
-    );
-    await expect(accordionTitleContainer(page).nth(0)).toBeVisible();
-
-    await accordionTitleContainer(page).nth(0).press("ArrowDown");
-    await expect(accordionTitleContainer(page).nth(1)).toHaveCSS(
-      "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
-    );
-    await expect(accordionTitleContainer(page).nth(1)).toBeVisible();
-
-    await accordionTitleContainer(page).nth(1).press("ArrowDown");
-    await expect(accordionTitleContainer(page).nth(2)).toHaveCSS(
-      "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
-    );
-    await expect(accordionTitleContainer(page).nth(2)).toBeVisible();
-  });
-
-  test("should move to the last grouped accordion using End key and check it is focused", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionGroupComponent />);
-
-    await accordionTitleContainer(page).nth(0).focus();
-
-    await accordionTitleContainer(page).nth(0).press("End");
-
-    await expect(accordionTitleContainer(page).nth(2)).toHaveCSS(
-      "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
-    );
-    await expect(accordionTitleContainer(page).nth(2)).toBeVisible();
-  });
-
-  test("should move to the first grouped accordion using Home key and check it is focused", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionGroupComponent />);
-
-    await accordionTitleContainer(page).nth(2).focus();
-
-    await accordionTitleContainer(page).nth(2).press("Home");
-
-    await expect(accordionTitleContainer(page).nth(0)).toHaveCSS(
-      "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
-    );
-    await expect(accordionTitleContainer(page).nth(0)).toBeVisible();
-  });
-});
-
-test.describe("should change content height when children change", () => {
-  test("should have proper height", async ({ mount, page }) => {
-    await mount(<DynamicContent />);
-    await assertCssValueIsApproximately(accordionContent(page), "height", 49);
-    await getDataElementByValue(page, ACCORDION_ADD_CONTENT).click();
-    await assertCssValueIsApproximately(accordionContent(page), "height", 66);
-    await getDataElementByValue(page, ACCORDION_ADD_CONTENT).click();
-    await assertCssValueIsApproximately(accordionContent(page), "height", 83);
-    await getDataElementByValue(page, ACCORDION_REMOVE_CONTENT).click();
-    await assertCssValueIsApproximately(accordionContent(page), "height", 66);
-    await getDataElementByValue(page, ACCORDION_REMOVE_CONTENT).click();
-    await assertCssValueIsApproximately(accordionContent(page), "height", 49);
-  });
-});
-
 test.describe("Accessibility tests for Accordion", () => {
-  test("should pass accessibility tests for AccordionDefault", async ({
+  test("should pass accessibility tests for default example", async ({
     mount,
     page,
   }) => {
@@ -510,7 +197,7 @@ test.describe("Accessibility tests for Accordion", () => {
     await checkAccessibility(page);
   });
 
-  test("should pass accessibility tests for AccordionDefault expanded", async ({
+  test("should pass accessibility tests for expanded example", async ({
     mount,
     page,
   }) => {
@@ -519,16 +206,7 @@ test.describe("Accessibility tests for Accordion", () => {
     await checkAccessibility(page);
   });
 
-  test("should pass accessibility tests for Accordion with disableContentPadding", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionDefault disableContentPadding />);
-
-    await checkAccessibility(page);
-  });
-
-  test("should pass accessibility tests for Accordion size small", async ({
+  test("should pass accessibility tests for small size example", async ({
     mount,
     page,
   }) => {
@@ -537,7 +215,7 @@ test.describe("Accessibility tests for Accordion", () => {
     await checkAccessibility(page);
   });
 
-  test("should pass accessibility tests for Accordion with subTitle", async ({
+  test("should pass accessibility tests for example with subTitle", async ({
     mount,
     page,
   }) => {
@@ -546,7 +224,7 @@ test.describe("Accessibility tests for Accordion", () => {
     await checkAccessibility(page);
   });
 
-  test("should pass accessibility tests for Accordion with full borders", async ({
+  test("should pass accessibility tests for full border example", async ({
     mount,
     page,
   }) => {
@@ -555,88 +233,7 @@ test.describe("Accessibility tests for Accordion", () => {
     await checkAccessibility(page);
   });
 
-  test("should pass accessibility tests for Accordion with full borders expanded", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionDefault borders="full" expanded />);
-
-    await checkAccessibility(page);
-  });
-
-  test("should pass accessibility tests for Accordion with left aligned icon", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionDefault iconAlign="left" />);
-
-    await checkAccessibility(page);
-  });
-
-  test("should pass accessibility tests for Accordion with 500px width", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionDefault width="500px" />);
-
-    await checkAccessibility(page);
-  });
-
-  [
-    [0, 0],
-    [1, 1],
-    [2, 2],
-    [3, 3],
-    [4, 4],
-    [5, 5],
-    [6, 6],
-  ].forEach(([margin, padding]) => {
-    test(`should pass accessibility tests for Accordion with margin set to ${margin} and padding set to ${padding}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<AccordionDefault m={margin} p={padding} />);
-
-      await checkAccessibility(page);
-    });
-  });
-
-  [0, 1, 2, 3, 4, 5, 6].forEach((padding) => {
-    test(`should pass accessibility tests for Accordion with title padding set to ${padding}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <AccordionDefault
-          headerSpacing={{
-            p: padding,
-          }}
-        />,
-      );
-
-      await checkAccessibility(page);
-    });
-  });
-
-  test("should pass accessibility tests for Accordion with Box and different paddings", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionWithBoxAndDifferentPaddings />);
-
-    await checkAccessibility(page);
-  });
-
-  test("should pass accessibility tests for AccordionGroup", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionGroupDefault />);
-
-    await checkAccessibility(page);
-  });
-
-  test("should pass accessibility tests for AccordionGroupValidation", async ({
+  test("should pass accessibility tests for group validation example", async ({
     mount,
     page,
   }) => {
@@ -645,7 +242,7 @@ test.describe("Accessibility tests for Accordion", () => {
     await checkAccessibility(page);
   });
 
-  test("should pass accessibility tests for AccordionWithDefinitionList", async ({
+  test("should pass accessibility tests for example with Definition List", async ({
     mount,
     page,
   }) => {
@@ -654,37 +251,11 @@ test.describe("Accessibility tests for Accordion", () => {
     await checkAccessibility(page);
   });
 
-  test("should pass accessibility tests for Accordion when variant is subtle", async ({
+  test("should pass accessibility tests when variant is subtle", async ({
     mount,
     page,
   }) => {
     await mount(<AccordionDefault variant="subtle" />);
-
-    await checkAccessibility(page);
-  });
-
-  test("should pass accessibility tests for Accordion when title is a string", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<AccordionDefault title="title" />);
-
-    await checkAccessibility(page);
-  });
-
-  test("should pass accessibility tests for Accordion when title is a React node", async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <AccordionDefault
-        title={
-          <Typography variant="h4" backgroundColor="blue" color="yellow">
-            Title
-          </Typography>
-        }
-      />,
-    );
 
     await checkAccessibility(page);
   });

--- a/src/components/accordion/accordion.stories.tsx
+++ b/src/components/accordion/accordion.stories.tsx
@@ -64,18 +64,25 @@ export const WithComplexTitle: Story = () => {
 WithComplexTitle.storyName = "With Complex Title";
 
 export const WithDisableContentPadding: Story = () => {
+  const [accordionExpanded, setAccordionExpanded] = useState<boolean>(true);
+  const toggleAccordion = () => {
+    setAccordionExpanded(!accordionExpanded);
+  };
+
   return (
-    <Accordion disableContentPadding title="Heading">
+    <Accordion
+      disableContentPadding
+      title="Heading"
+      expanded={accordionExpanded}
+      onChange={toggleAccordion}
+    >
       <Box mt={2}>Content</Box>
       <Box>Content</Box>
       <Box>Content</Box>
     </Accordion>
   );
 };
-WithDisableContentPadding.storyName = "With Disabled Content Padding";
-WithDisableContentPadding.parameters = {
-  chromatic: { disableSnapshot: false },
-};
+WithDisableContentPadding.storyName = "Content Padding Disabled";
 
 export const Small: Story = () => {
   return (

--- a/src/components/accordion/accordion.test.tsx
+++ b/src/components/accordion/accordion.test.tsx
@@ -316,6 +316,12 @@ describe("Accordion", () => {
     );
   });
 
+  it("should not render `subtitle` when `variant` is 'subtle'", () => {
+    render(<Accordion variant="subtle" title="Title" subTitle="Subtitle" />);
+
+    expect(screen.queryByText("Subtitle")).not.toBeInTheDocument();
+  });
+
   // coverage - disableContentPadding is tested in Chromatic
   it("renders content without paddings if `disableCustomPadding` is applied", () => {
     render(<Accordion title="Title" disableContentPadding />);

--- a/src/components/accordion/components.test-pw.tsx
+++ b/src/components/accordion/components.test-pw.tsx
@@ -218,7 +218,7 @@ export const AccordionDefault = (props: Partial<AccordionProps>) => {
   );
 };
 
-export const AccordionWithBoxAndDifferentPaddings = () => {
+export const AccordionWithBoxAndCustomPaddings = () => {
   return (
     <Box>
       <Accordion


### PR DESCRIPTION
### Proposed behaviour

Our unit testing and regression testing frameworks need to be optimised. Use GitHub Copilot in VS Code to analyse the `*.test.tsx`, `*.pw.tsx`, and `*.stories.tsx` files to rapidly identify duplicate tests across the platforms, remove unnecessary code, flaky tests and speed up the carbon repo build time.

### Current behaviour

The Playwright test suite takes ~20 minutes to run. Some tests are flaky, requiring repeated reruns which adds additional time to the build. Historically, requirements around test coverage have resulted in tests being duplicated in the regression test suite that are already in unit test, resulting in a longer build time than is necessary. Accessibility tests exist for most components that would not detect an accessibility violation.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [x] Tested in provided StackBlitz sandbox/Storybook
- [x] Add new Playwright test coverage if required
- [x] Carbon implementation matches Design System/designs
- [x] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

Aim to move individual keystroke and prop test cases into Jest where possible if not covered already, move styling tests, presentation type (icon positions, button types etc) tests, and user interactions into Chromatic snapshot tests, leave convoluted test scenarios and a11y tests in Playwright. Assess coverage and remove unnecessary tests that add no value, particularly among the accessibility test cases. More details are contained in the associated tickets in Jira, including suggested successful prompts and guidelines. After implementing the changes:

1. Check Jest coverage is still at 100% after changes have been made (run `npm run test`).
2. Check the Playwright suite runs without error.
3. Ensure Chromatic differences are expected. The changes have not caused any unexpected changes in other components.
