### PR TITLE
build(deps): resolve node-tar vulnerability and set minimum npm version to 11.9 in package.json

### DIFF
--- a/.github/workflows/chromatic-push.yml
+++ b/.github/workflows/chromatic-push.yml
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ">=24.11.0 24"
-      - name: Update npm to 11.8
-        run: npm install -g npm@11.8
+      - name: Update npm to 11.9
+        run: npm install -g npm@11.9
       - run: npm ci
       - uses: chromaui/action@v1
         with:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -45,9 +45,8 @@ jobs:
         with:
           node-version: ">=24.11.0 24"
 
-      - name: Update npm to 11.8
-        run: npm install -g npm@11.8
-
+      - name: Update npm to 11.9
+        run: npm install -g npm@11.9
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ">=24.11.0 24"
-      - name: Update npm to 11.8
-        run: npm install -g npm@11.8
+      - name: Update npm to 11.9
+        run: npm install -g npm@11.9
 
       - run: npm ci
       - run: npx prettier --check './src/**/*.{js,jsx,ts,tsx}'
@@ -35,8 +35,8 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: npm
 
-      - name: Update npm to 11.8
-        run: npm install -g npm@11.8
+      - name: Update npm to 11.9
+        run: npm install -g npm@11.9
 
       - name: Install dependencies
         run: npm ci
@@ -89,8 +89,8 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: npm
 
-      - name: Update npm to 11.8
-        run: npm install -g npm@11.8
+      - name: Update npm to 11.9
+        run: npm install -g npm@11.9
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -33,8 +33,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Update npm to 11.8
-        run: npm install -g npm@11.8
+      - name: Update npm to 11.9
+        run: npm install -g npm@11.9
 
       - name: Install dependencies
         run: |
@@ -66,8 +66,8 @@ jobs:
         with:
           node-version: ">=24.11.0 24"
 
-      - name: Update npm to 11.8
-        run: npm install -g npm@11.8
+      - name: Update npm to 11.9
+        run: npm install -g npm@11.9
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/semantic-commit-lint.yml
+++ b/.github/workflows/semantic-commit-lint.yml
@@ -16,8 +16,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ">=24.11.0 24"
-      - name: Update npm to 11.8
-        run: npm install -g npm@11.8
+      - name: Update npm to 11.9
+        run: npm install -g npm@11.9
       - id: install_dependencies
         run: npm ci
       - id: lint_commits

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ">=24.11.0 24"
-      - name: Update npm to 11.8
-        run: npm install -g npm@11.8
+      - name: Update npm to 11.9
+        run: npm install -g npm@11.9
       - run: npm ci
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v3.0.1
@@ -57,8 +57,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ">=24.11.0 24"
-      - name: Update npm to 11.8
-        run: npm install -g npm@11.8
+      - name: Update npm to 11.9
+        run: npm install -g npm@11.9
       - run: npm ci
       - name: Generate metadata file
         run: npm run generate-metadata

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -13,8 +13,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: ">=24.11.0 24"
-      - name: Update npm to 11.8
-        run: npm install -g npm@11.8
+      - name: Update npm to 11.9
+        run: npm install -g npm@11.9
       - run: npm ci
       - run: npm run build-storybook:prod
       - uses: aws-actions/configure-aws-credentials@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -169,7 +169,7 @@
         "vite-plugin-static-copy": "^3.1.2"
       },
       "engines": {
-        "npm": ">=11.8.0"
+        "npm": ">=11.9.0"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.9.5"
@@ -8871,6 +8871,20 @@
         "acorn-walk": "^8.0.2"
       }
     },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "dev": true,
@@ -8941,6 +8955,8 @@
     },
     "node_modules/ajv-formats": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -8958,6 +8974,8 @@
     },
     "node_modules/ajv-keywords": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -11380,13 +11398,15 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.1",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
+      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
+        "tapable": "^2.3.0"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -11704,7 +11724,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT",
       "peer": true
@@ -13529,6 +13551,8 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "peer": true
@@ -16724,12 +16748,18 @@
       }
     },
     "node_modules/loader-runner": {
-      "version": "4.3.0",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/loader-utils": {
@@ -18732,9 +18762,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.8.0.tgz",
-      "integrity": "sha512-n19sJeW+RGKdkHo8SCc5xhSwkKhQUFfZaFzSc+EsYXLjSqIV0tl72aDYQVuzVvfrbysGwdaQsNLNy58J10EBSQ==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.9.0.tgz",
+      "integrity": "sha512-BBZoU926FCypj4b7V7ElinxsWcy4Kss88UG3ejFYmKyq7Uc5XnT34Me2nEhgCOaL5qY4HvGu5aI92C4OYd7NaA==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -18814,8 +18844,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.1.10",
-        "@npmcli/config": "^10.5.0",
+        "@npmcli/arborist": "^9.2.0",
+        "@npmcli/config": "^10.6.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -18828,7 +18858,7 @@
         "archy": "~1.0.0",
         "cacache": "^20.0.3",
         "chalk": "^5.6.2",
-        "ci-info": "^4.3.1",
+        "ci-info": "^4.4.0",
         "cli-columns": "^4.0.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
@@ -18840,11 +18870,11 @@
         "is-cidr": "^6.0.1",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.0.13",
-        "libnpmexec": "^10.1.12",
-        "libnpmfund": "^7.0.13",
+        "libnpmdiff": "^8.1.0",
+        "libnpmexec": "^10.2.0",
+        "libnpmfund": "^7.0.14",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.0.13",
+        "libnpmpack": "^9.1.0",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -18854,7 +18884,7 @@
         "minipass": "^7.1.1",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.1.0",
+        "node-gyp": "^12.2.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -18864,7 +18894,7 @@
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.0.4",
+        "pacote": "^21.1.0",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
@@ -18873,7 +18903,7 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.0",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.4",
+        "tar": "^7.5.7",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -18972,7 +19002,7 @@
       }
     },
     "node_modules/npm/node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19018,7 +19048,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.1.10",
+      "version": "9.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19065,7 +19095,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.5.0",
+      "version": "10.6.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19454,7 +19484,7 @@
       }
     },
     "node_modules/npm/node_modules/ci-info": {
-      "version": "4.3.1",
+      "version": "4.4.0",
       "dev": true,
       "funding": [
         {
@@ -19608,12 +19638,12 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "13.0.0",
+      "version": "13.0.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minimatch": "^10.1.1",
+        "minimatch": "^10.1.2",
         "minipass": "^7.1.2",
         "path-scurry": "^2.0.0"
       },
@@ -19757,12 +19787,12 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.1",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "5.0.1"
+        "cidr-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=20"
@@ -19839,12 +19869,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.0.13",
+      "version": "8.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.10",
+        "@npmcli/arborist": "^9.2.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -19858,12 +19888,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.1.12",
+      "version": "10.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.10",
+        "@npmcli/arborist": "^9.2.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -19881,12 +19911,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.13",
+      "version": "7.0.14",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.10"
+        "@npmcli/arborist": "^9.2.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -19906,12 +19936,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.0.13",
+      "version": "9.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.1.10",
+        "@npmcli/arborist": "^9.2.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -19981,7 +20011,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.4",
+      "version": "11.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -20012,12 +20042,12 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.1.1",
+      "version": "10.1.2",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
+        "@isaacs/brace-expansion": "^5.0.1"
       },
       "engines": {
         "node": "20 || >=22"
@@ -20048,13 +20078,13 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
+        "minipass-sized": "^2.0.0",
         "minizlib": "^3.0.1"
       },
       "engines": {
@@ -20113,24 +20143,12 @@
       }
     },
     "node_modules/npm/node_modules/minipass-sized": {
-      "version": "1.0.3",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
         "node": ">=8"
@@ -20173,7 +20191,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.1.0",
+      "version": "12.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20185,7 +20203,7 @@
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^7.5.2",
+        "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
         "which": "^6.0.0"
       },
@@ -20350,7 +20368,7 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.0.4",
+      "version": "21.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -20701,7 +20719,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.4",
+      "version": "7.5.7",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -26177,12 +26195,18 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.1",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/temp-dir": {
@@ -26250,7 +26274,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.3.14",
+      "version": "5.3.16",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.16.tgz",
+      "integrity": "sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -26285,6 +26311,8 @@
     },
     "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
       "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -26298,7 +26326,9 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-      "version": "4.3.2",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -26318,6 +26348,8 @@
     },
     "node_modules/terser-webpack-plugin/node_modules/supports-color": {
       "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -27735,7 +27767,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.4.2",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+      "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -27764,35 +27798,38 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.99.7",
+      "version": "5.105.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
+      "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
-        "@types/estree": "^1.0.6",
+        "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.14.0",
-        "browserslist": "^4.24.0",
+        "acorn": "^8.15.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.1",
-        "es-module-lexer": "^1.2.1",
+        "enhanced-resolve": "^5.19.0",
+        "es-module-lexer": "^2.0.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
         "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
+        "loader-runner": "^4.3.1",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.2",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.11",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.2.3"
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "terser-webpack-plugin": "^5.3.16",
+        "watchpack": "^2.5.1",
+        "webpack-sources": "^3.3.3"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -27811,7 +27848,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.2.3",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
+      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -27834,7 +27873,9 @@
       }
     },
     "node_modules/webpack/node_modules/schema-utils": {
-      "version": "4.3.2",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "esm"
   ],
   "engines": {
-    "npm": ">=11.8.0"
+    "npm": ">=11.9.0"
   },
   "scripts": {
     "setup": "npm ci && npm run prepare",


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Rebuilds lock file with npm 11.9 to resolve vulnerabilities with node-tar and webpack
Ensures minimum npm version used is 11.9 via package.json engines property
Ensures workflows use npm 11.9

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
minimum npm version is 11.8
vulnerabilities flagged with node-tar and webpack 
workflows use npm 11.8

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide


#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
