### PR TITLE
fix(loader): add missing ai variants to ring type

### DIFF
--- a/skills/carbon-react/components/loader.md
+++ b/skills/carbon-react/components/loader.md
@@ -241,6 +241,45 @@ description: Carbon Loader component props and usage examples.
 ```
 
 
+### Ring AI Stacked Variant
+
+**Render**
+
+```tsx
+() => (
+    <Box>
+      <Loader loaderType="ring" variant="ai-stacked" />
+    </Box>
+  )
+```
+
+
+### Ring AI Inline Variant
+
+**Render**
+
+```tsx
+() => (
+    <Box>
+      <Loader loaderType="ring" variant="ai-inline" />
+    </Box>
+  )
+```
+
+
+### Ring AI Inline Variant Inversed
+
+**Render**
+
+```tsx
+() => (
+    <Box backgroundColor="#1c1c1c" p="8px">
+      <Loader loaderType="ring" variant="ai-inline" inverse />
+    </Box>
+  )
+```
+
+
 ### Is Tracked
 
 **Render**
@@ -323,6 +362,16 @@ description: Carbon Loader component props and usage examples.
 ```tsx
 () => (
     <>
+      <Box height="50px">
+        <Button m={2} buttonType="gradient-grey" onClick={() => {}}>
+          <Loader
+            loaderType="ring"
+            variant="ai-inline"
+            size="extra-small"
+            showLabel
+          />
+        </Button>
+      </Box>
       <Box height="50px">
         <Button m={2} buttonType="primary" onClick={() => {}}>
           <Loader

--- a/src/components/loader/__next__/internal/ring-loader.component.tsx
+++ b/src/components/loader/__next__/internal/ring-loader.component.tsx
@@ -5,6 +5,7 @@ import {
   StyledRingCircleSvg,
   StyledLoaderLabel,
   StyledRingLoaderWrapper,
+  StyledGradientFill,
 } from "../loader.style";
 
 import useLocale from "../../../../hooks/__internal__/useLocale";
@@ -33,14 +34,15 @@ const RingLoader = ({
 }: LoaderProps) => {
   const locale = useLocale();
 
+  const isAiRingVariant = variant === "ai-stacked" || variant === "ai-inline";
   const ringVariant =
-    variant && ["stacked", "inline"].includes(variant) ? variant : "stacked";
+    variant === "inline" || variant === "ai-inline" ? "inline" : "stacked";
   const ringSize =
     size && ["extra-small", "small", "large"].includes(size) ? size : "medium";
 
   return (
     <StyledRingLoaderWrapper
-      loaderVariant={variant}
+      loaderVariant={ringVariant}
       data-role="ring-loader-container"
     >
       <StyledRingCircleSvg
@@ -54,11 +56,31 @@ const RingLoader = ({
         viewBox="0 0 24 24"
         isSuccess={isSuccess}
         isError={isError}
+        isGradientVariant={isAiRingVariant}
       >
+        {isAiRingVariant && (
+          <defs>
+            <mask id="ai-ring-mask">
+              <rect width="24" height="24" fill="black" />
+              <circle data-role="gradient-mask-arc" />
+            </mask>
+          </defs>
+        )}
         <circle data-role="outer-arc" />
-        <circle data-role="inner-arc" />
+        {isAiRingVariant ? (
+          <foreignObject
+            x="0"
+            y="0"
+            width="24"
+            height="24"
+            mask="url(#ai-ring-mask)"
+          >
+            <StyledGradientFill data-role="gradient-fill" />
+          </foreignObject>
+        ) : (
+          <circle data-role="inner-arc" />
+        )}
       </StyledRingCircleSvg>
-
       {showLabel && (
         <StyledLoaderLabel
           inverse={inverse}

--- a/src/components/loader/__next__/loader-test.stories.tsx
+++ b/src/components/loader/__next__/loader-test.stories.tsx
@@ -23,7 +23,14 @@ const meta: Meta<typeof Loader> = {
     },
     variant: {
       control: { type: "select" },
-      options: ["typical", "ai", "stacked", "inline"],
+      options: [
+        "typical",
+        "ai",
+        "stacked",
+        "inline",
+        "ai-stacked",
+        "ai-inline",
+      ],
     },
     loaderLabel: {
       control: { type: "text" },
@@ -130,6 +137,22 @@ export const Variants: Story = {
       <Box backgroundColor="#1c1c1c" p="8px">
         <Loader loaderType="ring" variant="inline" inverse />
       </Box>
+      <h2>Ring AI Stacked</h2>
+      <Box>
+        <Loader loaderType="ring" variant="ai-stacked" />
+      </Box>
+      <h2>Ring AI Inline</h2>
+      <Box>
+        <Loader loaderType="ring" variant="ai-inline" />
+      </Box>
+      <h2>Ring AI Stacked Inversed</h2>
+      <Box backgroundColor="#1c1c1c" p="8px">
+        <Loader loaderType="ring" variant="ai-stacked" inverse />
+      </Box>
+      <h2>Ring AI Inline Inversed</h2>
+      <Box backgroundColor="#1c1c1c" p="8px">
+        <Loader loaderType="ring" variant="ai-inline" inverse />
+      </Box>
     </>
   ),
 };
@@ -158,6 +181,16 @@ TrackedStates.storyName = "Tracked States";
 export const InsideButtons: Story = {
   render: () => (
     <>
+      <Box height="50px">
+        <Button m={2} buttonType="gradient-grey" onClick={() => {}}>
+          <Loader
+            loaderType="ring"
+            variant="ai-inline"
+            size="extra-small"
+            showLabel
+          />
+        </Button>
+      </Box>
       <Box height="50px">
         <Button m={2} buttonType="primary" onClick={() => {}}>
           <Loader

--- a/src/components/loader/__next__/loader.component.tsx
+++ b/src/components/loader/__next__/loader.component.tsx
@@ -13,7 +13,13 @@ import StandaloneLoader from "./internal/standalone-loader.component";
 import RingLoader from "./internal/ring-loader.component";
 import StarsLoader from "./internal/stars-loader.component";
 
-type LOADER_VARIANTS = "typical" | "ai" | "stacked" | "inline";
+type LOADER_VARIANTS =
+  | "typical"
+  | "ai"
+  | "stacked"
+  | "inline"
+  | "ai-stacked"
+  | "ai-inline";
 
 type LOADER_SIZES = "extra-small" | "small" | "medium" | "large";
 

--- a/src/components/loader/__next__/loader.config.js
+++ b/src/components/loader/__next__/loader.config.js
@@ -1,6 +1,6 @@
 const LOADER_TYPES = ["standalone", "ring", "star"];
 const STANDALONE_VARIANTS = ["typical", "ai"];
-const RING_VARIANTS = ["stacked", "inline"];
+const RING_VARIANTS = ["stacked", "inline", "ai-stacked", "ai-inline"];
 const STANDALONE_SIZES = ["small", "medium", "large"];
 const RING_SIZES = ["extra-small", "small", "medium", "large"];
 

--- a/src/components/loader/__next__/loader.mdx
+++ b/src/components/loader/__next__/loader.mdx
@@ -6,7 +6,7 @@ import * as LoaderStories from "./loader.stories";
 <Meta of={LoaderStories} />
 
 # Loader
-Use the `Loader` component to clearly indicate that a task or data is still loading, helping users understand they should wait rather than refresh the page or abandon the process. The `Loader` component offers three loading types: `standalone` (with `typical` and `ai` variants), `ring` (with `inline` or `stacked` variants) and `star` for clear visual feedback.
+Use the `Loader` component to clearly indicate that a task or data is still loading, helping users understand they should wait rather than refresh the page or abandon the process. The `Loader` component offers three loading types: `standalone` (with `typical` and `ai` variants), `ring` (with `inline`, `stacked`, `ai-stacked` and `ai-inline` variants) and `star` for clear visual feedback.
 
 ## Contents
 
@@ -57,7 +57,7 @@ The `standalone` loader type comes with two variants: `typical` (default) and `a
 
 #### Ring variants
 
-The `ring` loader type comes with two variants: `stacked` (default) and `inline`.
+The `ring` loader type comes with four variants: `stacked` (default), `inline`, `ai-stacked` and `ai-inline`.
 
 #### Stacked
 
@@ -66,6 +66,14 @@ The `ring` loader type comes with two variants: `stacked` (default) and `inline`
 #### Inline
 
 <Canvas of={LoaderStories.RingInlineVariant} />
+
+#### A.I. Stacked
+
+<Canvas of={LoaderStories.RingAiStackedVariant} />
+
+#### A.I. Inline
+
+<Canvas of={LoaderStories.RingAiInlineVariant} />
 
 ### Loader Sizes
 
@@ -86,7 +94,7 @@ You can use the `inverse` prop to render the Loader's standalone and ring types 
 
 <Canvas of={LoaderStories.StandaloneTypicalVariantInversed} />
 
-#### Standalone AI inversed
+#### Standalone A.I inversed
 
 <Canvas of={LoaderStories.StandaloneAiVariantInversed} />
 
@@ -97,6 +105,10 @@ You can use the `inverse` prop to render the Loader's standalone and ring types 
 #### Ring inline inversed
 
 <Canvas of={LoaderStories.RingInlineVariantInversed} />
+
+#### Ring A.I inline inversed
+
+<Canvas of={LoaderStories.RingAiInlineVariantInversed} />
 
 ### Is Tracked
 

--- a/src/components/loader/__next__/loader.pw.tsx
+++ b/src/components/loader/__next__/loader.pw.tsx
@@ -16,16 +16,18 @@ test.describe("Accessibility tests for Loader component", () => {
     });
   });
 
-  (["stacked", "inline"] as const).forEach((variant) => {
-    test(`should pass accessibility tests for Ring Loader with variant ${variant}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<Loader loaderType="ring" variant={variant} />);
+  (["stacked", "inline", "ai-stacked", "ai-inline"] as const).forEach(
+    (variant) => {
+      test(`should pass accessibility tests for Ring Loader with variant ${variant}`, async ({
+        mount,
+        page,
+      }) => {
+        await mount(<Loader loaderType="ring" variant={variant} />);
 
-      await checkAccessibility(page);
-    });
-  });
+        await checkAccessibility(page);
+      });
+    },
+  );
 
   test(`should pass accessibility tests for Star Loader`, async ({
     mount,

--- a/src/components/loader/__next__/loader.stories.tsx
+++ b/src/components/loader/__next__/loader.stories.tsx
@@ -162,6 +162,33 @@ export const RingInlineVariantInversed: Story = {
 };
 RingInlineVariantInversed.storyName = "Ring Inline Variant Inversed";
 
+export const RingAiStackedVariant: Story = {
+  render: () => (
+    <Box>
+      <Loader loaderType="ring" variant="ai-stacked" />
+    </Box>
+  ),
+};
+RingAiStackedVariant.storyName = "Ring AI Stacked Variant";
+
+export const RingAiInlineVariant: Story = {
+  render: () => (
+    <Box>
+      <Loader loaderType="ring" variant="ai-inline" />
+    </Box>
+  ),
+};
+RingAiInlineVariant.storyName = "Ring AI Inline Variant";
+
+export const RingAiInlineVariantInversed: Story = {
+  render: () => (
+    <Box backgroundColor="#1c1c1c" p="8px">
+      <Loader loaderType="ring" variant="ai-inline" inverse />
+    </Box>
+  ),
+};
+RingAiInlineVariantInversed.storyName = "Ring AI Inline Variant Inversed";
+
 export const RingIsTracked: Story = {
   render: () => (
     <Box>
@@ -220,6 +247,16 @@ DisabledMotion.storyName = "Disabled Motion";
 export const InsideButtons: Story = {
   render: () => (
     <>
+      <Box height="50px">
+        <Button m={2} buttonType="gradient-grey" onClick={() => {}}>
+          <Loader
+            loaderType="ring"
+            variant="ai-inline"
+            size="extra-small"
+            showLabel
+          />
+        </Button>
+      </Box>
       <Box height="50px">
         <Button m={2} buttonType="primary" onClick={() => {}}>
           <Loader

--- a/src/components/loader/__next__/loader.style.ts
+++ b/src/components/loader/__next__/loader.style.ts
@@ -193,6 +193,7 @@ export const StyledRingCircleSvg = styled.svg<RingSvgProps>`
     isTracked,
     isError,
     isSuccess,
+    isGradientVariant,
     animationTime,
   }) => {
     const dimension = `${ringDimensions[size]}px`;
@@ -214,7 +215,9 @@ export const StyledRingCircleSvg = styled.svg<RingSvgProps>`
       circle[data-role="inner-arc"] {
         fill: transparent;
         stroke-width: ${strokeWidth}px;
-        stroke: ${getStrokeColor({ inverse, isSuccess, isError })};
+        stroke: ${isGradientVariant
+          ? "none"
+          : getStrokeColor({ inverse, isSuccess, isError })};
         stroke-linecap: round;
         stroke-dasharray: 100px;
         stroke-dashoffset: 95px;
@@ -229,13 +232,49 @@ export const StyledRingCircleSvg = styled.svg<RingSvgProps>`
         animation-timing-function: cubic-bezier(0, 0, 1, 1);
         animation-iteration-count: ${hasMotion ? "infinite" : "none"};
       }
+
+      ${isGradientVariant &&
+      css`
+        circle[data-role="gradient-mask-arc"] {
+          fill: none;
+          stroke: white;
+          stroke-width: ${strokeWidth}px;
+          stroke-linecap: round;
+          stroke-dasharray: 100px;
+          stroke-dashoffset: 95px;
+          transform-origin: 12px 12px 0px;
+          cx: 12px;
+          cy: 12px;
+          r: 10px;
+          transform: rotate(-90deg);
+
+          animation-name: ${untrackedAnimation};
+          ${hasMotion && `animation-duration: ${animationTime}s;`}
+          animation-timing-function: cubic-bezier(0, 0, 1, 1);
+          animation-iteration-count: ${hasMotion ? "infinite" : "none"};
+        }
+      `}
+
+      ${!isGradientVariant &&
+      css`
+        ${StyledNextButton} & circle[data-role="inner-arc"],
+        ${StyledButton} & circle[data-role="inner-arc"] {
+          stroke: currentColor;
+        }
+      `}
     `;
   }}
+`;
 
-  ${StyledNextButton} & circle[data-role="inner-arc"],
-  ${StyledButton} & circle[data-role="inner-arc"] {
-    stroke: currentColor;
-  }
+export const StyledGradientFill = styled.div`
+  width: 100%;
+  height: 100%;
+  background: radial-gradient(
+    1514.52% 80.26% at 56.89% 94.74%,
+    var(--mode-color-ai-alt-stop-1) 0%,
+    var(--mode-color-ai-alt-stop-2) 51.22%,
+    var(--mode-color-ai-stop-3) 100%
+  );
 `;
 
 const STAR_CONTAINER_SIZE = "40px";

--- a/src/components/loader/__next__/loader.test.tsx
+++ b/src/components/loader/__next__/loader.test.tsx
@@ -206,6 +206,54 @@ test("renders correctly when `loaderType` is `ring` and variant is `inline`", ()
   );
 });
 
+test("renders correctly when `loaderType` is `ring` and variant is `ai-stacked`", () => {
+  render(
+    <Loader loaderLabel="Loading" loaderType="ring" variant="ai-stacked" />,
+  );
+
+  expect(screen.getByTestId("ring-loader-container")).toHaveStyleRule(
+    "flex-direction",
+    "column",
+  );
+
+  expect(screen.getByTestId("gradient-fill")).toHaveStyleRule(
+    "background",
+    "radial-gradient( 1514.52% 80.26% at 56.89% 94.74%, var(--mode-color-ai-alt-stop-1) 0%, var(--mode-color-ai-alt-stop-2) 51.22%, var(--mode-color-ai-stop-3) 100% )",
+  );
+
+  expect(screen.queryByTestId("inner-arc")).not.toBeInTheDocument();
+});
+
+test("renders correctly when `loaderType` is `ring` and variant is `ai-inline`", () => {
+  render(
+    <Loader loaderLabel="Loading" loaderType="ring" variant="ai-inline" />,
+  );
+
+  expect(screen.getByTestId("ring-loader-container")).toHaveStyleRule(
+    "flex-direction",
+    "row",
+  );
+
+  expect(screen.getByTestId("gradient-fill")).toHaveStyleRule(
+    "background",
+    "radial-gradient( 1514.52% 80.26% at 56.89% 94.74%, var(--mode-color-ai-alt-stop-1) 0%, var(--mode-color-ai-alt-stop-2) 51.22%, var(--mode-color-ai-stop-3) 100% )",
+  );
+
+  expect(screen.queryByTestId("inner-arc")).not.toBeInTheDocument();
+});
+
+test("does not apply ai ring gradient when variant is `ai`", () => {
+  render(<Loader loaderLabel="Loading" loaderType="ring" variant="ai" />);
+
+  expect(screen.getByRole("presentation")).toHaveStyleRule(
+    "stroke",
+    "#000000",
+    {
+      modifier: "circle[data-role='inner-arc']",
+    },
+  );
+});
+
 test("renders correctly when `loaderType` is `ring` and `inverse` prop is set", () => {
   render(<Loader loaderLabel="Loading" loaderType="ring" inverse />);
   expect(screen.getByRole("presentation")).toHaveStyleRule("stroke", "#FFF", {
@@ -262,6 +310,15 @@ test("renders correctly when `loaderType` is `ring` and `hasMotion` prop is not 
     "animation-iteration-count",
     "none",
     { modifier: "circle[data-role='inner-arc']" },
+  );
+});
+
+test("renders correctly when `loaderType` is `ring` and variant is `ai-stacked` and `hasMotion` prop is not set", () => {
+  render(<Loader loaderType="ring" variant="ai-stacked" hasMotion={false} />);
+  expect(screen.getByRole("presentation")).toHaveStyleRule(
+    "animation-iteration-count",
+    "none",
+    { modifier: "circle[data-role='gradient-mask-arc']" },
   );
 });
 


### PR DESCRIPTION
fix #7868

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

adds two new variants to the component: `"ai-stacked"` and `"ai-inverse"`

`"ai-stacked"`

<img width="132" height="123" alt="Screenshot 2026-04-14 at 16 38 59" src="https://github.com/user-attachments/assets/f5a58646-d17c-44be-ae65-fc52f79d2856" />

`"ai-inline"`

<img width="196" height="93" alt="Screenshot 2026-04-14 at 16 39 07" src="https://github.com/user-attachments/assets/9fa7010f-62fa-4731-84d1-adc8392dcf35" />

`"ai-inline"` with `inverse` (same styles would be applied on just `ai-stacked` too with `inline` also being true). This has been tested, and a regression has been captured, I just followed the current documentation convention.

<img width="180" height="83" alt="Screenshot 2026-04-14 at 16 39 16" src="https://github.com/user-attachments/assets/aa80b6d1-eb48-4894-9c81-31288fdcd9e6" />

`"ai-inline"` inside of a `Button` component

<img width="164" height="58" alt="Screenshot 2026-04-14 at 16 39 24" src="https://github.com/user-attachments/assets/9b4fbb5e-46de-4a1c-8702-bac6747a39ba" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

No ai variants when the component is rendered as a ring

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

View the `"Variants"` and `"InsideButtons"` test stories in `loader-test.stories.tsx` to see all new variants
