### PR TITLE
feat(tabs): add es-ES status translations

### DIFF
--- a/src/locales/es-es.ts
+++ b/src/locales/es-es.ts
@@ -161,6 +161,11 @@ const esES: Partial<Locale> = {
   pod: {
     undo: () => "Deshacer",
   },
+  tabs: {
+    error: (tabTitle) => `Hay errores en la pestaña ${tabTitle}`,
+    info: (tabTitle) => `Hay información relevante en la pestaña ${tabTitle}`,
+    warning: (tabTitle) => `Hay avisos en la pestaña ${tabTitle}`,
+  },
   textEditor: {
     boldAria: () => "Negrita",
     cancelButton: () => "Cancelar",


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Adds status translations for the `es-ES` locale

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, there are status translations for every locale apart from `es-ES`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
