### PR TITLE
test(switch): refine testing suite

### DIFF
--- a/src/components/switch/switch.pw.tsx
+++ b/src/components/switch/switch.pw.tsx
@@ -1,329 +1,16 @@
 import React from "react";
 import { test, expect } from "../../../playwright/helpers/base-test";
 import { SwitchProps } from ".";
-import { SwitchComponent, WithMargin } from "./components.test-pw";
-import {
-  switchDataComponent,
-  switchInput,
-  switchLabel,
-} from "../../../playwright/components/switch/index";
-import {
-  assertCssValueIsApproximately,
-  checkAccessibility,
-} from "../../../playwright/support/helper";
+import { SwitchComponent } from "./components.test-pw";
+import { switchInput } from "../../../playwright/components/switch/index";
+import { checkAccessibility } from "../../../playwright/support/helper";
 import { CHARACTERS, SIZE } from "../../../playwright/support/constants";
 
 test.describe("Prop tests for Switch component", () => {
-  [
-    CHARACTERS.STANDARD,
-    CHARACTERS.DIACRITICS,
-    CHARACTERS.SPECIALCHARACTERS,
-  ].forEach((label) => {
-    test(`should render with ${label} as label`, async ({ mount, page }) => {
-      await mount(<SwitchComponent label={label} />);
-
-      await expect(switchLabel(page)).toHaveText(label);
-    });
-  });
-
   test("should render with autoFocus prop", async ({ mount, page }) => {
     await mount(<SwitchComponent autoFocus />);
 
     await expect(switchInput(page)).toBeFocused();
-  });
-
-  test("should render with checked state set to true", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SwitchComponent checked />);
-
-    await expect(switchInput(page)).toBeChecked();
-  });
-
-  test("should render with checked state set to false", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SwitchComponent checked={false} />);
-
-    await expect(switchInput(page)).not.toBeChecked();
-  });
-
-  test("should render with disabled set to true", async ({ mount, page }) => {
-    await mount(<SwitchComponent disabled />);
-
-    await expect(switchInput(page)).toBeDisabled();
-    await expect(switchLabel(page)).toBeDisabled();
-  });
-
-  test("should render with disabled set to false", async ({ mount, page }) => {
-    await mount(<SwitchComponent disabled={false} />);
-
-    await expect(switchInput(page)).toBeEnabled();
-    await expect(switchLabel(page)).toBeEnabled();
-  });
-
-  test("should render properly with loading prop set to true", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SwitchComponent loading checked={false} />);
-
-    await expect(switchInput(page)).toBeDisabled();
-    await expect(page.locator('[data-role="switch-loader"]')).toBeVisible();
-  });
-
-  test("should render properly with loading prop set to false", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SwitchComponent loading={false} checked={false} />);
-
-    await expect(switchInput(page)).toBeEnabled();
-    await expect(page.locator('[data-role="switch-loader"]')).toBeHidden();
-  });
-
-  test("should render with data-element", async ({ mount, page }) => {
-    await mount(<SwitchComponent data-element={CHARACTERS.STANDARD} />);
-
-    await expect(switchDataComponent(page)).toHaveAttribute(
-      "data-element",
-      CHARACTERS.STANDARD,
-    );
-  });
-
-  test("should render with data-role", async ({ mount, page }) => {
-    await mount(<SwitchComponent data-role={CHARACTERS.STANDARD} />);
-
-    await expect(switchDataComponent(page)).toHaveAttribute(
-      "data-role",
-      CHARACTERS.STANDARD,
-    );
-  });
-
-  test("should render with id", async ({ mount, page }) => {
-    await mount(<SwitchComponent id={CHARACTERS.STANDARD} />);
-
-    await expect(switchInput(page)).toHaveId(CHARACTERS.STANDARD);
-  });
-
-  test("should render with name", async ({ mount, page }) => {
-    await mount(<SwitchComponent name={CHARACTERS.STANDARD} />);
-
-    await expect(switchInput(page)).toHaveAttribute(
-      "name",
-      CHARACTERS.STANDARD,
-    );
-  });
-
-  test("should render with value", async ({ mount, page }) => {
-    await mount(<SwitchComponent value="switchvalue" />);
-
-    await expect(switchInput(page)).toHaveValue("switchvalue");
-  });
-
-  (
-    [
-      [SIZE.SMALL, 40, 24],
-      [SIZE.LARGE, 72, 40],
-    ] as [SwitchProps["size"], number, number][]
-  ).forEach(([size, width, height]) => {
-    test(`should render with size set to ${size}`, async ({ mount, page }) => {
-      await mount(<SwitchComponent size={size} />);
-
-      await assertCssValueIsApproximately(switchInput(page), "height", height);
-      await assertCssValueIsApproximately(switchInput(page), "width", width);
-    });
-  });
-
-  [true, false].forEach((boolVal) => {
-    test(`should render with labelInline set to ${boolVal}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<SwitchComponent labelInline={boolVal} />);
-
-      await expect(switchDataComponent(page)).toHaveCSS(
-        "flex-direction",
-        boolVal ? "row" : "column",
-      );
-    });
-  });
-
-  (
-    [
-      [1, 8],
-      [2, 16],
-    ] as [SwitchProps["labelSpacing"], number][]
-  ).forEach(([spacing, expectedMargin]) => {
-    test(`should render with labelSpacing set to ${spacing} when labelInline`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <SwitchComponent labelInline label="Label" labelSpacing={spacing} />,
-      );
-
-      await assertCssValueIsApproximately(
-        switchLabel(page),
-        "margin-right",
-        expectedMargin,
-      );
-    });
-  });
-
-  (
-    [
-      [10, 93],
-      [30, 293],
-      [80, 793],
-    ] as [SwitchProps["labelWidth"], number][]
-  ).forEach(([labelWidth, expectedWidth]) => {
-    test(`should render with labelWidth prop set to ${labelWidth} and with correct label width ratio`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <div style={{ width: "1000px" }}>
-          <SwitchComponent labelInline labelWidth={labelWidth} />
-        </div>,
-      );
-
-      await assertCssValueIsApproximately(
-        switchLabel(page),
-        "width",
-        expectedWidth,
-      );
-    });
-  });
-
-  [
-    CHARACTERS.STANDARD,
-    CHARACTERS.DIACRITICS,
-    CHARACTERS.SPECIALCHARACTERS,
-  ].forEach((hint) => {
-    test(`should render with inputHint "${hint}"`, async ({ mount, page }) => {
-      await mount(<SwitchComponent inputHint={hint} />);
-
-      await expect(page.locator('[data-element="input-hint"]')).toHaveText(
-        hint,
-      );
-    });
-  });
-
-  test("should render with custom processingLabel when loading", async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <SwitchComponent
-        loading
-        processingLabel="Please wait..."
-        checked={false}
-      />,
-    );
-
-    await expect(page.getByText("Please wait...")).toBeVisible();
-  });
-
-  test("label should have margin-bottom of 3px when no inputHint", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SwitchComponent />);
-
-    await expect(switchLabel(page)).toHaveCSS("margin-bottom", "8px");
-  });
-
-  test("label should not have margin-bottom when inputHint is provided", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SwitchComponent inputHint="Some hint text" />);
-
-    await expect(switchLabel(page)).toHaveCSS("margin-bottom", "0px");
-  });
-
-  test("label should not have margin-bottom when labelInline is true", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SwitchComponent labelInline />);
-
-    await expect(switchLabel(page)).toHaveCSS("margin-bottom", "0px");
-  });
-
-  test("renders with the expected border radius on track", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SwitchComponent />);
-
-    await expect(switchDataComponent(page).locator("div").nth(2)).toHaveCSS(
-      "border-radius",
-      "999px",
-    );
-  });
-});
-
-test.describe("Event tests", () => {
-  test("should call onChange callback when a click event is triggered", async ({
-    mount,
-    page,
-  }) => {
-    let callbackCount = 0;
-
-    await mount(
-      <SwitchComponent
-        onChange={() => {
-          callbackCount += 1;
-        }}
-      />,
-    );
-
-    await switchInput(page).click();
-
-    expect(callbackCount).toBe(1);
-  });
-
-  test("should call onBlur callback when a blur event is triggered", async ({
-    mount,
-    page,
-  }) => {
-    let callbackCount = 0;
-
-    await mount(
-      <SwitchComponent
-        onBlur={() => {
-          callbackCount += 1;
-        }}
-      />,
-    );
-
-    await switchInput(page).focus();
-    await switchInput(page).blur();
-
-    expect(callbackCount).toBe(1);
-  });
-
-  test("should call onFocus callback when a focus event is triggered", async ({
-    mount,
-    page,
-  }) => {
-    let callbackCount = 0;
-
-    await mount(
-      <SwitchComponent
-        onFocus={() => {
-          callbackCount += 1;
-        }}
-      />,
-    );
-
-    await switchInput(page).focus();
-
-    expect(callbackCount).toBe(1);
   });
 });
 
@@ -352,24 +39,6 @@ test.describe("Accessibility tests", () => {
 
       await checkAccessibility(page);
     });
-  });
-
-  test("check accessibility with data-element prop set", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SwitchComponent data-element={CHARACTERS.STANDARD} />);
-
-    await checkAccessibility(page);
-  });
-
-  test("check accessibility with data-role prop set", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SwitchComponent data-role={CHARACTERS.STANDARD} />);
-
-    await checkAccessibility(page);
   });
 
   test("check accessibility with autoFocus prop set", async ({
@@ -411,53 +80,6 @@ test.describe("Accessibility tests", () => {
     await checkAccessibility(page);
   });
 
-  test("check accessibility with id prop set", async ({ mount, page }) => {
-    await mount(<SwitchComponent id={CHARACTERS.STANDARD} />);
-
-    await checkAccessibility(page);
-  });
-
-  [true, false].forEach((boolVal) => {
-    test(`check accessibility when labelInline is set to ${boolVal}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<SwitchComponent labelInline={boolVal} />);
-
-      await checkAccessibility(page);
-    });
-  });
-
-  ([10, 30, 80] as SwitchProps["labelWidth"][]).forEach((labelWidth) => {
-    test(`check accessibility with labelWidth set to ${labelWidth}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<SwitchComponent labelInline labelWidth={labelWidth} />);
-
-      await checkAccessibility(page);
-    });
-  });
-
-  ([1, 2] as SwitchProps["labelSpacing"][]).forEach((spacing) => {
-    test(`check accessibility with labelSpacing set to ${spacing}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <SwitchComponent labelInline label="label" labelSpacing={spacing} />,
-      );
-
-      await checkAccessibility(page);
-    });
-  });
-
-  test("check accessibility with name prop", async ({ mount, page }) => {
-    await mount(<SwitchComponent name={CHARACTERS.STANDARD} />);
-
-    await checkAccessibility(page);
-  });
-
   ([SIZE.SMALL, SIZE.LARGE] as SwitchProps["size"][]).forEach((size) => {
     test(`check accessibility with size set to ${size}`, async ({
       mount,
@@ -467,12 +89,6 @@ test.describe("Accessibility tests", () => {
 
       await checkAccessibility(page);
     });
-  });
-
-  test("check accessibility with value prop", async ({ mount, page }) => {
-    await mount(<SwitchComponent value="switchvalue" />);
-
-    await checkAccessibility(page);
   });
 
   [
@@ -512,15 +128,6 @@ test.describe("Accessibility tests", () => {
     await mount(
       <SwitchComponent loading processingLabelBelowSwitch checked={false} />,
     );
-
-    await checkAccessibility(page);
-  });
-
-  test("check accessibility for WithMargin example", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<WithMargin />);
 
     await checkAccessibility(page);
   });

--- a/src/components/switch/switch.stories.tsx
+++ b/src/components/switch/switch.stories.tsx
@@ -15,6 +15,7 @@ const meta: Meta<typeof Switch> = {
   },
   parameters: {
     themeProvider: { chromatic: { theme: "sage" } },
+    chromatic: { disableSnapshot: true },
   },
 };
 

--- a/src/components/switch/switch.test.tsx
+++ b/src/components/switch/switch.test.tsx
@@ -71,6 +71,32 @@ describe("Switch", () => {
       );
     });
 
+    it("passes data-element to the outer wrapper", () => {
+      renderSwitch({
+        "data-role": "switch-wrapper",
+        "data-element": "my-element",
+      });
+      expect(screen.getByTestId("switch-wrapper")).toHaveAttribute(
+        "data-element",
+        "my-element",
+      );
+    });
+
+    it("passes the name attribute to the input", () => {
+      renderSwitch({ name: "my-switch-name" });
+      expect(screen.getByRole("switch")).toHaveAttribute(
+        "name",
+        "my-switch-name",
+      );
+    });
+
+    it("passes the value attribute to the input", () => {
+      renderSwitch({ value: "switch-val" });
+      // toHaveValue() does not support checkbox inputs, so we must use toHaveAttribute
+      // eslint-disable-next-line jest-dom/prefer-to-have-value
+      expect(screen.getByRole("switch")).toHaveAttribute("value", "switch-val");
+    });
+
     it("exports the component as a named export", () => {
       expect(NamedSwitch).toBeDefined();
     });
@@ -125,6 +151,21 @@ describe("Switch", () => {
       renderSwitch({ onChange });
       fireEvent.click(screen.getByRole("switch"));
       expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onBlur when the input loses focus", () => {
+      const onBlur = jest.fn();
+      renderSwitch({ onBlur });
+      fireEvent.focus(screen.getByRole("switch"));
+      fireEvent.blur(screen.getByRole("switch"));
+      expect(onBlur).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onFocus when the input gains focus", () => {
+      const onFocus = jest.fn();
+      renderSwitch({ onFocus });
+      fireEvent.focus(screen.getByRole("switch"));
+      expect(onFocus).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
### Proposed behaviour

Removes a number of Playwright tests that duplicate either Jest or Chromatic ones for the Switch component

### Current behaviour

There are a number of tests that exist in different forms in all the testing suites we do(Jest, Playwright, Chromatic) which cause a prolonged time of execution for no additional value.


### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

This should decrease the time of execution without compromising testing and coverage

### Testing instructions

<!--
How can a reviewer test this PR?

Make sure the Playwright tests pass<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
