### PR TITLE
test(help): refine testing suite

### DIFF
--- a/skills/carbon-react/components/help.md
+++ b/skills/carbon-react/components/help.md
@@ -108,7 +108,7 @@ description: Carbon Help component props and usage examples.
 ```tsx
 () => (
   <Box my={64} mx={300}>
-    <Help tooltipBgColor="lightblue" tooltipFontColor="black">
+    <Help tooltipBgColor="lightblue" tooltipFontColor="black" isFocused>
       The background and font color are overridden
     </Help>
   </Box>
@@ -116,7 +116,7 @@ description: Carbon Help component props and usage examples.
 ```
 
 
-### With Icons
+### With Icons and Focused
 
 **Render**
 
@@ -126,7 +126,7 @@ description: Carbon Help component props and usage examples.
     <>
       {(["error", "add", "minus", "settings"] as const).map((icon) => (
         <Box m={65} key={icon}>
-          <Help type={`${icon}`}>
+          <Help type={`${icon}`} data-role="target">
             {`This is the Help component with the ${icon} icon`}
           </Help>
         </Box>

--- a/src/components/help/help.mdx
+++ b/src/components/help/help.mdx
@@ -52,7 +52,7 @@ props accept and valid css color value.
 
 Using the `type` prop, different icons can be specified. In this example type has been assigned `error`, `add`, `minus` and `settings`
 
-<Canvas of={HelpStories.WithIcons} />
+<Canvas of={HelpStories.WithIconsAndFocused} />
 
 ## Help with href
 

--- a/src/components/help/help.pw.tsx
+++ b/src/components/help/help.pw.tsx
@@ -5,14 +5,10 @@ import HelpComponentTest from "./component.test-pw";
 import Box from "../../../src/components/box";
 import {
   getDataElementByValue,
-  icon,
   tooltipPreview,
 } from "../../../playwright/components/index";
 import helpComponent from "../../../playwright/components/help";
-import {
-  checkAccessibility,
-  containsClass,
-} from "../../../playwright/support/helper";
+import { checkAccessibility } from "../../../playwright/support/helper";
 import { COLOR, CHARACTERS } from "../../../playwright/support/constants";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
@@ -25,133 +21,7 @@ const colors = [
   ["brown", COLOR.BROWN, COLOR.WHITE],
 ];
 
-test("should have the expected styling when focused", async ({
-  mount,
-  page,
-}) => {
-  await mount(<HelpComponentTest />);
-
-  const elementLocator = helpComponent(page);
-  await elementLocator.focus();
-  await expect(helpComponent(page).locator("span")).toHaveCSS(
-    "box-shadow",
-    "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
-  );
-  await expect(helpComponent(page).locator("span")).toHaveCSS(
-    "outline",
-    "rgba(0, 0, 0, 0) solid 3px",
-  );
-});
-
 test.describe("Testing Help component properties", () => {
-  testData.forEach((ariaLabel) => {
-    test(`should check ariaLabel as ${ariaLabel}`, async ({ mount, page }) => {
-      await mount(<HelpComponentTest ariaLabel={ariaLabel} />);
-
-      await expect(helpComponent(page)).toHaveAttribute(
-        "aria-label",
-        ariaLabel,
-      );
-    });
-  });
-
-  testData.forEach((className) => {
-    test(`should check className as ${className}`, async ({ mount, page }) => {
-      await mount(<HelpComponentTest className={className} />);
-
-      await containsClass(helpComponent(page), className);
-    });
-  });
-
-  testData.forEach((children) => {
-    test(`should check children as ${children}`, async ({ mount, page }) => {
-      await mount(<Help> {children} </Help>);
-
-      await helpComponent(page).hover();
-      const tooltip = getDataElementByValue(page, "tooltip");
-      await expect(tooltip).toBeVisible();
-      await expect(tooltip).toHaveText(children);
-    });
-  });
-
-  testData.forEach((helpId) => {
-    test(`should check id as ${helpId}`, async ({ mount, page }) => {
-      await mount(<HelpComponentTest helpId={helpId} />);
-
-      await expect(helpComponent(page)).toHaveId(helpId);
-    });
-  });
-
-  ["https://carbon.sage.com", "https://www.google.com"].forEach((hrefLink) => {
-    test(`should check href link as ${hrefLink}`, async ({ mount, page }) => {
-      await mount(<HelpComponentTest href={hrefLink} />);
-
-      await expect(helpComponent(page)).toHaveAttribute("href", hrefLink);
-    });
-  });
-
-  [true, false].forEach((boolVal) => {
-    test(`should check when isFocused prop is passed as ${boolVal}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <HelpComponentTest isFocused={boolVal}>
-          {tooltipText}
-        </HelpComponentTest>,
-      );
-
-      const tooltip = getDataElementByValue(page, "tooltip");
-      if (boolVal === true) {
-        await expect(tooltip).toBeVisible();
-      } else {
-        await expect(tooltip).toBeHidden();
-      }
-    });
-  });
-
-  [-1, 0, 1].forEach((tabIndex) => {
-    test(`should check tabIndex as ${tabIndex}`, async ({ mount, page }) => {
-      await mount(<HelpComponentTest tabIndex={tabIndex} />);
-
-      await page.keyboard.press("Tab");
-      if (tabIndex === -1) {
-        await expect(helpComponent(page)).not.toBeFocused();
-      } else {
-        await expect(helpComponent(page)).toBeFocused();
-      }
-    });
-  });
-
-  colors.forEach(([names, color]) => {
-    test(`should check tooltipBgColor as ${names}`, async ({ mount, page }) => {
-      await mount(
-        <HelpComponentTest tooltipBgColor={color} isFocused>
-          {tooltipText}
-        </HelpComponentTest>,
-      );
-
-      const tooltip = getDataElementByValue(page, "tooltip");
-      await expect(tooltip).toHaveCSS("background-color", color);
-    });
-  });
-
-  colors.forEach(([names, color]) => {
-    test(`should check tooltipFontColor as ${names}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <HelpComponentTest tooltipFontColor={color} isFocused>
-          {tooltipText}
-        </HelpComponentTest>,
-      );
-
-      const tooltip = getDataElementByValue(page, "tooltip");
-      await expect(tooltip).toHaveCSS("color", color);
-    });
-  });
-
   (["top", "bottom", "left", "right"] as HelpProps["position"][]).forEach(
     (position) => {
       test(`should render tooltipFlipOverrides as ${position}`, async ({
@@ -173,58 +43,6 @@ test.describe("Testing Help component properties", () => {
       });
     },
   );
-
-  testData.forEach((tooltipId) => {
-    test(`should check tooltipId as ${tooltipId}`, async ({ mount, page }) => {
-      await mount(
-        <HelpComponentTest tooltipId={tooltipId} isFocused>
-          {tooltipText}
-        </HelpComponentTest>,
-      );
-
-      const tooltip = getDataElementByValue(page, "tooltip");
-      await expect(tooltip).toHaveId(tooltipId);
-    });
-  });
-
-  (
-    ["top", "bottom", "left", "right"] as ["top", "bottom", "left", "right"]
-  ).forEach((tooltipPosition) => {
-    test(`should render with tooltip positioned ${tooltipPosition}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <HelpComponentTest tooltipPosition={tooltipPosition} isFocused>
-          {`This tooltip is positioned ${tooltipPosition}`}
-        </HelpComponentTest>,
-      );
-
-      await expect(helpComponent(page)).toBeVisible();
-      const tooltip = getDataElementByValue(page, "tooltip");
-      await expect(tooltip).toBeVisible();
-      await expect(tooltip).toHaveAttribute("data-placement", tooltipPosition);
-    });
-  });
-
-  (
-    ["error", "add", "minus", "settings"] as [
-      "error",
-      "add",
-      "minus",
-      "settings",
-    ]
-  ).forEach((iconType) => {
-    test(`should render with iconType prop passed as ${iconType}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<HelpComponentTest isFocused type={iconType} />);
-
-      await expect(icon(page)).toBeVisible();
-      await expect(icon(page)).toHaveAttribute("type", iconType);
-    });
-  });
 });
 
 test.describe("Accessibility tests for Help component", () => {

--- a/src/components/help/help.stories.tsx
+++ b/src/components/help/help.stories.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
-
 import generateStyledSystemProps from "../../../.storybook/utils/styled-system-props";
-
 import Box from "../box";
 import Icon from "../icon";
 import Help from ".";
@@ -59,22 +57,26 @@ export const WithTooltipPosition: Story = () => {
   );
 };
 WithTooltipPosition.storyName = "With Tooltip Position";
+WithTooltipPosition.parameters = { chromatic: { disableSnapshot: false } };
 
 export const WithTooltipColorOverrides: Story = () => (
   <Box my={64} mx={300}>
-    <Help tooltipBgColor="lightblue" tooltipFontColor="black">
+    <Help tooltipBgColor="lightblue" tooltipFontColor="black" isFocused>
       The background and font color are overridden
     </Help>
   </Box>
 );
 WithTooltipColorOverrides.storyName = "With Tooltip Color Overrides";
+WithTooltipColorOverrides.parameters = {
+  chromatic: { disableSnapshot: false },
+};
 
-export const WithIcons: Story = () => {
+export const WithIconsAndFocused: Story = () => {
   return (
     <>
       {(["error", "add", "minus", "settings"] as const).map((icon) => (
         <Box m={65} key={icon}>
-          <Help type={`${icon}`}>
+          <Help type={`${icon}`} data-role="target">
             {`This is the Help component with the ${icon} icon`}
           </Help>
         </Box>
@@ -82,7 +84,11 @@ export const WithIcons: Story = () => {
     </>
   );
 };
-WithIcons.storyName = "With Icons";
+WithIconsAndFocused.storyName = "With Icons and Focused";
+WithIconsAndFocused.parameters = {
+  chromatic: { disableSnapshot: false },
+  pseudo: { focus: "[data-role='target']" },
+};
 
 export const WithHref: Story = () => {
   return (

--- a/src/components/help/help.test.tsx
+++ b/src/components/help/help.test.tsx
@@ -136,3 +136,21 @@ test("renders with provided `helpId` and `tooltipId`", async () => {
     "bar",
   );
 });
+
+test("is not keyboard focusable when tabIndex is -1", async () => {
+  const user = userEvent.setup();
+  render(<Help tabIndex={-1} />);
+
+  await user.tab();
+
+  expect(screen.getByRole("button", { name: "help" })).not.toHaveFocus();
+});
+
+test("is keyboard focusable when tabIndex is 0 or greater", async () => {
+  const user = userEvent.setup();
+  render(<Help tabIndex={0} />);
+
+  await user.tab();
+
+  expect(screen.getByRole("button", { name: "help" })).toHaveFocus();
+});


### PR DESCRIPTION
### Proposed behaviour

Removes a number of Playwright tests that duplicate either Jest or Chromatic ones for the `Help` component

### Current behaviour

There are a number of tests that exist in different forms in all the testing suites we do(Jest, Playwright, Chromatic) which cause a prolonged time of execution for no additional value.


### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

This should decrease the time of execution without compromising testing and coverage

### Testing instructions

Make sure the Playwright tests pass
