### PR TITLE
fix(action-popover-item): ensure enter keydown triggers href redirect

### DIFF
--- a/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
+++ b/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
@@ -106,7 +106,6 @@ export const ActionPopoverItem = ({
     selectedSubmenuRef,
     setSelectedSubmenuRef,
   } = useActionPopoverContext();
-  const isHref = !!href;
   const [containerPosition, setContainerPosition] = useState<
     ContainerPosition | undefined
   >(undefined);
@@ -249,12 +248,13 @@ export const ActionPopoverItem = ({
           }
           e.preventDefault();
         } else if (Events.isEnterKey(e)) {
-          if (isHref && download) {
-            ref.current?.click();
+          // In this popover keyboard flow, Enter on non-link items does not always reach the
+          // same activation path as mouse clicks, so we trigger the shared click handler
+          // explicitly. For link items, keep native anchor Enter behavior.
+          if (!href) {
+            e.preventDefault();
+            onClick(e as React.KeyboardEvent<HTMLButtonElement>);
           }
-          e.preventDefault();
-          // this type assertion should be safe as the onclick handler is designed to catch events propagating from the inner buttons
-          onClick(e as React.KeyboardEvent<HTMLButtonElement>);
         }
       } else if (Events.isEnterKey(e)) {
         e.stopPropagation();
@@ -265,9 +265,8 @@ export const ActionPopoverItem = ({
       submenu,
       currentSubmenuPosition,
       setSelectedSubmenuRef,
-      isHref,
-      download,
       onClick,
+      href,
     ],
   );
 
@@ -319,7 +318,7 @@ export const ActionPopoverItem = ({
         tabIndex={0}
         isDisabled={disabled}
         {...(disabled && { "aria-disabled": true })}
-        {...(isHref && { as: "a" as unknown as undefined, download, href })}
+        {...(!!href && { as: "a" as unknown as undefined, download, href })}
         {...(submenu && itemSubmenuProps)}
       >
         {submenu && checkRef(ref) && (

--- a/src/components/action-popover/action-popover-test.stories.tsx
+++ b/src/components/action-popover/action-popover-test.stories.tsx
@@ -23,6 +23,7 @@ export default {
   title: "Action Popover/Test",
   includeStories: [
     "Default",
+    "HrefItemsBasic",
     "LongMenuExample",
     "WithAriaAttributes",
     "WithoutDefaultAriaLabel",
@@ -36,6 +37,20 @@ export default {
     },
   },
 };
+
+export const HrefItemsBasic = () => (
+  <ActionPopover>
+    <ActionPopoverItem href="http://www.sage.com">
+      Item with href
+    </ActionPopoverItem>
+    <ActionPopoverItem
+      href="data:text/plain;charset=utf-8,Hello%20world"
+      download
+    >
+      Item with href and download
+    </ActionPopoverItem>
+  </ActionPopover>
+);
 
 export const Default = () => {
   const submenu = (

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -213,6 +213,18 @@ export const ActionPopover = forwardRef<
 
     const onButtonKeyDown = useCallback(
       (e: React.KeyboardEvent<HTMLElement>) => {
+        // Only handle keydown events originating from the trigger button itself.
+        // This prevents menu item keydowns (e.g., Enter on an href link) from bubbling
+        // up and being intercepted by this handler, which would prevent native navigation.
+        const target = e.target as HTMLElement | null;
+        const fromTrigger = Boolean(
+          target?.closest("[data-element='action-popover-button']"),
+        );
+
+        if (!fromTrigger) {
+          return;
+        }
+
         if (
           Events.isSpaceKey(e) ||
           Events.isDownKey(e) ||

--- a/src/components/action-popover/action-popover.test.tsx
+++ b/src/components/action-popover/action-popover.test.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import { render, screen, act, within } from "@testing-library/react";
+import { render, screen, act, within, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as floatingUi from "@floating-ui/dom";
 
@@ -654,6 +654,47 @@ test.each(["ArrowDown", "Space", "Enter", "ArrowUp"] as const)(
     expect(onOpen).toHaveBeenCalledTimes(1);
   },
 );
+
+test("pressing a non-handled key when focused on the menu button does not open the menu", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(
+    <ActionPopover>
+      <ActionPopoverItem>example item 1</ActionPopoverItem>
+      <ActionPopoverItem>example item 2</ActionPopoverItem>
+    </ActionPopover>,
+  );
+
+  screen.getByRole("button").focus();
+  await user.keyboard("a");
+
+  expect(screen.queryByRole("list")).not.toBeInTheDocument();
+});
+
+test("pressing Enter on an href menu item does not get default-prevented by the trigger keydown handler", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(
+    <ActionPopover>
+      <ActionPopoverItem href="/target-page">Go to target</ActionPopoverItem>
+    </ActionPopover>,
+  );
+
+  await user.click(screen.getByRole("button"));
+
+  const link = screen.getByRole("link", { name: "Go to target" });
+  link.focus();
+
+  const event = new KeyboardEvent("keydown", {
+    key: "Enter",
+    bubbles: true,
+    cancelable: true,
+  });
+
+  fireEvent(link, event);
+
+  expect(event.defaultPrevented).toBe(false);
+});
 
 test.each(["ArrowDown", "Space", "Enter"] as const)(
   "pressing %s key when focused on the menu button selects the first focusable item",


### PR DESCRIPTION
fix #7945 

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

When the enter key is pressed on a focused `ActionPopoverItem`, a redirect event occurs. Also, a synthetic click event has been removed for download behaviour, the browser now handles all native click events on enter key on `ActionPopoverItem`'s which are rendered with an `href`

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, the default behaviour is accidentally prevented, this prevents a redirect occurring when the enter key is pressed on a focused `ActionPopoverItem`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Navigate to the new `Href Items Basic` test story, assert the enter key behaviour matches default browser behaviour.
