### PR TITLE
fix(text-editor): span from initialValue not being styled

### DIFF
--- a/src/components/text-editor/text-editor-interaction.stories.tsx
+++ b/src/components/text-editor/text-editor-interaction.stories.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { StoryFn, StoryObj } from "@storybook/react";
 import { userEvent, within, expect, waitFor } from "@storybook/test";
 
-import TextEditor, { Mention, MentionsPlugin } from ".";
+import TextEditor, { createFromHTML, Mention, MentionsPlugin } from ".";
 import { allowInteractions } from "../../../.storybook/interaction-toggle/reduced-motion";
 import DefaultDecorator from "../../../.storybook/utils/default-decorator";
 import CarbonProvider from "../carbon-provider";
@@ -64,6 +64,15 @@ const renderMentionsEditor = () => (
   />
 );
 
+const renderInitialValueEditor = () => (
+  <TextEditor
+    labelText="Text Editor"
+    initialValue={createFromHTML(
+      '<p><span>paragraph</span></p><p><span style="font-weight: 700; font-size: 24px; line-height: 30px;">title</span></p><p><span style="font-weight: 500; font-size: 21px; line-height: 26.25px;">subtitle</span></p><p><span style="font-weight: 500; font-size: 18px; line-height: 22.5px;">section header</span></p><p><span style="font-weight: 500; font-size: 16px; line-height: 20px;">section subheader&ZeroWidthSpace;</span></p>',
+    )}
+  />
+);
+
 const openMentionsAndHighlightOption = async (
   canvasElement: HTMLElement,
   optionIndex: number,
@@ -90,6 +99,25 @@ const openMentionsAndHighlightOption = async (
   for (let i = 0; i < optionIndex; i += 1) {
     await userEvent.keyboard("{ArrowDown}");
   }
+};
+
+const selectAllTextAndApplyStyles = async (canvasElement: HTMLElement) => {
+  if (!allowInteractions()) {
+    return;
+  }
+
+  const canvas = within(canvasElement);
+  const textbox = canvas.getByRole("textbox");
+
+  await userEvent.click(textbox);
+
+  await userEvent.keyboard("{Control>}a{/Control}");
+
+  await userEvent.keyboard("{Control>}b{/Control}");
+  await userEvent.keyboard("{Control>}u{/Control}");
+  await userEvent.keyboard("{Control>}i{/Control}");
+
+  await userEvent.click(textbox);
 };
 
 export const OpenMentionsPopoverDefaultAvatar: Story = {
@@ -262,5 +290,24 @@ export const OpenHyperlinkDialogWithErrors: Story = {
 
 OpenHyperlinkDialogWithErrors.storyName = "Open Hyperlink Dialog With Errors";
 OpenHyperlinkDialogWithErrors.parameters = {
+  chromatic: { disableSnapshot: false },
+};
+
+export const AppliesStylingCorrectly: Story = {
+  render: renderInitialValueEditor,
+  play: async ({ canvasElement }) => {
+    await selectAllTextAndApplyStyles(canvasElement);
+  },
+  decorators: [
+    (StoryToRender) => (
+      <DefaultDecorator>
+        <StoryToRender />
+      </DefaultDecorator>
+    ),
+  ],
+};
+
+AppliesStylingCorrectly.storyName = "Applies Styling Correctly";
+AppliesStylingCorrectly.parameters = {
   chromatic: { disableSnapshot: false },
 };

--- a/src/components/text-editor/text-editor.style.ts
+++ b/src/components/text-editor/text-editor.style.ts
@@ -27,7 +27,7 @@ export const StyledWrapper = styled.div`
   position: relative;
 
   .textBold {
-    font-weight: bold;
+    font-weight: bold !important;
   }
 
   .textItalic {


### PR DESCRIPTION
### Proposed behaviour

To correctly apply text styling (`italic`, `bold`, `underline`) across all the typography variants, two issues needed to be addressed:

1. DOM reconciliation after styling changes

We needed to ensure the DOM updates correctly after applying styles to selected text. This was resolved in a previous PR: https://github.com/Sage/carbon/pull/7833

2. Bold styling not reflected visually

When an `initialValue` is provided to the `TextEditor`, the `importDom()` method from `StyledSpanNode` is used. This method returns `StyledSpanNode` elements with default `font-weight` values applied via inline styles.

When the Bold button is clicked in the toolbar, the editor applies a `textBold` class to the selected `StyledSpanNode`. However, because inline styles have higher specificity than CSS classes, the `font-weight` change is not visually reflected.

This issue is specific to bold styling because `font-weight` is applied by default. Italic and underline stylings are not affected, as there are no default inline values for `font-style` (italic) or `text-decoration` (underline) that need to be overridden.

Possible solutions:
- Refactor `StyledSpanNode` to use classes instead of inline styles
Instead of applying `font-weight`, `font-size`, and `line-height` via inline styles when creating `StyledSpanNode`, we could use CSS classes. This would allow future overrides without specificity conflicts. However, this approach would require a significant refactor.

- Remove inline `font-weight` before applying bold
Strip the inline `font-weight` from the selected `StyledSpanNode` before dispatching the bold command. This is more complex, as we would need to store the original value and restore it when bold is toggled off.

- Remove the default value of `400` for `font-weight` inside `importNode()`
Eliminating the default inline value would resolve the conflict, but it could introduce unintended styling changes elsewhere.

- Increase CSS specificity of the bold rule
By adding `!important` to `font-weight: bold;` in the `.textBold` class, we can override the inline style and ensure the bold styling is visible across all typography variants.

Final decision

Although using `!important` is generally discouraged, it is the most practical solution in this case. It allows us to override the default inline `font-weight` consistently across all the typography variants and revert to the original value when bold is toggled off, without requiring major refactoring or added complexity.

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

When the TextEditor is used with `initialValue`, the styling (bold, italic, underline) is not applied across all the typography variants.

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [X] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Open the storybook
Open the storybook page : `text-editor--setting-initial-values` or `text-editor-interactions--applies-styling-correctly`
