### PR TITLE
test(textbox): refine testing suite

### DIFF
--- a/src/components/textbox/textbox.pw.tsx
+++ b/src/components/textbox/textbox.pw.tsx
@@ -1,157 +1,14 @@
 import React from "react";
 import { test, expect } from "../../../playwright/helpers/base-test";
-import {
-  checkAccessibility,
-  verifyRequiredAsteriskForLabel,
-} from "../../../playwright/support/helper";
-import {
-  getDataElementByValue,
-  getDataRoleByValue,
-  characterLimit,
-  visuallyHiddenCharacterCount,
-} from "../../../playwright/components";
+import { checkAccessibility } from "../../../playwright/support/helper";
+import { visuallyHiddenCharacterCount } from "../../../playwright/components";
 import {
   TextboxComponent,
-  TextboxComponentWithPositionedChildren,
   TextboxValidationsAsABoolean,
   TextboxValidationsAsAString,
-  TextboxNewValidationsAsAStringOnGreyBackground,
   TextboxComponentWithCharacterLimit,
 } from "./components.test-pw";
-import { textbox, textboxInput } from "../../../playwright/components/textbox";
-
-import { CHARACTERS } from "../../../playwright/support/constants";
-
-const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
-
-test.describe("Prop checks for Textbox component", () => {
-  test("should render with data-element prop", async ({ mount, page }) => {
-    await mount(<TextboxComponent data-element={CHARACTERS.STANDARD} />);
-
-    await expect(
-      getDataElementByValue(page, CHARACTERS.STANDARD),
-    ).toBeVisible();
-  });
-
-  test("should render with data-role prop", async ({ mount, page }) => {
-    await mount(<TextboxComponent data-role={CHARACTERS.STANDARD} />);
-
-    await expect(getDataRoleByValue(page, CHARACTERS.STANDARD)).toBeVisible();
-  });
-
-  test("should render with id prop", async ({ mount, page }) => {
-    await mount(<TextboxComponent id={CHARACTERS.STANDARD} />);
-
-    await expect(textboxInput(page)).toHaveId(CHARACTERS.STANDARD);
-  });
-
-  testData.forEach((labelVals) => {
-    test(`should render with label prop ${labelVals}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<TextboxComponent label={labelVals} />);
-
-      const label = getDataElementByValue(page, "label");
-
-      await expect(label).toHaveText(labelVals);
-    });
-  });
-
-  test(`should render with a visually hidden character count when the characterLimit prop is passed`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextboxComponent characterLimit={4} />);
-
-    await expect(visuallyHiddenCharacterCount(page)).toHaveCount(1);
-  });
-
-  test(`should not render with a visually hidden character count when the characterLimit prop is not passed`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextboxComponent />);
-
-    await expect(visuallyHiddenCharacterCount(page)).toHaveCount(0);
-  });
-
-  test("should render with required prop", async ({ mount, page }) => {
-    await mount(<TextboxComponent required />);
-
-    await verifyRequiredAsteriskForLabel(page);
-  });
-
-  test("should render character count when the number of characters typed is under the characterLimit", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextboxComponent characterLimit={15} />);
-
-    await textboxInput(page).fill("12345678901");
-
-    await expect(characterLimit(page)).toHaveText("4 characters left");
-    await expect(characterLimit(page)).toHaveCSS(
-      "color",
-      "rgba(0, 0, 0, 0.55)",
-    );
-  });
-
-  test("should render character count when exactly 1 character is left under the characterLimit", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextboxComponent characterLimit={12} />);
-
-    await textboxInput(page).fill("12345678901");
-
-    await expect(characterLimit(page)).toHaveText("1 character left");
-    await expect(characterLimit(page)).toHaveCSS(
-      "color",
-      "rgba(0, 0, 0, 0.55)",
-    );
-  });
-
-  test("should render warning when the number of characters typed exceeds the characterLimit", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextboxComponent characterLimit={5} />);
-
-    await textboxInput(page).fill("12345678901");
-
-    await expect(characterLimit(page)).toHaveText("6 characters too many");
-    await expect(characterLimit(page)).toHaveCSS("color", "rgb(203, 55, 74)");
-  });
-
-  test("should render warning when the number of characters typed exceeds the characterLimit by exactly 1", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextboxComponent characterLimit={10} />);
-
-    await textboxInput(page).fill("12345678901");
-
-    await expect(characterLimit(page)).toHaveText("1 character too many");
-    await expect(characterLimit(page)).toHaveCSS("color", "rgb(203, 55, 74)");
-  });
-
-  test("should render with autoFocus prop", async ({ mount, page }) => {
-    await mount(<TextboxComponent autoFocus />);
-
-    await expect(textboxInput(page)).toBeFocused();
-  });
-
-  test("should render with positionedChildren prop", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextboxComponentWithPositionedChildren />);
-
-    const textboxParent = textbox(page).locator("..");
-    await expect(textboxParent.locator("button")).toBeVisible();
-  });
-});
+import { textboxInput } from "../../../playwright/components/textbox";
 
 test.describe("Accessibility tests for Textbox component", () => {
   test("should pass accessibility tests for default component with a set value and label", async ({
@@ -163,56 +20,11 @@ test.describe("Accessibility tests for Textbox component", () => {
     await checkAccessibility(page);
   });
 
-  test("should pass accessibility tests when autoFocus prop is passed", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextboxComponent autoFocus />);
-
-    await checkAccessibility(page);
-  });
-
   test("should pass accessibility tests when characterLimit prop is passed", async ({
     mount,
     page,
   }) => {
     await mount(<TextboxComponent characterLimit={5} />);
-
-    await checkAccessibility(page);
-  });
-
-  test("should pass accessibility tests when disabled prop is passed", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextboxComponent disabled />);
-
-    await checkAccessibility(page);
-  });
-
-  test("should pass accessibility tests when prefix prop is passed", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextboxComponent prefix="foo" />);
-
-    await checkAccessibility(page);
-  });
-
-  test("should pass accessibility tests when readOnly prop is passed", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextboxComponent readOnly />);
-
-    await checkAccessibility(page);
-  });
-
-  test("should pass accessibility tests when required prop is passed", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextboxComponent required />);
 
     await checkAccessibility(page);
   });
@@ -231,15 +43,6 @@ test.describe("Accessibility tests for Textbox component", () => {
     page,
   }) => {
     await mount(<TextboxValidationsAsAString />);
-
-    await checkAccessibility(page);
-  });
-
-  test("should pass accessibility tests when string validations are passed and used against a grey background", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextboxNewValidationsAsAStringOnGreyBackground />);
 
     await checkAccessibility(page);
   });

--- a/src/components/textbox/textbox.test.tsx
+++ b/src/components/textbox/textbox.test.tsx
@@ -666,3 +666,8 @@ describe("when validation message changes", () => {
     );
   });
 });
+
+test("applies autoFocus to the input", () => {
+  render(<Textbox value="foo" onChange={() => {}} label="Textbox" autoFocus />);
+  expect(screen.getByRole("textbox")).toHaveFocus();
+});


### PR DESCRIPTION
### Proposed behaviour

Removes a number of Playwright tests that duplicate either Jest or Chromatic ones for the Textbox component

### Current behaviour

There are a number of tests that exist in different forms in all the testing suites we do(Jest, Playwright, Chromatic) which cause a prolonged time of execution for no additional value.

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

This should decrease the time of execution without compromising testing and coverage

### Testing instructions

Make sure the Playwright tests pass
