### PR TITLE
fix(textbox, select, textarea): ensure width is maintained when a flex item

### DIFF
--- a/src/__internal__/form-field/form-field.style.ts
+++ b/src/__internal__/form-field/form-field.style.ts
@@ -5,6 +5,8 @@ import applyBaseTheme from "../../style/themes/apply-base-theme";
 const FormFieldStyle = styled.div.attrs(applyBaseTheme)`
   position: relative;
   margin-bottom: var(--fieldSpacing);
+  flex-grow: 1;
+
   & + & {
     margin-top: 16px;
   }

--- a/src/components/select/select.style.ts
+++ b/src/components/select/select.style.ts
@@ -16,6 +16,7 @@ export interface StyledSelectProps
 const StyledSelect = styled.div.attrs(applyBaseTheme)<StyledSelectProps>`
   ${({ hasTextCursor, disabled, readOnly, theme, transparent, isOpen }) => css`
     margin-bottom: var(--fieldSpacing);
+    flex-grow: 1;
     ${margin}
 
     position: relative;

--- a/src/components/select/simple-select/simple-select-test.stories.tsx
+++ b/src/components/select/simple-select/simple-select-test.stories.tsx
@@ -1010,3 +1010,25 @@ export const SimpleSelectWithAriaDescribedby = () => {
 
 SimpleSelectWithAriaDescribedby.storyName =
   "SimpleSelect with aria-describedby";
+
+export const InFlexContainer = () => {
+  const [value, setValue] = useState("Textbox");
+  const handleChange = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(target.value);
+  };
+  return (
+    <Box display="flex">
+      <Select
+        name="simple"
+        id="simple"
+        label="Color"
+        value={value}
+        onChange={handleChange}
+      >
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+      </Select>
+    </Box>
+  );
+};

--- a/src/components/textarea/textarea-test.stories.tsx
+++ b/src/components/textarea/textarea-test.stories.tsx
@@ -439,3 +439,15 @@ AutoFocusStory.parameters = {
   chromatic: { disableSnapshot: false },
   themeProvider: { chromatic: { theme: "sage" } },
 };
+
+export const InFlexContainer = () => {
+  const [value, setValue] = useState("Textbox");
+  const handleChange = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(target.value);
+  };
+  return (
+    <Box display="flex">
+      <Textarea label="Textarea" value={value} onChange={handleChange} />
+    </Box>
+  );
+};

--- a/src/components/textarea/textarea.style.ts
+++ b/src/components/textarea/textarea.style.ts
@@ -18,6 +18,8 @@ export interface StyledTextAreaProps extends Pick<TextareaProps, "minHeight"> {
 
 const StyledTextarea = styled.div.attrs(applyBaseTheme)<StyledTextAreaProps>`
   margin-bottom: var(--fieldSpacing);
+  flex-grow: 1;
+
   ${margin};
 
   ${StyledInput} {

--- a/src/components/textbox/textbox-test.stories.tsx
+++ b/src/components/textbox/textbox-test.stories.tsx
@@ -309,3 +309,23 @@ export const FormFieldRelativePosition = () => {
   );
 };
 FormFieldRelativePosition.storyName = "Form Field Relative Position";
+
+export const InFlexContainer = () => {
+  const [value, setValue] = useState("Textbox");
+  const handleChange = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(target.value);
+  };
+  return (
+    <>
+      In flexbox with one input:
+      <Box display="flex" mb={2}>
+        <Textbox label="Textbox" value={value} onChange={handleChange} />
+      </Box>
+      In flexbox with two inputs:
+      <Box display="flex" gap={2}>
+        <Textbox label="Textbox" value={value} onChange={handleChange} />
+        <Textbox label="Textbox" value={value} onChange={handleChange} m={0} />
+      </Box>
+    </>
+  );
+};

--- a/src/components/time/time.component.tsx
+++ b/src/components/time/time.component.tsx
@@ -313,7 +313,7 @@ const Time = React.forwardRef<TimeHandle, TimeProps>(
         {...filterStyledSystemMarginProps(rest)}
         {...tagComponent("time", rest)}
       >
-        <Box display="flex">
+        <Box display="flex" alignItems="end">
           <div>
             <StyledLabel
               aria-label={hrsAriaLabel}
@@ -346,6 +346,7 @@ const Time = React.forwardRef<TimeHandle, TimeProps>(
             justifyContent="center"
             mx={1}
             aria-hidden="true"
+            alignSelf="center"
           >
             <span>&nbsp;</span>
             <Typography isDisabled={disabled} variant="span" mb="-4px">


### PR DESCRIPTION
fix #7718

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Add `flex-grow: 1` to `Select`, `FormField` (Textbox) and `Textarea` outermost container to ensure they extend to maximum width available when rendered within a flexbox.

<img width="1204" height="207" alt="image" src="https://github.com/user-attachments/assets/6e0d6e07-6bb7-4555-8ff6-e6dad625ce51" />


### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

`Select`, `Textbox` and `Textarea` components default to minimum content width when they are flex items. 

<img width="272" height="128" alt="image" src="https://github.com/user-attachments/assets/52178fe9-4bc7-41bd-b1f0-f3cab95fbccd" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

See https://stackblitz.com/edit/parsium-carbon-starter-nglktc7h?file=src%2FApp.tsx for issue demo.
See new story `InFlexContainer` for fix in `Textbox`, `Textarea` and `Select`.
