### PR TITLE
feat(text-editor): add support for exporting editor HTML and style

### DIFF
--- a/src/components/text-editor/__internal__/__ui__/Toolbar/buttons/buttons.test.tsx
+++ b/src/components/text-editor/__internal__/__ui__/Toolbar/buttons/buttons.test.tsx
@@ -13,6 +13,7 @@ import { SaveButton } from ".";
 
 const mockedSerializeRespone = {
   htmlString: "<p><br></p>",
+  htmlWithInlineStyles: "<p><br></p>",
   json: {
     root: {
       children: [],
@@ -55,6 +56,9 @@ describe("Command buttons", () => {
       await user.click(saveButton);
       expect(onSave).toHaveBeenCalledTimes(1);
       expect(onSave.mock.calls[0][0].htmlString).toEqual("<p><br></p>");
+      expect(onSave.mock.calls[0][0].htmlWithInlineStyles).toContain(
+        "font-family: 'Sage UI', sans-serif;",
+      );
     });
   });
 });

--- a/src/components/text-editor/__internal__/__utils__/helpers.test.ts
+++ b/src/components/text-editor/__internal__/__utils__/helpers.test.ts
@@ -3,6 +3,7 @@ import {
   createEmpty,
   createFromHTML,
   DeserializeHTML,
+  generateHTMLWithInlineStyles,
   SerializeLexical,
   validateUrl,
 } from "./helpers";
@@ -39,7 +40,7 @@ describe("DeserializeHTML", () => {
 });
 
 describe("SerializeEditor", () => {
-  it("serializes editor content to HTML and JSON", async () => {
+  it("serializes editor content to HTML, HTML with inline styles, and JSON", async () => {
     const editor = createHeadlessEditor({
       namespace: "test",
       nodes: [],
@@ -55,10 +56,14 @@ describe("SerializeEditor", () => {
       });
     });
 
-    const { htmlString, json } = SerializeLexical(editor);
+    const { htmlString, htmlWithInlineStyles, json } = SerializeLexical(editor);
 
     expect(htmlString).toEqual(
       '<p><span style="white-space: pre-wrap;">Hello World!</span></p>',
+    );
+    expect(htmlWithInlineStyles).toContain("Hello World!");
+    expect(htmlWithInlineStyles).toContain(
+      "font-family: 'Sage UI', sans-serif;",
     );
     expect(json).toEqual({
       root: {
@@ -103,5 +108,140 @@ describe("validateUrl", () => {
   it("returns false when the URL is invalid", () => {
     const invalidUrl = "example.url";
     expect(validateUrl(invalidUrl)).toBe(false);
+  });
+});
+
+describe("generateHTMLWithInlineStyles", () => {
+  it("converts textBold class to font-weight style", () => {
+    const html = '<p class="textBold">Bold text</p>';
+    const result = generateHTMLWithInlineStyles(html);
+    expect(result).toContain("font-weight: bold;");
+    expect(result).not.toContain('class="textBold"');
+  });
+
+  it("converts textItalic class to font-style style", () => {
+    const html = '<p class="textItalic">Italic text</p>';
+    const result = generateHTMLWithInlineStyles(html);
+    expect(result).toContain("font-style: italic;");
+    expect(result).not.toContain('class="textItalic"');
+  });
+
+  it("converts textUnderline class to text-decoration style", () => {
+    const html = '<p class="textUnderline">Underline text</p>';
+    const result = generateHTMLWithInlineStyles(html);
+    expect(result).toContain("text-decoration: underline;");
+    expect(result).not.toContain('class="textUnderline"');
+  });
+
+  it("converts multiple format classes on same element", () => {
+    const html =
+      '<p class="textBold textItalic textUnderline">Formatted text</p>';
+    const result = generateHTMLWithInlineStyles(html);
+    expect(result).toContain("font-weight: bold;");
+    expect(result).toContain("font-style: italic;");
+    expect(result).toContain("text-decoration: underline;");
+  });
+
+  it("applies font family to all non-link elements", () => {
+    const html = "<p>Text</p><span>More text</span><div>Even more</div>";
+    const result = generateHTMLWithInlineStyles(html);
+
+    const fontFamilyMatches = result.match(/font-family:/g);
+    expect(fontFamilyMatches).toBeTruthy();
+  });
+
+  it("applies link styles to anchor elements", () => {
+    const html = '<a href="https://example.com">Link</a>';
+    const result = generateHTMLWithInlineStyles(html);
+    expect(result).toContain("color: #007e45ff;");
+    expect(result).toContain("cursor: pointer;");
+    expect(result).toContain("text-decoration: underline;");
+    expect(result).toContain("font-family: 'Sage UI', sans-serif;");
+  });
+
+  it("preserves existing inline styles", () => {
+    const html = '<p style="color: red;">Text</p>';
+    const result = generateHTMLWithInlineStyles(html);
+    expect(result).toContain("color: red;");
+    expect(result).toContain("font-family: 'Sage UI', sans-serif;");
+  });
+
+  it("merges format classes with existing inline styles", () => {
+    const html = '<p class="textBold" style="color: red;">Bold red text</p>';
+    const result = generateHTMLWithInlineStyles(html);
+    expect(result).toContain("color: red;");
+    expect(result).toContain("font-weight: bold;");
+    expect(result).toContain("font-family: 'Sage UI', sans-serif;");
+  });
+
+  it("removes class attribute when empty after conversion", () => {
+    const html = '<p class="textBold">Text</p>';
+    const result = generateHTMLWithInlineStyles(html);
+    // Should not have empty class attribute
+    expect(result).not.toContain('class=""');
+  });
+
+  it("keeps class attribute if non-format classes remain", () => {
+    const html = '<p class="textBold myClass">Text</p>';
+    const result = generateHTMLWithInlineStyles(html);
+    expect(result).toContain('class="myClass"');
+    expect(result).toContain("font-weight: bold;");
+  });
+
+  it("handles nested elements with formatting", () => {
+    const html =
+      '<div><p class="textBold"><span class="textItalic">Nested formatted text</span></p></div>';
+    const result = generateHTMLWithInlineStyles(html);
+    expect(result).toContain("font-weight: bold;");
+    expect(result).toContain("font-style: italic;");
+  });
+
+  it("handles elements with only whitespace", () => {
+    const html = '<p class="textBold">   </p>';
+    const result = generateHTMLWithInlineStyles(html);
+    expect(result).toContain("font-weight: bold;");
+  });
+
+  it("handles mixed anchor and non-anchor elements", () => {
+    const html =
+      '<p class="textBold">Text</p><a class="textItalic" href="#">Link</a>';
+    const result = generateHTMLWithInlineStyles(html);
+    // Paragraph should have font-family but not link styles
+    const paragraphSection = result.split("<a")[0];
+    expect(paragraphSection).toContain("font-family: 'Sage UI', sans-serif;");
+    expect(paragraphSection).not.toContain("color: #007e45ff;");
+    // Link should have link styles
+    expect(result).toContain("color: #007e45ff;");
+  });
+
+  it("handles empty HTML", () => {
+    const html = "";
+    const result = generateHTMLWithInlineStyles(html);
+    expect(result).toBe("");
+  });
+
+  it("handles HTML with only text nodes", () => {
+    const html = "Plain text";
+    const result = generateHTMLWithInlineStyles(html);
+    expect(result).toContain("Plain text");
+  });
+
+  it("handles elements with no classes or styles", () => {
+    const html = "<p>Simple paragraph</p>";
+    const result = generateHTMLWithInlineStyles(html);
+    expect(result).toContain("font-family: 'Sage UI', sans-serif;");
+  });
+
+  it("handles self-closing elements", () => {
+    const html = '<div><img src="test.jpg" /><p>Text</p></div>';
+    const result = generateHTMLWithInlineStyles(html);
+    expect(result).toContain("font-family: 'Sage UI', sans-serif;");
+  });
+
+  it("handles unrecognized classes alongside format classes", () => {
+    const html = '<p class="textBold unknownClass anotherClass">Text</p>';
+    const result = generateHTMLWithInlineStyles(html);
+    expect(result).toContain("font-weight: bold;");
+    expect(result).toContain('class="unknownClass anotherClass"');
   });
 });

--- a/src/components/text-editor/__internal__/__utils__/helpers.ts
+++ b/src/components/text-editor/__internal__/__utils__/helpers.ts
@@ -7,16 +7,84 @@ import { getTheme } from "./theme";
 
 import Logger from "../../../../__internal__/utils/logger";
 
+const fontFamily = "font-family: 'Sage UI', sans-serif;";
+const linkStyles = `color: #007e45ff; cursor: pointer; text-decoration: underline; ${fontFamily}`;
+
+const classToStyleMap: Record<string, string> = {
+  textBold: "font-weight: bold;",
+  textItalic: "font-style: italic;",
+  textUnderline: "text-decoration: underline;",
+};
+
 /**
- * This helper takes the current state of the editor and serializes it into two formats:
+ * Post-processes HTML serialized from the Lexical editor, converting class-based
+ * text formatting to inline styles and applying brand-consistent defaults to all elements.
+ *
+ * Specifically:
+ * - Converts Lexical's text format classes (textBold, textItalic, textUnderline)
+ *   to their inline style equivalents
+ * - Applies the Sage UI font family to all elements
+ * - Applies link styles (color, cursor, underline) to anchor elements
+ * - Preserves any existing inline styles set by Lexical (e.g. white-space: pre-wrap)
+ *
+ * This ensures the output HTML is portable and renders correctly in contexts where
+ * the Lexical stylesheet is not present, such as email templates or external consumers.
+ */
+const generateHTMLWithInlineStyles = (html: string): string => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, "text/html");
+
+  doc.body.querySelectorAll("*").forEach((el) => {
+    const element = el as HTMLElement;
+
+    // Accumulate new inline styles
+    const newStyles: string[] = [];
+
+    // Map class names to inline styles
+    const classList = Array.from(element.classList);
+    classList.forEach((className) => {
+      const mappedStyle = classToStyleMap[className];
+      if (mappedStyle) {
+        newStyles.push(mappedStyle);
+        element.classList.remove(className);
+      }
+    });
+
+    // Apply link styles
+    if (element.tagName === "A") {
+      newStyles.push(linkStyles);
+    } else {
+      // Apply font family to all non-link elements (links get it via linkStyles)
+      newStyles.push(fontFamily);
+    }
+
+    // Merge with any existing inline styles
+    const existingStyle = element.getAttribute("style") ?? "";
+    const mergedStyle = [existingStyle, ...newStyles].filter(Boolean).join(" ");
+
+    element.setAttribute("style", mergedStyle);
+
+    // Remove class attribute if now empty
+    if (element.classList.length === 0) {
+      element.removeAttribute("class");
+    }
+  });
+
+  return doc.body.innerHTML;
+};
+
+/**
+ * This helper takes the current state of the editor and serializes it into three formats:
  * 1. HTML
- * 2. JSON
+ * 2. HTML with inline styles (for use in email templates and contexts without stylesheets)
+ * 3. JSON
  * This allows the editor state to be saved and restored at a later time, in a format suitable
  * for the majority of customers' use cases.
  */
 
 const SerializeLexical = (editor: LexicalEditor) => {
-  let htmlString;
+  let htmlString: string | undefined;
+  let htmlWithInlineStyles: string | undefined;
   let json;
 
   editor.read(() => {
@@ -26,9 +94,11 @@ const SerializeLexical = (editor: LexicalEditor) => {
     json = editorState.toJSON();
     // Generate HTML from the editor state
     htmlString = $generateHtmlFromNodes(editor, null);
+    // Generate HTML with inline styles for portable use
+    htmlWithInlineStyles = generateHTMLWithInlineStyles(htmlString);
   });
 
-  return { htmlString, json };
+  return { htmlString, htmlWithInlineStyles, json };
 };
 
 /**
@@ -104,6 +174,7 @@ const createEmpty = () => {
 };
 
 export {
+  generateHTMLWithInlineStyles,
   createEmpty,
   createFromHTML,
   DeserializeHTML,

--- a/src/components/text-editor/__internal__/__utils__/interfaces.types.ts
+++ b/src/components/text-editor/__internal__/__utils__/interfaces.types.ts
@@ -182,6 +182,7 @@ export interface SaveProps {
 
 export interface EditorFormattedValues {
   htmlString?: string;
+  htmlWithInlineStyles?: string;
   json?: {
     root: {
       children: SaveProps[];

--- a/src/components/text-editor/text-editor.mdx
+++ b/src/components/text-editor/text-editor.mdx
@@ -84,9 +84,12 @@ Providing an `onChange` callback allows for accessing any content updates within
 #### Parameters
 
 - `value`: The updated text content as a string.
-- `formattedValues`: An object containing two properties that represent the editor's content in a serialised format. This can be used to save the content to an external store like a database or local storage.
+- `formattedValues`: An object containing three properties that represent the editor's content in a serialised format. This can be used to save the content to an external store like a database or local storage.
   - `htmlString`: A HTML representation of the editor content, as a string.
+  - `htmlWithInlineStyles` (optional): A HTML representation of the editor content with all formatting converted to inline styles. This format is portable and suitable for use in email templates or contexts where stylesheets are not available.
   - `json`: The JSON representation of the editor content, as a string.
+
+> **Note**: The `htmlWithInlineStyles` property is optional and is only provided if you need portable HTML output. You can ignore this property if you only need `htmlString` or `json`.
 
 > **Note**: `TextEditor` is an uncontrolled component. See [Externally overwriting the editor's content](#externally-overwriting-the-editors-content) for details on updating content after initialization.
 
@@ -105,13 +108,13 @@ Updating the component's `key` will force React to re-create it, which will rese
 ### onSave Handler
 
 To handle the content of the editor when the `Save` button is clicked, you can set the `onSave` property to a function. The callback function
-returns two values: the JSON and HTML content of the editor. The value of `json` reflects the structure that the editor understands/uses
+returns three values: the JSON, HTML, and HTML with inline styles content of the editor. The value of `json` reflects the structure that the editor understands/uses
 internally; the value of `htmlString` is the raw content of the editor in HTML format (note that the HTML returned is not complete HTML - only
-the content of the editor is converted).
+the content of the editor is converted); the value of `htmlWithInlineStyles` is the HTML content with all formatting converted to inline styles, making it suitable for use in email templates and other contexts where stylesheets are not available.
 
 If the `onSave` property is not provided, the `Save` button will not be displayed.
 
-Type into the editor and the click the **Show Data Formats** button in the example below to see the JSON and HTML content of the editor.
+Type into the editor and the click the **Show Data Formats** button in the example below to see the JSON, HTML, and HTML with inline styles content of the editor.
 
 <Canvas of={TextEditorStories.OnSave} />
 

--- a/src/components/text-editor/text-editor.stories.tsx
+++ b/src/components/text-editor/text-editor.stories.tsx
@@ -185,11 +185,14 @@ export const OnChange: Story = () => {
   const [valueHTML, setValueHTML] = React.useState<string | undefined>(
     undefined,
   );
+  const [valueHTMLWithInlineStyles, setValueHTMLWithInlineStyles] =
+    React.useState<string | undefined>(undefined);
 
   const handleChange = useCallback(
     (value: string, formattedValues: EditorFormattedValues) => {
       setValueString(value);
       setValueHTML(formattedValues.htmlString);
+      setValueHTMLWithInlineStyles(formattedValues.htmlWithInlineStyles);
     },
     [],
   );
@@ -205,6 +208,12 @@ export const OnChange: Story = () => {
       <div>
         HTML formatted content:{" "}
         {valueHTML === "<p><br></p>" ? "No content" : valueHTML}
+      </div>
+      <div>
+        HTML with inline styles (portable):{" "}
+        {valueHTMLWithInlineStyles === "<p><br></p>"
+          ? "No content"
+          : valueHTMLWithInlineStyles}
       </div>
     </Box>
   );
@@ -258,6 +267,7 @@ ExternallyOverwriting.parameters = {
 export const OnSave: Story = () => {
   const [data, setData] = useState<EditorFormattedValues>({
     htmlString: "<p><br></p>",
+    htmlWithInlineStyles: "<p><br></p>",
     json: undefined,
   });
   const [showData, setShowData] = useState(false);
@@ -267,7 +277,9 @@ export const OnSave: Story = () => {
         <TextEditor
           namespace="storybook-onsave"
           labelText="Text Editor"
-          onSave={({ htmlString, json }) => setData({ htmlString, json })}
+          onSave={({ htmlString, htmlWithInlineStyles, json }) =>
+            setData({ htmlString, htmlWithInlineStyles, json })
+          }
         />
       </>
       <Button
@@ -290,6 +302,12 @@ export const OnSave: Story = () => {
               HTML
             </Typography>
             {data?.htmlString || "No content"}
+          </Box>
+          <Box maxWidth="30%">
+            <Typography variant="h4" mb={1}>
+              HTML with Inline Styles
+            </Typography>
+            {data?.htmlWithInlineStyles || "No content"}
           </Box>
           <Box maxWidth="30%">
             <Typography variant="h4" mb={1}>

--- a/src/components/text-editor/text-editor.test.tsx
+++ b/src/components/text-editor/text-editor.test.tsx
@@ -515,6 +515,60 @@ test("serialisation of editor", async () => {
   expect(mockSave).toHaveBeenCalledTimes(1);
 });
 
+test("onChange receives htmlWithInlineStyles in formatted values", async () => {
+  const user = userEvent.setup();
+  const onChange = jest.fn();
+
+  render(
+    <TextEditor
+      labelText="Text Editor"
+      onChange={onChange}
+      initialValue={JSON.stringify(initialValue)}
+    />,
+  );
+
+  const editor = screen.getByRole("textbox");
+  await user.type(editor, "test");
+
+  await waitFor(() => {
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  // Verify the most recent call included htmlWithInlineStyles with font-family
+  const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+  const formattedValues = lastCall[1] as EditorFormattedValues;
+
+  expect(formattedValues.htmlWithInlineStyles).toBeDefined();
+  expect(formattedValues.htmlWithInlineStyles).toContain(
+    "font-family: 'Sage UI', sans-serif;",
+  );
+});
+
+test("onSave receives htmlWithInlineStyles in formatted values", async () => {
+  const user = userEvent.setup();
+  const onSave = jest.fn();
+
+  render(
+    <TextEditor
+      labelText="Text Editor"
+      onSave={(values: EditorFormattedValues) => onSave(values)}
+      initialValue={JSON.stringify(initialValue)}
+    />,
+  );
+
+  const saveButton = screen.getByText("Save");
+  await user.click(saveButton);
+
+  expect(onSave).toHaveBeenCalledTimes(1);
+
+  const formattedValues = onSave.mock.calls[0][0] as EditorFormattedValues;
+
+  expect(formattedValues.htmlWithInlineStyles).toBeDefined();
+  expect(formattedValues.htmlWithInlineStyles).toContain(
+    "font-family: 'Sage UI', sans-serif;",
+  );
+});
+
 test("editor is focused when the focus method is invoked via a click on the editor label", async () => {
   const user = userEvent.setup();
 


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
