### PR TITLE
feat(form): add new disableStickyOnSmallScreen prop - FE-7686

### DIFF
--- a/skills/carbon-react/components/dialog.md
+++ b/skills/carbon-react/components/dialog.md
@@ -679,7 +679,9 @@ function SmallScreenBehaviorRender({
         <Typography mt={2}>
           On small screen devices (below 600px), the dialog becomes full width,
           the dimmer is removed, and the header/footer are no longer sticky.
-          This improves accessibility on mobile devices.
+          This improves accessibility on mobile devices. We also have a
+          `disableStickyOnSmallScreen` prop that means Form can also be used
+          within a Dialog without a sticky footer on small screen devices.
         </Typography>
         <Dialog
           {...args}
@@ -689,23 +691,37 @@ function SmallScreenBehaviorRender({
             setOpen(false);
             setTimeout(() => buttonRef.current?.focusButton(), 0);
           }}
-          footer={<Buttons />}
         >
-          <Typography>
-            This dialog demonstrates small screen accessibility behavior.
-          </Typography>
-          <Textbox label="First Name" value="" onChange={() => {}} />
-          <Textbox label="Middle Name" value="" onChange={() => {}} />
-          <Textbox label="Surname" value="" onChange={() => {}} />
-          <Textbox label="Birth Place" value="" onChange={() => {}} />
-          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
-          <Textbox label="Address" value="" onChange={() => {}} />
-          <Textbox label="First Name" value="" onChange={() => {}} />
-          <Textbox label="Middle Name" value="" onChange={() => {}} />
-          <Textbox label="Surname" value="" onChange={() => {}} />
-          <Textbox label="Birth Place" value="" onChange={() => {}} />
-          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
-          <Textbox label="Address" value="" onChange={() => {}} />
+          <Form
+            stickyFooter
+            disableStickyOnSmallScreen
+            leftSideButtons={
+              <Button onClick={() => setOpen(false)}>Cancel</Button>
+            }
+            saveButton={
+              <Button buttonType="primary" type="submit">
+                Save
+              </Button>
+            }
+          >
+            <Typography>
+              This dialog demonstrates small screen accessibility behavior. On
+              small screens, both the dialog header and the Form&apos;s sticky
+              footer are disabled.
+            </Typography>
+            <Textbox label="First Name" value="" onChange={() => {}} />
+            <Textbox label="Middle Name" value="" onChange={() => {}} />
+            <Textbox label="Surname" value="" onChange={() => {}} />
+            <Textbox label="Birth Place" value="" onChange={() => {}} />
+            <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+            <Textbox label="Address" value="" onChange={() => {}} />
+            <Textbox label="First Name" value="" onChange={() => {}} />
+            <Textbox label="Middle Name" value="" onChange={() => {}} />
+            <Textbox label="Surname" value="" onChange={() => {}} />
+            <Textbox label="Birth Place" value="" onChange={() => {}} />
+            <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+            <Textbox label="Address" value="" onChange={() => {}} />
+          </Form>
         </Dialog>
       </>
     );

--- a/skills/carbon-react/components/dialog.md
+++ b/skills/carbon-react/components/dialog.md
@@ -679,9 +679,9 @@ function SmallScreenBehaviorRender({
         <Typography mt={2}>
           On small screen devices (below 600px), the dialog becomes full width,
           the dimmer is removed, and the header/footer are no longer sticky.
-          This improves accessibility on mobile devices. We also have a
-          `disableStickyOnSmallScreen` prop that means Form can also be used
-          within a Dialog without a sticky footer on small screen devices.
+          This improves accessibility on mobile devices. Form also has a
+          `disableStickyOnSmallScreen` prop, which allows it to be used within a
+          Dialog without a sticky footer on small screen devices.
         </Typography>
         <Dialog
           {...args}

--- a/skills/carbon-react/components/dialog.md
+++ b/skills/carbon-react/components/dialog.md
@@ -679,7 +679,9 @@ function SmallScreenBehaviorRender({
         <Typography mt={2}>
           On small screen devices (below 600px), the dialog becomes full width,
           the dimmer is removed, and the header/footer are no longer sticky.
-          This improves accessibility on mobile devices.
+          This improves accessibility on mobile devices. Form also has a
+          `disableStickyOnSmallScreen` prop, which allows it to be used within a
+          Dialog without a sticky footer on small screen devices.
         </Typography>
         <Dialog
           {...args}
@@ -689,23 +691,37 @@ function SmallScreenBehaviorRender({
             setOpen(false);
             setTimeout(() => buttonRef.current?.focus(), 0);
           }}
-          footer={<Buttons />}
         >
-          <Typography>
-            This dialog demonstrates small screen accessibility behavior.
-          </Typography>
-          <Textbox label="First Name" value="" onChange={() => {}} />
-          <Textbox label="Middle Name" value="" onChange={() => {}} />
-          <Textbox label="Surname" value="" onChange={() => {}} />
-          <Textbox label="Birth Place" value="" onChange={() => {}} />
-          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
-          <Textbox label="Address" value="" onChange={() => {}} />
-          <Textbox label="First Name" value="" onChange={() => {}} />
-          <Textbox label="Middle Name" value="" onChange={() => {}} />
-          <Textbox label="Surname" value="" onChange={() => {}} />
-          <Textbox label="Birth Place" value="" onChange={() => {}} />
-          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
-          <Textbox label="Address" value="" onChange={() => {}} />
+          <Form
+            stickyFooter
+            disableStickyOnSmallScreen
+            leftSideButtons={
+              <Button onClick={() => setOpen(false)}>Cancel</Button>
+            }
+            saveButton={
+              <Button buttonType="primary" type="submit">
+                Save
+              </Button>
+            }
+          >
+            <Typography>
+              This dialog demonstrates small screen accessibility behavior. On
+              small screens, both the dialog header and the Form&apos;s sticky
+              footer are disabled.
+            </Typography>
+            <Textbox label="First Name" value="" onChange={() => {}} />
+            <Textbox label="Middle Name" value="" onChange={() => {}} />
+            <Textbox label="Surname" value="" onChange={() => {}} />
+            <Textbox label="Birth Place" value="" onChange={() => {}} />
+            <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+            <Textbox label="Address" value="" onChange={() => {}} />
+            <Textbox label="First Name" value="" onChange={() => {}} />
+            <Textbox label="Middle Name" value="" onChange={() => {}} />
+            <Textbox label="Surname" value="" onChange={() => {}} />
+            <Textbox label="Birth Place" value="" onChange={() => {}} />
+            <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+            <Textbox label="Address" value="" onChange={() => {}} />
+          </Form>
         </Dialog>
       </>
     );

--- a/skills/carbon-react/components/form.md
+++ b/skills/carbon-react/components/form.md
@@ -17,6 +17,7 @@ description: Carbon Form component props and usage examples.
 | --- | --- | --- | --- | --- | --- |
 | buttonAlignment | "left" \| "right" \| undefined | No |  | Alignment of buttons | "right" |
 | children | React.ReactNode | No |  | Child elements |  |
+| disableStickyOnSmallScreen | boolean \| undefined | No |  | When true, disables the sticky behaviour of the footer on small screen devices (below 600px). | false |
 | errorCount | number \| undefined | No |  | The total number of errors present in the form |  |
 | fieldSpacing | 0 \| 1 \| 2 \| 3 \| 4 \| 5 \| 6 \| 7 \| undefined | No |  | Spacing between form fields, given number will be multiplied by base spacing unit (8) | 3 |
 | footerChildren | React.ReactNode | No |  | Custom content to render in the form's footer |  |

--- a/skills/carbon-react/components/form.md
+++ b/skills/carbon-react/components/form.md
@@ -17,6 +17,7 @@ description: Carbon Form component props and usage examples.
 | --- | --- | --- | --- | --- | --- |
 | buttonAlignment | "left" \| "right" \| undefined | No |  | Alignment of buttons | "right" |
 | children | React.ReactNode | No |  | Child elements |  |
+| disableStickyOnSmallScreen | boolean \| undefined | No |  | When true, disables the sticky behaviour of the footer on small screen devices (below 600px). | false |
 | errorCount | number \| undefined | No |  | The total number of errors present in the form |  |
 | fieldSpacing | 0 \| 1 \| 2 \| 3 \| 4 \| 5 \| 6 \| 7 \| undefined | No |  | Spacing between form fields, given number will be multiplied by base spacing unit (8) | 3 |
 | footerChildren | React.ReactNode | No |  | Custom content to render in the form's footer |  |
@@ -645,6 +646,47 @@ description: Carbon Form component props and usage examples.
             <Option text="White" value="10" />
             <Option text="Yellow" value="11" />
           </MultiSelect>
+          {Array.from({ length: 10 }).map((_, index) => (
+            <Textbox
+              key={`textbox-${index + 1}`}
+              label="Textbox"
+              value=""
+              onChange={() => {}}
+            />
+          ))}
+        </Form>
+      </Dialog>
+    </>
+  );
+}
+```
+
+
+### In Dialog with Sticky Footer Disabled on Small Screen
+
+**Render**
+
+```tsx
+() => {
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open Preview</Button>
+      <Dialog
+        open={isOpen}
+        onCancel={() => setIsOpen(false)}
+        title="Form in Dialog"
+        subtitle="Sticky footer disabled on small screens"
+        disableStickyOnSmallScreen
+      >
+        <Form
+          leftSideButtons={
+            <Button onClick={() => setIsOpen(false)}>Cancel</Button>
+          }
+          saveButton={<Button buttonType="primary">Submit</Button>}
+          stickyFooter
+          disableStickyOnSmallScreen
+        >
           {Array.from({ length: 10 }).map((_, index) => (
             <Textbox
               key={`textbox-${index + 1}`}

--- a/skills/carbon-react/components/form.md
+++ b/skills/carbon-react/components/form.md
@@ -662,6 +662,47 @@ description: Carbon Form component props and usage examples.
 ```
 
 
+### In Dialog with Sticky Footer Disabled on Small Screen
+
+**Render**
+
+```tsx
+() => {
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open Preview</Button>
+      <Dialog
+        open={isOpen}
+        onCancel={() => setIsOpen(false)}
+        title="Form in Dialog"
+        subtitle="Sticky footer disabled on small screens"
+        disableStickyOnSmallScreen
+      >
+        <Form
+          leftSideButtons={
+            <Button onClick={() => setIsOpen(false)}>Cancel</Button>
+          }
+          saveButton={<Button buttonType="primary">Submit</Button>}
+          stickyFooter
+          disableStickyOnSmallScreen
+        >
+          {Array.from({ length: 10 }).map((_, index) => (
+            <Textbox
+              key={`textbox-${index + 1}`}
+              label="Textbox"
+              value=""
+              onChange={() => {}}
+            />
+          ))}
+        </Form>
+      </Dialog>
+    </>
+  );
+}
+```
+
+
 ### In Dialog Full Screen
 
 **Render**

--- a/src/components/dialog/dialog.stories.tsx
+++ b/src/components/dialog/dialog.stories.tsx
@@ -640,9 +640,9 @@ export const SmallScreenBehavior: Story = {
         <Typography mt={2}>
           On small screen devices (below 600px), the dialog becomes full width,
           the dimmer is removed, and the header/footer are no longer sticky.
-          This improves accessibility on mobile devices. We also have a
-          `disableStickyOnSmallScreen` prop that means Form can also be used
-          within a Dialog without a sticky footer on small screen devices.
+          This improves accessibility on mobile devices. Form also has a
+          `disableStickyOnSmallScreen` prop, which allows it to be used within a
+          Dialog without a sticky footer on small screen devices.
         </Typography>
         <Dialog
           {...args}

--- a/src/components/dialog/dialog.stories.tsx
+++ b/src/components/dialog/dialog.stories.tsx
@@ -640,7 +640,9 @@ export const SmallScreenBehavior: Story = {
         <Typography mt={2}>
           On small screen devices (below 600px), the dialog becomes full width,
           the dimmer is removed, and the header/footer are no longer sticky.
-          This improves accessibility on mobile devices.
+          This improves accessibility on mobile devices. We also have a
+          `disableStickyOnSmallScreen` prop that means Form can also be used
+          within a Dialog without a sticky footer on small screen devices.
         </Typography>
         <Dialog
           {...args}
@@ -650,23 +652,37 @@ export const SmallScreenBehavior: Story = {
             setOpen(false);
             setTimeout(() => buttonRef.current?.focusButton(), 0);
           }}
-          footer={<Buttons />}
         >
-          <Typography>
-            This dialog demonstrates small screen accessibility behavior.
-          </Typography>
-          <Textbox label="First Name" value="" onChange={() => {}} />
-          <Textbox label="Middle Name" value="" onChange={() => {}} />
-          <Textbox label="Surname" value="" onChange={() => {}} />
-          <Textbox label="Birth Place" value="" onChange={() => {}} />
-          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
-          <Textbox label="Address" value="" onChange={() => {}} />
-          <Textbox label="First Name" value="" onChange={() => {}} />
-          <Textbox label="Middle Name" value="" onChange={() => {}} />
-          <Textbox label="Surname" value="" onChange={() => {}} />
-          <Textbox label="Birth Place" value="" onChange={() => {}} />
-          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
-          <Textbox label="Address" value="" onChange={() => {}} />
+          <Form
+            stickyFooter
+            disableStickyOnSmallScreen
+            leftSideButtons={
+              <Button onClick={() => setOpen(false)}>Cancel</Button>
+            }
+            saveButton={
+              <Button buttonType="primary" type="submit">
+                Save
+              </Button>
+            }
+          >
+            <Typography>
+              This dialog demonstrates small screen accessibility behavior. On
+              small screens, both the dialog header and the Form&apos;s sticky
+              footer are disabled.
+            </Typography>
+            <Textbox label="First Name" value="" onChange={() => {}} />
+            <Textbox label="Middle Name" value="" onChange={() => {}} />
+            <Textbox label="Surname" value="" onChange={() => {}} />
+            <Textbox label="Birth Place" value="" onChange={() => {}} />
+            <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+            <Textbox label="Address" value="" onChange={() => {}} />
+            <Textbox label="First Name" value="" onChange={() => {}} />
+            <Textbox label="Middle Name" value="" onChange={() => {}} />
+            <Textbox label="Surname" value="" onChange={() => {}} />
+            <Textbox label="Birth Place" value="" onChange={() => {}} />
+            <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+            <Textbox label="Address" value="" onChange={() => {}} />
+          </Form>
         </Dialog>
       </>
     );

--- a/src/components/dialog/dialog.stories.tsx
+++ b/src/components/dialog/dialog.stories.tsx
@@ -638,7 +638,9 @@ export const SmallScreenBehavior: Story = {
         <Typography mt={2}>
           On small screen devices (below 600px), the dialog becomes full width,
           the dimmer is removed, and the header/footer are no longer sticky.
-          This improves accessibility on mobile devices.
+          This improves accessibility on mobile devices. Form also has a
+          `disableStickyOnSmallScreen` prop, which allows it to be used within a
+          Dialog without a sticky footer on small screen devices.
         </Typography>
         <Dialog
           {...args}
@@ -648,23 +650,37 @@ export const SmallScreenBehavior: Story = {
             setOpen(false);
             setTimeout(() => buttonRef.current?.focus(), 0);
           }}
-          footer={<Buttons />}
         >
-          <Typography>
-            This dialog demonstrates small screen accessibility behavior.
-          </Typography>
-          <Textbox label="First Name" value="" onChange={() => {}} />
-          <Textbox label="Middle Name" value="" onChange={() => {}} />
-          <Textbox label="Surname" value="" onChange={() => {}} />
-          <Textbox label="Birth Place" value="" onChange={() => {}} />
-          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
-          <Textbox label="Address" value="" onChange={() => {}} />
-          <Textbox label="First Name" value="" onChange={() => {}} />
-          <Textbox label="Middle Name" value="" onChange={() => {}} />
-          <Textbox label="Surname" value="" onChange={() => {}} />
-          <Textbox label="Birth Place" value="" onChange={() => {}} />
-          <Textbox label="Favourite Colour" value="" onChange={() => {}} />
-          <Textbox label="Address" value="" onChange={() => {}} />
+          <Form
+            stickyFooter
+            disableStickyOnSmallScreen
+            leftSideButtons={
+              <Button onClick={() => setOpen(false)}>Cancel</Button>
+            }
+            saveButton={
+              <Button buttonType="primary" type="submit">
+                Save
+              </Button>
+            }
+          >
+            <Typography>
+              This dialog demonstrates small screen accessibility behavior. On
+              small screens, both the dialog header and the Form&apos;s sticky
+              footer are disabled.
+            </Typography>
+            <Textbox label="First Name" value="" onChange={() => {}} />
+            <Textbox label="Middle Name" value="" onChange={() => {}} />
+            <Textbox label="Surname" value="" onChange={() => {}} />
+            <Textbox label="Birth Place" value="" onChange={() => {}} />
+            <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+            <Textbox label="Address" value="" onChange={() => {}} />
+            <Textbox label="First Name" value="" onChange={() => {}} />
+            <Textbox label="Middle Name" value="" onChange={() => {}} />
+            <Textbox label="Surname" value="" onChange={() => {}} />
+            <Textbox label="Birth Place" value="" onChange={() => {}} />
+            <Textbox label="Favourite Colour" value="" onChange={() => {}} />
+            <Textbox label="Address" value="" onChange={() => {}} />
+          </Form>
         </Dialog>
       </>
     );

--- a/src/components/form/form.component.tsx
+++ b/src/components/form/form.component.tsx
@@ -38,6 +38,10 @@ export interface FormProps extends SpaceProps, TagProps {
   footerChildren?: React.ReactNode;
   /** Enables the sticky footer. */
   stickyFooter?: boolean;
+  /**
+   * When true, disables the sticky behaviour of the footer on small screen devices (below 600px).
+   */
+  disableStickyOnSmallScreen?: boolean;
   /** Background variant for the sticky footer. */
   stickyFooterVariant?: "light" | "grey";
   /** The total number of warnings present in the form */
@@ -62,6 +66,7 @@ export const Form = ({
   footerChildren,
   stickyFooter,
   stickyFooterVariant = "light",
+  disableStickyOnSmallScreen = false,
   fieldSpacing = 3,
   noValidate = true,
   height,
@@ -115,6 +120,7 @@ export const Form = ({
           hasFooterChildren={!!footerChildren}
           stickyFooter={stickyFooter}
           {...(stickyFooter && { stickyFooterVariant })}
+          disableStickyOnSmallScreen={disableStickyOnSmallScreen}
           buttonAlignment={buttonAlignment}
           fullWidthButtons={fullWidthButtons}
           {...footerPadding}

--- a/src/components/form/form.component.tsx
+++ b/src/components/form/form.component.tsx
@@ -38,6 +38,10 @@ export interface FormProps extends SpaceProps, TagProps {
   footerChildren?: React.ReactNode;
   /** Enables the sticky footer. */
   stickyFooter?: boolean;
+  /**
+   * When true, disables the sticky behaviour of the footer on small screen devices (below 600px).
+   */
+  disableStickyOnSmallScreen?: boolean;
   /** Background variant for the sticky footer. */
   stickyFooterVariant?: "light" | "grey";
   /** The total number of warnings present in the form */
@@ -62,6 +66,7 @@ export const Form = ({
   footerChildren,
   stickyFooter,
   stickyFooterVariant = "light",
+  disableStickyOnSmallScreen = false,
   fieldSpacing = 3,
   noValidate = true,
   height,
@@ -115,6 +120,7 @@ export const Form = ({
           $hasFooterChildren={!!footerChildren}
           $stickyFooter={stickyFooter}
           {...(stickyFooter && { $stickyFooterVariant: stickyFooterVariant })}
+          disableStickyOnSmallScreen={disableStickyOnSmallScreen}
           $buttonAlignment={buttonAlignment}
           $fullWidthButtons={fullWidthButtons}
           {...footerPadding}

--- a/src/components/form/form.mdx
+++ b/src/components/form/form.mdx
@@ -22,7 +22,9 @@ To use Form, import the `Form` and pass the content, usually various inputs, as 
 You can provide a save button using the `saveButton` prop.
 
 ```javascript
-import Form, { RequiredFieldsIndicator } from "carbon-react/lib/components/form";
+import Form, {
+  RequiredFieldsIndicator,
+} from "carbon-react/lib/components/form";
 ```
 
 ## Examples
@@ -70,7 +72,7 @@ When either `errorCount` or `warningCount` or both are provided, summary with th
 
 ### Required Fields Indicator
 
-The `RequiredFieldsIndicator` component visually indicates that form fields are required using an asterisk prefix. It can be used 
+The `RequiredFieldsIndicator` component visually indicates that form fields are required using an asterisk prefix. It can be used
 within a `Form` to provide users with a clear indication of which fields are mandatory, or used independently.
 
 <Canvas of={FormStories.RequiredFieldsIndicatorStory} />
@@ -80,7 +82,10 @@ within a `Form` to provide users with a clear indication of which fields are man
 You can set the `required` or `isOptional` on any `Form` input to make them mandatory or optional. You can also
 include an indicator within the `Form` by importing the `RequiredFieldsIndicator` component.
 
-<Canvas name="with optional or required label" of={FormStories.WithBothOptionalOrRequired} />
+<Canvas
+  name="with optional or required label"
+  of={FormStories.WithBothOptionalOrRequired}
+/>
 
 ### Buttons variations
 
@@ -101,6 +106,14 @@ It is possible to render `Form` as a content of `Dialog` component.
 #### With sticky footer
 
 <Canvas of={FormStories.InDialogWithStickyFooter} />
+
+#### With sticky footer disabled on small screens
+
+When `disableStickyOnSmallScreen` is set alongside `stickyFooter`, the footer loses its sticky positioning on small screen
+devices (below 600px). This improves accessibility on mobile devices by preventing the footer from obscuring content when
+the viewport is too narrow. This is particularly useful when `Form` is used inside a `Dialog`.
+
+<Canvas of={FormStories.InDialogWithDisabledStickyFooterOnSmallScreen} />
 
 ### In full-screen `Dialog`
 

--- a/src/components/form/form.stories.tsx
+++ b/src/components/form/form.stories.tsx
@@ -604,6 +604,46 @@ InDialogWithStickyFooter.parameters = {
   themeProvider: { chromatic: { theme: "sage" } },
 };
 
+export const InDialogWithDisabledStickyFooterOnSmallScreen = () => {
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open Preview</Button>
+      <Dialog
+        open={isOpen}
+        onCancel={() => setIsOpen(false)}
+        title="Form in Dialog"
+        subtitle="Sticky footer disabled on small screens"
+        disableStickyOnSmallScreen
+      >
+        <Form
+          leftSideButtons={
+            <Button onClick={() => setIsOpen(false)}>Cancel</Button>
+          }
+          saveButton={<Button buttonType="primary">Submit</Button>}
+          stickyFooter
+          disableStickyOnSmallScreen
+        >
+          {Array.from({ length: 10 }).map((_, index) => (
+            <Textbox
+              key={`textbox-${index + 1}`}
+              label="Textbox"
+              value=""
+              onChange={() => {}}
+            />
+          ))}
+        </Form>
+      </Dialog>
+    </>
+  );
+};
+InDialogWithDisabledStickyFooterOnSmallScreen.storyName =
+  "In Dialog with Sticky Footer Disabled on Small Screen";
+InDialogWithDisabledStickyFooterOnSmallScreen.parameters = {
+  chromatic: { viewports: [1200, 320] },
+  themeProvider: { chromatic: { theme: "sage" } },
+};
+
 export const InDialogFullScreen = () => {
   const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (

--- a/src/components/form/form.style.ts
+++ b/src/components/form/form.style.ts
@@ -52,6 +52,7 @@ interface StyledFormFooterProps {
   $stickyFooterVariant?: "light" | "grey";
   $fullWidthButtons?: boolean;
   $buttonAlignment?: FormButtonAlignment;
+  disableStickyOnSmallScreen?: boolean;
 }
 
 export const StyledFormFooter = styled.div.attrs(
@@ -102,6 +103,15 @@ export const StyledFormFooter = styled.div.attrs(
   `}
 
   ${padding}
+
+  ${({ disableStickyOnSmallScreen }) =>
+    disableStickyOnSmallScreen &&
+    css`
+      @media screen and (max-width: 600px) {
+        position: static;
+        box-shadow: none;
+      }
+    `}
 `;
 
 interface StyledFormProps extends StyledFormContentProps {

--- a/src/components/form/form.style.ts
+++ b/src/components/form/form.style.ts
@@ -52,6 +52,7 @@ interface StyledFormFooterProps {
   stickyFooterVariant?: "light" | "grey";
   fullWidthButtons?: boolean;
   buttonAlignment?: FormButtonAlignment;
+  disableStickyOnSmallScreen?: boolean;
 }
 
 export const StyledFormFooter = styled.div.attrs(
@@ -102,6 +103,15 @@ export const StyledFormFooter = styled.div.attrs(
   `}
 
   ${padding}
+
+  ${({ disableStickyOnSmallScreen }) =>
+    disableStickyOnSmallScreen &&
+    css`
+      @media screen and (max-width: 600px) {
+        position: static;
+        box-shadow: none;
+      }
+    `}
 `;
 
 interface StyledFormProps extends StyledFormContentProps {

--- a/src/components/form/form.test.tsx
+++ b/src/components/form/form.test.tsx
@@ -303,3 +303,25 @@ test('renders with correct styles when `stickyFooterVariant` is "grey"', () => {
     "1px solid var(--colorsUtilityMajor050)",
   );
 });
+
+// for coverage - the `disableStickyOnSmallScreen` prop is captured by Chromatic.
+test("disables sticky footer on small screens when `disableStickyOnSmallScreen` and `stickyFooter` are set", () => {
+  render(
+    <Form
+      stickyFooter
+      disableStickyOnSmallScreen
+      saveButton={<Button>Save</Button>}
+    />,
+  );
+
+  expect(screen.getByTestId("form-footer")).toHaveStyleRule(
+    "position",
+    "static",
+    { media: "screen and (max-width: 600px)" },
+  );
+  expect(screen.getByTestId("form-footer")).toHaveStyleRule(
+    "box-shadow",
+    "none",
+    { media: "screen and (max-width: 600px)" },
+  );
+});

--- a/src/components/form/form.test.tsx
+++ b/src/components/form/form.test.tsx
@@ -305,7 +305,7 @@ test('renders with correct styles when `stickyFooterVariant` is "grey"', () => {
 });
 
 // for coverage - the `disableStickyOnSmallScreen` prop is captured by Chromatic.
-test("disables sticky footer unconditionally when `disableStickyOnSmallScreen` and `stickyFooter` are set", () => {
+test("disables sticky footer on small screens when `disableStickyOnSmallScreen` and `stickyFooter` are set", () => {
   render(
     <Form
       stickyFooter

--- a/src/components/form/form.test.tsx
+++ b/src/components/form/form.test.tsx
@@ -303,3 +303,25 @@ test('renders with correct styles when `stickyFooterVariant` is "grey"', () => {
     "1px solid var(--colorsUtilityMajor050)",
   );
 });
+
+// for coverage - the `disableStickyOnSmallScreen` prop is captured by Chromatic.
+test("disables sticky footer unconditionally when `disableStickyOnSmallScreen` and `stickyFooter` are set", () => {
+  render(
+    <Form
+      stickyFooter
+      disableStickyOnSmallScreen
+      saveButton={<Button>Save</Button>}
+    />,
+  );
+
+  expect(screen.getByTestId("form-footer")).toHaveStyleRule(
+    "position",
+    "static",
+    { media: "screen and (max-width: 600px)" },
+  );
+  expect(screen.getByTestId("form-footer")).toHaveStyleRule(
+    "box-shadow",
+    "none",
+    { media: "screen and (max-width: 600px)" },
+  );
+});


### PR DESCRIPTION
Ensures that disableStickyOnSmallScreen can work with Form inside of a Dialog with the same prop applied.

fix #7973

### Proposed behaviour

Adds a new prop to Form called `disableStickyOnSmallScreen` that can be used in conjunction with Dialog's prop of the same name to allow Form's to be used in Dialog on a small screen and have the same styling applied.

### Current behaviour

`disableStickyOnSmallScreen` only exists in Dialog so can hinder the flow of Forms in a Dialog.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

- There should be no functional regressions with Dialog or Form.
- `small-screen-behavior` example now includes Form with the `disableStickyOnSmallScreen` prop. Above 600px the footer should be sticky and below 600px the footer should not be sticky. 
