### PR TITLE
feat(required-fields-indicator): align component with fusion DS

### DIFF
--- a/docs/validations.stories.tsx
+++ b/docs/validations.stories.tsx
@@ -135,7 +135,7 @@ export const ValidationRedesign: StoryObj = () => {
     <CarbonProvider validationRedesignOptIn>
       <Form>
         <RequiredFieldsIndicator mb={2}>
-          Fill in all fields marked with
+          Indicates required information
         </RequiredFieldsIndicator>
         <Textarea
           label="Textarea"
@@ -163,7 +163,7 @@ export const ValidationRedesignWithGroupedInputs: StoryObj = () => {
     <CarbonProvider validationRedesignOptIn>
       <Form>
         <RequiredFieldsIndicator mb={2}>
-          Fill in all fields marked with
+          Indicates required information
         </RequiredFieldsIndicator>
         <RadioButtonGroup
           legend="Radio Button Group"
@@ -214,7 +214,7 @@ export const ValidationRedesignMessageBottom: StoryObj = () => {
     <CarbonProvider validationRedesignOptIn>
       <Form>
         <RequiredFieldsIndicator mb={2}>
-          Fill in all fields marked with
+          Indicates required information
         </RequiredFieldsIndicator>
 
         <Textbox

--- a/skills/carbon-react/components/form.md
+++ b/skills/carbon-react/components/form.md
@@ -380,6 +380,19 @@ description: Carbon Form component props and usage examples.
 ```
 
 
+### Required Fields Indicator
+
+**Render**
+
+```tsx
+() => (
+  <RequiredFieldsIndicator m={2}>
+    Indicates required information
+  </RequiredFieldsIndicator>
+)
+```
+
+
 ### WithBothOptionalOrRequired
 
 **Render**
@@ -388,7 +401,7 @@ description: Carbon Form component props and usage examples.
 (args: FormProps) => (
   <Box m={1}>
     <RequiredFieldsIndicator mb={2}>
-      <Typography variant="b">Fill in all fields marked with</Typography>
+      <Typography variant="b">Indicates required information</Typography>
     </RequiredFieldsIndicator>
     <Form
       {...args}

--- a/src/components/form/form.mdx
+++ b/src/components/form/form.mdx
@@ -68,6 +68,13 @@ When either `errorCount` or `warningCount` or both are provided, summary with th
 
 <Canvas of={FormStories.WithBothErrorsAndWarningsSummary} />
 
+### Required Fields Indicator
+
+The `RequiredFieldsIndicator` component visually indicates that form fields are required using an asterisk prefix. It can be used 
+within a `Form` to provide users with a clear indication of which fields are mandatory, or used independently.
+
+<Canvas of={FormStories.RequiredFieldsIndicatorStory} />
+
 ### Example with optional and required fields
 
 You can set the `required` or `isOptional` on any `Form` input to make them mandatory or optional. You can also

--- a/src/components/form/form.stories.tsx
+++ b/src/components/form/form.stories.tsx
@@ -28,6 +28,7 @@ const defaultOpenState = isChromatic();
 const meta: Meta<typeof Form> = {
   title: "Form",
   component: Form,
+  subcomponents: { RequiredFieldsIndicator },
   args: {
     onSubmit: (ev: React.FormEvent) => {
       ev.preventDefault();
@@ -340,10 +341,17 @@ export const WithButtonsAlignedToTheLeft: Story = (args: FormProps) => (
 );
 WithButtonsAlignedToTheLeft.storyName = "With Buttons Aligned to the Left";
 
+export const RequiredFieldsIndicatorStory: Story = () => (
+  <RequiredFieldsIndicator m={2}>
+    Indicates required information
+  </RequiredFieldsIndicator>
+);
+RequiredFieldsIndicatorStory.storyName = "Required Fields Indicator";
+
 export const WithBothOptionalOrRequired: Story = (args: FormProps) => (
   <Box m={1}>
     <RequiredFieldsIndicator mb={2}>
-      <Typography variant="b">Fill in all fields marked with</Typography>
+      <Typography variant="b">Indicates required information</Typography>
     </RequiredFieldsIndicator>
     <Form
       {...args}

--- a/src/components/form/required-fields-indicator/required-fields-indicator.component.tsx
+++ b/src/components/form/required-fields-indicator/required-fields-indicator.component.tsx
@@ -2,26 +2,33 @@ import React from "react";
 import styled from "styled-components";
 import { margin, MarginProps } from "styled-system";
 import applyBaseTheme from "../../../style/themes/apply-base-theme";
-import StyledTypography from "../../typography/typography.style";
 
 export interface RequiredIndicatorProps extends MarginProps {
-  children: React.ReactNode;
+  /** Content to be displayed alongside the required fields indicator */
+  children?: React.ReactNode;
 }
 
-const StyledIndicatorContainer = styled.div.attrs(applyBaseTheme)`
-  ${margin}
+export const RequiredFieldsIndicator = ({
+  children,
+  ...rest
+}: RequiredIndicatorProps) => {
+  const StyledIndicatorContainer = styled.div.attrs(applyBaseTheme)`
+    ${margin}
 
-  ${StyledTypography} {
-    color: var(--colorsUtilityYin090);
-  }
-  ::after {
-    content: "*";
-    color: var(--colorsSemanticNegative500);
-    font-weight: 500;
-    margin-left: var(--spacing050);
-  }
-`;
+    color: var(--input-labelset-label-default);
+    font: var(--global-font-static-comp-medium-m);
 
-export default ({ children, ...rest }: RequiredIndicatorProps) => (
-  <StyledIndicatorContainer {...rest}>{children}</StyledIndicatorContainer>
-);
+    ::before {
+      content: "*";
+      color: var(--input-labelset-label-required);
+      font: var(--global-font-static-comp-medium-m);
+      margin-right: var(--global-space-comp-xs);
+    }
+  `;
+
+  return (
+    <StyledIndicatorContainer {...rest}>{children}</StyledIndicatorContainer>
+  );
+};
+
+export default RequiredFieldsIndicator;

--- a/src/components/text-editor/__internal__/__ui__/Toolbar/toolbar.component.tsx
+++ b/src/components/text-editor/__internal__/__ui__/Toolbar/toolbar.component.tsx
@@ -34,9 +34,8 @@ import { TEXT_EDITOR_ACTION_TYPES } from "../../__utils__/constants";
 import Textbox from "../../../../textbox";
 import { $createLinkNode } from "@lexical/link";
 import Dialog from "../../../../dialog";
-import Form from "../../../../form";
+import Form, { RequiredFieldsIndicator } from "../../../../form";
 import Box from "../../../../box";
-import Typography from "../../../../typography";
 
 const Toolbar = ({
   contentEditorRef,
@@ -417,13 +416,9 @@ const Toolbar = ({
           >
             {/* Layout container */}
             <Box display="flex" flexDirection="column" gap="16px">
-              {/* TO-DO: Replace hard-coded overrides from Typography with supported variants when supported */}
-              <Typography fontSize="14px" fontWeight="500" lineHeight="21px">
-                <span style={{ color: "var(--input-labelset-label-required)" }}>
-                  *
-                </span>{" "}
+              <RequiredFieldsIndicator>
                 {locale.textEditor.hyperlink.formKey?.()}
-              </Typography>
+              </RequiredFieldsIndicator>
 
               {/* Block layout container */}
               <Box display="flex" gap="24px" flexWrap="wrap">


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Aligns the component with fusion DS designs, now uses new tokens and renders the asterisk on the left. Now children are no longer required, so the component can be self-closing and used in other compositions

<img width="304" height="81" alt="Screenshot 2026-05-13 at 15 24 02" src="https://github.com/user-attachments/assets/010e8f49-00b1-4654-8dab-f7eb3e0099ef" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

N/A

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
