### PR TITLE
fix(split-button, multi-action-button): ensure autoUpdate does not run when popover is closed

### DIFF
--- a/src/__internal__/popover/popover.component.tsx
+++ b/src/__internal__/popover/popover.component.tsx
@@ -35,9 +35,13 @@ export interface PopoverProps {
    */
   reference: RefObject<HTMLElement>;
   /**
-   * Determines if the popover is currently open/visible or not. Defaults to true.
+   * Whether the Popover is open, determines if autoUpdate runs in useFloating.
    */
   isOpen?: boolean;
+  /**
+   * Applies display: none to the content wrapper.
+   */
+  hide?: boolean;
   /**
    * Whether to update the position of the floating element on every animation frame if required. This is optimized for performance but can still be costly. Use with caution!
    * [https://floating-ui.com/docs/autoUpdate#animationframe](https://floating-ui.com/docs/autoUpdate#animationframe)
@@ -66,6 +70,7 @@ const PopoverRoot = ({
   middleware = defaultMiddleware,
   disableBackgroundUI,
   isOpen = true,
+  hide,
   animationFrame,
   popoverStrategy = "absolute",
   childRefOverride,
@@ -95,7 +100,7 @@ const PopoverRoot = ({
   });
 
   return (
-    <StyledPopoverContent isOpen={isOpen}>
+    <StyledPopoverContent hide={hide}>
       {disableBackgroundUI ? (
         <StyledBackdrop data-role="popup-backdrop">{content}</StyledBackdrop>
       ) : (

--- a/src/__internal__/popover/popover.style.ts
+++ b/src/__internal__/popover/popover.style.ts
@@ -17,9 +17,9 @@ export const StyledBackdrop = styled.div.attrs(applyBaseTheme)`
 `;
 
 type StyledPopoverContentProps = {
-  isOpen?: boolean;
+  hide?: boolean;
 };
 
 export const StyledPopoverContent = styled.div<StyledPopoverContentProps>`
-  ${({ isOpen }) => !isOpen && "display: none;"}
+  ${({ hide }) => hide && "display: none;"}
 `;

--- a/src/__internal__/popover/popover.test.tsx
+++ b/src/__internal__/popover/popover.test.tsx
@@ -31,9 +31,9 @@ test("popup content is visible by default", () => {
   expect(screen.getByText("I float!")).toBeVisible();
 });
 
-test("popup content is visible when isOpen prop is true", () => {
+test("popup content is visible when hide prop is false", () => {
   render(
-    <Popover isOpen reference={{ current: null }}>
+    <Popover hide={false} reference={{ current: null }}>
       <div>I float!</div>
     </Popover>,
   );
@@ -41,9 +41,9 @@ test("popup content is visible when isOpen prop is true", () => {
   expect(screen.getByText("I float!")).toBeVisible();
 });
 
-test("popup content is hidden when isOpen prop is false", () => {
+test("popup content is hidden when hide prop is true", () => {
   render(
-    <Popover isOpen={false} reference={{ current: null }}>
+    <Popover hide reference={{ current: null }}>
       <div>I float!</div>
     </Popover>,
   );

--- a/src/components/multi-action-button/multi-action-button.component.tsx
+++ b/src/components/multi-action-button/multi-action-button.component.tsx
@@ -3,6 +3,7 @@ import React, {
   forwardRef,
   useImperativeHandle,
   useContext,
+  useMemo,
 } from "react";
 import { WidthProps } from "styled-system";
 import { flip, offset } from "@floating-ui/dom";
@@ -103,8 +104,19 @@ export const MultiActionButton = forwardRef<
 
     useAdaptiveSidebarModalFocus(() => hideButtons());
 
+    const floatingMiddleware = useMemo(
+      () => [
+        offset(6),
+        flip({
+          fallbackStrategy: "initialPlacement",
+        }),
+      ],
+      [],
+    );
+
     const renderAdditionalButtons = () => (
       <Popover
+        isOpen={showAdditionalButtons}
         disableBackgroundUI={isInFlatTable && showAdditionalButtons}
         disablePortal
         placement={
@@ -114,12 +126,7 @@ export const MultiActionButton = forwardRef<
         }
         reference={buttonNode}
         popoverStrategy="fixed"
-        middleware={[
-          offset(6),
-          flip({
-            fallbackStrategy: "initialPlacement",
-          }),
-        ]}
+        middleware={floatingMiddleware}
       >
         <StyledButtonChildrenContainer
           id={submenuId.current}

--- a/src/components/select/__internal__/select-list/select-list.component.tsx
+++ b/src/components/select/__internal__/select-list/select-list.component.tsx
@@ -91,8 +91,9 @@ export interface SelectListProps {
   listPlacement?: ListPlacement;
   /** Use the opposite list placement if the set placement does not fit */
   flipEnabled?: boolean;
-  /** @private @ignore
-   * Hides the list (with CSS display: none) if not set
+  /**
+   * @private @ignore
+   * Flag to determine if the list is open.
    */
   isOpen?: boolean;
   /** array of selected values, if rendered as part of a MultiSelect */
@@ -692,6 +693,7 @@ const SelectList = React.forwardRef(
           reference={anchorRef}
           middleware={popoverMiddleware}
           isOpen={isOpen}
+          hide={!isOpen}
           disableBackgroundUI
           animationFrame
         >

--- a/src/components/split-button/split-button.component.tsx
+++ b/src/components/split-button/split-button.component.tsx
@@ -4,6 +4,7 @@ import React, {
   forwardRef,
   useImperativeHandle,
   useEffect,
+  useMemo,
 } from "react";
 import { ThemeContext } from "styled-components";
 import { MarginProps } from "styled-system";
@@ -217,8 +218,19 @@ export const SplitButton = forwardRef<SplitButtonHandle, SplitButtonProps>(
       </>
     );
 
+    const floatingMiddleware = useMemo(
+      () => [
+        offset(6),
+        flip({
+          fallbackStrategy: "initialPlacement",
+        }),
+      ],
+      [],
+    );
+
     const renderAdditionalButtons = () => (
       <Popover
+        isOpen={showAdditionalButtons}
         disableBackgroundUI={isInFlatTable && showAdditionalButtons}
         disablePortal
         placement={
@@ -228,12 +240,7 @@ export const SplitButton = forwardRef<SplitButtonHandle, SplitButtonProps>(
         }
         popoverStrategy="fixed"
         reference={buttonNode}
-        middleware={[
-          offset(6),
-          flip({
-            fallbackStrategy: "initialPlacement",
-          }),
-        ]}
+        middleware={floatingMiddleware}
       >
         <StyledSplitButtonChildrenContainer
           data-role="split-button-children-container"

--- a/src/components/split-button/split-button.test.tsx
+++ b/src/components/split-button/split-button.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import * as floatingUi from "@floating-ui/dom";
 import SplitButton, { SplitButtonHandle } from "./split-button.component";
 import Button from "../button";
 import { SizeOptions } from "../button/button.component";
@@ -109,6 +110,35 @@ test("renders child buttons when toggle button is clicked", async () => {
   expect(
     await screen.findByRole("button", { name: "Extra Button 3" }),
   ).toBeVisible();
+});
+
+test("only starts and cleans up floating autoUpdate when additional buttons are visible", async () => {
+  jest.clearAllMocks();
+
+  const user = userEvent.setup();
+  const cleanupSpy = jest.fn();
+  const autoUpdateSpy = jest
+    .spyOn(floatingUi, "autoUpdate")
+    .mockImplementation(() => cleanupSpy);
+
+  render(
+    <SplitButton text="Main">
+      <Button>Single Button</Button>
+    </SplitButton>,
+  );
+
+  expect(autoUpdateSpy).not.toHaveBeenCalled();
+
+  const toggle = screen.getByRole("button", { name: "Show more" });
+  await user.click(toggle);
+
+  expect(autoUpdateSpy).toHaveBeenCalledTimes(1);
+
+  await user.click(toggle);
+
+  expect(cleanupSpy).toHaveBeenCalledTimes(1);
+
+  jest.resetAllMocks();
 });
 
 test("should focus the main button when the focusMainButton on the ref handle is invoked", async () => {

--- a/src/hooks/__internal__/useFloating/useFloating.test.tsx
+++ b/src/hooks/__internal__/useFloating/useFloating.test.tsx
@@ -77,6 +77,69 @@ test("autoUpdate is invoked with proper arguments across different states", () =
   });
 });
 
+test("does not invoke autoUpdate when closed", () => {
+  jest.clearAllMocks();
+  const autoUpdateSpy = jest.spyOn(floatingUi, "autoUpdate");
+
+  render(<MockComponent isOpen={false} />);
+
+  expect(autoUpdateSpy).not.toHaveBeenCalled();
+
+  jest.restoreAllMocks();
+});
+
+test("calls autoUpdate cleanup when closing", () => {
+  jest.clearAllMocks();
+  const cleanupSpy = jest.fn();
+  const autoUpdateSpy = jest
+    .spyOn(floatingUi, "autoUpdate")
+    .mockImplementation(() => cleanupSpy);
+
+  const { rerender } = render(<MockComponent isOpen />);
+
+  expect(autoUpdateSpy).toHaveBeenCalledTimes(1);
+  expect(cleanupSpy).not.toHaveBeenCalled();
+
+  rerender(<MockComponent isOpen={false} />);
+
+  expect(cleanupSpy).toHaveBeenCalledTimes(1);
+
+  jest.restoreAllMocks();
+});
+
+test("does not invoke autoUpdate across rerenders while closed even with new middleware references", () => {
+  jest.clearAllMocks();
+  const autoUpdateSpy = jest.spyOn(floatingUi, "autoUpdate");
+
+  const { rerender } = render(
+    <MockComponent
+      isOpen={false}
+      middleware={[floatingUi.offset(6)]}
+      placement="bottom"
+    />,
+  );
+
+  rerender(
+    <MockComponent
+      isOpen={false}
+      middleware={[floatingUi.offset(8)]}
+      placement="top"
+    />,
+  );
+
+  rerender(
+    <MockComponent
+      isOpen={false}
+      middleware={[floatingUi.flip()]}
+      strategy="fixed"
+    />,
+  );
+
+  expect(autoUpdateSpy).not.toHaveBeenCalled();
+
+  jest.restoreAllMocks();
+});
+
 test("saves floating element original styles and restores them after closing", async () => {
   const { rerender } = render(<MockComponent isOpen />);
 


### PR DESCRIPTION
fix: #7802

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

In SplitButton and MultiActionButton:
- `autoUpdate` only runs if the popover is open
- memoize middleware array
- ensure resize and scroll event listeners are only set up when popover is open

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

In SplitButton and MultiActionButton:
- `autoUpdate` is called even if popover is closed
- middleware array is recreated on every re-render
- resize observers are permanently set up

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

- `SelectList` has been impacted by some of the changes but there should be no visual or functional changes. 
- All components using `Popover` internally should have no detectable changes to consumers. 
-`SplitButton` and `MultiActionButton` to be tested with VO - should have no changes to behaviour. 