### PR TITLE
feat: update focus styling to be inline with DS - FE-7630

### DIFF
--- a/playwright/support/helper.ts
+++ b/playwright/support/helper.ts
@@ -358,7 +358,7 @@ export const checkNewFocusStyling = async (locator: Locator) => {
     window.getComputedStyle(el, "after").getPropertyValue("outline"),
   );
   expect(shadowValue).toBe(
-    `rgba(0, 0, 0, 0.9) 0px 0px 0px 3px inset, rgb(255, 188, 25) 0px 0px 0px 6px inset`,
+    `rgb(255, 181, 0) 0px 0px 0px 2px inset, rgb(0, 0, 0) 0px 0px 0px 4px inset`,
   );
   expect(outlineValue).toBe(`rgba(0, 0, 0, 0) solid 3px`);
 };

--- a/src/components/button-minor/button-minor.pw.tsx
+++ b/src/components/button-minor/button-minor.pw.tsx
@@ -67,7 +67,7 @@ test.describe("check Focus Outline & Border Radius for Button Minor Component", 
     await outlined.focus();
     await expect(outlined).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     await expect(outlined).toHaveCSS("outline", "rgba(0, 0, 0, 0) solid 3px");
   });

--- a/src/components/confirm/confirm.pw.tsx
+++ b/src/components/confirm/confirm.pw.tsx
@@ -480,7 +480,7 @@ test.describe("should render Confirm component", () => {
     const focusedButton = page.getByRole("button").first();
     await expect(focusedButton).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     await expect(focusedButton).toHaveCSS(
       "outline",
@@ -498,7 +498,7 @@ test.describe("should render Confirm component", () => {
 
     await expect(page.getByRole("button").first()).not.toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
   });
 

--- a/src/components/dialog/dialog.pw.tsx
+++ b/src/components/dialog/dialog.pw.tsx
@@ -579,7 +579,7 @@ test.describe("Fullscreen Dialog component", () => {
         .filter({ hasText: "This should be focused first now" });
       await expect(focusedButton).toHaveCSS(
         "box-shadow",
-        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+        "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
       );
       await expect(focusedButton).toHaveCSS(
         "outline",

--- a/src/components/flat-table/flat-table.pw.tsx
+++ b/src/components/flat-table/flat-table.pw.tsx
@@ -863,7 +863,7 @@ test.describe("Prop tests", () => {
       .locator("div:nth-child(2)");
     await expect(checkboxParent).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
 
     await expect(
@@ -895,7 +895,7 @@ test.describe("Prop tests", () => {
         .locator("div:nth-child(2)"),
     ).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
 
     await expect(
@@ -939,7 +939,7 @@ test.describe("Prop tests", () => {
         .locator("div:nth-child(2)"),
     ).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     for await (const i of indexes(4)) {
       await expect(
@@ -988,7 +988,7 @@ test.describe("Prop tests", () => {
         .locator("div:nth-child(2)"),
     ).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     for await (const i of indexes(4)) {
       await expect(
@@ -1057,7 +1057,7 @@ test.describe("Prop tests", () => {
       .locator("div:nth-child(2)");
     await expect(bodyRowParent).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     await expect(
       flatTableBodyRows(page).first().locator("td").first(),
@@ -1733,7 +1733,7 @@ test.describe("Prop tests", () => {
       .locator("div:nth-child(2)");
     await expect(bodyRowByPosition0Parent).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
 
     const bodyRowByPosition1Input = flatTableBodyRowByPosition(page, 1).locator(
@@ -1749,7 +1749,7 @@ test.describe("Prop tests", () => {
       .locator("div:nth-child(2)");
     await expect(bodyRowByPosition1Parent).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
   });
 
@@ -1776,7 +1776,7 @@ test.describe("Prop tests", () => {
       .locator("div:nth-child(2)");
     await expect(bodyRowByPosition0Parent).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     await expect(
       flatTableBodyRowByPosition(page, 1).locator("input"),
@@ -1809,7 +1809,7 @@ test.describe("Prop tests", () => {
         .locator("div:nth-child(2)"),
     ).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
   });
 
@@ -2336,7 +2336,7 @@ test.describe("Prop tests", () => {
 
     await expect(flatTableWrapper(page)).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     await expect(flatTableWrapper(page)).toHaveCSS(
       "outline",

--- a/src/components/heading/heading.pw.tsx
+++ b/src/components/heading/heading.pw.tsx
@@ -132,7 +132,7 @@ test.describe("Heading component", () => {
     await backLinkAnchor.focus();
     await expect(backLinkAnchor).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     await expect(backLinkAnchor).toHaveCSS(
       "outline",

--- a/src/components/icon-button/icon-button.pw.tsx
+++ b/src/components/icon-button/icon-button.pw.tsx
@@ -12,7 +12,7 @@ test.describe("check IconButton component focus outlines and border radius", () 
     await iconButton(page).focus();
     await expect(iconButton(page)).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
 
     await expect(iconButton(page)).toHaveCSS(

--- a/src/components/menu/menu.pw.tsx
+++ b/src/components/menu/menu.pw.tsx
@@ -345,7 +345,7 @@ test.describe("Prop tests for Menu component", () => {
     await expect(button).toBeFocused();
     await expect(button).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     await page.keyboard.press("Tab");
     const item2 = menuItem(page).last().locator("a");

--- a/src/components/pager/pager.pw.tsx
+++ b/src/components/pager/pager.pw.tsx
@@ -63,7 +63,7 @@ test.describe("Styling tests", () => {
 
     await expect(inputParent).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     await expect(inputParent).toHaveCSS(
       "outline",

--- a/src/components/search/search.pw.tsx
+++ b/src/components/search/search.pw.tsx
@@ -48,7 +48,7 @@ test.describe("When focused", () => {
 
     await expect(searchDefaultInputElementParent).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
   });
 
@@ -68,7 +68,7 @@ test.describe("When focused", () => {
 
     await expect(searchButtonElement).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
   });
 });

--- a/src/components/select/filterable-select/filterable-select.pw.tsx
+++ b/src/components/select/filterable-select/filterable-select.pw.tsx
@@ -66,7 +66,7 @@ test("should have the expected styling when focused", async ({
   await inputElement.focus();
   await expect(inputElement.locator("..")).toHaveCSS(
     "box-shadow",
-    "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+    "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
   );
   await expect(inputElement.locator("..")).toHaveCSS(
     "outline",

--- a/src/components/select/multi-select/multi-select.pw.tsx
+++ b/src/components/select/multi-select/multi-select.pw.tsx
@@ -81,7 +81,7 @@ test("should have the expected styling when focused", async ({
   await inputElement.focus();
   await expect(inputElement.locator("..")).toHaveCSS(
     "box-shadow",
-    "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+    "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
   );
   await expect(inputElement.locator("..")).toHaveCSS(
     "outline",
@@ -941,7 +941,7 @@ test.describe("MultiSelect component", () => {
     await closeIcon.focus();
     await expect(closeIcon).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     await expect(closeIcon).toHaveCSS("background-color", "rgb(0, 103, 56)");
   });

--- a/src/components/select/simple-select/simple-select.pw.tsx
+++ b/src/components/select/simple-select/simple-select.pw.tsx
@@ -67,7 +67,7 @@ test("should have the expected styling when focused", async ({
   await selectInputElement.focus();
   await expect(selectInputElement.locator("..")).toHaveCSS(
     "box-shadow",
-    "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+    "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
   );
   await expect(selectInputElement.locator("..")).toHaveCSS(
     "outline",

--- a/src/components/simple-color-picker/simple-color-picker.pw.tsx
+++ b/src/components/simple-color-picker/simple-color-picker.pw.tsx
@@ -79,7 +79,7 @@ test("should have the expected styling when focused", async ({
   const focusedColor = simpleColorDiv(page, 0);
   await expect(focusedColor).toHaveCSS(
     "box-shadow",
-    "rgba(0, 0, 0, 0.9) 0px 0px 0px 3px inset, rgb(255, 188, 25) 0px 0px 0px 6px inset",
+    "rgb(255, 181, 0) 0px 0px 0px 2px inset, rgb(0, 0, 0) 0px 0px 0px 4px inset",
   );
   await expect(focusedColor).toHaveCSS("outline", "rgba(0, 0, 0, 0) solid 3px");
 });

--- a/src/components/split-button/split-button.pw.tsx
+++ b/src/components/split-button/split-button.pw.tsx
@@ -35,7 +35,7 @@ test.describe("Styling tests", () => {
     await mainButton(page).focus();
     await expect(mainButton(page)).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     await expect(mainButton(page)).toHaveCSS(
       "outline",
@@ -44,7 +44,7 @@ test.describe("Styling tests", () => {
     await splitToggleButton(page).focus();
     await expect(splitToggleButton(page)).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     await expect(splitToggleButton(page)).toHaveCSS(
       "outline",

--- a/src/components/switch/switch.pw.tsx
+++ b/src/components/switch/switch.pw.tsx
@@ -48,7 +48,7 @@ test.describe("Prop tests for Switch component", () => {
 
     await expect(switchStyling(page)).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
 
     await expect(switchStyling(page)).toHaveCSS(

--- a/src/components/text-editor/text-editor.pw.tsx
+++ b/src/components/text-editor/text-editor.pw.tsx
@@ -202,7 +202,7 @@ test.describe("Prop tests", () => {
 
       await expect(editorWrapper).not.toHaveCSS(
         "box-shadow",
-        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+        "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
       );
       await expect(editor).not.toBeFocused();
 
@@ -214,7 +214,7 @@ test.describe("Prop tests", () => {
 
       await expect(editorWrapper).toHaveCSS(
         "box-shadow",
-        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+        "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
       );
       await expect(editor).toBeFocused();
     });
@@ -246,7 +246,7 @@ test.describe("Prop tests", () => {
 
       await expect(editorWrapper).not.toHaveCSS(
         "box-shadow",
-        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+        "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
       );
       await expect(editor).not.toBeFocused();
 
@@ -262,7 +262,7 @@ test.describe("Prop tests", () => {
 
       await expect(editorWrapper).toHaveCSS(
         "box-shadow",
-        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+        "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
       );
       await expect(editor).toBeFocused();
     });
@@ -294,7 +294,7 @@ test.describe("Prop tests", () => {
 
       await expect(editorWrapper).not.toHaveCSS(
         "box-shadow",
-        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+        "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
       );
       await expect(editor).not.toBeFocused();
 
@@ -310,7 +310,7 @@ test.describe("Prop tests", () => {
 
       await expect(editorWrapper).toHaveCSS(
         "box-shadow",
-        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+        "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
       );
       await expect(editor).toBeFocused();
     });
@@ -334,7 +334,7 @@ test.describe("Prop tests", () => {
 
       await expect(editorWrapper).not.toHaveCSS(
         "box-shadow",
-        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+        "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
       );
       await expect(editor).not.toBeFocused();
 
@@ -346,7 +346,7 @@ test.describe("Prop tests", () => {
 
       await expect(editorWrapper).toHaveCSS(
         "box-shadow",
-        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+        "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
       );
       await expect(editor).toBeFocused();
 
@@ -378,7 +378,7 @@ test.describe("Prop tests", () => {
 
       await expect(editorWrapper).not.toHaveCSS(
         "box-shadow",
-        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+        "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
       );
       await expect(editor).not.toBeFocused();
 
@@ -394,7 +394,7 @@ test.describe("Prop tests", () => {
 
       await expect(editorWrapper).toHaveCSS(
         "box-shadow",
-        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+        "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
       );
 
       await expect(editor).toBeFocused();
@@ -426,7 +426,7 @@ test.describe("Prop tests", () => {
 
       await expect(editorWrapper).not.toHaveCSS(
         "box-shadow",
-        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+        "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
       );
       await expect(editor).not.toBeFocused();
 
@@ -442,7 +442,7 @@ test.describe("Prop tests", () => {
 
       await expect(editorWrapper).toHaveCSS(
         "box-shadow",
-        "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+        "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
       );
       await expect(editor).toBeFocused();
 

--- a/src/components/textarea/textarea.pw.tsx
+++ b/src/components/textarea/textarea.pw.tsx
@@ -404,7 +404,7 @@ test.describe("Props tests for Textarea component", () => {
 
     await expect(textarea(page)).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
   });
 

--- a/src/components/textbox/textbox.pw.tsx
+++ b/src/components/textbox/textbox.pw.tsx
@@ -416,7 +416,7 @@ test.describe("Prop checks for Textbox component", () => {
     await expect(textboxInput(page)).toBeFocused();
     await expect(textbox(page)).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     await expect(textbox(page)).toHaveCSS(
       "outline",

--- a/src/components/tile-select/tile-select.pw.tsx
+++ b/src/components/tile-select/tile-select.pw.tsx
@@ -43,7 +43,7 @@ test.describe("check Focus Outline & Border Radius", () => {
 
     await expect(focusedElement).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     await expect(focusedElement).toHaveCSS(
       "outline",

--- a/src/components/toast/toast.pw.tsx
+++ b/src/components/toast/toast.pw.tsx
@@ -146,7 +146,7 @@ test.describe("Toast component", () => {
 
     await expect(icon).toHaveCSS(
       "box-shadow",
-      "rgb(255, 188, 25) 0px 0px 0px 3px, rgba(0, 0, 0, 0.9) 0px 0px 0px 6px",
+      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
     );
     await expect(icon).toHaveCSS("outline", "rgba(0, 0, 0, 0) solid 3px");
   });

--- a/src/components/vertical-menu/vertical-menu.pw.tsx
+++ b/src/components/vertical-menu/vertical-menu.pw.tsx
@@ -521,7 +521,7 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
 
     await expect(menuItem2).toHaveCSS(
       "box-shadow",
-      "rgba(0, 0, 0, 0.9) 0px 0px 0px 3px inset, rgb(255, 188, 25) 0px 0px 0px 6px inset",
+      "rgb(255, 181, 0) 0px 0px 0px 2px inset, rgb(0, 0, 0) 0px 0px 0px 4px inset",
     );
     await expect(menuItem2).toHaveCSS("outline", "rgba(0, 0, 0, 0) solid 3px");
   });

--- a/src/style/utils/add-focus-styling.ts
+++ b/src/style/utils/add-focus-styling.ts
@@ -1,10 +1,8 @@
 export default (inset = false) => {
-  let focusStyling =
-    "0px 0px 0px var(--borderWidth300) var(--colorsSemanticFocus500), 0px 0px 0px var(--borderWidth600) var(--colorsUtilityYin090)";
+  let focusStyling = "var(--focus-shadow-default)";
 
   if (inset) {
-    focusStyling =
-      "inset 0px 0px 0px var(--borderWidth300) var(--colorsUtilityYin090), inset 0px 0px 0px var(--borderWidth600) var(--colorsSemanticFocus500)";
+    focusStyling = "var(--focus-shadow-inset)";
   }
 
   return `


### PR DESCRIPTION
### Proposed behaviour

Focus styling should use the new DS fusion tokens.

<img width="162" height="134" alt="Screenshot 2026-04-23 at 13 49 28" src="https://github.com/user-attachments/assets/8e061f2d-db13-4017-87e9-31c9b444b451" />

### Current behaviour

Old focus styling not using tokens.

<img width="176" height="151" alt="Screenshot 2026-04-23 at 13 49 43" src="https://github.com/user-attachments/assets/63cea7a7-e803-4df1-ad07-d8c229de2c2c" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

Every component that has focus styling will probably need testing manually if we don't have any interaction tests for it.