### PR TITLE
test(portrait): refine testing suite

### DIFF
--- a/src/components/portrait/portrait-test.stories.tsx
+++ b/src/components/portrait/portrait-test.stories.tsx
@@ -1,12 +1,18 @@
 import React from "react";
 import { action } from "@storybook/addon-actions";
+import Box from "../box";
 import { ICONS } from "../icon/icon-config";
 import { PORTRAIT_SHAPES, PORTRAIT_SIZES } from "./portrait.config";
 import Portrait, { PortraitProps } from "./portrait.component";
 
 export default {
   title: "Portrait/Test",
-  includeStories: ["Default", "CustomColors"],
+  includeStories: [
+    "Default",
+    "CustomColors",
+    "TooltipVariants",
+    "DesignTokenColors",
+  ],
   parameters: {
     info: { disable: true },
     chromatic: {
@@ -83,6 +89,110 @@ CustomColors.args = {
   backgroundColor: "#000000",
   foregroundColor: "#FFFFFF",
 };
+
+export const TooltipVariants = () => {
+  const src =
+    "https://avataaars.io/?avatarStyle=Transparent&topType=LongHairStraight&accessoriesType=Blank&hairColor=BrownDark&facialHairType=Blank&clotheType=BlazerShirt&eyeType=Default&eyebrowType=Default&mouthType=Default&skinColor=Light";
+  return (
+    <Box display="flex" flexDirection="column" gap={16} p={16}>
+      <Box display="flex" gap={16}>
+        {(["top", "bottom", "left", "right"] as const).map((position) => (
+          <Box key={position} p={8}>
+            <Portrait
+              tooltipMessage={`Tooltip ${position}`}
+              tooltipPosition={position}
+              tooltipIsVisible
+              src={src}
+            />
+          </Box>
+        ))}
+      </Box>
+      <Box display="flex" gap={16}>
+        <Box p={8}>
+          <Portrait
+            tooltipMessage="Tooltip with custom background"
+            tooltipBgColor="rebeccapurple"
+            tooltipIsVisible
+            src={src}
+          />
+        </Box>
+        <Box p={8}>
+          <Portrait
+            tooltipMessage="Error tooltip"
+            tooltipType="error"
+            tooltipIsVisible
+            src={src}
+          />
+        </Box>
+        <Box p={8}>
+          <Portrait
+            tooltipMessage="Medium tooltip"
+            tooltipSize="medium"
+            tooltipIsVisible
+            src={src}
+          />
+        </Box>
+        <Box p={8}>
+          <Portrait
+            tooltipMessage="Large tooltip"
+            tooltipSize="large"
+            tooltipIsVisible
+            src={src}
+          />
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+TooltipVariants.storyName = "Tooltip Variants";
+TooltipVariants.parameters = { chromatic: { disableSnapshot: false } };
+
+export const DesignTokenColors = () => {
+  const tokens = [
+    "colorsUtilityMajor500",
+    "colorsActionMajor500",
+    "colorsSemanticFocus500",
+    "colorsSemanticNegative500",
+  ] as const;
+  return (
+    <Box display="flex" flexDirection="column" gap={4} p={4}>
+      <Box display="flex" gap={2}>
+        {tokens.map((token) => (
+          <Portrait
+            key={`bg-${token}`}
+            backgroundColor={`var(--${token})`}
+            foregroundColor="#FFFFFF"
+          />
+        ))}
+      </Box>
+      <Box display="flex" gap={2}>
+        {tokens.map((token) => (
+          <Portrait
+            key={`fg-${token}`}
+            foregroundColor={`var(--${token})`}
+            backgroundColor="#FFFFFF"
+          />
+        ))}
+      </Box>
+      <Box display="flex" gap={2}>
+        <Portrait backgroundColor="#A3CAF0" foregroundColor="#000000" />
+        <Portrait backgroundColor="#FD9BA3" foregroundColor="#000000" />
+        <Portrait
+          backgroundColor="#000000"
+          foregroundColor="#FFFFFF"
+          initials="MK"
+        />
+        <Portrait
+          backgroundColor="#FFFFFF"
+          foregroundColor="#000000"
+          initials="MK"
+        />
+      </Box>
+    </Box>
+  );
+};
+DesignTokenColors.storyName = "Design Token Colors";
+DesignTokenColors.parameters = { chromatic: { disableSnapshot: false } };
 
 export const PortraitDefaultComponent = ({ ...props }) => {
   return <Portrait {...props} />;

--- a/src/components/portrait/portrait.pw.tsx
+++ b/src/components/portrait/portrait.pw.tsx
@@ -1,26 +1,12 @@
 import React from "react";
 import { test, expect } from "../../../playwright/helpers/base-test";
-import { getDataElementByValue, icon } from "../../../playwright/components";
-import {
-  portraitImage,
-  portraitInitials,
-  portraitPreview,
-} from "../../../playwright/components/portrait/index";
-import {
-  CHARACTERS,
-  COLOR,
-  SIZE,
-  VALIDATION,
-} from "../../../playwright/support/constants";
+import { getDataElementByValue } from "../../../playwright/components";
+import { portraitPreview } from "../../../playwright/components/portrait/index";
+import { CHARACTERS } from "../../../playwright/support/constants";
 import {
   checkAccessibility,
   getDesignTokensByCssProperty,
 } from "../../../playwright/support/helper";
-import Box from "../../../src/components/box";
-import {
-  PORTRAIT_SIZE_PARAMS,
-  PORTRAIT_SIZES,
-} from "../../../src/components/portrait/portrait.config";
 import {
   PortraitComponent,
   PortraitDefaultComponent,
@@ -28,169 +14,11 @@ import {
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
-const colors = [
-  ["orange", COLOR.ORANGE],
-  ["red", COLOR.RED],
-  ["black", COLOR.BLACK],
-  ["brown", COLOR.BROWN],
-];
-
-const testImage = "https://avataaars.io/";
-
 const imageURLs = [
   "https://avataaars.io/?avatarStyle=Transparent&topType=LongHairStraight&accessoriesType=Blank&hairColor=BrownDark&facialHairType=Blank&clotheType=BlazerShirt&eyeType=Default&eyebrowType=Default&mouthType=Default&skinColor=Light",
 ];
 
-const portraitSizes = PORTRAIT_SIZES.map((size) => [
-  size,
-  PORTRAIT_SIZE_PARAMS[size].dimensions,
-]);
-
 test.describe("Prop checks for Portrait component", () => {
-  ["SPM", "JM", "AR", "MJ"].forEach((passInitials) => {
-    test(`should render with initials as ${passInitials}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitDefaultComponent initials={passInitials} />);
-
-      await expect(portraitInitials(page)).toHaveText(passInitials);
-    });
-  });
-
-  [
-    ["SPMMMMM", "SPM"],
-    ["JMMMMM", "JMM"],
-    ["ARRRR", "ARR"],
-    ["MJJJ", "MJJ"],
-  ].forEach(([passInitials, maxInitials]) => {
-    test(`should render with a maximum of three initials when passed initials are ${passInitials} `, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitDefaultComponent initials={passInitials} />);
-
-      await expect(portraitInitials(page)).toHaveText(maxInitials);
-    });
-  });
-
-  imageURLs.forEach((url) => {
-    test(`should render with src prop passed as ${url}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitDefaultComponent src={url} />);
-
-      await expect(portraitImage(page)).toHaveAttribute("src", url);
-    });
-  });
-
-  portraitSizes.forEach(([size, heightAndWidth]) => {
-    test(`should render with size prop passed as ${size}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitDefaultComponent size={size} />);
-
-      await expect(portraitPreview(page)).toHaveCSS(
-        "height",
-        `${heightAndWidth}px`,
-      );
-      await expect(portraitPreview(page)).toHaveCSS(
-        "width",
-        `${heightAndWidth}px`,
-      );
-    });
-  });
-
-  test("should render with alt text", async ({ mount, page }) => {
-    await mount(
-      <PortraitDefaultComponent src={testImage} alt="playwright-test" />,
-    );
-
-    await expect(portraitImage(page)).toHaveAttribute("alt", "playwright-test");
-  });
-
-  [
-    ["square", "0px"],
-    ["circle", "50%"],
-  ].forEach(([shape, radius]) => {
-    test(`should render with shape prop passed as ${shape}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitDefaultComponent shape={shape} />);
-
-      await expect(portraitPreview(page)).toHaveCSS("border-radius", radius);
-    });
-  });
-
-  ["error", "warning", "info"].forEach((iconType) => {
-    test(`should render with iconType prop passed as ${iconType}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitDefaultComponent iconType={iconType} />);
-
-      await expect(icon(page)).toBeVisible();
-      await expect(icon(page)).toHaveAttribute("data-element", iconType);
-    });
-  });
-
-  portraitSizes.forEach(([size, heightAndWidth]) => {
-    test(`should render with size prop passed as ${size} with icon`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitDefaultComponent size={size} />);
-
-      await expect(portraitPreview(page)).toHaveCSS(
-        "height",
-        `${heightAndWidth}px`,
-      );
-      await expect(portraitPreview(page)).toHaveCSS(
-        "width",
-        `${heightAndWidth}px`,
-      );
-    });
-  });
-
-  portraitSizes.forEach(([size, heightAndWidth]) => {
-    test(`should render with size prop passed as ${size} with initials`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitDefaultComponent initials="JD" size={size} />);
-
-      await expect(portraitPreview(page)).toHaveCSS(
-        "height",
-        `${heightAndWidth}px`,
-      );
-      await expect(portraitPreview(page)).toHaveCSS(
-        "width",
-        `${heightAndWidth}px`,
-      );
-    });
-  });
-
-  portraitSizes.forEach(([size, heightAndWidth]) => {
-    test(`should render with size prop passed as ${size} - with src`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitDefaultComponent src={testImage} size={size} />);
-
-      await expect(portraitPreview(page)).toHaveCSS(
-        "height",
-        `${heightAndWidth}px`,
-      );
-      await expect(portraitPreview(page)).toHaveCSS(
-        "width",
-        `${heightAndWidth}px`,
-      );
-    });
-  });
-
   (
     [
       ["without", false, "rgb(242, 245, 246)", "--colorsUtilityReadOnly400"],
@@ -236,193 +64,6 @@ test.describe("Prop checks for Portrait component", () => {
       await expect(portraitPreview(page)).toHaveCSS("color", color);
     });
   });
-
-  test("should render with correct border", async ({ mount, page }) => {
-    await mount(<PortraitDefaultComponent />);
-
-    await expect(portraitPreview(page)).toHaveCSS(
-      "border",
-      "1px solid rgb(204, 214, 219)",
-    );
-  });
-
-  testData.forEach((tooltipMessage) => {
-    test(`should render with tooltipMessage as ${tooltipMessage}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitDefaultComponent tooltipMessage={tooltipMessage} />);
-
-      await portraitPreview(page).hover();
-
-      const tooltip = getDataElementByValue(page, "tooltip");
-
-      await expect(tooltip).toBeVisible();
-      await expect(tooltip).toHaveText(tooltipMessage);
-    });
-  });
-
-  testData.forEach((tooltipId) => {
-    test(`should render with tooltipId as ${tooltipId}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <PortraitDefaultComponent tooltipMessage="foo" tooltipId={tooltipId} />,
-      );
-
-      await portraitPreview(page).hover();
-
-      const tooltip = getDataElementByValue(page, "tooltip");
-
-      await expect(tooltip).toBeVisible();
-      await expect(tooltip).toHaveId(tooltipId);
-    });
-  });
-
-  [
-    [true, "with"],
-    [false, "without"],
-  ].forEach(([boolVal, renderState]) => {
-    test(`should render ${renderState} a tooltip, when visibility prop is ${boolVal}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <PortraitComponent tooltipMessage="foo" tooltipIsVisible={boolVal} />,
-      );
-
-      const tooltip = getDataElementByValue(page, "tooltip");
-
-      if (boolVal) {
-        await expect(tooltip).toBeVisible();
-        await expect(tooltip).toHaveText("foo");
-      } else {
-        await expect(tooltip).toBeHidden();
-      }
-    });
-  });
-
-  ["top", "bottom", "left", "right"].forEach((tooltipPosition) => {
-    test(`should render with tooltip positioned ${tooltipPosition}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <Box p={200}>
-          <PortraitComponent tooltipPosition={tooltipPosition} />{" "}
-        </Box>,
-      );
-
-      const tooltip = getDataElementByValue(page, "tooltip");
-
-      await expect(tooltip).toBeVisible();
-      await expect(tooltip).toHaveAttribute("data-placement", tooltipPosition);
-    });
-  });
-
-  test("should render with a tooltip error", async ({ mount, page }) => {
-    await mount(<PortraitComponent tooltipType="error" />);
-
-    const tooltip = getDataElementByValue(page, "tooltip");
-
-    await expect(tooltip).toHaveCSS("background-color", VALIDATION.ERROR);
-  });
-
-  [
-    [SIZE.MEDIUM, "14px"],
-    [SIZE.LARGE, "16px"],
-  ].forEach(([tooltipSize, fontSize]) => {
-    test(`should render with a ${tooltipSize} size tooltip`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitComponent tooltipSize={tooltipSize} />);
-
-      const tooltip = getDataElementByValue(page, "tooltip");
-
-      await expect(tooltip).toBeVisible();
-      await expect(tooltip).toHaveCSS("font-size", fontSize);
-    });
-  });
-
-  colors.forEach(([names, color]) => {
-    test(`should render with a tooltip with a ${names} background color`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitComponent tooltipBgColor={color} />);
-
-      const tooltip = getDataElementByValue(page, "tooltip");
-
-      await expect(tooltip).toHaveCSS("background-color", color);
-    });
-  });
-
-  colors.forEach(([names, color]) => {
-    test(`should render with a tooltip with a ${names} font color`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitComponent tooltipFontColor={color} />);
-
-      const tooltip = getDataElementByValue(page, "tooltip");
-
-      await expect(tooltip).toHaveCSS("color", color);
-    });
-  });
-
-  [
-    { token: "colorsUtilityMajor500", rgb: "(0, 50, 76)" },
-    { token: "colorsActionMajor500", rgb: "(0, 126, 69)" },
-    { token: "colorsSemanticFocus500", rgb: "(255, 188, 25)" },
-    { token: "colorsSemanticNegative500", rgb: "(203, 55, 74)" },
-  ].forEach(({ token, rgb }) => {
-    test(`should substitute the correct background colour when a design system token (${token}) is provided`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <PortraitDefaultComponent backgroundColor={`var(--${token})`} />,
-      );
-
-      await expect(portraitPreview(page)).toHaveCSS(
-        "background-color",
-        `rgb${rgb}`,
-      );
-    });
-  });
-
-  [
-    { token: "colorsUtilityMajor500", rgb: "(0, 50, 76)" },
-    { token: "colorsActionMajor500", rgb: "(0, 126, 69)" },
-    { token: "colorsSemanticFocus500", rgb: "(255, 188, 25)" },
-    { token: "colorsSemanticNegative500", rgb: "(203, 55, 74)" },
-  ].forEach(({ token, rgb }) => {
-    test(`should substitute the correct foreground colour when a design system token (${token}) is provided`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <PortraitDefaultComponent foregroundColor={`var(--${token})`} />,
-      );
-
-      await expect(portraitPreview(page)).toHaveCSS("color", `rgb${rgb}`);
-    });
-  });
-});
-
-test.describe("Event checks for Portrait component", () => {
-  test("should render and call onClick callback when a click event", async ({
-    mount,
-    page,
-  }) => {
-    let callbackCount = 0;
-    await mount(<PortraitDefaultComponent onClick={(callbackCount += 1)} />);
-
-    await portraitPreview(page).click();
-    expect(callbackCount).toBe(1);
-  });
 });
 
 test.describe("Accessibility tests for Portrait component", () => {
@@ -437,17 +78,6 @@ test.describe("Accessibility tests for Portrait component", () => {
     });
   });
 
-  portraitSizes.forEach(([size]) => {
-    test(`should pass accessibility checks when size is ${size}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitDefaultComponent size={size} />);
-
-      await checkAccessibility(page);
-    });
-  });
-
   test("should pass accessibility checks when alt text is passed", async ({
     mount,
     page,
@@ -457,44 +87,11 @@ test.describe("Accessibility tests for Portrait component", () => {
     await checkAccessibility(page);
   });
 
-  ["square", "circle"].forEach((shape) => {
-    test(`should pass accessibility checks when shape is ${shape}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitDefaultComponent shape={shape} />);
-
-      await checkAccessibility(page);
-    });
-  });
-
-  ["error", "warning", "info"].forEach((iconType) => {
-    test(`should pass accessibility checks when iconType is ${iconType}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitDefaultComponent iconType={iconType} />);
-
-      await checkAccessibility(page);
-    });
-  });
-
-  ["SPM", "JM", "AR", "MJ"].forEach((passInitials) => {
-    test(`should pass accessibility checks when initials are ${passInitials}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitDefaultComponent initials={passInitials} />);
-
-      await checkAccessibility(page);
-    });
-  });
-
   (
     [
-      ["without", false, "rgb(242, 245, 246)"],
-      ["with", true, "rgb(153, 173, 183)"],
-    ] as [string, boolean, string][]
+      ["without", false],
+      ["with", true],
+    ] as [string, boolean][]
   ).forEach(([renderState, boolVal]) => {
     test(`should pass accessibility checks ${renderState} dark background variant, when darkBackground prop is ${boolVal}`, async ({
       mount,
@@ -503,30 +100,6 @@ test.describe("Accessibility tests for Portrait component", () => {
       await mount(<PortraitDefaultComponent darkBackground={boolVal} />);
 
       await checkAccessibility(page);
-    });
-  });
-
-  testData.forEach((tooltipMessage) => {
-    test(`should pass accessibility checks when toolTipMessage is ${tooltipMessage}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <PortraitComponent tooltipIsVisible tooltipMessage={tooltipMessage} />,
-      );
-
-      await checkAccessibility(page, getDataElementByValue(page, "tooltip"));
-    });
-  });
-
-  testData.forEach((tooltipId) => {
-    test(`should pass accessibility checks when tooltipId is ${tooltipId}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitComponent tooltipId={tooltipId} />);
-
-      await checkAccessibility(page, getDataElementByValue(page, "tooltip"));
     });
   });
 
@@ -550,22 +123,6 @@ test.describe("Accessibility tests for Portrait component", () => {
     await checkAccessibility(page, getDataElementByValue(page, "tooltip"));
   });
 
-  ["top", "bottom", "left", "right"].forEach((tooltipPosition) => {
-    test(`should pass accessibility checks with tooltip positioned ${tooltipPosition}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <PortraitComponent
-          tooltipPosition={tooltipPosition}
-          tooltipIsVisible
-        />,
-      );
-
-      await checkAccessibility(page, getDataElementByValue(page, "tooltip"));
-    });
-  });
-
   test("should pass accessibility checks with a tooltip error", async ({
     mount,
     page,
@@ -575,14 +132,12 @@ test.describe("Accessibility tests for Portrait component", () => {
     await checkAccessibility(page, getDataElementByValue(page, "tooltip"));
   });
 
-  [SIZE.MEDIUM, SIZE.LARGE].forEach((tooltipSize) => {
-    test(`should pass accessibility checks with a ${tooltipSize} size tooltip`, async ({
+  testData.forEach((tooltipId) => {
+    test(`should pass accessibility checks when tooltipId is ${tooltipId}`, async ({
       mount,
       page,
     }) => {
-      await mount(
-        <PortraitComponent tooltipSize={tooltipSize} tooltipIsVisible />,
-      );
+      await mount(<PortraitComponent tooltipIsVisible tooltipId={tooltipId} />);
 
       await checkAccessibility(page, getDataElementByValue(page, "tooltip"));
     });
@@ -596,64 +151,5 @@ test.describe("Accessibility tests for Portrait component", () => {
     await mount(<PortraitDefaultComponent onClick={(callbackCount += 1)} />);
 
     await checkAccessibility(page);
-  });
-
-  [
-    { value: "#A3CAF0", label: "paleblue" },
-    { value: "#FD9BA3", label: "palepink" },
-    { value: "#B4AEEA", label: "palepurple" },
-    { value: "#ECE6AF", label: "palegoldenrod" },
-    { value: "#EBAEDE", label: "paleorchid" },
-    { value: "#EBC7AE", label: "paledesert" },
-    { value: "#AEECEB", label: "paleturquoise" },
-    { value: "#AEECD6", label: "palemint" },
-    { value: "#000000", label: "black" },
-    { value: "#FFFFFF", label: "white" },
-    { value: "#2F4F4F", label: "darkslategray" },
-    { value: "#696969", label: "dimgray" },
-    { value: "#808080", label: "gray" },
-    { value: "#A9A9A9", label: "darkgray" },
-    { value: "#C0C0C0", label: "silver" },
-    { value: "#D3D3D3", label: "lightgray" },
-    { value: "#DCDCDC", label: "gainsboro" },
-    { value: "#F5F5F5", label: "whitesmoke" },
-    { value: "#FFFFE0", label: "lightyellow" },
-    { value: "#FFFACD", label: "lemonchiffon" },
-    { value: "#FAFAD2", label: "lightgoldenrodyellow" },
-    { value: "#FFE4B5", label: "moccasin" },
-    { value: "#FFDAB9", label: "peachpuff" },
-    { value: "#FFDEAD", label: "navajowhite" },
-    { value: "#F5DEB3", label: "wheat" },
-    { value: "#FFF8DC", label: "cornsilk" },
-    { value: "#FFFFF0", label: "ivory" },
-    { value: "#0000FF", label: "blue" },
-    { value: "#0000CD", label: "mediumblue" },
-    { value: "#00008B", label: "darkblue" },
-    { value: "#000080", label: "navy" },
-    { value: "#191970", label: "midnightblue" },
-    { value: "#4169E1", label: "royalblue" },
-    { value: "#4682B4", label: "steelblue" },
-    { value: "#5F9EA0", label: "cadetblue" },
-    { value: "#6495ED", label: "cornflowerblue" },
-    { value: "#87CEFA", label: "lightskyblue" },
-    { value: "#87CEEB", label: "skyblue" },
-    { value: "#00BFFF", label: "deepskyblue" },
-    { value: "#1E90FF", label: "dodgerblue" },
-    { value: "#ADD8E6", label: "lightblue" },
-    { value: "#B0C4DE", label: "lightsteelblue" },
-    { value: "#708090", label: "slateblue" },
-    { value: "#6A5ACD", label: "slateblue2" },
-    { value: "#7B68EE", label: "mediumslateblue" },
-    { value: "#8A2BE2", label: "blueviolet" },
-    { value: "#9370DB", label: "mediumpurple" },
-  ].forEach(({ label, value }) => {
-    test(`should pass accessibility checks when backgroundColor is ${label} (${value})`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<PortraitDefaultComponent backgroundColor={value} />);
-
-      await checkAccessibility(page);
-    });
   });
 });

--- a/src/components/portrait/portrait.stories.tsx
+++ b/src/components/portrait/portrait.stories.tsx
@@ -27,11 +27,13 @@ export const Default: Story = () => {
   return <Portrait />;
 };
 Default.storyName = "Default";
+Default.parameters = { chromatic: { disableSnapshot: true } };
 
 export const Initials: Story = () => {
   return <Portrait initials="MK" />;
 };
 Initials.storyName = "Initials";
+Initials.parameters = { chromatic: { disableSnapshot: true } };
 
 export const Src: Story = () => {
   return (
@@ -39,6 +41,7 @@ export const Src: Story = () => {
   );
 };
 Src.storyName = "Src";
+Src.parameters = { chromatic: { disableSnapshot: true } };
 
 export const IconType: Story = () => {
   return <Portrait iconType="image" />;
@@ -58,6 +61,7 @@ export const WithTooltip: Story = () => {
   );
 };
 WithTooltip.storyName = "With Tooltip";
+WithTooltip.parameters = { chromatic: { disableSnapshot: true } };
 
 export const Sizes: Story = () => {
   return (
@@ -261,3 +265,4 @@ export const CustomColors: Story = () => {
   );
 };
 CustomColors.storyName = "Custom Color";
+CustomColors.parameters = { chromatic: { disableSnapshot: true } };

--- a/src/components/portrait/portrait.test.tsx
+++ b/src/components/portrait/portrait.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
+import { CHARACTERS } from "../../../playwright/support/constants";
 
 import Portrait from ".";
 
@@ -128,6 +129,50 @@ test("allows a custom tooltip id to be set via the `tooltipId` prop", () => {
 
   const tooltip = screen.getByText("foo");
   expect(tooltip).toHaveAttribute("id", "foo");
+});
+
+[CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS].forEach(
+  (tooltipMessage) => {
+    test(`renders a tooltip with special characters in the message: "${tooltipMessage}"`, async () => {
+      render(<Portrait data-role="portrait" tooltipMessage={tooltipMessage} />);
+
+      const user = userEvent.setup();
+      const portrait = screen.getByTestId("portrait");
+      await user.hover(portrait);
+      const tooltip = await screen.findByText(tooltipMessage);
+
+      expect(tooltip).toBeVisible();
+    });
+  },
+);
+
+[CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS].forEach((tooltipId) => {
+  test(`sets a custom tooltip id with special characters: "${tooltipId}"`, () => {
+    render(
+      <Portrait
+        data-role="portrait"
+        tooltipMessage="foo"
+        tooltipIsVisible
+        tooltipId={tooltipId}
+      />,
+    );
+
+    const tooltip = screen.getByText("foo");
+    expect(tooltip).toHaveAttribute("id", tooltipId);
+  });
+});
+
+[
+  ["SPMMMMM", "SPM"],
+  ["JMMMMM", "JMM"],
+  ["ARRRR", "ARR"],
+  ["MJJJ", "MJJ"],
+].forEach(([input, expected]) => {
+  test(`truncates initials to a maximum of three characters when passed "${input}"`, () => {
+    render(<Portrait initials={input} />);
+
+    expect(screen.getByText(expected)).toBeVisible();
+  });
 });
 
 test("allows a custom onClick function to be passed via the `onClick` prop", async () => {


### PR DESCRIPTION
### Proposed behaviour

Removes a number of Playwright tests that duplicate either Jest or Chromatic ones for the 'Portrait' component

### Current behaviour

There are a number of tests that exist in different forms in all the testing suites we do(Jest, Playwright, Chromatic) which cause a prolonged time of execution for no additional value.

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

This should decrease the time of execution without compromising testing and coverage

### Testing instructions

Make sure the Playwright tests pass