### PR TITLE
fix(character-counter): fixed character counter inconsistencies

### DIFF
--- a/src/components/text-editor/__internal__/__ui__/CharacterCounter/character-counter.component.tsx
+++ b/src/components/text-editor/__internal__/__ui__/CharacterCounter/character-counter.component.tsx
@@ -45,7 +45,7 @@ const CharacterCounterPlugin = ({
     },
     [locale],
   );
-  const [debouncedValue, setDebouncedValue] = useState<number>(0);
+  const [debouncedValue, setDebouncedValue] = useState<number>(maxChars);
 
   // Calculate the number of characters remaining
   const rawCharactersRemaining = useMemo(() => {
@@ -70,13 +70,15 @@ const CharacterCounterPlugin = ({
       <StyledCharacterCounter
         data-role={`${namespace}-character-limit`}
         marginTop={marginTop ?? "var(--spacing050)"}
+        aria-hidden="true"
       >
         {locale.textEditor.characterCounter(
           getFormatNumber(rawCharactersRemaining),
         )}
       </StyledCharacterCounter>
       <VisuallyHiddenCharacterCounter
-        id={`${namespace}-live-character-counter`}
+        data-role={`${namespace}-hidden-live-character-counter`}
+        id={`${namespace}-hidden-live-character-counter`}
         aria-live={isFocused ? "polite" : "off"}
       >
         {locale.textEditor.characterCounter(getFormatNumber(debouncedValue))}

--- a/src/components/text-editor/__internal__/__ui__/CharacterCounter/character-counter.test.tsx
+++ b/src/components/text-editor/__internal__/__ui__/CharacterCounter/character-counter.test.tsx
@@ -54,6 +54,21 @@ const initialValue = {
 };
 
 describe("CharacterCounterPlugin", () => {
+  it("renders the character counter with the correct initial count", async () => {
+    render(
+      <TextEditor
+        labelText="Test Editor"
+        namespace="test"
+        characterLimit={100}
+      />,
+    );
+
+    const hiddenCounter = screen.getByTestId(
+      "test-hidden-live-character-counter",
+    );
+    expect(hiddenCounter).toHaveTextContent("100 characters remaining");
+  });
+
   /*
    * `getBoundingClientRect` is not implemented on `Range` objects in jsdom.
    * Lexical calls this during DOM selection updates after user interactions.


### PR DESCRIPTION
fixes: #7825

### Proposed behaviour

Two changes were introduced to the `CharacterCounter` plugin:
- The initial value was updated from 0 to `maxChars` to ensure it is announced correctly by VoiceOver when the component first loads.
- The visual character counter was removed from the accessibility tree using `aria-hidden="true"`, so it is only announced once.

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour
- When the text editor component loads for the first time, if we are navigating while the VoiceOver is on, the character count is announced as zero when focusing the visually hidden character counter using the keyboard navigation.
- While navigating with VoiceOver enabled, the character count is announced twice, as focus moves first to the visible character counter and then to the hidden one.

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
- Open the storybook and go to the Text Editor demo page
- Open VoiceOver
- Navigate using the Control + Arrows keys