### PR TITLE
feat(decimal): align component with fusion DS - FE-7146

### DIFF
--- a/skills/carbon-react/components/decimal.md
+++ b/skills/carbon-react/components/decimal.md
@@ -259,6 +259,10 @@ description: Carbon Decimal component props and usage examples.
 | part | string \| undefined | No |  |  |  |  |  |
 | pattern | string \| undefined | No |  |  |  |  |  |
 | placeholder | string \| undefined | No |  |  |  | Placeholder string to be displayed in input |  |
+| popoverContainerAriaLabel | string \| undefined | No |  |  |  | Sets the accessible name (aria-label) on the PopoverContainer dialog |  |
+| popoverContainerContent | React.ReactNode | No |  |  |  | Content to render inside a PopoverContainer, displayed via a button at the right of the input |  |
+| popoverPosition | ("left" \| "right" \| "center") \| undefined | No |  |  |  | Sets the position of the PopoverContainer dialog relative to its trigger button |  |
+| popoverTriggerAriaLabel | string \| undefined | No |  |  |  | Sets the aria-label on the popover trigger button |  |
 | precision | 0 \| 1 \| 2 \| 3 \| 4 \| 5 \| 6 \| 7 \| 8 \| 9 \| 10 \| 11 \| 12 \| 13 \| 14 \| 15 \| undefined | No |  |  |  | The decimal precision of the value in the input |  |
 | prefix | string \| undefined | No |  |  |  | Emphasized part of the displayed text |  |
 | property | string \| undefined | No |  |  |  |  |  |
@@ -277,6 +281,7 @@ description: Carbon Decimal component props and usage examples.
 | src | string \| undefined | No |  |  |  |  |  |
 | step | string \| number \| undefined | No |  |  |  |  |  |
 | style | CSSProperties \| undefined | No |  |  |  |  |  |
+| suffix | string \| undefined | No |  |  |  | A suffix to display alongside the input. Please note that if a prefix is also provided, only the prefix will be rendered. |  |
 | suppressContentEditableWarning | boolean \| undefined | No |  |  |  |  |  |
 | suppressHydrationWarning | boolean \| undefined | No |  |  |  |  |  |
 | tabIndex | number \| undefined | No |  |  |  |  |  |

--- a/src/__internal__/input/input.component.tsx
+++ b/src/__internal__/input/input.component.tsx
@@ -157,8 +157,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             {...rest}
           />
           {inputIcon}
+          {children}
         </div>
-        {children}
       </InputContainer>
     );
   },

--- a/src/__internal__/input/input.test.tsx
+++ b/src/__internal__/input/input.test.tsx
@@ -84,6 +84,24 @@ test("should call `onFocus` callback prop when input gains focus", async () => {
   expect(handleFocus).toHaveBeenCalled();
 });
 
+// Required for coverage of the else-branch of `if (type === "text")` in handleFocus function.
+test("should not call `selectTextOnFocus` when input type is not 'text'", () => {
+  const handleFocus = jest.fn();
+  render(
+    <Input
+      type="password"
+      value="secret"
+      onChange={() => {}}
+      onFocus={handleFocus}
+      data-role="input"
+    />,
+  );
+
+  const input = screen.getByTestId("input");
+  fireEvent.focus(input);
+  expect(handleFocus).toHaveBeenCalled();
+});
+
 test("should render with `required` prop", () => {
   render(<Input required value="" onChange={() => {}} />);
 

--- a/src/components/decimal/__internal__/decimal-popover-button.component.tsx
+++ b/src/components/decimal/__internal__/decimal-popover-button.component.tsx
@@ -1,0 +1,69 @@
+import React, { forwardRef, useImperativeHandle, useRef } from "react";
+
+import { ButtonProps } from "../../button/__next__";
+import { RenderOpenProps } from "../../popover-container";
+import {
+  StyledDecimalPopoverButton,
+  StyledDecimalPopoverButtonWrapper,
+} from "./decimal-popover-button.style";
+
+type DecimalPopoverButtonProps = Pick<
+  RenderOpenProps,
+  | "onClick"
+  | "data-element"
+  | "aria-label"
+  | "aria-expanded"
+  | "aria-haspopup"
+  | "id"
+> & {
+  size?: ButtonProps["size"];
+};
+
+const DecimalPopoverButton = forwardRef<
+  HTMLButtonElement,
+  DecimalPopoverButtonProps
+>(
+  (
+    {
+      onClick,
+      "data-element": dataElement,
+      "aria-label": ariaLabel,
+      "aria-expanded": ariaExpanded,
+      "aria-haspopup": ariaHasPopup,
+      id,
+      size,
+    },
+    ref,
+  ) => {
+    const wrapperRef = useRef<HTMLSpanElement>(null);
+
+    // PopoverContainer compares openButtonRef.current with document.activeElement
+    // and uses indexOf() against the DOM's focusable elements list. It therefore
+    // needs the ref to point at the real <button> element, not a ButtonHandle
+    // object. We resolve it here via querySelector once the span has mounted.
+    useImperativeHandle(
+      ref,
+      () => wrapperRef.current?.querySelector("button") as HTMLButtonElement,
+    );
+
+    return (
+      <StyledDecimalPopoverButtonWrapper ref={wrapperRef}>
+        <StyledDecimalPopoverButton
+          onClick={onClick as React.MouseEventHandler<HTMLElement>}
+          data-element={dataElement}
+          aria-label={ariaLabel}
+          aria-haspopup={ariaHasPopup}
+          aria-expanded={ariaExpanded}
+          id={id}
+          iconType="ellipsis_vertical"
+          variantType="subtle"
+          size={size}
+        />
+      </StyledDecimalPopoverButtonWrapper>
+    );
+  },
+);
+
+DecimalPopoverButton.displayName = "DecimalPopoverButton";
+
+export default DecimalPopoverButton;

--- a/src/components/decimal/__internal__/decimal-popover-button.style.ts
+++ b/src/components/decimal/__internal__/decimal-popover-button.style.ts
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+import Button from "../../button/__next__";
+
+const StyledDecimalPopoverButton = styled(Button)`
+  border-radius: 0 var(--global-radius-action-m) var(--global-radius-action-m) 0;
+  border-left: none;
+`;
+
+const StyledDecimalPopoverButtonWrapper = styled.span`
+  display: contents;
+`;
+
+export { StyledDecimalPopoverButton, StyledDecimalPopoverButtonWrapper };

--- a/src/components/decimal/__internal__/decimal-popover-button.test.tsx
+++ b/src/components/decimal/__internal__/decimal-popover-button.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import DecimalPopoverButton from "./decimal-popover-button.component";
+
+describe("DecimalPopoverButton", () => {
+  it("focuses the underlying button when focus() is called on the ref", () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(
+      <DecimalPopoverButton
+        ref={ref}
+        aria-label="decimal popover trigger"
+        aria-haspopup={"dialog"}
+        aria-expanded={false}
+        onClick={() => {}}
+      />,
+    );
+
+    ref.current?.focus();
+
+    expect(
+      screen.getByRole("button", { name: "decimal popover trigger" }),
+    ).toHaveFocus();
+  });
+});

--- a/src/components/decimal/components.test-pw.tsx
+++ b/src/components/decimal/components.test-pw.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 
 import Decimal, { DecimalProps, CustomEvent } from ".";
 import Box from "../box/box.component";
+import { Select } from "../..";
 
 const DefaultStory = (
   args: Partial<DecimalProps> & { message?: string | boolean },
@@ -57,5 +58,34 @@ export const Validations = () => {
         )),
       )}
     </>
+  );
+};
+
+export const DecimalWithPopoverContainer = () => {
+  const [state, setState] = useState("0.01");
+  const setValue = ({ target }: CustomEvent) => {
+    setState(target.value.rawValue);
+  };
+  return (
+    <Decimal
+      label="Decimal"
+      value={state}
+      onChange={setValue}
+      popoverContainerContent={
+        <Box m="24px">
+          <Select
+            name="simple"
+            id="simple"
+            label="Select a colour"
+            value="1"
+            onChange={() => {}}
+          >
+            <option value="1">Amber</option>
+            <option value="2">Black</option>
+            <option value="3">Blue</option>
+          </Select>
+        </Box>
+      }
+    />
   );
 };

--- a/src/components/decimal/decimal-test.stories.tsx
+++ b/src/components/decimal/decimal-test.stories.tsx
@@ -2,7 +2,9 @@ import React, { useState } from "react";
 import { action } from "storybook/actions";
 import { StoryFn } from "@storybook/react-vite";
 
-import Decimal, { CustomEvent } from "./decimal.component";
+import Decimal, { CustomEvent, DecimalProps } from "./decimal.component";
+import Box from "../box";
+import { Select, Option } from "../select";
 import {
   CommonTextboxArgs,
   commonTextboxArgTypes,
@@ -188,3 +190,102 @@ export const DecimalCustomOnChangeStory = (args: CommonTextboxArgs) => {
 };
 DecimalCustomOnChangeStory.storyName = "Custom onChange";
 DecimalCustomOnChangeStory.args = commonArgs;
+
+export const PopoverContainerWithSizes = () => {
+  const sizes = ["small", "medium", "large"] as const;
+  const [values, setValues] = useState<Record<string, string>>({
+    small: "0.01",
+    medium: "0.01",
+    large: "0.01",
+  });
+  const [selectValues, setSelectValues] = useState<Record<string, string>>({
+    small: "1",
+    medium: "1",
+    large: "1",
+  });
+
+  return (
+    <>
+      {sizes.map((size) => (
+        <Decimal
+          key={size}
+          label={`Decimal - ${size}`}
+          size={size}
+          value={values[size]}
+          onChange={(e: CustomEvent) =>
+            setValues((prev) => ({
+              ...prev,
+              [size]: e.target.value.rawValue,
+            }))
+          }
+          popoverContainerContent={
+            <Box m="24px">
+              <Select
+                name={`select-${size}`}
+                id={`select-${size}`}
+                label="Select a colour"
+                value={selectValues[size]}
+                onChange={(ev) =>
+                  setSelectValues((prev) => ({
+                    ...prev,
+                    [size]: ev.target.value,
+                  }))
+                }
+              >
+                <Option text="Amber" value="1" />
+                <Option text="Black" value="2" />
+                <Option text="Blue" value="3" />
+                <Option text="Green" value="4" />
+                <Option text="Red" value="5" />
+              </Select>
+            </Box>
+          }
+          mb={2}
+        />
+      ))}
+    </>
+  );
+};
+PopoverContainerWithSizes.storyName = "Popover Container With Sizes";
+
+export const PopoverContainerSizeControlled: StoryFn<
+  Pick<DecimalProps, "size">
+> = ({ size }: Pick<DecimalProps, "size">) => {
+  const [value, setValue] = useState("0.01");
+  const [selectValue, setSelectValue] = useState("1");
+
+  return (
+    <Decimal
+      label="Decimal"
+      size={size}
+      value={value}
+      onChange={(e: CustomEvent) => setValue(e.target.value.rawValue)}
+      popoverContainerContent={
+        <Box m="24px">
+          <Select
+            name="simple"
+            id="simple"
+            label="Select a colour"
+            value={selectValue}
+            onChange={(ev) => setSelectValue(ev.target.value)}
+          >
+            <Option text="Amber" value="1" />
+            <Option text="Black" value="2" />
+            <Option text="Blue" value="3" />
+            <Option text="Green" value="4" />
+            <Option text="Red" value="5" />
+          </Select>
+        </Box>
+      }
+      maxWidth="40%"
+    />
+  );
+};
+PopoverContainerSizeControlled.storyName = "Popover Container Size Controlled";
+PopoverContainerSizeControlled.args = { size: "medium" };
+PopoverContainerSizeControlled.argTypes = {
+  size: {
+    options: ["small", "medium", "large"],
+    control: { type: "select" },
+  },
+};

--- a/src/components/decimal/decimal.component.tsx
+++ b/src/components/decimal/decimal.component.tsx
@@ -2,10 +2,16 @@ import React, { useState, useEffect, useCallback, useContext } from "react";
 import invariant from "invariant";
 
 import Textbox, { CommonTextboxProps } from "../textbox";
+import PopoverContainer, {
+  PopoverContainerProps,
+  RenderOpenProps,
+} from "../popover-container";
 import LocaleContext from "../../__internal__/i18n-context";
+import DecimalPopoverButton from "./__internal__/decimal-popover-button.component";
 import usePrevious from "../../hooks/__internal__/usePrevious";
 import Logger from "../../__internal__/utils/logger";
 import tagComponent from "../../__internal__/utils/helpers/tags/tags";
+import StyledSuffix from "./decimal.style";
 
 export interface CustomEvent {
   target: {
@@ -28,12 +34,22 @@ export interface DecimalProps
   id?: string;
   /** The width of the input as a percentage */
   inputWidth?: number;
-  /** Handler for change event */
-  onChange: (ev: CustomEvent) => void;
-  /** Handler for blur event */
-  onBlur?: (ev: CustomEvent) => void;
+  /** The locale string - default en */
+  locale?: string;
   /** The input name */
   name?: string;
+  /** Handler for blur event */
+  onBlur?: (ev: CustomEvent) => void;
+  /** Handler for change event */
+  onChange: (ev: CustomEvent) => void;
+  /** Sets the accessible name (aria-label) on the PopoverContainer dialog */
+  popoverContainerAriaLabel?: string;
+  /** Content to render inside a PopoverContainer, displayed via a button at the right of the input */
+  popoverContainerContent?: React.ReactNode;
+  /** Sets the position of the PopoverContainer dialog relative to its trigger button */
+  popoverPosition?: PopoverContainerProps["position"];
+  /** Sets the aria-label on the popover trigger button */
+  popoverTriggerAriaLabel?: string;
   /** The decimal precision of the value in the input */
   precision?:
     | 0
@@ -54,25 +70,34 @@ export interface DecimalProps
     | 15;
   /** If true, the component will be read-only */
   readOnly?: boolean;
+  /** A suffix to display alongside the input. Please note that if a prefix is also provided, only the prefix will be rendered. */
+  suffix?: string;
   /** The value of the input */
   value: string;
-  /** The locale string - default en */
-  locale?: string;
 }
 
 export const Decimal = React.forwardRef(
   (
     {
       align = "right",
-      precision = 2,
-      inputWidth,
-      readOnly,
-      onChange,
-      onBlur,
-      id,
-      name,
       allowEmptyValue = false,
+      fieldHelp,
+      id,
+      inputWidth,
+      labelHelp,
       locale,
+      name,
+      onBlur,
+      onChange,
+      popoverContainerAriaLabel,
+      popoverContainerContent,
+      popoverPosition,
+      popoverTriggerAriaLabel,
+      precision = 2,
+      prefix,
+      readOnly,
+      size,
+      suffix,
       value,
       ...rest
     }: DecimalProps,
@@ -301,9 +326,52 @@ export const Decimal = React.forwardRef(
           data-component="decimal"
           id={id}
           ref={ref}
+          prefix={prefix}
+          fieldHelp={fieldHelp}
+          labelHelp={labelHelp}
+          size={size}
           {...rest}
           {...tagComponent("decimal", rest)}
-        />
+        >
+          {!prefix && suffix && (
+            <StyledSuffix data-element="textbox-suffix">{suffix}</StyledSuffix>
+          )}
+          {popoverContainerContent && (
+            <PopoverContainer
+              position={popoverPosition}
+              containerAriaLabel={
+                popoverContainerAriaLabel ||
+                l.decimal.ariaLabels.popoverContent()
+              }
+              renderOpenComponent={({
+                ref,
+                onClick,
+                "data-element": dataElement,
+                "aria-label": ariaLabel,
+                "aria-expanded": ariaExpanded,
+                "aria-haspopup": ariaHasPopup,
+                id: btnId,
+              }: RenderOpenProps) => (
+                <DecimalPopoverButton
+                  ref={ref}
+                  onClick={onClick}
+                  data-element={dataElement}
+                  aria-label={
+                    popoverTriggerAriaLabel ||
+                    ariaLabel ||
+                    l.decimal.ariaLabels.popoverTrigger()
+                  }
+                  aria-haspopup={ariaHasPopup}
+                  aria-expanded={ariaExpanded}
+                  id={btnId}
+                  size={size}
+                />
+              )}
+            >
+              {popoverContainerContent}
+            </PopoverContainer>
+          )}
+        </Textbox>
         <input
           name={name}
           value={toStandardDecimal(stateValue)}

--- a/src/components/decimal/decimal.mdx
+++ b/src/components/decimal/decimal.mdx
@@ -45,6 +45,18 @@ import Decimal from "carbon-react/lib/components/decimal";
 
 <Canvas of={DecimalStories.Prefix} />
 
+### Suffix
+
+<Canvas of={DecimalStories.Suffix} />
+
+**Note:** `prefix` takes precedence over `suffix`.
+
+### With Popover Container
+
+Use the `popoverContainerContent` prop to render content inside a [PopoverContainer](../?path=/docs/popover-container--docs) accessible via a button at the right of the input. Use the `popoverPosition` prop to control the position of the popover dialog relative to the trigger button.
+
+<Canvas of={DecimalStories.WithPopoverContainer} /> If both props are supplied, only the prefix will be rendered and a console warning will be logged. Use one or the other.
+
 ### ReadOnly
 
 <Canvas of={DecimalStories.ReadOnly} />
@@ -60,7 +72,6 @@ import Decimal from "carbon-react/lib/components/decimal";
 ### With custom maxWidth
 
 <Canvas of={DecimalStories.WithCustomMaxWidth} />
-
 
 ### Required
 

--- a/src/components/decimal/decimal.pw.tsx
+++ b/src/components/decimal/decimal.pw.tsx
@@ -3,7 +3,12 @@ import { test } from "../../../playwright/helpers/base-test";
 import { checkAccessibility } from "../../../playwright/support/helper";
 
 import Decimal from "../../../src/components/decimal";
-import { WithFieldHelp, Required, Validations } from "./components.test-pw";
+import {
+  WithFieldHelp,
+  Required,
+  Validations,
+  DecimalWithPopoverContainer,
+} from "./components.test-pw";
 
 test.describe("Accessibility tests for Decimal component", () => {
   test("should pass accessibility tests for Decimal with field help", async ({
@@ -40,6 +45,15 @@ test.describe("Accessibility tests for Decimal component", () => {
     await mount(
       <Decimal label="Decimal" onChange={() => {}} value="0.01" readOnly />,
     );
+
+    await checkAccessibility(page);
+  });
+
+  test("should pass accessibility tests for Decimal with PopoverContainer", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<DecimalWithPopoverContainer />);
 
     await checkAccessibility(page);
   });

--- a/src/components/decimal/decimal.stories.tsx
+++ b/src/components/decimal/decimal.stories.tsx
@@ -3,6 +3,8 @@ import { ArgTypes, Meta, StoryObj } from "@storybook/react-vite";
 
 import Decimal, { DecimalProps, CustomEvent } from ".";
 import generateStyledSystemProps from "../../../.storybook/utils/styled-system-props";
+import Box from "../box";
+import { Select, Option } from "../select";
 
 const styledSystemProps = generateStyledSystemProps({
   margin: true,
@@ -30,7 +32,7 @@ export const DefaultStory: Story = {
     };
     return <Decimal {...args} value={state} onChange={setValue} />;
   },
-  args: { label: "Decimal" },
+  args: { label: "Decimal", required: true },
   name: "Default",
 };
 
@@ -68,6 +70,102 @@ export const Prefix: Story = {
   ...DefaultStory,
   args: { ...DefaultStory.args, prefix: "£", maxWidth: "20%" },
   name: "Prefix",
+};
+
+export const Suffix: Story = {
+  ...DefaultStory,
+  args: { ...DefaultStory.args, suffix: "kg", maxWidth: "20%" },
+  name: "Suffix",
+};
+
+export const WithPopoverContainer: Story = {
+  render: (args: DecimalProps) => {
+    const [state, setState] = useState("0.01");
+    const [selectValue, setSelectValue] = useState("1");
+    const setValue = ({ target }: CustomEvent) => {
+      setState(target.value.rawValue);
+    };
+    return (
+      <Decimal
+        {...args}
+        value={state}
+        onChange={setValue}
+        popoverContainerContent={
+          <Box m="24px">
+            <Select
+              name="simple"
+              id="simple"
+              label="Select a colour"
+              value={selectValue}
+              onChange={(ev) => setSelectValue(ev.target.value)}
+            >
+              <Option text="Amber" value="1" />
+              <Option text="Black" value="2" />
+              <Option text="Blue" value="3" />
+              <Option text="Brown" value="4" />
+              <Option text="Green" value="5" />
+              <Option text="Orange" value="6" />
+              <Option text="Pink" value="7" />
+              <Option text="Purple" value="8" />
+              <Option text="Red" value="9" />
+              <Option text="White" value="10" />
+              <Option text="Yellow" value="11" />
+            </Select>
+          </Box>
+        }
+      />
+    );
+  },
+  args: { label: "Decimal", maxWidth: "40%" },
+  name: "With Popover Container",
+};
+
+export const WithPopoverPosition: Story = {
+  render: (args: DecimalProps) => {
+    const [state, setState] = useState("0.01");
+    const [selectValue, setSelectValue] = useState("1");
+    const setValue = ({ target }: CustomEvent) => {
+      setState(target.value.rawValue);
+    };
+    return (
+      <Decimal
+        {...args}
+        value={state}
+        onChange={setValue}
+        popoverContainerContent={
+          <Box m="24px">
+            <Select
+              name="simple"
+              id="simple"
+              label="Select a colour"
+              value={selectValue}
+              onChange={(ev) => setSelectValue(ev.target.value)}
+            >
+              <Option text="Amber" value="1" />
+              <Option text="Black" value="2" />
+              <Option text="Blue" value="3" />
+              <Option text="Brown" value="4" />
+              <Option text="Green" value="5" />
+              <Option text="Orange" value="6" />
+              <Option text="Pink" value="7" />
+              <Option text="Purple" value="8" />
+              <Option text="Red" value="9" />
+              <Option text="White" value="10" />
+              <Option text="Yellow" value="11" />
+            </Select>
+          </Box>
+        }
+      />
+    );
+  },
+  args: { label: "Decimal", maxWidth: "40%", popoverPosition: "left" },
+  argTypes: {
+    popoverPosition: {
+      options: ["left", "right", "center"],
+      control: { type: "select" },
+    },
+  },
+  name: "With Popover Position",
 };
 
 export const ReadOnly: Story = {

--- a/src/components/decimal/decimal.style.ts
+++ b/src/components/decimal/decimal.style.ts
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+
+const StyledSuffix = styled.span`
+  font: var(--global-font-static-comp-medium-m);
+  margin-right: var(--global-space-comp-m);
+`;
+
+export default StyledSuffix;

--- a/src/components/decimal/decimal.test.tsx
+++ b/src/components/decimal/decimal.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Decimal from "./decimal.component";
@@ -356,6 +356,49 @@ test("logs an error when precision changes", () => {
   );
 });
 
+describe("prefix and suffix props", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the prefix when only prefix is supplied", () => {
+    render(<Decimal value="1.00" onChange={jest.fn} prefix="£" />);
+    expect(screen.getByText("£")).toHaveAttribute(
+      "data-element",
+      "textbox-prefix",
+    );
+  });
+
+  it("renders the suffix when only suffix is supplied", () => {
+    render(<Decimal value="1.00" onChange={jest.fn} suffix="kg" />);
+    expect(screen.getByText("kg")).toHaveAttribute(
+      "data-element",
+      "textbox-suffix",
+    );
+  });
+
+  it("renders only the prefix when both prefix and suffix are supplied", () => {
+    render(<Decimal value="1.00" onChange={jest.fn} prefix="£" suffix="kg" />);
+    expect(screen.getByText("£")).toHaveAttribute(
+      "data-element",
+      "textbox-prefix",
+    );
+    expect(screen.queryByText("kg")).not.toBeInTheDocument();
+  });
+
+  it("does not log a warning when only prefix is supplied", () => {
+    const loggerSpy = jest.spyOn(Logger, "warn");
+    render(<Decimal value="1.00" onChange={jest.fn} prefix="£" />);
+    expect(loggerSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not log a warning when only suffix is supplied", () => {
+    const loggerSpy = jest.spyOn(Logger, "warn");
+    render(<Decimal value="1.00" onChange={jest.fn} suffix="kg" />);
+    expect(loggerSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe("check events for Decimal component", () => {
   (
     [
@@ -394,4 +437,151 @@ describe("check events for Decimal component", () => {
     expect(decimalInput).toHaveValue("123.00");
     expect(callbackCount).toBe(1);
   });
+});
+
+describe("popoverContainerContent and popoverPosition props", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("does not render a popover trigger button when popoverContainerContent is not supplied", () => {
+    render(<Decimal value="1.00" onChange={jest.fn} />);
+    expect(
+      screen.queryByRole("button", { name: "Decimal popover trigger" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders a popover trigger button when popoverContainerContent is supplied", () => {
+    render(
+      <Decimal
+        value="1.00"
+        onChange={jest.fn}
+        popoverContainerContent={<p>Popover content</p>}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Decimal popover trigger" }),
+    ).toBeVisible();
+  });
+
+  it("trigger button has aria-haspopup set to dialog", () => {
+    render(
+      <Decimal
+        value="1.00"
+        onChange={jest.fn}
+        popoverContainerContent={<p>Popover content</p>}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Decimal popover trigger" }),
+    ).toHaveAttribute("aria-haspopup", "dialog");
+  });
+
+  it("trigger button has aria-expanded set to false when the popover is closed", () => {
+    render(
+      <Decimal
+        value="1.00"
+        onChange={jest.fn}
+        popoverContainerContent={<p>Popover content</p>}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Decimal popover trigger" }),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("trigger button has data-element set to popover-container-open-component", () => {
+    render(
+      <Decimal
+        value="1.00"
+        onChange={jest.fn}
+        popoverContainerContent={<p>Popover content</p>}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: "Decimal popover trigger" }),
+    ).toHaveAttribute("data-element", "popover-container-open-component");
+  });
+
+  it("opens the popover when the trigger button is clicked", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(
+      <Decimal
+        value="1.00"
+        onChange={jest.fn}
+        popoverContainerContent={<p>Popover content</p>}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Decimal popover trigger" }),
+    );
+
+    expect(await screen.findByRole("dialog")).toBeVisible();
+    expect(screen.getByText("Popover content")).toBeVisible();
+  });
+
+  it("trigger button has aria-expanded set to true when the popover is open", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(
+      <Decimal
+        value="1.00"
+        onChange={jest.fn}
+        popoverContainerContent={<p>Popover content</p>}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Decimal popover trigger" }),
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Decimal popover trigger" }),
+    ).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("closes the popover when the trigger button is clicked again", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(
+      <Decimal
+        value="1.00"
+        onChange={jest.fn}
+        popoverContainerContent={<p>Popover content</p>}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Decimal popover trigger",
+    });
+    await user.click(trigger);
+    await screen.findByRole("dialog");
+
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it.each(["left", "right", "center"] as const)(
+    "renders correctly with popoverPosition set to %s",
+    (position) => {
+      render(
+        <Decimal
+          value="1.00"
+          onChange={jest.fn}
+          popoverContainerContent={<p>Popover content</p>}
+          popoverPosition={position}
+        />,
+      );
+      expect(
+        screen.getByRole("button", { name: "Decimal popover trigger" }),
+      ).toBeVisible();
+    },
+  );
 });

--- a/src/components/textbox/__internal__/__next__/text-input.component.tsx
+++ b/src/components/textbox/__internal__/__next__/text-input.component.tsx
@@ -224,6 +224,22 @@ export const TextInput = React.forwardRef(
       [onClick, disabled, readOnly],
     );
 
+    const handleWrapperClick = useCallback(
+      (ev: React.MouseEvent<HTMLElement>) => {
+        if (
+          disabled ||
+          readOnly ||
+          document.activeElement === localRef.current ||
+          !ev.currentTarget.contains(ev.target as Node)
+        ) {
+          return;
+        }
+
+        localRef.current?.focus();
+      },
+      [disabled, readOnly],
+    );
+
     return (
       <StyledTextInput
         data-element={dataElement}
@@ -266,15 +282,8 @@ export const TextInput = React.forwardRef(
           $size={actualSize}
           $maxWidth={maxWidth}
           $inputWidth={inputWidth}
-          onClick={() => {
-            if (
-              !disabled &&
-              !readOnly &&
-              document.activeElement !== localRef.current
-            ) {
-              localRef.current?.focus();
-            }
-          }}
+          onClick={handleWrapperClick}
+          data-is-open={dataIsOpen}
         >
           {validationMessagePositionTop && validationMessage}
           <Input

--- a/src/components/textbox/__internal__/__next__/text-input.test.tsx
+++ b/src/components/textbox/__internal__/__next__/text-input.test.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { createPortal } from "react-dom";
 import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import TextInput from ".";
 import { testStyledSystemMargin } from "../../../../__spec_helper__/__internal__/test-utils";
 import createGuid from "../../../../__internal__/utils/helpers/guid";
@@ -455,3 +457,28 @@ test.each([
     expect(locator).toHaveStyleRule("gap", expectedGap);
   },
 );
+
+test("should not focus the input when a click event bubbles from a React portal (target is not a DOM descendant of the wrapper)", async () => {
+  // createPortal renders content into a DOM node that lives outside the
+  // InputWrapper's subtree, but the React synthetic click event still bubbles
+  // up through the React component tree to InputWrapper's onClick handler.
+  // The guard `ev.currentTarget.contains(ev.target)` should return false for
+  // such events and bail out before calling focus().
+  const user = userEvent.setup();
+  const portalRoot = document.createElement("div");
+  document.body.appendChild(portalRoot);
+
+  const PortalContent = () => createPortal(<button>portal</button>, portalRoot);
+
+  render(
+    <TextInput label="label" value="foo" onChange={() => {}}>
+      <PortalContent />
+    </TextInput>,
+  );
+
+  await user.click(screen.getByRole("button", { name: "portal" }));
+
+  expect(screen.getByRole("textbox")).not.toHaveFocus();
+
+  document.body.removeChild(portalRoot);
+});

--- a/src/locales/de-de.ts
+++ b/src/locales/de-de.ts
@@ -42,6 +42,12 @@ const deDE: Partial<Locale> = {
       nextMonthButton: () => "Nächster Monat",
     },
   },
+  decimal: {
+    ariaLabels: {
+      popoverTrigger: () => "Dezimal-Popover-Auslöser",
+      popoverContent: () => "Dezimal-Popover-Inhalt",
+    },
+  },
   dialog: {
     ariaLabels: {
       close: () => "Schließen",

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -49,6 +49,12 @@ const enGB: Locale = {
     },
     dateFormatOverride: undefined,
   },
+  decimal: {
+    ariaLabels: {
+      popoverTrigger: () => "Decimal popover trigger",
+      popoverContent: () => "Decimal popover content",
+    },
+  },
   dialog: {
     ariaLabels: {
       close: () => "Close",

--- a/src/locales/es-es.ts
+++ b/src/locales/es-es.ts
@@ -48,6 +48,12 @@ const esES: Partial<Locale> = {
       nextMonthButton: () => "Mes siguiente",
     },
   },
+  decimal: {
+    ariaLabels: {
+      popoverTrigger: () => "Activador del elemento emergente decimal",
+      popoverContent: () => "Contenido del elemento emergente decimal",
+    },
+  },
   dialog: {
     ariaLabels: {
       close: () => "Cerrar",

--- a/src/locales/fr-ca.ts
+++ b/src/locales/fr-ca.ts
@@ -48,6 +48,12 @@ const frCA: Partial<Locale> = {
       nextMonthButton: () => "Mois suivant",
     },
   },
+  decimal: {
+    ariaLabels: {
+      popoverTrigger: () => "Déclencheur de contextuel décimal",
+      popoverContent: () => "Contenu du contextuel décimal",
+    },
+  },
   dialog: {
     ariaLabels: {
       close: () => "Fermer",

--- a/src/locales/fr-fr.ts
+++ b/src/locales/fr-fr.ts
@@ -48,6 +48,12 @@ const frFR: Partial<Locale> = {
       nextMonthButton: () => "Mois suivant",
     },
   },
+  decimal: {
+    ariaLabels: {
+      popoverTrigger: () => "Déclencheur de contextuel décimal",
+      popoverContent: () => "Contenu du contextuel décimal",
+    },
+  },
   dialog: {
     ariaLabels: {
       close: () => "Fermer",

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -37,6 +37,12 @@ interface Locale {
     };
     dateFormatOverride?: string;
   };
+  decimal: {
+    ariaLabels: {
+      popoverTrigger: () => string;
+      popoverContent: () => string;
+    };
+  };
   dialog: {
     ariaLabels: {
       close: () => string;

--- a/src/locales/pt-pt.ts
+++ b/src/locales/pt-pt.ts
@@ -50,6 +50,12 @@ const ptPT: Partial<Locale> = {
     },
     dateFormatOverride: undefined,
   },
+  decimal: {
+    ariaLabels: {
+      popoverTrigger: () => "Acionador de popover decimal",
+      popoverContent: () => "Conteúdo do popover decimal",
+    },
+  },
   dialog: {
     ariaLabels: {
       close: () => "Fechar",


### PR DESCRIPTION
### Proposed behaviour
 Updates Decimal to be inline with that of the Fusion DS.
 
- Add `suffix` prop
- Add `PopoverContainer` support
- Add PopoverPosition support

<img width="748" height="200" alt="Screenshot 2026-05-18 at 15 50 13" src="https://github.com/user-attachments/assets/03223d1c-8d24-4e20-9522-038ea4bd8fa8" />

<img width="182" height="124" alt="Screenshot 2026-05-18 at 15 48 40" src="https://github.com/user-attachments/assets/8f44e49d-d5a4-43cc-9537-d232ea422555" />

<img width="655" height="330" alt="Screenshot 2026-05-18 at 15 49 38" src="https://github.com/user-attachments/assets/cee402b5-3bfa-4011-ac24-5beaaf0c6dc7" />

<img width="745" height="352" alt="Screenshot 2026-05-18 at 15 50 35" src="https://github.com/user-attachments/assets/71870d83-d1c1-42ad-a1eb-cf146630e6ff" />

### Current behaviour

Decimal is out of date with Fusion DS

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

- Component should match designs on the associated ticket.
- No functional regressions should occur due to this work.
