### PR TITLE
fix(advanced-color-picker): adjust component max-width to fit dialog

### DIFF
--- a/src/components/advanced-color-picker/advanced-color-picker.style.ts
+++ b/src/components/advanced-color-picker/advanced-color-picker.style.ts
@@ -47,8 +47,22 @@ const StyledAdvancedColorPickerPreview = styled.div`
 `;
 
 const DialogStyle = styled(Dialog)`
+  [data-component="dialog"] {
+    max-width: fit-content;
+  }
+
   ${StyledDialogContent} {
     padding: var(--spacing200);
+  }
+
+  [data-element="close"] {
+    position: absolute;
+    top: var(--spacing200);
+    right: var(--spacing200);
+
+    [data-component="icon"] {
+      position: static;
+    }
   }
 
   ${StyledColorOptions} {


### PR DESCRIPTION
### Proposed behaviour
- Adjusts the `advanced-color-picker` style file to better fill the `dialog` following updates to that component.

<img width="327" height="261" alt="Screenshot 2026-06-01 at 15 58 00" src="https://github.com/user-attachments/assets/74f82266-f0a1-4e75-af99-6481bb688eca" />


<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour
- There is unused white space in the `dialog` when opening the component due to the changes in sizing of the component.
<img width="551" height="265" alt="Screenshot 2026-06-01 at 14 15 40" src="https://github.com/user-attachments/assets/95542ff9-0e15-4137-8001-c88ab3fa5adb" />

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions
- Ensure the Advanced Color Picker stories render as expected.
<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
