### PR TITLE
chore(popover-menu): add new internal dropdown version of component

### DIFF
--- a/.storybook/interaction-toggle/reduced-motion.tsx
+++ b/.storybook/interaction-toggle/reduced-motion.tsx
@@ -12,15 +12,16 @@ export const allowInteractions = () => {
 };
 
 export const InteractionToggle = () => {
-  const [disableInteractions, setDisableInteractions] = useState(
-    window?.localStorage.getItem(STORAGE_KEY) === "true",
-  );
+  const [disableInteractions, setDisableInteractions] = useState(false);
 
   useEffect(() => {
+    const storedValue = window?.localStorage.getItem(STORAGE_KEY);
+    setDisableInteractions(storedValue === "true");
+
     const reducedMotion = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
-    if (window?.localStorage.getItem(STORAGE_KEY) === null && reducedMotion) {
+    if (storedValue === null && reducedMotion) {
       window?.localStorage?.setItem(STORAGE_KEY, "true");
       setDisableInteractions(true);
     }

--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -8,7 +8,9 @@ const playwrightDir = resolve(__dirname, "./playwright");
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: resolve(__dirname, "./src/components"),
+  testDir: resolve(__dirname, "./src"),
+
+  testMatch: /.*\.pw\.tsx/,
 
   snapshotDir: resolve(playwrightDir, "./__snapshots__"),
 
@@ -47,7 +49,6 @@ export default defineConfig({
       },
     },
   },
-  testMatch: /.*\.pw\.tsx/,
 
   projects: [
     {

--- a/src/__internal__/popover-menu/components.test-pw.tsx
+++ b/src/__internal__/popover-menu/components.test-pw.tsx
@@ -1,0 +1,177 @@
+import React, { useState } from "react";
+import {
+  MenuItem,
+  MenuItemDivider,
+  MenuItemHeading,
+  MenuItemLabel,
+  MenuItemLeading,
+  MenuItemSubtext,
+  PopoverMenu,
+} from ".";
+import Icon from "../../components/icon";
+import TextInput from "../../components/textbox/__internal__/__next__";
+
+type Size = "small" | "medium" | "large";
+
+interface PopoverMenuComponentProps {
+  size?: Size;
+  width?: string;
+  withDisabledItems?: boolean;
+  openByDefault?: boolean;
+}
+
+export const PopoverMenuComponent = ({
+  size = "medium",
+  width,
+  withDisabledItems = false,
+  openByDefault = false,
+}: PopoverMenuComponentProps) => {
+  const [open, setOpen] = useState(openByDefault);
+  const [value, setValue] = useState("");
+
+  return (
+    <div style={{ margin: "200px", paddingBottom: "400px" }}>
+      <PopoverMenu<HTMLInputElement>
+        size={size}
+        width={width}
+        open={open}
+        onOpen={() => setOpen(true)}
+        onClose={() => setOpen(false)}
+        popoverControl={(ref, props) => (
+          <TextInput
+            size={size}
+            label="Choose an option"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            ref={ref}
+            {...props}
+            onClick={() => setOpen((p) => !p)}
+          />
+        )}
+      >
+        <MenuItem
+          onClick={() => {
+            setOpen(false);
+            setValue("One");
+          }}
+          selected={value === "One"}
+        >
+          <MenuItemLeading selectedIcon={value === "One"}>
+            <Icon type="home" />
+          </MenuItemLeading>
+          <MenuItemLabel prefix="Item: ">one</MenuItemLabel>
+          <MenuItemSubtext>Subtext for one</MenuItemSubtext>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            setOpen(false);
+            setValue("Two");
+          }}
+          selected={value === "Two"}
+          disabled={withDisabledItems}
+        >
+          <MenuItemLeading selectedIcon={value === "Two"}>
+            <Icon type="home" />
+          </MenuItemLeading>
+          <MenuItemLabel prefix="Item: ">two</MenuItemLabel>
+        </MenuItem>
+        <MenuItemDivider />
+        <MenuItemHeading text="More options">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Three");
+            }}
+            selected={value === "Three"}
+          >
+            <MenuItemLeading selectedIcon={value === "Three"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">three</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Four");
+            }}
+            selected={value === "Four"}
+            disabled={withDisabledItems}
+          >
+            <MenuItemLeading selectedIcon={value === "Four"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">four</MenuItemLabel>
+          </MenuItem>
+        </MenuItemHeading>
+      </PopoverMenu>
+    </div>
+  );
+};
+
+export const PopoverMenuWithPreselection = ({
+  size = "medium",
+}: {
+  size?: Size;
+}) => {
+  const [open, setOpen] = useState(true);
+  const [value, setValue] = useState("Two");
+
+  return (
+    <div style={{ margin: "200px", paddingBottom: "400px" }}>
+      <PopoverMenu<HTMLInputElement>
+        size={size}
+        open={open}
+        onOpen={() => setOpen(true)}
+        onClose={() => setOpen(false)}
+        popoverControl={(ref, props) => (
+          <TextInput
+            size={size}
+            label="Choose an option"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            ref={ref}
+            {...props}
+            onClick={() => setOpen((p) => !p)}
+          />
+        )}
+      >
+        <MenuItem
+          onClick={() => {
+            setOpen(false);
+            setValue("One");
+          }}
+          selected={value === "One"}
+        >
+          <MenuItemLeading selectedIcon={value === "One"}>
+            <Icon type="home" />
+          </MenuItemLeading>
+          <MenuItemLabel prefix="Item: ">one</MenuItemLabel>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            setOpen(false);
+            setValue("Two");
+          }}
+          selected={value === "Two"}
+        >
+          <MenuItemLeading selectedIcon={value === "Two"}>
+            <Icon type="home" />
+          </MenuItemLeading>
+          <MenuItemLabel prefix="Item: ">two</MenuItemLabel>
+        </MenuItem>
+        <MenuItem
+          onClick={() => {
+            setOpen(false);
+            setValue("Three");
+          }}
+          selected={value === "Three"}
+        >
+          <MenuItemLeading selectedIcon={value === "Three"}>
+            <Icon type="home" />
+          </MenuItemLeading>
+          <MenuItemLabel prefix="Item: ">three</MenuItemLabel>
+        </MenuItem>
+      </PopoverMenu>
+    </div>
+  );
+};

--- a/src/__internal__/popover-menu/contexts/index.ts
+++ b/src/__internal__/popover-menu/contexts/index.ts
@@ -1,0 +1,3 @@
+export { PopoverMenuContext } from "./popover-menu.context";
+export type { PopoverMenuContextProps } from "./popover-menu.context";
+export { default as MenuHeadingContext } from "./menu-heading.context";

--- a/src/__internal__/popover-menu/contexts/menu-heading.context.ts
+++ b/src/__internal__/popover-menu/contexts/menu-heading.context.ts
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export default createContext<{ headingId: string } | null>(null);

--- a/src/__internal__/popover-menu/contexts/popover-menu.context.ts
+++ b/src/__internal__/popover-menu/contexts/popover-menu.context.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+
+export interface PopoverMenuContextProps {
+  size: "small" | "medium" | "large";
+}
+
+export const PopoverMenuContext = createContext<PopoverMenuContextProps>({
+  size: "medium",
+});

--- a/src/__internal__/popover-menu/hooks/index.ts
+++ b/src/__internal__/popover-menu/hooks/index.ts
@@ -1,0 +1,5 @@
+export {
+  useHandleDropdownMenuKeyDown,
+  itemQuerySelector,
+  setFocus,
+} from "./useHandleDropdownMenuKeyDown";

--- a/src/__internal__/popover-menu/hooks/useHandleDropdownMenuKeyDown.ts
+++ b/src/__internal__/popover-menu/hooks/useHandleDropdownMenuKeyDown.ts
@@ -1,0 +1,134 @@
+import { useCallback, MutableRefObject } from "react";
+
+export const itemQuerySelector =
+  "li[data-component='popover-menu-item']:not([aria-disabled='true'])";
+
+export const setFocus = (el?: HTMLElement) => {
+  el?.setAttribute("data-has-focus", "true");
+
+  el?.scrollIntoView?.({
+    block: "nearest",
+    inline: "nearest",
+  });
+};
+
+export const useHandleDropdownMenuKeyDown = (
+  ref: MutableRefObject<HTMLUListElement | null>,
+  setAriaActivedescendant: React.Dispatch<React.SetStateAction<string>>,
+) =>
+  useCallback(
+    (ev: React.KeyboardEvent<HTMLElement>) => {
+      const items = Array.from(
+        ref.current?.querySelectorAll(itemQuerySelector) ||
+          /* istanbul ignore next */ [],
+      );
+      const firstItem = items[0] as HTMLElement | undefined;
+      const lastItem = items[items.length - 1] as HTMLElement | undefined;
+      const highlightedItem = items.find(
+        (item) => item.getAttribute("data-has-focus") === "true",
+      ) as HTMLElement | undefined;
+      const selectedItem = items.find(
+        (item) => item.getAttribute("aria-selected") === "true",
+      ) as HTMLElement | undefined;
+
+      if (ev.key === "ArrowDown") {
+        ev.preventDefault();
+
+        if (!highlightedItem) {
+          const itemToFocus = selectedItem ?? firstItem;
+          setAriaActivedescendant(
+            itemToFocus?.id ?? /* istanbul ignore next */ "",
+          );
+          setFocus(itemToFocus);
+
+          return;
+        }
+
+        highlightedItem.setAttribute("data-has-focus", "false");
+
+        if (lastItem === highlightedItem) {
+          setAriaActivedescendant(
+            firstItem?.id ?? /* istanbul ignore next */ "",
+          );
+          setFocus(firstItem);
+
+          return;
+        }
+
+        const currentIndex = items.indexOf(highlightedItem);
+        const itemToFocus = items[(currentIndex + 1) % items.length] as
+          | HTMLElement
+          | undefined;
+        setAriaActivedescendant(
+          itemToFocus?.id ?? /* istanbul ignore next */ "",
+        );
+        setFocus(itemToFocus);
+
+        return;
+      }
+
+      if (ev.key === "ArrowUp") {
+        ev.preventDefault();
+
+        if (!highlightedItem) {
+          const itemToFocus = selectedItem ?? lastItem;
+          setAriaActivedescendant(
+            itemToFocus?.id ?? /* istanbul ignore next */ "",
+          );
+          setFocus(itemToFocus);
+
+          return;
+        }
+
+        highlightedItem.setAttribute("data-has-focus", "false");
+
+        if (firstItem === highlightedItem) {
+          setAriaActivedescendant(
+            lastItem?.id ?? /* istanbul ignore next */ "",
+          );
+          setFocus(lastItem);
+
+          return;
+        }
+
+        const currentIndex = items.indexOf(highlightedItem);
+        const itemToFocus = items[
+          (currentIndex - 1 + items.length) % items.length
+        ] as HTMLElement | undefined;
+        setAriaActivedescendant(
+          itemToFocus?.id ?? /* istanbul ignore next */ "",
+        );
+        setFocus(itemToFocus);
+
+        return;
+      }
+
+      if (ev.key === "Home") {
+        ev.preventDefault();
+        setAriaActivedescendant(firstItem?.id ?? /* istanbul ignore next */ "");
+        highlightedItem?.setAttribute("data-has-focus", "false");
+        setFocus(firstItem);
+
+        return;
+      }
+
+      if (ev.key === "End") {
+        ev.preventDefault();
+        setAriaActivedescendant(lastItem?.id ?? /* istanbul ignore next */ "");
+        highlightedItem?.setAttribute("data-has-focus", "false");
+        setFocus(lastItem);
+
+        return;
+      }
+
+      if (ev.key === "Enter") {
+        /* istanbul ignore else */
+        if (highlightedItem) {
+          ev.preventDefault();
+          ev.stopPropagation();
+          highlightedItem.click();
+        }
+      }
+    },
+    [ref, setAriaActivedescendant],
+  );

--- a/src/__internal__/popover-menu/index.ts
+++ b/src/__internal__/popover-menu/index.ts
@@ -1,0 +1,10 @@
+export { default as PopoverMenu } from "./popover-menu.component";
+export {
+  MenuItem,
+  MenuItemLeading,
+  MenuItemLabel,
+  MenuItemSubtext,
+  MenuItemDivider,
+  MenuItemHeading,
+} from "./menu-item";
+export type { PopoverMenuProps } from "./popover-menu.component";

--- a/src/__internal__/popover-menu/menu-item/index.ts
+++ b/src/__internal__/popover-menu/menu-item/index.ts
@@ -1,0 +1,6 @@
+export { default as MenuItem } from "./menu-item.component";
+export { MenuItemLeading } from "./menu-item-content";
+export { MenuItemLabel } from "./menu-item-content";
+export { MenuItemSubtext } from "./menu-item-content";
+export { default as MenuItemDivider } from "./menu-item-divider";
+export { default as MenuItemHeading } from "./menu-item-heading";

--- a/src/__internal__/popover-menu/menu-item/menu-item-content/index.ts
+++ b/src/__internal__/popover-menu/menu-item/menu-item-content/index.ts
@@ -1,0 +1,3 @@
+export { default as MenuItemLeading } from "./menu-item-leading.component";
+export { default as MenuItemLabel } from "./menu-item-label.component";
+export { default as MenuItemSubtext } from "./menu-item-subtext.component";

--- a/src/__internal__/popover-menu/menu-item/menu-item-content/menu-item-label.component.tsx
+++ b/src/__internal__/popover-menu/menu-item/menu-item-content/menu-item-label.component.tsx
@@ -1,0 +1,47 @@
+import React, { useContext } from "react";
+import styled, { css } from "styled-components";
+import {
+  PopoverMenuContext,
+  type PopoverMenuContextProps,
+} from "../../contexts";
+
+interface StyledMenuItemLabelProps {
+  $size: PopoverMenuContextProps["size"];
+}
+
+const StyledMenuItemLabel = styled.span<StyledMenuItemLabelProps>`
+  grid-column: -2 / -1;
+  grid-row: 1;
+
+  ${({ $size }) => css`
+    span.menu-item-label-prefix {
+      font: var(--global-font-static-comp-medium-${$size.charAt(0)});
+    }
+  `}
+`;
+
+export interface MenuItemLabelProps {
+  children: React.ReactNode;
+  prefix?: string;
+}
+
+const MenuItemLabel = ({ children, prefix }: MenuItemLabelProps) => {
+  const { size } = useContext(PopoverMenuContext);
+  return (
+    <StyledMenuItemLabel data-element="menu-item-label" $size={size}>
+      {prefix && (
+        <span
+          data-element="menu-item-label-prefix"
+          className="menu-item-label-prefix"
+        >
+          {prefix}
+        </span>
+      )}
+      {children}
+    </StyledMenuItemLabel>
+  );
+};
+
+MenuItemLabel.displayName = "PopoverMenuItemLabel";
+
+export default MenuItemLabel;

--- a/src/__internal__/popover-menu/menu-item/menu-item-content/menu-item-leading.component.tsx
+++ b/src/__internal__/popover-menu/menu-item/menu-item-content/menu-item-leading.component.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import styled from "styled-components";
+import Icon from "../../../../components/icon";
+
+const StyledMenuItemLeading = styled.span`
+  display: flex;
+  grid-row: 1;
+
+  [data-component="icon"] {
+    width: 20px;
+    height: 20px;
+  }
+`;
+
+const StyledSelectedIconWrapper = styled.span<{ $hasIcon: boolean }>`
+  ${({ $hasIcon }) => `
+    visibility: ${$hasIcon ? "visible" : "hidden"};
+  `}
+`;
+
+const MenuItemLeading = ({
+  children,
+  selectedIcon = false,
+}: {
+  children: React.ReactNode;
+  selectedIcon?: boolean;
+}) => {
+  return (
+    <StyledMenuItemLeading className="menu-item-leading" data-element="leading">
+      <StyledSelectedIconWrapper
+        data-role="selected-icon-wrapper"
+        $hasIcon={selectedIcon}
+      >
+        <Icon type="tick_thick" data-role="selected-icon" />
+      </StyledSelectedIconWrapper>
+      {children}
+    </StyledMenuItemLeading>
+  );
+};
+
+MenuItemLeading.displayName = "PopoverMenuItemLeading";
+
+export default MenuItemLeading;

--- a/src/__internal__/popover-menu/menu-item/menu-item-content/menu-item-subtext.component.tsx
+++ b/src/__internal__/popover-menu/menu-item/menu-item-content/menu-item-subtext.component.tsx
@@ -1,0 +1,46 @@
+import React, { useContext } from "react";
+import styled, { css } from "styled-components";
+import {
+  PopoverMenuContext,
+  type PopoverMenuContextProps,
+} from "../../contexts";
+
+interface StyledMenuItemSubtextProps {
+  $size: PopoverMenuContextProps["size"];
+}
+
+const StyledMenuItemSubtext = styled.span<StyledMenuItemSubtextProps>`
+  grid-column: -2 / -1;
+  grid-row: 2;
+  color: var(--input-dropdown-label-subtxt);
+
+  ${({ $size }) => css`
+    ${($size === "small" || $size === "medium") &&
+    `
+      font: var(--global-font-static-comp-regular-xs);
+    `}
+
+    ${$size === "large" &&
+    `
+      font: var(--global-font-static-comp-regular-s);
+    `}
+  `}
+`;
+
+const MenuItemSubtext = ({ children }: { children: React.ReactNode }) => {
+  const { size } = useContext(PopoverMenuContext);
+
+  return (
+    <StyledMenuItemSubtext
+      data-element="menu-item-subtext"
+      className="menu-item-subtext"
+      $size={size}
+    >
+      {children}
+    </StyledMenuItemSubtext>
+  );
+};
+
+MenuItemSubtext.displayName = "PopoverMenuItemSubtext";
+
+export default MenuItemSubtext;

--- a/src/__internal__/popover-menu/menu-item/menu-item-divider/index.ts
+++ b/src/__internal__/popover-menu/menu-item/menu-item-divider/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./menu-item-divider.component";

--- a/src/__internal__/popover-menu/menu-item/menu-item-divider/menu-item-divider.component.tsx
+++ b/src/__internal__/popover-menu/menu-item/menu-item-divider/menu-item-divider.component.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import styled from "styled-components";
+import Divider from "../../../../components/divider";
+
+const StyledMenuItemDivider = styled.li`
+  margin: var(--global-space-comp-m);
+
+  hr {
+    background-color: var(--container-standard-border-default);
+    height: var(--global-borderwidth-xs);
+  }
+`;
+
+const MenuItemDivider = () => (
+  <StyledMenuItemDivider
+    data-component="popover-menu-divider"
+    aria-hidden="true"
+  >
+    <Divider m={0} type="horizontal" />
+  </StyledMenuItemDivider>
+);
+
+MenuItemDivider.displayName = "PopoverMenuItemDivider";
+
+export default MenuItemDivider;

--- a/src/__internal__/popover-menu/menu-item/menu-item-heading/index.ts
+++ b/src/__internal__/popover-menu/menu-item/menu-item-heading/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./menu-item-heading.component";

--- a/src/__internal__/popover-menu/menu-item/menu-item-heading/menu-item-heading.component.tsx
+++ b/src/__internal__/popover-menu/menu-item/menu-item-heading/menu-item-heading.component.tsx
@@ -1,0 +1,57 @@
+import React, { useContext, useRef } from "react";
+import styled from "styled-components";
+import { PopoverMenuContext, MenuHeadingContext } from "../../contexts";
+import guid from "../../../utils/helpers/guid";
+
+const StyledMenuHeading = styled.li<{ $size: string }>`
+  div[data-element="text"] {
+    ${({ $size }) => {
+      const fontSize = $size.charAt(0);
+      return `
+        padding: 0 var(--global-space-comp-m);
+        font: var(--global-font-static-comp-medium-${fontSize});
+        margin-left: calc(var(--global-space-comp-m) - 2px);
+      `;
+    }}
+    color: var(--input-dropdown-label-alt);
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    overflow: hidden;
+  }
+`;
+
+const MenuItemHeading = ({
+  children,
+  text,
+}: {
+  children: React.ReactNode;
+  text: string;
+}) => {
+  const { size } = useContext(PopoverMenuContext);
+  const headingId = useRef(`popover-menu-heading-${guid()}`);
+
+  return (
+    <StyledMenuHeading
+      data-component="popover-menu-item-heading"
+      $size={size}
+      role="option"
+    >
+      <div data-element="text" id={headingId.current}>
+        {text}
+      </div>
+      <MenuHeadingContext.Provider value={{ headingId: headingId.current }}>
+        <ul role="listbox" aria-label={text}>
+          {children}
+        </ul>
+      </MenuHeadingContext.Provider>
+    </StyledMenuHeading>
+  );
+};
+
+MenuItemHeading.displayName = "PopoverMenuItemHeading";
+
+export default MenuItemHeading;

--- a/src/__internal__/popover-menu/menu-item/menu-item.component.tsx
+++ b/src/__internal__/popover-menu/menu-item/menu-item.component.tsx
@@ -1,0 +1,142 @@
+import React, { useContext, useRef } from "react";
+import styled, { css } from "styled-components";
+import {
+  PopoverMenuContext,
+  type PopoverMenuContextProps,
+  MenuHeadingContext,
+} from "../contexts";
+import guid from "../../utils/helpers/guid";
+
+export interface MenuItemProps {
+  children: React.ReactNode;
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+  selected?: boolean;
+  disabled?: boolean;
+  id?: string;
+}
+
+interface StyledMenuItemProps {
+  $size?: PopoverMenuContextProps["size"];
+  $disabled?: boolean;
+}
+
+const StyledMenuItem = styled.li<StyledMenuItemProps>`
+  width: 100%;
+  position: relative;
+  box-sizing: border-box;
+
+  &:not(:has(button)):not(:has(a)) {
+    ${({ $disabled }) =>
+      $disabled
+        ? `
+          * {
+          color: var(--input-dropdown-label-disabled);
+          }
+          cursor: not-allowed;
+        `
+        : `
+          color: var(--input-dropdown-label-alt);
+          cursor: pointer;
+
+          :hover {
+            * {
+              color: var(--input-dropdown-label-hover);
+            }
+            background-color: var(--input-dropdown-bg-hover);
+          }
+      `}
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    column-gap: var(--global-space-comp-xs);
+
+    &:not(:has(.menu-item-leading)) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  &[data-has-focus="true"] {
+    outline: var(--focus-borderalt) solid var(--global-borderwidth-s);
+    outline-offset: calc(var(--global-borderwidth-s) * -1);
+  }
+
+  ${({ $size }) => css`
+    ${$size === "small" &&
+    `
+      padding: var(--global-space-comp-xs) 0;
+
+      &:not(:has(.menu-item-subtext)) {
+        min-height: var(--global-size-s);
+      }
+      
+      *:not(.menu-item-subtext):not(.menu-item-label-prefix) {
+        font: var(--global-font-static-comp-regular-s);
+      }
+    `}
+
+    ${$size === "medium" &&
+    `
+      padding: var(--global-space-comp-s) 0;
+
+      &:not(:has(.menu-item-subtext)) {
+        min-height: var(--global-size-m);
+      }
+
+      *:not(.menu-item-subtext):not(.menu-item-label-prefix) {
+        font: var(--global-font-static-comp-regular-m);
+      }
+    `}
+  
+    ${$size === "large" &&
+    `
+      padding: var(--global-space-comp-m) 0;
+
+      &:not(:has(.menu-item-subtext)) {
+        min-height: var(--global-size-l);
+      }
+
+      *:not(.menu-item-subtext):not(.menu-item-label-prefix) {
+        font: var(--global-font-static-comp-regular-l);
+      }
+    `}
+  `}
+`;
+
+const MenuItem = ({
+  children,
+  onClick,
+  selected,
+  disabled,
+  id,
+  ...rest
+}: MenuItemProps) => {
+  const ref = useRef<HTMLLIElement | null>(null);
+  const { size } = useContext<PopoverMenuContextProps>(PopoverMenuContext);
+  const itemId = useRef(id ?? `popover-menu-item-${guid()}`).current;
+  const context = useContext(MenuHeadingContext);
+  const headingId = context?.headingId;
+
+  return (
+    <StyledMenuItem
+      ref={ref}
+      data-component="popover-menu-item"
+      className={`popover-menu-item${disabled ? "-disabled" : ""}`}
+      $size={size}
+      onClick={!disabled ? onClick : undefined}
+      onMouseDown={!disabled ? (ev) => ev.preventDefault() : undefined}
+      role="option"
+      aria-selected={selected && !disabled}
+      aria-disabled={disabled}
+      $disabled={disabled}
+      id={itemId}
+      {...rest}
+      aria-describedby={headingId}
+    >
+      {children}
+    </StyledMenuItem>
+  );
+};
+
+MenuItem.displayName = "PopoverMenuItem";
+
+export default MenuItem;

--- a/src/__internal__/popover-menu/menu-item/menu-item.test.tsx
+++ b/src/__internal__/popover-menu/menu-item/menu-item.test.tsx
@@ -1,0 +1,172 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import MenuItem from "./menu-item.component";
+import MenuItemLeading from "./menu-item-content/menu-item-leading.component";
+import MenuItemLabel from "./menu-item-content/menu-item-label.component";
+import MenuItemSubtext from "./menu-item-content/menu-item-subtext.component";
+import { PopoverMenuContext } from "../contexts";
+import Icon from "../../../components/icon";
+
+test("renders with data-component attribute", () => {
+  render(
+    <ul>
+      <MenuItem>Menu item</MenuItem>
+    </ul>,
+  );
+
+  expect(screen.getByRole("option")).toHaveAttribute(
+    "data-component",
+    "popover-menu-item",
+  );
+});
+
+test("renders with popover-menu-item class name", () => {
+  render(
+    <ul>
+      <MenuItem>Menu item</MenuItem>
+    </ul>,
+  );
+
+  expect(screen.getByRole("option")).toHaveClass("popover-menu-item");
+});
+
+test("renders with popover-menu-item-disabled class name", () => {
+  render(
+    <ul>
+      <MenuItem disabled>Menu item</MenuItem>
+    </ul>,
+  );
+
+  expect(screen.getByRole("option")).toHaveClass("popover-menu-item-disabled");
+});
+
+test("does not set aria-selected to false by default", () => {
+  render(
+    <ul>
+      <MenuItem>Menu item</MenuItem>
+    </ul>,
+  );
+
+  expect(screen.getByRole("option")).not.toHaveAttribute(
+    "aria-selected",
+    "false",
+  );
+});
+
+test("sets aria-selected to false when selected is false", () => {
+  render(
+    <ul>
+      <MenuItem selected={false}>Menu item</MenuItem>
+    </ul>,
+  );
+
+  expect(screen.getByRole("option")).toHaveAttribute("aria-selected", "false");
+});
+
+test("sets aria-selected to true when selected is true", () => {
+  render(
+    <ul>
+      <MenuItem selected>Menu item</MenuItem>
+    </ul>,
+  );
+
+  expect(screen.getByRole("option")).toHaveAttribute("aria-selected", "true");
+});
+
+test("does not set aria-selected to true when selected and disabled are true", () => {
+  render(
+    <ul>
+      <MenuItem selected disabled>
+        Menu item
+      </MenuItem>
+    </ul>,
+  );
+
+  const option = screen.getByRole("option");
+
+  expect(option).toHaveAttribute("aria-selected", "false");
+  expect(option).toHaveAttribute("aria-disabled", "true");
+});
+
+test("calls onClick when clicked", async () => {
+  const onClick = jest.fn();
+  const user = userEvent.setup();
+  render(
+    <ul>
+      <MenuItem onClick={onClick}>Menu item</MenuItem>
+    </ul>,
+  );
+
+  await user.click(screen.getByRole("option"));
+
+  expect(onClick).toHaveBeenCalledTimes(1);
+});
+
+test.each(["small", "medium", "large"] as const)(
+  "renders with size %s from context",
+  (size) => {
+    render(
+      <PopoverMenuContext.Provider value={{ size }}>
+        <ul>
+          <MenuItem>Menu item</MenuItem>
+        </ul>
+      </PopoverMenuContext.Provider>,
+    );
+
+    const item = screen.getByRole("option");
+
+    expect(item).toHaveStyleRule(
+      "min-height",
+      `var(--global-size-${size[0]})`,
+      { modifier: ":not(:has(.menu-item-subtext))" },
+    );
+    expect(item).toHaveStyleRule(
+      "font",
+      `var(--global-font-static-comp-regular-${size[0]})`,
+      { modifier: `*:not(.menu-item-subtext):not(.menu-item-label-prefix)` },
+    );
+  },
+);
+
+test("should render the selected icon when selectedIcon on MenuItemLeading is true", () => {
+  render(
+    <PopoverMenuContext.Provider value={{ size: "medium" }}>
+      <ul>
+        <MenuItem>
+          <MenuItemLeading selectedIcon>
+            <Icon type="home" />
+          </MenuItemLeading>
+          <MenuItemLabel>Menu item</MenuItemLabel>
+          <MenuItemSubtext>Subtext</MenuItemSubtext>
+        </MenuItem>
+      </ul>
+    </PopoverMenuContext.Provider>,
+  );
+
+  expect(screen.getByTestId("selected-icon")).toBeVisible();
+  expect(screen.getByTestId("selected-icon-wrapper")).toHaveStyle(
+    "visibility: visible",
+  );
+});
+
+test("should not render the selected icon when selectedIcon on MenuItemLeading is false", () => {
+  render(
+    <PopoverMenuContext.Provider value={{ size: "medium" }}>
+      <ul>
+        <MenuItem>
+          <MenuItemLeading selectedIcon={false}>
+            <Icon type="home" />
+          </MenuItemLeading>
+          <MenuItemLabel>Menu item</MenuItemLabel>
+          <MenuItemSubtext>Subtext</MenuItemSubtext>
+        </MenuItem>
+      </ul>
+    </PopoverMenuContext.Provider>,
+  );
+
+  expect(screen.queryByTestId("selected-icon")).not.toBeVisible();
+  expect(screen.getByTestId("selected-icon-wrapper")).toHaveStyle(
+    "visibility: hidden",
+  );
+});

--- a/src/__internal__/popover-menu/popover-menu-interaction.stories.tsx
+++ b/src/__internal__/popover-menu/popover-menu-interaction.stories.tsx
@@ -1,0 +1,265 @@
+import React from "react";
+import { StoryObj } from "@storybook/react-vite";
+import { userEvent, within, expect, waitFor } from "storybook/test";
+import {
+  MenuItem,
+  MenuItemDivider,
+  MenuItemHeading,
+  MenuItemLabel,
+  MenuItemLeading,
+  MenuItemSubtext,
+  PopoverMenu,
+  PopoverMenuProps,
+} from ".";
+import Icon from "../../components/icon";
+import TextInput from "../../components/textbox/__internal__/__next__";
+import { allowInteractions } from "../../../.storybook/interaction-toggle/reduced-motion";
+
+export default {
+  title: "Popover Menu/Interactions",
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
+  },
+};
+
+const items = [
+  "Alpha",
+  "Beta",
+  "Gamma",
+  "Delta",
+  "Epsilon",
+  "Zeta",
+  "Eta",
+  "Theta",
+];
+
+type Size = NonNullable<PopoverMenuProps["size"]>;
+type Width = NonNullable<PopoverMenuProps["width"]>;
+
+const PopoverMenuWithState = ({
+  size,
+  hasDisabledItem,
+  hasSelection,
+  width,
+}: {
+  size: Size;
+  hasDisabledItem?: boolean;
+  hasSelection?: boolean;
+  width?: Width;
+}) => {
+  const [open, setOpen] = React.useState(false);
+  const [value, setValue] = React.useState(hasSelection ? "Delta" : "");
+
+  return (
+    <div style={{ margin: "220px" }}>
+      <PopoverMenu<HTMLInputElement>
+        size={size}
+        width={width}
+        open={open}
+        onOpen={() => setOpen(true)}
+        onClose={() => setOpen(false)}
+        popoverControl={(ref, props) => (
+          <TextInput
+            size={size}
+            label={size}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            ref={ref}
+            {...props}
+            onClick={() => setOpen((p) => !p)}
+          />
+        )}
+      >
+        {items.map((item, i) => (
+          <MenuItem
+            key={item}
+            onClick={() => {
+              setOpen(false);
+              setValue(item);
+            }}
+            selected={value === item}
+            disabled={hasDisabledItem && item === "Gamma"}
+          >
+            <MenuItemLeading selectedIcon={value === item}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix={`${i + 1}: `}>{item}</MenuItemLabel>
+            {i % 3 === 0 && <MenuItemSubtext>Subtext</MenuItemSubtext>}
+          </MenuItem>
+        ))}
+        <MenuItemDivider />
+        <MenuItemHeading text="More options">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Extra");
+            }}
+            selected={value === "Extra"}
+          >
+            <MenuItemLeading selectedIcon={value === "Extra"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel>Extra</MenuItemLabel>
+          </MenuItem>
+        </MenuItemHeading>
+      </PopoverMenu>
+    </div>
+  );
+};
+
+type Story = StoryObj<typeof PopoverMenuWithState>;
+
+const storyParams = {
+  chromatic: { disableSnapshot: false },
+};
+
+const decorator = (StoryToRender: React.ComponentType): React.ReactElement => (
+  <div style={{ height: "100vh", width: "100vw" }}>
+    <StoryToRender />
+  </div>
+);
+
+const playKeyboardDown = async ({
+  canvasElement,
+}: {
+  canvasElement: HTMLElement;
+}) => {
+  if (!allowInteractions()) return;
+
+  const canvas = within(canvasElement);
+  const input = canvas.getByRole("combobox");
+  await userEvent.click(input);
+  const listboxes = await within(document.body).findAllByRole("listbox");
+  await expect(listboxes[0]).toBeVisible();
+
+  for (let i = 0; i < 11; i++) {
+    await userEvent.keyboard("{ArrowDown}");
+  }
+
+  await waitFor(() => {
+    const allOptions = within(document.body).getAllByRole("option");
+
+    // Loop from first, Gamma disabled so skipped, land on Delta
+    expect(allOptions[3]).toHaveAttribute("data-has-focus", "true");
+    expect(allOptions[2]).not.toHaveAttribute("data-has-focus", "true");
+  });
+};
+
+const playKeyboardUp = async ({
+  canvasElement,
+}: {
+  canvasElement: HTMLElement;
+}) => {
+  if (!allowInteractions()) return;
+
+  const canvas = within(canvasElement);
+  const input = canvas.getByRole("combobox");
+  await userEvent.click(input);
+  const listboxes = await within(document.body).findAllByRole("listbox");
+  await expect(listboxes[0]).toBeVisible();
+
+  for (let i = 10; i > 0; i--) {
+    await userEvent.keyboard("{ArrowUp}");
+  }
+
+  await waitFor(() => {
+    const allOptions = within(document.body).getAllByRole("option");
+
+    // Loop from last, Gamma disabled so skipped, land on Theta
+    expect(allOptions[7]).toHaveAttribute("data-has-focus", "true");
+    expect(allOptions[2]).not.toHaveAttribute("data-has-focus", "true");
+  });
+};
+
+const playSelectedItemFocused = async ({
+  canvasElement,
+}: {
+  canvasElement: HTMLElement;
+}) => {
+  if (!allowInteractions()) return;
+
+  const canvas = within(canvasElement);
+  const input = canvas.getByRole("combobox") as HTMLInputElement;
+  await userEvent.click(input);
+
+  const listboxes = await within(document.body).findAllByRole("listbox");
+  await expect(listboxes[0]).toBeVisible();
+
+  await userEvent.keyboard("{ArrowUp}");
+
+  await waitFor(() => {
+    const options = within(document.body).getAllByRole("option");
+    // Delta is pre-selected it should receive virtual focus
+    expect(options[3]).toHaveAttribute("data-has-focus", "true");
+  });
+};
+
+export const SmallKeyboardDown: Story = {
+  render: () => <PopoverMenuWithState size="small" hasDisabledItem />,
+  play: playKeyboardDown,
+  decorators: [(StoryToRender) => decorator(StoryToRender)],
+};
+SmallKeyboardDown.storyName =
+  "small — navigation arrow down skips disabled item";
+SmallKeyboardDown.parameters = storyParams;
+
+export const MediumKeyboardDown: Story = {
+  render: () => <PopoverMenuWithState size="medium" hasDisabledItem />,
+  play: playKeyboardDown,
+  decorators: [(StoryToRender) => decorator(StoryToRender)],
+};
+MediumKeyboardDown.storyName =
+  "medium — navigation arrow down skips disabled item";
+MediumKeyboardDown.parameters = storyParams;
+
+export const LargeKeyboardDown: Story = {
+  render: () => <PopoverMenuWithState size="large" hasDisabledItem />,
+  play: playKeyboardDown,
+  decorators: [(StoryToRender) => decorator(StoryToRender)],
+};
+LargeKeyboardDown.storyName =
+  "large — navigation arrow down skips disabled item";
+LargeKeyboardDown.parameters = storyParams;
+
+export const SmallKeyboardUp: Story = {
+  render: () => <PopoverMenuWithState size="small" hasDisabledItem />,
+  play: playKeyboardUp,
+  decorators: [(StoryToRender) => decorator(StoryToRender)],
+};
+SmallKeyboardUp.storyName = "small — navigation arrow up skips disabled item";
+SmallKeyboardUp.parameters = storyParams;
+
+export const MediumKeyboardUp: Story = {
+  render: () => <PopoverMenuWithState size="medium" hasDisabledItem />,
+  play: playKeyboardUp,
+  decorators: [(StoryToRender) => decorator(StoryToRender)],
+};
+MediumKeyboardUp.storyName = "medium — navigation arrow up skips disabled item";
+MediumKeyboardUp.parameters = storyParams;
+
+export const LargeKeyboardUp: Story = {
+  render: () => <PopoverMenuWithState size="large" hasDisabledItem />,
+  play: playKeyboardUp,
+  decorators: [(StoryToRender) => decorator(StoryToRender)],
+};
+LargeKeyboardUp.storyName = "large — navigation arrow up skips disabled item";
+LargeKeyboardUp.parameters = storyParams;
+
+export const CustomWidth: Story = {
+  render: () => (
+    <PopoverMenuWithState size="medium" width="400px" hasDisabledItem />
+  ),
+  play: playKeyboardDown,
+  decorators: [(StoryToRender) => decorator(StoryToRender)],
+};
+CustomWidth.storyName = "custom width with middle item highlighted";
+CustomWidth.parameters = storyParams;
+
+export const SelectedItemFocusedWithIcon: Story = {
+  render: () => <PopoverMenuWithState size="medium" hasSelection />,
+  play: playSelectedItemFocused,
+  decorators: [(StoryToRender) => decorator(StoryToRender)],
+};
+SelectedItemFocusedWithIcon.storyName =
+  "enter with pre-selected item — focuses selected item with icon";
+SelectedItemFocusedWithIcon.parameters = storyParams;

--- a/src/__internal__/popover-menu/popover-menu-test.stories.tsx
+++ b/src/__internal__/popover-menu/popover-menu-test.stories.tsx
@@ -1,0 +1,1267 @@
+import React from "react";
+import {
+  MenuItem,
+  MenuItemDivider,
+  PopoverMenu,
+  MenuItemHeading,
+  MenuItemLabel,
+  MenuItemLeading,
+  MenuItemSubtext,
+} from ".";
+import Icon from "../../components/icon";
+
+import TextInput from "../../components/textbox/__internal__/__next__";
+
+export default {
+  title: "Popover Menu/Test",
+  includeStories: [
+    "Small",
+    "SmallWithDisabledItems",
+    "SmallWithCustomWidth",
+    "Medium",
+    "MediumWithDisabledItems",
+    "MediumWithCustomWidth",
+    "Large",
+    "LargeWithDisabledItems",
+    "LargeWithCustomWidth",
+    "HoverItem",
+  ],
+  parameters: {
+    info: { disable: true },
+    chromatic: {
+      disableSnapshot: true,
+    },
+  },
+};
+
+export const Small = () => {
+  const [open, setOpen] = React.useState<boolean>(false);
+  const [value, setValue] = React.useState<string>("");
+  return (
+    <div style={{ display: "flex", gap: "24px", margin: "180px" }}>
+      <PopoverMenu<HTMLInputElement>
+        size="small"
+        open={open}
+        onOpen={() => {
+          setOpen(true);
+        }}
+        onClose={() => {
+          if (open) {
+            setOpen(false);
+          }
+        }}
+        popoverControl={(ref, props) => (
+          <TextInput
+            size="small"
+            label="small"
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Tab" && open) {
+                setOpen(false);
+                return;
+              }
+
+              if ((e.key === "Enter" || e.key === "ArrowDown") && !open) {
+                setOpen(true);
+              }
+            }}
+            onClick={() => {
+              if (!open) {
+                setOpen(true);
+              }
+            }}
+            ref={ref}
+            {...props}
+          />
+        )}
+      >
+        <MenuItemHeading text="Heading">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("One");
+            }}
+            selected={value === "One"}
+          >
+            <MenuItemLeading selectedIcon={value === "One"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">one</MenuItemLabel>
+            <MenuItemSubtext>Subtext</MenuItemSubtext>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Two");
+            }}
+            selected={value === "Two"}
+          >
+            <MenuItemLeading selectedIcon={value === "Two"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">two</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Three");
+            }}
+            selected={value === "Three"}
+          >
+            <MenuItemLeading selectedIcon={value === "Three"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">three</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Four");
+            }}
+            selected={value === "Four"}
+          >
+            <MenuItemLeading selectedIcon={value === "Four"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">four</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Five");
+            }}
+            selected={value === "Five"}
+          >
+            <MenuItemLeading selectedIcon={value === "Five"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">five</MenuItemLabel>
+          </MenuItem>
+        </MenuItemHeading>
+      </PopoverMenu>
+    </div>
+  );
+};
+
+Small.storyName = "small";
+
+export const SmallWithDisabledItems = () => {
+  const [open, setOpen] = React.useState<boolean>(false);
+  const [value, setValue] = React.useState<string>("");
+  return (
+    <div style={{ display: "flex", gap: "24px", margin: "180px" }}>
+      <PopoverMenu<HTMLInputElement>
+        size="small"
+        open={open}
+        onOpen={() => {
+          setOpen(true);
+        }}
+        onClose={() => {
+          if (open) {
+            setOpen(false);
+          }
+        }}
+        popoverControl={(ref, props) => (
+          <TextInput
+            size="small"
+            label="small"
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Tab" && open) {
+                setOpen(false);
+                return;
+              }
+
+              if ((e.key === "Enter" || e.key === "ArrowDown") && !open) {
+                setOpen(true);
+              }
+            }}
+            onClick={() => {
+              if (!open) {
+                setOpen(true);
+              }
+            }}
+            ref={ref}
+            {...props}
+          />
+        )}
+      >
+        <MenuItemHeading text="Heading">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("One");
+            }}
+            selected={value === "One"}
+            disabled
+          >
+            <MenuItemLeading>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">one</MenuItemLabel>
+            <MenuItemSubtext>Subtext</MenuItemSubtext>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Two");
+            }}
+            selected={value === "Two"}
+          >
+            <MenuItemLeading selectedIcon={value === "Two"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">two</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Three");
+            }}
+            selected={value === "Three"}
+          >
+            <MenuItemLeading selectedIcon={value === "Three"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">three</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Four");
+            }}
+            selected={value === "Four"}
+          >
+            <MenuItemLeading selectedIcon={value === "Four"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">four</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Five");
+            }}
+            selected={value === "Five"}
+          >
+            <MenuItemLeading selectedIcon={value === "Five"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">five</MenuItemLabel>
+          </MenuItem>
+        </MenuItemHeading>
+        <MenuItemDivider />
+        <MenuItemHeading text="Heading">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Six");
+            }}
+            disabled
+          >
+            <MenuItemLeading>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">six</MenuItemLabel>
+            <MenuItemSubtext>Subtext</MenuItemSubtext>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Seven");
+            }}
+            selected={value === "Seven"}
+          >
+            <MenuItemLeading selectedIcon={value === "Seven"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">seven</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Eight");
+            }}
+            selected={value === "Eight"}
+          >
+            <MenuItemLeading selectedIcon={value === "Eight"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">eight</MenuItemLabel>
+          </MenuItem>
+        </MenuItemHeading>
+      </PopoverMenu>
+    </div>
+  );
+};
+
+SmallWithDisabledItems.storyName = "small with disabled items";
+
+export const SmallWithCustomWidth = () => {
+  const [open, setOpen] = React.useState<boolean>(false);
+  const [value, setValue] = React.useState<string>("");
+  return (
+    <div style={{ display: "flex", gap: "24px", margin: "180px" }}>
+      <PopoverMenu<HTMLInputElement>
+        width="300px"
+        size="small"
+        open={open}
+        onOpen={() => {
+          setOpen(true);
+        }}
+        onClose={() => {
+          if (open) {
+            setOpen(false);
+          }
+        }}
+        popoverControl={(ref, props) => (
+          <TextInput
+            size="small"
+            label="small"
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Tab" && open) {
+                setOpen(false);
+                return;
+              }
+
+              if ((e.key === "Enter" || e.key === "ArrowDown") && !open) {
+                setOpen(true);
+              }
+            }}
+            onClick={() => {
+              if (!open) {
+                setOpen(true);
+              }
+            }}
+            ref={ref}
+            {...props}
+          />
+        )}
+      >
+        <MenuItemHeading text="Heading">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("One");
+            }}
+            selected={value === "One"}
+          >
+            <MenuItemLeading selectedIcon={value === "One"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">one</MenuItemLabel>
+            <MenuItemSubtext>Subtext</MenuItemSubtext>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Two");
+            }}
+            selected={value === "Two"}
+          >
+            <MenuItemLeading selectedIcon={value === "Two"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">two</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Three");
+            }}
+            selected={value === "Three"}
+          >
+            <MenuItemLeading selectedIcon={value === "Three"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">three</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Four");
+            }}
+            selected={value === "Four"}
+          >
+            <MenuItemLeading selectedIcon={value === "Four"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">four</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Five");
+            }}
+            selected={value === "Five"}
+          >
+            <MenuItemLeading selectedIcon={value === "Five"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">five</MenuItemLabel>
+          </MenuItem>
+        </MenuItemHeading>
+      </PopoverMenu>
+    </div>
+  );
+};
+
+SmallWithCustomWidth.storyName = "small with custom width";
+
+export const Medium = () => {
+  const [open, setOpen] = React.useState<boolean>(false);
+  const [value, setValue] = React.useState<string>("");
+  return (
+    <div style={{ display: "flex", gap: "24px", margin: "210px 180px 180px" }}>
+      <PopoverMenu<HTMLInputElement>
+        size="medium"
+        open={open}
+        onOpen={() => {
+          setOpen(true);
+        }}
+        onClose={() => {
+          if (open) {
+            setOpen(false);
+          }
+        }}
+        popoverControl={(ref, props) => (
+          <TextInput
+            size="medium"
+            label="medium"
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Tab" && open) {
+                setOpen(false);
+                return;
+              }
+
+              if ((e.key === "Enter" || e.key === "ArrowDown") && !open) {
+                setOpen(true);
+              }
+            }}
+            onClick={() => {
+              if (!open) {
+                setOpen(true);
+              }
+            }}
+            ref={ref}
+            {...props}
+          />
+        )}
+      >
+        <MenuItemHeading text="Heading">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("One");
+            }}
+            selected={value === "One"}
+          >
+            <MenuItemLeading selectedIcon={value === "One"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">one</MenuItemLabel>
+            <MenuItemSubtext>Subtext</MenuItemSubtext>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Two");
+            }}
+            selected={value === "Two"}
+          >
+            <MenuItemLeading selectedIcon={value === "Two"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">two</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Three");
+            }}
+            selected={value === "Three"}
+          >
+            <MenuItemLeading selectedIcon={value === "Three"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">three</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Four");
+            }}
+            selected={value === "Four"}
+          >
+            <MenuItemLeading selectedIcon={value === "Four"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">four</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Five");
+            }}
+            selected={value === "Five"}
+          >
+            <MenuItemLeading selectedIcon={value === "Five"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">five</MenuItemLabel>
+          </MenuItem>
+        </MenuItemHeading>
+      </PopoverMenu>
+    </div>
+  );
+};
+
+Medium.storyName = "medium";
+
+export const MediumWithDisabledItems = () => {
+  const [open, setOpen] = React.useState<boolean>(false);
+  const [value, setValue] = React.useState<string>("");
+  return (
+    <div style={{ display: "flex", gap: "24px", margin: "250px 180px 180px" }}>
+      <PopoverMenu<HTMLInputElement>
+        size="medium"
+        open={open}
+        onOpen={() => {
+          setOpen(true);
+        }}
+        onClose={() => {
+          if (open) {
+            setOpen(false);
+          }
+        }}
+        popoverControl={(ref, props) => (
+          <TextInput
+            size="medium"
+            label="medium"
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Tab" && open) {
+                setOpen(false);
+                return;
+              }
+
+              if ((e.key === "Enter" || e.key === "ArrowDown") && !open) {
+                setOpen(true);
+              }
+            }}
+            onClick={() => {
+              if (!open) {
+                setOpen(true);
+              }
+            }}
+            ref={ref}
+            {...props}
+          />
+        )}
+      >
+        <MenuItemHeading text="Heading">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("One");
+            }}
+            selected={value === "One"}
+            disabled
+          >
+            <MenuItemLeading>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">one</MenuItemLabel>
+            <MenuItemSubtext>Subtext</MenuItemSubtext>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Two");
+            }}
+            selected={value === "Two"}
+          >
+            <MenuItemLeading selectedIcon={value === "Two"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">two</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Three");
+            }}
+            selected={value === "Three"}
+          >
+            <MenuItemLeading selectedIcon={value === "Three"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">three</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Four");
+            }}
+            selected={value === "Four"}
+          >
+            <MenuItemLeading selectedIcon={value === "Four"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">four</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Five");
+            }}
+            selected={value === "Five"}
+          >
+            <MenuItemLeading selectedIcon={value === "Five"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">five</MenuItemLabel>
+          </MenuItem>
+        </MenuItemHeading>
+        <MenuItemDivider />
+        <MenuItemHeading text="Heading">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Six");
+            }}
+            disabled
+          >
+            <MenuItemLeading>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">six</MenuItemLabel>
+            <MenuItemSubtext>Subtext</MenuItemSubtext>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Seven");
+            }}
+            selected={value === "Seven"}
+          >
+            <MenuItemLeading selectedIcon={value === "Seven"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">seven</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Eight");
+            }}
+            selected={value === "Eight"}
+          >
+            <MenuItemLeading selectedIcon={value === "Eight"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">eight</MenuItemLabel>
+          </MenuItem>
+        </MenuItemHeading>
+      </PopoverMenu>
+    </div>
+  );
+};
+
+MediumWithDisabledItems.storyName = "medium with disabled items";
+
+export const MediumWithCustomWidth = () => {
+  const [open, setOpen] = React.useState<boolean>(false);
+  const [value, setValue] = React.useState<string>("");
+  return (
+    <div style={{ display: "flex", gap: "24px", margin: "210px 180px 180px" }}>
+      <PopoverMenu<HTMLInputElement>
+        width="300px"
+        size="medium"
+        open={open}
+        onOpen={() => {
+          setOpen(true);
+        }}
+        onClose={() => {
+          if (open) {
+            setOpen(false);
+          }
+        }}
+        popoverControl={(ref, props) => (
+          <TextInput
+            size="medium"
+            label="medium"
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Tab" && open) {
+                setOpen(false);
+                return;
+              }
+
+              if ((e.key === "Enter" || e.key === "ArrowDown") && !open) {
+                setOpen(true);
+              }
+            }}
+            onClick={() => {
+              if (!open) {
+                setOpen(true);
+              }
+            }}
+            ref={ref}
+            {...props}
+          />
+        )}
+      >
+        <MenuItemHeading text="Heading">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("One");
+            }}
+            selected={value === "One"}
+          >
+            <MenuItemLeading selectedIcon={value === "One"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">one</MenuItemLabel>
+            <MenuItemSubtext>Subtext</MenuItemSubtext>
+          </MenuItem>
+        </MenuItemHeading>
+        <MenuItemDivider />
+        <MenuItemHeading text="Heading">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Two");
+            }}
+            selected={value === "Two"}
+          >
+            <MenuItemLeading selectedIcon={value === "Two"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">two</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Three");
+            }}
+            selected={value === "Three"}
+          >
+            <MenuItemLeading selectedIcon={value === "Three"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">three</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Four");
+            }}
+            selected={value === "Four"}
+          >
+            <MenuItemLeading selectedIcon={value === "Four"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">four</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Five");
+            }}
+            selected={value === "Five"}
+          >
+            <MenuItemLeading selectedIcon={value === "Five"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">five</MenuItemLabel>
+          </MenuItem>
+        </MenuItemHeading>
+      </PopoverMenu>
+    </div>
+  );
+};
+
+MediumWithCustomWidth.storyName = "medium with custom width";
+
+export const Large = () => {
+  const [open, setOpen] = React.useState<boolean>(false);
+  const [value, setValue] = React.useState<string>("");
+  return (
+    <div style={{ display: "flex", gap: "24px", margin: "250px 180px 180px" }}>
+      <PopoverMenu<HTMLInputElement>
+        size="large"
+        open={open}
+        onOpen={() => {
+          setOpen(true);
+        }}
+        onClose={() => {
+          if (open) {
+            setOpen(false);
+          }
+        }}
+        popoverControl={(ref, props) => (
+          <TextInput
+            size="large"
+            label="large"
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Tab" && open) {
+                setOpen(false);
+                return;
+              }
+
+              if ((e.key === "Enter" || e.key === "ArrowDown") && !open) {
+                setOpen(true);
+              }
+            }}
+            onClick={() => {
+              if (!open) {
+                setOpen(true);
+              }
+            }}
+            ref={ref}
+            {...props}
+          />
+        )}
+      >
+        <MenuItemHeading text="Heading">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("One");
+            }}
+            selected={value === "One"}
+          >
+            <MenuItemLeading selectedIcon={value === "One"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">one</MenuItemLabel>
+            <MenuItemSubtext>Subtext</MenuItemSubtext>
+          </MenuItem>
+        </MenuItemHeading>
+        <MenuItemDivider />
+        <MenuItemHeading text="Heading">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Two");
+            }}
+            selected={value === "Two"}
+          >
+            <MenuItemLeading selectedIcon={value === "Two"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">two</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Three");
+            }}
+            selected={value === "Three"}
+          >
+            <MenuItemLeading selectedIcon={value === "Three"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">three</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Four");
+            }}
+            selected={value === "Four"}
+          >
+            <MenuItemLeading selectedIcon={value === "Four"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">four</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Five");
+            }}
+            selected={value === "Five"}
+          >
+            <MenuItemLeading selectedIcon={value === "Five"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">five</MenuItemLabel>
+          </MenuItem>
+        </MenuItemHeading>
+      </PopoverMenu>
+    </div>
+  );
+};
+
+Large.storyName = "large";
+
+export const LargeWithDisabledItems = () => {
+  const [open, setOpen] = React.useState<boolean>(false);
+  const [value, setValue] = React.useState<string>("");
+  return (
+    <div style={{ display: "flex", gap: "24px", margin: "250px 180px 180px" }}>
+      <PopoverMenu<HTMLInputElement>
+        size="large"
+        open={open}
+        onOpen={() => {
+          setOpen(true);
+        }}
+        onClose={() => {
+          if (open) {
+            setOpen(false);
+          }
+        }}
+        popoverControl={(ref, props) => (
+          <TextInput
+            size="large"
+            label="large"
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Tab" && open) {
+                setOpen(false);
+                return;
+              }
+
+              if ((e.key === "Enter" || e.key === "ArrowDown") && !open) {
+                setOpen(true);
+              }
+            }}
+            onClick={() => {
+              if (!open) {
+                setOpen(true);
+              }
+            }}
+            ref={ref}
+            {...props}
+          />
+        )}
+      >
+        <MenuItemHeading text="Heading">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("One");
+            }}
+            selected={value === "One"}
+            disabled
+          >
+            <MenuItemLeading>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">one</MenuItemLabel>
+            <MenuItemSubtext>Subtext</MenuItemSubtext>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Two");
+            }}
+            selected={value === "Two"}
+          >
+            <MenuItemLeading selectedIcon={value === "Two"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">two</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Three");
+            }}
+            selected={value === "Three"}
+          >
+            <MenuItemLeading selectedIcon={value === "Three"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">three</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Four");
+            }}
+            selected={value === "Four"}
+          >
+            <MenuItemLeading selectedIcon={value === "Four"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">four</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Five");
+            }}
+            selected={value === "Five"}
+          >
+            <MenuItemLeading selectedIcon={value === "Five"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">five</MenuItemLabel>
+          </MenuItem>
+        </MenuItemHeading>
+        <MenuItemDivider />
+        <MenuItemHeading text="Heading">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Six");
+            }}
+            disabled
+          >
+            <MenuItemLeading>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">six</MenuItemLabel>
+            <MenuItemSubtext>Subtext</MenuItemSubtext>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Seven");
+            }}
+            selected={value === "Seven"}
+          >
+            <MenuItemLeading selectedIcon={value === "Seven"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">seven</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Eight");
+            }}
+            selected={value === "Eight"}
+          >
+            <MenuItemLeading selectedIcon={value === "Eight"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">eight</MenuItemLabel>
+          </MenuItem>
+        </MenuItemHeading>
+      </PopoverMenu>
+    </div>
+  );
+};
+
+LargeWithDisabledItems.storyName = "large with disabled items";
+
+export const LargeWithCustomWidth = () => {
+  const [open, setOpen] = React.useState<boolean>(false);
+  const [value, setValue] = React.useState<string>("");
+  return (
+    <div style={{ display: "flex", gap: "24px", margin: "250px 180px 180px" }}>
+      <PopoverMenu<HTMLInputElement>
+        width="300px"
+        size="large"
+        open={open}
+        onOpen={() => {
+          setOpen(true);
+        }}
+        onClose={() => {
+          if (open) {
+            setOpen(false);
+          }
+        }}
+        popoverControl={(ref, props) => (
+          <TextInput
+            size="large"
+            label="large"
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Tab" && open) {
+                setOpen(false);
+                return;
+              }
+
+              if ((e.key === "Enter" || e.key === "ArrowDown") && !open) {
+                setOpen(true);
+              }
+            }}
+            onClick={() => {
+              if (!open) {
+                setOpen(true);
+              }
+            }}
+            ref={ref}
+            {...props}
+          />
+        )}
+      >
+        <MenuItemHeading text="Heading">
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("One");
+            }}
+            selected={value === "One"}
+          >
+            <MenuItemLeading selectedIcon={value === "One"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">one</MenuItemLabel>
+            <MenuItemSubtext>Subtext</MenuItemSubtext>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Two");
+            }}
+            selected={value === "Two"}
+          >
+            <MenuItemLeading selectedIcon={value === "Two"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">two</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Three");
+            }}
+            selected={value === "Three"}
+          >
+            <MenuItemLeading selectedIcon={value === "Three"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">three</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Four");
+            }}
+            selected={value === "Four"}
+          >
+            <MenuItemLeading selectedIcon={value === "Four"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">four</MenuItemLabel>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              setOpen(false);
+              setValue("Five");
+            }}
+            selected={value === "Five"}
+          >
+            <MenuItemLeading selectedIcon={value === "Five"}>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">five</MenuItemLabel>
+          </MenuItem>
+        </MenuItemHeading>
+      </PopoverMenu>
+    </div>
+  );
+};
+
+LargeWithCustomWidth.storyName = "large with custom width";
+
+export const HoverItem = () => {
+  return (
+    <div style={{ display: "flex", gap: "24px", margin: "180px" }}>
+      <PopoverMenu<HTMLInputElement>
+        size="large"
+        open
+        onOpen={() => {}}
+        onClose={() => {}}
+        popoverControl={(ref, props) => (
+          <TextInput
+            size="large"
+            label="large"
+            value={""}
+            onChange={() => {}}
+            ref={ref}
+            {...props}
+          />
+        )}
+      >
+        <MenuItemHeading text="Heading">
+          <MenuItem onClick={() => {}}>
+            <MenuItemLeading>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">one</MenuItemLabel>
+            <MenuItemSubtext>Subtext</MenuItemSubtext>
+          </MenuItem>
+          <MenuItem data-role="hover-target" onClick={() => {}}>
+            <MenuItemLeading selectedIcon>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">two</MenuItemLabel>
+            <MenuItemSubtext>Subtext</MenuItemSubtext>
+          </MenuItem>
+          <MenuItem onClick={() => {}}>
+            <MenuItemLeading>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">three</MenuItemLabel>
+          </MenuItem>
+        </MenuItemHeading>
+        <MenuItemDivider />
+        <MenuItem onClick={() => {}} disabled>
+          <MenuItemLeading>
+            <Icon type="home" />
+          </MenuItemLeading>
+          <MenuItemLabel prefix="Item: ">four</MenuItemLabel>
+          <MenuItemSubtext>Subtext</MenuItemSubtext>
+        </MenuItem>
+        <MenuItem onClick={() => {}}>
+          <MenuItemLeading>
+            <Icon type="home" />
+          </MenuItemLeading>
+          <MenuItemLabel prefix="Item: ">five</MenuItemLabel>
+          <MenuItemSubtext>Subtext</MenuItemSubtext>
+        </MenuItem>
+        <MenuItem onClick={() => {}}>
+          <MenuItemLeading>
+            <Icon type="home" />
+          </MenuItemLeading>
+          <MenuItemLabel prefix="Item: ">six</MenuItemLabel>
+        </MenuItem>
+      </PopoverMenu>
+    </div>
+  );
+};
+
+HoverItem.parameters = {
+  chromatic: { disableSnapshot: false },
+  pseudo: {
+    hover: "[data-role='hover-target']",
+  },
+};

--- a/src/__internal__/popover-menu/popover-menu.component.tsx
+++ b/src/__internal__/popover-menu/popover-menu.component.tsx
@@ -1,0 +1,273 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import styled, { css } from "styled-components";
+import Popover from "../popover";
+import { flip, offset, size } from "@floating-ui/dom";
+import wrapChildrenInMenuItems from "./utils";
+import useClickAwayListener from "../../hooks/__internal__/useClickAwayListener";
+import { ButtonHandle } from "../../components/button/__next__";
+import { useHandleDropdownMenuKeyDown } from "./hooks";
+import guid from "../utils/helpers/guid";
+import { PopoverMenuContext, type PopoverMenuContextProps } from "./contexts";
+import { TagProps } from "../utils/helpers/tags";
+
+const PopoverControlWrapper = styled.div`
+  display: inline-block;
+`;
+
+interface ListProps {
+  $size: PopoverMenuContextProps["size"];
+}
+
+export const List = styled.ul<ListProps>`
+  margin: var(--global-space-none);
+  padding: var(--global-space-none);
+  background-color: var(--popover-bg-default);
+  overflow: hidden auto;
+  display: flex;
+  flex-direction: column;
+
+  ${({ $size }) => css`
+    max-height: calc(5 * var(--global-size-${$size.charAt(0)}));
+  `}
+  list-style: none;
+`;
+
+const paddingSize = {
+  small: "var(--global-space-comp-xs)",
+  medium: "var(--global-space-comp-s)",
+  large: "var(--global-space-comp-m)",
+};
+
+const MenuWrapper = styled.div<{ $size: PopoverMenuContextProps["size"] }>`
+  padding: ${({ $size }) => css`
+    ${paddingSize[$size]} var(--global-space-none)
+  `};
+  box-shadow: var(--global-depth-lvl1);
+  border-radius: var(--global-radius-container-m);
+  background-color: var(--popover-bg-default);
+  width: max-content;
+  max-width: 100%;
+  max-height: 100%;
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+`;
+
+interface PopoverControlProps {
+  "aria-haspopup": "listbox" | "menu";
+  "aria-controls"?: string;
+  "aria-expanded"?: boolean;
+  role?: string;
+  "aria-activedescendant"?: string;
+}
+
+type FocusableHandle =
+  | NonNullable<ButtonHandle>
+  | HTMLElement
+  | HTMLButtonElement
+  | HTMLAnchorElement
+  | HTMLInputElement;
+
+function isFocusButtonHandle(
+  handle: FocusableHandle,
+): handle is NonNullable<ButtonHandle> {
+  return "focusButton" in handle;
+}
+
+export interface PopoverMenuProps<
+  TRef extends FocusableHandle = NonNullable<ButtonHandle>,
+> extends TagProps {
+  /** The content of the popover menu */
+  children: React.ReactNode;
+  /** Whether the popover menu is open or not */
+  open: boolean;
+  /** The element that the popover menu is anchored to */
+  popoverControl?: (
+    ref: React.RefObject<TRef>,
+    props: PopoverControlProps,
+  ) => React.ReactNode;
+  size?: PopoverMenuContextProps["size"];
+  /** Placement of the popover menu */
+  placement?:
+    | "top"
+    | "bottom"
+    | "left"
+    | "right"
+    | "top-start"
+    | "top-end"
+    | "bottom-start"
+    | "bottom-end"
+    | "left-start"
+    | "left-end"
+    | "right-start"
+    | "right-end";
+  /** Middleware for the popover menu */
+  middleware?: typeof menuPopoverMiddleware;
+  /** Ref for the submenu control element */
+  submenuControlRef?: React.RefObject<HTMLElement>;
+  /** id applied to the outer wrapper element (e.g. for aria-controls) */
+  id?: string;
+  /** Blur handler for the outer wrapper element */
+  onBlur?: React.FocusEventHandler<HTMLElement>;
+  /** Callback when the popover menu is opened */
+  onOpen: () => void;
+  /** Callback when the popover menu is closed */
+  onClose: (e?: Event, value?: string) => void;
+  /** Set the custom width of the menu */
+  width?: string;
+  /** Aria labelledby for the listbox */
+  listboxAriaLabelledBy?: string;
+}
+
+const OFFSET = 8;
+
+const menuPopoverMiddleware = (width?: string) => [
+  offset(OFFSET),
+  flip({
+    fallbackStrategy: "initialPlacement",
+  }),
+  size({
+    apply({ rects, elements }) {
+      elements.floating.style.width = width || `${rects.reference.width}px`;
+    },
+  }),
+];
+
+const focusControl = (handle: FocusableHandle | null) => {
+  /* istanbul ignore if */
+  if (!handle) {
+    return;
+  }
+
+  if (isFocusButtonHandle(handle)) {
+    handle.focusButton();
+  } else {
+    handle.focus();
+  }
+};
+
+const PopoverMenu = <TRef extends FocusableHandle = NonNullable<ButtonHandle>>({
+  children,
+  open,
+  popoverControl,
+  size = "medium",
+  placement = "bottom-end",
+  onOpen,
+  onClose,
+  width,
+  listboxAriaLabelledBy,
+  ...rest
+}: PopoverMenuProps<TRef>) => {
+  const controlWrapperRef = useRef<HTMLDivElement | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const listRef = useRef<HTMLUListElement | null>(null);
+  const listId = useRef(`popover-menu-scroll-wrapper-${guid()}`);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const wrappedChildren = wrapChildrenInMenuItems(children);
+  const controlRef = useRef<TRef>(null);
+  const handleClickInside = useClickAwayListener(onClose);
+  const computedMiddleware = menuPopoverMiddleware(width);
+  const [ariaActivedescendant, setAriaActivedescendant] = useState<string>("");
+
+  const handleMainWrapperKeyDown = useCallback(
+    (ev: KeyboardEvent) => {
+      if (open && ev.key === "Escape") {
+        ev.preventDefault();
+        onClose();
+        focusControl(controlRef.current);
+      }
+    },
+    [open, onClose],
+  );
+
+  useEffect(() => {
+    const { current: wrapperEl } = wrapperRef;
+
+    wrapperEl?.addEventListener("click", handleClickInside, { passive: true });
+    wrapperEl?.addEventListener("keydown", handleMainWrapperKeyDown);
+
+    return () => {
+      wrapperEl?.removeEventListener("click", handleClickInside);
+      wrapperEl?.removeEventListener("keydown", handleMainWrapperKeyDown);
+    };
+  }, [handleClickInside, handleMainWrapperKeyDown]);
+
+  const handleDropdownMenuKeyDown = useHandleDropdownMenuKeyDown(
+    listRef,
+    setAriaActivedescendant,
+  );
+
+  const handleControlKeyDown: React.KeyboardEventHandler<HTMLElement> =
+    useCallback(
+      (ev) => {
+        if (
+          open &&
+          controlWrapperRef.current?.contains(document.activeElement)
+        ) {
+          handleDropdownMenuKeyDown(ev);
+
+          return;
+        }
+      },
+      [open, handleDropdownMenuKeyDown],
+    );
+
+  useEffect(() => {
+    if (!open) {
+      setAriaActivedescendant("");
+    }
+  }, [open]);
+
+  return (
+    <div ref={wrapperRef} data-component="popover-menu" {...rest}>
+      {popoverControl && (
+        <PopoverControlWrapper
+          ref={controlWrapperRef}
+          onKeyDown={handleControlKeyDown}
+          data-component="popover-menu-control"
+        >
+          {popoverControl(controlRef, {
+            "aria-haspopup": "listbox",
+            "aria-controls": listId.current,
+            "aria-expanded": open,
+            role: "combobox",
+            "aria-activedescendant":
+              open && ariaActivedescendant ? ariaActivedescendant : undefined,
+          })}
+        </PopoverControlWrapper>
+      )}
+      <PopoverMenuContext.Provider value={{ size }}>
+        {open && (
+          <Popover
+            placement={placement}
+            reference={controlWrapperRef}
+            isOpen={open}
+            data-component="popover-menu"
+            middleware={computedMiddleware}
+            disablePortal
+            popoverStrategy="fixed"
+          >
+            <MenuWrapper
+              $size={size}
+              data-role="menu-wrapper"
+              onMouseDown={(e) => e.preventDefault()}
+              ref={scrollRef}
+            >
+              <List
+                $size={size}
+                ref={listRef}
+                role="listbox"
+                id={listId.current}
+                aria-labelledby={listboxAriaLabelledBy}
+              >
+                {wrappedChildren}
+              </List>
+            </MenuWrapper>
+          </Popover>
+        )}
+      </PopoverMenuContext.Provider>
+    </div>
+  );
+};
+
+export default PopoverMenu;

--- a/src/__internal__/popover-menu/popover-menu.pw.tsx
+++ b/src/__internal__/popover-menu/popover-menu.pw.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { test } from "../../../playwright/helpers/base-test";
+import { checkAccessibility } from "../../../playwright/support/helper";
+import {
+  PopoverMenuComponent,
+  PopoverMenuWithPreselection,
+} from "./components.test-pw";
+
+test.describe("Accessibility tests", () => {
+  test("passes accessibility tests when open", async ({ mount, page }) => {
+    await mount(<PopoverMenuComponent openByDefault />);
+    await checkAccessibility(page);
+  });
+
+  (["small", "medium", "large"] as const).forEach((size) => {
+    test(`passes accessibility tests with size ${size} and menu open`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(<PopoverMenuComponent size={size} openByDefault />);
+      await checkAccessibility(page);
+    });
+  });
+
+  test("passes accessibility tests with a custom width", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<PopoverMenuComponent width="400px" openByDefault />);
+    await checkAccessibility(page);
+  });
+
+  test("passes accessibility tests with disabled items", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<PopoverMenuComponent withDisabledItems openByDefault />);
+    await checkAccessibility(page);
+  });
+
+  test("passes accessibility tests with first item keyboard-highlighted via ArrowDown", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<PopoverMenuComponent openByDefault />);
+    await page.keyboard.press("ArrowDown");
+    await checkAccessibility(page);
+  });
+
+  test("passes accessibility tests with middle item keyboard-highlighted via ArrowDown", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<PopoverMenuComponent openByDefault />);
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+    await checkAccessibility(page);
+  });
+
+  test("passes accessibility tests with last item keyboard-highlighted via ArrowUp", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<PopoverMenuComponent openByDefault />);
+    await page.keyboard.press("ArrowUp");
+    await checkAccessibility(page);
+  });
+
+  test("passes accessibility tests with disabled item skipped via ArrowDown", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<PopoverMenuComponent withDisabledItems openByDefault />);
+    // ArrowDown twice: first item highlighted, then disabled item skipped to third
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+    await checkAccessibility(page);
+  });
+
+  test("passes accessibility tests with selected item and tick icon visible", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<PopoverMenuWithPreselection />);
+    await checkAccessibility(page);
+  });
+
+  test("passes accessibility tests with selected item keyboard-highlighted", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<PopoverMenuWithPreselection />);
+    // ArrowDown from no highlight jumps to selected item ("Two" at index 1)
+    await page.keyboard.press("ArrowDown");
+    await checkAccessibility(page);
+  });
+
+  (["small", "medium", "large"] as const).forEach((size) => {
+    test(`passes accessibility tests with size ${size} and selected item with icon`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(<PopoverMenuWithPreselection size={size} />);
+      await checkAccessibility(page);
+    });
+  });
+});

--- a/src/__internal__/popover-menu/popover-menu.test.tsx
+++ b/src/__internal__/popover-menu/popover-menu.test.tsx
@@ -1,0 +1,627 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import PopoverMenu, { PopoverMenuProps } from "./popover-menu.component";
+import {
+  MenuItem,
+  MenuItemDivider,
+  MenuItemHeading,
+  MenuItemLeading,
+  MenuItemLabel,
+  MenuItemSubtext,
+} from "./menu-item";
+import userEvent from "@testing-library/user-event";
+import Button from "../../components/button/__next__";
+import Icon from "../../components/icon";
+
+const renderPopoverMenu = ({
+  open = false,
+  children,
+  onOpen = () => {},
+  onClose = () => {},
+  ...props
+}: Partial<PopoverMenuProps<HTMLInputElement>> = {}) => {
+  return render(
+    <PopoverMenu<HTMLInputElement>
+      open={open}
+      onOpen={onOpen}
+      onClose={onClose}
+      popoverControl={(ref, controlProps) => (
+        <input
+          aria-label="combobox-label"
+          ref={ref}
+          {...controlProps}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") onOpen();
+          }}
+        />
+      )}
+      {...props}
+    >
+      {children ?? (
+        <>
+          <MenuItem id="item-1">
+            <MenuItemLeading>
+              <Icon type="home" />
+            </MenuItemLeading>
+            <MenuItemLabel prefix="Item: ">1</MenuItemLabel>
+            <MenuItemSubtext>Subtext</MenuItemSubtext>
+          </MenuItem>
+          <MenuItemDivider />
+          <MenuItemHeading text="Heading">
+            <MenuItem id="item-2">
+              <MenuItemLabel>Item 2</MenuItemLabel>
+            </MenuItem>
+          </MenuItemHeading>
+          <MenuItem id="item-3">
+            <MenuItemLabel>Item 3</MenuItemLabel>
+          </MenuItem>
+        </>
+      )}
+    </PopoverMenu>,
+  );
+};
+
+const MenuWithState = ({ children }: { children: React.ReactNode }) => {
+  const [open, setOpen] = React.useState(false);
+
+  return (
+    <PopoverMenu<HTMLInputElement>
+      open={open}
+      onOpen={() => setOpen(true)}
+      onClose={() => setOpen(false)}
+      popoverControl={(ref, controlProps) => (
+        <input
+          aria-label="combobox-label"
+          ref={ref}
+          {...controlProps}
+          onClick={() => setOpen(true)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") setOpen(true);
+          }}
+        />
+      )}
+    >
+      {children}
+    </PopoverMenu>
+  );
+};
+
+const focusTrigger = () =>
+  screen.getByRole("combobox", { name: "combobox-label" }).focus();
+
+test("does not render the list when closed", () => {
+  renderPopoverMenu();
+
+  expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+});
+
+test("renders the list with options when open", () => {
+  renderPopoverMenu({ open: true });
+
+  expect(screen.getAllByRole("listbox")[0]).toBeInTheDocument();
+  expect(screen.getAllByRole("option")).toHaveLength(4);
+});
+
+test("wrapper has expected data- attributes", () => {
+  renderPopoverMenu({
+    "data-role": "popover-menu-role",
+    "data-element": "popover-menu-element",
+  });
+  const wrapper = screen.getByTestId("popover-menu-role");
+
+  expect(wrapper).toHaveAttribute("data-component", "popover-menu");
+  expect(wrapper).toHaveAttribute("data-element", "popover-menu-element");
+});
+
+test("popoverControl button receives aria-haspopup='listbox'", () => {
+  renderPopoverMenu();
+
+  expect(
+    screen.getByRole("combobox", { name: "combobox-label" }),
+  ).toHaveAttribute("aria-haspopup", "listbox");
+});
+
+test("popoverControl receives aria-expanded='false' when closed", () => {
+  renderPopoverMenu({ open: false });
+
+  expect(
+    screen.getByRole("combobox", { name: "combobox-label" }),
+  ).toHaveAttribute("aria-expanded", "false");
+});
+
+test("popoverControl button receives aria-expanded='true' when open", () => {
+  renderPopoverMenu({ open: true });
+
+  expect(
+    screen.getByRole("combobox", { name: "combobox-label" }),
+  ).toHaveAttribute("aria-expanded", "true");
+});
+
+test("aria-controls on the button references the listbox id", () => {
+  renderPopoverMenu({ open: true });
+
+  const button = screen.getByRole("combobox", { name: "combobox-label" });
+  const listbox = screen.getAllByRole("listbox")[0];
+
+  expect(button).toHaveAttribute("aria-controls", listbox.id);
+});
+
+test("id prop is applied to the outer wrapper element", () => {
+  renderPopoverMenu({
+    id: "my-menu",
+    "data-role": "popover-menu-role",
+    open: true,
+  });
+
+  expect(screen.getByTestId("popover-menu-role")).toHaveAttribute(
+    "id",
+    "my-menu",
+  );
+});
+
+describe("when the list opens", () => {
+  it("calls the onOpen callback", async () => {
+    const user = userEvent.setup();
+    const onOpen = jest.fn();
+    renderPopoverMenu({ open: false, onOpen });
+
+    focusTrigger();
+    await user.keyboard("{Enter}");
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("focuses the selected item when the list is opened and the the user presses ArrowDown", async () => {
+    const user = userEvent.setup();
+    render(
+      <MenuWithState>
+        <MenuItem>Item 1</MenuItem>
+        <MenuItem selected>Item 2</MenuItem>
+        <MenuItem>Item 3</MenuItem>
+      </MenuWithState>,
+    );
+
+    focusTrigger();
+    await user.keyboard("{Enter}");
+    const items = Array.from(screen.queryAllByRole("option") || []);
+    const selectedItem = items.find(
+      (item) => item.getAttribute("aria-selected") === "true",
+    );
+    await user.keyboard("{ArrowDown}");
+
+    expect(selectedItem).toHaveAttribute("data-has-focus", "true");
+
+    await user.keyboard("{ArrowDown}");
+
+    expect(selectedItem).not.toHaveAttribute("data-has-focus", "true");
+    expect(items[2]).toHaveAttribute("data-has-focus", "true");
+  });
+
+  it("focuses first item when the selected item is disabled and the list is opened", async () => {
+    const user = userEvent.setup();
+    render(
+      <MenuWithState>
+        <MenuItem>Item 1</MenuItem>
+        <MenuItem selected disabled>
+          Item 2
+        </MenuItem>
+        <MenuItem>Item 3</MenuItem>
+      </MenuWithState>,
+    );
+
+    focusTrigger();
+    await user.keyboard("{Enter}");
+    await user.keyboard("{ArrowDown}");
+
+    const items = Array.from(screen.queryAllByRole("option") || []);
+
+    expect(items[0]).toHaveAttribute("data-has-focus", "true");
+  });
+
+  it("focuses the selected item when the list is opened and the user presses ArrowUp", async () => {
+    const user = userEvent.setup();
+    render(
+      <MenuWithState>
+        <MenuItem>Item 1</MenuItem>
+        <MenuItem selected>Item 2</MenuItem>
+        <MenuItem>Item 3</MenuItem>
+      </MenuWithState>,
+    );
+
+    focusTrigger();
+    await user.keyboard("{Enter}");
+
+    const items = Array.from(screen.queryAllByRole("option") || []);
+
+    const selectedItem = items.find(
+      (item) => item.getAttribute("aria-selected") === "true",
+    );
+
+    await user.keyboard("{ArrowUp}");
+
+    expect(selectedItem).toHaveAttribute("data-has-focus", "true");
+
+    await user.keyboard("{ArrowUp}");
+
+    expect(selectedItem).not.toHaveAttribute("data-has-focus", "true");
+    expect(items[0]).toHaveAttribute("data-has-focus", "true");
+  });
+});
+
+test("focuses the last item when list is open and nothing is highlighted or selected", async () => {
+  const user = userEvent.setup();
+  renderPopoverMenu({ open: true });
+
+  focusTrigger();
+  await user.keyboard("{Enter}");
+  await user.keyboard("{ArrowUp}");
+
+  const options = screen.getAllByRole("option");
+  const last = options[options.length - 1];
+  expect(last).toHaveAttribute("data-has-focus", "true");
+});
+
+test("shows list when user clicks the control and focuses selected item on ArrowDown", async () => {
+  const user = userEvent.setup();
+  render(
+    <MenuWithState>
+      <MenuItem>Item 1</MenuItem>
+      <MenuItem selected>Item 2</MenuItem>
+      <MenuItem>Item 3</MenuItem>
+    </MenuWithState>,
+  );
+
+  await user.click(screen.getByRole("combobox", { name: "combobox-label" }));
+
+  const items = Array.from(screen.queryAllByRole("option") || []);
+
+  const selectedItem = items.find(
+    (item) => item.getAttribute("aria-selected") === "true",
+  );
+
+  await user.keyboard("{ArrowDown}");
+
+  expect(selectedItem).toHaveAttribute("data-has-focus", "true");
+
+  await user.keyboard("{ArrowDown}");
+
+  expect(selectedItem).not.toHaveAttribute("data-has-focus", "true");
+  expect(items[2]).toHaveAttribute("data-has-focus", "true");
+});
+
+test("shows list when user clicks the control and focuses selected item on ArrowUp", async () => {
+  const user = userEvent.setup();
+  render(
+    <MenuWithState>
+      <MenuItem>Item 1</MenuItem>
+      <MenuItem selected>Item 2</MenuItem>
+      <MenuItem>Item 3</MenuItem>
+    </MenuWithState>,
+  );
+
+  await user.click(screen.getByRole("combobox", { name: "combobox-label" }));
+
+  const items = Array.from(screen.queryAllByRole("option") || []);
+
+  const selectedItem = items.find(
+    (item) => item.getAttribute("aria-selected") === "true",
+  );
+
+  await user.keyboard("{ArrowUp}");
+
+  expect(selectedItem).toHaveAttribute("data-has-focus", "true");
+
+  await user.keyboard("{ArrowUp}");
+
+  expect(selectedItem).not.toHaveAttribute("data-has-focus", "true");
+  expect(items[0]).toHaveAttribute("data-has-focus", "true");
+});
+
+test("calls onClose when Escape is pressed while open and control is an input", async () => {
+  const user = userEvent.setup();
+  const onClose = jest.fn();
+  renderPopoverMenu({ open: true, onClose });
+
+  focusTrigger();
+  await user.keyboard("{Escape}");
+
+  expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test("calls onClose when Escape is pressed while open and control is a Button", async () => {
+  const user = userEvent.setup();
+  const onClose = jest.fn();
+  render(
+    <PopoverMenu
+      open
+      onOpen={() => {}}
+      onClose={onClose}
+      popoverControl={(
+        ref,
+        {
+          "aria-haspopup": ariaHasPopup,
+          "aria-controls": ariaControls,
+          "aria-expanded": ariaExpanded,
+        },
+      ) => (
+        <Button
+          aria-label="button-label"
+          ref={ref}
+          aria-haspopup={ariaHasPopup}
+          aria-controls={ariaControls}
+          aria-expanded={ariaExpanded}
+        >
+          Button
+        </Button>
+      )}
+    >
+      <MenuItem>Item 1</MenuItem>
+    </PopoverMenu>,
+  );
+
+  screen.getByRole("button", { name: "button-label" }).focus();
+  await user.keyboard("{Escape}");
+
+  expect(onClose).toHaveBeenCalledTimes(1);
+});
+
+test("ArrowDown focuses the first item when list is open and nothing is highlighted", async () => {
+  const user = userEvent.setup();
+  renderPopoverMenu({ open: true });
+
+  focusTrigger();
+  await user.keyboard("{ArrowDown}");
+  const [first] = screen.getAllByRole("option");
+
+  expect(first).toHaveAttribute("data-has-focus", "true");
+  expect(
+    screen.getByRole("combobox", { name: "combobox-label" }),
+  ).toHaveAttribute("aria-activedescendant", "item-1");
+});
+
+test("ArrowDown advances the highlight to the next item", async () => {
+  const user = userEvent.setup();
+  renderPopoverMenu({ open: true });
+
+  focusTrigger();
+  await user.keyboard("{ArrowDown}");
+  await user.keyboard("{ArrowDown}");
+  const options = screen.getAllByRole("option");
+
+  expect(options[0]).not.toHaveAttribute("data-has-focus", "true");
+  expect(options[2]).toHaveAttribute("data-has-focus", "true");
+  expect(
+    screen.getByRole("combobox", { name: "combobox-label" }),
+  ).toHaveAttribute("aria-activedescendant", "item-2");
+});
+
+test("ArrowDown wraps from the last item back to the first", async () => {
+  const user = userEvent.setup();
+  renderPopoverMenu({
+    open: true,
+    children: (
+      <>
+        <MenuItem>Item 1</MenuItem>
+        <MenuItem>Item 2</MenuItem>
+      </>
+    ),
+  });
+
+  focusTrigger();
+  await user.keyboard("{ArrowDown}");
+  await user.keyboard("{ArrowDown}");
+  await user.keyboard("{ArrowDown}");
+  const [first, second] = screen.getAllByRole("option");
+
+  expect(first).toHaveAttribute("data-has-focus", "true");
+  expect(second).not.toHaveAttribute("data-has-focus", "true");
+});
+
+test("ArrowUp retreats the highlight to the previous item", async () => {
+  const user = userEvent.setup();
+  renderPopoverMenu({ open: true });
+
+  focusTrigger();
+  await user.keyboard("{ArrowDown}");
+  await user.keyboard("{ArrowDown}");
+  await user.keyboard("{ArrowUp}");
+  const [first, second] = screen.getAllByRole("option");
+
+  expect(first).toHaveAttribute("data-has-focus", "true");
+  expect(second).not.toHaveAttribute("data-has-focus", "true");
+  expect(
+    screen.getByRole("combobox", { name: "combobox-label" }),
+  ).toHaveAttribute("aria-activedescendant", "item-1");
+});
+
+test("ArrowUp wraps from the first item to the last", async () => {
+  const user = userEvent.setup();
+  renderPopoverMenu({ open: true });
+
+  focusTrigger();
+  await user.keyboard("{ArrowDown}");
+  await user.keyboard("{ArrowUp}");
+  const options = screen.getAllByRole("option");
+  const last = options[options.length - 1];
+
+  expect(last).toHaveAttribute("data-has-focus", "true");
+  expect(
+    screen.getByRole("combobox", { name: "combobox-label" }),
+  ).toHaveAttribute("aria-activedescendant", "item-3");
+});
+
+test("Home moves the highlight to the first item", async () => {
+  const user = userEvent.setup();
+  renderPopoverMenu({ open: true });
+
+  focusTrigger();
+  await user.keyboard("{ArrowDown}");
+  await user.keyboard("{ArrowDown}");
+  await user.keyboard("{Home}");
+  const [first, second] = screen.getAllByRole("option");
+
+  expect(first).toHaveAttribute("data-has-focus", "true");
+  expect(second).not.toHaveAttribute("data-has-focus", "true");
+  expect(
+    screen.getByRole("combobox", { name: "combobox-label" }),
+  ).toHaveAttribute("aria-activedescendant", "item-1");
+});
+
+test("Home moves the highlight to the first item that is not disabled", async () => {
+  const user = userEvent.setup();
+  renderPopoverMenu({
+    open: true,
+    children: (
+      <>
+        <MenuItem id="item-1" disabled>
+          Item 1
+        </MenuItem>
+        <MenuItem id="item-2">Item 2</MenuItem>
+        <MenuItem id="item-3">Item 3</MenuItem>
+        <MenuItem id="item-4">Item 4</MenuItem>
+      </>
+    ),
+  });
+
+  focusTrigger();
+  await user.keyboard("{ArrowDown}");
+  await user.keyboard("{ArrowDown}");
+  await user.keyboard("{Home}");
+  const [first, second] = screen.getAllByRole("option");
+
+  expect(first).not.toHaveAttribute("data-has-focus", "true");
+  expect(second).toHaveAttribute("data-has-focus", "true");
+  expect(
+    screen.getByRole("combobox", { name: "combobox-label" }),
+  ).toHaveAttribute("aria-activedescendant", "item-2");
+});
+
+test("End moves the highlight to the last item", async () => {
+  const user = userEvent.setup();
+  renderPopoverMenu({ open: true });
+
+  focusTrigger();
+  await user.keyboard("{ArrowDown}");
+  await user.keyboard("{End}");
+  const options = screen.getAllByRole("option");
+  const last = options[options.length - 1];
+
+  expect(last).toHaveAttribute("data-has-focus", "true");
+  expect(
+    screen.getByRole("combobox", { name: "combobox-label" }),
+  ).toHaveAttribute("aria-activedescendant", "item-3");
+});
+
+test("End moves the highlight to the last item that is not disabled", async () => {
+  const user = userEvent.setup();
+  renderPopoverMenu({
+    open: true,
+    children: (
+      <>
+        <MenuItem id="item-1">Item 1</MenuItem>
+        <MenuItem id="item-2">Item 2</MenuItem>
+        <MenuItem id="item-3">Item 3</MenuItem>
+        <MenuItem id="item-4" disabled>
+          Item 4
+        </MenuItem>
+      </>
+    ),
+  });
+
+  focusTrigger();
+  await user.keyboard("{ArrowDown}");
+  await user.keyboard("{End}");
+
+  const options = screen.getAllByRole("option");
+  expect(options[2]).toHaveAttribute("data-has-focus", "true");
+  expect(
+    screen.getByRole("combobox", { name: "combobox-label" }),
+  ).toHaveAttribute("aria-activedescendant", "item-3");
+});
+
+test("Enter clicks the currently highlighted item", async () => {
+  const user = userEvent.setup();
+  const onItemClick = jest.fn();
+  renderPopoverMenu({
+    open: true,
+    children: (
+      <>
+        <MenuItem onClick={onItemClick}>Item 1</MenuItem>
+        <MenuItem>Item 2</MenuItem>
+      </>
+    ),
+  });
+
+  focusTrigger();
+  await user.keyboard("{ArrowDown}");
+  await user.keyboard("{Enter}");
+
+  expect(onItemClick).toHaveBeenCalledTimes(1);
+});
+
+test("renders the list container with the expected max-height when size is small", () => {
+  renderPopoverMenu({ open: true, size: "small" });
+
+  const listbox = screen.getAllByRole("listbox")[0];
+
+  expect(listbox).toHaveStyleRule(
+    "max-height",
+    "calc(5 * var(--global-size-s))",
+  );
+});
+
+test("renders the list container with the expected max-height when size is medium", () => {
+  renderPopoverMenu({ open: true, size: "medium" });
+
+  const listbox = screen.getAllByRole("listbox")[0];
+
+  expect(listbox).toHaveStyleRule(
+    "max-height",
+    "calc(5 * var(--global-size-m))",
+  );
+});
+
+test("renders the list container with the expected max-height when size is large", () => {
+  renderPopoverMenu({ open: true, size: "large" });
+
+  const listbox = screen.getAllByRole("listbox")[0];
+
+  expect(listbox).toHaveStyleRule(
+    "max-height",
+    "calc(5 * var(--global-size-l))",
+  );
+});
+
+test("wraps any non-option children in list item with role of option", () => {
+  render(
+    <PopoverMenu
+      open
+      onOpen={() => {}}
+      onClose={() => {}}
+      popoverControl={() => <button>Control</button>}
+    >
+      <button>Not an option</button>
+    </PopoverMenu>,
+  );
+
+  expect(screen.getByRole("option", { name: "Not an option" })).toBeVisible();
+});
+
+test("clicking the menu wrapper does not close the menu", async () => {
+  const user = userEvent.setup();
+  const onClose = jest.fn();
+  render(
+    <PopoverMenu
+      open
+      onOpen={() => {}}
+      onClose={onClose}
+      popoverControl={() => <button>Control</button>}
+    >
+      <MenuItem>Option 1</MenuItem>
+    </PopoverMenu>,
+  );
+
+  await user.click(screen.getByTestId("menu-wrapper"));
+
+  expect(onClose).not.toHaveBeenCalled();
+});

--- a/src/__internal__/popover-menu/utils/index.ts
+++ b/src/__internal__/popover-menu/utils/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./wrap-children-in-menu-items.util";

--- a/src/__internal__/popover-menu/utils/wrap-children-in-menu-items.util.tsx
+++ b/src/__internal__/popover-menu/utils/wrap-children-in-menu-items.util.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { MenuItem, MenuItemDivider, MenuItemHeading } from "../menu-item";
+
+const wrapChildrenInItem = (
+  children: React.ReactNode,
+): React.ReactNode[] | undefined => {
+  return React.Children.map(children, (child) => {
+    /* istanbul ignore if */
+    if (!React.isValidElement(child)) {
+      return null;
+    }
+
+    // Recursively unwrap Fragments
+    if (child.type === React.Fragment) {
+      return wrapChildrenInItem(child.props.children);
+    }
+
+    // If the child is already a MenuItem, MenuItemDivider, or MenuItemHeading, don't wrap it again
+    if (
+      child.type === MenuItem ||
+      child.type === MenuItemDivider ||
+      child.type === MenuItemHeading
+    ) {
+      return child;
+    }
+
+    return <MenuItem>{child}</MenuItem>;
+  })
+    ?.flat()
+    .filter(Boolean);
+};
+
+export default wrapChildrenInItem;

--- a/src/components/icon/icon.style.ts
+++ b/src/components/icon/icon.style.ts
@@ -203,6 +203,19 @@ const StyledIcon = styled.span.attrs(applyBaseTheme)<
       ${styleOverrides}
     `;
   }}
+
+  ${StyledNextButton} &, .popover-menu-item & {
+    color: currentColor;
+  }
+
+  .mentions-list-item && {
+    color: currentColor;
+  }
+
+  .mentions-list-item:hover &&,
+  .mentions-list-item.selected && {
+    color: currentColor;
+  }
 `;
 
 export default StyledIcon;


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Delivers first phase of internal `PopoverMenu` component to be implemented as part of `Search` alignment work

Functionality:
- Popover is controlled via `open` props and exposes `onOpen` and `onClose` callbacks
- renders `listbox` and `option` children
- supports any node as a control to anchor the popover to and control open state
- opens when `enter` pressed on control element (this is purely a story/demo implementation)
- opens when user clicks on control
- items not focused on open
- list renders below control, flips if no space below
- default is to match width of control
- supports custom `width` being set on list
-  up/down arrow focuses first item when list is open
- `arrow` keys navigate items and apply secondary focus state (focus stays on control), loops at start/end
- `end` key focuses last item
- `home` focuses first
- closes when `escape` key pressed
- closes when click event outside of component detected
- supports `small`, `medium` and `large` `size`
- scrollbar rendered when there items exceed 5 times the min height of item (based on size)
- scrolls to item highlighted
- renders `selected` icon state
- supports icons and profiles via composition
- supports `prefix`
- supports main label text
- supports `subtext`
- enter key on highlighted item or clicking one selects and closes list
- aria-selected added to `selected` item (unless disabled)
- aria-disabled added to `disabled` item
- supports passing headings and dividers

Additional:
- test and interaction stories added, these can be replaced when component is integrated with other public facing components
- playwright accessibility tests added

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
There is no `PopoverMenu`

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
