### PR TITLE
test(message): refine testing suite

### DIFF
--- a/src/components/message/components.test-pw.tsx
+++ b/src/components/message/components.test-pw.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState } from "react";
 import Button from "../button";
 import Message, { MessageProps } from "./message.component";
 
@@ -14,27 +14,4 @@ const MessageComponent = (props: MessageProps) => {
   );
 };
 
-const MessageComponentWithRef = (props: MessageProps) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const messageRef: React.Ref<HTMLDivElement> = useRef(null);
-
-  useEffect(() => {
-    if (isOpen) messageRef.current?.focus();
-  });
-
-  return (
-    <div>
-      {!isOpen && <Button onClick={() => setIsOpen(true)}>Open Message</Button>}
-      <Message
-        open={isOpen}
-        onDismiss={() => setIsOpen(false)}
-        ref={messageRef}
-        {...props}
-      >
-        Some custom message
-      </Message>
-    </div>
-  );
-};
-
-export { MessageComponent, MessageComponentWithRef };
+export default MessageComponent;

--- a/src/components/message/message-test.stories.tsx
+++ b/src/components/message/message-test.stories.tsx
@@ -49,7 +49,7 @@ export const WithNoTitle: Story = {
   },
   parameters: {
     themeProvider: { chromatic: { theme: "sage" } },
-    chromatic: { disableSnapshot: false },
+    chromatic: { disableSnapshot: true },
   },
 };
 
@@ -73,7 +73,7 @@ export const WithNoCloseIcon: Story = {
   },
   parameters: {
     themeProvider: { chromatic: { theme: "sage" } },
-    chromatic: { disableSnapshot: false },
+    chromatic: { disableSnapshot: true },
   },
 };
 
@@ -91,7 +91,7 @@ export const WithLongTextWrapping: Story = {
   },
   parameters: {
     themeProvider: { chromatic: { theme: "sage" } },
-    chromatic: { disableSnapshot: false },
+    chromatic: { disableSnapshot: true },
   },
 };
 
@@ -116,5 +116,15 @@ export const WithCustomContent: Story = {
   args: {
     title: "Custom Content",
     width: "400px",
+  },
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
+    chromatic: { disableSnapshot: false },
+  },
+  play: async ({ canvasElement }) => {
+    const closeButton = canvasElement.querySelector<HTMLButtonElement>(
+      'button[data-element="close"]',
+    );
+    closeButton?.focus();
   },
 };

--- a/src/components/message/message.pw.tsx
+++ b/src/components/message/message.pw.tsx
@@ -1,133 +1,14 @@
 import React from "react";
-import { test, expect } from "../../../playwright/helpers/base-test";
-import {
-  MessageComponent,
-  MessageComponentWithRef,
-} from "./components.test-pw";
-import Message, { MessageProps } from ".";
+import { test } from "../../../playwright/helpers/base-test";
+import MessageComponent from "./components.test-pw";
+import { MessageProps } from ".";
 import { checkAccessibility } from "../../../playwright/support/helper";
-
-import messagePreview from "../../../playwright/components/message";
 
 import { CHARACTERS } from "../../../playwright/support/constants";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
-test.describe("Tests for Message component properties", () => {
-  testData.forEach((children) => {
-    test(`should check ${children} as children for Message component`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<Message>{children}</Message>);
-
-      await expect(page.getByTestId("message-content")).toHaveText(children);
-    });
-  });
-
-  testData.forEach((id) => {
-    test(`should check ${id} as id for Message component`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<MessageComponent id={id} />);
-
-      await expect(messagePreview(page)).toHaveId(id);
-    });
-  });
-
-  test("should check when open is true for Message component", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<MessageComponent open />);
-    await expect(messagePreview(page)).toBeVisible();
-  });
-
-  test("should check when open is false for Message component", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<MessageComponent open={false} />);
-    await expect(messagePreview(page)).toBeHidden();
-  });
-
-  test(`should focus component when open is true and component has a ref`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<MessageComponentWithRef />);
-
-    await page.getByRole("button").click();
-    await expect(messagePreview(page)).toBeFocused();
-  });
-
-  testData.forEach((title) => {
-    test(`should check ${title} as title for Message component`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<MessageComponent title={title} />);
-      await expect(page.getByTestId("message-content")).toContainText(title);
-    });
-  });
-
-  test("should check showCloseIcon when it's true for Message component", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<MessageComponent showCloseIcon />);
-    await expect(page.getByRole("button", { name: "Close" })).toBeVisible();
-  });
-
-  test("should check showCloseIcon when it's false for Message component", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<MessageComponent showCloseIcon={false} />);
-    await expect(page.getByRole("button", { name: "Close" })).toBeHidden();
-  });
-
-  testData.forEach((ariaLabel) => {
-    test(`should check closeButtonAriaLabel as ${ariaLabel} for Message component`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<MessageComponent closeButtonAriaLabel={ariaLabel} />);
-
-      await expect(page.getByRole("button")).toHaveAccessibleName(ariaLabel);
-    });
-  });
-
-  test("should call onDismiss callback when a click event is triggered", async ({
-    mount,
-    page,
-  }) => {
-    let callbackCount = 0;
-    await mount(
-      <MessageComponent
-        onDismiss={() => {
-          callbackCount += 1;
-        }}
-      />,
-    );
-    await page.getByRole("button", { name: "Close" }).click();
-    expect(callbackCount).toBe(1);
-  });
-
-  test("should focus icon button when open is true for Message component and tab key is pressed", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<MessageComponentWithRef />);
-    await page.getByRole("button").click();
-    await expect(messagePreview(page)).toBeFocused();
-    await page.keyboard.press("Tab");
-    await expect(page.getByRole("button", { name: "Close" })).toBeFocused();
-  });
-});
-
-test.describe("Accessibility tests for Message component", () => {
+test.describe("Accessibility tests", () => {
   (
     [
       "error",
@@ -144,20 +25,14 @@ test.describe("Accessibility tests for Message component", () => {
       "callout-subtle",
     ] as MessageProps["variant"][]
   ).forEach((variant) => {
-    test(`should check ${variant} as variant for accessibility tests`, async ({
-      mount,
-      page,
-    }) => {
+    test(`should check ${variant} as variant`, async ({ mount, page }) => {
       await mount(<MessageComponent variant={variant} />);
       await checkAccessibility(page);
     });
   });
 
   testData.forEach((id) => {
-    test(`should check ${id} as id for accessibility tests`, async ({
-      mount,
-      page,
-    }) => {
+    test(`should check ${id} as id`, async ({ mount, page }) => {
       await mount(<MessageComponent id={id} />);
 
       await checkAccessibility(page);
@@ -165,17 +40,14 @@ test.describe("Accessibility tests for Message component", () => {
   });
 
   testData.forEach((title) => {
-    test(`should check ${title} as title for accessibility tests`, async ({
-      mount,
-      page,
-    }) => {
+    test(`should check ${title} as title`, async ({ mount, page }) => {
       await mount(<MessageComponent title={title} />);
       await checkAccessibility(page);
     });
   });
 
   [true, false].forEach((boolVal) => {
-    test(`should check ${boolVal} for transparent background for accessibility tests`, async ({
+    test(`should check ${boolVal} for transparent background`, async ({
       mount,
       page,
     }) => {
@@ -185,7 +57,7 @@ test.describe("Accessibility tests for Message component", () => {
   });
 
   [true, false].forEach((boolVal) => {
-    test(`should check showCloseIcon when it's ${boolVal} for accessibility tests`, async ({
+    test(`should check showCloseIcon when it's ${boolVal}`, async ({
       mount,
       page,
     }) => {
@@ -195,7 +67,7 @@ test.describe("Accessibility tests for Message component", () => {
   });
 
   testData.forEach((ariaLabel) => {
-    test(`should check closeButtonAriaLabel as ${ariaLabel} for accessibility tests`, async ({
+    test(`should check closeButtonAriaLabel as ${ariaLabel}`, async ({
       mount,
       page,
     }) => {

--- a/src/components/message/message.stories.tsx
+++ b/src/components/message/message.stories.tsx
@@ -13,6 +13,7 @@ const meta: Meta<typeof Message> = {
   title: "Message",
   component: Message,
   parameters: {
+    chromatic: { disableSnapshot: true },
     themeProvider: { chromatic: { theme: "sage" } },
   },
   argTypes: {
@@ -96,6 +97,9 @@ export const Variant: Story = {
   args: {
     mb: 2,
   },
+  parameters: {
+    chromatic: { disableSnapshot: false },
+  },
 };
 
 export const SubtleVariant: Story = {
@@ -149,6 +153,9 @@ export const SubtleVariant: Story = {
   args: {
     mb: 2,
   },
+  parameters: {
+    chromatic: { disableSnapshot: false },
+  },
 };
 
 export const SizeLarge: Story = {
@@ -178,9 +185,6 @@ export const ShowCloseIcon: Story = () => {
   );
 };
 ShowCloseIcon.storyName = "Show Close Icon";
-ShowCloseIcon.parameters = {
-  chromatic: { disableSnapshot: true },
-};
 
 export const Transparent: Story = () => {
   const [isOpen, setIsOpen] = useState(true);
@@ -206,6 +210,3 @@ export const Transparent: Story = () => {
   );
 };
 Transparent.storyName = "Transparent";
-Transparent.parameters = {
-  chromatic: { disableSnapshot: true },
-};


### PR DESCRIPTION
### Proposed behaviour
This PR aims to eliminate redundant Playwright tests in the Message component, keeping only accessibility tests in Playwright.
<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour
A number of tests are present in multiple test suites, and certain flaky tests may cause failures or substantially increase execution time.
<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context
This should significantly reduce the amount of time taken for Playwright test to run in the Message component without losing any coverage in Jest.
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
Ensure the Playwright tests pass and Chromatic snapshots are correct.
<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
