### PR TITLE
chore(storybook): ensure node_modules and coverage are ignored for hmr

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -93,6 +93,11 @@ const config: StorybookConfig = {
           "~@sage": path.resolve(__dirname, "../node_modules/@sage/"),
         },
       },
+      server: {
+        watch: {
+          ignored: ["**/coverage/**", "**/node_modules/**"],
+        },
+      },
       build: {
         rollupOptions: {
           output: {


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Ensures test coverage and node_module file updates are not watched by storybook's vite dev server

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
vite dev sever is watching changes to coverage and node_modules

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
On master:
- `npm start`
-  then in new terminal window `npm test src/components/popover-container/popover-container.test.tsx`
-  storybook will refresh

Do the same on this branch and no refresh should happen

