### PR TITLE
fix(use-media-query): optimise hook to avoid uneccessary rerenders

### DIFF
--- a/src/__spec_helper__/mock-match-media.ts
+++ b/src/__spec_helper__/mock-match-media.ts
@@ -1,6 +1,7 @@
 let mocked = false;
 let _matches = false;
-const removeEventListener = jest.fn();
+const removeEventListenerCB = jest.fn();
+let _changeListeners: Set<() => void> = new Set();
 
 export const setupMatchMediaMock = () => {
   if (typeof window === "undefined") {
@@ -10,11 +11,18 @@ export const setupMatchMediaMock = () => {
   Object.defineProperty(global.window, "matchMedia", {
     writable: true,
     value: (query: string) => ({
-      matches: _matches,
+      get matches() {
+        return _matches;
+      },
       media: query,
       onchange: null,
-      addEventListener: noop,
-      removeEventListener,
+      addEventListener: (_event: string, handler: () => void) => {
+        _changeListeners.add(handler);
+      },
+      removeEventListener: (_event: string, handler: () => void) => {
+        _changeListeners.delete(handler);
+        removeEventListenerCB();
+      },
       dispatchEvent: noop,
     }),
   });
@@ -28,5 +36,12 @@ export const mockMatchMedia = (matches: boolean) => {
     );
   }
   _matches = matches;
-  return { removeEventListener };
+  _changeListeners = new Set();
+  return { removeEventListener: removeEventListenerCB };
+};
+
+/** Simulate a media query change — updates `matches` and fires captured listeners */
+export const simulateMediaQueryChange = (matches: boolean) => {
+  _matches = matches;
+  _changeListeners.forEach((l) => l());
 };

--- a/src/components/loader/loader.component.tsx
+++ b/src/components/loader/loader.component.tsx
@@ -46,6 +46,8 @@ export const Loader = ({
     "screen and (prefers-reduced-motion: no-preference)",
   );
 
+  // handle server side rendering and the case where window becomes available after first render
+  /* istanbul ignore if */
   if (allowMotion === undefined) {
     return <StyledLoaderPlaceholder />;
   }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,4 +1,5 @@
 import { type ModalList } from "./__internal__/modal/modal-manager";
+import { type QueryEntry } from "./hooks/useMediaQuery/useMediaQuery";
 
 declare global {
   module "*.png";
@@ -16,6 +17,7 @@ declare global {
       originalValues: string[];
       restoreValues?: (() => void) | null;
     };
+    __CARBON_INTERNALS_MEDIA_QUERY_CACHE?: Map<string, QueryEntry>;
   }
 }
 

--- a/src/hooks/__internal__/useIsAboveBreakpoint/useIsAboveBreakpoint.ts
+++ b/src/hooks/__internal__/useIsAboveBreakpoint/useIsAboveBreakpoint.ts
@@ -3,7 +3,12 @@ import useMediaQuery from "../../useMediaQuery";
 export default function useIsAboveBreakpoint(
   breakpoint?: number,
 ): boolean | undefined {
-  const matchesQuery = useMediaQuery(`(min-width:${breakpoint}px)`);
-  if (!breakpoint) return undefined;
+  const query = breakpoint ? `(min-width:${breakpoint}px)` : "";
+  const matchesQuery = useMediaQuery(query);
+
+  if (!query) {
+    return undefined;
+  }
+
   return matchesQuery;
 }

--- a/src/hooks/useMediaQuery/useMediaQuery.server.test.tsx
+++ b/src/hooks/useMediaQuery/useMediaQuery.server.test.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { renderToString } from "react-dom/server";
+
+import useMediaQuery from ".";
+
+const TestComponent = () => {
+  const matchQuery = useMediaQuery("(min-width:960px)");
+  return <span>{`${matchQuery}`}</span>;
+};
+
+test("returns undefined in a server-side environment", () => {
+  const view = renderToString(<TestComponent />);
+  expect(view).toContain("undefined");
+});
+
+test("renders without errors when window is not available", () => {
+  expect(() => renderToString(<TestComponent />)).not.toThrow();
+});

--- a/src/hooks/useMediaQuery/useMediaQuery.test.tsx
+++ b/src/hooks/useMediaQuery/useMediaQuery.test.tsx
@@ -1,13 +1,21 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 
 import useMediaQuery from ".";
 import { mockMatchMedia } from "../../__spec_helper__/__internal__/test-utils";
+import { simulateMediaQueryChange } from "../../__spec_helper__/mock-match-media";
 
-const TestComponent = () => {
-  const matchQuery = useMediaQuery("(min-width:960px)");
+const STORAGE_PREFIX = "__CARBON_MQ_";
+const NORMALIZED_QUERY = "(min-width: 960px)";
+
+const TestComponent = ({ query = "(min-width:960px)" }: { query?: string }) => {
+  const matchQuery = useMediaQuery(query);
   return <span>{`${matchQuery}`}</span>;
 };
+
+afterEach(() => {
+  sessionStorage.clear();
+});
 
 test("renders 'false' when the media query does not match", () => {
   mockMatchMedia(false);
@@ -35,4 +43,158 @@ test("removes event listener when the component unmounts", () => {
   expect(screen.getByText("true")).toBeInTheDocument();
   unmount();
   expect(removeListenerFn.mock.calls.length).toEqual(1);
+});
+
+test("only calls the removeEventListener once when multiple components are using the same query and unmount", () => {
+  const { removeEventListener } = mockMatchMedia(true);
+  const removeListenerFn: jest.Mock = removeEventListener;
+  removeListenerFn.mockClear();
+
+  const { unmount } = render(
+    <>
+      <TestComponent />
+      <TestComponent />
+    </>,
+  );
+
+  expect(screen.getAllByText("true").length).toEqual(2);
+  unmount();
+  expect(removeListenerFn.mock.calls.length).toEqual(1);
+});
+
+test("updates all subscribers when the media query changes", () => {
+  mockMatchMedia(false);
+
+  render(
+    <>
+      <TestComponent />
+      <TestComponent />
+    </>,
+  );
+
+  expect(screen.getAllByText("false")).toHaveLength(2);
+
+  act(() => {
+    simulateMediaQueryChange(true);
+  });
+
+  expect(screen.getAllByText("true")).toHaveLength(2);
+});
+
+describe("sessionStorage caching", () => {
+  test("writes the matched value to sessionStorage on mount", () => {
+    mockMatchMedia(true);
+
+    render(<TestComponent />);
+
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}${NORMALIZED_QUERY}`)).toBe(
+      "true",
+    );
+  });
+
+  test("reads a cached `true` value from sessionStorage on mount", () => {
+    sessionStorage.setItem(`${STORAGE_PREFIX}${NORMALIZED_QUERY}`, "true");
+    mockMatchMedia(true);
+
+    render(<TestComponent />);
+
+    expect(screen.getByText("true")).toBeInTheDocument();
+  });
+
+  test("reads a cached `false` value from sessionStorage on mount", () => {
+    sessionStorage.setItem(`${STORAGE_PREFIX}${NORMALIZED_QUERY}`, "false");
+    mockMatchMedia(false);
+
+    render(<TestComponent />);
+
+    expect(screen.getByText("false")).toBeInTheDocument();
+  });
+
+  test("corrects a stale sessionStorage value with the live matchMedia result", () => {
+    sessionStorage.setItem(`${STORAGE_PREFIX}${NORMALIZED_QUERY}`, "true");
+    mockMatchMedia(false);
+
+    render(<TestComponent />);
+
+    expect(screen.getByText("false")).toBeInTheDocument();
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}${NORMALIZED_QUERY}`)).toBe(
+      "false",
+    );
+  });
+
+  test("updates sessionStorage when the media query changes", () => {
+    mockMatchMedia(false);
+
+    render(<TestComponent />);
+
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}${NORMALIZED_QUERY}`)).toBe(
+      "false",
+    );
+
+    act(() => {
+      simulateMediaQueryChange(true);
+    });
+
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}${NORMALIZED_QUERY}`)).toBe(
+      "true",
+    );
+  });
+
+  test("handles sessionStorage being unavailable", () => {
+    const getItemSpy = jest
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("SecurityError");
+      });
+    const setItemSpy = jest
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("SecurityError");
+      });
+
+    mockMatchMedia(true);
+
+    render(<TestComponent />);
+
+    expect(screen.getByText("true")).toBeInTheDocument();
+
+    getItemSpy.mockRestore();
+    setItemSpy.mockRestore();
+  });
+
+  test("returns undefined when sessionStorage has no cached value and no matchMedia yet", () => {
+    mockMatchMedia(false);
+
+    render(<TestComponent query="" />);
+
+    expect(screen.getByText("undefined")).toBeInTheDocument();
+  });
+});
+
+describe("query normalization", () => {
+  test("normalizes whitespace variations to the same query", () => {
+    mockMatchMedia(true);
+
+    const { unmount } = render(<TestComponent query="(min-width:960px)" />);
+    expect(screen.getByText("true")).toBeInTheDocument();
+    unmount();
+
+    render(<TestComponent query="( min-width:  960px )" />);
+    expect(screen.getByText("true")).toBeInTheDocument();
+
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}${NORMALIZED_QUERY}`)).toBe(
+      "true",
+    );
+  });
+
+  test("strips @media prefix before normalizing", () => {
+    mockMatchMedia(true);
+
+    render(<TestComponent query="@media (min-width:960px)" />);
+
+    expect(screen.getByText("true")).toBeInTheDocument();
+    expect(sessionStorage.getItem(`${STORAGE_PREFIX}${NORMALIZED_QUERY}`)).toBe(
+      "true",
+    );
+  });
 });

--- a/src/hooks/useMediaQuery/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery/useMediaQuery.ts
@@ -1,29 +1,156 @@
-import { useLayoutEffect, useState } from "react";
+import { useLayoutEffect, useCallback, useState, useEffect } from "react";
 import { getWindow } from "../../__internal__/dom/globals";
 
-export default function useMediaQuery(queryInput: string): boolean | undefined {
-  const query = queryInput.replace(/^@media( ?)/m, "");
+type Listener = () => void;
 
-  const [match, setMatch] = useState<boolean | undefined>(undefined);
+// Changes to this should be treated as a breaking change
+export interface QueryEntry {
+  mediaQueryList: MediaQueryList;
+  listeners: Set<Listener>;
+  nativeHandler: () => void;
+  refCount: number;
+}
 
-  useLayoutEffect(() => {
-    const browserWindow = getWindow();
+const browserWindow = getWindow();
+// Can't have a guard against window being undefined. It could lead to uneven hook
+// calls if the window is not available on first render but becomes available later.
+// There is a guard to make the hooks noop but useLayoutEffect throws warnings in SSR
+// which causes tests to fail
+const useIsomorphicLayoutEffect = browserWindow ? useLayoutEffect : useEffect;
+const CACHE_KEY = "__CARBON_INTERNALS_MEDIA_QUERY_CACHE" as const;
+const STORAGE_PREFIX = "__CARBON_MQ_";
 
+const getQueryCache = (windowObject: Window): Map<string, QueryEntry> => {
+  if (!windowObject[CACHE_KEY]) {
+    windowObject[CACHE_KEY] = new Map<string, QueryEntry>();
+  }
+
+  return windowObject[CACHE_KEY];
+};
+
+const getOrCreateEntry = (
+  query: string,
+  windowObject: Window,
+): { entry: QueryEntry; cache: Map<string, QueryEntry> } => {
+  const cache = getQueryCache(windowObject);
+  const existing = cache.get(query);
+
+  /* if the query already exists do not add again, just return the existing entry */
+  if (existing) {
+    return { entry: existing, cache };
+  }
+
+  /* create a new entry for this media query */
+  const mediaQueryList = windowObject.matchMedia(query);
+  const entry: QueryEntry = {
+    mediaQueryList,
+    listeners: new Set(),
+    nativeHandler: () => {
+      entry.listeners.forEach((l) => l());
+    },
+    refCount: 0,
+  };
+  mediaQueryList.addEventListener("change", entry.nativeHandler);
+  cache.set(query, entry);
+
+  return { entry, cache };
+};
+
+const subscribe = (
+  query: string,
+  listener: Listener,
+  windowObject: Window,
+): { matches: boolean; unsubscribe: () => void } => {
+  const { entry, cache } = getOrCreateEntry(query, windowObject);
+  entry.refCount += 1;
+  entry.listeners.add(listener);
+
+  return {
+    matches: entry.mediaQueryList.matches,
+    unsubscribe: () => {
+      entry.listeners.delete(listener);
+      entry.refCount -= 1;
+
+      if (!entry.refCount) {
+        entry.mediaQueryList.removeEventListener("change", entry.nativeHandler);
+        cache.delete(query);
+      }
+    },
+  };
+};
+
+const readCached = (query: string): boolean | undefined => {
+  try {
+    const stored = sessionStorage.getItem(`${STORAGE_PREFIX}${query}`);
+    if (stored === "true") {
+      return true;
+    }
+    if (stored === "false") {
+      return false;
+    }
+
+    return undefined;
+  } catch {
+    // sessionStorage unavailable (SSR, sandboxed iframe, quota)
+    return undefined;
+  }
+};
+
+const writeCached = (query: string, matches: boolean): void => {
+  try {
+    sessionStorage.setItem(`${STORAGE_PREFIX}${query}`, String(matches));
+  } catch {
+    // sessionStorage unavailable (SSR, sandboxed iframe, quota)
+  }
+};
+
+const normalizeQuery = (query: string): string =>
+  query
+    .replace(/\s+/g, " ")
+    .replace(/:\s*/g, ": ")
+    .replace(/\(\s*/g, "(")
+    .replace(/\s*\)/g, ")")
+    .trim();
+
+export default (queryInput: string): boolean | undefined => {
+  const query = normalizeQuery(
+    queryInput?.replace(/^@media( ?)/m, "") ?? /* istanbul ignore next */ "",
+  );
+  const [match, setMatch] = useState<boolean | undefined>(() =>
+    browserWindow && query ? readCached(query) : undefined,
+  );
+  const updateMatch = useCallback(() => {
     /* istanbul ignore if */
     if (!browserWindow) {
+      return;
+    }
+
+    const cache = getQueryCache(browserWindow);
+    const entry = cache.get(query);
+
+    /* istanbul ignore else */
+    if (entry) {
+      setMatch(entry.mediaQueryList.matches);
+      writeCached(query, entry.mediaQueryList.matches);
+    }
+  }, [query]);
+
+  useIsomorphicLayoutEffect(() => {
+    /* istanbul ignore if */
+    if (!browserWindow || !query) {
       return undefined;
     }
 
-    const queryList = browserWindow.matchMedia(query);
-    const updateMatch = () => setMatch(queryList.matches);
+    const { matches, unsubscribe } = subscribe(
+      query,
+      updateMatch,
+      browserWindow,
+    );
+    setMatch(matches);
+    writeCached(query, matches);
 
-    updateMatch();
-    queryList.addEventListener("change", updateMatch);
-
-    return () => {
-      queryList.removeEventListener("change", updateMatch);
-    };
-  }, [query]);
+    return unsubscribe;
+  }, [query, updateMatch]);
 
   return match;
-}
+};


### PR DESCRIPTION
fix #7884

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Update `useMediaQuery` to cache query calls.
Now there is one listener per query string and each component is registered to respond to that
Ensures that `useAboveBreakpoint` doesn't initialise a media query if `breakpoint` is undefined

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
`useMediaQuery` does not cache
Each time a component registers a query a listener is set up which is triggered via updates and runs the effect
`useAboveBreakpoint` is applying media queries even when `breakpoint` is not defined meaning we get listeners setup for things like `min-width:undefinedpx` etc
### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required
- [x] Typescript `d.ts` file added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Just confirm the functionality isn't lost from this update
I will cut a beta for the MFE testing side of things and provide testing project once it's confirmed nothing as has broken in storybook etc
