### PR TITLE
test(loader): refine testing suite

### DIFF
--- a/src/components/loader-spinner/loader-spinner.stories.tsx
+++ b/src/components/loader-spinner/loader-spinner.stories.tsx
@@ -16,7 +16,10 @@ const meta: Meta<typeof LoaderSpinner> = {
   argTypes: {
     ...styledSystemProps,
   },
-  parameters: { themeProvider: { chromatic: { theme: "sage" } } },
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export default meta;

--- a/src/components/loader/__next__/loader-test.stories.tsx
+++ b/src/components/loader/__next__/loader-test.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import Box from "../../box";
+import Button from "../../button/button.component";
 
 import generateStyledSystemProps from "../../../../.storybook/utils/styled-system-props";
 
@@ -48,7 +49,7 @@ const meta: Meta<typeof Loader> = {
   args: {
     loaderType: "standalone",
   },
-  parameters: { chromatic: { disableSnapshot: true } },
+  parameters: { chromatic: { disableSnapshot: false } },
 };
 
 export default meta;
@@ -62,3 +63,182 @@ export const Default: Story = {
   ),
 };
 Default.storyName = "Default";
+
+export const Sizes: Story = {
+  render: () => (
+    <>
+      <h2>Standalone Sizes</h2>
+      <Box>
+        <Loader loaderType="standalone" size="small" />
+      </Box>
+      <Box>
+        <Loader loaderType="standalone" size="medium" />
+      </Box>
+      <Box>
+        <Loader loaderType="standalone" size="large" />
+      </Box>
+      <h2>Ring Sizes</h2>
+      <Box>
+        <Loader loaderType="ring" size="extra-small" />
+      </Box>
+      <Box>
+        <Loader loaderType="ring" size="small" />
+      </Box>
+      <Box>
+        <Loader loaderType="ring" size="medium" />
+      </Box>
+      <Box>
+        <Loader loaderType="ring" size="large" />
+      </Box>
+    </>
+  ),
+};
+Sizes.storyName = "Sizes";
+
+export const Variants: Story = {
+  render: () => (
+    <>
+      <h2>Standalone Typical</h2>
+      <Box>
+        <Loader loaderType="standalone" variant="typical" />
+      </Box>
+      <h2>Standalone Typical Inversed</h2>
+      <Box backgroundColor="#1c1c1c" p="8px">
+        <Loader loaderType="standalone" variant="typical" inverse />
+      </Box>
+      <h2>Standalone AI</h2>
+      <Box>
+        <Loader loaderType="standalone" variant="ai" />
+      </Box>
+      <h2>Standalone AI Inversed</h2>
+      <Box backgroundColor="#1c1c1c" p="8px">
+        <Loader loaderType="standalone" variant="ai" inverse />
+      </Box>
+      <h2>Ring Stacked</h2>
+      <Box>
+        <Loader loaderType="ring" variant="stacked" />
+      </Box>
+      <h2>Ring Stacked Inversed</h2>
+      <Box backgroundColor="#1c1c1c" p="8px">
+        <Loader loaderType="ring" variant="stacked" inverse />
+      </Box>
+      <h2>Ring Inline</h2>
+      <Box>
+        <Loader loaderType="ring" variant="inline" />
+      </Box>
+      <h2>Ring Inline Inversed</h2>
+      <Box backgroundColor="#1c1c1c" p="8px">
+        <Loader loaderType="ring" variant="inline" inverse />
+      </Box>
+    </>
+  ),
+};
+Variants.storyName = "Variants";
+
+export const TrackedStates: Story = {
+  render: () => (
+    <>
+      <h2>Is Tracked</h2>
+      <Box>
+        <Loader loaderType="ring" isTracked />
+      </Box>
+      <h2>Tracked Error State</h2>
+      <Box>
+        <Loader loaderType="ring" isTracked isError />
+      </Box>
+      <h2>Tracked Success State</h2>
+      <Box>
+        <Loader loaderType="ring" isTracked isSuccess />
+      </Box>
+    </>
+  ),
+};
+TrackedStates.storyName = "Tracked States";
+
+export const InsideButtons: Story = {
+  render: () => (
+    <>
+      <Box height="50px">
+        <Button m={2} buttonType="primary" onClick={() => {}}>
+          <Loader
+            loaderType="ring"
+            variant="inline"
+            size="extra-small"
+            showLabel
+          />
+        </Button>
+      </Box>
+      <Box height="50px">
+        <Button m={2} buttonType="secondary" onClick={() => {}}>
+          <Loader
+            loaderType="ring"
+            variant="inline"
+            size="extra-small"
+            showLabel
+          />
+        </Button>
+      </Box>
+      <Box height="50px">
+        <Button m={2} buttonType="tertiary" onClick={() => {}}>
+          <Loader
+            loaderType="ring"
+            variant="inline"
+            size="extra-small"
+            showLabel
+          />
+        </Button>
+      </Box>
+      <Box height="50px">
+        <Button m={2} buttonType="primary" destructive onClick={() => {}}>
+          <Loader
+            loaderType="ring"
+            variant="inline"
+            size="extra-small"
+            showLabel
+          />
+        </Button>
+      </Box>
+      <Box height="50px">
+        <Button m={2} buttonType="secondary" onClick={() => {}} destructive>
+          <Loader
+            loaderType="ring"
+            variant="inline"
+            size="extra-small"
+            showLabel
+          />
+        </Button>
+      </Box>
+      <Box height="50px">
+        <Button m={2} buttonType="tertiary" onClick={() => {}} destructive>
+          <Loader
+            loaderType="ring"
+            variant="inline"
+            size="extra-small"
+            showLabel
+          />
+        </Button>
+      </Box>
+      <Box height="50px">
+        <Button m={2} buttonType="gradient-grey" onClick={() => {}}>
+          <Loader
+            loaderType="ring"
+            variant="inline"
+            size="extra-small"
+            showLabel
+          />
+        </Button>
+      </Box>
+      <Box height="50px">
+        <Button m={2} buttonType="gradient-white" onClick={() => {}}>
+          <Loader
+            loaderType="ring"
+            variant="inline"
+            size="extra-small"
+            showLabel
+          />
+        </Button>
+      </Box>
+    </>
+  ),
+};
+InsideButtons.storyName = "Inside Buttons";

--- a/src/components/loader/__next__/loader.stories.tsx
+++ b/src/components/loader/__next__/loader.stories.tsx
@@ -10,7 +10,7 @@ import Button from "../../button/button.component";
 const meta: Meta<typeof Loader> = {
   title: "Loader",
   component: Loader,
-  parameters: { chromatic: { disabledSnapshot: false } },
+  parameters: { chromatic: { disableSnapshot: true } },
 };
 
 export default meta;

--- a/src/components/loader/loader-square.test.tsx
+++ b/src/components/loader/loader-square.test.tsx
@@ -81,15 +81,18 @@ test("when inside button, the expected white background colour is applied", () =
   const loaderSquares = screen.getAllByTestId("loader-square");
 
   expect(loaderSquares[0]).toHaveStyleRule(
-    "backgroundColor: var(--colorsUtilityYang100)",
+    "background-color",
+    "var(--colorsUtilityYang100)",
   );
 
   expect(loaderSquares[1]).toHaveStyleRule(
-    "backgroundColor: var(--colorsUtilityYang100)",
+    "background-color",
+    "var(--colorsUtilityYang100)",
   );
 
   expect(loaderSquares[2]).toHaveStyleRule(
-    "backgroundColor: var(--colorsUtilityYang100)",
+    "background-color",
+    "var(--colorsUtilityYang100)",
   );
 });
 

--- a/src/components/loader/loader.pw.tsx
+++ b/src/components/loader/loader.pw.tsx
@@ -1,192 +1,26 @@
 import React from "react";
-import { test, expect } from "../../../playwright/helpers/base-test";
+import { test } from "../../../playwright/helpers/base-test";
 
 import Loader from ".";
 import LoaderInsideButton from "./components.test-pw";
-import { LOADER_SIZES } from "./loader.config";
-import {
-  loader,
-  loaderInsideButton,
-} from "../../../playwright/components/loader/index";
-import {
-  checkAccessibility,
-  getStyle,
-} from "../../../playwright/support/helper";
+import { checkAccessibility } from "../../../playwright/support/helper";
 
-test.describe("check props for Loader component test", () => {
-  [
-    {
-      size: LOADER_SIZES[0],
-      expectedHeight: "12px",
-      expectedWidth: "12px",
-      expectedMargin: "6px",
-    },
-    {
-      size: LOADER_SIZES[1],
-      expectedHeight: "16px",
-      expectedWidth: "16px",
-      expectedMargin: "8px",
-    },
-    {
-      size: LOADER_SIZES[2],
-      expectedHeight: "20px",
-      expectedWidth: "20px",
-      expectedMargin: "8px",
-    },
-  ].forEach(({ size, expectedHeight, expectedWidth, expectedMargin }) => {
-    test(`should render Loader using ${size} as size`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<Loader size={size} />);
-
-      const loaderNth = (index: number) => loader(page, index);
-
-      const loaderWithCssByNth = async (index: number) => {
-        const heightVal = await getStyle(loaderNth(index), "height");
-        const widthVal = await getStyle(loaderNth(index), "width");
-        const marginRightVal = await getStyle(loaderNth(index), "margin-right");
-        const animationDelayVal = await getStyle(
-          loaderNth(index),
-          "animation-delay",
-        );
-        return [heightVal, widthVal, marginRightVal, animationDelayVal];
-      };
-
-      expect(await loaderWithCssByNth(0)).toEqual([
-        expectedHeight,
-        expectedWidth,
-        expectedMargin,
-        "0s",
-      ]);
-      expect(await loaderWithCssByNth(1)).toEqual([
-        expectedHeight,
-        expectedWidth,
-        expectedMargin,
-        "0.2s",
-      ]);
-      expect(await loaderWithCssByNth(2)).toEqual([
-        expectedHeight,
-        expectedWidth,
-        "0px",
-        "0.4s",
-      ]);
-    });
-  });
-
-  [
-    { size: LOADER_SIZES[0], width: 100 },
-    { size: LOADER_SIZES[1], width: 116 },
-    { size: LOADER_SIZES[2], width: 128 },
-  ].forEach(({ size, width }) => {
-    test(`should render Loader using ${size} as size in Button`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<LoaderInsideButton size={size} />);
-
-      const heightVal = await getStyle(loaderInsideButton(page), "height");
-      const widthVal = await getStyle(loaderInsideButton(page), "width");
-
-      expect(heightVal).toEqual("40px");
-      expect(widthVal).toEqual(`${width}px`);
-    });
-  });
-
-  test("should render Loader inside the Button component with correct color", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<LoaderInsideButton />);
-
-    const color = "rgb(255, 255, 255)";
-
-    const colorVal = async (index: number) => {
-      return getStyle(loader(page, index), "color");
-    };
-
-    expect(await colorVal(0)).toBe(color);
-    expect(await colorVal(1)).toBe(color);
-    expect(await colorVal(2)).toBe(color);
-  });
-
-  test("should render Loader with isActive prop set to false", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<LoaderInsideButton isActive={false} />);
-
-    const backgroundColor = "rgb(255, 255, 255)";
-
-    const colorVal = async (index: number) => {
-      return getStyle(loader(page, index), "background-color");
-    };
-
-    expect(await colorVal(0)).toEqual(backgroundColor);
-    expect(await colorVal(1)).toEqual(backgroundColor);
-    expect(await colorVal(2)).toEqual(backgroundColor);
-  });
-
-  test("should render with expected border radius styling", async ({
+test.describe("Accessibility tests for Loader component", () => {
+  test("should pass accessibility tests for Loader default story", async ({
     mount,
     page,
   }) => {
     await mount(<Loader />);
 
-    const borderRadius = await getStyle(loader(page, 0), "border-radius");
-
-    expect(borderRadius).toEqual("50%");
+    await checkAccessibility(page);
   });
 
-  test("should render Loader inside the Button component and be able to focus it", async ({
+  test("should pass accessibility tests for loading state", async ({
     mount,
     page,
   }) => {
     await mount(<LoaderInsideButton />);
 
-    await loaderInsideButton(page).focus();
-
-    const focusStyle = await getStyle(loaderInsideButton(page), "box-shadow");
-
-    expect(focusStyle).toEqual(
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
-    );
-  });
-
-  [0, 1, 2].forEach((index) => {
-    test(`when the variant prop is set to 'gradient' it should apply correct colour to loader square ${
-      index + 1
-    }`, async ({ mount, page }) => {
-      await mount(<Loader variant="gradient" />);
-
-      const loaderNth = loader(page, index);
-      const squareColour = await getStyle(loaderNth, "color");
-
-      const expectedDelays = ["0s", "0.2s", "0.4s"];
-      const animationDelayVal = await getStyle(loaderNth, "animation-delay");
-
-      expect(squareColour).toBe(await getStyle(loaderNth, "color"));
-      expect(animationDelayVal).toBe(expectedDelays[index]);
-    });
-  });
-
-  test.describe("Accessibility tests for Loader component", () => {
-    test("should pass accessibility tests for Loader default story", async ({
-      mount,
-      page,
-    }) => {
-      await mount(<Loader />);
-
-      await checkAccessibility(page);
-    });
-
-    test("should pass accessibility tests for loading state", async ({
-      mount,
-      page,
-    }) => {
-      await mount(<LoaderInsideButton />);
-
-      await checkAccessibility(page);
-    });
+    await checkAccessibility(page);
   });
 });


### PR DESCRIPTION
### Proposed behaviour

Removes a number of Playwright tests that duplicate either Jest or Chromatic ones for the Drawer component

### Current behaviour

There are a number of tests that exist in different forms in all the testing suites we do(Jest, Playwright, Chromatic) which cause a prolonged time of execution for no additional value.

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

This should decrease the time of execution without compromising testing and coverage

### Testing instructions

Make sure the Playwright tests pass