### PR TITLE
fix(text-editor): ensure that links can be added after initial render

### DIFF
--- a/src/components/text-editor/__internal__/__ui__/Toolbar/toolbar.component.tsx
+++ b/src/components/text-editor/__internal__/__ui__/Toolbar/toolbar.component.tsx
@@ -77,6 +77,23 @@ const Toolbar = ({
   const [linkUrlError, setLinkUrlError] = useState(false);
   const linkTextRef = useRef<HTMLInputElement>(null);
   const linkUrlRef = useRef<HTMLInputElement>(null);
+  // Track whether the editor had DOM focus when the hyperlink dialog was opened.
+  // This distinguishes a real user-placed cursor from the stale selection that
+  // Lexical restores from the initialValue JSON (which is never cleared when the
+  // editor has never been focused).
+  const editorWasFocusedRef = useRef(false);
+
+  const handleOpenHyperlinkDialog = useCallback(() => {
+    const rootElement = editor.getRootElement();
+    // Test has been covered in a Playwright test as it relies on DOM focus which is difficult to test in a JSDOM environment.
+    // istanbul ignore else -
+    if (rootElement) {
+      editorWasFocusedRef.current = rootElement.contains(
+        document.activeElement,
+      );
+    }
+    setHyperlinkDialogOpen(true);
+  }, [editor]);
 
   // Get the locale to enable translations
   const locale = useLocale();
@@ -224,27 +241,28 @@ const Toolbar = ({
       // Create a link node with the provided text and URL
       editor.update(() => {
         const root = $getRoot();
-        const numberOfChildren = root.getChildrenSize();
-        const selection = $getSelection();
         const linkNode = $createLinkNode(linkUrl);
         linkNode.append($createTextNode(linkText));
 
-        if (numberOfChildren === 0) {
-          // If there are no children, create a paragraph and append the link
-          const paragraphNode = $createParagraphNode();
-          paragraphNode.append(linkNode);
-          root.append(paragraphNode);
-          paragraphNode.selectEnd(); // move cursor after the inserted link
+        // Only use the Lexical selection if the editor was genuinely focused when
+        // the dialog opened. Without this check, Lexical's stale JSON-initialised
+        // selection (which is never cleared when the editor has never been focused)
+        // would be used, causing the link to be inserted into the wrong place or
+        // silently dropped.
+        const selection = editorWasFocusedRef.current ? $getSelection() : null;
+
+        if ($isRangeSelection(selection)) {
+          selection.insertNodes([linkNode]);
         } else {
-          // If there are children, insert link at the current cursor position
-          if ($isRangeSelection(selection)) {
-            selection.insertNodes([linkNode]);
+          // No user-placed cursor - append the link to the end of the document
+          const last = root.getLastChild();
+          if ($isParagraphNode(last)) {
+            last.append(linkNode);
           } else {
-            // Fallback: append to the last paragraph if selection is not available
-            const last = root.getLastChild();
-            if ($isParagraphNode(last)) {
-              last.append(linkNode);
-            }
+            // Last node is not a paragraph (e.g. a list) - create one to hold the link
+            const paragraphNode = $createParagraphNode();
+            paragraphNode.append(linkNode);
+            root.append(paragraphNode);
           }
         }
       });
@@ -370,7 +388,7 @@ const Toolbar = ({
                   !showTextFormattingSection &&
                   !showListFormattingSection
                 }
-                setDialogOpen={setHyperlinkDialogOpen}
+                setDialogOpen={handleOpenHyperlinkDialog}
                 size={size}
               />
             </ButtonGroup>

--- a/src/components/text-editor/components.test-pw.tsx
+++ b/src/components/text-editor/components.test-pw.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import TextEditor from "./text-editor.component";
 import MentionsPlugin from "./__internal__";
+import { createFromHTML } from "./__internal__/__utils__/helpers";
 
 const TextEditorDefaultComponent = ({ ...props }) => {
   return (
@@ -144,5 +145,15 @@ export const TextEditorWithMentions = ({ ...args }) => (
         ]}
       />
     }
+  />
+);
+
+export const TextEditorWithOrderedListInitialValue = () => (
+  <TextEditor
+    labelText="Playwright Example"
+    namespace="pw-rte"
+    initialValue={createFromHTML(
+      `<p>Some text.</p><ol><li value="1">A list item</li></ol>`,
+    )}
   />
 );

--- a/src/components/text-editor/text-editor.pw.tsx
+++ b/src/components/text-editor/text-editor.pw.tsx
@@ -11,6 +11,7 @@ import TextEditorDefaultComponent, {
   TextEditorWithFooterOnSave,
   TextEditorWithFooterOnCancel,
   TextEditorWithMentions,
+  TextEditorWithOrderedListInitialValue,
 } from "./components.test-pw";
 import { EditorFormattedValues } from "./__internal__/__utils__/interfaces.types";
 
@@ -1811,6 +1812,163 @@ test.describe("Functionality tests", () => {
 
       await expect(titleInput).toBeEmpty();
       await expect(urlInput).toBeEmpty();
+    });
+
+    test("inserts a link into an empty editor that has never been focused", async ({
+      mount,
+      page,
+    }) => {
+      await mount(<TextEditorDefaultComponent />);
+
+      const linkButton = page.locator(
+        "button[data-role='pw-rte-hyperlink-button']",
+      );
+      await linkButton.click();
+
+      const titleInput = page.locator(
+        "div[data-role='pw-rte-hyperlink-text-field'] input",
+      );
+      await titleInput.fill("Carbon");
+      const urlInput = page.locator(
+        "div[data-role='pw-rte-hyperlink-link-field'] input",
+      );
+      await urlInput.fill("https://carbon.sage.com");
+      const saveButton = page.locator(
+        "button[data-role='pw-rte-hyperlink-save-button']",
+      );
+      await saveButton.click();
+
+      await expect(page.getByRole("link", { name: "Carbon" })).toBeVisible();
+    });
+
+    test("inserts a link after paragraph content when the editor has never been focused", async ({
+      mount,
+      page,
+    }) => {
+      await mount(
+        <TextEditorDefaultComponent
+          initialValue={JSON.stringify({
+            root: {
+              children: [
+                {
+                  children: [
+                    {
+                      detail: 0,
+                      format: 0,
+                      mode: "normal",
+                      style: "",
+                      text: "Some existing text.",
+                      type: "text",
+                      version: 1,
+                    },
+                  ],
+                  direction: null,
+                  format: "",
+                  indent: 0,
+                  type: "paragraph",
+                  version: 1,
+                  textFormat: 0,
+                  textStyle: "",
+                },
+              ],
+              direction: null,
+              format: "",
+              indent: 0,
+              type: "root",
+              version: 1,
+            },
+          })}
+        />,
+      );
+
+      const linkButton = page.locator(
+        "button[data-role='pw-rte-hyperlink-button']",
+      );
+      await linkButton.click();
+
+      const titleInput = page.locator(
+        "div[data-role='pw-rte-hyperlink-text-field'] input",
+      );
+      await titleInput.fill("Carbon");
+      const urlInput = page.locator(
+        "div[data-role='pw-rte-hyperlink-link-field'] input",
+      );
+      await urlInput.fill("https://carbon.sage.com");
+      const saveButton = page.locator(
+        "button[data-role='pw-rte-hyperlink-save-button']",
+      );
+      await saveButton.click();
+
+      await expect(page.getByRole("link", { name: "Carbon" })).toBeVisible();
+    });
+
+    test("inserts a link after an ordered list when the editor has never been focused", async ({
+      mount,
+      page,
+    }) => {
+      await mount(<TextEditorWithOrderedListInitialValue />);
+
+      const linkButton = page.locator(
+        "button[data-role='pw-rte-hyperlink-button']",
+      );
+      await linkButton.click();
+
+      const titleInput = page.locator(
+        "div[data-role='pw-rte-hyperlink-text-field'] input",
+      );
+      await titleInput.fill("Carbon");
+      const urlInput = page.locator(
+        "div[data-role='pw-rte-hyperlink-link-field'] input",
+      );
+      await urlInput.fill("https://carbon.sage.com");
+      const saveButton = page.locator(
+        "button[data-role='pw-rte-hyperlink-save-button']",
+      );
+      await saveButton.click();
+
+      await expect(page.getByRole("link", { name: "Carbon" })).toBeVisible();
+    });
+
+    test("inserts a link when the editor root element is null (getRootElement returns null)", async ({
+      mount,
+      page,
+    }) => {
+      await mount(<TextEditorDefaultComponent />);
+
+      // Patch the Lexical editor's getRootElement to return null so that the
+      // `if (rootElement)` branch in handleOpenHyperlinkDialog is not entered,
+      // leaving editorWasFocusedRef.current as false and falling back to
+      // appending the link at the end of the document.
+      await page.evaluate(() => {
+        const editorRoot = document.querySelector("[contenteditable]");
+        if (editorRoot) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const lexicalEditor = (editorRoot as any).__lexicalEditor;
+          if (lexicalEditor) {
+            lexicalEditor.getRootElement = () => null;
+          }
+        }
+      });
+
+      const linkButton = page.locator(
+        "button[data-role='pw-rte-hyperlink-button']",
+      );
+      await linkButton.click();
+
+      const titleInput = page.locator(
+        "div[data-role='pw-rte-hyperlink-text-field'] input",
+      );
+      await titleInput.fill("Test Link");
+      const urlInput = page.locator(
+        "div[data-role='pw-rte-hyperlink-link-field'] input",
+      );
+      await urlInput.fill("https://example.com");
+      const saveButton = page.locator(
+        "button[data-role='pw-rte-hyperlink-save-button']",
+      );
+      await saveButton.click();
+
+      await expect(page.getByRole("link", { name: "Test Link" })).toBeVisible();
     });
   });
 });


### PR DESCRIPTION
### Proposed behaviour

https://github.com/user-attachments/assets/bbe96932-7a43-4b2f-898d-f94692b24389

### Current behaviour

https://github.com/user-attachments/assets/d558c68f-5007-4a86-a679-d254c3f85a61

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Open the TextEditor component stories
- Navigate to setting-initial-values
- Click on hyperlink button
- Enter a link name and URL and save
- Observe that the link content appears at the end of the content