### PR TITLE
fix(skills): ensure consistent cross-platform output for build:skills script

### DIFF
--- a/scripts/skills/build_skills.mjs
+++ b/scripts/skills/build_skills.mjs
@@ -196,8 +196,9 @@ for (const candidate of uniqueComponentCandidates) {
       "**/*.pw.*",
       "**/*.mdx",
       "**/__internal__/**",
+      "**/__next__/**",
     ],
-  });
+  }).sort();
 
   for (const filePath of moduleFiles) {
     project.addSourceFileAtPathIfExists(filePath);
@@ -246,6 +247,11 @@ const storyDataByComponent = await extractStoryData(project, repoRoot);
 /** @type {Array<{path: string, content: string}>} */
 const wouldWrite = [];
 
+/** @type {Map<string, "lf" | "crlf">} */
+const lineEndingPreferences = !checkMode
+  ? await collectLineEndingPreferences([componentsOutDir, referencesDir, skillsRoot])
+  : new Map();
+
 if (!checkMode) {
   await fs.rm(componentsOutDir, { recursive: true, force: true });
   await fs.rm(referencesDir, { recursive: true, force: true });
@@ -265,7 +271,7 @@ for (const relativePath of docsReferenceFiles) {
   const fileName = path.basename(sourcePath);
   const targetPath = path.join(referencesDir, fileName).replace(/\.mdx?$/, ".md");
   const content = await fs.readFile(sourcePath, "utf8");
-  wouldWrite.push({ path: targetPath, content });
+  wouldWrite.push({ path: targetPath, content: content.replace(/\r\n/g, "\n") });
 }
 
 const indexLines = ["# Carbon Component Catalog", "", "## Components", ""];
@@ -307,7 +313,12 @@ if (checkMode) {
 } else {
   for (const { path: filePath, content } of wouldWrite) {
     await fs.mkdir(path.dirname(filePath), { recursive: true });
-    await fs.writeFile(filePath, content, "utf8");
+    const contentToWrite = await applyExistingLineEndingPreference(
+      filePath,
+      content,
+      lineEndingPreferences,
+    );
+    await fs.writeFile(filePath, contentToWrite, "utf8");
   }
   // eslint-disable-next-line no-console -- Log summary of generated components and output location
   console.log(
@@ -316,6 +327,71 @@ if (checkMode) {
       componentsOutDir,
     )}`,
   );
+}
+
+/**
+ * Normalize a file path for consistent key lookups across platforms.
+ * @param {string} filePath
+ * @returns {string}
+ */
+function normalizePathKey(filePath) {
+  return filePath.replace(/\\/g, "/").toLowerCase();
+}
+
+/**
+ * Collect line ending preferences from existing files in directories.
+ * @param {string[]} directories
+ * @returns {Promise<Map<string, "lf" | "crlf">>}
+ */
+async function collectLineEndingPreferences(directories) {
+  /** @type {Map<string, "lf" | "crlf">} */
+  const preferences = new Map();
+
+  for (const dir of directories) {
+    if (!existsSync(dir)) {
+      continue;
+    }
+
+    const files = await fs.readdir(dir, { recursive: true, withFileTypes: true });
+
+    for (const file of files) {
+      if (!file.isFile()) {
+        continue;
+      }
+
+      const fullPath = path.join(file.parentPath, file.name);
+
+      try {
+        const content = await fs.readFile(fullPath, "utf8");
+        const hasLines = content.includes("\r\n");
+        const key = normalizePathKey(fullPath);
+        preferences.set(key, hasLines ? "crlf" : "lf");
+      } catch {
+        // Ignore files we can't read
+      }
+    }
+  }
+
+  return preferences;
+}
+
+/**
+ * Apply existing line ending preference to content.
+ * @param {string} filePath
+ * @param {string} content
+ * @param {Map<string, "lf" | "crlf">} preferences
+ * @returns {Promise<string>}
+ */
+async function applyExistingLineEndingPreference(filePath, content, preferences) {
+  const key = normalizePathKey(filePath);
+  const preference = preferences.get(key);
+
+  // Default to LF for new files or if no preference found
+  if (preference === "crlf") {
+    return content.replace(/\n/g, "\r\n");
+  }
+
+  return content;
 }
 
 /**
@@ -462,7 +538,7 @@ function resolvePropsDefinition(
           "**/*.pw.*",
           "**/*.mdx",
         ],
-      });
+      }).sort();
 
       const resolvedDefinition = findTypeDefinitionInFiles(
         projectInstance,
@@ -755,11 +831,11 @@ async function extractStoryData(projectInstance, rootDir) {
   const storyFiles = fg.sync(
     ["src/**/*.stories.@(js|jsx|ts|tsx)", "docs/**/*.stories.@(js|jsx|ts|tsx)"],
     { cwd: rootDir, absolute: true },
-  );
+  ).sort();
   const mdxFiles = fg.sync(["src/**/*.mdx", "docs/**/*.mdx"], {
     cwd: rootDir,
     absolute: true,
-  });
+  }).sort();
 
   /** @type {Map<string, StoryEntry[]>} */
   const storyMap = new Map();
@@ -791,7 +867,7 @@ async function extractStoryData(projectInstance, rootDir) {
   }
 
   for (const filePath of mdxFiles) {
-    if (!filePath.includes(`${path.sep}src${path.sep}components${path.sep}`)) {
+    if (!filePath.replace(/\\/g, "/").includes("/src/components/")) {
       continue;
     }
     const componentName = inferComponentNameFromPath(filePath, rootDir);
@@ -799,7 +875,7 @@ async function extractStoryData(projectInstance, rootDir) {
       continue;
     }
     const content = await fs.readFile(filePath, "utf8");
-    const examples = extractMdxExamples(content);
+    const examples = extractMdxExamples(content.replace(/\r\n/g, "\n"));
     if (!examples.length) {
       continue;
     }
@@ -1149,7 +1225,7 @@ async function checkWouldWrite(wouldWrite, { componentsOutDir, referencesDir }) 
       }
       throw err;
     }
-    if (existing !== content) {
+    if (existing.replace(/\r\n/g, "\n") !== content.replace(/\r\n/g, "\n")) {
       diffs.push(`  Modified: ${path.relative(repoRoot, filePath)}`);
     }
   }
@@ -1404,10 +1480,10 @@ function renderComponentMarkdown(component, stories) {
     for (const prop of sortedProps) {
       const literals = prop.literals?.join(" | ") ?? "";
       const description = prop.description?.replace(/\s+/g, " ") ?? "";
-      const defaultValue = prop.defaultValue ?? "";
+      const defaultValue = (prop.defaultValue ?? "").replace(/\r/g, "");
       if (hasDeprecatedProps) {
         const deprecated = prop.deprecated ? "Yes" : "";
-        const deprecationReason = prop.deprecationReason ?? "";
+        const deprecationReason = (prop.deprecationReason ?? "").replace(/\s+/g, " ").trim();
         lines.push(
           `| ${prop.name} | ${escapePipes(prop.type)} | ${prop.required ? "Yes" : "No"} | ${escapePipes(literals)} | ${deprecated} | ${escapePipes(deprecationReason)} | ${escapePipes(description)} | ${escapePipes(defaultValue)} |`,
         );
@@ -1428,10 +1504,10 @@ function renderComponentMarkdown(component, stories) {
       lines.push(`### ${story.name}`);
       lines.push("");
       if (story.argsText) {
-        lines.push("**Args**", "", "```tsx", story.argsText, "```", "");
+        lines.push("**Args**", "", "```tsx", story.argsText.replace(/\r\n/g, "\n"), "```", "");
       }
       if (story.renderText) {
-        lines.push("**Render**", "", "```tsx", story.renderText, "```", "");
+        lines.push("**Render**", "", "```tsx", story.renderText.replace(/\r\n/g, "\n"), "```", "");
       }
       lines.push("");
     }

--- a/skills/carbon-react/components/button.md
+++ b/skills/carbon-react/components/button.md
@@ -77,6 +77,302 @@ description: Carbon Button component props and usage examples.
 | target | string \| undefined | No |  | Yes | HTML target attribute |  |  |
 
 ## Examples
+### Default
+
+**Render**
+
+```tsx
+() => {
+  return <Button>Button</Button>;
+}
+```
+
+
+### Button Content
+
+**Render**
+
+```tsx
+() => {
+  return (
+    <Box display={"flex"} gap={2}>
+      <Button aria-label="Return to the home page">
+        <Icon type="home" />
+      </Button>
+      <Button>
+        <>
+          <Icon type="home" />
+          Return to the home page
+        </>
+      </Button>
+      <Button>
+        <>
+          Return to the home page
+          <Icon type="home" />
+        </>
+      </Button>
+    </Box>
+  );
+}
+```
+
+
+### Click Handler
+
+**Render**
+
+```tsx
+() => {
+  const [value, setValue] = useState(0);
+  return (
+    <Button onClick={() => setValue((p) => p + 1)}>
+      Button Clicked {value} Times
+    </Button>
+  );
+}
+```
+
+
+### Variations
+
+**Render**
+
+```tsx
+(args: ButtonProps) => {
+  return (
+    <Box display="flex" flexDirection="row" gap="24px" alignItems="flex-start">
+      <Box display="flex" flexDirection="column" alignItems="flex-start">
+        <h1>Default</h1>
+        <h2>Primary</h2>
+        <>
+          <Button {...args} variant="default" variantType="primary" />
+        </>
+        <h2>Secondary</h2>
+        <>
+          <Button {...args} variant="default" variantType="secondary" />
+        </>
+        <h2>Tertiary</h2>
+        <>
+          <Button {...args} variant="default" variantType="tertiary" />
+        </>
+        <h2>Subtle</h2>
+        <>
+          <Button {...args} variant="default" variantType="subtle" />
+        </>
+      </Box>
+      <Box display="flex" flexDirection="column" alignItems="flex-start">
+        <h1>Destructive</h1>
+        <h2>Primary</h2>
+        <>
+          <Button {...args} variant="destructive" variantType="primary" />
+        </>
+        <h2>Secondary</h2>
+        <>
+          <Button {...args} variant="destructive" variantType="secondary" />
+        </>
+      </Box>
+      <Box display="flex" flexDirection="column" alignItems="flex-start">
+        <h1>Gradient</h1>
+        <h2>Secondary</h2>
+        <>
+          <Button {...args} variant="gradient" variantType="secondary" />
+        </>
+      </Box>
+    </Box>
+  );
+}
+```
+
+
+### Sizes
+
+**Render**
+
+```tsx
+() => {
+  return (
+    <Box display="flex" gap={3} flexDirection="row" alignItems={"flex-start"}>
+      <Button size="xs">XS</Button>
+      <Button size="small">Small</Button>
+      <Button>Medium</Button>
+      <Button size="large">Large</Button>
+    </Box>
+  );
+}
+```
+
+
+### Disabled
+
+**Render**
+
+```tsx
+() => {
+  return <Button disabled>Button</Button>;
+}
+```
+
+
+### Full-Width
+
+**Render**
+
+```tsx
+() => {
+  return (
+    <Box width="500px" display={"flex"} flexDirection={"column"} gap={1}>
+      <Button fullWidth>Full-Width Button</Button>
+      <br />
+      <br />
+      <Button>Normal Button</Button>
+    </Box>
+  );
+}
+```
+
+
+### Inverse
+
+**Render**
+
+```tsx
+() => {
+  return (
+    <Box
+      backgroundColor="#333"
+      p={2}
+      display="flex"
+      flexDirection="row"
+      gap={1}
+    >
+      <Button variant="default" variantType="primary" size="medium" inverse>
+        Primary Medium
+      </Button>
+      <Button variant="default" variantType="secondary" size="medium" inverse>
+        Secondary Medium
+      </Button>
+      <Button variant="default" variantType="tertiary" size="medium" inverse>
+        Tertiary Medium
+      </Button>
+      <Button variant="default" variantType="subtle" size="medium" inverse>
+        Subtle Medium
+      </Button>
+    </Box>
+  );
+}
+```
+
+
+### Loading
+
+**Render**
+
+```tsx
+() => {
+  return (
+    <Box display={"flex"} flexDirection={"column"} gap={2}>
+      <Button>
+        <Loader variant="inline" loaderType="ring" size="extra-small" />
+      </Button>
+      <Button>
+        <Loader
+          variant="inline"
+          loaderType="ring"
+          loaderLabel="Chargement..."
+          size="extra-small"
+        />
+      </Button>
+    </Box>
+  );
+}
+```
+
+
+### Wrapping Text
+
+**Render**
+
+```tsx
+() => {
+  return (
+    <Box width="80px" display={"flex"} gap={2}>
+      <Button noWrap>No Wrapping</Button>
+      <Button noWrap={false}>With Wrapping</Button>
+    </Box>
+  );
+}
+```
+
+
+### HTML Button Types
+
+**Render**
+
+```tsx
+() => {
+  return (
+    <Box width="80px" display={"flex"} gap={2}>
+      <Button type="button">Button</Button>
+      <Button type="reset">Reset</Button>
+      <Button type="submit">Submit</Button>
+    </Box>
+  );
+}
+```
+
+
+### As a Link
+
+**Render**
+
+```tsx
+() => {
+  return (
+    <Box>
+      <Button ml={2} mt={2} variantType="primary" href="/">
+        I&#39;m a link
+      </Button>
+      <Button
+        mt={2}
+        variantType="primary"
+        href="/"
+        target="_blank"
+        rel="noopener noreferrer"
+        ml={4}
+      >
+        I&#39;m a link that opens in a new tab
+      </Button>
+    </Box>
+  );
+}
+```
+
+
+### Programmatic Focus
+
+**Render**
+
+```tsx
+() => {
+  const buttonRef = useRef<ButtonHandle>(null);
+
+  return (
+    <Box display="flex" gap={2}>
+      <Button ref={buttonRef} variantType="primary">
+        Button to Focus
+      </Button>
+      <Button
+        variantType="secondary"
+        onClick={() => buttonRef.current?.focusButton()}
+      >
+        Focus other button
+      </Button>
+    </Box>
+  );
+}
+```
+
+
 ### Primary
 
 **Render**
@@ -1084,302 +1380,6 @@ description: Carbon Button component props and usage examples.
     <Box width="40px">
       <Button ml={2} mt={2} buttonType="gradient-grey" noWrap>
         Long button text
-      </Button>
-    </Box>
-  );
-}
-```
-
-
-### Default
-
-**Render**
-
-```tsx
-() => {
-  return <Button>Button</Button>;
-}
-```
-
-
-### Button Content
-
-**Render**
-
-```tsx
-() => {
-  return (
-    <Box display={"flex"} gap={2}>
-      <Button aria-label="Return to the home page">
-        <Icon type="home" />
-      </Button>
-      <Button>
-        <>
-          <Icon type="home" />
-          Return to the home page
-        </>
-      </Button>
-      <Button>
-        <>
-          Return to the home page
-          <Icon type="home" />
-        </>
-      </Button>
-    </Box>
-  );
-}
-```
-
-
-### Click Handler
-
-**Render**
-
-```tsx
-() => {
-  const [value, setValue] = useState(0);
-  return (
-    <Button onClick={() => setValue((p) => p + 1)}>
-      Button Clicked {value} Times
-    </Button>
-  );
-}
-```
-
-
-### Variations
-
-**Render**
-
-```tsx
-(args: ButtonProps) => {
-  return (
-    <Box display="flex" flexDirection="row" gap="24px" alignItems="flex-start">
-      <Box display="flex" flexDirection="column" alignItems="flex-start">
-        <h1>Default</h1>
-        <h2>Primary</h2>
-        <>
-          <Button {...args} variant="default" variantType="primary" />
-        </>
-        <h2>Secondary</h2>
-        <>
-          <Button {...args} variant="default" variantType="secondary" />
-        </>
-        <h2>Tertiary</h2>
-        <>
-          <Button {...args} variant="default" variantType="tertiary" />
-        </>
-        <h2>Subtle</h2>
-        <>
-          <Button {...args} variant="default" variantType="subtle" />
-        </>
-      </Box>
-      <Box display="flex" flexDirection="column" alignItems="flex-start">
-        <h1>Destructive</h1>
-        <h2>Primary</h2>
-        <>
-          <Button {...args} variant="destructive" variantType="primary" />
-        </>
-        <h2>Secondary</h2>
-        <>
-          <Button {...args} variant="destructive" variantType="secondary" />
-        </>
-      </Box>
-      <Box display="flex" flexDirection="column" alignItems="flex-start">
-        <h1>Gradient</h1>
-        <h2>Secondary</h2>
-        <>
-          <Button {...args} variant="gradient" variantType="secondary" />
-        </>
-      </Box>
-    </Box>
-  );
-}
-```
-
-
-### Sizes
-
-**Render**
-
-```tsx
-() => {
-  return (
-    <Box display="flex" gap={3} flexDirection="row" alignItems={"flex-start"}>
-      <Button size="xs">XS</Button>
-      <Button size="small">Small</Button>
-      <Button>Medium</Button>
-      <Button size="large">Large</Button>
-    </Box>
-  );
-}
-```
-
-
-### Disabled
-
-**Render**
-
-```tsx
-() => {
-  return <Button disabled>Button</Button>;
-}
-```
-
-
-### Full-Width
-
-**Render**
-
-```tsx
-() => {
-  return (
-    <Box width="500px" display={"flex"} flexDirection={"column"} gap={1}>
-      <Button fullWidth>Full-Width Button</Button>
-      <br />
-      <br />
-      <Button>Normal Button</Button>
-    </Box>
-  );
-}
-```
-
-
-### Inverse
-
-**Render**
-
-```tsx
-() => {
-  return (
-    <Box
-      backgroundColor="#333"
-      p={2}
-      display="flex"
-      flexDirection="row"
-      gap={1}
-    >
-      <Button variant="default" variantType="primary" size="medium" inverse>
-        Primary Medium
-      </Button>
-      <Button variant="default" variantType="secondary" size="medium" inverse>
-        Secondary Medium
-      </Button>
-      <Button variant="default" variantType="tertiary" size="medium" inverse>
-        Tertiary Medium
-      </Button>
-      <Button variant="default" variantType="subtle" size="medium" inverse>
-        Subtle Medium
-      </Button>
-    </Box>
-  );
-}
-```
-
-
-### Loading
-
-**Render**
-
-```tsx
-() => {
-  return (
-    <Box display={"flex"} flexDirection={"column"} gap={2}>
-      <Button>
-        <Loader variant="inline" loaderType="ring" size="extra-small" />
-      </Button>
-      <Button>
-        <Loader
-          variant="inline"
-          loaderType="ring"
-          loaderLabel="Chargement..."
-          size="extra-small"
-        />
-      </Button>
-    </Box>
-  );
-}
-```
-
-
-### Wrapping Text
-
-**Render**
-
-```tsx
-() => {
-  return (
-    <Box width="80px" display={"flex"} gap={2}>
-      <Button noWrap>No Wrapping</Button>
-      <Button noWrap={false}>With Wrapping</Button>
-    </Box>
-  );
-}
-```
-
-
-### HTML Button Types
-
-**Render**
-
-```tsx
-() => {
-  return (
-    <Box width="80px" display={"flex"} gap={2}>
-      <Button type="button">Button</Button>
-      <Button type="reset">Reset</Button>
-      <Button type="submit">Submit</Button>
-    </Box>
-  );
-}
-```
-
-
-### As a Link
-
-**Render**
-
-```tsx
-() => {
-  return (
-    <Box>
-      <Button ml={2} mt={2} variantType="primary" href="/">
-        I&#39;m a link
-      </Button>
-      <Button
-        mt={2}
-        variantType="primary"
-        href="/"
-        target="_blank"
-        rel="noopener noreferrer"
-        ml={4}
-      >
-        I&#39;m a link that opens in a new tab
-      </Button>
-    </Box>
-  );
-}
-```
-
-
-### Programmatic Focus
-
-**Render**
-
-```tsx
-() => {
-  const buttonRef = useRef<ButtonHandle>(null);
-
-  return (
-    <Box display="flex" gap={2}>
-      <Button ref={buttonRef} variantType="primary">
-        Button to Focus
-      </Button>
-      <Button
-        variantType="secondary"
-        onClick={() => buttonRef.current?.focusButton()}
-      >
-        Focus other button
       </Button>
     </Box>
   );

--- a/skills/carbon-react/components/grid-container.md
+++ b/skills/carbon-react/components/grid-container.md
@@ -316,15 +316,9 @@ description: Carbon GridContainer component props and usage examples.
 | aria-valuemin | number \| undefined | No |  |  |  | Defines the minimum allowed value for a range widget. |  |
 | aria-valuenow | number \| undefined | No |  |  |  | Defines the current value for a range widget. |  |
 | aria-valuetext | string \| undefined | No |  |  |  | Defines the human readable text alternative of aria-valuenow for a range widget. |  |
-| gridColumnGap | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Yes | use column-gap
-
-[MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap) | The column-gap CSS property sets the size of the gap (gutter) between an element's columns. |  |
-| gridGap | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Yes | use gap
-
-[MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) | The gap CSS property sets the gaps (gutters) between rows and columns. It is a shorthand for row-gap and column-gap. |  |
-| gridRowGap | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Yes | use row-gap
-
-[MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap) | The row-gap CSS property sets the size of the gap (gutter) between an element's rows. |  |
+| gridColumnGap | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Yes | use column-gap [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap) | The column-gap CSS property sets the size of the gap (gutter) between an element's columns. |  |
+| gridGap | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Yes | use gap [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/gap) | The gap CSS property sets the gaps (gutters) between rows and columns. It is a shorthand for row-gap and column-gap. |  |
+| gridRowGap | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Yes | use row-gap [MDN reference](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap) | The row-gap CSS property sets the size of the gap (gutter) between an element's rows. |  |
 | onKeyPress | KeyboardEventHandler<T> \| undefined | No |  | Yes | Use `onKeyUp` or `onKeyDown` instead |  |  |
 | onKeyPressCapture | KeyboardEventHandler<T> \| undefined | No |  | Yes | Use `onKeyUpCapture` or `onKeyDownCapture` instead |  |  |
 | aria-dropeffect | "copy" \| "link" \| "none" \| "execute" \| "move" \| "popup" \| undefined | No |  | Yes | in ARIA 1.1 | Indicates what functions can be performed when a dragged object is released on the drop target. |  |

--- a/skills/carbon-react/components/loader.md
+++ b/skills/carbon-react/components/loader.md
@@ -45,107 +45,6 @@ description: Carbon Loader component props and usage examples.
 **Render**
 
 ```tsx
-() => {
-  return <Loader />;
-}
-```
-
-
-### With Gradient Variant
-
-**Render**
-
-```tsx
-() => <Loader variant="gradient" />
-```
-
-
-### Small
-
-**Render**
-
-```tsx
-() => {
-  return <Loader size="small" />;
-}
-```
-
-
-### Large
-
-**Render**
-
-```tsx
-() => {
-  return <Loader size="large" />;
-}
-```
-
-
-### Inside Button
-
-**Render**
-
-```tsx
-() => {
-  const [isLoading, setIsLoading] = useState(false);
-  const mimicLoading = () => {
-    setIsLoading(true);
-    setTimeout(() => {
-      setIsLoading(false);
-    }, 5000);
-  };
-  const handleButtonClick = () => {
-    mimicLoading();
-  };
-  const buttonContent = isLoading ? <Loader isInsideButton /> : "Click me";
-
-  return (
-    <div aria-live="polite">
-      <Button m={2} buttonType="primary" onClick={handleButtonClick}>
-        {buttonContent}
-      </Button>
-    </div>
-  );
-}
-```
-
-
-### Conditional Rendering
-
-**Render**
-
-```tsx
-() => {
-  const [isLoading, setIsLoading] = useState(false);
-  const mimicLoading = () => {
-    setIsLoading(true);
-    setTimeout(() => {
-      setIsLoading(false);
-    }, 5000);
-  };
-  const handleButtonClick = () => {
-    mimicLoading();
-  };
-
-  return (
-    <div aria-live="polite">
-      <Button m={2} buttonType="primary" onClick={handleButtonClick}>
-        Render Loader
-      </Button>
-
-      {isLoading ? <Loader /> : "Content to Load"}
-    </div>
-  );
-}
-```
-
-
-### Default
-
-**Render**
-
-```tsx
 (args: LoaderProps) => (
     <Box>
       <Loader {...args} />
@@ -506,5 +405,106 @@ description: Carbon Loader component props and usage examples.
       </Box>
     </>
   )
+```
+
+
+### Default
+
+**Render**
+
+```tsx
+() => {
+  return <Loader />;
+}
+```
+
+
+### With Gradient Variant
+
+**Render**
+
+```tsx
+() => <Loader variant="gradient" />
+```
+
+
+### Small
+
+**Render**
+
+```tsx
+() => {
+  return <Loader size="small" />;
+}
+```
+
+
+### Large
+
+**Render**
+
+```tsx
+() => {
+  return <Loader size="large" />;
+}
+```
+
+
+### Inside Button
+
+**Render**
+
+```tsx
+() => {
+  const [isLoading, setIsLoading] = useState(false);
+  const mimicLoading = () => {
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 5000);
+  };
+  const handleButtonClick = () => {
+    mimicLoading();
+  };
+  const buttonContent = isLoading ? <Loader isInsideButton /> : "Click me";
+
+  return (
+    <div aria-live="polite">
+      <Button m={2} buttonType="primary" onClick={handleButtonClick}>
+        {buttonContent}
+      </Button>
+    </div>
+  );
+}
+```
+
+
+### Conditional Rendering
+
+**Render**
+
+```tsx
+() => {
+  const [isLoading, setIsLoading] = useState(false);
+  const mimicLoading = () => {
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+    }, 5000);
+  };
+  const handleButtonClick = () => {
+    mimicLoading();
+  };
+
+  return (
+    <div aria-live="polite">
+      <Button m={2} buttonType="primary" onClick={handleButtonClick}>
+        Render Loader
+      </Button>
+
+      {isLoading ? <Loader /> : "Content to Load"}
+    </div>
+  );
+}
 ```
 

--- a/skills/carbon-react/components/tab.md
+++ b/skills/carbon-react/components/tab.md
@@ -18,16 +18,45 @@ description: Carbon Tab component props and usage examples.
 | controls | string | Yes |  |  |  | The tab panel that this tab controls |  |
 | id | string | Yes |  |  |  | The ID of the tab |  |
 | label | React.ReactNode | Yes |  |  |  | The label shown on the tab |  |
-| error | string \| boolean \| undefined | No |  |  |  | The error state of the tab | false |
+| ariaLabelledby | string \| undefined | No |  |  |  |  |  |
+| children | React.ReactNode | No |  |  |  | The child elements of Tab component. |  |
+| error | string \| boolean \| undefined | No |  |  |  | The error state of the tab |  |
 | hasCustomLayout | boolean \| undefined | No |  |  |  |  |  |
 | headerWidth | string \| undefined | No |  |  |  |  |  |
-| href | string \| undefined | No |  |  |  |  |  |
+| isTabSelected | boolean \| undefined | No |  |  |  |  |  |
 | leftSlot | React.ReactNode | No |  |  |  | The item shown to the left of the label |  |
+| p | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on top, left, bottom and right |  |
+| padding | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on top, left, bottom and right |  |
+| paddingBottom | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on bottom |  |
+| paddingLeft | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on left |  |
+| paddingRight | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on right |  |
+| paddingTop | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on top |  |
+| paddingX | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on left and right |  |
+| paddingY | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on top and bottom |  |
+| pb | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on bottom |  |
+| pl | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on left |  |
+| pr | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on right |  |
+| pt | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on top |  |
+| px | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on left and right |  |
+| py | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on top and bottom |  |
 | rightSlot | React.ReactNode | No |  |  |  | The item shown to the right of the label |  |
-| warning | string \| boolean \| undefined | No |  |  |  | The warning state of the tab | false |
+| role | string \| undefined | No |  |  |  |  |  |
+| titleProps | { "data-role"?: string; } \| undefined | No |  |  |  | Additional props to be passed to the Tab's corresponding title. |  |
+| validationStatusOverride | { error?: boolean; warning?: boolean; info?: boolean; } \| undefined | No |  |  |  |  |  |
+| warning | string \| boolean \| undefined | No |  |  |  | The warning state of the tab |  |
 | data-element | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
 | data-role | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
-| info | string \| boolean \| undefined | No |  | Yes | to be removed when legacy `Tabs` and `Tab` are removed | The info state of the tab | false |
+| customLayout | React.ReactNode | No |  | Yes | Support for customLayout will be removed in a future release, it is recommended to use the `label` prop instead. | Overrides default layout with a one defined in this prop |  |
+| errorMessage | string \| undefined | No |  | Yes | Message displayed when Tab has error The legacy validation pattern is being removed in a future release. |  |  |
+| href | string \| undefined | No |  | Yes | Using tabs as links is inaccessible; this prop will be deprecated in a future release. | Allows Tab to be a link |  |
+| info | string \| boolean \| undefined | No |  | Yes | to be removed when legacy `Tabs` and `Tab` are removed | The info state of the tab |  |
+| infoMessage | string \| undefined | No |  | Yes | Message displayed when Tab has info The legacy validation pattern is being removed in a future release. |  |  |
+| position | "left" \| "top" \| undefined | No |  | Yes | Support will be removed in a future release. | The position of the Tab. |  |
+| siblings | React.ReactNode | No |  | Yes | Support for siblings will be removed in a future release. It is recommended to use `label` prop to compose what you want. | Additional content to display with title |  |
+| tabId | string \| undefined | No |  | Yes | Support will be removed in a future release, it is recommended to use `id` instead. | A unique ID to identify this specific tab. |  |
+| title | string \| undefined | No |  | Yes | Support will be removed in a future release, it is recommended to use `label` prop instead. | The title of the Tab. |  |
+| titlePosition | "before" \| "after" \| undefined | No |  | Yes | Support for titlePosition will be removed in a future release. It is recommended to use `label` prop to compose what you want. | Position title before or after siblings |  |
+| warningMessage | string \| undefined | No |  | Yes | Message displayed when Tab has warning The legacy validation pattern is being removed in a future release. |  |  |
 
 ## Examples
 ### Default

--- a/skills/carbon-react/components/tabs.md
+++ b/skills/carbon-react/components/tabs.md
@@ -33,7 +33,7 @@ description: Carbon Tabs component props and usage examples.
 | onTabChange | ((tabId: string) => void) \| undefined | No |  |  |  | A callback for when a tab is changed. You can use this to manually control tab changing or to fire other events when a tab is changed. |  |
 | position | "left" \| "top" \| undefined | No |  |  |  | The position of the tab title. |  |
 | selectedTabId | string \| undefined | No |  |  |  | Allows manual control over the currently selected tab. |  |
-| size | "large" \| "default" \| undefined | No |  |  |  | Sets size of the tab titles. | "medium" |
+| size | "large" \| "default" \| undefined | No |  |  |  | Sets size of the tab titles. |  |
 | validationStatusOverride | { [id: string]: { error?: boolean; warning?: boolean; info?: boolean; }; } \| undefined | No |  |  |  | An object to support overriding validation statuses, when the Tabs have custom targets for example. The `id` property should match the `tabId`s for the rendered Tabs. |  |
 | data-element | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
 | data-role | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
@@ -46,6 +46,577 @@ description: Carbon Tabs component props and usage examples.
 | variant | "default" \| "alternate" \| undefined | No |  | Yes | Support for alternate styling variants on tab titles has been removed. | Adds an alternate styling variant to the tab titles. |  |
 
 ## Examples
+### Default
+
+**Args**
+
+```tsx
+{
+  orientation: "horizontal",
+  size: "medium",
+}
+```
+
+**Render**
+
+```tsx
+({ ...args }) => {
+  return (
+    <Tabs {...args}>
+      <TabList ariaLabel="Sample Tabs">
+        <Tab
+          id="tab-1--default"
+          controls="tab-panel-1--default"
+          label="Tab One"
+        />
+        <Tab
+          id="tab-2--default"
+          controls="tab-panel-2--default"
+          label="Tab Two"
+        />
+        <Tab
+          id="tab-3--default"
+          controls="tab-panel-3--default"
+          label="Tab Three"
+        />
+      </TabList>
+      <TabPanel id="tab-panel-1--default" tabId="tab-1--default">
+        <Typography>Content 1</Typography>
+      </TabPanel>
+      <TabPanel id="tab-panel-2--default" tabId="tab-2--default">
+        <Typography>Content 2</Typography>
+      </TabPanel>
+      <TabPanel id="tab-panel-3--default" tabId="tab-3--default">
+        <Typography>Content 3</Typography>
+      </TabPanel>
+    </Tabs>
+  );
+}
+```
+
+
+### Large Size
+
+**Args**
+
+```tsx
+{
+  orientation: "horizontal",
+  size: "large",
+}
+```
+
+**Render**
+
+```tsx
+({ ...args }) => {
+  return (
+    <Tabs {...args}>
+      <TabList ariaLabel="Sample Tabs">
+        <Tab
+          id="tab-1--large-size"
+          controls="tab-panel-1--large-size"
+          label="Tab One"
+        />
+        <Tab
+          id="tab-2--large-size"
+          controls="tab-panel-2--large-size"
+          label="Tab Two"
+        />
+        <Tab
+          id="tab-3--large-size"
+          controls="tab-panel-3--large-size"
+          label="Tab Three"
+        />
+      </TabList>
+      <TabPanel id="tab-panel-1--large-size" tabId="tab-1--large-size">
+        <Typography>Content 1</Typography>
+      </TabPanel>
+      <TabPanel id="tab-panel-2--large-size" tabId="tab-2--large-size">
+        <Typography>Content 2</Typography>
+      </TabPanel>
+      <TabPanel id="tab-panel-3--large-size" tabId="tab-3--large-size">
+        <Typography>Content 3</Typography>
+      </TabPanel>
+    </Tabs>
+  );
+}
+```
+
+
+### Vertical Orientation
+
+**Args**
+
+```tsx
+{
+  orientation: "vertical",
+  size: "medium",
+}
+```
+
+**Render**
+
+```tsx
+({ ...args }) => {
+  return (
+    <Tabs {...args}>
+      <TabList ariaLabel="Sample Tabs">
+        <Tab
+          id="tab-1--vertical"
+          controls="tab-panel-1--vertical"
+          label="Tab One"
+        />
+        <Tab
+          id="tab-2--vertical"
+          controls="tab-panel-2--vertical"
+          label="Tab Two"
+        />
+        <Tab
+          id="tab-3--vertical"
+          controls="tab-panel-3--vertical"
+          label="Tab Three"
+        />
+      </TabList>
+      <TabPanel id="tab-panel-1--vertical" tabId="tab-1--vertical">
+        <Typography>Content 1</Typography>
+      </TabPanel>
+      <TabPanel id="tab-panel-2--vertical" tabId="tab-2--vertical">
+        <Typography>Content 2</Typography>
+      </TabPanel>
+      <TabPanel id="tab-panel-3--vertical" tabId="tab-3--vertical">
+        <Typography>Content 3</Typography>
+      </TabPanel>
+    </Tabs>
+  );
+}
+```
+
+
+### Tab Overflow
+
+**Args**
+
+```tsx
+{
+  orientation: "horizontal",
+  size: "medium",
+}
+```
+
+**Render**
+
+```tsx
+({ ...args }) => {
+  const tabCount = 20;
+  return (
+    <Tabs {...args}>
+      <TabList ariaLabel="Sample Tabs">
+        {Array.from({ length: tabCount }, (_, index) => (
+          <Tab
+            key={`tab-${index + 1}--overflow`}
+            id={`tab-${index + 1}--overflow`}
+            controls={`tab-panel-${index + 1}--overflow`}
+            label={`Tab ${index + 1}`}
+          />
+        ))}
+      </TabList>
+      {Array.from({ length: tabCount }, (_, index) => (
+        <TabPanel
+          key={`tab-panel-${index + 1}--overflow`}
+          id={`tab-panel-${index + 1}--overflow`}
+          tabId={`tab-${index + 1}--overflow`}
+        >
+          <Typography>{`Content ${index + 1}`}</Typography>
+        </TabPanel>
+      ))}
+    </Tabs>
+  );
+}
+```
+
+
+### Title Slots
+
+**Args**
+
+```tsx
+{
+  orientation: "horizontal",
+  size: "medium",
+}
+```
+
+**Render**
+
+```tsx
+({ ...args }) => {
+  return (
+    <Tabs {...args}>
+      <TabList ariaLabel="Sample Tabs">
+        <Tab id="tab-1--slots" controls="tab-panel-1--slots" label="No Slots" />
+        <Tab
+          id="tab-2--slots"
+          controls="tab-panel-2--slots"
+          label="Left slot"
+          leftSlot={<Icon type="home" />}
+        />
+        <Tab
+          id="tab-3--slots"
+          controls="tab-panel-3--slots"
+          label="Right slot"
+          rightSlot={<Pill>Label</Pill>}
+        />
+        <Tab
+          id="tab-4--slots"
+          controls="tab-panel-4--slots"
+          label="Both slots"
+          leftSlot={<Icon type="home" />}
+          rightSlot={<Pill>Label</Pill>}
+        />
+      </TabList>
+      <TabPanel id="tab-panel-1--slots" tabId="tab-1--slots">
+        <Typography>Content 1</Typography>
+      </TabPanel>
+      <TabPanel id="tab-panel-2--slots" tabId="tab-2--slots">
+        <Typography>Content 2</Typography>
+      </TabPanel>
+      <TabPanel id="tab-panel-3--slots" tabId="tab-3--slots">
+        <Typography>Content 3</Typography>
+      </TabPanel>
+      <TabPanel id="tab-panel-4--slots" tabId="tab-4--slots">
+        <Typography>Content 4</Typography>
+      </TabPanel>
+    </Tabs>
+  );
+}
+```
+
+
+### With Error And Warning
+
+**Args**
+
+```tsx
+{
+  orientation: "horizontal",
+  size: "medium",
+}
+```
+
+**Render**
+
+```tsx
+({ ...args }) => {
+  return (
+    <Tabs {...args}>
+      <TabList ariaLabel="Sample Tabs">
+        <Tab
+          id="tab-1--validation"
+          controls="tab-panel-1--validation"
+          label="Default"
+        />
+        <Tab
+          id="tab-2--validation"
+          controls="tab-panel-2--validation"
+          label="Error"
+          error
+        />
+        <Tab
+          id="tab-3--validation"
+          controls="tab-panel-3--validation"
+          label="Warning"
+          warning
+        />
+      </TabList>
+
+      <TabPanel id="tab-panel-1--validation" tabId={"tab-1--validation"}>
+        Content 1
+      </TabPanel>
+
+      <TabPanel id="tab-panel-2--validation" tabId={"tab-2--validation"}>
+        Content 2
+      </TabPanel>
+
+      <TabPanel id="tab-panel-3--validation" tabId={"tab-3--validation"}>
+        Content 3
+      </TabPanel>
+    </Tabs>
+  );
+}
+```
+
+
+### With Error And Warning In Form
+
+**Args**
+
+```tsx
+{
+  orientation: "horizontal",
+  size: "medium",
+}
+```
+
+**Render**
+
+```tsx
+({ ...args }) => {
+  return (
+    <Tabs {...args}>
+      <TabList ariaLabel="Sample Tabs">
+        <Tab
+          id="tab-1--validation-form"
+          controls="tab-panel-1--validation-form"
+          label="Default"
+        />
+        <Tab
+          id="tab-2--validation-form"
+          controls="tab-panel-2--validation-form"
+          label="Error"
+        />
+        <Tab
+          id="tab-3--validation-form"
+          controls="tab-panel-3--validation-form"
+          label="Warning"
+        />
+      </TabList>
+
+      <TabPanel
+        id="tab-panel-1--validation-form"
+        tabId={"tab-1--validation-form"}
+      >
+        <Form
+          onSubmit={() => {}}
+          saveButton={
+            <Button buttonType="primary" type="submit">
+              Save
+            </Button>
+          }
+        >
+          <Textbox label="Textbox" onChange={() => {}} value="" />
+        </Form>
+      </TabPanel>
+
+      <TabPanel
+        id="tab-panel-2--validation-form"
+        tabId={"tab-2--validation-form"}
+      >
+        <Form
+          onSubmit={() => {}}
+          saveButton={
+            <Button buttonType="primary" type="submit">
+              Save
+            </Button>
+          }
+        >
+          <Textbox
+            label="Textbox"
+            onChange={() => {}}
+            value=""
+            error="Textbox must not be blank"
+          />
+        </Form>
+      </TabPanel>
+
+      <TabPanel
+        id="tab-panel-3--validation-form"
+        tabId={"tab-3--validation-form"}
+      >
+        <Form
+          onSubmit={() => {}}
+          saveButton={
+            <Button buttonType="primary" type="submit">
+              Save
+            </Button>
+          }
+        >
+          <Textbox
+            label="Textbox"
+            onChange={() => {}}
+            value=""
+            warning="Textbox must not be blank"
+          />
+        </Form>
+      </TabPanel>
+    </Tabs>
+  );
+}
+```
+
+
+### Pre-Selected Tab
+
+**Args**
+
+```tsx
+{
+  orientation: "horizontal",
+  size: "medium",
+  selectedTabId: "tab-3--pre-selected",
+}
+```
+
+**Render**
+
+```tsx
+({ ...args }) => {
+  return (
+    <Tabs {...args}>
+      <TabList ariaLabel="Sample Tabs">
+        <Tab
+          id="tab-1--pre-selected"
+          controls="tab-panel-1--pre-selected"
+          label="Tab One"
+        />
+        <Tab
+          id="tab-2--pre-selected"
+          controls="tab-panel-2--pre-selected"
+          label="Tab Two"
+        />
+        <Tab
+          id="tab-3--pre-selected"
+          controls="tab-panel-3--pre-selected"
+          label="Tab Three"
+        />
+      </TabList>
+      <TabPanel id="tab-panel-1--pre-selected" tabId="tab-1--pre-selected">
+        <Typography>Content 1</Typography>
+      </TabPanel>
+      <TabPanel id="tab-panel-2--pre-selected" tabId="tab-2--pre-selected">
+        <Typography>Content 2</Typography>
+      </TabPanel>
+      <TabPanel id="tab-panel-3--pre-selected" tabId="tab-3--pre-selected">
+        <Typography>Content 3</Typography>
+      </TabPanel>
+    </Tabs>
+  );
+}
+```
+
+
+### Focusing a Tab Programmatically
+
+**Render**
+
+```tsx
+({ ...args }) => {
+  const tabsHandle = useRef<TabsHandle>(null);
+
+  return (
+    <>
+      <Tabs {...args}>
+        <TabList ariaLabel="Sample Tabs" ref={tabsHandle}>
+          <Tab
+            id="tab-1--programmatic"
+            controls="tab-panel-1--programmatic"
+            label="Tab One"
+          />
+          <Tab
+            id="tab-2--programmatic"
+            controls="tab-panel-2--programmatic"
+            label="Tab Two"
+          />
+          <Tab
+            id="tab-3--programmatic"
+            controls="tab-panel-3--programmatic"
+            label="Tab Three"
+          />
+        </TabList>
+        <TabPanel id="tab-panel-1--programmatic" tabId="tab-1--programmatic">
+          <Typography>Content 1</Typography>
+        </TabPanel>
+        <TabPanel id="tab-panel-2--programmatic" tabId="tab-2--programmatic">
+          <Typography>Content 2</Typography>
+        </TabPanel>
+        <TabPanel id="tab-panel-3--programmatic" tabId="tab-3--programmatic">
+          <Typography>Content 3</Typography>
+        </TabPanel>
+      </Tabs>
+      <Box mt={2} display={"flex"} gap={2}>
+        <Button
+          buttonType="primary"
+          onClick={() => tabsHandle.current?.focusTab("tab-1--programmatic")}
+        >
+          Focus Tab 1
+        </Button>
+        <Button
+          buttonType="primary"
+          onClick={() => tabsHandle.current?.focusTab("tab-2--programmatic")}
+        >
+          Focus Tab 2
+        </Button>
+        <Button
+          buttonType="primary"
+          onClick={() => tabsHandle.current?.focusTab("tab-3--programmatic")}
+        >
+          Focus Tab 3
+        </Button>
+      </Box>
+    </>
+  );
+}
+```
+
+
+### Handle Tab Changes
+
+**Args**
+
+```tsx
+{
+  orientation: "horizontal",
+  size: "medium",
+}
+```
+
+**Render**
+
+```tsx
+({ ...args }) => {
+  const [newUrl, setNewUrl] = useState("");
+  const handleTabChange = useCallback((tabId: string) => {
+    setNewUrl(`${window.location}?tabId=${tabId}`);
+  }, []);
+
+  return (
+    <>
+      <Tabs {...args}>
+        <TabList ariaLabel="Sample Tabs" onTabChange={handleTabChange}>
+          <Tab
+            id="tab-1--default"
+            controls="tab-panel-1--default"
+            label="Tab One"
+          />
+          <Tab
+            id="tab-2--default"
+            controls="tab-panel-2--default"
+            label="Tab Two"
+          />
+          <Tab
+            id="tab-3--default"
+            controls="tab-panel-3--default"
+            label="Tab Three"
+          />
+        </TabList>
+        <TabPanel id="tab-panel-1--default" tabId="tab-1--default">
+          <Typography>Content 1</Typography>
+        </TabPanel>
+        <TabPanel id="tab-panel-2--default" tabId="tab-2--default">
+          <Typography>Content 2</Typography>
+        </TabPanel>
+        <TabPanel id="tab-panel-3--default" tabId="tab-3--default">
+          <Typography>Content 3</Typography>
+        </TabPanel>
+      </Tabs>
+
+      <p>URL for tab: {newUrl || "No tab change detected"}</p>
+    </>
+  );
+}
+```
+
+
 ### Default
 
 **Render**
@@ -711,577 +1282,6 @@ description: Carbon Tabs component props and usage examples.
         </Tab>
       </Tabs>
     </CarbonProvider>
-  );
-}
-```
-
-
-### Default
-
-**Args**
-
-```tsx
-{
-  orientation: "horizontal",
-  size: "medium",
-}
-```
-
-**Render**
-
-```tsx
-({ ...args }) => {
-  return (
-    <Tabs {...args}>
-      <TabList ariaLabel="Sample Tabs">
-        <Tab
-          id="tab-1--default"
-          controls="tab-panel-1--default"
-          label="Tab One"
-        />
-        <Tab
-          id="tab-2--default"
-          controls="tab-panel-2--default"
-          label="Tab Two"
-        />
-        <Tab
-          id="tab-3--default"
-          controls="tab-panel-3--default"
-          label="Tab Three"
-        />
-      </TabList>
-      <TabPanel id="tab-panel-1--default" tabId="tab-1--default">
-        <Typography>Content 1</Typography>
-      </TabPanel>
-      <TabPanel id="tab-panel-2--default" tabId="tab-2--default">
-        <Typography>Content 2</Typography>
-      </TabPanel>
-      <TabPanel id="tab-panel-3--default" tabId="tab-3--default">
-        <Typography>Content 3</Typography>
-      </TabPanel>
-    </Tabs>
-  );
-}
-```
-
-
-### Large Size
-
-**Args**
-
-```tsx
-{
-  orientation: "horizontal",
-  size: "large",
-}
-```
-
-**Render**
-
-```tsx
-({ ...args }) => {
-  return (
-    <Tabs {...args}>
-      <TabList ariaLabel="Sample Tabs">
-        <Tab
-          id="tab-1--large-size"
-          controls="tab-panel-1--large-size"
-          label="Tab One"
-        />
-        <Tab
-          id="tab-2--large-size"
-          controls="tab-panel-2--large-size"
-          label="Tab Two"
-        />
-        <Tab
-          id="tab-3--large-size"
-          controls="tab-panel-3--large-size"
-          label="Tab Three"
-        />
-      </TabList>
-      <TabPanel id="tab-panel-1--large-size" tabId="tab-1--large-size">
-        <Typography>Content 1</Typography>
-      </TabPanel>
-      <TabPanel id="tab-panel-2--large-size" tabId="tab-2--large-size">
-        <Typography>Content 2</Typography>
-      </TabPanel>
-      <TabPanel id="tab-panel-3--large-size" tabId="tab-3--large-size">
-        <Typography>Content 3</Typography>
-      </TabPanel>
-    </Tabs>
-  );
-}
-```
-
-
-### Vertical Orientation
-
-**Args**
-
-```tsx
-{
-  orientation: "vertical",
-  size: "medium",
-}
-```
-
-**Render**
-
-```tsx
-({ ...args }) => {
-  return (
-    <Tabs {...args}>
-      <TabList ariaLabel="Sample Tabs">
-        <Tab
-          id="tab-1--vertical"
-          controls="tab-panel-1--vertical"
-          label="Tab One"
-        />
-        <Tab
-          id="tab-2--vertical"
-          controls="tab-panel-2--vertical"
-          label="Tab Two"
-        />
-        <Tab
-          id="tab-3--vertical"
-          controls="tab-panel-3--vertical"
-          label="Tab Three"
-        />
-      </TabList>
-      <TabPanel id="tab-panel-1--vertical" tabId="tab-1--vertical">
-        <Typography>Content 1</Typography>
-      </TabPanel>
-      <TabPanel id="tab-panel-2--vertical" tabId="tab-2--vertical">
-        <Typography>Content 2</Typography>
-      </TabPanel>
-      <TabPanel id="tab-panel-3--vertical" tabId="tab-3--vertical">
-        <Typography>Content 3</Typography>
-      </TabPanel>
-    </Tabs>
-  );
-}
-```
-
-
-### Tab Overflow
-
-**Args**
-
-```tsx
-{
-  orientation: "horizontal",
-  size: "medium",
-}
-```
-
-**Render**
-
-```tsx
-({ ...args }) => {
-  const tabCount = 20;
-  return (
-    <Tabs {...args}>
-      <TabList ariaLabel="Sample Tabs">
-        {Array.from({ length: tabCount }, (_, index) => (
-          <Tab
-            key={`tab-${index + 1}--overflow`}
-            id={`tab-${index + 1}--overflow`}
-            controls={`tab-panel-${index + 1}--overflow`}
-            label={`Tab ${index + 1}`}
-          />
-        ))}
-      </TabList>
-      {Array.from({ length: tabCount }, (_, index) => (
-        <TabPanel
-          key={`tab-panel-${index + 1}--overflow`}
-          id={`tab-panel-${index + 1}--overflow`}
-          tabId={`tab-${index + 1}--overflow`}
-        >
-          <Typography>{`Content ${index + 1}`}</Typography>
-        </TabPanel>
-      ))}
-    </Tabs>
-  );
-}
-```
-
-
-### Title Slots
-
-**Args**
-
-```tsx
-{
-  orientation: "horizontal",
-  size: "medium",
-}
-```
-
-**Render**
-
-```tsx
-({ ...args }) => {
-  return (
-    <Tabs {...args}>
-      <TabList ariaLabel="Sample Tabs">
-        <Tab id="tab-1--slots" controls="tab-panel-1--slots" label="No Slots" />
-        <Tab
-          id="tab-2--slots"
-          controls="tab-panel-2--slots"
-          label="Left slot"
-          leftSlot={<Icon type="home" />}
-        />
-        <Tab
-          id="tab-3--slots"
-          controls="tab-panel-3--slots"
-          label="Right slot"
-          rightSlot={<Pill>Label</Pill>}
-        />
-        <Tab
-          id="tab-4--slots"
-          controls="tab-panel-4--slots"
-          label="Both slots"
-          leftSlot={<Icon type="home" />}
-          rightSlot={<Pill>Label</Pill>}
-        />
-      </TabList>
-      <TabPanel id="tab-panel-1--slots" tabId="tab-1--slots">
-        <Typography>Content 1</Typography>
-      </TabPanel>
-      <TabPanel id="tab-panel-2--slots" tabId="tab-2--slots">
-        <Typography>Content 2</Typography>
-      </TabPanel>
-      <TabPanel id="tab-panel-3--slots" tabId="tab-3--slots">
-        <Typography>Content 3</Typography>
-      </TabPanel>
-      <TabPanel id="tab-panel-4--slots" tabId="tab-4--slots">
-        <Typography>Content 4</Typography>
-      </TabPanel>
-    </Tabs>
-  );
-}
-```
-
-
-### With Error And Warning
-
-**Args**
-
-```tsx
-{
-  orientation: "horizontal",
-  size: "medium",
-}
-```
-
-**Render**
-
-```tsx
-({ ...args }) => {
-  return (
-    <Tabs {...args}>
-      <TabList ariaLabel="Sample Tabs">
-        <Tab
-          id="tab-1--validation"
-          controls="tab-panel-1--validation"
-          label="Default"
-        />
-        <Tab
-          id="tab-2--validation"
-          controls="tab-panel-2--validation"
-          label="Error"
-          error
-        />
-        <Tab
-          id="tab-3--validation"
-          controls="tab-panel-3--validation"
-          label="Warning"
-          warning
-        />
-      </TabList>
-
-      <TabPanel id="tab-panel-1--validation" tabId={"tab-1--validation"}>
-        Content 1
-      </TabPanel>
-
-      <TabPanel id="tab-panel-2--validation" tabId={"tab-2--validation"}>
-        Content 2
-      </TabPanel>
-
-      <TabPanel id="tab-panel-3--validation" tabId={"tab-3--validation"}>
-        Content 3
-      </TabPanel>
-    </Tabs>
-  );
-}
-```
-
-
-### With Error And Warning In Form
-
-**Args**
-
-```tsx
-{
-  orientation: "horizontal",
-  size: "medium",
-}
-```
-
-**Render**
-
-```tsx
-({ ...args }) => {
-  return (
-    <Tabs {...args}>
-      <TabList ariaLabel="Sample Tabs">
-        <Tab
-          id="tab-1--validation-form"
-          controls="tab-panel-1--validation-form"
-          label="Default"
-        />
-        <Tab
-          id="tab-2--validation-form"
-          controls="tab-panel-2--validation-form"
-          label="Error"
-        />
-        <Tab
-          id="tab-3--validation-form"
-          controls="tab-panel-3--validation-form"
-          label="Warning"
-        />
-      </TabList>
-
-      <TabPanel
-        id="tab-panel-1--validation-form"
-        tabId={"tab-1--validation-form"}
-      >
-        <Form
-          onSubmit={() => {}}
-          saveButton={
-            <Button buttonType="primary" type="submit">
-              Save
-            </Button>
-          }
-        >
-          <Textbox label="Textbox" onChange={() => {}} value="" />
-        </Form>
-      </TabPanel>
-
-      <TabPanel
-        id="tab-panel-2--validation-form"
-        tabId={"tab-2--validation-form"}
-      >
-        <Form
-          onSubmit={() => {}}
-          saveButton={
-            <Button buttonType="primary" type="submit">
-              Save
-            </Button>
-          }
-        >
-          <Textbox
-            label="Textbox"
-            onChange={() => {}}
-            value=""
-            error="Textbox must not be blank"
-          />
-        </Form>
-      </TabPanel>
-
-      <TabPanel
-        id="tab-panel-3--validation-form"
-        tabId={"tab-3--validation-form"}
-      >
-        <Form
-          onSubmit={() => {}}
-          saveButton={
-            <Button buttonType="primary" type="submit">
-              Save
-            </Button>
-          }
-        >
-          <Textbox
-            label="Textbox"
-            onChange={() => {}}
-            value=""
-            warning="Textbox must not be blank"
-          />
-        </Form>
-      </TabPanel>
-    </Tabs>
-  );
-}
-```
-
-
-### Pre-Selected Tab
-
-**Args**
-
-```tsx
-{
-  orientation: "horizontal",
-  size: "medium",
-  selectedTabId: "tab-3--pre-selected",
-}
-```
-
-**Render**
-
-```tsx
-({ ...args }) => {
-  return (
-    <Tabs {...args}>
-      <TabList ariaLabel="Sample Tabs">
-        <Tab
-          id="tab-1--pre-selected"
-          controls="tab-panel-1--pre-selected"
-          label="Tab One"
-        />
-        <Tab
-          id="tab-2--pre-selected"
-          controls="tab-panel-2--pre-selected"
-          label="Tab Two"
-        />
-        <Tab
-          id="tab-3--pre-selected"
-          controls="tab-panel-3--pre-selected"
-          label="Tab Three"
-        />
-      </TabList>
-      <TabPanel id="tab-panel-1--pre-selected" tabId="tab-1--pre-selected">
-        <Typography>Content 1</Typography>
-      </TabPanel>
-      <TabPanel id="tab-panel-2--pre-selected" tabId="tab-2--pre-selected">
-        <Typography>Content 2</Typography>
-      </TabPanel>
-      <TabPanel id="tab-panel-3--pre-selected" tabId="tab-3--pre-selected">
-        <Typography>Content 3</Typography>
-      </TabPanel>
-    </Tabs>
-  );
-}
-```
-
-
-### Focusing a Tab Programmatically
-
-**Render**
-
-```tsx
-({ ...args }) => {
-  const tabsHandle = useRef<TabsHandle>(null);
-
-  return (
-    <>
-      <Tabs {...args}>
-        <TabList ariaLabel="Sample Tabs" ref={tabsHandle}>
-          <Tab
-            id="tab-1--programmatic"
-            controls="tab-panel-1--programmatic"
-            label="Tab One"
-          />
-          <Tab
-            id="tab-2--programmatic"
-            controls="tab-panel-2--programmatic"
-            label="Tab Two"
-          />
-          <Tab
-            id="tab-3--programmatic"
-            controls="tab-panel-3--programmatic"
-            label="Tab Three"
-          />
-        </TabList>
-        <TabPanel id="tab-panel-1--programmatic" tabId="tab-1--programmatic">
-          <Typography>Content 1</Typography>
-        </TabPanel>
-        <TabPanel id="tab-panel-2--programmatic" tabId="tab-2--programmatic">
-          <Typography>Content 2</Typography>
-        </TabPanel>
-        <TabPanel id="tab-panel-3--programmatic" tabId="tab-3--programmatic">
-          <Typography>Content 3</Typography>
-        </TabPanel>
-      </Tabs>
-      <Box mt={2} display={"flex"} gap={2}>
-        <Button
-          buttonType="primary"
-          onClick={() => tabsHandle.current?.focusTab("tab-1--programmatic")}
-        >
-          Focus Tab 1
-        </Button>
-        <Button
-          buttonType="primary"
-          onClick={() => tabsHandle.current?.focusTab("tab-2--programmatic")}
-        >
-          Focus Tab 2
-        </Button>
-        <Button
-          buttonType="primary"
-          onClick={() => tabsHandle.current?.focusTab("tab-3--programmatic")}
-        >
-          Focus Tab 3
-        </Button>
-      </Box>
-    </>
-  );
-}
-```
-
-
-### Handle Tab Changes
-
-**Args**
-
-```tsx
-{
-  orientation: "horizontal",
-  size: "medium",
-}
-```
-
-**Render**
-
-```tsx
-({ ...args }) => {
-  const [newUrl, setNewUrl] = useState("");
-  const handleTabChange = useCallback((tabId: string) => {
-    setNewUrl(`${window.location}?tabId=${tabId}`);
-  }, []);
-
-  return (
-    <>
-      <Tabs {...args}>
-        <TabList ariaLabel="Sample Tabs" onTabChange={handleTabChange}>
-          <Tab
-            id="tab-1--default"
-            controls="tab-panel-1--default"
-            label="Tab One"
-          />
-          <Tab
-            id="tab-2--default"
-            controls="tab-panel-2--default"
-            label="Tab Two"
-          />
-          <Tab
-            id="tab-3--default"
-            controls="tab-panel-3--default"
-            label="Tab Three"
-          />
-        </TabList>
-        <TabPanel id="tab-panel-1--default" tabId="tab-1--default">
-          <Typography>Content 1</Typography>
-        </TabPanel>
-        <TabPanel id="tab-panel-2--default" tabId="tab-2--default">
-          <Typography>Content 2</Typography>
-        </TabPanel>
-        <TabPanel id="tab-panel-3--default" tabId="tab-3--default">
-          <Typography>Content 3</Typography>
-        </TabPanel>
-      </Tabs>
-
-      <p>URL for tab: {newUrl || "No tab change detected"}</p>
-    </>
   );
 }
 ```


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Ensures the skills script has a deterministic output cross platform

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently the skills script is not deterministic cross platform, and results in different diffs and outputs when ran on unix v windows

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
