### PR TITLE
chore: add carbon z-index tokens to static build of fusion tokens

### DIFF
--- a/scripts/generate_tokens/generate_tokens.mjs
+++ b/scripts/generate_tokens/generate_tokens.mjs
@@ -108,19 +108,33 @@ const filterDarkModeDuplicates = () => {
 // Generate CSS strings
 const lightCSS = generateFusionTokens(light);
 
+const zIndexTokens = `
+  --carbon-zindex-small-overlay: 10;
+  --carbon-zindex-overlay: 1000;
+  --carbon-zindex-nav: 2998;
+  --carbon-zindex-global-nav: 2999;
+  --carbon-zindex-modal: 3000;
+  --carbon-zindex-header: 4000;
+  --carbon-zindex-full-screen-modal: 5000;
+  --carbon-zindex-popover: 6000;
+  --carbon-zindex-notification: 7000;
+  --carbon-zindex-above-all: 9999;
+`;
+
 let staticTokensCSS;
 if (includeDarkMode) {
   const darkCSS = generateFusionTokens(filterDarkModeDuplicates());
   staticTokensCSS = `
 ${lightCSS}
-
-carbon-dark-mode, [data-carbon-theme="dark"] {
+${zIndexTokens}
+.carbon-dark-mode, [data-carbon-theme="dark"] {
   ${darkCSS}
 }
 `;
 } else {
   staticTokensCSS = `
 ${lightCSS}
+${zIndexTokens}
 `;
 }
 

--- a/src/components/tokens-wrapper/__internal__/static-tokens/__snapshots__/static-tokens.test.ts.snap
+++ b/src/components/tokens-wrapper/__internal__/static-tokens/__snapshots__/static-tokens.test.ts.snap
@@ -1251,7 +1251,18 @@ exports[`builds the static tokens as expected 1`] = `
   --table-footer-border-default: var(--mode-color-generic-fg-soft);
   --table-footer-label-default: var(--mode-color-generic-txt-severe);
 
-carbon-dark-mode, [data-carbon-theme="dark"] {
+  --carbon-zindex-small-overlay: 10;
+  --carbon-zindex-overlay: 1000;
+  --carbon-zindex-nav: 2998;
+  --carbon-zindex-global-nav: 2999;
+  --carbon-zindex-modal: 3000;
+  --carbon-zindex-header: 4000;
+  --carbon-zindex-full-screen-modal: 5000;
+  --carbon-zindex-popover: 6000;
+  --carbon-zindex-notification: 7000;
+  --carbon-zindex-above-all: 9999;
+
+.carbon-dark-mode, [data-carbon-theme="dark"] {
     --mode-color-ai-stop-1: #00d639;
   --mode-color-ai-stop-2: #00d6de;
   --mode-color-ai-stop-3: #9d60ff;


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Adds the following to the static fusion tokens scoped in Carbon

```
const zIndexTokens = `
  --carbon-zindex-small-overlay: 10;
  --carbon-zindex-overlay: 1000;
  --carbon-zindex-nav: 2998;
  --carbon-zindex-global-nav: 2999;
  --carbon-zindex-modal: 3000;
  --carbon-zindex-header: 4000;
  --carbon-zindex-full-screen-modal: 5000;
  --carbon-zindex-popover: 6000;
  --carbon-zindex-notification: 7000;
  --carbon-zindex-above-all: 9999;
`;
```
### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
There are no z-index tokens included in the fusion token set

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
