### PR TITLE
chore(deps): update design token fusion to latest - FE-7647

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-url": "^8.0.2",
         "@sage/design-tokens": "^4.17.0",
-        "@sage/design-tokens-fusion": "npm:@sage/design-tokens@^18.2.1",
+        "@sage/design-tokens-fusion": "npm:@sage/design-tokens@^18.4.0",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
@@ -6089,9 +6089,9 @@
     },
     "node_modules/@sage/design-tokens-fusion": {
       "name": "@sage/design-tokens",
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/@sage/design-tokens/-/design-tokens-18.2.1.tgz",
-      "integrity": "sha512-c373wivJtdgkF6MQ12zYeBYlmNxHJeB/YbiWO3pcHWkyuO2LQSg6fZBJi8p7yoC1pVc75MOKmESOQlhda9y1uA==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@sage/design-tokens/-/design-tokens-18.4.0.tgz",
+      "integrity": "sha512-OqoUAajSxpYFTsrXcEpLPA7FB9yQj9pMCwLiH5l6Ck5ga8zdbVfFDapP0dWoqIahSbsC2hSo3aU44lZEpeJn3A==",
       "dev": true,
       "license": "SEE LICENSE IN https://github.com/Sage/design-tokens/blob/master/license"
     },

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-url": "^8.0.2",
     "@sage/design-tokens": "^4.17.0",
-    "@sage/design-tokens-fusion": "npm:@sage/design-tokens@^18.2.1",
+    "@sage/design-tokens-fusion": "npm:@sage/design-tokens@^18.4.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",

--- a/src/components/tokens-wrapper/__internal__/static-tokens/__snapshots__/static-tokens.test.ts.snap
+++ b/src/components/tokens-wrapper/__internal__/static-tokens/__snapshots__/static-tokens.test.ts.snap
@@ -580,7 +580,7 @@ exports[`builds the static tokens as expected 1`] = `
   --button-typical-tertiary-inverse-label-default: var(--mode-color-action-grayscale-inverse-default);
   --button-typical-tertiary-inverse-label-hover: var(--mode-color-action-grayscale-inverse-with-hover);
   --button-typical-subtle-bg-active: var(--mode-color-action-grayscale-active-alt);
-  --button-typical-subtle-bg-hover: var(--mode-color-action-grayscale-hover-alt);
+  --button-typical-subtle-bg-hover: var(--mode-color-generic-bg-delicate);
   --button-typical-subtle-label-active: var(--mode-color-action-grayscale-with-active-alt);
   --button-typical-subtle-label-disabled: var(--mode-color-action-inactive-txt);
   --button-typical-subtle-label-default: var(--mode-color-action-grayscale-default);
@@ -594,7 +594,7 @@ exports[`builds the static tokens as expected 1`] = `
   --button-typical-toggle-bg-active-disabled: var(--mode-color-action-inactive-default);
   --button-typical-toggle-label-active-disabled: var(--mode-color-action-inactive-txt-alt);
   --button-typical-toggle-bg-active: var(--mode-color-action-grayscale-active);
-  --button-typical-toggle-bg-hover: var(--mode-color-action-grayscale-hover-alt);
+  --button-typical-toggle-bg-hover: var(--mode-color-generic-bg-delicate);
   --button-typical-toggle-border-default: var(--mode-color-action-grayscale-default);
   --button-typical-toggle-border-disabled: var(--mode-color-action-inactive-default);
   --button-typical-toggle-label-active: var(--mode-color-action-grayscale-with-active);
@@ -617,7 +617,7 @@ exports[`builds the static tokens as expected 1`] = `
   --container-action-bg-footer-default: var(--mode-color-generic-bg-nought);
   --container-action-bg-default: var(--mode-color-generic-bg-nought);
   --container-action-bg-disabled: var(--mode-color-action-inactive-default-alt);
-  --container-action-bg-hover: var(--mode-color-action-grayscale-hover-alt);
+  --container-action-bg-hover: var(--mode-color-generic-bg-delicate);
   --container-action-border-active: var(--mode-color-action-grayscale-active);
   --container-action-border-alt: var(--mode-color-generic-fg-moderate);
   --container-action-borderalt-hover: var(--mode-color-action-grayscale-default);
@@ -649,15 +649,16 @@ exports[`builds the static tokens as expected 1`] = `
   --container-standard-border-alt: var(--mode-color-generic-fg-firm);
   --container-standard-border-default: var(--mode-color-generic-fg-soft);
   --container-standard-dimmer: var(--mode-color-action-inactive-mask);
-  --container-standard-icon: var(--mode-color-generic-fg-firm);
   --container-standard-txt-alt: var(--mode-color-generic-txt-moderate);
   --container-standard-txt-default: var(--mode-color-generic-txt-severe);
+  --container-standard-icon: var(--mode-color-generic-txt-severe);
   --container-standard-inverse-bg-alt: var(--mode-color-generic-bg-inverse-delicate);
   --container-standard-inverse-border-alt: var(--mode-color-generic-fg-inverse-firm);
   --container-standard-inverse-bg-default: var(--mode-color-generic-bg-inverse-nought);
   --container-standard-inverse-border-default: var(--mode-color-generic-fg-inverse-soft);
   --container-standard-inverse-txt-alt: var(--mode-color-generic-txt-inverse-moderate);
   --container-standard-inverse-txt-default: var(--mode-color-generic-txt-inverse-severe);
+  --container-standard-inverse-icon: var(--mode-color-generic-txt-inverse-severe);
   --container-standard-priority-bg-ai: var(--mode-color-status-ai-inverse-default-vertical);
   --container-standard-priority-bg-caution: var(--mode-color-status-warning-default);
   --container-standard-priority-bg-negative: var(--mode-color-status-negative-default);
@@ -690,6 +691,8 @@ exports[`builds the static tokens as expected 1`] = `
   --focus-inverse-borderalt: var(--mode-color-action-focus-inverse-default);
   --focus-inverse-border: var(--mode-color-action-focus-inverse-with-default);
   --focus-inverse-label: var(--mode-color-action-focus-inverse-txt);
+  --focus-shadow-default: 0 0 0 2px var(--focus-borderalt), 0 0 0 4px var(--focus-border);
+  --focus-shadow-inset: inset 0 0 0 2px var(--focus-border), inset 0 0 0 4px var(--focus-borderalt);
   --dataviz-chart-bar-fuchsia-bg-alt: var(--mode-color-colorcode-pink-faint);
   --dataviz-chart-bar-fuchsia-bg-default: var(--mode-color-colorcode-pink-intense);
   --dataviz-chart-bar-fuchsia-border: var(--mode-color-colorcode-pink-intense);


### PR DESCRIPTION
### Proposed behaviour

Upgrade `design-token-fusion` to latest 18.4.0 version.

### Current behaviour

Current `design-token-fusion` version that Carbon uses is 18.2.1.


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

N/A