### PR TITLE
fix(textbox): ensure label is announced when prefix is passed

### DIFF
--- a/src/__internal__/input/input.component.tsx
+++ b/src/__internal__/input/input.component.tsx
@@ -36,6 +36,8 @@ export interface InputProps
   size?: "small" | "medium" | "large";
   /** Emphasised text to be displayed before the input */
   prefix?: string;
+  /** ID for the prefix span element */
+  prefixId?: string;
   /** Additional children to be rendered before the input */
   leftChildren?: React.ReactNode;
   /** Text alignment within the input */
@@ -85,6 +87,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       name,
       onFocus,
       prefix,
+      prefixId,
       readOnly,
       size,
       type = "text",
@@ -94,7 +97,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ) => {
     const localRef = useRef<HTMLInputElement>(null);
     const combinedRef = combineRefs(ref, localRef);
-    const prefixId = prefix ? `${id}-prefix` : undefined;
 
     useEffect(() => {
       if (autoFocus) {
@@ -111,10 +113,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       },
       [onFocus, type],
     );
-
-    const ariaLabelledByString = prefixId
-      ? `${prefixId} ${ariaLabelledBy || ""}`.trim()
-      : ariaLabelledBy;
 
     return (
       <InputContainer
@@ -144,7 +142,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             disabled={disabled}
             readOnly={readOnly}
             aria-describedby={ariaDescribedBy}
-            aria-labelledby={ariaLabelledByString}
+            aria-labelledby={ariaLabelledBy}
             type={type}
             onFocus={handleFocus}
             id={id}

--- a/src/components/textbox/__internal__/__next__/text-input.component.tsx
+++ b/src/components/textbox/__internal__/__next__/text-input.component.tsx
@@ -170,11 +170,13 @@ export const TextInput = React.forwardRef(
     });
     const hintId = useRef(guid());
     const inputHintId = inputHint ? hintId.current : undefined;
+    const inputPrefixId = prefix ? `${uniqueId}-prefix` : undefined;
 
     const resolvedInputWidth =
       inputWidth ?? (labelInline ? INLINE_INPUT_WIDTH : INPUT_WIDTH);
     const ariaDescribedByString = [
       inputHintId,
+      inputPrefixId,
       ariaDescribedBy,
       ariaDescribedByProp,
     ]
@@ -285,6 +287,7 @@ export const TextInput = React.forwardRef(
             inputIcon={inputIcon}
             size={size}
             prefix={prefix}
+            prefixId={inputPrefixId}
             leftChildren={leftChildren}
             type={type}
             {...stateProps}

--- a/src/components/textbox/__internal__/__next__/text-input.test.tsx
+++ b/src/components/textbox/__internal__/__next__/text-input.test.tsx
@@ -160,6 +160,20 @@ test("should announce the error message after the input hint", () => {
   );
 });
 
+test("should include the prefix in the accessible description when `prefix` prop is provided", () => {
+  render(
+    <TextInput
+      prefix="£"
+      id="test-input"
+      label="label"
+      value="foo"
+      onChange={() => {}}
+    />,
+  );
+
+  expect(screen.getByRole("textbox")).toHaveAccessibleDescription("£");
+});
+
 test("should render with a warning border via the `warning` prop", () => {
   render(
     <TextInput


### PR DESCRIPTION
fix #7843 , fix #7976 

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Removes the `prefix` from the accessible name and makes it part of the accessible description instead. Now a label or an `aria-labelledby` string is announced depending on their presence, and the `prefix` is added to the inputs accessible description when passed.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

 Currently due to a bug in our internal `Input` component, when a `prefix` is passed a concatenated string is passed down to the internal `aria-labelledby`attribute, however this does not include the `label`. Therefore, when a `prefix` and a `label` is passed, the `label` is not announced.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Use your preferred screen reader software on a compatible browser, find the `"Prefix"` story on `Textbox` and focus on it. It should announce the label first as part of the accessible name, then the prefix afterwards as part of the accessible description instead.