### PR TITLE
fix(a11y): resolve contrast failures for label, hint, legend and button-toggle-group

### DIFF
--- a/src/__internal__/fieldset/__next__/fieldset.component.tsx
+++ b/src/__internal__/fieldset/__next__/fieldset.component.tsx
@@ -101,6 +101,7 @@ const Fieldset = ({
     >
       {legend && (
         <StyledLegend
+          aria-disabled={isDisabled || undefined}
           data-element="legend"
           $align={legendAlign}
           $isRequired={isRequired}

--- a/src/__internal__/fieldset/__next__/fieldset.test.tsx
+++ b/src/__internal__/fieldset/__next__/fieldset.test.tsx
@@ -200,6 +200,7 @@ test("renders with expected styles when `isDisabled` is true", () => {
     "color",
     "var(--input-labelset-label-disabled)",
   );
+  expect(screen.getByText("Legend")).toHaveAttribute("aria-disabled", "true");
 });
 
 testStyledSystemMargin(

--- a/src/__internal__/fieldset/fieldset.component.tsx
+++ b/src/__internal__/fieldset/fieldset.component.tsx
@@ -206,6 +206,7 @@ const Fieldset = ({
             align={legendAlignment}
             isRequired={isRequired}
             isDisabled={isDisabled}
+            aria-disabled={isDisabled || undefined}
             data-element="legend"
             data-role="legend"
             isLarge={size === "large"}
@@ -218,6 +219,7 @@ const Fieldset = ({
           <HintText
             id={inputHintId}
             isDisabled={isDisabled}
+            aria-disabled={isDisabled || undefined}
             align={legendAlignment}
             isLarge={size === "large"}
           >
@@ -255,6 +257,7 @@ const Fieldset = ({
                 align={legendAlignment}
                 rightPadding={legendSpacing}
                 {...legendMargin}
+                aria-disabled={isDisabled || undefined}
                 data-element="legend"
                 data-role="legend"
                 isRequired={isRequired}

--- a/src/__internal__/fieldset/fieldset.style.ts
+++ b/src/__internal__/fieldset/fieldset.style.ts
@@ -60,9 +60,9 @@ export const StyledLegend = styled.legend<StyledLegendProps>`
   ${({ isDisabled }) =>
     isDisabled &&
     css`
-      color: var(--colorsUtilityYin030);
+      color: var(--input-labelset-label-disabled);
       ::after {
-        color: var(--colorsUtilityYin030);
+        color: var(--input-labelset-label-disabled);
       }
     `}
 

--- a/src/__internal__/fieldset/fieldset.test.tsx
+++ b/src/__internal__/fieldset/fieldset.test.tsx
@@ -254,7 +254,7 @@ describe("when `applyNewValidation` is provided", () => {
     expect(inputs).toBeRequired();
   });
 
-  it("renders with expected styles when `isDisabled` is true", () => {
+  it("renders with expected styles and set aria-disabled when `isDisabled` is true", () => {
     render(
       <Fieldset
         applyNewValidation
@@ -269,8 +269,16 @@ describe("when `applyNewValidation` is provided", () => {
     const legend = screen.getByText("Legend");
     const hint = screen.getByText("input hint");
 
-    expect(legend).toHaveStyleRule("color", "var(--colorsUtilityYin030)");
-    expect(hint).toHaveStyleRule("color", "var(--colorsUtilityYin030)");
+    expect(legend).toHaveStyleRule(
+      "color",
+      "var(--input-labelset-label-disabled)",
+    );
+    expect(hint).toHaveStyleRule(
+      "color",
+      "var(--input-labelset-label-disabled)",
+    );
+    expect(legend).toHaveAttribute("aria-disabled", "true");
+    expect(hint).toHaveAttribute("aria-disabled", "true");
   });
 
   // coverage

--- a/src/__internal__/hint-text/hint-text.component.tsx
+++ b/src/__internal__/hint-text/hint-text.component.tsx
@@ -20,6 +20,7 @@ export const HintText = ({ children, id, size, disabled }: HintTextProps) => {
       id={id}
       $size={size}
       $disabled={disabled}
+      aria-disabled={disabled || undefined}
     >
       {children}
     </StyledHintText>

--- a/src/__internal__/hint-text/hint-text.test.tsx
+++ b/src/__internal__/hint-text/hint-text.test.tsx
@@ -48,7 +48,7 @@ test("should apply small font size when `size` prop is 'small'", () => {
   );
 });
 
-test("should apply disabled colour when `disabled` prop is true", () => {
+test("should apply disabled colour and set aria-disabled when `disabled` prop is true", () => {
   render(
     <HintText size="medium" disabled>
       hint text
@@ -60,6 +60,7 @@ test("should apply disabled colour when `disabled` prop is true", () => {
     "color",
     "var(--input-labelset-label-disabled)",
   );
+  expect(element).toHaveAttribute("aria-disabled", "true");
 });
 
 test("should apply alt colour when `disabled` prop is false", () => {

--- a/src/__internal__/label/label.component.tsx
+++ b/src/__internal__/label/label.component.tsx
@@ -37,6 +37,7 @@ export const Label = ({
       $readOnly={readOnly}
       data-component="label"
       data-element="label"
+      aria-disabled={disabled || undefined}
     >
       {children}
     </StyledLabel>

--- a/src/__internal__/label/label.test.tsx
+++ b/src/__internal__/label/label.test.tsx
@@ -120,7 +120,7 @@ test("should apply medium font to required indicator by default", () => {
   );
 });
 
-test("should apply disabled colour when `disabled` prop is true", () => {
+test("should apply disabled colour and set aria-disabled when `disabled` prop is true", () => {
   render(
     <Label size="medium" disabled>
       Disabled
@@ -132,6 +132,7 @@ test("should apply disabled colour when `disabled` prop is true", () => {
     "color",
     "var(--input-labelset-label-disabled)",
   );
+  expect(label).toHaveAttribute("aria-disabled", "true");
 });
 
 test("should apply default colour when `disabled` prop is false", () => {

--- a/src/__internal__/legacy-hint-text/hint-text.component.tsx
+++ b/src/__internal__/legacy-hint-text/hint-text.component.tsx
@@ -48,6 +48,7 @@ export const HintText = ({
   return (
     <StyledHintText
       align={align}
+      aria-disabled={isDisabled || undefined}
       data-element="input-hint"
       data-role="hint-text"
       fontWeight={fontWeight}

--- a/src/__internal__/legacy-hint-text/hint-text.style.tsx
+++ b/src/__internal__/legacy-hint-text/hint-text.style.tsx
@@ -7,7 +7,7 @@ const getColor = (isDarkBackground?: boolean, isDisabled?: boolean) => {
     return "var(--colorsUtilityYang080)";
   }
   if (isDisabled) {
-    return "var(--colorsUtilityYin030)";
+    return "var(--input-labelset-label-disabled)";
   }
   return "var(--colorsUtilityYin055)";
 };

--- a/src/__internal__/legacy-hint-text/hint-text.test.tsx
+++ b/src/__internal__/legacy-hint-text/hint-text.test.tsx
@@ -57,7 +57,7 @@ test("renders correctly when disabled", () => {
   expect(screen.getByText("foo")).toBeVisible();
   expect(screen.getByText("foo")).toHaveStyleRule(
     `color`,
-    "var(--colorsUtilityYin030)",
+    "var(--input-labelset-label-disabled)",
   );
 });
 

--- a/src/__internal__/legacy-label/label.component.tsx
+++ b/src/__internal__/legacy-label/label.component.tsx
@@ -177,6 +177,7 @@ export const Label = ({
       onClick={onClick}
     >
       <StyledLabel
+        aria-disabled={disabled || undefined}
         data-element="label"
         disabled={disabled}
         id={labelId}

--- a/src/__internal__/legacy-label/label.style.ts
+++ b/src/__internal__/legacy-label/label.style.ts
@@ -39,7 +39,7 @@ const StyledLabel = styled.label<StyledLabelProps>`
   ${({ disabled }) =>
     disabled &&
     css`
-      color: var(--colorsUtilityYin030);
+      color: var(--input-labelset-label-disabled);
     `}
 `;
 

--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.style.ts
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.style.ts
@@ -31,7 +31,8 @@ const StyledButtonToggleGroup = styled.div
     disabled &&
     css`
       cursor: not-allowed;
-      box-shadow: inset 0px 0px 0px 1px var(--colorsActionDisabled600);
+      box-shadow: inset 0px 0px 0px 1px
+        var(--button-typical-toggle-border-disabled);
     `}
 
   ${({ fullWidth }) =>

--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.test.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.test.tsx
@@ -153,13 +153,13 @@ test("should render with disabled child buttons and expected styles when disable
   expect(screen.getByRole("button", { name: "Bar" })).toBeDisabled();
   expect(screen.getByRole("group")).toHaveStyleRule(
     "box-shadow",
-    "inset 0px 0px 0px 1px var(--colorsActionDisabled600)",
+    "inset 0px 0px 0px 1px var(--button-typical-toggle-border-disabled)",
   );
   expect(screen.getByRole("group")).toHaveStyleRule("cursor: not-allowed");
 
   expect(screen.getByText("Group Hint Text")).toHaveStyleRule(
     "color",
-    "var(--colorsUtilityYin030)",
+    "var(--input-labelset-label-disabled)",
   );
 });
 

--- a/src/components/button-toggle/button-toggle.style.ts
+++ b/src/components/button-toggle/button-toggle.style.ts
@@ -131,9 +131,9 @@ const StyledButtonToggle = styled.button.attrs(
       cursor: not-allowed;
 
       & {
-        color: var(--colorsActionMinorYin030);
+        color: var(--button-typical-toggle-label-disabled);
         ${StyledIcon} {
-          color: var(--colorsActionMinorYin030);
+          color: var(--button-typical-toggle-label-disabled);
         }
       }
 

--- a/src/components/select/__internal__/select-textbox/select-textbox.component.tsx
+++ b/src/components/select/__internal__/select-textbox/select-textbox.component.tsx
@@ -232,6 +232,7 @@ const SelectTextbox = React.forwardRef(
           !shouldRenderInput ? (
             <StyledSelectText
               aria-hidden
+              aria-disabled={disabled || undefined}
               data-element="select-text"
               data-role="select-text"
               $disabled={disabled}

--- a/src/components/select/__internal__/select-textbox/select-textbox.test.tsx
+++ b/src/components/select/__internal__/select-textbox/select-textbox.test.tsx
@@ -42,6 +42,21 @@ test("renders as a disabled combobox if disabled prop is true", () => {
   expect(input).toBeDisabled();
 });
 
+test("sets aria-disabled on the select text when disabled", () => {
+  render(
+    <ControlledSelectTextbox
+      selectType="simple"
+      label="Select Colour"
+      disabled
+    />,
+  );
+
+  expect(screen.getByTestId("select-text")).toHaveAttribute(
+    "aria-disabled",
+    "true",
+  );
+});
+
 test("does not focus the input when the disabled prop is true and user clicks on the SelectText component", async () => {
   const user = userEvent.setup();
   render(

--- a/src/components/textbox/textbox.component.tsx
+++ b/src/components/textbox/textbox.component.tsx
@@ -355,6 +355,7 @@ export const Textbox = React.forwardRef(
               float: "right",
             }}
             id={`${uniqueId}-field-help`}
+            aria-disabled={disabled || undefined}
           >
             {fieldHelp}
           </span>


### PR DESCRIPTION
### Proposed behaviour

- add aria-disabled to label, hint and legend when set to disabled
- update label, hint, legend and button-toggle-group to use the new tokens for the disabled states

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

- contrast errors are being flagged by axe when button-toggle-group is disabled but this is a more general issue with label and hint when it's set to disabled

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
