### PR TITLE
fix(select): ensure popover renders above validation message

### DIFF
--- a/src/__internal__/input/input.component.tsx
+++ b/src/__internal__/input/input.component.tsx
@@ -46,6 +46,10 @@ export interface InputProps
    * @private @internal @ignore
    */
   "data-is-transparent"?: boolean;
+  /**
+   * @private @internal @ignore
+   */
+  "data-is-open"?: boolean;
 }
 
 const selectTextOnFocus = (
@@ -78,6 +82,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       autoFocus,
       error,
       "data-is-transparent": dataIsTransparent,
+      "data-is-open": dataIsOpen,
       children,
       disabled,
       id,
@@ -123,6 +128,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         $isDisabled={disabled}
         $isReadOnly={readOnly}
         data-is-transparent={dataIsTransparent}
+        data-is-open={dataIsOpen}
       >
         <div
           data-role="input-text-container"

--- a/src/__internal__/input/input.style.ts
+++ b/src/__internal__/input/input.style.ts
@@ -165,6 +165,20 @@ const InputContainer = styled.div<InputContainerProps>`
   ${pagerStyleOverrides}
 
   ${numeralDateStyles}
+  
+  &[data-is-open="true"] {
+    z-index: var(
+      --adaptiveSidebarModalBackdrop,
+      var(--carbon-zindex-above-all)
+    );
+
+    &:focus-within:has(:focus:not(button)) {
+      z-index: var(
+        --adaptiveSidebarModalBackdrop,
+        var(--carbon-zindex-above-all)
+      );
+    }
+  }
 `;
 
 export default InputContainer;

--- a/src/components/select/simple-select/simple-select-interaction.stories.tsx
+++ b/src/components/select/simple-select/simple-select-interaction.stories.tsx
@@ -534,3 +534,44 @@ export const NestedInDialog: Story = {
     ),
   ],
 };
+
+export const OpenWithValidationBelow: Story = {
+  render: () => (
+    <Box height={300}>
+      <InteractiveComponent
+        onChange={() => {}}
+        name="simple"
+        id="simple"
+        label="Color"
+        error="Error message"
+        validationMessagePositionTop={false}
+      >
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+        <Option text="Brown" value="4" />
+        <Option text="Green" value="5" />
+      </InteractiveComponent>
+    </Box>
+  ),
+  play: async ({ canvasElement }) => {
+    if (!allowInteractions()) {
+      return;
+    }
+    const canvas = within(canvasElement);
+    const select = canvas.getByRole("combobox", { name: "Color" });
+    await userEvent.click(select, { delay: 100 });
+    await expect(
+      await within(document.body).findByRole("option", { name: "Amber" }),
+    ).toBeVisible();
+  },
+  decorators: [
+    (StoryToRender) => (
+      <DefaultDecorator>
+        <StoryToRender />
+      </DefaultDecorator>
+    ),
+  ],
+};
+
+OpenWithValidationBelow.storyName = "Open With Validation Below";

--- a/src/components/textbox/__internal__/__next__/text-input.component.tsx
+++ b/src/components/textbox/__internal__/__next__/text-input.component.tsx
@@ -275,7 +275,6 @@ export const TextInput = React.forwardRef(
               localRef.current?.focus();
             }
           }}
-          data-is-open={dataIsOpen}
         >
           {validationMessagePositionTop && validationMessage}
           <Input
@@ -299,6 +298,7 @@ export const TextInput = React.forwardRef(
             prefixId={inputPrefixId}
             leftChildren={leftChildren}
             type={type}
+            data-is-open={dataIsOpen}
             {...stateProps}
             {...filterOutStyledSystemSpacingProps(rest)}
           >

--- a/src/components/textbox/__internal__/__next__/text-input.style.ts
+++ b/src/components/textbox/__internal__/__next__/text-input.style.ts
@@ -119,10 +119,6 @@ const InputWrapper = styled.div<InputWrapperProps>`
     ${$maxWidth && `max-width: ${$maxWidth};`}
     width: ${$inputWidth ? `${$inputWidth}%` : "100%"};
   `}
-
-  &[data-is-open="true"] {
-    z-index: var(--adaptiveSidebarModalBackdrop, 9999);
-  }
 `;
 
 export { StyledTextInput, LabelWrapper, InputWrapper };


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Moves the `z-index` applied to the input wrapper to the input container instead, as it was previously accidentally moving the error message to the top of the z-index stack.

**DOM order**:

-Input wrapper 
--Input container (z-index 9999 set here)
--Error Message 

<img width="190" height="184" alt="Screenshot 2026-06-02 at 16 25 02" src="https://github.com/user-attachments/assets/5c06bac3-6f0d-488c-957f-a473bcb3a54c" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, the `z-index` is applied to the input wrapper, which means all children inherit its `z-index` placing the error message above the `Select` list popover in the `z-index` stack

**DOM order**:

-Input wrapper (z-index 9999 set here)
--Input container (z-index 9999 inherited here)
--Error Message  (z-index 9999 inherited here)

<img width="241" height="205" alt="Screenshot 2026-06-02 at 16 24 49" src="https://github.com/user-attachments/assets/3a748e6d-e4ed-4593-a3fe-cba7f7a04d84" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Compare the new interaction story added `Open With Validation Below` with the validations' story on master https://carbon.sbc-ui.com/?path=/story/select-test--validation and verify the error message is no longer visible below the `Select` popover list 