### PR TITLE
test(split-button): refine testing suite

### DIFF
--- a/src/components/split-button/split-button.pw.tsx
+++ b/src/components/split-button/split-button.pw.tsx
@@ -9,353 +9,13 @@ import { Accordion } from "../accordion";
 import SplitButton, { SplitButtonProps } from ".";
 import Button from "../button";
 import Box from "../box";
-import { buttonSubtextPreview } from "../../../playwright/components/button";
-import {
-  getStyle,
-  assertCssValueIsApproximately,
-  checkAccessibility,
-} from "../../../playwright/support/helper";
-import { icon, getDataElementByValue } from "../../../playwright/components";
-import {
-  splitToggleButton,
-  additionalButton,
-  additionalButtonsContainer,
-  splitMainButtonDataComponent,
-  mainButton,
-  splitMainButton,
-} from "../../../playwright/components/split-button";
+import { checkAccessibility } from "../../../playwright/support/helper";
+import { splitToggleButton } from "../../../playwright/components/split-button";
 import { CHARACTERS } from "../../../playwright/support/constants";
 
 const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
 
-test.describe("Styling tests", () => {
-  test(`should render with the expected styling`, async ({ mount, page }) => {
-    await mount(<SplitButtonList />);
-
-    await mainButton(page).focus();
-    await expect(mainButton(page)).toHaveCSS(
-      "box-shadow",
-      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
-    );
-    await expect(mainButton(page)).toHaveCSS(
-      "outline",
-      "rgba(0, 0, 0, 0) solid 3px",
-    );
-    await splitToggleButton(page).focus();
-    await expect(splitToggleButton(page)).toHaveCSS(
-      "box-shadow",
-      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
-    );
-    await expect(splitToggleButton(page)).toHaveCSS(
-      "outline",
-      "rgba(0, 0, 0, 0) solid 3px",
-    );
-  });
-
-  (
-    [
-      ["primary", "rgb(0, 126, 69)", "rgb(255, 255, 255)", "rgba(0, 0, 0, 0)"],
-      ["secondary", "rgba(0, 0, 0, 0)", "rgb(0, 126, 69)", "rgb(0, 126, 69)"],
-    ] as [SplitButtonProps["buttonType"], string, string, string][]
-  ).forEach(([buttonType, backgroundColor, color, borderColor]) => {
-    test(`should render ${buttonType} SplitButton with ${backgroundColor} background color, ${color} color and ${borderColor} border color`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<SplitButtonList buttonType={buttonType} />);
-
-      await expect(mainButton(page)).toHaveCSS(
-        "background-color",
-        backgroundColor,
-      );
-      await expect(mainButton(page)).toHaveCSS("color", color);
-      await expect(mainButton(page)).toHaveCSS("border-color", borderColor);
-    });
-  });
-
-  test(`should render with the expected border radius on main and toggle buttons`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SplitButtonList />);
-
-    await expect(mainButton(page)).toHaveCSS(
-      "border-radius",
-      "32px 0px 0px 32px",
-    );
-    await expect(splitToggleButton(page)).toHaveCSS(
-      "border-radius",
-      "0px 32px 32px 0px",
-    );
-  });
-
-  test(`should render with the expected border radius on children container and buttons`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SplitButtonList />);
-
-    await splitToggleButton(page).nth(0).click();
-    await expect(additionalButtonsContainer(page)).toHaveCSS(
-      "border-radius",
-      "8px",
-    );
-    await expect(additionalButton(page, 0)).toHaveCSS(
-      "border-radius",
-      "8px 8px 0px 0px",
-    );
-    await expect(additionalButton(page, 1)).toHaveCSS("border-radius", "0px");
-    await expect(additionalButton(page, 2)).toHaveCSS(
-      "border-radius",
-      "0px 0px 8px 8px",
-    );
-  });
-
-  test(`should render with the expected border radius when some children buttons have href prop`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <SplitButton text="default text">
-        <Button href="#">Button 1</Button>
-        <Button>Button 2</Button>
-        <Button href="#">Button 3</Button>
-      </SplitButton>,
-    );
-
-    await splitToggleButton(page).nth(0).click();
-    await expect(additionalButtonsContainer(page)).toHaveCSS(
-      "border-radius",
-      "8px",
-    );
-    await expect(
-      additionalButtonsContainer(page).locator("a").nth(0),
-    ).toHaveCSS("border-radius", "8px 8px 0px 0px");
-    await expect(
-      additionalButtonsContainer(page).locator("button").nth(0),
-    ).toHaveCSS("border-radius", "0px");
-    await expect(
-      additionalButtonsContainer(page).locator("a").nth(1),
-    ).toHaveCSS("border-radius", "0px 0px 8px 8px");
-  });
-
-  test("should render with additional buttons min-width computed based on the component's width", async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <SplitButtonList size="large">
-        <Button>Button 1</Button>
-        <Button>Button 2</Button>
-        <Button>Button 3</Button>
-      </SplitButtonList>,
-    );
-
-    await splitToggleButton(page).nth(0).click();
-
-    const transformValue = await getStyle(
-      additionalButtonsContainer(page),
-      "min-width",
-    );
-    const transformValueAsNumber = +transformValue.replace("px", "");
-
-    expect(transformValueAsNumber).toBeLessThan(156);
-    expect(transformValueAsNumber).toBeGreaterThan(154);
-  });
-
-  test(`should render with the expected border radius when there is only on one child button`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <SplitButton text="default text">
-        <Button>Button 1</Button>
-      </SplitButton>,
-    );
-
-    await splitToggleButton(page).nth(0).click();
-    await expect(additionalButton(page, 0)).toHaveCSS("border-radius", "8px");
-  });
-});
-
-test.describe("Prop tests", () => {
-  testData.forEach((text) => {
-    test(`should render with ${text} as text`, async ({ mount, page }) => {
-      await mount(<SplitButtonList text={text} />);
-
-      await expect(page.getByRole("button", { name: text })).toBeVisible();
-    });
-  });
-
-  testData.forEach((subtext) => {
-    test(`should render with ${subtext} as subtext`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<SplitButtonList size="large" subtext={subtext} />);
-
-      await expect(buttonSubtextPreview(page)).toHaveText(subtext);
-    });
-  });
-
-  test(`should render with data-element prop`, async ({ mount, page }) => {
-    await mount(
-      <SplitButtonList data-element="split-button-playwright-element" />,
-    );
-
-    await expect(splitMainButton(page)).toHaveAttribute(
-      "data-element",
-      "split-button-playwright-element",
-    );
-  });
-
-  test(`should render with data-role prop`, async ({ mount, page }) => {
-    await mount(<SplitButtonList data-role="split-button-playwright-role" />);
-
-    await expect(splitMainButton(page)).toHaveAttribute(
-      "data-role",
-      "split-button-playwright-role",
-    );
-  });
-
-  (["left", "right"] as SplitButtonProps["align"][]).forEach((alignment) => {
-    test(`should render with alignment to the ${alignment}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<SplitButtonList align={alignment} />);
-
-      await getDataElementByValue(page, "dropdown").click();
-      await expect(additionalButton(page, 1)).toHaveCSS(
-        "justify-content",
-        alignment as string,
-      );
-    });
-  });
-
-  (
-    [
-      ["left", 198],
-      ["right", 242],
-    ] as [SplitButtonProps["position"], number][]
-  ).forEach(([position, value]) => {
-    test(`should render with menu position to the ${position}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<SplitButtonList ml="200px" position={position} />);
-
-      await getDataElementByValue(page, "dropdown").click();
-      const listContainer = additionalButtonsContainer(page);
-      await expect(listContainer).toHaveCSS("position", "fixed");
-      await assertCssValueIsApproximately(listContainer, "top", 46);
-      await assertCssValueIsApproximately(listContainer, "left", value);
-    });
-  });
-
-  test(`should render with component disabled`, async ({ mount, page }) => {
-    await mount(<SplitButtonList disabled />);
-
-    await mainButton(page).hover();
-    await expect(splitMainButton(page).locator("button").nth(0)).toBeDisabled();
-    await expect(splitMainButton(page).locator("button").nth(1)).toBeDisabled();
-  });
-
-  (
-    [
-      ["after", "left"],
-      ["before", "right"],
-    ] as [SplitButtonProps["iconPosition"], string][]
-  ).forEach(([iconPosition, margin]) => {
-    test(`should render with icon position ${iconPosition}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <SplitButtonList iconType="add" iconPosition={iconPosition}>
-          IconPosition
-        </SplitButtonList>,
-      );
-
-      await expect(icon(page).first()).toHaveCSS(`margin-${margin}`, "8px");
-    });
-  });
-});
-
-test.describe("Events tests", () => {
-  test(`should click a main element of SplitButton component`, async ({
-    mount,
-    page,
-  }) => {
-    let callbackCount = 0;
-    await mount(
-      <SplitButtonList
-        onClick={() => {
-          callbackCount += 1;
-        }}
-      />,
-    );
-
-    await splitMainButtonDataComponent(page, 0).click();
-    expect(callbackCount).toBe(1);
-  });
-});
-
 test.describe("Functional tests", () => {
-  test(`should render component in a hidden container and expand by clicking`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <Accordion title="Heading">
-        <SplitButtonList />
-      </Accordion>,
-    );
-
-    await page.getByRole("button", { name: "Heading" }).click();
-    await getDataElementByValue(page, "dropdown").click();
-    await expect(additionalButton(page, 0)).toBeVisible();
-    await expect(additionalButton(page, 1)).toBeVisible();
-    await expect(additionalButton(page, 2)).toBeVisible();
-    await expect(splitToggleButton(page)).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
-  });
-
-  test(`should render component in a hidden container and expand by pressing Enter key and clicking`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <Accordion title="Heading">
-        <SplitButtonList />
-      </Accordion>,
-    );
-
-    await page.getByRole("button", { name: "Heading" }).click();
-    await getDataElementByValue(page, "dropdown").click();
-    await expect(additionalButton(page, 0)).toBeVisible();
-    await expect(additionalButton(page, 1)).toBeVisible();
-    await expect(additionalButton(page, 2)).toBeVisible();
-    await expect(splitToggleButton(page)).toHaveAttribute(
-      "aria-expanded",
-      "true",
-    );
-  });
-
-  test(`should render component and expand by clicking toggle button`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SplitButtonList />);
-
-    await splitToggleButton(page).nth(0).click();
-    await expect(additionalButton(page, 0)).toBeVisible();
-    await expect(additionalButton(page, 1)).toBeVisible();
-    await expect(additionalButton(page, 2)).toBeVisible();
-  });
-
   test(`closes the list and focuses the next element on the page, when Tab key is pressed on last child button`, async ({
     mount,
     page,
@@ -423,19 +83,6 @@ test.describe("Accessibility tests", () => {
     );
   });
 
-  test(`should pass accessibility tests when the additional buttons are opened`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<SplitButtonList />);
-
-    await splitToggleButton(page).nth(0).click();
-    await checkAccessibility(
-      page,
-      page.getByRole("button", { name: "Button 1" }),
-    );
-  });
-
   test(`should pass accessibility tests when disabled`, async ({
     mount,
     page,
@@ -445,82 +92,31 @@ test.describe("Accessibility tests", () => {
     await checkAccessibility(page);
   });
 
-  (["primary", "secondary"] as SplitButtonProps["buttonType"][]).forEach(
-    (buttonType) => {
-      test(`should pass accessibility tests for ${buttonType} button`, async ({
-        mount,
-        page,
-      }) => {
-        await mount(<SplitButtonList buttonType={buttonType} />);
+  test(`should pass accessibility tests for primary button`, async ({
+    mount,
+    page,
+  }) => {
+    await mount(<SplitButtonList buttonType="primary" />);
 
-        await checkAccessibility(page);
-      });
-    },
-  );
+    await checkAccessibility(page);
+  });
 
-  (["primary", "secondary"] as SplitButtonProps["buttonType"][]).forEach(
-    (buttonType) => {
-      test(`should pass accessibility tests for ${buttonType} button type when open`, async ({
-        mount,
-        page,
-      }) => {
-        await mount(<SplitButtonList buttonType={buttonType} />);
+  test(`should pass accessibility tests for primary button type when open`, async ({
+    mount,
+    page,
+  }) => {
+    await mount(<SplitButtonList buttonType="primary" />);
 
-        await splitToggleButton(page).nth(0).click();
-        await checkAccessibility(page);
-      });
-    },
-  );
+    await splitToggleButton(page).nth(0).click();
+    await checkAccessibility(page);
+  });
 
-  (["primary", "secondary"] as SplitButtonProps["buttonType"][]).forEach(
-    (buttonType) => {
-      test(`should pass accessibility tests when hovering on ${buttonType} button`, async ({
-        mount,
-        page,
-      }) => {
-        await mount(<SplitButtonList buttonType={buttonType} />);
-
-        await splitMainButtonDataComponent(page, 0).click();
-
-        await checkAccessibility(page);
-      });
-    },
-  );
-
-  (["primary", "secondary"] as SplitButtonProps["buttonType"][]).forEach(
-    (buttonType) => {
-      test(`should pass accessibility tests with ${buttonType} button type hovered`, async ({
-        mount,
-        page,
-      }) => {
-        await mount(<SplitButtonList buttonType={buttonType} />);
-
-        await splitToggleButton(page).nth(0).hover();
-
-        await checkAccessibility(page);
-      });
-    },
-  );
-
-  (["small", "medium", "large"] as SplitButtonProps["size"][]).forEach(
-    (size) => {
-      test(`should pass accessibility tests with Sizes prop set to ${size}`, async ({
-        mount,
-        page,
-      }) => {
-        await mount(<SplitButtonList size={size} />);
-
-        await checkAccessibility(page);
-      });
-    },
-  );
-
-  (["left", "right"] as SplitButtonProps["align"][]).forEach((alignment) => {
-    test(`should pass accessibility tests with Align prop set to ${alignment}`, async ({
+  (["small", "large"] as SplitButtonProps["size"][]).forEach((size) => {
+    test(`should pass accessibility tests with Sizes prop set to ${size}`, async ({
       mount,
       page,
     }) => {
-      await mount(<SplitButtonList align={alignment} />);
+      await mount(<SplitButtonList size={size} />);
 
       await checkAccessibility(page);
     });


### PR DESCRIPTION
### Proposed behaviour

Removes a number of Playwright tests that duplicate either Jest or Chromatic ones for the Tabs component

### Current behaviour

There are a number of tests that exist in different forms in all the testing suites we do(Jest, Playwright, Chromatic) which cause a prolonged time of execution for no additional value.

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

This should decrease the time of execution without compromising testing and coverage

### Testing instructions

Make sure the Playwright tests pass
