### PR TITLE
feat(box): add support for aria-atomic prop

### DIFF
--- a/skills/carbon-react/components/box.md
+++ b/skills/carbon-react/components/box.md
@@ -104,6 +104,7 @@ description: Carbon Box component props and usage examples.
 | data-component | string \| undefined | No |  |  |  |
 | data-element | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
 | data-role | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
+| aria-atomic | "true" \| "false" \| undefined | No |  | Indicates whether AT will announce all, or only parts of, the changed region |  |
 | aria-hidden | "true" \| "false" \| undefined | No |  | Set the container to be hidden from screen readers |  |
 | aria-live | "off" \| "assertive" \| "polite" \| undefined | No |  | Make the container an aria-live region |  |
 

--- a/skills/carbon-react/components/dismissible-box.md
+++ b/skills/carbon-react/components/dismissible-box.md
@@ -106,6 +106,7 @@ description: Carbon DismissibleBox component props and usage examples.
 | data-component | string \| undefined | No |  |  |  |
 | data-element | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
 | data-role | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
+| aria-atomic | "true" \| "false" \| undefined | No |  | Indicates whether AT will announce all, or only parts of, the changed region |  |
 | aria-hidden | "true" \| "false" \| undefined | No |  | Set the container to be hidden from screen readers |  |
 | aria-live | "off" \| "assertive" \| "polite" \| undefined | No |  | Make the container an aria-live region |  |
 

--- a/skills/carbon-react/components/flex-tile-cell.md
+++ b/skills/carbon-react/components/flex-tile-cell.md
@@ -104,6 +104,7 @@ description: Carbon FlexTileCell component props and usage examples.
 | data-component | string \| undefined | No |  |  |  |
 | data-element | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
 | data-role | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
+| aria-atomic | "true" \| "false" \| undefined | No |  | Indicates whether AT will announce all, or only parts of, the changed region |  |
 | aria-hidden | "true" \| "false" \| undefined | No |  | Set the container to be hidden from screen readers |  |
 | aria-live | "off" \| "assertive" \| "polite" \| undefined | No |  | Make the container an aria-live region |  |
 

--- a/src/components/box/box.component.tsx
+++ b/src/components/box/box.component.tsx
@@ -87,6 +87,8 @@ export interface BoxProps
   "data-component"?: string;
   /** @private @internal @ignore */
   tabIndex?: number;
+  /** Indicates whether AT will announce all, or only parts of, the changed region */
+  "aria-atomic"?: "true" | "false";
 }
 
 export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
@@ -116,6 +118,7 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
       hidden,
       "aria-hidden": ariaHidden,
       "aria-live": ariaLive,
+      "aria-atomic": ariaAtomic,
       ...rest
     }: BoxProps,
     ref,
@@ -162,6 +165,7 @@ export const Box = React.forwardRef<HTMLDivElement, BoxProps>(
         aria-hidden={ariaHidden}
         hidden={hidden}
         aria-live={ariaLive}
+        aria-atomic={ariaAtomic}
         {...tagComponent(dataComponent, rest)}
         {...filterStyledSystemMarginProps(rest)}
         {...filterStyledSystemPaddingProps(rest)}

--- a/src/components/box/box.test.tsx
+++ b/src/components/box/box.test.tsx
@@ -144,3 +144,81 @@ it("applies the correct styling from the cssProps, when the width and height are
     height: "50%",
   });
 });
+
+describe("ARIA attributes", () => {
+  describe("aria-hidden", () => {
+    test("visible element renders with the 'aria-hidden' attribute and correct value when 'true' is passed", () => {
+      render(<Box aria-hidden="true" data-role="box" />);
+
+      const box = screen.getByTestId("box");
+      expect(box).toHaveAttribute("aria-hidden", "true");
+    });
+
+    test("visible element renders with the 'aria-hidden' attribute and correct value when 'false' is passed", () => {
+      render(<Box aria-hidden="false" data-role="box" />);
+
+      const box = screen.getByTestId("box");
+      expect(box).toHaveAttribute("aria-hidden", "false");
+    });
+
+    test("visible element renders without the 'aria-hidden' attribute if not passed", () => {
+      render(<Box data-role="box" />);
+
+      const box = screen.getByTestId("box");
+      expect(box).not.toHaveAttribute("aria-hidden");
+    });
+  });
+
+  describe("aria-live", () => {
+    test("visible element renders with the 'aria-live' attribute and correct value when 'off' is passed", () => {
+      render(<Box aria-live="off" data-role="box" />);
+
+      const box = screen.getByTestId("box");
+      expect(box).toHaveAttribute("aria-live", "off");
+    });
+
+    test("visible element renders with the 'aria-live' attribute and correct value when 'assertive' is passed", () => {
+      render(<Box aria-live="assertive" data-role="box" />);
+
+      const box = screen.getByTestId("box");
+      expect(box).toHaveAttribute("aria-live", "assertive");
+    });
+
+    test("visible element renders with the 'aria-live' attribute and correct value when 'polite' is passed", () => {
+      render(<Box aria-live="polite" data-role="box" />);
+
+      const box = screen.getByTestId("box");
+      expect(box).toHaveAttribute("aria-live", "polite");
+    });
+
+    test("visible element renders without the 'aria-live' attribute if not passed", () => {
+      render(<Box data-role="box" />);
+
+      const box = screen.getByTestId("box");
+      expect(box).not.toHaveAttribute("aria-live");
+    });
+  });
+
+  describe("aria-atomic", () => {
+    test("visible element renders with the 'aria-atomic' attribute and correct value when 'true' is passed", () => {
+      render(<Box aria-atomic="true" data-role="box" />);
+
+      const box = screen.getByTestId("box");
+      expect(box).toHaveAttribute("aria-atomic", "true");
+    });
+
+    test("visible element renders with the 'aria-atomic' attribute and correct value when 'false' is passed", () => {
+      render(<Box aria-atomic="false" data-role="box" />);
+
+      const box = screen.getByTestId("box");
+      expect(box).toHaveAttribute("aria-atomic", "false");
+    });
+
+    test("visible element renders without the 'aria-atomic' attribute if not passed", () => {
+      render(<Box data-role="box" />);
+
+      const box = screen.getByTestId("box");
+      expect(box).not.toHaveAttribute("aria-atomic");
+    });
+  });
+});


### PR DESCRIPTION
### Proposed behaviour

Add support for `aria-atomic` to `Box` as it tends to go hand-in-hand with `aria-live`

### Current behaviour

`Box` currently supports `aria-live` to allow screen readers to notify when content changes, however there is no support for `aria-atomic` which indicates how much of the changed region should be announced

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

1. Create a`Box`.
2. Add `aria-atomic` and `aria-live` to it.
3. Implement functionality to automatically change the content within the `Box`.
4. Turn on a screen reader such as VoiceOver.
5. Observe that changes are correctly announced.