### PR TITLE
test(radio-button): refine testing suite

### DIFF
--- a/src/components/radio-button/radio-button.pw.tsx
+++ b/src/components/radio-button/radio-button.pw.tsx
@@ -35,46 +35,6 @@ test("keyboard navigation works correctly in RadioButtonGroup", async ({
   await expect(radio1).toBeFocused();
 });
 
-test("clicking on a RadioButton selects it", async ({ mount, page }) => {
-  await mount(<RadioButtonGroupControlled />);
-
-  const radio1 = page.getByRole("radio", { name: "Radio Button 1" });
-  const radio2 = page.getByRole("radio", { name: "Radio Button 2" });
-  const radio3 = page.getByRole("radio", { name: "Radio Button 3" });
-
-  await radio1.click();
-  await expect(radio1).toBeChecked();
-  await expect(radio2).not.toBeChecked();
-  await expect(radio3).not.toBeChecked();
-
-  await radio2.click();
-  await expect(radio1).not.toBeChecked();
-  await expect(radio2).toBeChecked();
-  await expect(radio3).not.toBeChecked();
-
-  await radio3.click();
-  await expect(radio1).not.toBeChecked();
-  await expect(radio2).not.toBeChecked();
-  await expect(radio3).toBeChecked();
-});
-
-test("renders `progressiveDisclosure` when RadioButton is selected and closes when another RadioButton is selected", async ({
-  mount,
-  page,
-}) => {
-  await mount(<RadioButtonWithProgressiveDisclosure />);
-
-  await page.getByRole("radio", { name: "Radio Button 1" }).click();
-  await expect(
-    page.getByRole("textbox", { name: "Revealed Textbox" }),
-  ).toBeVisible();
-
-  await page.getByRole("radio", { name: "Radio Button 2" }).click();
-  await expect(
-    page.getByRole("textbox", { name: "Revealed Textbox" }),
-  ).toBeHidden();
-});
-
 test.describe("Accessibility tests for RadioButton", () => {
   test("should pass accessibility when `legend` is set", async ({
     mount,

--- a/src/components/radio-button/radio-button.stories.tsx
+++ b/src/components/radio-button/radio-button.stories.tsx
@@ -23,6 +23,7 @@ const meta: Meta<typeof RadioButtonGroup> = {
   },
   parameters: {
     themeProvider: { chromatic: { theme: "sage" } },
+    chromatic: { disableSnapshot: true },
     controls: {
       exclude: ["children", "onBlur", "onChange", "value", "name"],
     },
@@ -219,9 +220,6 @@ export const ProgressiveDisclosure: Story = () => {
   );
 };
 ProgressiveDisclosure.storyName = "Progressive Disclosure";
-ProgressiveDisclosure.parameters = {
-  chromatic: { disableSnapshot: true },
-};
 
 export const WithCustomLabels: Story = () => {
   const [value, setValue] = useState("");
@@ -266,6 +264,9 @@ export const WithCustomLabels: Story = () => {
   );
 };
 WithCustomLabels.storyName = "With Custom Labels";
+WithCustomLabels.parameters = {
+  chromatic: { disableSnapshot: false },
+};
 
 export const Required: Story = {
   ...WithLegend,
@@ -282,5 +283,8 @@ export const Disabled: Story = {
     ...WithLegend.args,
     id: "disabled",
     disabled: true,
+  },
+  parameters: {
+    chromatic: { disableSnapshot: false },
   },
 };


### PR DESCRIPTION
### Proposed behaviour

Removes a number of Playwright tests that duplicate either Jest or Chromatic ones for the 'Radio Button' component

### Current behaviour

There are a number of tests that exist in different forms in all the testing suites we do(Jest, Playwright, Chromatic) which cause a prolonged time of execution for no additional value.

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

This should decrease the time of execution without compromising testing and coverage

### Testing instructions

Make sure the Playwright tests pass