### PR TITLE
feat(sort, flat-table-header): add additional aria support and general accessibility improvements

### DIFF
--- a/src/components/box/box.component.tsx
+++ b/src/components/box/box.component.tsx
@@ -81,6 +81,8 @@ export interface BoxProps
   opacity?: string | number;
   /** Set the container to be hidden from screen readers */
   "aria-hidden"?: "true" | "false";
+  /** Make the container an aria-live region */
+  "aria-live"?: "off" | "assertive" | "polite";
   /** @private @internal @ignore */
   "data-component"?: string;
   /** @private @internal @ignore */
@@ -113,6 +115,7 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
       width,
       hidden,
       "aria-hidden": ariaHidden,
+      "aria-live": ariaLive,
       ...rest
     }: BoxProps,
     ref,
@@ -158,6 +161,7 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
         $borderRadius={borderRadius}
         aria-hidden={ariaHidden}
         hidden={hidden}
+        aria-live={ariaLive}
         {...tagComponent(dataComponent, rest)}
         {...filterStyledSystemMarginProps(rest)}
         {...filterStyledSystemPaddingProps(rest)}

--- a/src/components/flat-table/flat-table-header/flat-table-header.component.tsx
+++ b/src/components/flat-table/flat-table-header/flat-table-header.component.tsx
@@ -8,6 +8,8 @@ import { useStrictFlatTableContext } from "../__internal__/strict-flat-table.con
 import guid from "../../../__internal__/utils/helpers/guid";
 import useTableCell from "../__internal__/use-table-cell";
 
+type SortType = "ascending" | "descending" | "none";
+
 export interface FlatTableHeaderProps extends PaddingProps, TagProps {
   /** Content alignment */
   align?: TableCellAlign;
@@ -49,6 +51,16 @@ export const FlatTableHeader = ({
     internalId.current,
   );
 
+  const getSortElementDirection = () => {
+    const sortElement = ref.current?.querySelector("[data-component='sort']");
+
+    if (!sortElement) {
+      return undefined;
+    }
+
+    return sortElement.getAttribute("data-sort-type") as SortType;
+  };
+
   return (
     <StyledFlatTableHeader
       ref={ref}
@@ -68,6 +80,7 @@ export const FlatTableHeader = ({
       data-element={dataElement || "flat-table-header"}
       data-role={dataRole}
       id={internalId.current}
+      aria-sort={getSortElementDirection()}
     >
       <div data-role="flat-table-header-content">{children}</div>
     </StyledFlatTableHeader>

--- a/src/components/flat-table/flat-table-header/flat-table-header.test.tsx
+++ b/src/components/flat-table/flat-table-header/flat-table-header.test.tsx
@@ -9,6 +9,7 @@ import FlatTable from "../flat-table.component";
 import FlatTableRow from "../flat-table-row";
 import FlatTableHead from "../flat-table-head/flat-table-head.component";
 import FlatTableBody from "../flat-table-body";
+import Sort from "../sort";
 
 test("logs error when not used within FlatTable", () => {
   const loggerSpy = jest.spyOn(Logger, "error").mockImplementation(() => {});
@@ -254,4 +255,55 @@ test("should render with the expected background-color when `alternativeBgColor`
     getAlternativeBackgroundColor("transparent-base"),
     { modifier: "&&&" },
   );
+});
+
+test("should set the `aria-sort` attribute to 'none' when the `Sort` component is a child and has no `sortType` set", () => {
+  render(
+    <FlatTable>
+      <FlatTableHead>
+        <FlatTableRow>
+          <FlatTableHeader>
+            <Sort>Column header</Sort>
+          </FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+    </FlatTable>,
+  );
+
+  const cell = screen.getByRole("columnheader");
+  expect(cell).toHaveAttribute("aria-sort", "none");
+});
+
+test("should set the `aria-sort` attribute to 'ascending' when the `Sort` component is a child and has `sortType` set to 'ascending'", () => {
+  render(
+    <FlatTable>
+      <FlatTableHead>
+        <FlatTableRow>
+          <FlatTableHeader>
+            <Sort sortType="ascending">Column header</Sort>
+          </FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+    </FlatTable>,
+  );
+
+  const cell = screen.getByRole("columnheader");
+  expect(cell).toHaveAttribute("aria-sort", "ascending");
+});
+
+test("should set the `aria-sort` attribute to 'descending' when the `Sort` component is a child and has `sortType` set to 'descending'", () => {
+  render(
+    <FlatTable>
+      <FlatTableHead>
+        <FlatTableRow>
+          <FlatTableHeader>
+            <Sort sortType="descending">Column header</Sort>
+          </FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+    </FlatTable>,
+  );
+
+  const cell = screen.getByRole("columnheader");
+  expect(cell).toHaveAttribute("aria-sort", "descending");
 });

--- a/src/components/flat-table/flat-table-test.stories.tsx
+++ b/src/components/flat-table/flat-table-test.stories.tsx
@@ -38,6 +38,7 @@ import SplitButton from "../../components/split-button";
 import MultiActionButton from "../../components/multi-action-button";
 import DateRange, { DateRangeChangeEvent } from "../date-range";
 import PopoverContainer from "../popover-container";
+import Typography from "../typography";
 
 export default {
   title: "Flat Table/Test",
@@ -1342,32 +1343,37 @@ export const ExtendedColumnSorting = (args: FlatTableProps) => {
   }, [data, sortBy, sortType]);
 
   return (
-    <FlatTable {...args} title="Sales Overview Table">
-      <FlatTableHead>
-        <FlatTableRow>
-          {headers.map(({ name, label, isActive }) => (
-            <FlatTableHeader key={name}>
-              <Sort
-                onClick={() => handleSortClick(name)}
-                {...(isActive && { sortType })}
-              >
-                {label}
-              </Sort>
-            </FlatTableHeader>
-          ))}
-        </FlatTableRow>
-      </FlatTableHead>
-
-      <FlatTableBody>
-        {sortedData.map((row) => (
-          <FlatTableRow key={row.id}>
-            {headers.map(({ name }) => (
-              <FlatTableCell key={name}>{row[name]}</FlatTableCell>
+    <>
+      <Typography as="div" role="status" aria-live="polite" screenReaderOnly>
+        {`Sort by ${sortBy} (${sortType})`}
+      </Typography>
+      <FlatTable {...args} title="Sales Overview Table">
+        <FlatTableHead>
+          <FlatTableRow>
+            {headers.map(({ name, label, isActive }) => (
+              <FlatTableHeader key={name}>
+                <Sort
+                  onClick={() => handleSortClick(name)}
+                  {...(isActive && { sortType })}
+                >
+                  {label}
+                </Sort>
+              </FlatTableHeader>
             ))}
           </FlatTableRow>
-        ))}
-      </FlatTableBody>
-    </FlatTable>
+        </FlatTableHead>
+
+        <FlatTableBody>
+          {sortedData.map((row) => (
+            <FlatTableRow key={row.id}>
+              {headers.map(({ name }) => (
+                <FlatTableCell key={name}>{row[name]}</FlatTableCell>
+              ))}
+            </FlatTableRow>
+          ))}
+        </FlatTableBody>
+      </FlatTable>
+    </>
   );
 };
 

--- a/src/components/flat-table/flat-table.stories.tsx
+++ b/src/components/flat-table/flat-table.stories.tsx
@@ -27,6 +27,7 @@ import {
   FlatTableRowHeaderProps,
   FlatTableProps,
 } from ".";
+import Typography from "../typography";
 
 type SortType = "ascending" | "descending";
 type SortValue = "client" | "total";
@@ -1450,25 +1451,30 @@ export const WithSortingHeaders: Story = {
     };
 
     return (
-      <FlatTable {...args} title="Table for sorting headers">
-        <FlatTableHead>
-          <FlatTableRow>
-            {headData.map(({ name, isActive }) => {
-              return (
-                <FlatTableHeader key={name}>
-                  <Sort
-                    onClick={() => handleClick(name)}
-                    {...(isActive && { sortType })}
-                  >
-                    {name}
-                  </Sort>
-                </FlatTableHeader>
-              );
-            })}
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>{renderSortedData(sortValue)}</FlatTableBody>
-      </FlatTable>
+      <>
+        <Typography as="div" role="status" aria-live="polite" screenReaderOnly>
+          {`Sort by ${sortValue} (${sortType})`}
+        </Typography>
+        <FlatTable {...args} title="Table for sorting headers">
+          <FlatTableHead>
+            <FlatTableRow>
+              {headData.map(({ name, isActive }) => {
+                return (
+                  <FlatTableHeader key={name}>
+                    <Sort
+                      onClick={() => handleClick(name)}
+                      {...(isActive && { sortType })}
+                    >
+                      {name}
+                    </Sort>
+                  </FlatTableHeader>
+                );
+              })}
+            </FlatTableRow>
+          </FlatTableHead>
+          <FlatTableBody>{renderSortedData(sortValue)}</FlatTableBody>
+        </FlatTable>
+      </>
     );
   },
   name: "With Sorting Headers",
@@ -1579,29 +1585,34 @@ export const WithSortingHeadersAndCustomAccessibleName: Story = {
     };
 
     return (
-      <FlatTable
-        {...args}
-        title="Table for sorting headers with custom accessible name"
-      >
-        <FlatTableHead>
-          <FlatTableRow>
-            {headData.map(({ name, isActive }) => {
-              return (
-                <FlatTableHeader key={name}>
-                  <Sort
-                    accessibleName={`Sort ${name}s in an ${sortType} order`}
-                    onClick={() => handleClick(name)}
-                    {...(isActive && { sortType })}
-                  >
-                    {name}
-                  </Sort>
-                </FlatTableHeader>
-              );
-            })}
-          </FlatTableRow>
-        </FlatTableHead>
-        <FlatTableBody>{renderSortedData(sortValue)}</FlatTableBody>
-      </FlatTable>
+      <>
+        <Typography as="div" role="status" aria-live="polite" screenReaderOnly>
+          {`Sort by ${sortValue} (${sortType})`}
+        </Typography>
+        <FlatTable
+          {...args}
+          title="Table for sorting headers with custom accessible name"
+        >
+          <FlatTableHead>
+            <FlatTableRow>
+              {headData.map(({ name, isActive }) => {
+                return (
+                  <FlatTableHeader key={name}>
+                    <Sort
+                      accessibleName={`Sort ${name}s in an ${sortType} order`}
+                      onClick={() => handleClick(name)}
+                      {...(isActive && { sortType })}
+                    >
+                      {name}
+                    </Sort>
+                  </FlatTableHeader>
+                );
+              })}
+            </FlatTableRow>
+          </FlatTableHead>
+          <FlatTableBody>{renderSortedData(sortValue)}</FlatTableBody>
+        </FlatTable>
+      </>
     );
   },
   name: "With Sorting Headers and custom accessible name",

--- a/src/components/flat-table/sort/sort.test.tsx
+++ b/src/components/flat-table/sort/sort.test.tsx
@@ -9,6 +9,7 @@ import FlatTable, { FlatTableProps } from "../flat-table.component";
 import FlatTableHead from "../flat-table-head";
 import FlatTableRow from "../flat-table-row";
 import FlatTableHeader from "../flat-table-header";
+import I18nProvider from "../../i18n-provider";
 
 test("logs error when not within FlatTable", () => {
   const loggerSpy = jest.spyOn(Logger, "error").mockImplementation(() => {});
@@ -38,6 +39,76 @@ test("should not render Icon if `sortType` does not exist", () => {
   );
 
   expect(screen.queryByTestId("icon")).not.toBeInTheDocument();
+});
+
+test("should render with the expected `aria-roledescription` attribute", () => {
+  render(
+    <FlatTable>
+      <FlatTableHead>
+        <FlatTableRow>
+          <FlatTableHeader>
+            <Sort>Name</Sort>
+          </FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+    </FlatTable>,
+  );
+
+  expect(screen.getByRole("button")).toHaveAttribute(
+    "aria-roledescription",
+    "Sortable column header",
+  );
+});
+
+test("should render with the overridden `aria-roledescription` attribute", () => {
+  render(
+    <FlatTable>
+      <FlatTableHead>
+        <FlatTableRow>
+          <FlatTableHeader>
+            <Sort aria-roledescription="Custom sortable column header">
+              Name
+            </Sort>
+          </FlatTableHeader>
+        </FlatTableRow>
+      </FlatTableHead>
+    </FlatTable>,
+  );
+
+  expect(screen.getByRole("button")).toHaveAttribute(
+    "aria-roledescription",
+    "Custom sortable column header",
+  );
+});
+
+test("should render with the overridden `aria-describedby` and `aria-roledescription` attribute via the I18nProvider", () => {
+  render(
+    <I18nProvider
+      locale={{
+        sort: {
+          accessibleName: () => "foo",
+          ariaRoleDescription: () => "Custom sortable column header",
+        },
+      }}
+    >
+      <FlatTable>
+        <FlatTableHead>
+          <FlatTableRow>
+            <FlatTableHeader>
+              <Sort aria-roledescription="Custom sortable column header">
+                Name
+              </Sort>
+            </FlatTableHeader>
+          </FlatTableRow>
+        </FlatTableHead>
+      </FlatTable>
+    </I18nProvider>,
+  );
+
+  expect(screen.getByRole("button")).toHaveAttribute(
+    "aria-roledescription",
+    "Custom sortable column header",
+  );
 });
 
 test("should render 'sort_up' Icon if `sortType` is 'ascending'", () => {
@@ -72,7 +143,8 @@ test("should render 'sort_down' Icon if `sortType` is 'descending'", () => {
   expect(screen.getByTestId("icon")).toHaveAttribute("type", "sort_down");
 });
 
-test("should render the correct accessible name when the `accessibleName` prop is passed", () => {
+test("should log a deprecation warning when the `accessibleName` prop is passed", () => {
+  const loggerSpy = jest.spyOn(Logger, "deprecate");
   const customAccessibleName =
     "Sort all accountants below in an ascending order.";
   render(
@@ -89,79 +161,11 @@ test("should render the correct accessible name when the `accessibleName` prop i
     </FlatTable>,
   );
 
-  expect(screen.getByRole("button")).toHaveAccessibleName(customAccessibleName);
-});
-
-test("should render a default accessible name when a child and the `sortType` prop is passed", () => {
-  render(
-    <FlatTable>
-      <FlatTableHead>
-        <FlatTableRow>
-          <FlatTableHeader>
-            <Sort sortType="ascending">Name</Sort>
-          </FlatTableHeader>
-        </FlatTableRow>
-      </FlatTableHead>
-    </FlatTable>,
+  expect(loggerSpy).toHaveBeenCalledWith(
+    "The `accessibleName` prop has been deprecated in favour of using `aria-live` regions. Please use an `aria-live` region to announce changes in sort order to assistive technologies.",
   );
 
-  expect(screen.getByRole("button")).toHaveAccessibleName(
-    "Sort all Name in an ascending order.",
-  );
-});
-
-test("should render a default accessible name when just a child is passed", () => {
-  render(
-    <FlatTable>
-      <FlatTableHead>
-        <FlatTableRow>
-          <FlatTableHeader>
-            <Sort>Name</Sort>
-          </FlatTableHeader>
-        </FlatTableRow>
-      </FlatTableHead>
-    </FlatTable>,
-  );
-
-  expect(screen.getByRole("button")).toHaveAccessibleName(
-    "Sort all Name in an ascending or descending order.",
-  );
-});
-
-test("should render a default accessible name when just the `sortType` prop is passed", () => {
-  render(
-    <FlatTable>
-      <FlatTableHead>
-        <FlatTableRow>
-          <FlatTableHeader>
-            <Sort sortType="ascending" />
-          </FlatTableHeader>
-        </FlatTableRow>
-      </FlatTableHead>
-    </FlatTable>,
-  );
-
-  expect(screen.getByRole("button")).toHaveAccessibleName(
-    "Sort all contents in an ascending order.",
-  );
-});
-
-test("should render a default accessible name when neither a child or the `sortType` prop is passed", () => {
-  render(
-    <FlatTable>
-      <FlatTableHead>
-        <FlatTableRow>
-          <FlatTableHeader>
-            <Sort />
-          </FlatTableHeader>
-        </FlatTableRow>
-      </FlatTableHead>
-    </FlatTable>,
-  );
-
-  expect(screen.getByRole("button")).toHaveAccessibleName(
-    "Sort all contents in an ascending or descending order.",
-  );
+  loggerSpy.mockRestore();
 });
 
 test("should call `onClick` callback when user clicks on the element and prop is passed", async () => {

--- a/src/components/typography/typography.component.tsx
+++ b/src/components/typography/typography.component.tsx
@@ -85,6 +85,10 @@ export interface TypographyProps extends SpaceProps, TagProps {
    * Override the default color of the rendered element to match disabled styling
    * */
   isDisabled?: boolean;
+  /** Make the element an aria-live region */
+  "aria-live"?: "off" | "assertive" | "polite";
+  /** Set the role of the element when it is a live region */
+  role?: "status" | "alert";
   /** @private @ignore Set whether the component should be recognised by assistive technologies */
   "aria-hidden"?: "true" | "false";
   /**
@@ -138,6 +142,8 @@ export const Typography = ({
   children,
   screenReaderOnly,
   isDisabled,
+  "aria-live": ariaLive,
+  role,
   "aria-hidden": ariaHidden,
   className,
   ...rest
@@ -168,6 +174,8 @@ export const Typography = ({
       isDisabled={isDisabled}
       aria-hidden={ariaHidden}
       className={className}
+      role={role}
+      aria-live={ariaLive}
       {...tagComponent(dataComponent, rest)}
       {...filterStyledSystemMarginProps(rest)}
       {...filterStyledSystemPaddingProps(rest)}

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -235,6 +235,7 @@ const enGB: Locale = {
           ? ` in an ${sortType} order.`
           : " in an ascending or descending order."
       }`,
+    ariaRoleDescription: () => "Sortable column header",
   },
   splitButton: {
     ariaLabel: () => "Show more",

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -192,10 +192,16 @@ interface Locale {
     };
   };
   sort: {
-    accessibleName: (
+    /**
+     * @deprecated The `sort.accessibleName` locale string is deprecated in favour of using `aria-live` regions.
+     * Use an `aria-live` region to announce changes in sort order to assistive technologies.
+     */
+    accessibleName?: (
       sortContent?: string,
       sortType?: "ascending" | "descending",
     ) => string;
+    /* TODO make ariaRoleDescription required as part of FE-7599 */
+    ariaRoleDescription?: () => string;
   };
   splitButton: {
     ariaLabel: () => string;


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
**Sort**:
- Replaces `Typography` component with a `display: none` `span`.
- Replaces `aria-labelledby` with `aria-describedby`.
- Adds `aria-roledescription` and translation override support

**FlatTableHeader**:
- Adds `aria-sort` and computes value based on state of `Sort` rendered within it.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Typography component used
`aria-labelledby` set on `Sort`
No `aria-roledescription` attribute on `Sort`
No `aria-sort` on `FlatTableHeader`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
