### PR TITLE
test(menu): fix flaking search focus test

### DIFF
--- a/src/components/menu/menu.pw.tsx
+++ b/src/components/menu/menu.pw.tsx
@@ -24,6 +24,7 @@ import {
   continuePressingSHIFTTAB,
   checkAccessibility,
   waitForAnimationEnd,
+  waitForElementFocus,
 } from "../../../playwright/support/helper";
 import { CHARACTERS } from "../../../playwright/support/constants";
 import {
@@ -89,11 +90,16 @@ test.describe("Prop tests for Menu component", () => {
     }) => {
       await mount(<MenuComponentSearch />);
 
-      await page.keyboard.press("Tab");
+      const menuTrigger = submenu(page).first().locator("button");
+      await menuTrigger.focus();
+      await expect(menuTrigger).toBeFocused();
       await page.keyboard.press("Enter");
+      await expect(submenuBlock(page).first()).toBeVisible();
       await continuePressingTAB(page, tabs);
       await page.keyboard.press(key);
-      await expect(searchDefaultInput(page)).toBeFocused();
+      const searchInput = searchDefaultInput(page);
+      await waitForElementFocus(page, searchInput);
+      await expect(searchInput).toBeFocused();
     });
   });
 


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Uses better focused based awaits to circumvent any flakiness within this test:

`"should verify the Search component is focusable by pressing the ArrowUp/ArrowDown key"`

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, there is some flakiness in this test:

`"should verify the Search component is focusable by pressing the ArrowUp/ArrowDown key"`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
