### PR TITLE
feat(tabs): add translations for tabs status messages

### DIFF
--- a/src/locales/de-de.ts
+++ b/src/locales/de-de.ts
@@ -154,6 +154,11 @@ const deDE: Partial<Locale> = {
   pod: {
     undo: () => "Rückgängig",
   },
+  tabs: {
+    error: () => "enthält Fehler",
+    warning: () => "enthält Warnungen",
+    info: () => "enthält Informationen",
+  },
   textEditor: {
     boldAria: () => "Fett",
     cancelButton: () => "Abbrechen",

--- a/src/locales/es-es.ts
+++ b/src/locales/es-es.ts
@@ -161,6 +161,11 @@ const esES: Partial<Locale> = {
   pod: {
     undo: () => "Deshacer",
   },
+  tabs: {
+    error: () => "contiene errores",
+    warning: () => "contiene avisos",
+    info: () => "contiene información",
+  },
   textEditor: {
     boldAria: () => "Negrita",
     cancelButton: () => "Cancelar",

--- a/src/locales/fr-ca.ts
+++ b/src/locales/fr-ca.ts
@@ -163,6 +163,11 @@ const frCA: Partial<Locale> = {
   pod: {
     undo: () => "Annuler",
   },
+  tabs: {
+    error: () => "contient des erreurs",
+    warning: () => "contient des avertissements",
+    info: () => "contient des informations",
+  },
   textEditor: {
     boldAria: () => "Gras",
     cancelButton: () => "Annuler",

--- a/src/locales/fr-fr.ts
+++ b/src/locales/fr-fr.ts
@@ -163,6 +163,11 @@ const frFR: Partial<Locale> = {
   pod: {
     undo: () => "Annuler",
   },
+  tabs: {
+    error: () => "contient des erreurs",
+    warning: () => "contient des avertissements",
+    info: () => "contient des informations",
+  },
   textEditor: {
     boldAria: () => "Gras",
     cancelButton: () => "Annuler",

--- a/src/locales/pt-pt.ts
+++ b/src/locales/pt-pt.ts
@@ -167,6 +167,11 @@ const ptPT: Partial<Locale> = {
   pod: {
     undo: () => "Anular",
   },
+  tabs: {
+    error: () => "contém erros",
+    warning: () => "contém avisos",
+    info: () => "contém informações",
+  },
   textEditor: {
     boldAria: () => "Negrito",
     cancelButton: () => "Cancelar",


### PR DESCRIPTION
### Proposed behaviour

Add translations for tabs status messages.

### Current behaviour

Translation into English only for tab status messages.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
