### PR TITLE
fix(multi-select): filter out empty string values

### DIFF
--- a/src/components/select/multi-select/multi-select-test.stories.tsx
+++ b/src/components/select/multi-select/multi-select-test.stories.tsx
@@ -420,16 +420,19 @@ export const MultiSelectObjectAsValueComponent = (
     setValue(event.target.value as unknown as Record<string, unknown>[]);
   }
   return (
-    <MultiSelect
-      label="color"
-      value={value}
-      onChange={onChangeHandler}
-      {...props}
-    >
-      {optionListValues.map((option) => (
-        <Option key={option.id} text={option.text} value={option} />
-      ))}
-    </MultiSelect>
+    <>
+      <MultiSelect
+        label="color"
+        value={value}
+        onChange={onChangeHandler}
+        {...props}
+      >
+        {optionListValues.map((option) => (
+          <Option key={option.id} text={option.text} value={option} />
+        ))}
+      </MultiSelect>
+      <Box mt={2}>{"Value: " + JSON.stringify(value)}</Box>
+    </>
   );
 };
 

--- a/src/components/select/multi-select/multi-select.component.tsx
+++ b/src/components/select/multi-select/multi-select.component.tsx
@@ -196,9 +196,11 @@ export const MultiSelect = React.forwardRef<HTMLInputElement, MultiSelectProps>(
         ) => (string | Record<string, unknown>)[],
         selectionConfirmed?: boolean,
       ) => {
+        // filters out any empty string values so it is not returned to the onChange
         const newValue = updateFunction(
           value as (string | Record<string, unknown>)[],
-        );
+        ).filter((v) => v !== "");
+
         // only call onChange if an option has been selected or deselected
         if (newValue.length !== value?.length) {
           onChange(createCustomEvent(newValue, selectionConfirmed));

--- a/src/components/select/multi-select/multi-select.test.tsx
+++ b/src/components/select/multi-select/multi-select.test.tsx
@@ -711,6 +711,23 @@ describe("when dropdown list is opened", () => {
 
     expect(screen.getByRole("combobox")).toHaveValue("");
   });
+
+  test("does not call onChange when Enter key is pressed with no highlighted option after opening list by click", async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    render(
+      <InteractiveComponent label="Colour" onChange={onChange} value={[]}>
+        <Option text="amber" value="amber" />
+        <Option text="blue" value="blue" />
+      </InteractiveComponent>,
+    );
+
+    await user.click(screen.getByRole("combobox"));
+    await user.keyboard("{Enter}");
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });
 
 test.each(["Backspace", "Delete"])(


### PR DESCRIPTION
fix #7997

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Filters out empty string values, so these are not returned to the user via `onChange`. Prevents consumers from handling filtering, instead the filtering is baked in to the component.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, the component does not filter out empty string values, so these are returned to the user via `onChange`. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

The stringified JSON value has been added to the already existing `"Multi Select Object As Value Component"` story, open the multi select on this story with no option selected and press the enter key. Assert that the value is now just an empty array (correct behaviour). 

Then repeat the same steps on [this stackblitz](https://stackblitz.com/edit/parsium-carbon-starter-z4hefsm7?file=src%2FApp.tsx) and assert the array includes an empty string (incorrect behaviour)