### PR TITLE
fix(filterable-select): refactor updateValues to avoid rerender issue

### DIFF
--- a/src/components/select/filterable-select/filterable-select.component.tsx
+++ b/src/components/select/filterable-select/filterable-select.component.tsx
@@ -204,44 +204,44 @@ export const FilterableSelect = React.forwardRef<
 
     const updateValues = useCallback(
       (newFilterText: string, isDeleteEvent: boolean) => {
-        setSelectedValue(() => {
-          const trimmed = newFilterText.trimStart();
-          const match = findElementWithMatchingText(
-            trimmed,
-            children,
-          ) as React.ReactElement;
-          const isFilterCleared = isDeleteEvent && !newFilterText.length;
+        const trimmed = newFilterText.trimStart();
+        const match = findElementWithMatchingText(
+          trimmed,
+          children,
+        ) as React.ReactElement;
+        const isFilterCleared = isDeleteEvent && !newFilterText.length;
 
-          if (!match || isFilterCleared || match.props.disabled) {
-            setTextValue(newFilterText);
-            triggerChange("", false);
+        if (!match || isFilterCleared || match.props.disabled) {
+          setTextValue(newFilterText);
+          triggerChange("", false);
 
-            return "";
-          }
+          setSelectedValue("");
+          return;
+        }
 
-          if (trimmed.length) {
-            triggerChange(match.props.value, false);
-          }
+        if (trimmed.length) {
+          triggerChange(match.props.value, false);
+        }
 
-          if (isDeleteEvent) {
-            setTextValue(newFilterText);
+        if (isDeleteEvent) {
+          setTextValue(newFilterText);
 
-            return match.props.value;
-          }
+          setSelectedValue(match.props.value);
+          return;
+        }
 
-          if (
-            trimmed.length &&
-            match.props.text?.toLowerCase().startsWith(trimmed.toLowerCase())
-          ) {
-            setTextValue(match.props.text);
-          } else {
-            setTextValue(newFilterText);
-          }
+        if (
+          trimmed.length &&
+          match.props.text?.toLowerCase().startsWith(trimmed.toLowerCase())
+        ) {
+          setTextValue(match.props.text);
+        } else {
+          setTextValue(newFilterText);
+        }
 
-          setHighlightedValue(match.props.value);
+        setHighlightedValue(match.props.value);
 
-          return match.props.value;
-        });
+        setSelectedValue(match.props.value);
       },
       [children, triggerChange],
     );


### PR DESCRIPTION
refactor updateValues to not use a functional state update, which is unnecessary here. The calling of other state update functions inside this function is likely to be the cause of recursive rerender issues that we are seeing.

fix #7919

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
