### PR TITLE
build: exclude .storybook and scripts directories from coverage report

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -31,6 +31,8 @@ const baseProjectConfig: Config = {
     "<rootDir>/node_modules",
     "<rootDir>/lib",
     "<rootDir>/esm",
+    "<rootDir>/.storybook",
+    "<rootDir>/scripts",
   ],
   transformIgnorePatterns: [
     `<rootDir>/node_modules/(?!(${esmOnlyPackages.join("|")}))`,


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Excludes .storybook and scripts directories from the coverage report

<img width="737" height="652" alt="Screenshot 2026-02-10 at 15 20 17" src="https://github.com/user-attachments/assets/2b3c530f-7ebf-415e-8d88-a117e4c5a743" />


### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, .storybook and scripts directories are included in the coverage report

<img width="731" height="722" alt="Screenshot 2026-02-10 at 15 41 24" src="https://github.com/user-attachments/assets/8cd20d19-2057-4f30-8d34-5fe3c4df322e" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
