### PR TITLE
docs(message): amend advice on programmatic focus and aria-live regions

### DIFF
--- a/src/components/message/message.mdx
+++ b/src/components/message/message.mdx
@@ -37,12 +37,16 @@ To change the `aria-label` of the close button, you can use the `closeButtonAria
 
 <Canvas of={MessageStories.WithCloseButton} />
 
-### Programmatic Focus
+### Programmatic Focus and Aria-Live Regions
 
-When rendering a `Message`, we recommend ensuring focus is managed appropriately to provide the best experience for users.
-This can be done by programmatically moving focus to the `Message` component when it appears to ensure users are aware of the newly rendered content and that is announced by screen readers.
+Programmatic focus should only be used for "error" messages to ensure users are immediately aware of critical issues.
+This can be done by programmatically moving focus to the `Message` component when an error appears to ensure users are aware of the newly rendered content and that it is announced by screen readers.
 
 **Note:** The `Message` component will not render with a focus outline when focused programmatically, this is done intentionally as the container is not meant to be interacted with directly.
+
+For non-error messages, we recommend using aria-live regions to announce messages to screen reader users. Aria-live regions should be rendered to the page on load and remain present in the DOM.
+Place messages within the aria-live region to ensure they are announced automatically without requiring focus management.
+This approach works well for success, warning, info, and other non-critical message variants that should be announced but do not require immediate focus.
 
 <Canvas of={MessageStories.ProgrammaticFocus} />
 

--- a/src/components/message/message.stories.tsx
+++ b/src/components/message/message.stories.tsx
@@ -57,6 +57,7 @@ export const ProgrammaticFocus: Story = () => {
         open={isOpen}
         ref={messageRef}
         onDismiss={() => setIsOpen(false)}
+        variant="error"
       >
         Some custom message
       </Message>


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Updates our guidance on the `Message` components documentation to clarify when programmatic focus should be used & add some guidance on the usage of aria-live regions to announce non-error messages.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Updates our guidance on the `Message` components documentation which provides some information on the usage of programmatic focus, but it includes a non-error message in the code example which is incorrect. There is also no guidance on the usage of aria-live regions.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
