### PR TITLE
feat(tabs): add support for data- tag props on next components

### DIFF
--- a/src/components/tabs/__next__/tabs.component.tsx
+++ b/src/components/tabs/__next__/tabs.component.tsx
@@ -30,13 +30,19 @@ import useLocale from "../../../hooks/__internal__/useLocale";
 import Icon from "../../icon";
 import { TabProvider } from "./tab.context";
 import usePrevious from "../../../hooks/__internal__/usePrevious";
+import tagComponent from "../../../__internal__/utils/helpers/tags";
 
-export const TabPanel = ({ children, id, tabId }: TabPanelProps) => {
+export const TabPanel = ({ children, id, tabId, ...rest }: TabPanelProps) => {
   const { activeTab } = useTabs();
 
   return (
     <TabProvider tabId={tabId} visible={tabId === activeTab}>
-      <StyledTabPanel id={id} role="tabpanel" aria-labelledby={tabId}>
+      <StyledTabPanel
+        id={id}
+        role="tabpanel"
+        aria-labelledby={tabId}
+        {...tagComponent("tab-panel", rest)}
+      >
         {children}
       </StyledTabPanel>
     </TabProvider>
@@ -54,6 +60,7 @@ export const Tab = ({
   rightSlot,
   warning = false,
   info = false,
+  ...rest
 }: TabProps) => {
   const locale = useLocale();
   const [internalError, setInternalError] = useState<boolean | string>(error);
@@ -212,6 +219,7 @@ export const Tab = ({
         type="button"
         tabIndex={activeTab === id ? 0 : -1}
         warning={internalWarning}
+        {...tagComponent("tab", rest)}
       >
         {typeof label === "string" ? (
           <span className="tab-title-content-wrapper">
@@ -232,7 +240,7 @@ export const Tab = ({
 };
 
 export const TabList = forwardRef<TabsHandle, TabListProps>(
-  ({ ariaLabel, children, onTabChange }: TabListProps, ref) => {
+  ({ ariaLabel, children, onTabChange, ...rest }: TabListProps, ref) => {
     const tabListRef = useRef<HTMLDivElement>(null);
     const {
       activeTab,
@@ -428,6 +436,7 @@ export const TabList = forwardRef<TabsHandle, TabListProps>(
             role="tablist"
             size={size}
             tabIndex={-1}
+            {...tagComponent("tab-list", rest)}
           >
             {children}
             <Spacer />
@@ -445,6 +454,7 @@ export const Tabs = ({
   orientation = "horizontal",
   selectedTabId,
   size = "medium",
+  ...rest
 }: TabsProps) => {
   return (
     <TabsProvider
@@ -453,7 +463,11 @@ export const Tabs = ({
       selectedTabId={selectedTabId}
       size={size}
     >
-      <StyledTabs id="tabs-container" orientation={orientation}>
+      <StyledTabs
+        id="tabs-container"
+        orientation={orientation}
+        {...tagComponent("tabs", rest)}
+      >
         {children}
       </StyledTabs>
     </TabsProvider>

--- a/src/components/tabs/__next__/tabs.test.tsx
+++ b/src/components/tabs/__next__/tabs.test.tsx
@@ -515,3 +515,47 @@ test("invokes the onTabChange handler the active tab changes", async () => {
   await user.click(tab1);
   expect(mockTabChangeFn).toHaveBeenCalledWith("tab-1");
 });
+
+test("applies the `data-element` and `data-role` props to expected elements", () => {
+  render(
+    <Tabs data-element="tabs-foo" data-role="tabs-bar">
+      <TabList
+        ariaLabel="Sample Tabs"
+        data-element="tablist-foo"
+        data-role="tablist-bar"
+      >
+        <Tab
+          data-element="tab-foo"
+          data-role="tab-bar"
+          id="tab-1"
+          controls="tab-panel-1"
+          label="Tab One"
+        />
+      </TabList>
+      <TabPanel
+        data-element="tabpanel-foo"
+        data-role="tabpanel-bar"
+        id="tab-panel-1"
+        tabId="tab-1"
+      >
+        <Typography>Content 1</Typography>
+      </TabPanel>
+    </Tabs>,
+  );
+  const tabs = screen.getByTestId("tabs-bar");
+  const tabsList = screen.getByRole("tablist");
+  const tab1 = screen.getByRole("tab", { name: "Tab One" });
+  const tabPanel1 = screen.getByRole("tabpanel");
+
+  expect(tabs).toHaveAttribute("data-component", "tabs");
+  expect(tabs).toHaveAttribute("data-element", "tabs-foo");
+  expect(tabsList).toHaveAttribute("data-component", "tab-list");
+  expect(tabsList).toHaveAttribute("data-element", "tablist-foo");
+  expect(tabsList).toHaveAttribute("data-role", "tablist-bar");
+  expect(tab1).toHaveAttribute("data-component", "tab");
+  expect(tab1).toHaveAttribute("data-element", "tab-foo");
+  expect(tab1).toHaveAttribute("data-role", "tab-bar");
+  expect(tabPanel1).toHaveAttribute("data-component", "tab-panel");
+  expect(tabPanel1).toHaveAttribute("data-element", "tabpanel-foo");
+  expect(tabPanel1).toHaveAttribute("data-role", "tabpanel-bar");
+});

--- a/src/components/tabs/__next__/tabs.types.ts
+++ b/src/components/tabs/__next__/tabs.types.ts
@@ -1,4 +1,5 @@
 import React, { Dispatch, SetStateAction } from "react";
+import { TagProps } from "../../../__internal__/utils/helpers/tags";
 
 export type TabValidationRecord = Record<string, string | boolean>;
 export type ValidationRecord = Record<string, TabValidationRecord>;
@@ -40,7 +41,7 @@ export interface TabsContextProps {
   setInfos: (childId: string, tabId: string, info: string | boolean) => void;
 }
 
-export interface TabPanelProps {
+export interface TabPanelProps extends TagProps {
   /** The content to be shown in the tab panel */
   children?: React.ReactNode;
   /** The ID of the tab panel */
@@ -49,7 +50,7 @@ export interface TabPanelProps {
   tabId: string;
 }
 
-export interface TabListProps {
+export interface TabListProps extends TagProps {
   /** The label read out when the tab list gains focus */
   ariaLabel: string;
   /** The tabs to be shown in the tab list */
@@ -58,7 +59,7 @@ export interface TabListProps {
   onTabChange?: (tabId: string) => void;
 }
 
-export interface TabProps {
+export interface TabProps extends TagProps {
   /** The tab panel that this tab controls */
   controls: string;
   /** The ID of the tab */
@@ -80,7 +81,7 @@ export interface TabProps {
   info?: boolean | string;
 }
 
-export interface TabsProps {
+export interface TabsProps extends TagProps {
   /** The tab list to be rendered within this set of tabs  */
   children?: React.ReactNode;
   /** The label associated with this set of tabs, for assistive technologies */


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Extend `TagProps` on all public facing `__next__` components in `Tabs` directory

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
No support for tag props on next version of Tabs

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
