### PR TITLE
feat(search): align with fusion DS

### DIFF
--- a/skills/carbon-react/components/search.md
+++ b/skills/carbon-react/components/search.md
@@ -13,48 +13,54 @@ description: Carbon Search component props and usage examples.
 - Props interface: `SearchProps`
 
 ## Props
-| Name | Type | Required | Literals | Description | Default |
-| --- | --- | --- | --- | --- | --- |
-| onChange | (ev: SearchEvent) => void | Yes |  | Prop for `onChange` events |  |
-| value | string | Yes |  | Current value |  |
-| error | string \| boolean \| undefined | No |  | Indicate that error has occurred. |  |
-| id | string \| undefined | No |  | Prop for `id` |  |
-| info | string \| boolean \| undefined | No |  | [Legacy] Indicate additional information. |  |
-| inputHint | string \| undefined | No |  | A hint string rendered before the input but after the label. Intended to describe the purpose or content of the input. |  |
-| label | string \| undefined | No |  | Label content |  |
-| m | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top, left, bottom and right |  |
-| margin | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top, left, bottom and right |  |
-| marginBottom | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on bottom |  |
-| marginLeft | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on left |  |
-| marginRight | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on right |  |
-| marginTop | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top |  |
-| marginX | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on left and right |  |
-| marginY | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top and bottom |  |
-| maxWidth | string \| undefined | No |  | Prop for specifying the max-width of the input. Leaving the `maxWidth` prop with no value will default the width to '100%' |  |
-| mb | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on bottom |  |
-| ml | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on left |  |
-| mr | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on right |  |
-| mt | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top |  |
-| mx | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on left and right |  |
-| my | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top and bottom |  |
-| name | string \| undefined | No |  | Prop for `name` |  |
-| onBlur | ((ev: React.FocusEvent<HTMLInputElement>) => void) \| undefined | No |  | Prop for `onBlur` events |  |
-| onClick | ((ev: SearchEvent) => void) \| undefined | No |  | Prop for `onClick` events. `onClick` events are triggered when the `searchButton` is clicked |  |
-| onFocus | ((ev: React.FocusEvent<HTMLInputElement>) => void) \| undefined | No |  | Prop for `onFocus` events |  |
-| onKeyDown | ((ev: React.KeyboardEvent<HTMLInputElement>) => void) \| undefined | No |  | Prop for `onKeyDown` events |  |
-| placeholder | string \| undefined | No |  | Prop for a placeholder |  |
-| searchButton | string \| boolean \| undefined | No |  | Pass a boolean to render a search Button with default text. Pass a string to override the text in the search Button |  |
-| searchButtonAriaLabel | string \| undefined | No |  | Prop to specify the aria-label of the search button |  |
-| searchButtonDataProps | TagProps \| undefined | No |  | Data tag prop bag for searchButton |  |
-| searchWidth | string \| undefined | No |  | Prop for specifying an input width length. Leaving the `searchWidth` prop with no value will default the width to '100%' |  |
-| tabIndex | number \| undefined | No |  | Input tabindex |  |
-| tooltipPosition | "left" \| "right" \| "bottom" \| "top" \| undefined | No |  | [Legacy] Overrides the default tooltip position |  |
-| triggerOnClear | boolean \| undefined | No |  | Sets whether the onClick action should be triggered when the Search cross icon is clicked. |  |
-| variant | "default" \| "dark" \| undefined | No |  | Prop to specify the styling of the search component |  |
-| warning | string \| boolean \| undefined | No |  | Indicate that warning has occurred. |  |
-| data-element | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
-| data-role | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
-| aria-label | string \| undefined | No |  | Prop to specify the aria-label of the search component |  |
+| Name | Type | Required | Literals | Deprecated | Deprecation reason | Description | Default |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| onChange | (ev: SearchEvent) => void | Yes |  |  |  | Prop for `onChange` events on the Search input |  |
+| value | string | Yes |  |  |  | Current value |  |
+| className | string \| undefined | No |  |  |  |  |  |
+| error | string \| boolean \| undefined | No |  |  |  | Indicate that error has occurred. |  |
+| id | string \| undefined | No |  |  |  | Unique identifier for the input. Label id will be based on it, using following pattern: [id]-label. Will use a randomly generated GUID if none is provided. |  |
+| info | string \| boolean \| undefined | No |  |  |  | [Legacy] Indicate additional information. |  |
+| inputHint | string \| undefined | No |  |  |  | A hint string rendered before the input but after the label. Intended to describe the purpose or content of the input. |  |
+| inputWidth | number \| undefined | No |  |  |  | The width of the input as a percentage |  |
+| inverse | boolean \| undefined | No |  |  |  | When set to `true`, inverts the Search input and button styling for use on darker backgrounds. |  |
+| label | string \| undefined | No |  |  |  | Label content |  |
+| labelInline | boolean \| undefined | No |  |  |  | When true label is inline. |  |
+| m | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top, left, bottom and right |  |
+| margin | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top, left, bottom and right |  |
+| marginBottom | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on bottom |  |
+| marginLeft | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on left |  |
+| marginRight | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on right |  |
+| marginTop | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top |  |
+| marginX | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on left and right |  |
+| marginY | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top and bottom |  |
+| maxWidth | string \| undefined | No |  |  |  | Prop for specifying the max-width of the Search input. Leaving the `maxWidth` prop with no value will default the width to '100%' |  |
+| mb | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on bottom |  |
+| ml | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on left |  |
+| mr | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on right |  |
+| mt | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top |  |
+| mx | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on left and right |  |
+| my | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top and bottom |  |
+| name | string \| undefined | No |  |  |  | Name of the input |  |
+| onBlur | ((ev: React.FocusEvent<HTMLInputElement>) => void) \| undefined | No |  |  |  | Event handler for the blur event |  |
+| onClick | ((ev: SearchEvent) => void) \| undefined | No |  |  |  | Prop for `onClick` events on the Search button. `onClick` events are triggered when the Search button is clicked or when the Search input's cross icon is clicked if the `triggerOnClear` prop is set to `true`. |  |
+| onFocus | ((ev: React.FocusEvent<HTMLInputElement>) => void) \| undefined | No |  |  |  | Event handler for the focus event |  |
+| onKeyDown | ((ev: React.KeyboardEvent<HTMLInputElement>) => void) \| undefined | No |  |  |  | Specify a callback triggered on keyDown |  |
+| required | boolean \| undefined | No |  |  |  | Flag to configure component as mandatory |  |
+| searchButtonAriaLabel | string \| undefined | No |  |  |  | Prop to specify the accessible name of the Search button |  |
+| searchButtonDataProps | TagProps \| undefined | No |  |  |  | Data tag prop bag for searchButton |  |
+| size | "small" \| "medium" \| "large" \| undefined | No |  |  |  | Size of an input |  |
+| triggerOnClear | boolean \| undefined | No |  |  |  | Sets whether the `onClick` action should be triggered when the Search cross icon is clicked. |  |
+| data-element | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
+| data-role | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
+| aria-label | string \| undefined | No |  |  |  | Prop to specify the accessible name of the Search input. To be used when no visible label is provided |  |
+| placeholder | string \| undefined | No |  | Yes | This prop no longer has any effect. This prop will eventually be removed. |  |  |
+| searchButton | string \| boolean \| undefined | No |  | Yes | This prop no longer has any effect. This prop will eventually be removed. Pass a boolean to render a search Button with default text. Pass a string to override the text in the search Button |  |  |
+| searchWidth | string \| undefined | No |  | Yes | This prop no longer has any effect. This prop will eventually be removed. Use `inputWidth` instead. Prop for specifying the width of the Search container. This value is mapped to `inputWidth`. Leaving the `searchWidth` prop with no value will default the width to '100%' |  |  |
+| tabIndex | number \| undefined | No |  | Yes | This prop no longer has any effect. This prop will eventually be removed. Input tabindex |  |  |
+| tooltipPosition | "left" \| "right" \| "bottom" \| "top" \| undefined | No |  | Yes | `tooltipPosition` has been deprecated, the functionality will no longer work. |  |  |
+| variant | "default" \| "dark" \| undefined | No |  | Yes | This prop no longer has any effect. This prop will eventually be removed. `variant="dark"` is mapped to `inverse={true}` to preserve legacy behavior. |  |  |
+| warning | string \| boolean \| undefined | No |  | Yes | This prop no longer has any effect. This prop will eventually be removed. |  |  |
 
 ## Examples
 ### Default
@@ -64,15 +70,8 @@ description: Carbon Search component props and usage examples.
 ```tsx
 () => {
   const [value, setValue] = useState("");
-  return (
-    <Search
-      placeholder="Search..."
-      onChange={(e) => {
-        setValue(e.target.value);
-      }}
-      value={value}
-    />
-  );
+
+  return <Search value={value} onChange={(e) => setValue(e.target.value)} />;
 }
 ```
 
@@ -85,115 +84,45 @@ description: Carbon Search component props and usage examples.
 () => {
   const [value, setValue] = useState("Here is some text");
   return (
-    <Box m={1}>
-      <Search
-        label="Search"
-        inputHint="Hint text (optional)."
-        onChange={(e) => setValue(e.target.value)}
-        value={value}
-      />
-    </Box>
-  );
-}
-```
-
-
-### With Search Button
-
-**Render**
-
-```tsx
-() => {
-  const [value, setValue] = useState("Here is some text");
-  return (
-    <Box m={1}>
-      <Search
-        onChange={(e) => setValue(e.target.value)}
-        value={value}
-        searchButton
-        searchButtonAriaLabel="search button aria label"
-      />
-    </Box>
-  );
-}
-```
-
-
-### With Search Button text override via prop
-
-**Render**
-
-```tsx
-() => {
-  const [value, setValue] = useState("Here is some text");
-  return (
-    <Box m={1}>
-      <Search
-        onChange={(e) => setValue(e.target.value)}
-        value={value}
-        searchButton="Find"
-      />
-    </Box>
-  );
-}
-```
-
-
-### With Search Button text override via locale
-
-**Render**
-
-```tsx
-() => {
-  const [value, setValue] = useState("Here is some text");
-  return (
-    <Box m={1}>
-      <I18nProvider locale={{ search: { searchButtonText: () => "Find" } }}>
-        <Search
-          onChange={(e) => setValue(e.target.value)}
-          value={value}
-          searchButton
-        />
-      </I18nProvider>
-    </Box>
-  );
-}
-```
-
-
-### Custom Width
-
-**Render**
-
-```tsx
-() => {
-  const [value, setValue] = useState("");
-  return (
     <Search
-      placeholder="Search..."
+      label="Search"
+      inputHint="Hint text (optional)."
       onChange={(e) => setValue(e.target.value)}
       value={value}
-      searchWidth="375px"
     />
   );
 }
 ```
 
 
-### Custom Max Width
+### Sizes
 
 **Render**
 
 ```tsx
 () => {
-  const [value, setValue] = useState("Here is some text");
+  const [valueS, setValueS] = useState("");
+  const [valueM, setValueM] = useState("");
+  const [valueL, setValueL] = useState("");
   return (
-    <Box m={1}>
+    <Box display="flex" flexDirection="column" gap={3}>
       <Search
-        onChange={(e) => setValue(e.target.value)}
-        value={value}
-        searchButton
-        maxWidth="50%"
+        label="Small"
+        size="small"
+        onChange={(e) => setValueS(e.target.value)}
+        value={valueS}
+      />
+      <Search
+        label="Medium"
+        size="medium"
+        onChange={(e) => setValueM(e.target.value)}
+        value={valueM}
+      />
+      <Search
+        label="Large"
+        size="large"
+        onChange={(e) => setValueL(e.target.value)}
+        value={valueL}
       />
     </Box>
   );
@@ -201,36 +130,7 @@ description: Carbon Search component props and usage examples.
 ```
 
 
-### Dark Background variant
-
-**Render**
-
-```tsx
-() => {
-  const [value, setValue] = useState("Here is some text");
-  return (
-    <Box width="700px" height="108px" p={4} backgroundColor="#000000">
-      <Search
-        placeholder="Search..."
-        onChange={(e) => setValue(e.target.value)}
-        value={value}
-        variant="dark"
-        mb={2}
-      />
-      <Search
-        placeholder="Search..."
-        onChange={(e) => setValue(e.target.value)}
-        value={value}
-        searchButton
-        variant="dark"
-      />
-    </Box>
-  );
-}
-```
-
-
-### Trigger on Clear
+### Custom Widths
 
 **Render**
 
@@ -238,17 +138,76 @@ description: Carbon Search component props and usage examples.
 () => {
   const [value, setValue] = useState("");
   return (
-    <>
+    <Box display="flex" flexDirection="column" gap={3}>
       <Search
-        id="test"
-        name="test"
-        placeholder="Search..."
-        triggerOnClear
+        label="searchWidth"
         onChange={(e) => setValue(e.target.value)}
         value={value}
-        searchButton
+        inputWidth={25}
       />
-    </>
+      <Search
+        label="maxWidth"
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+        maxWidth="75%"
+      />
+    </Box>
+  );
+}
+```
+
+
+### Inverse
+
+**Render**
+
+```tsx
+() => {
+  const [value, setValue] = useState("Here is some text");
+  return (
+    <Box
+      width="700px"
+      display="flex"
+      flexDirection="column"
+      p={3}
+      backgroundColor="#000000"
+    >
+      <Search
+        label="Inverse"
+        inputHint="Use this prop on darker backgrounds"
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+        inverse
+      />
+    </Box>
+  );
+}
+```
+
+
+### Label Inline
+
+**Render**
+
+```tsx
+() => {
+  const [value, setValue] = useState("");
+  return (
+    <Box display="flex" flexDirection="column" gap={3}>
+      <Search
+        label="Search"
+        labelInline
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+      />
+      <Search
+        label="Search with hint"
+        inputHint="Hint text (optional)."
+        labelInline
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+      />
+    </Box>
   );
 }
 ```

--- a/src/__internal__/hint-text/hint-text-style-overrides.style.ts
+++ b/src/__internal__/hint-text/hint-text-style-overrides.style.ts
@@ -1,0 +1,16 @@
+import { css } from "styled-components";
+
+/**
+ * Overrides for hint text when part of Search component
+ */
+const searchInverseStyles = css`
+  .search.inverse & {
+    color: var(--input-labelset-inverse-label-alt);
+  }
+`;
+
+const hintTextStyleOverrides = css`
+  ${searchInverseStyles}
+`;
+
+export default hintTextStyleOverrides;

--- a/src/__internal__/hint-text/hint-text.style.ts
+++ b/src/__internal__/hint-text/hint-text.style.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import hintTextStyleOverrides from "./hint-text-style-overrides.style";
 
 const getFontToken = (size: "small" | "medium" | "large") => {
   switch (size) {
@@ -23,6 +24,8 @@ const StyledHintText = styled.span<StyledHintTextProps>`
       : "var(--input-labelset-label-alt)"};
 
   font: ${({ $size }) => getFontToken($size)};
+
+  ${hintTextStyleOverrides}
 `;
 
 export default StyledHintText;

--- a/src/__internal__/input/input-style-overrides.style.ts
+++ b/src/__internal__/input/input-style-overrides.style.ts
@@ -13,11 +13,14 @@ export const dateStyleOverrides = css`
   }
 `;
 
+const searchCancelIcon =
+  "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M14.9497 5.05022C15.3403 5.44074 15.3403 6.07391 14.9497 6.46443L11.4142 9.99997L14.9497 13.5355C15.3403 13.926 15.3403 14.5592 14.9497 14.9497C14.5592 15.3402 13.9261 15.3402 13.5355 14.9497L10 11.4142L6.46446 14.9497C6.07394 15.3402 5.44077 15.3402 5.05025 14.9497C4.65972 14.5592 4.65972 13.926 5.05025 13.5355L8.58578 9.99997L5.05025 6.46443C4.65972 6.07391 4.65972 5.44074 5.05025 5.05022C5.44077 4.65969 6.07394 4.65969 6.46446 5.05022L10 8.58575L13.5355 5.05022C13.9261 4.65969 14.5592 4.65969 14.9497 5.05022Z'/%3E%3C/svg%3E\")";
+
 /**
  * Overrides for input when part of Search component
  */
 const searchBaseStyles = css`
-  .search & {
+  .legacy-search & {
     height: 40px;
     box-sizing: border-box;
 
@@ -32,21 +35,21 @@ const searchBaseStyles = css`
 `;
 
 const searchNoBorderStyles = css`
-  .search:not(.with-button):not(.has-value) &:not(:focus-within) {
+  .legacy-search:not(.with-button):not(.has-value) &:not(:focus-within) {
     border-color: transparent;
     background: transparent;
   }
 `;
 
 const searchWithButtonStyles = css`
-  .search.with-button & {
+  .legacy-search.with-button & {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
 `;
 
 const searchDarkPlaceholderStyles = css`
-  .search.dark-background & {
+  .legacy-search.dark-background & {
     input {
       ::-moz-placeholder {
         color: var(--colorsUtilityYang080);
@@ -60,12 +63,12 @@ const searchDarkPlaceholderStyles = css`
 `;
 
 const searchDarkHasValueStyles = css`
-  .search.dark-background:not(.with-button) & {
+  .legacy-search.dark-background:not(.with-button) & {
     input {
       color: var(--input-typical-inverse-txt-default);
     }
   }
-  .search.dark-background.has-value:not(.with-button) & {
+  .legacy-search.dark-background.has-value:not(.with-button) & {
     .input-text-container,
     input {
       color: var(--colorsUtilityYang080);
@@ -80,7 +83,7 @@ const searchDarkHasValueStyles = css`
 `;
 
 const searchDarkWithButtonNoValueStyles = css`
-  .search.dark-background.with-button:not(.has-value) & {
+  .legacy-search.dark-background.with-button:not(.has-value) & {
     input {
       color: var(--colorsUtilityYang100);
     }
@@ -88,7 +91,7 @@ const searchDarkWithButtonNoValueStyles = css`
 `;
 
 const searchDarkNoButtonStyles = css`
-  .search.dark-background:not(.with-button) & {
+  .legacy-search.dark-background:not(.with-button) & {
     background-color: transparent;
     border-color: var(--colorsUtilityYang080);
   }
@@ -102,6 +105,89 @@ export const searchStyleOverrides = css`
   ${searchDarkHasValueStyles}
   ${searchDarkWithButtonNoValueStyles}
   ${searchDarkNoButtonStyles}
+`;
+
+const searchNewBaseStyles = css`
+  .search & {
+    --search-clear-icon-color: var(--button-typical-subtle-label-default);
+    --search-button-icon-color: var(--button-typical-subtle-label-default);
+    --search-button-hover-bg: var(--button-typical-subtle-bg-hover);
+    --search-button-hover-icon-color: var(--button-typical-subtle-label-hover);
+
+    input[type="search"]::-webkit-search-cancel-button {
+      -webkit-appearance: none;
+      appearance: none;
+      width: var(--global-size-2-xs);
+      height: var(--global-size-2-xs);
+      background-color: var(--search-clear-icon-color);
+      -webkit-mask: center / contain no-repeat ${searchCancelIcon};
+      mask: center / contain no-repeat ${searchCancelIcon};
+      cursor: pointer;
+    }
+
+    button {
+      border-radius: var(--global-radius-none) var(--global-radius-action-m)
+        var(--global-radius-action-m) var(--global-radius-none);
+    }
+
+    button:hover {
+      background-color: var(--search-button-hover-bg);
+    }
+
+    button span[type="search"] {
+      color: var(--search-button-icon-color);
+    }
+
+    button:hover span[type="search"] {
+      color: var(--search-button-hover-icon-color);
+    }
+
+    &:focus-within:has(:focus:not(button)) {
+      box-shadow: none;
+      -webkit-box-shadow: none;
+    }
+
+    .input-text-container input[type="search"]:focus {
+      border-radius: var(--global-radius-action-m) 0 0
+        var(--global-radius-action-m);
+      ${addFocusStyling()}
+      z-index: 2;
+    }
+  }
+`;
+
+const searchInverseStyles = css`
+  .search.inverse & {
+    --search-clear-icon-color: var(
+      --button-typical-subtle-inverse-label-default
+    );
+    --search-button-icon-color: var(
+      --button-typical-subtle-inverse-label-default
+    );
+    --search-button-hover-bg: var(--button-typical-subtle-inverse-bg-hover);
+    --search-button-hover-icon-color: var(
+      --button-typical-subtle-inverse-label-hover
+    );
+
+    background-color: var(--input-typical-inverse-bg-default);
+
+    &[data-role="input-container"] {
+      border-color: var(--input-typical-inverse-border-default);
+    }
+
+    .input-text-container input[type="search"] {
+      color: var(--input-typical-inverse-txt-default);
+    }
+  }
+
+  .search.inverse.error & {
+    border-color: var(--input-validation-inverse-border-error);
+  }
+`;
+
+export const searchNewStyleOverrides = css`
+  ${searchNewBaseStyles}
+  ${searchInverseStyles}
 `;
 
 /**

--- a/src/__internal__/input/input.style.ts
+++ b/src/__internal__/input/input.style.ts
@@ -3,6 +3,7 @@ import addFocusStyling from "../../style/utils/add-focus-styling";
 import {
   dateStyleOverrides,
   searchStyleOverrides,
+  searchNewStyleOverrides,
   selectStyleOverrides,
   pagerStyleOverrides,
   numeralDateStyles,
@@ -158,6 +159,7 @@ const InputContainer = styled.div<InputContainerProps>`
 
   ${dateStyleOverrides}
 
+  ${searchNewStyleOverrides}
   ${searchStyleOverrides}
 
   ${({ $size, $isDisabled, $isReadOnly }) =>

--- a/src/__internal__/label/label-style-overrides.style.ts
+++ b/src/__internal__/label/label-style-overrides.style.ts
@@ -1,0 +1,16 @@
+import { css } from "styled-components";
+
+/**
+ * Overrides for label when part of Search component
+ */
+const searchInverseStyles = css`
+  .search.inverse & {
+    color: var(--input-labelset-inverse-label-default);
+  }
+`;
+
+const labelStyleOverrides = css`
+  ${searchInverseStyles}
+`;
+
+export default labelStyleOverrides;

--- a/src/__internal__/label/label.style.ts
+++ b/src/__internal__/label/label.style.ts
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+import labelStyleOverrides from "./label-style-overrides.style";
 
 const getFontToken = (size: "small" | "medium" | "large") => {
   switch (size) {
@@ -60,6 +61,8 @@ const StyledLabel = styled.label<StyledLabelProps>`
   .time & {
     font: var(--global-font-static-comp-regular-m);
   }
+
+  ${labelStyleOverrides}
 `;
 
 export default StyledLabel;

--- a/src/__internal__/validation-message/__next__/validation-message-style-overrides.style.ts
+++ b/src/__internal__/validation-message/__next__/validation-message-style-overrides.style.ts
@@ -1,0 +1,16 @@
+import { css } from "styled-components";
+
+/**
+ * Overrides for validation message when part of Search component
+ */
+const validationMessageInverseStyles = css`
+  .search.inverse & {
+    color: var(--input-validation-inverse-label-error);
+  }
+`;
+
+const validationMessageStyleOverrides = css`
+  ${validationMessageInverseStyles}
+`;
+
+export default validationMessageStyleOverrides;

--- a/src/__internal__/validation-message/__next__/validation-message.style.ts
+++ b/src/__internal__/validation-message/__next__/validation-message.style.ts
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+import validationMessageStyleOverrides from "./validation-message-style-overrides.style";
 
 interface StyledValidationMessageProps {
   $isError?: boolean;
@@ -37,6 +38,8 @@ const StyledValidationMessage = styled.span<StyledValidationMessageProps>`
           ? "var(--global-font-static-comp-medium-s)"
           : "var(--global-font-static-comp-regular-s)"};
       `}
+
+      ${validationMessageStyleOverrides}
     `;
   }}
 `;

--- a/src/components/duelling-picklist/duelling-picklist.pw.tsx
+++ b/src/components/duelling-picklist/duelling-picklist.pw.tsx
@@ -85,7 +85,7 @@ test.describe(`should render Duelling-Picklist component`, () => {
     }) => {
       await mount(<DuellingPicklistComponent />);
 
-      const addItemButton = page.getByRole("button").first();
+      const addItemButton = page.getByRole("button", { name: "add" }).first();
       for (let i = 0; i < items; i++) {
         await addItemButton.click();
       }
@@ -111,7 +111,7 @@ test.describe(`should render Duelling-Picklist component`, () => {
   }) => {
     await mount(<DuellingPicklistComponent />);
 
-    const addItemButton = page.getByRole("button").first();
+    const addItemButton = page.getByRole("button", { name: "add" }).first();
     for (let i = 0; i < 10; i++) {
       await addItemButton.click();
     }
@@ -141,7 +141,7 @@ test.describe(`should render Duelling-Picklist component`, () => {
   }) => {
     await mount(<DuellingPicklistComponent />);
 
-    const addItemButton = page.getByRole("button").first();
+    const addItemButton = page.getByRole("button", { name: "add" }).first();
     await addItemButton.click();
     await expect(
       getDataElementByValue(page, "picklist").nth(0).locator("li"),
@@ -170,7 +170,7 @@ test.describe(`should render Duelling-Picklist component`, () => {
     }) => {
       await mount(<DuellingPicklistComponent />);
 
-      const addItemButton = page.getByRole("button").first();
+      const addItemButton = page.getByRole("button", { name: "add" }).first();
       await addItemButton.press(pressed);
       await expect(
         getDataElementByValue(page, "picklist").nth(0).locator("li"),
@@ -189,7 +189,7 @@ test.describe(`should render Duelling-Picklist component`, () => {
     }) => {
       await mount(<DuellingPicklistComponent />);
 
-      const addItemButton = page.getByRole("button").first();
+      const addItemButton = page.getByRole("button", { name: "add" }).first();
       for (let i = 0; i < 10; i++) {
         await addItemButton.click();
       }
@@ -332,7 +332,7 @@ test.describe(`should render Duelling-Picklist to test Picklist props`, () => {
     }) => {
       await mount(<DuellingPicklistComponent text={chars} />);
 
-      const addItemButton = page.getByRole("button").first();
+      const addItemButton = page.getByRole("button", { name: "add" }).first();
       for (let i = 0; i < 10; i++) {
         await addItemButton.click();
       }
@@ -383,7 +383,7 @@ test.describe(`should render Duelling-Picklist with external searchbar and acces
     }) => {
       await mount(<AlternativeSearch />);
 
-      await page.getByLabel("search").fill(searchString);
+      await page.getByLabel("search").first().fill(searchString);
       await expect(
         getDataElementByValue(page, "picklist").nth(0).locator("li"),
       ).toHaveCount(results);
@@ -502,7 +502,7 @@ test.describe(`check events for Duelling-Picklist component`, () => {
       />,
     );
 
-    const addItemButton = page.getByRole("button").first();
+    const addItemButton = page.getByRole("button", { name: "add" }).first();
     await addItemButton.click();
     expect(callbackCount).toBe(1);
   });
@@ -520,7 +520,9 @@ test.describe(`check events for Duelling-Picklist component`, () => {
       />,
     );
 
-    const removeItemButton = page.getByRole("button").first();
+    const removeItemButton = page
+      .getByRole("button", { name: "remove" })
+      .first();
     await removeItemButton.click();
     expect(callbackCount).toBe(1);
   });
@@ -532,14 +534,14 @@ test.describe(`check events for Duelling-Picklist component`, () => {
     }) => {
       let callbackCount = 0;
       await mount(
-        <DuellingPicklistComponentAssigned
+        <DuellingPicklistComponent
           onChange={() => {
             callbackCount += 1;
           }}
         />,
       );
 
-      const addItemButton = page.getByRole("button").first();
+      const addItemButton = page.getByRole("button", { name: "add" }).first();
       await addItemButton.press(pressed);
       expect(callbackCount).toBe(1);
     });
@@ -559,7 +561,9 @@ test.describe(`check events for Duelling-Picklist component`, () => {
         />,
       );
 
-      const removeItemButton = page.getByRole("button").first();
+      const removeItemButton = page
+        .getByRole("button", { name: "remove" })
+        .first();
       await removeItemButton.press(pressed);
       expect(callbackCount).toBe(1);
     });
@@ -651,7 +655,7 @@ test.describe("Border radius tests", () => {
   }) => {
     await mount(<DuellingPicklistComponent />);
 
-    const addItemButton = page.getByRole("button").first();
+    const addItemButton = page.getByRole("button", { name: "add" }).first();
     for (let i = 0; i < 5; i++) {
       await addItemButton.click();
     }

--- a/src/components/icon/icon.style.ts
+++ b/src/components/icon/icon.style.ts
@@ -72,7 +72,7 @@ const styleOverrides = css`
     color: currentColor;
   }
 
-  .search & {
+  .legacy-search & {
     color: var(--colorsUtilityYin065);
 
     &:hover {
@@ -80,7 +80,7 @@ const styleOverrides = css`
     }
   }
 
-  .search.dark-background:not(.with-button) & {
+  .legacy-search.dark-background:not(.with-button) & {
     color: var(--colorsUtilityYang080);
 
     :hover {

--- a/src/components/link/link.style.ts
+++ b/src/components/link/link.style.ts
@@ -306,7 +306,7 @@ const StyledLink = styled.span.attrs(applyBaseTheme)<
         }
       `}
 
-      > button, ${StyledButton}:not(.search-button) {
+      > button, ${StyledButton}:not(.legacy-search-button) {
         background-color: transparent;
         border: none;
         padding: 0;

--- a/src/components/menu/component.test-pw.tsx
+++ b/src/components/menu/component.test-pw.tsx
@@ -534,21 +534,23 @@ export const MenuFullScreenWithSearchButton = ({
   const [value, setValue] = useState(searchValue || "");
 
   return (
-    <MenuFullscreen isOpen onClose={() => {}}>
-      <MenuItem href="#">Menu Item before Search</MenuItem>
-      <MenuItem variant="alternate">
-        <Search
-          placeholder="Dark variant"
-          variant="dark"
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          searchButton
-        />
-      </MenuItem>
-      <MenuItem variant="alternate" href="#">
-        Menu Item after Search
-      </MenuItem>
-    </MenuFullscreen>
+    <Menu>
+      <MenuFullscreen isOpen onClose={() => {}}>
+        <MenuItem href="#">Menu Item before Search</MenuItem>
+        <MenuItem variant="alternate">
+          <Search
+            placeholder="Dark variant"
+            variant="dark"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            searchButton
+          />
+        </MenuItem>
+        <MenuItem variant="alternate" href="#">
+          Menu Item after Search
+        </MenuItem>
+      </MenuFullscreen>
+    </Menu>
   );
 };
 

--- a/src/components/menu/menu-full-screen/menu-full-screen.style.ts
+++ b/src/components/menu/menu-full-screen/menu-full-screen.style.ts
@@ -2,7 +2,7 @@ import styled, { css } from "styled-components";
 import applyBaseTheme from "../../../style/themes/apply-base-theme";
 import StyledIconButton from "../../icon-button/icon-button.style";
 import StyledBox from "../../box/box.style";
-import StyledSearch from "../../search/search.style";
+import StyledSearch from "../../search/__internal__/legacy/search.style";
 import StyledIcon from "../../icon/icon.style";
 import StyledButton from "../../button/button.style";
 import menuConfigVariants from "../menu.config";

--- a/src/components/menu/menu-item/menu-item.style.ts
+++ b/src/components/menu/menu-item/menu-item.style.ts
@@ -117,7 +117,7 @@ const StyledMenuItemWrapper = styled.a.attrs(applyBaseTheme).attrs({
       font-size: 14px;
       font-weight: 500;
 
-      &:not(.search-button) > ${StyledIcon} {
+      &:not(.legacy-search-button) > ${StyledIcon} {
         margin-right: var(--spacing050);
       }
     }
@@ -232,7 +232,7 @@ const StyledMenuItemWrapper = styled.a.attrs(applyBaseTheme).attrs({
             padding: 11px 16px;
           }
 
-          > a:has(${StyledButton}:not(.search-button)) {
+          > a:has(${StyledButton}:not(.legacy-search-button)) {
             height: 100%;
 
             ${StyledContent} {

--- a/src/components/search/__internal__/legacy/components.test-pw.tsx
+++ b/src/components/search/__internal__/legacy/components.test-pw.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import Search, { SearchProps } from "../..";
+import Box from "../../../box";
+import MenuContext from "../../../menu/__internal__/menu.context";
+
+const MenuContextProvider = ({ children }: { children: React.ReactNode }) => (
+  <MenuContext.Provider value={{ inMenu: true }}>
+    {children}
+  </MenuContext.Provider>
+);
+
+export const SearchComponent = (
+  props: Partial<SearchProps> & { value?: string },
+) => {
+  const [internalValue, setInternalValue] = React.useState(props.value ?? "");
+  return (
+    <MenuContextProvider>
+      <Search
+        placeholder="Search..."
+        onChange={(e) => setInternalValue(e.target.value)}
+        value={internalValue}
+        {...props}
+      />
+    </MenuContextProvider>
+  );
+};
+
+export const SearchComponentDarkBackground = (
+  props: Omit<SearchProps, "onChange" | "value">,
+) => {
+  const [value, setValue] = React.useState("foo");
+  return (
+    <Box width="700px" height="108px" bg="#003349">
+      <MenuContextProvider>
+        <Search
+          placeholder="Search..."
+          onChange={(e) => setValue(e.target.value)}
+          value={value}
+          variant="dark"
+          {...props}
+        />
+      </MenuContextProvider>
+    </Box>
+  );
+};

--- a/src/components/search/__internal__/legacy/search-button.style.ts
+++ b/src/components/search/__internal__/legacy/search-button.style.ts
@@ -1,8 +1,8 @@
 import styled from "styled-components";
-import StyledButton from "../button/button.style";
-import StyledIcon from "../icon/icon.style";
+import StyledButton from "../../../button/button.style";
+import StyledIcon from "../../../icon/icon.style";
 
-import applyBaseTheme from "../../style/themes/apply-base-theme";
+import applyBaseTheme from "../../../../style/themes/apply-base-theme";
 
 export const StyledButtonIcon = styled.div`
   &&& ${StyledIcon} {

--- a/src/components/search/__internal__/legacy/search.component.tsx
+++ b/src/components/search/__internal__/legacy/search.component.tsx
@@ -1,0 +1,318 @@
+import React, { useState, useRef, useImperativeHandle, useMemo } from "react";
+import invariant from "invariant";
+import { MarginProps } from "styled-system";
+import tagComponent, {
+  TagProps,
+} from "../../../../__internal__/utils/helpers/tags";
+import { filterStyledSystemMarginProps } from "../../../../style/utils";
+import StyledSearch from "./search.style";
+import StyledSearchButton from "./search-button.style";
+import Icon from "../../../icon";
+import Textbox, { CommonTextboxProps } from "../../../textbox";
+import Button from "../../../button";
+import { ValidationProps } from "../../../../__internal__/validations";
+import useLocale from "../../../../hooks/__internal__/useLocale";
+import Events from "../../../../__internal__/utils/helpers/events";
+
+export interface SearchEvent {
+  target: {
+    name?: string;
+    id?: string;
+    value: string;
+  };
+}
+
+export interface SearchProps
+  extends ValidationProps,
+    MarginProps,
+    TagProps,
+    Pick<CommonTextboxProps, "label" | "inputHint"> {
+  /** Prop to specify the aria-label of the search component */
+  "aria-label"?: string;
+  /** Prop to specify the aria-label of the search button */
+  searchButtonAriaLabel?: string;
+  /** Prop for `id` */
+  id?: string;
+  /** Prop for `name` */
+  name?: string;
+  /** Prop for `onBlur` events */
+  onBlur?: (ev: React.FocusEvent<HTMLInputElement>) => void;
+  /** Prop for `onChange` events */
+  onChange: (ev: SearchEvent) => void;
+  /** Prop for `onClick` events.
+   *  `onClick` events are triggered when the `searchButton` is clicked
+   */
+  onClick?: (ev: SearchEvent) => void;
+
+  /**
+   * Sets whether the onClick action should be triggered when the Search cross icon is clicked.
+   */
+  triggerOnClear?: boolean;
+  /** Prop for `onFocus` events */
+  onFocus?: (ev: React.FocusEvent<HTMLInputElement>) => void;
+  /** Prop for `onKeyDown` events */
+  onKeyDown?: (ev: React.KeyboardEvent<HTMLInputElement>) => void;
+  /** Prop for a placeholder */
+  placeholder?: string;
+  /**
+   * Pass a boolean to render a search Button with default text.
+   * Pass a string to override the text in the search Button
+   * */
+  searchButton?: boolean | string;
+  /** Data tag prop bag for searchButton */
+  searchButtonDataProps?: TagProps;
+  /**
+   * Prop for specifying an input width length.
+   * Leaving the `searchWidth` prop with no value will default the width to '100%'
+   */
+  searchWidth?: string;
+  /**
+   * Prop for specifying the max-width of the input.
+   * Leaving the `maxWidth` prop with no value will default the width to '100%'
+   */
+  maxWidth?: string;
+  /** Current value */
+  value: string;
+  /** Prop to specify the styling of the search component */
+  variant?: "default" | "dark";
+  /** Input tabindex */
+  tabIndex?: number;
+  /** [Legacy] Overrides the default tooltip position */
+  tooltipPosition?: "top" | "bottom" | "left" | "right";
+}
+
+export type SearchHandle = {
+  /** Programmatically focus on root container of Dialog. */
+  focus: () => void;
+} | null;
+
+export const Search = React.forwardRef<SearchHandle, SearchProps>(
+  (
+    {
+      onChange,
+      onClick,
+      onFocus,
+      onBlur,
+      onKeyDown,
+      value,
+      id,
+      name,
+      label,
+      inputHint,
+      searchWidth,
+      maxWidth,
+      searchButton,
+      searchButtonDataProps,
+      searchButtonAriaLabel,
+      placeholder,
+      variant = "default",
+      "aria-label": ariaLabel,
+      tabIndex,
+      error,
+      warning,
+      info,
+      tooltipPosition,
+      triggerOnClear,
+      ...rest
+    },
+    ref,
+  ) => {
+    const locale = useLocale();
+    const searchRef = useRef<HTMLDivElement>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useImperativeHandle<SearchHandle, SearchHandle>(
+      ref,
+      () => ({
+        focus() {
+          inputRef.current?.focus();
+        },
+      }),
+      [],
+    );
+
+    invariant(typeof value === "string", "This component has no initial value");
+
+    const [isFocused, setIsFocused] = useState(false);
+
+    const isSearchValueEmpty = value.length === 0;
+
+    let buttonProps = {};
+
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      onChange(event);
+    };
+
+    const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
+      setIsFocused(true);
+      if (onFocus) {
+        onFocus(event);
+      }
+    };
+
+    if (searchButton && onClick) {
+      buttonProps = {
+        onClick: () => {
+          onClick({
+            target: {
+              name,
+              id,
+              value,
+            },
+          });
+        },
+      };
+    }
+
+    const handleIconClick = () => {
+      onChange?.({
+        target: {
+          ...(name && { name }),
+          ...(id && { id }),
+          value: "",
+        },
+      });
+
+      if (triggerOnClear) {
+        onClick?.({
+          target: {
+            ...(name && { name }),
+            ...(id && { id }),
+            value: "",
+          },
+        });
+      }
+
+      inputRef.current?.focus();
+    };
+
+    const handleMouseDown = (event: React.MouseEvent<HTMLElement>) => {
+      event.preventDefault();
+    };
+
+    const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+      setIsFocused(false);
+
+      /* istanbul ignore else */
+      if (onBlur) {
+        onBlur(event);
+      }
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key.length === 1) {
+        event.stopPropagation();
+      }
+
+      if (Events.isEscKey(event) && !isSearchValueEmpty) {
+        event.stopPropagation();
+
+        onChange?.({
+          target: {
+            ...(name && { name }),
+            ...(id && { id }),
+            value: "",
+          },
+        });
+      }
+
+      if (onKeyDown) {
+        onKeyDown(event);
+      }
+    };
+
+    const searchButtonText =
+      typeof searchButton === "string"
+        ? searchButton
+        : locale.search.searchButtonText();
+    const searchHasValue = !!value?.length;
+
+    const { className: restClassName, ...filteredRest } = rest as Record<
+      string,
+      unknown
+    >;
+
+    const classNames = useMemo(
+      () =>
+        [
+          "legacy-search",
+          searchHasValue ? "has-value" : undefined,
+          variant === "dark" ? "dark-background" : undefined,
+          searchButton ? "with-button" : undefined,
+          restClassName,
+        ]
+          .filter(Boolean)
+          .join(" "),
+      [searchHasValue, variant, searchButton, restClassName],
+    );
+
+    return (
+      <StyledSearch
+        ref={searchRef}
+        isFocused={isFocused}
+        searchWidth={searchWidth}
+        maxWidth={maxWidth}
+        searchHasValue={searchHasValue}
+        showSearchButton={!!searchButton}
+        variant={variant}
+        id={id}
+        name={name}
+        {...filteredRest}
+        {...filterStyledSystemMarginProps(filteredRest)}
+        {...tagComponent("search", filteredRest)}
+        className={classNames}
+      >
+        <Textbox
+          placeholder={placeholder}
+          value={value}
+          inputIcon={!isSearchValueEmpty ? "cross" : undefined}
+          iconTabIndex={!isSearchValueEmpty ? 0 : -1}
+          iconOnClick={handleIconClick}
+          iconOnMouseDown={handleMouseDown}
+          aria-label={
+            ariaLabel || (label ? undefined : locale.search.searchButtonText())
+          }
+          label={label}
+          inputHint={inputHint}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          ref={inputRef}
+          tabIndex={tabIndex}
+          error={error}
+          warning={warning}
+          info={info}
+          leftChildren={
+            !searchButton ? <Icon type="search" ml={1} /> : undefined
+          }
+          tooltipPosition={tooltipPosition}
+          my={0} // prevents any form spacing being applied
+          maxWidth="100%"
+        />
+        {searchButton && (
+          <StyledSearchButton>
+            <Button
+              aria-label={searchButtonAriaLabel || searchButtonText}
+              size="medium"
+              px={2}
+              buttonType="primary"
+              iconPosition="before"
+              iconType="search"
+              className="legacy-search-button"
+              {...tagComponent(`${searchButtonText}-button`, {
+                "data-element": `${searchButtonText}-button`,
+                ...searchButtonDataProps,
+              })}
+              {...buttonProps}
+            >
+              {searchButtonText}
+            </Button>
+          </StyledSearchButton>
+        )}
+      </StyledSearch>
+    );
+  },
+);
+
+export default Search;

--- a/src/components/search/__internal__/legacy/search.pw.tsx
+++ b/src/components/search/__internal__/legacy/search.pw.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { test, expect } from "../../../../../playwright/helpers/base-test";
+import { checkAccessibility } from "../../../../../playwright/support/helper";
+import {
+  SearchComponent,
+  SearchComponentDarkBackground,
+} from "./components.test-pw";
+
+test.describe("Accessibility tests for Search", () => {
+  test("should check accessibility for searchButton", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<SearchComponent searchButton />);
+
+    await checkAccessibility(page);
+  });
+
+  // check accessibility when typing due to cursor colour changes
+  [true, false].forEach((showButton) => {
+    test(`should check accessibility with variant prop set to dark and 'searchButton' is ${showButton}`, async ({
+      mount,
+      page,
+    }) => {
+      await mount(<SearchComponentDarkBackground searchButton={showButton} />);
+
+      await checkAccessibility(page);
+
+      await page.keyboard.press("Tab");
+      await expect(page.getByRole("textbox")).toBeFocused();
+
+      await checkAccessibility(page);
+
+      await page.keyboard.type("hello world");
+
+      await checkAccessibility(page);
+    });
+  });
+});

--- a/src/components/search/__internal__/legacy/search.style.ts
+++ b/src/components/search/__internal__/legacy/search.style.ts
@@ -1,10 +1,10 @@
 import { margin } from "styled-system";
 import styled, { css } from "styled-components";
 
-import StyledInputIconToggle from "../../__internal__/input-icon-toggle/input-icon-toggle.style";
-import StyledIcon from "../icon/icon.style";
-import applyBaseTheme from "../../style/themes/apply-base-theme";
-import StyledFormField from "../../__internal__/form-field/form-field.style";
+import StyledInputIconToggle from "../../../../__internal__/input-icon-toggle/input-icon-toggle.style";
+import StyledIcon from "../../../icon/icon.style";
+import applyBaseTheme from "../../../../style/themes/apply-base-theme";
+import StyledFormField from "../../../../__internal__/form-field/form-field.style";
 
 interface StyledSearchProps {
   name?: string;

--- a/src/components/search/__internal__/legacy/search.test.tsx
+++ b/src/components/search/__internal__/legacy/search.test.tsx
@@ -1,0 +1,497 @@
+import React, { useRef } from "react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { enGB } from "../../../../locales";
+import Search, { SearchEvent, SearchHandle } from "./search.component";
+import { testStyledSystemMargin } from "../../../../__spec_helper__/__internal__/test-utils";
+
+import I18nProvider from "../../../i18n-provider";
+
+jest.mock("../../../../__internal__/utils/logger");
+
+const StatefulComponent = (props: {
+  value?: string;
+  changeHandler: (e: SearchEvent) => void;
+  name?: string;
+  id?: string;
+}) => {
+  const [value, setValue] = React.useState(props.value ?? "");
+  return (
+    <Search
+      placeholder="Search..."
+      onChange={(e) => {
+        setValue(e.target.value);
+        props.changeHandler(e);
+      }}
+      value={value}
+      {...props}
+    />
+  );
+};
+
+testStyledSystemMargin(
+  (props) => (
+    <Search data-role="search" value="" onChange={jest.fn} {...props} />
+  ),
+  () => screen.getByTestId("search"),
+);
+
+test("the search input has a default accessible name of `Search`", () => {
+  render(<Search value="" onChange={jest.fn} />);
+
+  expect(screen.getByRole("textbox")).toHaveAccessibleName("Search");
+});
+
+test("the label prop passes a custom accessible name to the search input", () => {
+  render(<Search value="" onChange={jest.fn} label="baz" />);
+
+  expect(screen.getByRole("textbox")).toHaveAccessibleName("baz");
+});
+
+test("the `aria-label` prop passes a custom accessible name to the search input", () => {
+  render(<Search value="" onChange={jest.fn} aria-label="foobar" />);
+
+  expect(screen.getByRole("textbox")).toHaveAccessibleName("foobar");
+});
+
+test("aria-label prop takes precedence over label prop for the search input accessible name", () => {
+  render(
+    <Search value="" onChange={jest.fn} aria-label="foobar" label="baz" />,
+  );
+
+  expect(screen.getByRole("textbox")).toHaveAccessibleName("foobar");
+});
+
+test("when the `searchButton` prop is `true`, a button with search icon is shown, and no icon appears in the textbox", () => {
+  render(
+    <Search
+      searchButton
+      value=""
+      searchButtonAriaLabel="search button"
+      onChange={jest.fn}
+    />,
+  );
+
+  const searchButton = screen.getByRole("button", { name: "search button" });
+  expect(searchButton).toBeVisible();
+  expect(within(searchButton).getByTestId("icon")).toHaveAttribute(
+    "type",
+    "search",
+  );
+  expect(
+    within(screen.getByTestId("input-text-container")).queryByTestId("icon"),
+  ).not.toBeInTheDocument();
+});
+
+test("when the `searchButton` prop is `true`, the appropriate `data-` tags can be set via `searchButtonDataProps`", () => {
+  render(
+    <Search
+      searchButton
+      value=""
+      searchButtonDataProps={{
+        "data-role": "foo",
+        "data-element": "bar",
+      }}
+      searchButtonAriaLabel="search button"
+      onChange={jest.fn}
+    />,
+  );
+
+  const searchButton = screen.getByRole("button", { name: "search button" });
+  expect(searchButton).toHaveAttribute("data-role", "foo");
+  expect(searchButton).toHaveAttribute("data-element", "bar");
+});
+
+test("when the `searchButton` prop is a string value, a button with search icon is shown, and no icon appears in the textbox", () => {
+  render(
+    <Search
+      searchButton="custom search button"
+      value=""
+      onChange={jest.fn}
+      searchButtonAriaLabel="search button"
+    />,
+  );
+
+  const searchButton = screen.getByRole("button", { name: "search button" });
+  expect(searchButton).toBeVisible();
+  expect(searchButton).toHaveTextContent("custom search button");
+  expect(within(searchButton).getByTestId("icon")).toHaveAttribute(
+    "type",
+    "search",
+  );
+  expect(
+    within(screen.getByTestId("input-text-container")).queryByTestId("icon"),
+  ).not.toBeInTheDocument();
+});
+
+test("when the `searchButton` prop is not passed, no button with is shown, and an icon is rendered in the textbox", () => {
+  render(
+    <Search
+      value=""
+      onChange={jest.fn}
+      searchButtonAriaLabel="search button"
+    />,
+  );
+
+  expect(
+    screen.queryByRole("button", { name: "search button" }),
+  ).not.toBeInTheDocument();
+  expect(
+    within(screen.getByTestId("input-text-container")).getByTestId("icon"),
+  ).toHaveAttribute("type", "search");
+});
+
+test("the search button text can be overridden via the locale context", () => {
+  render(
+    <I18nProvider
+      locale={{ search: { searchButtonText: () => "text override" } }}
+    >
+      <Search searchButton value="" onChange={jest.fn} />
+    </I18nProvider>,
+  );
+
+  expect(screen.getByRole("button")).toHaveTextContent("text override");
+});
+
+test("the search button uses the value from the locale context as a default accessible name", () => {
+  render(
+    <I18nProvider locale={enGB}>
+      <Search value="" searchButton onChange={jest.fn} />
+    </I18nProvider>,
+  );
+
+  expect(screen.getByRole("button")).toHaveAccessibleName("Search");
+});
+
+test("the `searchButtonAriaLabel` prop passes a custom accessible name to the search button", () => {
+  render(
+    <Search
+      searchButton
+      searchButtonAriaLabel="foobar button"
+      onChange={jest.fn}
+      value=""
+    />,
+  );
+
+  expect(screen.getByRole("button")).toHaveAccessibleName("foobar button");
+});
+
+test("the `onClick` callback prop is not called when the input is clicked", async () => {
+  const user = userEvent.setup();
+  const onClick = jest.fn();
+  render(<Search value="" onChange={jest.fn} onClick={onClick} />);
+
+  await user.click(screen.getByRole("textbox"));
+  expect(onClick).not.toHaveBeenCalled();
+});
+
+test("when the input is focused, the `onFocus` callback prop is called", async () => {
+  const user = userEvent.setup();
+  const onFocus = jest.fn();
+  render(<Search value="" onChange={jest.fn} onFocus={onFocus} />);
+
+  await user.tab();
+  expect(screen.getByRole("textbox")).toHaveFocus();
+  expect(onFocus).toHaveBeenCalledTimes(1);
+});
+
+test("when the input is blurred, the `onBlur` callback prop is called", async () => {
+  const user = userEvent.setup();
+  const onBlur = jest.fn();
+  render(<Search value="" onChange={jest.fn} onBlur={onBlur} />);
+
+  act(() => {
+    screen.getByRole("textbox").focus();
+  });
+  await user.tab();
+  expect(onBlur).toHaveBeenCalledTimes(1);
+});
+
+test("when a key is pressed, the `onKeyDown` callback prop is called", async () => {
+  const user = userEvent.setup();
+  const onKeyDown = jest.fn();
+  render(<Search value="" onChange={jest.fn} onKeyDown={onKeyDown} />);
+
+  await user.type(screen.getByRole("textbox"), "a");
+  expect(onKeyDown).toHaveBeenCalledTimes(1);
+});
+
+test("when the cross icon is clicked, the input value is cleared", async () => {
+  const user = userEvent.setup();
+  const onChange = jest.fn();
+  render(<StatefulComponent changeHandler={onChange} name="bar" id="baz" />);
+  await user.type(screen.getByRole("textbox"), "a");
+
+  await user.click(screen.getByTestId("input-icon-toggle"));
+
+  await waitFor(() => {
+    expect(screen.getByRole("textbox")).toHaveValue("");
+  });
+  expect(onChange).toHaveBeenCalledWith(
+    expect.objectContaining({ target: { value: "", name: "bar", id: "baz" } }),
+  );
+});
+
+test("when the cross icon is clicked, and the `triggerOnClear` props is passed, the `onClick` callback prop is called", async () => {
+  const user = userEvent.setup();
+  const onClick = jest.fn();
+  render(
+    <Search
+      value="foo"
+      onChange={jest.fn}
+      searchButton
+      triggerOnClear
+      onClick={onClick}
+      name="bar"
+      id="baz"
+    />,
+  );
+  await user.click(screen.getByTestId("input-icon-toggle"));
+
+  expect(onClick).toHaveBeenCalledWith({
+    target: {
+      name: "bar",
+      id: "baz",
+      value: "",
+    },
+  });
+});
+
+test("when the cross icon is clicked, and the `triggerOnClear` props is not passed, the `onClick` callback prop is not called", async () => {
+  const user = userEvent.setup();
+  const onClick = jest.fn();
+  render(
+    <Search
+      value="foo"
+      onChange={jest.fn}
+      searchButton
+      onClick={onClick}
+      name="bar"
+      id="baz"
+    />,
+  );
+  await user.click(screen.getByTestId("input-icon-toggle"));
+
+  expect(onClick).not.toHaveBeenCalled();
+});
+
+test("when the component is controlled, the input takes its value from the `value` prop", () => {
+  render(<Search value="Bar" onChange={jest.fn} />);
+
+  expect(screen.getByRole("textbox")).toHaveValue("Bar");
+});
+
+test("when the input value changes, the `onChange` callback prop is called", async () => {
+  const user = userEvent.setup();
+  const onChange = jest.fn();
+  render(<StatefulComponent changeHandler={onChange} />);
+
+  await user.type(screen.getByRole("textbox"), "a");
+  expect(onChange).toHaveBeenCalledTimes(1);
+  expect(onChange).toHaveBeenCalledWith(
+    expect.objectContaining({
+      target: expect.objectContaining({ value: "a" }),
+    }),
+  );
+});
+
+test("when the component is controlled, the `onClick` callback prop is called with the values in the input when the search button is clicked", async () => {
+  const user = userEvent.setup();
+  const onClick = jest.fn();
+  render(
+    <Search
+      value="FooBar"
+      id="Search"
+      name="Search"
+      onClick={onClick}
+      onChange={jest.fn}
+      searchButton
+      searchButtonAriaLabel="search button"
+    />,
+  );
+
+  await user.click(screen.getByRole("button", { name: "search button" }));
+  expect(onClick).toHaveBeenCalledTimes(1);
+  expect(onClick).toHaveBeenCalledWith(
+    expect.objectContaining({
+      target: { value: "FooBar", id: "Search", name: "Search" },
+    }),
+  );
+});
+
+test("the component's wrapper element has the appropriate `data-` tags", () => {
+  render(
+    <Search data-role="foo" data-element="bar" value="" onChange={jest.fn} />,
+  );
+
+  const search = screen.getByTestId("foo");
+
+  expect(search).toHaveAttribute("data-component", "search");
+  expect(search).toHaveAttribute("data-element", "bar");
+});
+
+test("do not render remove button when the input is empty", () => {
+  render(<Search value="" onChange={jest.fn} />);
+
+  expect(screen.queryByTestId("input-icon-toggle")).not.toBeInTheDocument();
+});
+
+test("render remove button when the input is not empty", () => {
+  render(<Search value="foo" onChange={jest.fn} />);
+
+  expect(screen.getByTestId("input-icon-toggle")).toBeVisible();
+});
+
+test("remove button can be reached via keyboard when present", async () => {
+  const user = userEvent.setup();
+  render(<Search value="foo" onChange={jest.fn} />);
+
+  act(() => {
+    screen.getByRole("textbox").focus();
+  });
+  await user.tab();
+
+  expect(screen.getByTestId("input-icon-toggle")).not.toHaveFocus();
+});
+
+test("when a character key is pressed, propagation of the event to parent elements is prevented", async () => {
+  const user = userEvent.setup();
+  const outerOnKeyDown = jest.fn();
+  render(
+    <button type="button" aria-label="foo" onKeyDown={outerOnKeyDown}>
+      <Search value="" onChange={jest.fn} />
+    </button>,
+  );
+
+  await user.type(screen.getByRole("textbox"), "a");
+  expect(outerOnKeyDown).not.toHaveBeenCalled();
+});
+
+test("when a number key is pressed, propagation of the event to parent elements is prevented", async () => {
+  const user = userEvent.setup();
+  const outerOnKeyDown = jest.fn();
+  render(
+    <button type="button" aria-label="foo" onKeyDown={outerOnKeyDown}>
+      <Search value="" onChange={jest.fn} />
+    </button>,
+  );
+
+  await user.type(screen.getByRole("textbox"), "2");
+  expect(outerOnKeyDown).not.toHaveBeenCalled();
+});
+
+test("when a non-alphanumeric key is pressed, propagation of the event to parent elements is not prevented", async () => {
+  const user = userEvent.setup();
+  const outerOnKeyDown = jest.fn();
+  render(
+    <button type="button" aria-label="foo" onKeyDown={outerOnKeyDown}>
+      <Search onChange={jest.fn} value="" />
+    </button>,
+  );
+
+  await user.type(screen.getByRole("textbox"), "{Tab}");
+  expect(outerOnKeyDown).toHaveBeenCalledWith(
+    expect.objectContaining({ key: "Tab" }),
+  );
+});
+
+test("the input can be programmatically focused using a ref", async () => {
+  const RefExample = () => {
+    const ref = useRef<SearchHandle>(null);
+
+    return (
+      <div>
+        <button type="button" onClick={() => ref.current?.focus()}>
+          Focus input
+        </button>
+        <Search value="foo" onChange={() => {}} ref={ref} />
+      </div>
+    );
+  };
+
+  const user = userEvent.setup();
+  render(<RefExample />);
+
+  await user.click(screen.getByRole("button", { name: "Focus input" }));
+
+  expect(screen.getByRole("textbox")).toHaveFocus();
+});
+
+// for coverage - dark variant styles are tested in Playwright
+test("should render the bottom border when variant is dark, the input is not focused and has a value", () => {
+  render(
+    <Search
+      data-role="search"
+      variant="dark"
+      value="search"
+      onChange={jest.fn}
+    />,
+  );
+
+  const search = screen.getByTestId("search");
+
+  expect(search).toHaveStyle({
+    "background-color": "rgba(0, 0, 0, 0)",
+  });
+  expect(search).toHaveStyleRule(
+    "border-bottom",
+    "var(--spacing025) solid var(--colorsUtilityYang080)",
+  );
+});
+
+// for coverage - `searchWidth` prop is tested in Playwright
+test("applies the correct width specified by the user", () => {
+  render(
+    <Search
+      data-role="search"
+      searchWidth="400px"
+      value=""
+      onChange={jest.fn}
+    />,
+  );
+
+  const search = screen.getByTestId("search");
+
+  expect(search).toHaveStyle({
+    display: "inline-flex",
+    width: "400px",
+  });
+  expect(search).toHaveStyleRule(
+    "border-bottom",
+    "var(--spacing025) solid var(--colorsUtilityMajor300)",
+  );
+  expect(search).toHaveStyleRule("font-size", "var(--fontSize100)");
+});
+
+// for coverage - `maxWidth` prop is tested in Playwright
+test("applies the correct maxWidth specified by the user", () => {
+  render(
+    <Search data-role="search" maxWidth="67%" value="" onChange={jest.fn} />,
+  );
+
+  const search = screen.getByTestId("search");
+
+  expect(search).toHaveStyle({
+    "max-width": "67%",
+  });
+});
+
+test("clears the value when the escape key is pressed", async () => {
+  const user = userEvent.setup();
+  const mockOnChange = jest.fn();
+  render(
+    <Search
+      value="foo"
+      onChange={mockOnChange}
+      name="search-bar"
+      id="search-id"
+    />,
+  );
+
+  const input = screen.getByRole("textbox");
+  await user.click(input);
+  await user.keyboard("{Escape}");
+  expect(screen.queryByText("foo")).not.toBeInTheDocument();
+  expect(mockOnChange).toHaveBeenCalled();
+});

--- a/src/components/search/components.test-pw.tsx
+++ b/src/components/search/components.test-pw.tsx
@@ -1,34 +1,39 @@
-import React from "react";
+import React, { useState } from "react";
 import Search, { SearchProps } from ".";
 import Box from "../box";
 
-export const SearchComponent = (
-  props: Partial<SearchProps> & { value?: string },
-) => {
-  const [internalValue, setInternalValue] = React.useState(props.value ?? "");
+export const SearchComponentWithLabelHintAndError = () => {
   return (
     <Search
-      placeholder="Search..."
-      onChange={(e) => setInternalValue(e.target.value)}
-      value={internalValue}
-      {...props}
+      label="Search"
+      value="Default with label, hint and error"
+      onChange={() => {}}
+      inputHint="Hint text"
+      error="Error message"
     />
   );
 };
 
-export const SearchComponentDarkBackground = (
-  props: Omit<SearchProps, "onChange" | "value">,
-) => {
-  const [value, setValue] = React.useState("foo");
+export const SearchComponentInverseWithLabelHintAndError = () => (
+  <Box width="700px" height="140px" backgroundColor="#000000">
+    <Search
+      label="Search"
+      inputHint="Hint text"
+      value="Inverse with label, hint and error"
+      onChange={() => {}}
+      inverse
+      error="Error message"
+    />
+  </Box>
+);
+
+export const SearchComponent = (props: Partial<SearchProps>) => {
+  const [value, setValue] = useState("");
   return (
-    <Box width="700px" height="108px" bg="#003349">
-      <Search
-        placeholder="Search..."
-        onChange={(e) => setValue(e.target.value)}
-        value={value}
-        variant="dark"
-        {...props}
-      />
-    </Box>
+    <Search
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      {...props}
+    />
   );
 };

--- a/src/components/search/search-interaction.stories.tsx
+++ b/src/components/search/search-interaction.stories.tsx
@@ -3,7 +3,7 @@ import { StoryObj, StoryFn } from "@storybook/react-vite";
 import { userEvent } from "storybook/test";
 
 import Box from "../box";
-import Search from "./search.component";
+import Search from ".";
 import Card from "../card";
 import Typography from "../typography";
 

--- a/src/components/search/search-test.stories.tsx
+++ b/src/components/search/search-test.stories.tsx
@@ -1,185 +1,141 @@
 import React, { useEffect, useRef, useState } from "react";
-import { action } from "storybook/actions";
-import Pill from "../pill/pill.component";
 import Box from "../box";
 import Search from ".";
-import { SearchEvent, SearchHandle } from "./search.component";
+import { SearchProps, SearchHandle } from "./search.component";
+
+const defaultSearchControlsInclude = [
+  "value",
+  "aria-label",
+  "searchButtonAriaLabel",
+  "id",
+  "name",
+  "label",
+  "inputHint",
+  "size",
+  "inputWidth",
+  "maxWidth",
+  "error",
+  "inverse",
+  "labelInline",
+  "required",
+  "triggerOnClear",
+];
+
+const defaultSearchArgTypes = {
+  inputWidth: {
+    control: {
+      type: "range" as const,
+      min: 0,
+      max: 100,
+      step: 1,
+    },
+  },
+  maxWidth: {
+    control: { type: "text" as const },
+  },
+  size: {
+    options: ["small", "medium", "large"],
+    control: { type: "select" as const },
+  },
+  error: {
+    options: ["false", "true", "message"],
+    mapping: {
+      false: false,
+      true: true,
+      message: "Error message",
+    },
+    control: { type: "select" as const },
+    labels: {
+      false: "false",
+      true: "true",
+      message: "Error message",
+    },
+  },
+  inverse: {
+    control: { type: "boolean" as const },
+  },
+  labelInline: {
+    control: { type: "boolean" as const },
+  },
+  required: {
+    control: { type: "boolean" as const },
+  },
+  triggerOnClear: {
+    control: { type: "boolean" as const },
+  },
+};
+
+const defaultSearchArgs: Partial<SearchProps> = {
+  value: "",
+  "aria-label": "Search",
+  searchButtonAriaLabel: "Search",
+  id: "search_id",
+  name: "search_name",
+  label: "",
+  inputHint: "",
+  size: "medium",
+  inputWidth: undefined,
+  maxWidth: "",
+  error: false,
+  inverse: false,
+  labelInline: false,
+  required: false,
+  triggerOnClear: false,
+};
 
 export default {
   title: "Search/Test",
   parameters: {
     info: { disable: true },
     chromatic: {
-      disableSnapshot: true,
+      disableSnapshot: false,
     },
     themeProvider: { chromatic: { theme: "sage" } },
   },
-  argTypes: {
-    variant: {
-      options: ["default", "dark"],
-      control: {
-        type: "select",
-      },
-    },
-  },
 };
 
-export const Default = ({ placeholder, ...args }: { placeholder?: string }) => {
-  const [value, setValue] = useState("");
-  const handleChange = (event: SearchEvent) => {
-    setValue(event.target.value);
-    action("change")(event.target.value);
-  };
-  const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-    action("blur")(event.target.value);
-  };
-  const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
-    action("focus")(event.target.value);
-  };
-  const handleClick = (event: SearchEvent) => {
-    action("click")(event.target.value);
-  };
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    action("keydown")(event.target);
-  };
+const DefaultTestStory = (args: SearchProps) => {
+  const { value: initialValue = "", onChange, ...rest } = args;
 
-  return (
+  const [value, setValue] = useState(initialValue);
+
+  useEffect(() => {
+    setValue(initialValue);
+  }, [initialValue]);
+
+  const search = (
     <Search
-      onChange={handleChange}
-      onBlur={handleBlur}
-      onClick={handleClick}
-      onFocus={handleFocus}
-      onKeyDown={handleKeyDown}
+      {...rest}
       value={value}
-      placeholder={placeholder}
-      name="search_name"
-      id="search_id"
-      {...args}
+      onChange={(e) => {
+        setValue(e.target.value);
+        onChange?.(e);
+      }}
     />
   );
+
+  if (rest.inverse) {
+    return (
+      <Box p={3} backgroundColor="#000000">
+        {search}
+      </Box>
+    );
+  }
+
+  return search;
 };
 
+export const Default = (args: SearchProps) => <DefaultTestStory {...args} />;
 Default.storyName = "Default";
-
-Default.args = {
-  placeholder: "Search...",
-  searchButton: true,
-  searchWidth: "",
-  threshold: 3,
-  variant: undefined,
-};
-
-export const FilterOnClear = () => {
-  const [value, setValue] = useState("");
-  const textArray = ["test value 1", "test value 2", "test value 3"];
-  const [filteredText, setFilteredText] = useState(textArray);
-
-  const updateFilteredElements = (searchValue: string) => {
-    if (searchValue === "") {
-      setFilteredText(textArray);
-    } else {
-      setFilteredText(textArray.filter((text) => text.includes(searchValue)));
-    }
-  };
-  return (
-    <>
-      <Search
-        id="test"
-        name="test"
-        placeholder="Search..."
-        triggerOnClear
-        onClick={(e) => updateFilteredElements(e.target.value)}
-        onChange={(e) => setValue(e.target.value)}
-        value={value}
-        searchButton
-      />
-
-      <div>
-        {filteredText.map((text) => (
-          <Pill key={text}>{text}</Pill>
-        ))}
-      </div>
-    </>
-  );
-};
-FilterOnClear.storyName = "Filter on clear";
-
-export const Validation = () => {
-  const [state, setState] = useState("");
-  const [state2, setState2] = useState("");
-  const [state4, setState4] = useState("");
-  const [state5, setState5] = useState("");
-
-  return (
-    <>
-      <Search
-        onChange={(ev) => setState(ev.target.value)}
-        value={state}
-        searchButton
-        error="Error Message"
-        mb={2}
-      />
-      <Search
-        onChange={(ev) => setState2(ev.target.value)}
-        value={state2}
-        searchButton
-        warning="Warning Message"
-        mb={2}
-      />
-
-      <Search
-        onChange={(ev) => setState4(ev.target.value)}
-        value={state4}
-        searchButton
-        error
-        mb={2}
-      />
-      <Search
-        onChange={(ev) => setState5(ev.target.value)}
-        value={state5}
-        searchButton
-        warning
-        mb={2}
-      />
-    </>
-  );
-};
-Validation.storyName = "Validation";
-Validation.parameters = {
-  chromatic: { disableSnapshot: false },
-  themeProvider: { chromatic: { theme: "sage" } },
-};
-
-export const HoverStyling = () => (
-  <>
-    <Box mb={4}>
-      <Search
-        placeholder="Search..."
-        onChange={() => {}}
-        value=""
-        aria-label="Search default"
-        data-role="search-default"
-      />
-    </Box>
-    <Box width="700px" p={4} backgroundColor="#003349">
-      <Search
-        placeholder="Search..."
-        onChange={() => {}}
-        value=""
-        variant="dark"
-        aria-label="Search dark"
-        data-role="search-dark"
-      />
-    </Box>
-  </>
-);
-HoverStyling.storyName = "Hover Styling";
-HoverStyling.parameters = {
-  chromatic: { disableSnapshot: false },
-  pseudo: {
-    hover: ["[data-role='search-default']", "[data-role='search-dark']"],
+Default.parameters = {
+  chromatic: { disableSnapshot: true },
+  controls: {
+    expanded: true,
+    include: defaultSearchControlsInclude,
   },
 };
+Default.argTypes = defaultSearchArgTypes;
+Default.args = defaultSearchArgs;
 
 const AutoFocusSearch = (props: React.ComponentProps<typeof Search>) => {
   const ref = useRef<SearchHandle>(null);
@@ -191,9 +147,29 @@ const AutoFocusSearch = (props: React.ComponentProps<typeof Search>) => {
   return <Search ref={ref} {...props} />;
 };
 
-export const FocusStyling = () => (
+export const HoverAndFocusStyling = () => (
   <>
-    <Box mb={4}>
+    <Box mb={4} width="700px" p={4}>
+      <Search
+        placeholder="Search..."
+        onChange={() => {}}
+        value=""
+        aria-label="Search default"
+        data-role="search-default"
+      />
+    </Box>
+    <Box width="700px" p={4} backgroundColor="#000000">
+      <Search
+        placeholder="Search..."
+        onChange={() => {}}
+        value=""
+        inverse
+        aria-label="Search inverse"
+        data-role="search-inverse"
+      />
+    </Box>
+
+    <Box mb={4} width="700px" p={4}>
       <AutoFocusSearch
         placeholder="Search..."
         onChange={() => {}}
@@ -201,22 +177,141 @@ export const FocusStyling = () => (
         aria-label="Search input"
       />
     </Box>
-    <Box>
+    <Box width="700px" p={4}>
       <Search
         placeholder="Search..."
         onChange={() => {}}
         value=""
-        searchButton
         aria-label="Search button"
         data-role="search-button-focus"
       />
     </Box>
   </>
 );
-FocusStyling.storyName = "Focus Styling";
-FocusStyling.parameters = {
-  chromatic: { disableSnapshot: false },
+HoverAndFocusStyling.storyName = "Hover & Focus Styling";
+HoverAndFocusStyling.parameters = {
   pseudo: {
+    hover: [
+      "[data-role='search-default'] .search-button",
+      "[data-role='search-inverse'] .search-button",
+    ],
     focus: "[data-role='search-button-focus'] .search-button",
   },
 };
+
+export const RegressionMatrix = () => (
+  <Box
+    width="820px"
+    display="grid"
+    gridTemplateColumns="repeat(2, minmax(0, 1fr))"
+    gap={3}
+  >
+    <Box p={4}>
+      <Search
+        onChange={() => {}}
+        value="Default configuration"
+        aria-label="Default configuration"
+      />
+    </Box>
+
+    <Box p={4} backgroundColor="#000000">
+      <Search
+        onChange={() => {}}
+        value="Inverse configuration"
+        inverse
+        aria-label="Inverse configuration"
+      />
+    </Box>
+
+    <Box p={4}>
+      <Search
+        onChange={() => {}}
+        value="Default with label and input hint"
+        label="Search"
+        inputHint="Input hint"
+        aria-label="Default with label and input hint"
+      />
+    </Box>
+
+    <Box p={4} backgroundColor="#000000">
+      <Search
+        onChange={() => {}}
+        value="Inverse with label and input hint"
+        inverse
+        label="Search"
+        inputHint="Input hint"
+        aria-label="Inverse with label and input hint"
+      />
+    </Box>
+
+    <Box p={4}>
+      <Search
+        onChange={() => {}}
+        value="Default with label, input hint and error"
+        label="Search"
+        inputHint="Input hint"
+        error="Error message"
+        aria-label="Default with label, input hint and error"
+      />
+    </Box>
+
+    <Box p={4} backgroundColor="#000000">
+      <Search
+        onChange={() => {}}
+        value="Inverse with label, input hint and error"
+        inverse
+        label="Search"
+        inputHint="Input hint"
+        error="Error message"
+        aria-label="Inverse with label, input hint and error"
+      />
+    </Box>
+
+    <Box p={4}>
+      <Search
+        onChange={() => {}}
+        value="Default with label inline and input hint"
+        label="Search"
+        inputHint="Input hint"
+        labelInline
+        aria-label="Default with label inline and input hint"
+      />
+    </Box>
+
+    <Box p={4} backgroundColor="#000000">
+      <Search
+        onChange={() => {}}
+        value="Inverse with label inline and input hint"
+        inverse
+        label="Search"
+        inputHint="Input hint"
+        labelInline
+        aria-label="Inverse with label inline and input hint"
+      />
+    </Box>
+
+    <Box p={4}>
+      <Search
+        onChange={() => {}}
+        value="Default required with label and input hint"
+        label="Search"
+        inputHint="Input hint"
+        required
+        aria-label="Default required with label and input hint"
+      />
+    </Box>
+
+    <Box p={4} backgroundColor="#000000">
+      <Search
+        onChange={() => {}}
+        value="Inverse required with label and input hint"
+        inverse
+        label="Search"
+        inputHint="Input hint"
+        required
+        aria-label="Inverse required with label and input hint"
+      />
+    </Box>
+  </Box>
+);
+RegressionMatrix.storyName = "Regression Matrix";

--- a/src/components/search/search.component.tsx
+++ b/src/components/search/search.component.tsx
@@ -1,16 +1,21 @@
-import React, { useState, useRef, useImperativeHandle, useMemo } from "react";
+import React, {
+  useEffect,
+  useRef,
+  useImperativeHandle,
+  useMemo,
+  useContext,
+} from "react";
 import invariant from "invariant";
 import { MarginProps } from "styled-system";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
-import { filterStyledSystemMarginProps } from "../../style/utils";
-import StyledSearch from "./search.style";
-import StyledSearchButton from "./search-button.style";
-import Icon from "../icon";
-import Textbox, { CommonTextboxProps } from "../textbox";
-import Button from "../button";
+import { CommonTextboxProps } from "../textbox";
+import Button, { type ButtonHandle } from "../button/__next__";
 import { ValidationProps } from "../../__internal__/validations";
 import useLocale from "../../hooks/__internal__/useLocale";
-import Events from "../../__internal__/utils/helpers/events";
+import Divider from "../divider";
+import TextInput from "../textbox/__internal__/__next__";
+import MenuContext from "../menu/__internal__/menu.context";
+import { Search as LegacySearch } from "./__internal__/legacy/search.component";
 
 export interface SearchEvent {
   target: {
@@ -20,39 +25,43 @@ export interface SearchEvent {
   };
 }
 
+export type SearchTextboxProps = Pick<
+  CommonTextboxProps,
+  | "tooltipPosition"
+  | "name"
+  | "id"
+  | "onFocus"
+  | "onKeyDown"
+  | "onBlur"
+  | "label"
+  | "inputHint"
+  | "size"
+  | "inputWidth"
+  | "className"
+  | "labelInline"
+  | "required"
+>;
+
 export interface SearchProps
   extends ValidationProps,
     MarginProps,
     TagProps,
-    Pick<CommonTextboxProps, "label" | "inputHint"> {
-  /** Prop to specify the aria-label of the search component */
+    SearchTextboxProps {
+  /** Prop to specify the accessible name of the Search input. To be used when no visible label is provided */
   "aria-label"?: string;
-  /** Prop to specify the aria-label of the search button */
+  /** Prop to specify the accessible name of the Search button */
   searchButtonAriaLabel?: string;
-  /** Prop for `id` */
-  id?: string;
-  /** Prop for `name` */
-  name?: string;
-  /** Prop for `onBlur` events */
-  onBlur?: (ev: React.FocusEvent<HTMLInputElement>) => void;
-  /** Prop for `onChange` events */
+  /** Prop for `onChange` events on the Search input */
   onChange: (ev: SearchEvent) => void;
-  /** Prop for `onClick` events.
-   *  `onClick` events are triggered when the `searchButton` is clicked
+  /** Prop for `onClick` events on the Search button.
+   *  `onClick` events are triggered when the Search button is clicked
+   *  or when the Search input's cross icon is clicked if the `triggerOnClear` prop is set to `true`.
    */
   onClick?: (ev: SearchEvent) => void;
-
-  /**
-   * Sets whether the onClick action should be triggered when the Search cross icon is clicked.
-   */
+  /** Sets whether the `onClick` action should be triggered when the Search cross icon is clicked. */
   triggerOnClear?: boolean;
-  /** Prop for `onFocus` events */
-  onFocus?: (ev: React.FocusEvent<HTMLInputElement>) => void;
-  /** Prop for `onKeyDown` events */
-  onKeyDown?: (ev: React.KeyboardEvent<HTMLInputElement>) => void;
-  /** Prop for a placeholder */
-  placeholder?: string;
   /**
+   * @deprecated This prop no longer has any effect. This prop will eventually be removed.
    * Pass a boolean to render a search Button with default text.
    * Pass a string to override the text in the search Button
    * */
@@ -60,28 +69,35 @@ export interface SearchProps
   /** Data tag prop bag for searchButton */
   searchButtonDataProps?: TagProps;
   /**
-   * Prop for specifying an input width length.
+   * @deprecated This prop no longer has any effect. This prop will eventually be removed. Use `inputWidth` instead.
+   * Prop for specifying the width of the Search container. This value is mapped to `inputWidth`.
    * Leaving the `searchWidth` prop with no value will default the width to '100%'
    */
   searchWidth?: string;
   /**
-   * Prop for specifying the max-width of the input.
+   * Prop for specifying the max-width of the Search input.
    * Leaving the `maxWidth` prop with no value will default the width to '100%'
    */
   maxWidth?: string;
+  /** @deprecated This prop no longer has any effect. This prop will eventually be removed. */
+  placeholder?: CommonTextboxProps["placeholder"];
   /** Current value */
   value: string;
-  /** Prop to specify the styling of the search component */
+  /** @deprecated This prop no longer has any effect. This prop will eventually be removed. `variant="dark"` is mapped to `inverse={true}` to preserve legacy behavior. */
   variant?: "default" | "dark";
-  /** Input tabindex */
+  /** @deprecated This prop no longer has any effect. This prop will eventually be removed. Input tabindex */
   tabIndex?: number;
-  /** [Legacy] Overrides the default tooltip position */
-  tooltipPosition?: "top" | "bottom" | "left" | "right";
+  /** When set to `true`, inverts the Search input and button styling for use on darker backgrounds. */
+  inverse?: boolean;
+  /** @deprecated This prop no longer has any effect. This prop will eventually be removed. */
+  warning?: CommonTextboxProps["warning"];
 }
 
 export type SearchHandle = {
-  /** Programmatically focus on root container of Dialog. */
+  /** Programmatically focus the search input. */
   focus: () => void;
+  /** Programmatically focus the search button. */
+  focusButton: () => void;
 } | null;
 
 export const Search = React.forwardRef<SearchHandle, SearchProps>(
@@ -89,226 +105,203 @@ export const Search = React.forwardRef<SearchHandle, SearchProps>(
     {
       onChange,
       onClick,
-      onFocus,
-      onBlur,
-      onKeyDown,
+      triggerOnClear,
       value,
       id,
       name,
       label,
-      inputHint,
-      searchWidth,
-      maxWidth,
-      searchButton,
+      placeholder,
       searchButtonDataProps,
       searchButtonAriaLabel,
-      placeholder,
-      variant = "default",
       "aria-label": ariaLabel,
-      tabIndex,
+      variant,
+      inverse,
       error,
-      warning,
-      info,
+      size,
+      inputWidth,
+      searchButton,
+      searchWidth,
+      maxWidth,
+      tabIndex,
       tooltipPosition,
-      triggerOnClear,
+      warning,
+      className,
       ...rest
     },
     ref,
   ) => {
     const locale = useLocale();
-    const searchRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLInputElement>(null);
+    const buttonRef = useRef<ButtonHandle>(null);
+    const legacyRef = useRef<SearchHandle>(null);
+
+    // in order to support backwards compatibility with the Search component when used within a Menu,
+    // we render the LegacySearch component instead of the new Search component when the Search component is rendered within a Menu.
+    // This is to avoid any breaking UI changes that may occur from the new Search component being rendered within a Menu
+    // as there are no designs for this in the fusion DS
+    const { inMenu } = useContext(MenuContext);
 
     useImperativeHandle<SearchHandle, SearchHandle>(
       ref,
       () => ({
         focus() {
+          if (inMenu) {
+            legacyRef.current?.focus();
+            return;
+          }
+
           inputRef.current?.focus();
         },
+        focusButton() {
+          buttonRef.current?.focusButton();
+        },
       }),
-      [],
+      [inMenu],
     );
 
     invariant(typeof value === "string", "This component has no initial value");
 
-    const [isFocused, setIsFocused] = useState(false);
+    const searchButtonText = locale.search.searchButtonText();
 
-    const isSearchValueEmpty = value.length === 0;
+    // calls onClick when search input is cleared using the native clear button in certain browsers (e.g. Chromium & Safari)
+    useEffect(() => {
+      if (!triggerOnClear || !onClick) return;
 
-    let buttonProps = {};
+      const inputElement = inputRef.current;
+      if (!inputElement) return;
 
-    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-      onChange(event);
-    };
+      const enterPressedRef = { current: false };
 
-    const handleFocus = (event: React.FocusEvent<HTMLInputElement>) => {
-      setIsFocused(true);
-      if (onFocus) {
-        onFocus(event);
-      }
-    };
+      const handleKeyDown = (event: KeyboardEvent) => {
+        enterPressedRef.current = event.key === "Enter";
+      };
 
-    if (searchButton && onClick) {
-      buttonProps = {
-        onClick: () => {
+      const handleNativeSearch = (event: Event) => {
+        const target = event.target as HTMLInputElement;
+
+        if (!target.value && !enterPressedRef.current) {
           onClick({
             target: {
-              name,
-              id,
-              value,
+              ...(name && { name }),
+              ...(id && { id }),
+              value: target.value,
             },
           });
-        },
+        }
+
+        enterPressedRef.current = false;
       };
-    }
 
-    const handleIconClick = () => {
-      onChange?.({
-        target: {
-          ...(name && { name }),
-          ...(id && { id }),
-          value: "",
-        },
-      });
+      inputElement.addEventListener("keydown", handleKeyDown);
+      inputElement.addEventListener("search", handleNativeSearch);
 
-      if (triggerOnClear) {
-        onClick?.({
-          target: {
-            ...(name && { name }),
-            ...(id && { id }),
-            value: "",
-          },
-        });
-      }
+      return () => {
+        inputElement.removeEventListener("keydown", handleKeyDown);
+        inputElement.removeEventListener("search", handleNativeSearch);
+      };
+    }, [triggerOnClear, onClick, name, id]);
 
-      inputRef.current?.focus();
+    const toFiniteNumber = (value?: string) => {
+      if (!value) return undefined;
+      const parsed = Number.parseFloat(value);
+
+      return Number.isNaN(parsed) ? undefined : parsed;
     };
 
-    const handleMouseDown = (event: React.MouseEvent<HTMLElement>) => {
-      event.preventDefault();
+    const mappedInputWidth = inputWidth ?? toFiniteNumber(searchWidth);
+
+    const legacyOnlyProps = {
+      searchButton,
+      searchWidth,
+      tabIndex,
+      tooltipPosition,
+      warning,
     };
-
-    const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-      setIsFocused(false);
-
-      /* istanbul ignore else */
-      if (onBlur) {
-        onBlur(event);
-      }
-    };
-
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-      if (event.key.length === 1) {
-        event.stopPropagation();
-      }
-
-      if (Events.isEscKey(event) && !isSearchValueEmpty) {
-        event.stopPropagation();
-
-        onChange?.({
-          target: {
-            ...(name && { name }),
-            ...(id && { id }),
-            value: "",
-          },
-        });
-      }
-
-      if (onKeyDown) {
-        onKeyDown(event);
-      }
-    };
-
-    const searchButtonText =
-      typeof searchButton === "string"
-        ? searchButton
-        : locale.search.searchButtonText();
-    const searchHasValue = !!value?.length;
-
-    const { className: restClassName, ...filteredRest } = rest as Record<
-      string,
-      unknown
-    >;
 
     const classNames = useMemo(
       () =>
         [
           "search",
-          searchHasValue ? "has-value" : undefined,
-          variant === "dark" ? "dark-background" : undefined,
-          searchButton ? "with-button" : undefined,
-          restClassName,
+          inverse || variant === "dark" ? "inverse" : undefined,
+          error ? "error" : undefined,
+          className,
         ]
           .filter(Boolean)
           .join(" "),
-      [searchHasValue, variant, searchButton, restClassName],
+      [inverse, variant, className, error],
     );
 
+    if (inMenu) {
+      return (
+        <LegacySearch
+          {...rest}
+          {...legacyOnlyProps}
+          onChange={onChange}
+          value={value}
+          id={id}
+          error={error}
+          placeholder={placeholder}
+          name={name}
+          label={label}
+          variant={variant}
+          aria-label={ariaLabel}
+          searchButtonAriaLabel={searchButtonAriaLabel}
+          searchButtonDataProps={searchButtonDataProps}
+          triggerOnClear={triggerOnClear}
+          onClick={onClick}
+          ref={legacyRef}
+        />
+      );
+    }
+
     return (
-      <StyledSearch
-        ref={searchRef}
-        isFocused={isFocused}
-        searchWidth={searchWidth}
-        maxWidth={maxWidth}
-        searchHasValue={searchHasValue}
-        showSearchButton={!!searchButton}
-        variant={variant}
+      <TextInput
+        {...rest}
+        {...tagComponent("search", rest)}
+        className={classNames}
         id={id}
         name={name}
-        {...filteredRest}
-        {...filterStyledSystemMarginProps(filteredRest)}
-        {...tagComponent("search", filteredRest)}
-        className={classNames}
-      >
-        <Textbox
-          placeholder={placeholder}
-          value={value}
-          inputIcon={!isSearchValueEmpty ? "cross" : undefined}
-          iconTabIndex={!isSearchValueEmpty ? 0 : -1}
-          iconOnClick={handleIconClick}
-          iconOnMouseDown={handleMouseDown}
-          aria-label={
-            ariaLabel || (label ? undefined : locale.search.searchButtonText())
-          }
-          label={label}
-          inputHint={inputHint}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          ref={inputRef}
-          tabIndex={tabIndex}
-          error={error}
-          warning={warning}
-          info={info}
-          leftChildren={
-            !searchButton ? <Icon type="search" ml={1} /> : undefined
-          }
-          tooltipPosition={tooltipPosition}
-          my={0} // prevents any form spacing being applied
-          maxWidth="100%"
-        />
-        {searchButton && (
-          <StyledSearchButton>
+        type="search"
+        label={label || ""}
+        onChange={onChange}
+        value={value}
+        size={size}
+        inputWidth={mappedInputWidth}
+        maxWidth={maxWidth}
+        error={error}
+        aria-label={
+          ariaLabel || (label ? undefined : locale.search.searchButtonText())
+        }
+        ref={inputRef}
+        inputIcon={
+          <>
+            <Divider
+              aria-hidden
+              data-role="search-divider"
+              height={`calc(100% - var(--global-space-comp-${size?.charAt(0) || "m"}))`}
+              p={0}
+              type="vertical"
+            />
             <Button
+              ref={buttonRef}
               aria-label={searchButtonAriaLabel || searchButtonText}
-              size="medium"
-              px={2}
-              buttonType="primary"
-              iconPosition="before"
-              iconType="search"
               className="search-button"
+              iconType="search"
+              inverse={inverse}
+              size={size}
+              variant="default"
+              variantType="subtle"
               {...tagComponent(`${searchButtonText}-button`, {
                 "data-element": `${searchButtonText}-button`,
                 ...searchButtonDataProps,
               })}
-              {...buttonProps}
-            >
-              {searchButtonText}
-            </Button>
-          </StyledSearchButton>
-        )}
-      </StyledSearch>
+              {...(onClick && {
+                onClick: () => onClick({ target: { name, id, value } }),
+              })}
+            />
+          </>
+        }
+      />
     );
   },
 );

--- a/src/components/search/search.mdx
+++ b/src/components/search/search.mdx
@@ -9,14 +9,15 @@ import TranslationKeysTable from "../../../.storybook/utils/translation-keys-tab
 
 <a
   target="_blank"
-  href="https://zeroheight.com/2ccf2b601/p/64709e-search"
+  href="https://designsystem.sage.com/fusion/pages/components/search/"
   style={{ color: "#007E45", fontWeight: "bold", textDecoration: "underline" }}
   rel="noreferrer"
 >
   Product Design System component
 </a>
 
-This search component should be used if you require the user to conduct a search.
+Use the Search component when users need to query or filter content. Built on the native `<input type="search">`,
+it provides a familiar input pattern with a built-in search button.
 
 ## Contents
 
@@ -41,55 +42,37 @@ import Search, { type SearchHandle } from "carbon-react/lib/components/search";
 
 ### With Label and Hint Text
 
-You can pass a visible label and hint text to the `Search` component via the `label` & `inputHint` props. 
+You can pass a visible label and hint text to the `Search` component via the `label` & `inputHint` props.
 
 When the `inputHint` prop is passed, please use a full stop `.` at the end. This forces a pause
 before any other announcements, this well help screen reader users understand the hint fully.
 
 <Canvas of={SearchStories.WithLabelAndInputHint} />
 
-### With Search Button
+### Sizes
 
-You can pass the `searchButton` prop to render a search button.
-This will render a button with the text "Search" and an aria-label of "search button".
-To override the the default aria-label, you can pass a string value to the `searchButtonAriaLabel` prop.
+The `Search` component supports three size options: `"small"`, `"medium"`, and `"large"`.
+The size prop controls the height and spacing of both the input and button.
 
-<Canvas of={SearchStories.WithSearchButton} />
+<Canvas of={SearchStories.Sizes} />
 
-You can override the text of the search button by passing a string value to the `searchButton` prop:
+### Custom Width & Max Width
 
+You can set a custom width for the `Search` input by using `inputWidth` prop, or set a custom max-width using the `maxWidth` prop.
 
-<Canvas of={SearchStories.WithSearchButtonPropTextOverride} />
+<Canvas of={SearchStories.CustomWidths} />
 
-Or, by using the locale provider to override the button's text via the `searchButtonText` translation key.
-Please note that the `searchButton` prop will take precedence over the locale value.
+### Inverse
 
-<Canvas of={SearchStories.WithSearchButtonLocaleOverride} />
+The `Search` component can be styled to render on dark backgrounds by passing the `inverse` prop.
 
-### Custom width
+<Canvas of={SearchStories.Inverse} />
 
-You can set a custom width for the search input by passing any valid CSS string value to the `searchWidth` prop.
+### Label Inline
 
-<Canvas of={SearchStories.CustomWidth} />
+You can render the label inline with the input by passing the `labelInline` prop.
 
-### Custom MaxWidth
-
-You can set a custom max-width for the search input by passing any valid CSS string value to the `maxWidth` prop.
-
-<Canvas of={SearchStories.WithCustomMaxWidth} />
-
-### Dark Background Styling
-
-The search component can be styled to render on dark backgrounds by passing the `variant` prop with the value "dark".
-
-<Canvas of={SearchStories.WithAltStyling} />
-
-### Trigger actions on clear
-
-It is possible to trigger actions such as filtering the search results when the cross icon is clicked.
-When the `triggerOnClear` prop is set to `true`, the `onClick` callback will be called when the cross icon is clicked.
-
-<Canvas of={SearchStories.TriggerOnClear} />
+<Canvas of={SearchStories.LabelInline} />
 
 ## Props
 
@@ -106,7 +89,7 @@ to the [i18nProvider](../?path=/docs/documentation-i18n--docs).
   translationData={[
     {
       name: "search.searchButtonText",
-      description: "The text for search button",
+      description: "The text for the `Search` button (now only used as the default accessible name for the Search button if no `ariaLabel` prop is provided).",
       type: "func",
       returnType: "string",
     },
@@ -117,6 +100,7 @@ to the [i18nProvider](../?path=/docs/documentation-i18n--docs).
 
 `Search`'s forwarded ref exposes the following imperative methods:
 
-| Method Name | Description                                  |
-| ----------- | -------------------------------------------- |
-| `focus()`   | Programmatically focuses the search input.   |
+| Method Name     | Description                                 |
+| --------------- | ------------------------------------------- |
+| `focus()`       | Programmatically focuses the search input.  |
+| `focusButton()` | Programmatically focuses the search button. |

--- a/src/components/search/search.pw.tsx
+++ b/src/components/search/search.pw.tsx
@@ -3,46 +3,61 @@ import { test, expect } from "../../../playwright/helpers/base-test";
 import { checkAccessibility } from "../../../playwright/support/helper";
 import {
   SearchComponent,
-  SearchComponentDarkBackground,
+  SearchComponentInverseWithLabelHintAndError,
+  SearchComponentWithLabelHintAndError,
 } from "./components.test-pw";
 
+test.describe("Search input behaviour", () => {
+  test("should clear the input when Escape is pressed", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<SearchComponent />);
+
+    const input = page.getByRole("searchbox");
+    await input.fill("foo");
+    await input.press("Escape");
+
+    await expect(input).toHaveValue("");
+  });
+
+  test("should clear the input when the close icon is clicked", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<SearchComponent />);
+
+    const input = page.getByRole("searchbox");
+    await input.fill("foo");
+
+    // The native Chromium cancel button (×) for <input type="search"> is rendered
+    // at the right-hand end of the input's content area when the input has a value
+    const box = await input.boundingBox();
+
+    if (box) {
+      await page.mouse.click(box.x + box.width - 16, box.y + box.height / 2);
+    }
+
+    await expect(input).toHaveValue("");
+  });
+});
+
 test.describe("Accessibility tests for Search", () => {
-  test("should check accessibility for searchButton", async ({
+  test("should check accessibility with label, hint text and error", async ({
     mount,
     page,
   }) => {
-    await mount(<SearchComponent searchButton />);
+    await mount(<SearchComponentWithLabelHintAndError />);
 
     await checkAccessibility(page);
   });
 
-  test("should check accessibility with validation error as string", async ({
+  test("should check accessibility with inverse, label, hint text and error", async ({
     mount,
     page,
   }) => {
-    await mount(<SearchComponent error="Message" />);
+    await mount(<SearchComponentInverseWithLabelHintAndError />);
 
     await checkAccessibility(page);
-  });
-
-  // check accessibility when typing due to cursor colour changes
-  [true, false].forEach((showButton) => {
-    test(`should check accessibility with variant prop set to dark and 'searchButton' is ${showButton}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<SearchComponentDarkBackground searchButton={showButton} />);
-
-      await checkAccessibility(page);
-
-      await page.keyboard.press("Tab");
-      await expect(page.getByRole("textbox")).toBeFocused();
-
-      await checkAccessibility(page);
-
-      await page.keyboard.type("hello world");
-
-      await checkAccessibility(page);
-    });
   });
 });

--- a/src/components/search/search.stories.tsx
+++ b/src/components/search/search.stories.tsx
@@ -5,7 +5,6 @@ import generateStyledSystemProps from "../../../.storybook/utils/styled-system-p
 
 import Box from "../box";
 import Search from ".";
-import I18nProvider from "../i18n-provider/i18n-provider.component";
 
 const styledSystemProps = generateStyledSystemProps({
   margin: true,
@@ -17,6 +16,9 @@ const meta: Meta<typeof Search> = {
   argTypes: {
     ...styledSystemProps,
   },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export default meta;
@@ -24,157 +26,114 @@ type Story = StoryObj<typeof Search>;
 
 export const Default: Story = () => {
   const [value, setValue] = useState("");
-  return (
-    <Search
-      placeholder="Search..."
-      onChange={(e) => {
-        setValue(e.target.value);
-      }}
-      value={value}
-    />
-  );
+
+  return <Search value={value} onChange={(e) => setValue(e.target.value)} />;
 };
 Default.storyName = "Default";
-Default.parameters = {
-  chromatic: { disableSnapshot: true },
-};
 
 export const WithLabelAndInputHint: Story = () => {
   const [value, setValue] = useState("Here is some text");
   return (
-    <Box m={1}>
-      <Search
-        label="Search"
-        inputHint="Hint text (optional)."
-        onChange={(e) => setValue(e.target.value)}
-        value={value}
-      />
-    </Box>
+    <Search
+      label="Search"
+      inputHint="Hint text (optional)."
+      onChange={(e) => setValue(e.target.value)}
+      value={value}
+    />
   );
 };
 WithLabelAndInputHint.storyName = "With Label and Input Hint";
 
-export const WithSearchButton: Story = () => {
-  const [value, setValue] = useState("Here is some text");
+export const Sizes: Story = () => {
+  const [valueS, setValueS] = useState("");
+  const [valueM, setValueM] = useState("");
+  const [valueL, setValueL] = useState("");
   return (
-    <Box m={1}>
+    <Box display="flex" flexDirection="column" gap={3}>
       <Search
-        onChange={(e) => setValue(e.target.value)}
-        value={value}
-        searchButton
-        searchButtonAriaLabel="search button aria label"
+        label="Small"
+        size="small"
+        onChange={(e) => setValueS(e.target.value)}
+        value={valueS}
+      />
+      <Search
+        label="Medium"
+        size="medium"
+        onChange={(e) => setValueM(e.target.value)}
+        value={valueM}
+      />
+      <Search
+        label="Large"
+        size="large"
+        onChange={(e) => setValueL(e.target.value)}
+        value={valueL}
       />
     </Box>
   );
 };
-WithSearchButton.storyName = "With Search Button";
+Sizes.storyName = "Sizes";
 
-export const WithSearchButtonPropTextOverride: Story = () => {
-  const [value, setValue] = useState("Here is some text");
-  return (
-    <Box m={1}>
-      <Search
-        onChange={(e) => setValue(e.target.value)}
-        value={value}
-        searchButton="Find"
-      />
-    </Box>
-  );
-};
-WithSearchButtonPropTextOverride.storyName =
-  "With Search Button text override via prop";
-WithSearchButtonPropTextOverride.parameters = {
-  chromatic: { disableSnapshot: true },
-};
-
-export const WithSearchButtonLocaleOverride: Story = () => {
-  const [value, setValue] = useState("Here is some text");
-  return (
-    <Box m={1}>
-      <I18nProvider locale={{ search: { searchButtonText: () => "Find" } }}>
-        <Search
-          onChange={(e) => setValue(e.target.value)}
-          value={value}
-          searchButton
-        />
-      </I18nProvider>
-    </Box>
-  );
-};
-WithSearchButtonLocaleOverride.storyName =
-  "With Search Button text override via locale";
-WithSearchButtonLocaleOverride.parameters = {
-  chromatic: { disableSnapshot: true },
-};
-
-export const CustomWidth: Story = () => {
+export const CustomWidths: Story = () => {
   const [value, setValue] = useState("");
   return (
-    <Search
-      placeholder="Search..."
-      onChange={(e) => setValue(e.target.value)}
-      value={value}
-      searchWidth="375px"
-    />
-  );
-};
-CustomWidth.storyName = "Custom Width";
-
-export const WithCustomMaxWidth: Story = () => {
-  const [value, setValue] = useState("Here is some text");
-  return (
-    <Box m={1}>
+    <Box display="flex" flexDirection="column" gap={3}>
       <Search
+        label="searchWidth"
         onChange={(e) => setValue(e.target.value)}
         value={value}
-        searchButton
-        maxWidth="50%"
+        inputWidth={25}
+      />
+      <Search
+        label="maxWidth"
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+        maxWidth="75%"
       />
     </Box>
   );
 };
-WithCustomMaxWidth.storyName = "Custom Max Width";
+CustomWidths.storyName = "Custom Widths";
 
-export const WithAltStyling: Story = () => {
+export const Inverse: Story = () => {
   const [value, setValue] = useState("Here is some text");
   return (
-    <Box width="700px" height="108px" p={4} backgroundColor="#000000">
+    <Box
+      width="700px"
+      display="flex"
+      flexDirection="column"
+      p={3}
+      backgroundColor="#000000"
+    >
       <Search
-        placeholder="Search..."
+        label="Inverse"
+        inputHint="Use this prop on darker backgrounds"
         onChange={(e) => setValue(e.target.value)}
         value={value}
-        variant="dark"
-        mb={2}
-      />
-      <Search
-        placeholder="Search..."
-        onChange={(e) => setValue(e.target.value)}
-        value={value}
-        searchButton
-        variant="dark"
+        inverse
       />
     </Box>
   );
 };
-WithAltStyling.storyName = "Dark Background variant";
+Inverse.storyName = "Inverse";
 
-export const TriggerOnClear: Story = () => {
+export const LabelInline: Story = () => {
   const [value, setValue] = useState("");
   return (
-    <>
+    <Box display="flex" flexDirection="column" gap={3}>
       <Search
-        id="test"
-        name="test"
-        placeholder="Search..."
-        triggerOnClear
+        label="Search"
+        labelInline
         onChange={(e) => setValue(e.target.value)}
         value={value}
-        searchButton
       />
-    </>
+      <Search
+        label="Search with hint"
+        inputHint="Hint text (optional)."
+        labelInline
+        onChange={(e) => setValue(e.target.value)}
+        value={value}
+      />
+    </Box>
   );
 };
-TriggerOnClear.storyName = "Trigger on Clear";
-TriggerOnClear.parameters = {
-  chromatic: { disableSnapshot: true },
-};
+LabelInline.storyName = "Label Inline";

--- a/src/components/search/search.test.tsx
+++ b/src/components/search/search.test.tsx
@@ -1,497 +1,312 @@
-import React, { useRef } from "react";
-import { act, render, screen, waitFor, within } from "@testing-library/react";
+import React, { useRef, useState } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import { enGB } from "../../locales";
-import Search, { SearchEvent, SearchHandle } from "./search.component";
-import { testStyledSystemMargin } from "../../__spec_helper__/__internal__/test-utils";
+import MenuContext from "../menu/__internal__/menu.context";
+import Search, { SearchHandle } from "./search.component";
 
-import I18nProvider from "../i18n-provider";
-
-jest.mock("../../__internal__/utils/logger");
-
-const StatefulComponent = (props: {
-  value?: string;
-  changeHandler: (e: SearchEvent) => void;
-  name?: string;
+const StatefulSearch = ({
+  triggerOnClear,
+  onClick,
+  id,
+  name,
+}: {
+  triggerOnClear?: boolean;
+  onClick?: (event: {
+    target: { id?: string; name?: string; value: string };
+  }) => void;
   id?: string;
+  name?: string;
 }) => {
-  const [value, setValue] = React.useState(props.value ?? "");
+  const [value, setValue] = useState("start");
+
   return (
     <Search
-      placeholder="Search..."
-      onChange={(e) => {
-        setValue(e.target.value);
-        props.changeHandler(e);
-      }}
       value={value}
-      {...props}
+      triggerOnClear={triggerOnClear}
+      onClick={onClick}
+      id={id}
+      name={name}
+      onChange={(event) => setValue(event.target.value)}
     />
   );
 };
 
-testStyledSystemMargin(
-  (props) => (
-    <Search data-role="search" value="" onChange={jest.fn} {...props} />
-  ),
-  () => screen.getByTestId("search"),
-);
+test("uses default locale text for input and button accessible names", () => {
+  render(<Search value="" onChange={jest.fn()} />);
 
-test("the search input has a default accessible name of `Search`", () => {
-  render(<Search value="" onChange={jest.fn} />);
-
-  expect(screen.getByRole("textbox")).toHaveAccessibleName("Search");
+  expect(screen.getByRole("searchbox", { name: "Search" })).toBeVisible();
+  expect(screen.getByRole("button", { name: "Search" })).toBeVisible();
 });
 
-test("the label prop passes a custom accessible name to the search input", () => {
-  render(<Search value="" onChange={jest.fn} label="baz" />);
+test("uses label for input accessible name", () => {
+  render(<Search value="" label="foo" onChange={jest.fn()} />);
 
-  expect(screen.getByRole("textbox")).toHaveAccessibleName("baz");
+  expect(screen.getByRole("searchbox", { name: "foo" })).toBeVisible();
 });
 
-test("the `aria-label` prop passes a custom accessible name to the search input", () => {
-  render(<Search value="" onChange={jest.fn} aria-label="foobar" />);
+test("aria-label takes precedence over label", () => {
+  render(<Search value="" label="foo" aria-label="bar" onChange={jest.fn()} />);
 
-  expect(screen.getByRole("textbox")).toHaveAccessibleName("foobar");
+  expect(screen.getByRole("searchbox", { name: "bar" })).toBeVisible();
 });
 
-test("aria-label prop takes precedence over label prop for the search input accessible name", () => {
+test("`searchButtonAriaLabel` overrides button accessible name", () => {
+  render(<Search value="" searchButtonAriaLabel="foo" onChange={jest.fn()} />);
+
+  expect(screen.getByRole("button", { name: "foo" })).toBeVisible();
+});
+
+test("adds inverse class to the search root when `inverse` is true", () => {
+  render(<Search inverse value="" onChange={jest.fn()} />);
+
+  expect(screen.getByRole("searchbox")).toHaveClass("search", "inverse");
+});
+
+test("adds inverse class to the search root when `variant` is `dark`", () => {
+  render(<Search variant="dark" value="" onChange={jest.fn()} />);
+
+  expect(screen.getByRole("searchbox")).toHaveClass("search", "inverse");
+});
+
+test("adds error class to the search root when `error` is present", () => {
+  render(<Search error value="" onChange={jest.fn()} />);
+
+  expect(screen.getByRole("searchbox")).toHaveClass("search", "error");
+});
+
+test("maps `searchWidth` to `inputWidth` when `inputWidth` is not provided", () => {
+  render(<Search value="" searchWidth="42" onChange={jest.fn()} />);
+
+  const inputWrapper = screen.getByTestId("input-wrapper");
+
+  expect(inputWrapper).toHaveStyleRule("width", "42%");
+});
+
+test("prefers `inputWidth` over `searchWidth` when both are provided", () => {
   render(
-    <Search value="" onChange={jest.fn} aria-label="foobar" label="baz" />,
+    <Search value="" inputWidth={30} searchWidth="55" onChange={jest.fn()} />,
   );
 
-  expect(screen.getByRole("textbox")).toHaveAccessibleName("foobar");
+  const inputWrapper = screen.getByTestId("input-wrapper");
+
+  expect(inputWrapper).toHaveStyleRule("width", "30%");
 });
 
-test("when the `searchButton` prop is `true`, a button with search icon is shown, and no icon appears in the textbox", () => {
-  render(
-    <Search
-      searchButton
-      value=""
-      searchButtonAriaLabel="search button"
-      onChange={jest.fn}
-    />,
-  );
+test("falls back to default width when `searchWidth` is not numeric", () => {
+  render(<Search value="" searchWidth="foo" onChange={jest.fn()} />);
 
-  const searchButton = screen.getByRole("button", { name: "search button" });
-  expect(searchButton).toBeVisible();
-  expect(within(searchButton).getByTestId("icon")).toHaveAttribute(
-    "type",
-    "search",
-  );
-  expect(
-    within(screen.getByTestId("input-text-container")).queryByTestId("icon"),
-  ).not.toBeInTheDocument();
+  const inputWrapper = screen.getByTestId("input-wrapper");
+
+  expect(inputWrapper).toHaveStyleRule("width", "100%");
 });
 
-test("when the `searchButton` prop is `true`, the appropriate `data-` tags can be set via `searchButtonDataProps`", () => {
-  render(
-    <Search
-      searchButton
-      value=""
-      searchButtonDataProps={{
-        "data-role": "foo",
-        "data-element": "bar",
-      }}
-      searchButtonAriaLabel="search button"
-      onChange={jest.fn}
-    />,
-  );
-
-  const searchButton = screen.getByRole("button", { name: "search button" });
-  expect(searchButton).toHaveAttribute("data-role", "foo");
-  expect(searchButton).toHaveAttribute("data-element", "bar");
-});
-
-test("when the `searchButton` prop is a string value, a button with search icon is shown, and no icon appears in the textbox", () => {
-  render(
-    <Search
-      searchButton="custom search button"
-      value=""
-      onChange={jest.fn}
-      searchButtonAriaLabel="search button"
-    />,
-  );
-
-  const searchButton = screen.getByRole("button", { name: "search button" });
-  expect(searchButton).toBeVisible();
-  expect(searchButton).toHaveTextContent("custom search button");
-  expect(within(searchButton).getByTestId("icon")).toHaveAttribute(
-    "type",
-    "search",
-  );
-  expect(
-    within(screen.getByTestId("input-text-container")).queryByTestId("icon"),
-  ).not.toBeInTheDocument();
-});
-
-test("when the `searchButton` prop is not passed, no button with is shown, and an icon is rendered in the textbox", () => {
-  render(
-    <Search
-      value=""
-      onChange={jest.fn}
-      searchButtonAriaLabel="search button"
-    />,
-  );
-
-  expect(
-    screen.queryByRole("button", { name: "search button" }),
-  ).not.toBeInTheDocument();
-  expect(
-    within(screen.getByTestId("input-text-container")).getByTestId("icon"),
-  ).toHaveAttribute("type", "search");
-});
-
-test("the search button text can be overridden via the locale context", () => {
-  render(
-    <I18nProvider
-      locale={{ search: { searchButtonText: () => "text override" } }}
-    >
-      <Search searchButton value="" onChange={jest.fn} />
-    </I18nProvider>,
-  );
-
-  expect(screen.getByRole("button")).toHaveTextContent("text override");
-});
-
-test("the search button uses the value from the locale context as a default accessible name", () => {
-  render(
-    <I18nProvider locale={enGB}>
-      <Search value="" searchButton onChange={jest.fn} />
-    </I18nProvider>,
-  );
-
-  expect(screen.getByRole("button")).toHaveAccessibleName("Search");
-});
-
-test("the `searchButtonAriaLabel` prop passes a custom accessible name to the search button", () => {
-  render(
-    <Search
-      searchButton
-      searchButtonAriaLabel="foobar button"
-      onChange={jest.fn}
-      value=""
-    />,
-  );
-
-  expect(screen.getByRole("button")).toHaveAccessibleName("foobar button");
-});
-
-test("the `onClick` callback prop is not called when the input is clicked", async () => {
+test("forwards click payload from search button", async () => {
   const user = userEvent.setup();
   const onClick = jest.fn();
-  render(<Search value="" onChange={jest.fn} onClick={onClick} />);
 
-  await user.click(screen.getByRole("textbox"));
-  expect(onClick).not.toHaveBeenCalled();
-});
-
-test("when the input is focused, the `onFocus` callback prop is called", async () => {
-  const user = userEvent.setup();
-  const onFocus = jest.fn();
-  render(<Search value="" onChange={jest.fn} onFocus={onFocus} />);
-
-  await user.tab();
-  expect(screen.getByRole("textbox")).toHaveFocus();
-  expect(onFocus).toHaveBeenCalledTimes(1);
-});
-
-test("when the input is blurred, the `onBlur` callback prop is called", async () => {
-  const user = userEvent.setup();
-  const onBlur = jest.fn();
-  render(<Search value="" onChange={jest.fn} onBlur={onBlur} />);
-
-  act(() => {
-    screen.getByRole("textbox").focus();
-  });
-  await user.tab();
-  expect(onBlur).toHaveBeenCalledTimes(1);
-});
-
-test("when a key is pressed, the `onKeyDown` callback prop is called", async () => {
-  const user = userEvent.setup();
-  const onKeyDown = jest.fn();
-  render(<Search value="" onChange={jest.fn} onKeyDown={onKeyDown} />);
-
-  await user.type(screen.getByRole("textbox"), "a");
-  expect(onKeyDown).toHaveBeenCalledTimes(1);
-});
-
-test("when the cross icon is clicked, the input value is cleared", async () => {
-  const user = userEvent.setup();
-  const onChange = jest.fn();
-  render(<StatefulComponent changeHandler={onChange} name="bar" id="baz" />);
-  await user.type(screen.getByRole("textbox"), "a");
-
-  await user.click(screen.getByTestId("input-icon-toggle"));
-
-  await waitFor(() => {
-    expect(screen.getByRole("textbox")).toHaveValue("");
-  });
-  expect(onChange).toHaveBeenCalledWith(
-    expect.objectContaining({ target: { value: "", name: "bar", id: "baz" } }),
-  );
-});
-
-test("when the cross icon is clicked, and the `triggerOnClear` props is passed, the `onClick` callback prop is called", async () => {
-  const user = userEvent.setup();
-  const onClick = jest.fn();
   render(
     <Search
+      id="search-id"
+      name="search-name"
       value="foo"
-      onChange={jest.fn}
-      searchButton
-      triggerOnClear
       onClick={onClick}
-      name="bar"
-      id="baz"
+      onChange={jest.fn()}
     />,
   );
-  await user.click(screen.getByTestId("input-icon-toggle"));
+
+  await user.click(screen.getByRole("button", { name: "Search" }));
 
   expect(onClick).toHaveBeenCalledWith({
-    target: {
-      name: "bar",
-      id: "baz",
-      value: "",
-    },
+    target: { id: "search-id", name: "search-name", value: "foo" },
   });
 });
 
-test("when the cross icon is clicked, and the `triggerOnClear` props is not passed, the `onClick` callback prop is not called", async () => {
+test("supports programmatic focus through ref handle", async () => {
   const user = userEvent.setup();
-  const onClick = jest.fn();
-  render(
-    <Search
-      value="foo"
-      onChange={jest.fn}
-      searchButton
-      onClick={onClick}
-      name="bar"
-      id="baz"
-    />,
-  );
-  await user.click(screen.getByTestId("input-icon-toggle"));
 
-  expect(onClick).not.toHaveBeenCalled();
-});
-
-test("when the component is controlled, the input takes its value from the `value` prop", () => {
-  render(<Search value="Bar" onChange={jest.fn} />);
-
-  expect(screen.getByRole("textbox")).toHaveValue("Bar");
-});
-
-test("when the input value changes, the `onChange` callback prop is called", async () => {
-  const user = userEvent.setup();
-  const onChange = jest.fn();
-  render(<StatefulComponent changeHandler={onChange} />);
-
-  await user.type(screen.getByRole("textbox"), "a");
-  expect(onChange).toHaveBeenCalledTimes(1);
-  expect(onChange).toHaveBeenCalledWith(
-    expect.objectContaining({
-      target: expect.objectContaining({ value: "a" }),
-    }),
-  );
-});
-
-test("when the component is controlled, the `onClick` callback prop is called with the values in the input when the search button is clicked", async () => {
-  const user = userEvent.setup();
-  const onClick = jest.fn();
-  render(
-    <Search
-      value="FooBar"
-      id="Search"
-      name="Search"
-      onClick={onClick}
-      onChange={jest.fn}
-      searchButton
-      searchButtonAriaLabel="search button"
-    />,
-  );
-
-  await user.click(screen.getByRole("button", { name: "search button" }));
-  expect(onClick).toHaveBeenCalledTimes(1);
-  expect(onClick).toHaveBeenCalledWith(
-    expect.objectContaining({
-      target: { value: "FooBar", id: "Search", name: "Search" },
-    }),
-  );
-});
-
-test("the component's wrapper element has the appropriate `data-` tags", () => {
-  render(
-    <Search data-role="foo" data-element="bar" value="" onChange={jest.fn} />,
-  );
-
-  const search = screen.getByTestId("foo");
-
-  expect(search).toHaveAttribute("data-component", "search");
-  expect(search).toHaveAttribute("data-element", "bar");
-});
-
-test("do not render remove button when the input is empty", () => {
-  render(<Search value="" onChange={jest.fn} />);
-
-  expect(screen.queryByTestId("input-icon-toggle")).not.toBeInTheDocument();
-});
-
-test("render remove button when the input is not empty", () => {
-  render(<Search value="foo" onChange={jest.fn} />);
-
-  expect(screen.getByTestId("input-icon-toggle")).toBeVisible();
-});
-
-test("remove button can be reached via keyboard when present", async () => {
-  const user = userEvent.setup();
-  render(<Search value="foo" onChange={jest.fn} />);
-
-  act(() => {
-    screen.getByRole("textbox").focus();
-  });
-  await user.tab();
-
-  expect(screen.getByTestId("input-icon-toggle")).not.toHaveFocus();
-});
-
-test("when a character key is pressed, propagation of the event to parent elements is prevented", async () => {
-  const user = userEvent.setup();
-  const outerOnKeyDown = jest.fn();
-  render(
-    <button type="button" aria-label="foo" onKeyDown={outerOnKeyDown}>
-      <Search value="" onChange={jest.fn} />
-    </button>,
-  );
-
-  await user.type(screen.getByRole("textbox"), "a");
-  expect(outerOnKeyDown).not.toHaveBeenCalled();
-});
-
-test("when a number key is pressed, propagation of the event to parent elements is prevented", async () => {
-  const user = userEvent.setup();
-  const outerOnKeyDown = jest.fn();
-  render(
-    <button type="button" aria-label="foo" onKeyDown={outerOnKeyDown}>
-      <Search value="" onChange={jest.fn} />
-    </button>,
-  );
-
-  await user.type(screen.getByRole("textbox"), "2");
-  expect(outerOnKeyDown).not.toHaveBeenCalled();
-});
-
-test("when a non-alphanumeric key is pressed, propagation of the event to parent elements is not prevented", async () => {
-  const user = userEvent.setup();
-  const outerOnKeyDown = jest.fn();
-  render(
-    <button type="button" aria-label="foo" onKeyDown={outerOnKeyDown}>
-      <Search onChange={jest.fn} value="" />
-    </button>,
-  );
-
-  await user.type(screen.getByRole("textbox"), "{Tab}");
-  expect(outerOnKeyDown).toHaveBeenCalledWith(
-    expect.objectContaining({ key: "Tab" }),
-  );
-});
-
-test("the input can be programmatically focused using a ref", async () => {
-  const RefExample = () => {
+  const SearchWithRefHandle = () => {
     const ref = useRef<SearchHandle>(null);
 
     return (
-      <div>
+      <>
         <button type="button" onClick={() => ref.current?.focus()}>
-          Focus input
+          focus
         </button>
-        <Search value="foo" onChange={() => {}} ref={ref} />
-      </div>
+        <Search ref={ref} value="" onChange={jest.fn()} />
+      </>
     );
   };
 
-  const user = userEvent.setup();
-  render(<RefExample />);
+  render(<SearchWithRefHandle />);
+  await user.click(screen.getByRole("button", { name: "focus" }));
 
-  await user.click(screen.getByRole("button", { name: "Focus input" }));
-
-  expect(screen.getByRole("textbox")).toHaveFocus();
+  expect(screen.getByRole("searchbox", { name: "Search" })).toHaveFocus();
 });
 
-// for coverage - dark variant styles are tested in Playwright
-test("should render the bottom border when variant is dark, the input is not focused and has a value", () => {
+test("supports programmatic focus through ref handle inside Menu context", async () => {
+  const user = userEvent.setup();
+
+  const SearchWithRefHandleInMenu = () => {
+    const ref = useRef<SearchHandle>(null);
+
+    return (
+      <>
+        <button type="button" onClick={() => ref.current?.focus()}>
+          focus
+        </button>
+        <MenuContext.Provider value={{ inMenu: true }}>
+          <Search ref={ref} value="" onChange={jest.fn()} />
+        </MenuContext.Provider>
+      </>
+    );
+  };
+
+  render(<SearchWithRefHandleInMenu />);
+  await user.click(screen.getByRole("button", { name: "focus" }));
+
+  expect(screen.getByRole("textbox", { name: "Search" })).toHaveFocus();
+});
+
+test("supports programmatic button focus through ref handle", async () => {
+  const user = userEvent.setup();
+
+  const SearchWithButtonFocus = () => {
+    const ref = useRef<SearchHandle>(null);
+
+    return (
+      <>
+        <button type="button" onClick={() => ref.current?.focusButton()}>
+          focus-button
+        </button>
+        <Search ref={ref} value="" onChange={jest.fn()} />
+      </>
+    );
+  };
+
+  render(<SearchWithButtonFocus />);
+  await user.click(screen.getByRole("button", { name: "focus-button" }));
+
+  expect(screen.getByRole("button", { name: "Search" })).toHaveFocus();
+});
+
+test("triggers onClick when native search clear event occurs with empty value", () => {
+  const onClick = jest.fn();
+
   render(
-    <Search
-      data-role="search"
-      variant="dark"
-      value="search"
-      onChange={jest.fn}
+    <StatefulSearch
+      triggerOnClear
+      onClick={onClick}
+      id="search-id"
+      name="search-name"
     />,
   );
 
-  const search = screen.getByTestId("search");
+  const input = screen.getByRole("searchbox", { name: "Search" });
+  fireEvent.change(input, { target: { value: "" } });
+  fireEvent(input, new Event("search", { bubbles: true }));
 
-  expect(search).toHaveStyle({
-    "background-color": "rgba(0, 0, 0, 0)",
-  });
-  expect(search).toHaveStyleRule(
-    "border-bottom",
-    "var(--spacing025) solid var(--colorsUtilityYang080)",
-  );
-});
-
-// for coverage - `searchWidth` prop is tested in Playwright
-test("applies the correct width specified by the user", () => {
-  render(
-    <Search
-      data-role="search"
-      searchWidth="400px"
-      value=""
-      onChange={jest.fn}
-    />,
-  );
-
-  const search = screen.getByTestId("search");
-
-  expect(search).toHaveStyle({
-    display: "inline-flex",
-    width: "400px",
-  });
-  expect(search).toHaveStyleRule(
-    "border-bottom",
-    "var(--spacing025) solid var(--colorsUtilityMajor300)",
-  );
-  expect(search).toHaveStyleRule("font-size", "var(--fontSize100)");
-});
-
-// for coverage - `maxWidth` prop is tested in Playwright
-test("applies the correct maxWidth specified by the user", () => {
-  render(
-    <Search data-role="search" maxWidth="67%" value="" onChange={jest.fn} />,
-  );
-
-  const search = screen.getByTestId("search");
-
-  expect(search).toHaveStyle({
-    "max-width": "67%",
+  expect(onClick).toHaveBeenCalledWith({
+    target: { id: "search-id", name: "search-name", value: "" },
   });
 });
 
-test("clears the value when the escape key is pressed", async () => {
-  const user = userEvent.setup();
-  const mockOnChange = jest.fn();
+test("does not trigger onClick for native search event when value is not empty", () => {
+  const onClick = jest.fn();
+
   render(
     <Search
       value="foo"
-      onChange={mockOnChange}
-      name="search-bar"
-      id="search-id"
+      triggerOnClear
+      onClick={onClick}
+      onChange={jest.fn()}
     />,
   );
 
-  const input = screen.getByRole("textbox");
-  await user.click(input);
-  await user.keyboard("{Escape}");
-  expect(screen.queryByText("foo")).not.toBeInTheDocument();
-  expect(mockOnChange).toHaveBeenCalled();
+  fireEvent(
+    screen.getByRole("searchbox", { name: "Search" }),
+    new Event("search", { bubbles: true }),
+  );
+
+  expect(onClick).not.toHaveBeenCalled();
+});
+
+test("does not trigger onClick for native search event fired by pressing Enter on an empty value", () => {
+  const onClick = jest.fn();
+
+  render(
+    <StatefulSearch
+      triggerOnClear
+      onClick={onClick}
+      id="search-id"
+      name="search-name"
+    />,
+  );
+
+  const input = screen.getByRole("searchbox", { name: "Search" });
+  fireEvent.change(input, { target: { value: "" } });
+  fireEvent.keyDown(input, { key: "Enter" });
+  fireEvent(input, new Event("search", { bubbles: true }));
+
+  expect(onClick).not.toHaveBeenCalled();
+});
+
+test("triggers onClick for native search clear event after Enter was pressed previously", () => {
+  const onClick = jest.fn();
+
+  render(
+    <StatefulSearch
+      triggerOnClear
+      onClick={onClick}
+      id="search-id"
+      name="search-name"
+    />,
+  );
+
+  const input = screen.getByRole("searchbox", { name: "Search" });
+  fireEvent.change(input, { target: { value: "" } });
+
+  fireEvent.keyDown(input, { key: "Enter" });
+  fireEvent(input, new Event("search", { bubbles: true }));
+  expect(onClick).not.toHaveBeenCalled();
+
+  fireEvent(input, new Event("search", { bubbles: true }));
+
+  expect(onClick).toHaveBeenCalledWith({
+    target: { id: "search-id", name: "search-name", value: "" },
+  });
+});
+
+test("does not wire native clear handling when `triggerOnClear` is false", () => {
+  const onClick = jest.fn();
+
+  render(
+    <Search
+      value=""
+      triggerOnClear={false}
+      onClick={onClick}
+      onChange={jest.fn()}
+    />,
+  );
+
+  const input = screen.getByRole("searchbox", { name: "Search" });
+  fireEvent.change(input, { target: { value: "" } });
+  fireEvent(input, new Event("search", { bubbles: true }));
+
+  expect(onClick).not.toHaveBeenCalled();
+});
+
+test("renders legacy Search search component when rendered inside Menu context", () => {
+  const onClick = jest.fn();
+
+  render(
+    <MenuContext.Provider value={{ inMenu: true }}>
+      <Search value="" triggerOnClear onClick={onClick} onChange={jest.fn()} />
+    </MenuContext.Provider>,
+  );
+
+  expect(screen.getByRole("textbox", { name: "Search" })).toBeVisible();
+  expect(
+    screen.queryByRole("button", { name: "Search" }),
+  ).not.toBeInTheDocument();
 });

--- a/src/components/textbox/__internal__/__next__/text-input.component.tsx
+++ b/src/components/textbox/__internal__/__next__/text-input.component.tsx
@@ -125,6 +125,7 @@ export const TextInput = React.forwardRef(
       "aria-describedby": ariaDescribedByProp,
       "aria-labelledby": ariaLabelledBy,
       children,
+      className,
       "data-component": dataComponent = "text-input",
       "data-element": dataElement,
       "data-is-open": dataIsOpen,
@@ -242,6 +243,7 @@ export const TextInput = React.forwardRef(
 
     return (
       <StyledTextInput
+        className={className}
         data-element={dataElement}
         data-role={dataRole}
         data-component={dataComponent}
@@ -289,6 +291,7 @@ export const TextInput = React.forwardRef(
           <Input
             id={uniqueId}
             name={uniqueName}
+            className={className}
             aria-invalid={hasError}
             aria-describedby={ariaDescribedByString}
             aria-labelledby={ariaLabelledBy}

--- a/src/components/textbox/__internal__/__next__/text-input.style.ts
+++ b/src/components/textbox/__internal__/__next__/text-input.style.ts
@@ -62,7 +62,7 @@ const StyledTextInput = styled.div.attrs(applyBaseTheme)<StyledTextInputProps>`
   .time & {
     gap: unset;
   }
-  .search & {
+  .legacy-search & {
     flex: 1 1 0%;
   }
 `;


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Aligns the `Search `component with fusion DS designs at the time of development also supports the rendering of a legacy `Search` version when used in `MenuItem`'s to maintain legacy support

<img width="827" height="508" alt="Screenshot 2026-06-05 at 14 20 54" src="https://github.com/user-attachments/assets/7cab3850-efac-48be-b52f-e2aa4aabf34b" />

<img width="774" height="491" alt="Screenshot 2026-06-05 at 14 23 33" src="https://github.com/user-attachments/assets/512d447b-9bc5-410c-b45a-b7ed8f0c3bf6" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, the `Search` component is not aligned with fusion DS.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
