### PR TITLE
chore(dialog): remove accidental warning message

### DIFF
--- a/src/components/dialog/dialog.component.tsx
+++ b/src/components/dialog/dialog.component.tsx
@@ -62,7 +62,6 @@ const mapHighlightVariantToGradientKeyLine = (
   return highlightVariant === "ai";
 };
 
-let dialogLegacyWarned = false;
 let deprecatedFullscreenTrigger = false;
 let deprecatedHighlightVariantTrigger = false;
 let deprecatedDisableCloseTrigger = false;
@@ -83,13 +82,6 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
     },
     ref,
   ) => {
-    if (!dialogLegacyWarned) {
-      Logger.warn(
-        "Warning: This version of the `Dialog` component is a migration wrapper...",
-      );
-      dialogLegacyWarned = true;
-    }
-
     if (!deprecatedFullscreenTrigger && fullscreen !== undefined) {
       deprecatedFullscreenTrigger = true;
       Logger.deprecate(


### PR DESCRIPTION
### Proposed behaviour

Remove accidental warning left in Dialog

### Current behaviour

Dialog contains a warning message that is no longer valid.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
