### PR TITLE
feat(fieldset): align with Fusion DS

### DIFF
--- a/skills/carbon-react/components/fieldset.md
+++ b/skills/carbon-react/components/fieldset.md
@@ -15,8 +15,12 @@ description: Carbon Fieldset component props and usage examples.
 ## Props
 | Name | Type | Required | Literals | Description | Default |
 | --- | --- | --- | --- | --- | --- |
-| children | React.ReactNode | No |  | Child elements |  |
-| legend | string \| undefined | No |  | The text for the fieldset's legend element. |  |
+| children | React.ReactNode | No |  | Inputs rendered within the fieldset. |  |
+| error | string \| undefined | No |  | Error message to be displayed when validation fails. |  |
+| id | string \| undefined | No |  | Set an id value on the fieldset. |  |
+| labelWeight | "bold" \| "regular" \| undefined | No |  | Set the label weight of the children input's label. | "regular" |
+| legend | string \| undefined | No |  | The content for the fieldset legend. |  |
+| legendHint | string \| undefined | No |  | Content for an additional hint text below the legend. |  |
 | m | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top, left, bottom and right |  |
 | margin | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top, left, bottom and right |  |
 | marginBottom | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on bottom |  |
@@ -31,100 +35,129 @@ description: Carbon Fieldset component props and usage examples.
 | mt | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top |  |
 | mx | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on left and right |  |
 | my | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top and bottom |  |
-| required | boolean \| undefined | No |  | Flag to configure fields as mandatory. |  |
+| orientation | "horizontal" \| "vertical" \| undefined | No |  | Set the orientation of the fieldset's children. | "vertical" |
+| required | boolean \| undefined | No |  | If true, an asterisk will be added to the legend and all inputs within the fieldset will be required. |  |
+| size | "small" \| "medium" \| "large" \| undefined | No |  | Set the size of the component. | "medium" |
+| validationMessagePositionTop | boolean \| undefined | No |  | Specifies whether the validation message should be displayed above the input. | true |
+| warning | string \| undefined | No |  | Warning message to be displayed when validation warning occurs. |  |
 | data-element | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
 | data-role | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
 
 ## Examples
 ### Default
 
+**Args**
+
+```tsx
+{
+    legend: "Fieldset Legend",
+  }
+```
+
 **Render**
 
 ```tsx
-() => (
-  <CarbonProvider validationRedesignOptIn>
-    <Form>
-      <Fieldset legend="Fieldset">
-        <Textbox label="Address Line 1" value={""} onChange={() => {}} />
-        <Textbox label="Address Line 2" value={""} onChange={() => {}} />
-        <Textbox label="City" value={""} onChange={() => {}} />
-        <Select label="Country" value={""} onChange={() => {}}>
-          <Option text="United Kingdom" value="uk" />
-          <Option text="Spain" value="sp" />
-          <Option text="France" value="fr" />
-          <Option text="Germany" value="ge" />
-        </Select>
-        <Textbox
-          label="Postcode"
-          maxWidth="100px"
-          value={""}
-          onChange={() => {}}
-        />
-      </Fieldset>
-    </Form>
-  </CarbonProvider>
-)
+(args) => (
+    <Fieldset {...args}>
+      <Textbox label="Input 1" value="Input Text" onChange={() => {}} />
+      <Textbox label="Input 2" value="Input Text" onChange={() => {}} />
+      <Textbox label="Input 3" value="Input Text" onChange={() => {}} />
+    </Fieldset>
+  )
 ```
 
 
-### With fieldSpacing
+### WithLegendHint
+
+**Args**
+
+```tsx
+{
+    ...Default.args,
+    legendHint: "Fieldset LegendHint",
+  }
+```
+
+
+### HorizontalOrientation
+
+**Args**
+
+```tsx
+{
+    ...Default.args,
+    orientation: "horizontal",
+  }
+```
+
+
+### Sizes
+
+**Args**
+
+```tsx
+{
+    mb: 4,
+  }
+```
 
 **Render**
 
 ```tsx
-() => (
-  <CarbonProvider validationRedesignOptIn>
-    <Form fieldSpacing={1}>
-      <Fieldset legend="Fieldset">
-        <Textbox label="Address Line 1" value={""} onChange={() => {}} />
-        <Textbox label="Address Line 2" value={""} onChange={() => {}} />
-        <Textbox label="City" value={""} onChange={() => {}} />
-        <Select label="Country" value={""} onChange={() => {}}>
-          <Option text="United Kingdom" value="uk" />
-          <Option text="Spain" value="sp" />
-          <Option text="France" value="fr" />
-          <Option text="Germany" value="ge" />
-        </Select>
-        <Textbox
-          label="Postcode"
-          maxWidth="100px"
-          value={""}
-          onChange={() => {}}
-        />
+(args) => (
+    <>
+      <Fieldset legend="Small Fieldset" size="small" {...args}>
+        <Textbox label="Input 1" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 2" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 3" value="Input Text" onChange={() => {}} />
       </Fieldset>
-    </Form>
-  </CarbonProvider>
-)
+      <Fieldset legend="Medium Fieldset" size="medium" {...args}>
+        <Textbox label="Input 1" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 2" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 3" value="Input Text" onChange={() => {}} />
+      </Fieldset>
+      <Fieldset legend="Large Fieldset" size="large" {...args}>
+        <Textbox label="Input 1" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 2" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 3" value="Input Text" onChange={() => {}} />
+      </Fieldset>
+    </>
+  )
+```
+
+
+### HorizontalSizes
+
+**Args**
+
+```tsx
+{
+    ...Sizes.args,
+    orientation: "horizontal",
+  }
+```
+
+
+### LabelFontWeight
+
+**Args**
+
+```tsx
+{
+    ...Default.args,
+    labelWeight: "bold",
+  }
 ```
 
 
 ### Required
 
-**Render**
+**Args**
 
 ```tsx
-() => (
-  <CarbonProvider validationRedesignOptIn>
-    <Form>
-      <Fieldset legend="Fieldset" required>
-        <Textbox label="Address Line 1" value={""} onChange={() => {}} />
-        <Textbox label="Address Line 2" value={""} onChange={() => {}} />
-        <Textbox label="City" value={""} onChange={() => {}} />
-        <Select label="Country" value={""} onChange={() => {}}>
-          <Option text="United Kingdom" value="uk" />
-          <Option text="Spain" value="sp" />
-          <Option text="France" value="fr" />
-          <Option text="Germany" value="ge" />
-        </Select>
-        <Textbox
-          label="Postcode"
-          maxWidth="100px"
-          value={""}
-          onChange={() => {}}
-        />
-      </Fieldset>
-    </Form>
-  </CarbonProvider>
-)
+{
+    ...Default.args,
+    required: true,
+  }
 ```
 

--- a/src/__internal__/checkable-input/checkable-input.component.tsx
+++ b/src/__internal__/checkable-input/checkable-input.component.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useRef, useContext } from "react";
 
 import {
   StyledCheckableInput,
@@ -12,6 +12,7 @@ import HiddenCheckableInput, {
 import guid from "../utils/helpers/guid";
 import useInputAccessibility from "../../hooks/__internal__/useInputAccessibility";
 import { ValidationProps } from "../validations";
+import FieldsetContext from "../../components/fieldset/__internal__/fieldset.context";
 
 export interface CommonCheckableInputProps
   extends ValidationProps,
@@ -101,6 +102,8 @@ const CheckableInput = React.forwardRef(
   ) => {
     const { current: id } = useRef(inputId || guid());
 
+    const { required: fieldsetRequired } = useContext(FieldsetContext);
+
     const { labelId, fieldHelpId, validationId, ariaDescribedBy } =
       useInputAccessibility({
         id,
@@ -149,7 +152,8 @@ const CheckableInput = React.forwardRef(
       onBlur,
       onChange,
       onFocus,
-      required,
+      // set required if checkbox is rendered within Fieldset, but avoid rendering asterisk
+      required: required || fieldsetRequired,
       ref,
       validationIconId: validationId,
       ...props,

--- a/src/__internal__/legacy-label/label.style.ts
+++ b/src/__internal__/legacy-label/label.style.ts
@@ -61,6 +61,10 @@ export const StyledLabelContainer = styled.div<StyledLabelContainerProps>`
   align-items: center;
   margin-bottom: 8px;
 
+  .fieldset-content & {
+    margin-bottom: var(--global-space-comp-xs);
+  }
+
   ${({ align }) => css`
     justify-content: ${align !== "right" ? "flex-start" : "flex-end"};
   `}

--- a/src/components/checkbox/checkbox.component.tsx
+++ b/src/components/checkbox/checkbox.component.tsx
@@ -12,6 +12,7 @@ import { TooltipProvider } from "../../__internal__/tooltip-provider";
 import CheckboxGroupContext from "./checkbox-group/__internal__/checkbox-group.context";
 import NewValidationContext from "../carbon-provider/__internal__/new-validation.context";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import FieldsetContext from "../fieldset/__internal__/fieldset.context";
 
 export interface CheckboxProps
   extends CommonCheckableInputProps,
@@ -87,6 +88,13 @@ export const Checkbox = React.forwardRef(
       info: contextInfo,
     } = checkboxGroupContext;
 
+    const { size: fieldsetSize, hasError: fieldsetError } =
+      useContext(FieldsetContext);
+    let actualSize = fieldsetSize || size;
+    if (actualSize === "medium") {
+      actualSize = "small";
+    }
+
     const inputProps = {
       ariaLabelledBy,
       onClick,
@@ -116,7 +124,7 @@ export const Checkbox = React.forwardRef(
     };
 
     const validationProps = {
-      error: contextError || error,
+      error: contextError || error || fieldsetError,
       warning: contextWarning || warning,
       ...(validationRedesignOptIn
         ? { validationOnLabel: false }
@@ -134,7 +142,7 @@ export const Checkbox = React.forwardRef(
         {...validationProps}
         fieldHelpInline={fieldHelpInline}
         reverse={reverse}
-        size={size}
+        size={actualSize}
         applyNewValidation={validationRedesignOptIn}
         {...marginProps}
         {...tagComponent("checkbox", {

--- a/src/components/date/date.component.tsx
+++ b/src/components/date/date.component.tsx
@@ -35,6 +35,7 @@ import DateRangeContext, {
 import useClickAwayListener from "../../hooks/__internal__/useClickAwayListener";
 import guid from "../../__internal__/utils/helpers/guid";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+import FieldsetContext from "../fieldset/__internal__/fieldset.context";
 
 interface CustomDateEvent {
   type: string;
@@ -195,6 +196,9 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
     const pickerTabGuardId = useRef(guid());
     const showValidationMessageOnTop =
       validationMessagePositionTopContext ?? validationMessagePositionTop;
+
+    const { size: fieldsetSize } = useContext(FieldsetContext);
+    const actualSize = fieldsetSize || size;
 
     const computeInvalidRawValue = (inputValue: string) =>
       allowEmptyValue && !inputValue.length ? inputValue : null;
@@ -473,7 +477,7 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
       <StyledDateInput
         ref={wrapperRef}
         role="presentation"
-        size={size}
+        size={actualSize}
         labelInline={labelInline}
         {...marginProps}
         applyDateRangeStyling={!!inputRefMap}
@@ -505,12 +509,12 @@ export const DateInput = React.forwardRef<HTMLInputElement, DateInputProps>(
           tooltipPosition={tooltipPosition}
           helpAriaLabel={helpAriaLabel}
           autoFocus={autoFocus}
-          size={size}
+          size={actualSize}
           disabled={disabled}
           readOnly={readOnly}
           inputWidth={inputWidth}
           labelWidth={labelWidth}
-          maxWidth={maxWidth ?? datePickerWidth[size]}
+          maxWidth={maxWidth ?? datePickerWidth[actualSize]}
           m={0}
           validationMessagePositionTop={showValidationMessageOnTop}
         />

--- a/src/components/fieldset/__internal__/fieldset.context.ts
+++ b/src/components/fieldset/__internal__/fieldset.context.ts
@@ -1,0 +1,9 @@
+import React from "react";
+
+type FieldsetContextType = {
+  size?: "small" | "medium" | "large";
+  hasError?: boolean;
+  required?: boolean;
+};
+
+export default React.createContext<FieldsetContextType>({});

--- a/src/components/fieldset/components.test-pw.tsx
+++ b/src/components/fieldset/components.test-pw.tsx
@@ -1,74 +1,15 @@
-import React, { useState } from "react";
+import React from "react";
 import Fieldset from "./fieldset.component";
 import { FieldsetProps } from "../../../src/components/fieldset";
 import Textbox from "../textbox";
-import Checkbox from "../checkbox/checkbox.component";
 
 const FieldsetComponent = (props: FieldsetProps) => {
-  const [textboxValue, setTextboxValue] = useState("");
-  const [checkboxValue, setCheckboxValue] = useState(false);
-
   return (
-    <div>
-      <Fieldset legend="Fieldset" {...props}>
-        <Textbox
-          label="First Name"
-          labelInline
-          labelAlign="right"
-          labelWidth={30}
-          value={textboxValue}
-          onChange={(e) => setTextboxValue(e.target.value)}
-        />
-        <Textbox
-          label="Last Name"
-          labelInline
-          labelAlign="right"
-          labelWidth={30}
-          value={textboxValue}
-          onChange={(e) => setTextboxValue(e.target.value)}
-        />
-        <Textbox
-          label="Address"
-          labelInline
-          labelAlign="right"
-          labelWidth={30}
-          value={textboxValue}
-          onChange={(e) => setTextboxValue(e.target.value)}
-        />
-        <Checkbox
-          label="Checkbox"
-          labelWidth={30}
-          labelSpacing={2}
-          reverse
-          checked={checkboxValue}
-          onChange={(e) => setCheckboxValue(e.target.checked)}
-        />
-        <Textbox
-          label="City"
-          labelInline
-          labelAlign="right"
-          labelWidth={30}
-          value={textboxValue}
-          onChange={(e) => setTextboxValue(e.target.value)}
-        />
-        <Textbox
-          label="Country"
-          labelInline
-          labelAlign="right"
-          labelWidth={30}
-          value={textboxValue}
-          onChange={(e) => setTextboxValue(e.target.value)}
-        />
-        <Textbox
-          label="Telephone"
-          labelInline
-          labelAlign="right"
-          labelWidth={30}
-          value={textboxValue}
-          onChange={(e) => setTextboxValue(e.target.value)}
-        />
-      </Fieldset>
-    </div>
+    <Fieldset {...props}>
+      <Textbox label="Input 1" value="Input Text" onChange={() => {}} />
+      <Textbox label="Input 2" value="Input Text" onChange={() => {}} />
+      <Textbox label="Input 3" value="Input Text" onChange={() => {}} />
+    </Fieldset>
   );
 };
 

--- a/src/components/fieldset/fieldset-test.stories.tsx
+++ b/src/components/fieldset/fieldset-test.stories.tsx
@@ -1,16 +1,23 @@
 import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
-import Fieldset from "./fieldset.component";
+import Fieldset from ".";
 import Textbox from "../textbox";
-import { Select, Option } from "../select";
-import Form from "../form";
+import Decimal from "../decimal";
+import Password from "../password";
+import DateInput from "../date";
+import Textarea from "../textarea";
+import TextEditor from "../text-editor";
+import { Select, MultiSelect, FilterableSelect, Option } from "../select";
 import { Checkbox } from "../checkbox";
-import CarbonProvider from "../carbon-provider";
+import { Tabs, Tab, TabList, TabPanel } from "../tabs/__next__";
 
 const meta: Meta<typeof Fieldset> = {
   title: "Fieldset/Test",
   component: Fieldset,
+  argTypes: {
+    legendHint: { control: "text" },
+  },
   parameters: {
     themeProvider: { chromatic: { theme: "sage" } },
     controls: {
@@ -22,136 +29,156 @@ const meta: Meta<typeof Fieldset> = {
 export default meta;
 type Story = StoryObj<typeof Fieldset>;
 
-export const Default: Story = ({ ...args }) => {
-  return (
+export const AllInputsSmall: Story = {
+  render: (args) => (
     <Fieldset {...args}>
-      <Textbox label="First Name" labelInline value={""} onChange={() => {}} />
-      <Textbox label="Last Name" labelInline value={""} onChange={() => {}} />
-      <Textbox label="Address" labelInline value={""} onChange={() => {}} />
-      <Textbox label="City" labelInline value={""} onChange={() => {}} />
-      <Checkbox
-        label="Checkbox"
-        labelWidth={17.25}
-        reverse
-        checked={false}
-        onChange={() => {}}
-      />
-      <Select
-        label="Country"
-        labelInline
-        labelWidth={30}
-        value={""}
-        onChange={() => {}}
-      >
-        <Option text="United Kingdom" value="uk" />
-        <Option text="Spain" value="sp" />
-        <Option text="France" value="fr" />
-        <Option text="Germany" value="ge" />
+      <Textbox label="Textbox" value="Input Text" onChange={() => {}} />
+      <Decimal label="Decimal" value="0.00" onChange={() => {}} />
+      <Password label="Password" value="Password" onChange={() => {}} />
+      <DateInput label="DateInput" value="10/10/2010" onChange={() => {}} />
+      <Checkbox label="Checkbox" checked onChange={() => {}} />
+      <Textarea label="Textarea" value="textarea" onChange={() => {}} />
+      <TextEditor labelText="TextEditor" onChange={() => {}} />
+      <Select label="Simple Select" value="1" onChange={() => {}}>
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
       </Select>
-      <Textbox value={""} onChange={() => {}} label="Telephone" labelInline />
+      <MultiSelect label="Multi Select" value={["1"]} onChange={() => {}}>
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+      </MultiSelect>
+      <FilterableSelect label="Filterable Select" value="1" onChange={() => {}}>
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+      </FilterableSelect>
     </Fieldset>
-  );
-};
-Default.storyName = "Default";
-Default.args = {
-  legend: "Personal Information",
+  ),
+  args: {
+    legend: "Fieldset Legend",
+    legendHint: "LegendHint",
+    error: "Error message (Fix is required)",
+    required: true,
+    size: "small",
+  },
 };
 
-export const InFormFieldSpacing: Story = () => (
-  <Form fieldSpacing={1}>
-    <Textbox
-      label="Separate Field"
-      labelInline
-      value={""}
-      onChange={() => {}}
-    />
-    <Fieldset>
-      <Textbox
-        label="Fieldset 1 Field 1"
-        labelInline
-        value={""}
-        onChange={() => {}}
-      />
-      <Textbox
-        label="Fieldset 1 Field 2"
-        labelInline
-        value={""}
-        onChange={() => {}}
-      />
-    </Fieldset>
-    <Fieldset>
-      <Textbox
-        label="Fieldset 2 Field 1"
-        labelInline
-        value={""}
-        onChange={() => {}}
-      />
-      <Textbox
-        label="Fieldset 2 Field 2"
-        labelInline
-        value={""}
-        onChange={() => {}}
-      />
-    </Fieldset>
-    <Textbox
-      label="Separate Field"
-      labelInline
-      value={""}
-      onChange={() => {}}
-    />
-  </Form>
-);
-InFormFieldSpacing.storyName = "In Form with fieldSpacing (legacy)";
+export const AllInputsMedium: Story = {
+  ...AllInputsSmall,
+  args: {
+    ...AllInputsSmall.args,
+    size: "medium",
+  },
+};
 
-export const Validation: Story = ({ ...args }) => (
-  <CarbonProvider validationRedesignOptIn>
-    <Form>
-      <Textbox label="Separate Field" value={""} onChange={() => {}} />
-      <Fieldset legend="Fieldset" {...args}>
-        <Textbox
-          label="Address Line 1"
-          error="Message"
-          value={""}
-          onChange={() => {}}
-        />
-        <Textbox
-          label="Address Line 2"
-          error="Message"
-          value={""}
-          onChange={() => {}}
-        />
-        <Checkbox label="Checkbox" checked={false} onChange={() => {}} />
-        <Textbox
-          label="City"
-          warning="Message"
-          value={""}
-          onChange={() => {}}
-        />
-        <Select
-          label="Country"
-          warning="Message"
-          value={""}
-          onChange={() => {}}
-        >
-          <Option text="United Kingdom" value="uk" />
-          <Option text="Spain" value="sp" />
-          <Option text="France" value="fr" />
-          <Option text="Germany" value="ge" />
-        </Select>
-        <Textbox
-          label="Postcode"
-          maxWidth="100px"
-          warning="Message"
-          value={""}
-          onChange={() => {}}
-        />
+export const AllInputsLarge: Story = {
+  ...AllInputsSmall,
+  args: {
+    ...AllInputsSmall.args,
+    size: "large",
+  },
+};
+
+export const ChildVariations: Story = {
+  render: (args) => (
+    <Fieldset mb={4} {...args}>
+      <Textbox
+        label="Textbox required"
+        value="Input Text"
+        required
+        onChange={() => {}}
+      />
+      <Textbox
+        label="Textbox with error"
+        value="Input Text"
+        error="Error message"
+        onChange={() => {}}
+      />
+      <Textbox
+        label="Textbox with warning"
+        value="Input Text"
+        warning="Warning message"
+        onChange={() => {}}
+      />
+      <Textbox
+        label="Textbox inline"
+        value="Input Text"
+        labelInline
+        onChange={() => {}}
+      />
+    </Fieldset>
+  ),
+  args: {
+    legend: "Fieldset Legend",
+    legendHint: "LegendHint",
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+};
+
+export const InTabs: Story = {
+  render: (args) => (
+    <Tabs>
+      <TabList ariaLabel="Tabs">
+        <Tab controls="tab-panel-1" id="tab-1" label="Tab One" />
+        <Tab controls="tab-panel-2" id="tab-2" label="Tab Two" />
+      </TabList>
+
+      <TabPanel id="tab-panel-1" tabId="tab-1">
+        <Fieldset error="Error Message" {...args}>
+          <Textbox
+            label="Textbox"
+            value="Input Text"
+            required
+            onChange={() => {}}
+          />
+        </Fieldset>
+      </TabPanel>
+
+      <TabPanel id="tab-panel-2" tabId="tab-2">
+        <Fieldset warning="Warning Message" {...args}>
+          <Textbox
+            label="Textbox"
+            value="Input Text"
+            required
+            onChange={() => {}}
+          />
+        </Fieldset>
+      </TabPanel>
+    </Tabs>
+  ),
+  args: {
+    legend: "Fieldset Legend",
+    legendHint: "LegendHint",
+  },
+};
+
+export const HorizontalSizes: Story = {
+  render: (args) => (
+    <>
+      <Fieldset legend="Small Fieldset" size="small" {...args}>
+        <Textbox label="Input 1" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 2" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 3" value="Input Text" onChange={() => {}} />
       </Fieldset>
-      <Textbox label="Separate Field" value={""} onChange={() => {}} />
-    </Form>
-  </CarbonProvider>
-);
-Validation.storyName = "New Validation";
-Validation.parameters = {
-  chromatic: { disableSnapshot: false },
-  themeProvider: { chromatic: { theme: "sage" } },
+      <Fieldset legend="Medium Fieldset" size="medium" {...args}>
+        <Textbox label="Input 1" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 2" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 3" value="Input Text" onChange={() => {}} />
+      </Fieldset>
+      <Fieldset legend="Large Fieldset" size="large" {...args}>
+        <Textbox label="Input 1" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 2" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 3" value="Input Text" onChange={() => {}} />
+      </Fieldset>
+    </>
+  ),
+  args: {
+    mb: 4,
+    orientation: "horizontal",
+    error: "Error Message",
+  },
 };

--- a/src/components/fieldset/fieldset.component.tsx
+++ b/src/components/fieldset/fieldset.component.tsx
@@ -1,58 +1,134 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useRef } from "react";
 import { MarginProps } from "styled-system";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
-import { FieldsetStyle, StyledLegend } from "./fieldset.style";
-import NewValidationContext from "../carbon-provider/__internal__/new-validation.context";
+import {
+  StyledFieldset,
+  StyledLegend,
+  StyledFieldsetContentWrapper,
+  StyledFieldsetContent,
+} from "./fieldset.style";
+import FieldsetContext from "./__internal__/fieldset.context";
+import ErrorBorder from "../../__internal__/error-border/error-border.style";
+import ValidationMessage from "../../__internal__/validation-message/__next__";
+import HintText from "../../__internal__/hint-text";
+import guid from "../../__internal__/utils/helpers/guid";
+import useRegisterValidationToTabs from "../../hooks/__internal__/useRegisterValidationToTabs/useRegisterValidationToTabs";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 
 export interface FieldsetProps extends MarginProps, TagProps {
-  /** Child elements */
+  /** Inputs rendered within the fieldset. */
   children?: React.ReactNode;
-  /** The text for the fieldset's legend element. */
+  /** Set an id value on the fieldset. */
+  id?: string;
+  /** The content for the fieldset legend. */
   legend?: string;
-  /** Flag to configure fields as mandatory. */
+  /** Content for an additional hint text below the legend. */
+  legendHint?: string;
+  /** Set the label weight of the children input's label. */
+  labelWeight?: "regular" | "bold";
+  /** Error message to be displayed when validation fails. */
+  error?: string;
+  /** Warning message to be displayed when validation warning occurs. */
+  warning?: string;
+  /** If true, an asterisk will be added to the legend and all inputs within the fieldset will be required. */
   required?: boolean;
+  /** Specifies whether the validation message should be displayed above the input. */
+  validationMessagePositionTop?: boolean;
+  /** Set the size of the component. */
+  size?: "small" | "medium" | "large";
+  /** Set the orientation of the fieldset's children. */
+  orientation?: "horizontal" | "vertical";
 }
 
 export const Fieldset = ({
   children,
+  id,
   legend,
+  legendHint,
+  labelWeight = "regular",
+  error,
+  warning,
   required,
+  validationMessagePositionTop = true,
+  size = "medium",
+  orientation = "vertical",
   ...rest
 }: FieldsetProps) => {
-  const [ref, setRef] = useState<HTMLFieldSetElement | null>(null);
-  const marginProps = filterStyledSystemMarginProps(rest);
-  const { validationRedesignOptIn } = useContext(NewValidationContext);
+  const internalId = useRef(guid());
+  const uniqueId = id || internalId.current;
 
-  useEffect(() => {
-    if (ref && required) {
-      Array.from(
-        ref.querySelectorAll("input") || /* istanbul ignore next */ [],
-      ).forEach((el) => {
-        el.setAttribute("required", "");
-      });
+  const legendHintId = legendHint ? `${uniqueId}-hint` : undefined;
+  const validationId = (error || warning) && `${uniqueId}-validation-message`;
+
+  useRegisterValidationToTabs(!!error, !!warning, uniqueId);
+
+  const ariaDescribedBy = [legendHintId, validationId]
+    .filter(Boolean)
+    .join(" ");
+
+  const validationMessage = () => {
+    if (error || warning) {
+      return (
+        <>
+          <ValidationMessage
+            error={error}
+            warning={warning}
+            id={validationId}
+            size={size}
+          />
+          <ErrorBorder $warning={!!(!error && warning)} />
+        </>
+      );
     }
-  }, [ref, required]);
+    return null;
+  };
 
   return (
-    <FieldsetStyle
-      ref={setRef}
-      newValidation={validationRedesignOptIn}
+    <StyledFieldset
+      id={uniqueId}
+      aria-describedby={ariaDescribedBy}
       {...rest}
-      {...marginProps}
+      {...filterStyledSystemMarginProps(rest)}
       {...tagComponent("fieldset", rest)}
     >
       {legend && (
-        <StyledLegend data-element="legend" isRequired={required}>
+        <StyledLegend
+          $isRequired={required}
+          data-element="legend"
+          data-role="legend"
+          $size={size}
+        >
           {legend}
         </StyledLegend>
       )}
-      {children}
-    </FieldsetStyle>
+      {legendHint && (
+        <HintText id={legendHintId} size={size}>
+          {legendHint}
+        </HintText>
+      )}
+      <StyledFieldsetContentWrapper
+        $size={size}
+        $hasLegend={!!(legend || legendHint)}
+      >
+        {validationMessagePositionTop && validationMessage()}
+        <StyledFieldsetContent
+          data-role="fieldset-content"
+          className="fieldset-content"
+          $orientation={orientation}
+          $size={size}
+          $labelWeight={labelWeight}
+        >
+          <FieldsetContext.Provider
+            value={{ size, hasError: !!error, required }}
+          >
+            {children}
+          </FieldsetContext.Provider>
+        </StyledFieldsetContent>
+        {!validationMessagePositionTop && validationMessage()}
+      </StyledFieldsetContentWrapper>
+    </StyledFieldset>
   );
 };
-
-Fieldset.displayName = "Fieldset";
 
 export default Fieldset;

--- a/src/components/fieldset/fieldset.mdx
+++ b/src/components/fieldset/fieldset.mdx
@@ -6,6 +6,15 @@ import * as FieldsetStories from "./fieldset.stories";
 
 # Fieldset
 
+<a
+  target="_blank"
+  href="https://zeroheight.com/35ee2cc26/v/latest/p/93a882-fieldset"
+  style={{ color: "#007E45", fontWeight: "bold", textDecoration: "underline" }}
+  rel="noreferrer"
+>
+  Product Design System component
+</a>
+
 This component can be used within a [Form](../?path=/docs/form--docs) component to group related fields together. 
 It will render a `<fieldset>` element with a `<legend>` element to provide a title for the group of fields.
 
@@ -23,24 +32,49 @@ import Fieldset from "carbon-react/lib/components/fieldset";
 
 ## Examples
 
-**Note:** The following examples use the `Fieldset` component wrapped within a `Form` as this is its intended use case, as well as the `validationRedesignOptIn` 
-feature flag on an ancestor [CarbonProvider](../?path=/docs/carbon-provider--docs) set to *true*.
-
 ### Default
+
+To use the `Fieldset` component, pass any valid Carbon input as a child.
 
 <Canvas of={FieldsetStories.Default} />
 
-### With `fieldSpacing`
+### With Legend Hint
 
-You can use the `fieldSpacing` prop on Form to adjust the spacing between inputs within the `Fieldset`. See the [Form - With Field Spacing](../?path=/docs/form--docs#field-spacing) example.
+To add a hint below the legend, pass the `legendHint` prop.
 
-<Canvas of={FieldsetStories.InFormFieldSpacing} />
+<Canvas of={FieldsetStories.WithLegendHint} />
+
+### Horizontal Orientation
+
+By default, the inputs will be rendered with a `"vertical"` orientation. 
+You can set the `orientation` prop to `"horizontal"` to render the inputs horizontally.
+
+<Canvas of={FieldsetStories.HorizontalOrientation} />
+
+### Sizes
+
+By default, the size of the component is set to `"medium"`, this can be changed by using the `size` prop.
+Note that setting the size of the `Fieldset` will also change the size of the inputs.
+
+<Canvas of={FieldsetStories.Sizes} />
+<Canvas of={FieldsetStories.HorizontalSizes} />
+
+### Label Font Weight
+
+The label of inputs within the `Fieldset` will be rendered with a `"regular"` font weight. 
+You can set the `labelWeight` prop to `"bold"` to render the input's labels with a bold font weight instead.
+
+<Canvas of={FieldsetStories.LabelFontWeight} />
 
 ### Required
 
-The `required` prop will add an asterisk to the legend and set all fields within the Fieldset to be required.
+Set the `required` prop to make all of the inputs within `Fieldset` required.
 
 <Canvas of={FieldsetStories.Required} />
+
+## Validation States
+
+This component supports input validation, see our [Validations](../?path=/docs/documentation-validations--docs) documentation page for more information.
 
 ## Props
 

--- a/src/components/fieldset/fieldset.pw.tsx
+++ b/src/components/fieldset/fieldset.pw.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 import { test } from "../../../playwright/helpers/base-test";
-import Fieldset from ".";
-import Form, { FormProps } from "../form";
 import FieldsetComponent from "./components.test-pw";
-import Textbox from "../textbox";
 import { checkAccessibility } from "../../../playwright/support/helper";
-import { VALIDATION, CHARACTERS } from "../../../playwright/support/constants";
+import { CHARACTERS } from "../../../playwright/support/constants";
 
 const specialCharacters = [
   CHARACTERS.STANDARD,
@@ -24,7 +21,7 @@ test.describe("Accessibility tests for Fieldset component", () => {
   });
 
   specialCharacters.forEach((chars) => {
-    test(`should pass accessibility tests when preview text is ${chars}`, async ({
+    test(`should pass accessibility tests when legend text is ${chars}`, async ({
       mount,
       page,
     }) => {
@@ -34,110 +31,32 @@ test.describe("Accessibility tests for Fieldset component", () => {
     });
   });
 
-  [
-    [VALIDATION.ERROR, "error", true],
-    [VALIDATION.WARNING, "warning", true],
-    [VALIDATION.INFO, "info", true],
-    ["rgb(102, 132, 148)", "error", false],
-    ["rgb(102, 132, 148)", "warning", false],
-    ["rgb(102, 132, 148)", "info", false],
-  ].forEach((borderColor, type, bool) => {
-    test(`should pass accessibility tests with input border color ${borderColor} when validation is ${type} and boolean prop is ${bool}`, async ({
+  specialCharacters.forEach((chars) => {
+    test(`should pass accessibility tests when legend hint text is ${chars}`, async ({
       mount,
       page,
     }) => {
-      await mount(
-        <Fieldset legend={`Fieldset ${type} as boolean`}>
-          <Textbox
-            label="Address"
-            labelInline
-            labelAlign="right"
-            {...{ [type]: bool }}
-            value=""
-            onChange={() => {}}
-          />
-        </Fieldset>,
-      );
+      await mount(<FieldsetComponent legendHint={chars} />);
 
       await checkAccessibility(page);
     });
   });
 
-  ([0, 4, 7] as FormProps["fieldSpacing"][]).forEach((spacing) => {
-    test(`should pass accessibility tests inside a Form when field spacing is ${spacing}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <Form fieldSpacing={spacing} data-element="form">
-          <Fieldset>
-            <Textbox
-              label="Fieldset 1 Field 1"
-              labelInline
-              value=""
-              onChange={() => {}}
-            />
-            <Textbox
-              label="Fieldset 1 Field 2"
-              labelInline
-              value=""
-              onChange={() => {}}
-            />
-          </Fieldset>
-          <Textbox
-            label="Separate Field"
-            labelInline
-            value=""
-            onChange={() => {}}
-          />
-        </Form>,
-      );
-      await checkAccessibility(page);
-    });
+  test(`should pass accessibility tests with error validation`, async ({
+    mount,
+    page,
+  }) => {
+    await mount(<FieldsetComponent error="error message" />);
+
+    await checkAccessibility(page);
   });
 
-  ["error", "warning", "info"].forEach((type) => {
-    test(`should pass accessibility tests with ${type} validation icon on input`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <Fieldset legend={`Fieldset ${type} on component`}>
-          <Textbox
-            label="Address"
-            labelInline
-            labelAlign="right"
-            {...{ [type]: "Message" }}
-            value=""
-            onChange={() => {}}
-          />
-        </Fieldset>,
-      );
+  test(`should pass accessibility tests with warning validation`, async ({
+    mount,
+    page,
+  }) => {
+    await mount(<FieldsetComponent warning="warning message" />);
 
-      await checkAccessibility(page);
-    });
-  });
-
-  ["error", "warning", "info"].forEach((type) => {
-    test(`should pass accessibility tests with ${type} validation icon on label`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <Fieldset legend={`Fieldset ${type} on label`}>
-          <Textbox
-            label="Address"
-            labelInline
-            labelAlign="right"
-            validationOnLabel
-            {...{ [type]: "Message" }}
-            value=""
-            onChange={() => {}}
-          />
-        </Fieldset>,
-      );
-
-      await checkAccessibility(page);
-    });
+    await checkAccessibility(page);
   });
 });

--- a/src/components/fieldset/fieldset.stories.tsx
+++ b/src/components/fieldset/fieldset.stories.tsx
@@ -2,10 +2,7 @@ import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 
 import Fieldset from ".";
-import { Select, Option } from "../select";
 import Textbox from "../textbox";
-import Form from "../form";
-import CarbonProvider from "../carbon-provider";
 
 import generateStyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
@@ -18,86 +15,97 @@ const meta: Meta<typeof Fieldset> = {
   component: Fieldset,
   argTypes: {
     ...styledSystemProps,
+    legendHint: { control: "text" },
   },
   parameters: {
+    chromatic: { disableSnapshot: true },
     themeProvider: { chromatic: { theme: "sage" } },
+    controls: {
+      exclude: ["children"],
+    },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Fieldset>;
 
-export const Default: Story = () => (
-  <CarbonProvider validationRedesignOptIn>
-    <Form>
-      <Fieldset legend="Fieldset">
-        <Textbox label="Address Line 1" value={""} onChange={() => {}} />
-        <Textbox label="Address Line 2" value={""} onChange={() => {}} />
-        <Textbox label="City" value={""} onChange={() => {}} />
-        <Select label="Country" value={""} onChange={() => {}}>
-          <Option text="United Kingdom" value="uk" />
-          <Option text="Spain" value="sp" />
-          <Option text="France" value="fr" />
-          <Option text="Germany" value="ge" />
-        </Select>
-        <Textbox
-          label="Postcode"
-          maxWidth="100px"
-          value={""}
-          onChange={() => {}}
-        />
-      </Fieldset>
-    </Form>
-  </CarbonProvider>
-);
-Default.storyName = "Default";
+export const Default: Story = {
+  render: (args) => (
+    <Fieldset {...args}>
+      <Textbox label="Input 1" value="Input Text" onChange={() => {}} />
+      <Textbox label="Input 2" value="Input Text" onChange={() => {}} />
+      <Textbox label="Input 3" value="Input Text" onChange={() => {}} />
+    </Fieldset>
+  ),
+  args: {
+    legend: "Fieldset Legend",
+  },
+};
 
-export const InFormFieldSpacing: Story = () => (
-  <CarbonProvider validationRedesignOptIn>
-    <Form fieldSpacing={1}>
-      <Fieldset legend="Fieldset">
-        <Textbox label="Address Line 1" value={""} onChange={() => {}} />
-        <Textbox label="Address Line 2" value={""} onChange={() => {}} />
-        <Textbox label="City" value={""} onChange={() => {}} />
-        <Select label="Country" value={""} onChange={() => {}}>
-          <Option text="United Kingdom" value="uk" />
-          <Option text="Spain" value="sp" />
-          <Option text="France" value="fr" />
-          <Option text="Germany" value="ge" />
-        </Select>
-        <Textbox
-          label="Postcode"
-          maxWidth="100px"
-          value={""}
-          onChange={() => {}}
-        />
-      </Fieldset>
-    </Form>
-  </CarbonProvider>
-);
-InFormFieldSpacing.storyName = "With fieldSpacing";
+export const WithLegendHint: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    legendHint: "Fieldset LegendHint",
+  },
+};
 
-export const Required: Story = () => (
-  <CarbonProvider validationRedesignOptIn>
-    <Form>
-      <Fieldset legend="Fieldset" required>
-        <Textbox label="Address Line 1" value={""} onChange={() => {}} />
-        <Textbox label="Address Line 2" value={""} onChange={() => {}} />
-        <Textbox label="City" value={""} onChange={() => {}} />
-        <Select label="Country" value={""} onChange={() => {}}>
-          <Option text="United Kingdom" value="uk" />
-          <Option text="Spain" value="sp" />
-          <Option text="France" value="fr" />
-          <Option text="Germany" value="ge" />
-        </Select>
-        <Textbox
-          label="Postcode"
-          maxWidth="100px"
-          value={""}
-          onChange={() => {}}
-        />
+export const HorizontalOrientation: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    orientation: "horizontal",
+  },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <>
+      <Fieldset legend="Small Fieldset" size="small" {...args}>
+        <Textbox label="Input 1" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 2" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 3" value="Input Text" onChange={() => {}} />
       </Fieldset>
-    </Form>
-  </CarbonProvider>
-);
-Required.storyName = "Required";
+      <Fieldset legend="Medium Fieldset" size="medium" {...args}>
+        <Textbox label="Input 1" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 2" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 3" value="Input Text" onChange={() => {}} />
+      </Fieldset>
+      <Fieldset legend="Large Fieldset" size="large" {...args}>
+        <Textbox label="Input 1" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 2" value="Input Text" onChange={() => {}} />
+        <Textbox label="Input 3" value="Input Text" onChange={() => {}} />
+      </Fieldset>
+    </>
+  ),
+  args: {
+    mb: 4,
+  },
+};
+
+export const HorizontalSizes: Story = {
+  ...Sizes,
+  args: {
+    ...Sizes.args,
+    orientation: "horizontal",
+  },
+};
+
+export const LabelFontWeight: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    labelWeight: "bold",
+  },
+  parameters: {
+    chromatic: { disableSnapshot: false },
+  },
+};
+
+export const Required: Story = {
+  ...Default,
+  args: {
+    ...Default.args,
+    required: true,
+  },
+};

--- a/src/components/fieldset/fieldset.style.ts
+++ b/src/components/fieldset/fieldset.style.ts
@@ -1,70 +1,111 @@
 import styled, { css } from "styled-components";
 import { margin } from "styled-system";
-
-import FormFieldStyle from "../../__internal__/form-field/form-field.style";
 import applyBaseTheme from "../../style/themes/apply-base-theme";
-import CheckboxStyle from "../checkbox/checkbox.style";
 
-export interface StyledFieldsetProps {
-  newValidation?: boolean;
-}
+const sizeMap = {
+  small: {
+    contentMargin: "var(--global-space-comp-xs)", // space between label set and content
+    validationGap: "var(--global-space-comp-xs)", // gap between validation and children
+    childrenGap: "var(--global-space-comp-m)",
+    legendFont: "var(--global-font-static-comp-medium-s)",
+    regularLabelFont: "var(--global-font-static-comp-regular-s)",
+    boldLabelFont: "var(--global-font-static-comp-medium-s)",
+  },
+  medium: {
+    contentMargin: "var(--global-space-comp-s)",
+    validationGap: "var(--global-space-comp-s)",
+    childrenGap: "var(--global-space-comp-l)",
+    legendFont: "var(--global-font-static-comp-medium-m)",
+    regularLabelFont: "var(--global-font-static-comp-regular-m)",
+    boldLabelFont: "var(--global-font-static-comp-medium-m)",
+  },
+  large: {
+    contentMargin: "var(--global-space-comp-m)",
+    validationGap: "var(--global-space-comp-s)",
+    childrenGap: "var(--global-space-comp-xl)",
+    legendFont: "var(--global-font-static-comp-medium-l)",
+    regularLabelFont: "var(--global-font-static-comp-regular-l)",
+    boldLabelFont: "var(--global-font-static-comp-medium-l)",
+  },
+};
 
-const FieldsetStyle = styled.fieldset.attrs(
-  applyBaseTheme,
-)<StyledFieldsetProps>`
+export type StyledFieldsetProps = {
+  $size: "small" | "medium" | "large";
+  $isRequired?: boolean;
+  $orientation?: "horizontal" | "vertical";
+  $labelWeight?: "regular" | "bold";
+  $hasLegend?: boolean;
+};
+
+export const StyledFieldset = styled.fieldset.attrs(applyBaseTheme)`
+  border: none;
+  padding: 0;
+  min-width: 0;
+  min-inline-size: 0;
   margin: 0;
   margin-bottom: var(--fieldSpacing);
   ${margin}
-  border: none;
-  padding: 0;
 
-  ${({ newValidation }) =>
-    !newValidation &&
-    css`
-      & * {
-        --fieldSpacing: 0;
-      }
-
-      &&&& ${FormFieldStyle} {
-        margin-top: 0;
-        margin-bottom: -1px;
-      }
-
-      & ${CheckboxStyle} {
-        padding-top: 8px;
-        padding-bottom: 8px;
-      }
-    `}
+  & * {
+    --fieldSpacing: 0;
+  }
 `;
 
-export interface StyledLegendProps {
-  /** Flag to configure fields as mandatory. */
-  isRequired?: boolean;
-}
+export const StyledLegend = styled.legend<StyledFieldsetProps>`
+  ${({ $isRequired, $size }) => css`
+    display: flex;
+    align-items: center;
+    padding: 0;
+    font: ${sizeMap[$size].legendFont};
+    color: var(--input-labelset-label-default);
 
-const StyledLegend = styled.legend<StyledLegendProps>`
-  display: flex;
-  align-items: center;
-  margin-bottom: var(--spacing250);
-  font-size: var(--fontSizes400);
-  font-weight: var(--fontWeights500);
-  color: var(--colorsUtilityYin090);
-  line-height: 24px;
-
-  ${({ isRequired }) =>
-    isRequired &&
+    ${$isRequired &&
     css`
       ::after {
         content: "*";
-        line-height: 24px;
-        color: var(--colorsSemanticNegative500);
-        font-weight: var(--fontWeights500);
-        margin-left: var(--spacing100);
-        position: relative;
-        top: 1px;
-        left: -4px;
+        color: var(--input-labelset-label-required);
+        font: ${sizeMap[$size].legendFont};
+        margin-left: var(--global-space-comp-xs);
       }
     `}
+  `};
 `;
 
-export { FieldsetStyle, StyledLegend };
+export const StyledFieldsetContentWrapper = styled.div<StyledFieldsetProps>`
+  ${({ $size, $hasLegend }) => css`
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    gap: ${sizeMap[$size].validationGap};
+
+    ${$hasLegend &&
+    css`
+      margin-top: ${sizeMap[$size].contentMargin};
+    `}
+  `};
+`;
+
+export const StyledFieldsetContent = styled.div<StyledFieldsetProps>`
+  ${({ $orientation, $size, $labelWeight }) => css`
+    display: flex;
+    flex-direction: column;
+    gap: ${sizeMap[$size].childrenGap};
+
+    ${$orientation === "horizontal" &&
+    css`
+      flex-direction: row;
+      flex-wrap: wrap;
+    `}
+
+    label {
+      font: ${sizeMap[$size].regularLabelFont};
+    }
+
+    ${$labelWeight === "bold" &&
+    css`
+      label {
+        font: ${sizeMap[$size].boldLabelFont};
+      }
+    `}
+  `};
+`;

--- a/src/components/fieldset/fieldset.test.tsx
+++ b/src/components/fieldset/fieldset.test.tsx
@@ -1,47 +1,126 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import Fieldset from "./fieldset.component";
+import Fieldset from ".";
 import Textbox from "../textbox";
+import Decimal from "../decimal";
+import Password from "../password";
+import DateInput from "../date";
+import Textarea from "../textarea";
+import TextEditor from "../text-editor";
+import { Select, MultiSelect, FilterableSelect, Option } from "../select";
+import { Checkbox } from "../checkbox";
 
-test("Fieldset Legend is rendered if supplied", () => {
+test("should render with provided `legend`", () => {
   render(<Fieldset legend="Legend" />);
+
   expect(screen.getByText("Legend")).toBeVisible();
 });
 
-test("Fieldset Legend is not rendered if omitted", () => {
-  render(<Fieldset />);
-  expect(screen.queryByText("Legend")).not.toBeInTheDocument();
+test("should render with provided `legendHint`", () => {
+  render(<Fieldset legendHint="Hint Text" />);
+
+  expect(screen.getByText("Hint Text")).toBeVisible();
+  expect(screen.getByRole("group")).toHaveAccessibleDescription("Hint Text");
 });
 
-test("Fieldset adds the required attribute to any child inputs when isRequired is true", () => {
-  render(
-    <Fieldset required>
-      <input title="Test" placeholder="Placeholder" />
-      <input title="Test" placeholder="Placeholder" />
-    </Fieldset>,
+test("should render with provided `error`", () => {
+  render(<Fieldset legend="Legend" error="Error message" />);
+
+  expect(screen.getByText("Error message")).toBeVisible();
+  expect(screen.getByRole("group")).toHaveAccessibleDescription(
+    "Error message",
   );
-  const inputs = screen.getAllByRole("textbox");
-  inputs.forEach((input) => expect(input).toBeRequired());
 });
 
-test("Fieldset does not add the required attribute to any child inputs when isRequired is falsy", () => {
-  render(
-    <Fieldset>
-      <input title="Test" placeholder="Placeholder" />
-      <input title="Test" placeholder="Placeholder" />
-    </Fieldset>,
+test("should render with provided `warning`", () => {
+  render(<Fieldset legend="Legend" warning="Warning message" />);
+
+  expect(screen.getByText("Warning message")).toBeVisible();
+  expect(screen.getByRole("group")).toHaveAccessibleDescription(
+    "Warning message",
   );
-  const inputs = screen.getAllByRole("textbox");
-  inputs.forEach((input) => expect(input).not.toBeRequired());
 });
 
-test("Fieldset Legend adds an asterisk after the text when the field is mandatory", () => {
+test("should set Carbon child inputs as required when `required` is set", () => {
   render(
-    <Fieldset legend="This is my custom legend" required>
-      <Textbox onChange={() => {}} value="" />
+    <Fieldset legend="Legend" required>
+      <Textbox label="Textbox" value="Input Text" onChange={() => {}} />
+      <Decimal label="Decimal" value="0.00" onChange={() => {}} />
+      <Password label="Password" value="Password" onChange={() => {}} />
+      <DateInput label="DateInput" value="10/10/2010" onChange={() => {}} />
+      <Checkbox label="Checkbox" checked onChange={() => {}} />
+      <Textarea label="Textarea" value="textarea" onChange={() => {}} />
+      <TextEditor labelText="TextEditor" onChange={() => {}} />
+      <Select label="Simple Select" value="1" onChange={() => {}}>
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+      </Select>
+      <MultiSelect label="Multi Select" value={["1"]} onChange={() => {}}>
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+      </MultiSelect>
+      <FilterableSelect label="Filterable Select" value="1" onChange={() => {}}>
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+      </FilterableSelect>
     </Fieldset>,
   );
 
-  const legend = screen.getByText("This is my custom legend");
-  expect(legend).toBeInTheDocument();
+  expect(screen.getByRole("textbox", { name: "Textbox" })).toBeRequired();
+  expect(screen.getByRole("textbox", { name: "Decimal" })).toBeRequired();
+  expect(screen.getByLabelText("Password")).toBeRequired();
+  expect(screen.getByRole("textbox", { name: "DateInput" })).toBeRequired();
+  expect(screen.getByRole("checkbox", { name: "Checkbox" })).toBeRequired();
+  expect(screen.getByRole("textbox", { name: "Textarea" })).toBeRequired();
+  expect(screen.getByRole("textbox", { name: "TextEditor" })).toBeRequired();
+  expect(
+    screen.getByRole("combobox", { name: "Simple Select" }),
+  ).toBeRequired();
+  expect(
+    screen.getByRole("combobox", { name: "Multi Select Amber" }),
+  ).toBeRequired();
+  expect(
+    screen.getByRole("combobox", { name: "Filterable Select" }),
+  ).toBeRequired();
+});
+
+// coverage - style overrides cannot be tested in jest
+test("should render child input label with bold font when `labelWeight` is set to 'bold'", () => {
+  render(
+    <Fieldset legend="Legend" labelWeight="bold">
+      <Textbox label="Label" value="Input Text" onChange={() => {}} />
+    </Fieldset>,
+  );
+
+  expect(screen.getByText("Label")).toHaveStyleRule(
+    "font",
+    "var(--global-font-static-comp-medium-m)",
+  );
+});
+
+// coverage
+test("should render with expected styles when `orientation` is 'horizontal'", () => {
+  render(
+    <Fieldset legend="Legend" orientation="horizontal">
+      <Textbox label="Label" value="Input Text" onChange={() => {}} />
+    </Fieldset>,
+  );
+
+  expect(screen.getByTestId("fieldset-content")).toHaveStyle({ flex: "row" });
+});
+
+// coverage
+test("should render with `validationMessagePositionTop` set to false", () => {
+  render(
+    <Fieldset
+      legend="Legend"
+      error="Error message"
+      validationMessagePositionTop={false}
+    />,
+  );
+
+  expect(screen.getByText("Error message")).toBeVisible();
 });

--- a/src/components/text-editor/text-editor.component.tsx
+++ b/src/components/text-editor/text-editor.component.tsx
@@ -21,6 +21,7 @@ import React, {
   useState,
   forwardRef,
   useEffect,
+  useContext,
 } from "react";
 
 import Label from "../../__internal__/legacy-label";
@@ -67,6 +68,7 @@ import {
   ToolbarPlugin,
 } from "./__internal__/__ui__";
 import StyledSpanEnterPlugin from "./__internal__/__plugins__/StyledSpanEnter/styled-span-enter.plugin";
+import FieldsetContext from "../fieldset/__internal__/fieldset.context";
 
 let deprecateValueTriggered = false;
 let deprecateOnCancelWarnTriggered = false;
@@ -133,6 +135,14 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
     const contentEditorRef = useRef<HTMLDivElement>(null);
     const [parentRef, setParentRef] = useState<HTMLDivElement | null>(null);
     const [isFocused, setIsFocused] = useState<boolean>(false);
+
+    const {
+      size: fieldsetSize,
+      hasError: fieldsetError,
+      required: fieldsetRequired,
+    } = useContext(FieldsetContext);
+    const actualSize = fieldsetSize || size;
+    const hasError = !!error || fieldsetError;
 
     useImperativeHandle<TextEditorHandle, TextEditorHandle>(
       ref,
@@ -238,7 +248,7 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
     const warningMessage = warning || characterLimitWarning;
 
     const getMarginsForSize = () => {
-      switch (size) {
+      switch (actualSize) {
         case "large":
           return "var(--spacing150)";
         case "small":
@@ -270,6 +280,7 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
             onClick={() => contentEditorRef.current?.focus()}
             isRequired={required}
             labelId={`${namespace}-label`}
+            isLarge={actualSize === "large"}
           >
             {labelText}
           </Label>
@@ -277,6 +288,7 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
           {inputHint && !readOnly && (
             <HintText
               id={`${namespace}-input-hint`}
+              isLarge={actualSize === "large"}
               marginBottom={getMarginsForSize()}
             >
               {inputHint}
@@ -320,20 +332,20 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
                       contentEditorRef.current?.innerHTML ||
                       initialValue.current
                     }
-                    size={size}
+                    size={actualSize}
                   />
                 ) : (
                   <>
                     <ToolbarPlugin
                       contentEditorRef={contentEditorRef}
                       hasHeader={Boolean(header)}
-                      size={size}
+                      size={actualSize}
                       {...toolbarProps}
                     />
 
                     <StyledTextEditor
                       data-role={`${namespace}-editor`}
-                      error={!!error}
+                      error={hasError}
                     >
                       <RichTextPlugin
                         contentEditable={
@@ -346,13 +358,13 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
                             previews={previews}
                             rows={rows}
                             readOnly={readOnly}
-                            required={required}
-                            error={!!error}
+                            required={required || fieldsetRequired}
+                            error={hasError}
                             warning={!!warning || !!characterLimitWarning}
                             validationMessagePositionTop={
                               validationMessagePositionTop
                             }
-                            size={size}
+                            size={actualSize}
                           />
                         }
                         placeholder={
@@ -387,7 +399,7 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(
                 {footer && (
                   <StyledFooterWrapper
                     data-role={`${namespace}-footer-wrapper`}
-                    size={size}
+                    size={actualSize}
                   >
                     {footer}
                   </StyledFooterWrapper>

--- a/src/components/textarea/textarea.component.tsx
+++ b/src/components/textarea/textarea.component.tsx
@@ -32,6 +32,7 @@ import Logger from "../../__internal__/utils/logger";
 import { BorderRadiusType } from "../box/box.component";
 import HintText from "../../__internal__/legacy-hint-text";
 import { filterStyledSystemMarginProps } from "../../style/utils";
+import FieldsetContext from "../fieldset/__internal__/fieldset.context";
 
 export interface TextareaProps
   extends ValidationProps,
@@ -200,6 +201,10 @@ export const Textarea = React.forwardRef(
     }
     const { validationRedesignOptIn } = useContext(NewValidationContext);
 
+    // should also consume size from context when this size added to textarea
+    const { hasError: fieldsetError, required: fieldsetRequired } =
+      useContext(FieldsetContext);
+
     const labelInlineWithNewValidation = validationRedesignOptIn
       ? false
       : labelInline;
@@ -363,14 +368,14 @@ export const Textarea = React.forwardRef(
           typeof inputWidth === "number" ? inputWidth : 100 - labelWidth
         }
         maxWidth={maxWidth}
-        error={error}
+        error={error || fieldsetError}
         warning={warning}
         info={info}
         borderRadius={borderRadius}
         hideBorders={hideBorders}
       >
         <Input
-          aria-invalid={!!error}
+          aria-invalid={!!error || fieldsetError}
           aria-labelledby={ariaLabelledBy}
           aria-describedby={combinedAriaDescribedBy}
           autoFocus={autoFocus}
@@ -388,7 +393,7 @@ export const Textarea = React.forwardRef(
           as="textarea"
           validationIconId={validationRedesignOptIn ? undefined : validationId}
           inputBorderRadius={borderRadius}
-          required={required}
+          required={required || fieldsetRequired}
           {...rest}
         />
         {children}

--- a/src/components/textbox/__internal__/__next__/text-input.component.tsx
+++ b/src/components/textbox/__internal__/__next__/text-input.component.tsx
@@ -24,6 +24,7 @@ import Label from "../../../../__internal__/label";
 import useRegisterValidationToTabs from "../../../../hooks/__internal__/useRegisterValidationToTabs/useRegisterValidationToTabs";
 import combineRefs from "../../../../__internal__/utils/helpers/combine-refs";
 import FieldsetValidationContext from "../../../../__internal__/fieldset-validation-context";
+import FieldsetContext from "../../../fieldset/__internal__/fieldset.context";
 
 export interface TextInputProps
   extends Omit<ValidationProps, "info">,
@@ -172,6 +173,14 @@ export const TextInput = React.forwardRef(
     const inputHintId = inputHint ? hintId.current : undefined;
     const inputPrefixId = prefix ? `${uniqueId}-prefix` : undefined;
 
+    const {
+      size: fieldsetSize,
+      hasError: fieldsetError,
+      required: fieldsetRequired,
+    } = useContext(FieldsetContext);
+    const actualSize = fieldsetSize || size;
+    const hasError = !!error || !!fieldsetError;
+
     const resolvedInputWidth =
       inputWidth ?? (labelInline ? INLINE_INPUT_WIDTH : INPUT_WIDTH);
     const ariaDescribedByString = [
@@ -189,7 +198,7 @@ export const TextInput = React.forwardRef(
     const validationMessage = hasValidationFailure && !disableErrorBorder && (
       <ValidationMessage
         id={validationId}
-        size={size}
+        size={actualSize}
         error={error}
         warning={warning}
       />
@@ -220,7 +229,7 @@ export const TextInput = React.forwardRef(
         data-element={dataElement}
         data-role={dataRole}
         data-component={dataComponent}
-        $size={size}
+        $size={actualSize}
         $labelInline={labelInline}
         $hasValidationFailure={labelInline && hasValidationFailure}
         {...filterStyledSystemMarginProps(rest)}
@@ -229,7 +238,7 @@ export const TextInput = React.forwardRef(
           <LabelWrapper
             data-role="label-wrapper"
             $labelInline={labelInline}
-            $size={size}
+            $size={actualSize}
             $labelWrapperWidth={
               labelInline && typeof resolvedInputWidth === "number"
                 ? 100 - resolvedInputWidth
@@ -239,14 +248,14 @@ export const TextInput = React.forwardRef(
             <Label
               id={labelId}
               htmlFor={uniqueId}
-              size={size}
+              size={actualSize}
               isRequired={required}
               {...stateProps}
             >
               {label}
             </Label>
             {inputHint && (
-              <HintText id={inputHintId} size={size} {...stateProps}>
+              <HintText id={inputHintId} size={actualSize} {...stateProps}>
                 {inputHint}
               </HintText>
             )}
@@ -254,7 +263,7 @@ export const TextInput = React.forwardRef(
         )}
         <InputWrapper
           data-role="input-wrapper"
-          $size={size}
+          $size={actualSize}
           $maxWidth={maxWidth}
           $inputWidth={inputWidth}
           onClick={() => {
@@ -272,20 +281,20 @@ export const TextInput = React.forwardRef(
           <Input
             id={uniqueId}
             name={uniqueName}
-            aria-invalid={!!error}
+            aria-invalid={hasError}
             aria-describedby={ariaDescribedByString}
             aria-labelledby={ariaLabelledBy}
             value={value}
             placeholder={!(disabled || readOnly) ? placeholder : undefined}
-            required={required}
+            required={required || fieldsetRequired}
             ref={combinedRef}
             autoFocus={autoFocus}
             onMouseDown={handleMouseDown}
             onClick={handleClick}
             onChange={onChange}
-            error={!!error}
+            error={hasError}
             inputIcon={inputIcon}
-            size={size}
+            size={actualSize}
             prefix={prefix}
             prefixId={inputPrefixId}
             leftChildren={leftChildren}

--- a/src/components/textbox/__internal__/__next__/text-input.style.ts
+++ b/src/components/textbox/__internal__/__next__/text-input.style.ts
@@ -55,6 +55,10 @@ const StyledTextInput = styled.div.attrs(applyBaseTheme)<StyledTextInputProps>`
     }
   }};
 
+  .fieldset-content & {
+    gap: var(--global-space-comp-xs);
+  }
+
   .time & {
     gap: unset;
   }

--- a/src/components/tile-select/tile-select.style.ts
+++ b/src/components/tile-select/tile-select.style.ts
@@ -2,7 +2,10 @@ import styled, { css } from "styled-components";
 import { margin } from "styled-system";
 import Fieldset from "../fieldset";
 import { Input } from "../../__internal__/legacy-input";
-import { StyledLegend } from "../fieldset/fieldset.style";
+import {
+  StyledLegend,
+  StyledFieldsetContent,
+} from "../fieldset/fieldset.style";
 import StyledIcon from "../icon/icon.style";
 import applyBaseTheme from "../../style/themes/apply-base-theme";
 import addFocusStyling from "../../style/utils/add-focus-styling";
@@ -185,11 +188,13 @@ const StyledTileSelectFieldset = styled(Fieldset).attrs(applyBaseTheme)<{
   ${margin}
 
   ${StyledLegend} {
-    margin-bottom: 16px;
     font-size: 16px;
-    line-height: 16px;
-    margin-left: -2px;
   }
+
+  ${StyledFieldsetContent} {
+    gap: 0px;
+  }
+
   ${({ multiSelect }) =>
     multiSelect &&
     css`


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Aligns `Fieldset` to Fusion DS and applies fusion-tokens.
- Adds `size` prop to support `"small"`, `"medium"` and `"large"` sizes.
- Adds `legendHint` prop to support hint text: 
<img width="302" height="158" alt="image" src="https://github.com/user-attachments/assets/afdf427c-170f-4225-b0b6-01b377417f5d" />

- Adds `orientation` prop to support `"horizontal"` and `"vertical"` layouts:
<img width="586" height="136" alt="image" src="https://github.com/user-attachments/assets/b0a64a35-7ba1-4935-ab4b-4910fec909ec" />
<img width="374" height="326" alt="image" src="https://github.com/user-attachments/assets/04b24f71-ee32-443b-83a5-0628cf2839fc" />


- Adds `error` and `warning` props to support validation:
<img width="354" height="173" alt="image" src="https://github.com/user-attachments/assets/12894b35-3ef5-4d5c-810b-482b904781f7" />
<img width="294" height="171" alt="image" src="https://github.com/user-attachments/assets/d9a56b2c-45f5-4a51-b27e-605072ba7e69" />

- Adds `labelWeight` prop to support `"regular"` and `"bold"` child input labels for all Carbon inputs:
<img width="209" height="128" alt="image" src="https://github.com/user-attachments/assets/bc655a4b-e6bc-45f1-b337-04092269e0a6" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

`Fieldset` is not aligned to Fusion DS.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
