### PR TITLE
feat(button-toggle): add single toggle support

### DIFF
--- a/skills/carbon-react/components/button-toggle.md
+++ b/skills/carbon-react/components/button-toggle.md
@@ -22,7 +22,8 @@ description: Carbon ButtonToggle component props and usage examples.
 | onBlur | ((ev: React.FocusEvent<HTMLButtonElement>) => void) \| undefined | No |  |  |  | Callback triggered by blur event on the button. |  |
 | onClick | ((ev: React.MouseEvent<HTMLButtonElement>) => void) \| undefined | No |  |  |  | Callback triggered by click event on the button. |  |
 | onFocus | ((ev: React.FocusEvent<HTMLButtonElement>) => void) \| undefined | No |  |  |  | Callback triggered by focus event on the button. |  |
-| size | "small" \| "medium" \| "large" \| undefined | No |  |  |  | ButtonToggle size |  |
+| pressed | boolean \| undefined | No |  |  |  | Set the pressed state of the toggle button when used outside of a group. |  |
+| size | "small" \| "medium" \| "large" \| undefined | No |  |  |  | ButtonToggle size | "medium" |
 | value | string \| undefined | No |  |  |  | An optional string by which to identify the button in an onChange handler on the parent ButtonToggleGroup. |  |
 | data-component | string \| undefined | No |  |  |  |  |  |
 | data-element | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
@@ -30,7 +31,6 @@ description: Carbon ButtonToggle component props and usage examples.
 | aria-label | string \| undefined | No |  |  |  | Prop to specify the aria-label of the component |  |
 | aria-labelledby | string \| undefined | No |  |  |  | Prop to specify the aria-labelledby property of the component |  |
 | buttonIconSize | "small" \| "large" \| undefined | No |  | Yes | `buttonIconSize` is no longer supported. | Sets the size of the buttonIcon |  |
-| pressed | boolean \| undefined | No |  | Yes | Please control the state of selected buttons through ButtonToggleGroup. | Set the pressed state of the toggle button. |  |
 
 ## Examples
 ### Default
@@ -62,6 +62,27 @@ ControlledButtonToggleGroup
     inputHint: "Hint Text",
     value: "with-label-2",
   }
+```
+
+
+### Single
+
+**Render**
+
+```tsx
+() => {
+  const [isPressed, setIsPressed] = useState(true);
+
+  const handleClick = () => {
+    setIsPressed(!isPressed);
+  };
+
+  return (
+    <ButtonToggle pressed={isPressed} onClick={handleClick}>
+      ButtonToggle
+    </ButtonToggle>
+  );
+}
 ```
 
 
@@ -168,7 +189,7 @@ ControlledButtonToggleGroup
 ```
 
 
-### Sizes
+### Sizes - Grouped
 
 **Render**
 
@@ -204,7 +225,7 @@ ControlledButtonToggleGroup
       <ButtonToggleGroup
         {...args}
         id="small"
-        label="Small"
+        label="Small ButtonToggleGroup"
         value={valueSmall}
         onChange={handleOnChangeSmall}
         size="small"
@@ -218,7 +239,7 @@ ControlledButtonToggleGroup
       <ButtonToggleGroup
         {...args}
         id="medium"
-        label="Medium"
+        label="Medium ButtonToggleGroup"
         value={valueMedium}
         onChange={handleOnChangeMedium}
         size="medium"
@@ -241,7 +262,7 @@ ControlledButtonToggleGroup
       <ButtonToggleGroup
         {...args}
         id="large"
-        label="Large"
+        label="Large ButtonToggleGroup"
         value={valueLarge}
         onChange={handleOnChangeLarge}
         size="large"
@@ -265,7 +286,58 @@ ControlledButtonToggleGroup
 ```
 
 
-### Icon Only
+### Sizes - Single
+
+**Render**
+
+```tsx
+() => {
+  const [isPressedSmall, setIsPressedSmall] = useState(true);
+  const [isPressedMedium, setIsPressedMedium] = useState(true);
+  const [isPressedLarge, setIsPressedLarge] = useState(true);
+
+  const handleClickSmall = () => {
+    setIsPressedSmall(!isPressedSmall);
+  };
+
+  const handleClickMedium = () => {
+    setIsPressedMedium(!isPressedMedium);
+  };
+
+  const handleClickLarge = () => {
+    setIsPressedLarge(!isPressedLarge);
+  };
+
+  return (
+    <Box display="flex" justifyContent="space-around">
+      <ButtonToggle
+        pressed={isPressedSmall}
+        onClick={handleClickSmall}
+        size="small"
+      >
+        <Icon aria-hidden type="placeholder" /> Small ButtonToggle
+      </ButtonToggle>
+      <ButtonToggle
+        pressed={isPressedMedium}
+        onClick={handleClickMedium}
+        size="medium"
+      >
+        <Icon aria-hidden type="placeholder" /> Medium ButtonToggle
+      </ButtonToggle>
+      <ButtonToggle
+        pressed={isPressedLarge}
+        onClick={handleClickLarge}
+        size="large"
+      >
+        <Icon aria-hidden type="placeholder" /> Large ButtonToggle
+      </ButtonToggle>
+    </Box>
+  );
+}
+```
+
+
+### Icon Only - Grouped
 
 **Render**
 
@@ -329,6 +401,57 @@ ControlledButtonToggleGroup
         </ButtonToggle>
       </ButtonToggleGroup>
     </>
+  );
+}
+```
+
+
+### Icon Only - Single
+
+**Render**
+
+```tsx
+() => {
+  const [isPressedSmall, setIsPressedSmall] = useState(true);
+  const [isPressedMedium, setIsPressedMedium] = useState(true);
+  const [isPressedLarge, setIsPressedLarge] = useState(true);
+
+  const handleClickSmall = () => {
+    setIsPressedSmall(!isPressedSmall);
+  };
+
+  const handleClickMedium = () => {
+    setIsPressedMedium(!isPressedMedium);
+  };
+
+  const handleClickLarge = () => {
+    setIsPressedLarge(!isPressedLarge);
+  };
+
+  return (
+    <Box display="flex" justifyContent="space-around">
+      <ButtonToggle
+        pressed={isPressedSmall}
+        onClick={handleClickSmall}
+        size="small"
+      >
+        <Icon ariaLabel="Placeholder 1" type="placeholder" />
+      </ButtonToggle>
+      <ButtonToggle
+        pressed={isPressedMedium}
+        onClick={handleClickMedium}
+        size="medium"
+      >
+        <Icon ariaLabel="Placeholder 2" type="placeholder" />
+      </ButtonToggle>
+      <ButtonToggle
+        pressed={isPressedLarge}
+        onClick={handleClickLarge}
+        size="large"
+      >
+        <Icon ariaLabel="Placeholder 3" type="placeholder" />
+      </ButtonToggle>
+    </Box>
   );
 }
 ```

--- a/src/components/button-toggle/button-toggle-group/__internal__/button-toggle-group.context.ts
+++ b/src/components/button-toggle/button-toggle-group/__internal__/button-toggle-group.context.ts
@@ -1,31 +1,17 @@
-import createStrictContext from "../../../../__internal__/utils/createStrictContext";
+import React from "react";
 
-type ButtonToggleGroupContextType = {
-  handleKeyDown: (ev: React.KeyboardEvent<HTMLButtonElement>) => void;
+type ButtonToggleGroupContext = {
+  handleKeyDown?: (ev: React.KeyboardEvent<HTMLButtonElement>) => void;
   pressedButtonValue?: string;
   onChange?: (ev: React.MouseEvent<HTMLButtonElement>, value?: string) => void;
-  allowDeselect: boolean;
-  isDisabled: boolean;
+  allowDeselect?: boolean;
+  isDisabled?: boolean;
   firstButton?: HTMLButtonElement;
   childButtonCallbackRef?: (button: HTMLButtonElement | null) => void;
   /** Identifier for the hint text, if it exists, that is rendered by ButtonToggleGroup */
   hintTextId?: string;
-  size: "small" | "medium" | "large";
+  size?: "small" | "medium" | "large";
   fullWidth?: boolean;
 };
 
-const [ButtonToggleGroupProvider, useButtonToggleGroupContext] =
-  createStrictContext<ButtonToggleGroupContextType>({
-    name: "ButtonToggleGroupContext",
-    errorMessage:
-      "Carbon ButtonToggleGroup: Context not found. Have you wrapped your Carbon subcomponents properly? See stack trace for more details.",
-    defaultValue: {
-      handleKeyDown: /* istanbul ignore next */ () => {},
-      pressedButtonValue: undefined,
-      allowDeselect: false,
-      isDisabled: false,
-      size: "medium",
-    },
-  });
-
-export { ButtonToggleGroupProvider, useButtonToggleGroupContext };
+export default React.createContext<ButtonToggleGroupContext>({});

--- a/src/components/button-toggle/button-toggle-group/button-toggle-group.component.tsx
+++ b/src/components/button-toggle/button-toggle-group/button-toggle-group.component.tsx
@@ -11,7 +11,7 @@ import {
 } from "./button-toggle-group.style";
 import { filterStyledSystemMarginProps } from "../../../style/utils";
 import Events from "../../../__internal__/utils/helpers/events";
-import { ButtonToggleGroupProvider } from "./__internal__/button-toggle-group.context";
+import ButtonToggleGroupContext from "./__internal__/button-toggle-group.context";
 import Label from "../../../__internal__/label";
 import HintText from "../../../__internal__/hint-text";
 
@@ -195,7 +195,7 @@ const ButtonToggleGroup = ({
         $isDisabled={disabled}
         $fullWidth={fullWidth}
       >
-        <ButtonToggleGroupProvider
+        <ButtonToggleGroupContext.Provider
           value={{
             handleKeyDown,
             pressedButtonValue: value,
@@ -210,7 +210,7 @@ const ButtonToggleGroup = ({
           }}
         >
           {children}
-        </ButtonToggleGroupProvider>
+        </ButtonToggleGroupContext.Provider>
       </StyledButtonToggleWrapper>
     </StyledButtonToggleGroup>
   );

--- a/src/components/button-toggle/button-toggle.component.tsx
+++ b/src/components/button-toggle/button-toggle.component.tsx
@@ -86,25 +86,20 @@ export const ButtonToggle = ({
     onChange?.(ev, newValue);
   }
 
-  const isInGroup = !!onChange;
+  const isInGroup = Boolean(onChange);
   const isPressed = isInGroup ? pressedButtonValue === value : pressed;
   const isFirstButton = buttonRef.current === firstButton;
   const tabbable = isPressed || (!pressedButtonValue && isFirstButton);
-  const tabIndex = tabbable ? 0 : -1;
 
   // map group size to button size when button is rendered within a group.
-  const mapGroupSizeToButtonSize = (
-    groupSize: "small" | "medium" | "large",
-  ) => {
-    switch (groupSize) {
-      case "small":
-        return "extraSmall";
-      case "medium":
-        return "small";
-      case "large":
-        return "medium";
-    }
-  };
+  const GROUP_SIZE_TO_BUTTON_SIZE = {
+    small: "extraSmall",
+    medium: "small",
+    large: "medium",
+  } as const;
+
+  const mapGroupSizeToButtonSize = (groupSize: "small" | "medium" | "large") =>
+    GROUP_SIZE_TO_BUTTON_SIZE[groupSize];
 
   const displaySize = contextSize
     ? mapGroupSizeToButtonSize(contextSize)
@@ -140,7 +135,7 @@ export const ButtonToggle = ({
       onBlur={onBlur}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
-      {...(isInGroup && { tabIndex: tabIndex })}
+      {...(isInGroup && { tabIndex: tabbable ? 0 : -1 })}
       ref={callbackRef}
       {...rest}
       {...tagComponent(dataComponent || "button-toggle", rest)}

--- a/src/components/button-toggle/button-toggle.component.tsx
+++ b/src/components/button-toggle/button-toggle.component.tsx
@@ -117,7 +117,7 @@ export const ButtonToggle = ({
   );
 
   invariant(
-    !(iconOnly && contextSize === "small"),
+    !(iconOnly && displaySize === "extraSmall"),
     "Cannot render an icon-only button in small size group.",
   );
 
@@ -145,7 +145,7 @@ export const ButtonToggle = ({
       {...rest}
       {...tagComponent(dataComponent || "button-toggle", rest)}
     >
-      {buttonIcon && contextSize !== "small" && (
+      {buttonIcon && displaySize !== "extraSmall" && (
         <Icon aria-hidden type={buttonIcon} />
       )}
       {children}

--- a/src/components/button-toggle/button-toggle.component.tsx
+++ b/src/components/button-toggle/button-toggle.component.tsx
@@ -1,8 +1,8 @@
-import React, { useRef } from "react";
+import React, { useRef, useContext } from "react";
 import invariant from "invariant";
 import StyledButtonToggle from "./button-toggle.style";
 import guid from "../../__internal__/utils/helpers/guid";
-import { useButtonToggleGroupContext } from "./button-toggle-group/__internal__/button-toggle-group.context";
+import ButtonToggleGroupContext from "./button-toggle-group/__internal__/button-toggle-group.context";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 import Icon, { IconType } from "../icon";
 import isIconOnly from "../button/__next__/__internal__/utils/is-icon-only";
@@ -20,10 +20,7 @@ export interface ButtonToggleProps extends TagProps {
   onFocus?: (ev: React.FocusEvent<HTMLButtonElement>) => void;
   /** Callback triggered by click event on the button. */
   onClick?: (ev: React.MouseEvent<HTMLButtonElement>) => void;
-  /**
-   * Set the pressed state of the toggle button.
-   * @deprecated Please control the state of selected buttons through ButtonToggleGroup.
-   * */
+  /** Set the pressed state of the toggle button when used outside of a group. */
   pressed?: boolean;
   /** An optional string by which to identify the button in an onChange handler on the parent ButtonToggleGroup. */
   value?: string;
@@ -55,7 +52,7 @@ export const ButtonToggle = ({
   onFocus,
   onClick,
   pressed,
-  size,
+  size = "medium",
   value,
   "data-component": dataComponent,
   ...rest
@@ -74,7 +71,7 @@ export const ButtonToggle = ({
     hintTextId,
     size: contextSize,
     fullWidth,
-  } = useButtonToggleGroupContext();
+  } = useContext(ButtonToggleGroupContext);
 
   const callbackRef = (element: HTMLButtonElement | null) => {
     buttonRef.current = element;
@@ -89,11 +86,24 @@ export const ButtonToggle = ({
     onChange?.(ev, newValue);
   }
 
-  const isPressed = pressedButtonValue === value || pressed;
+  const isInGroup = Boolean(onChange);
+  const isPressed = isInGroup ? pressedButtonValue === value : pressed;
   const isFirstButton = buttonRef.current === firstButton;
   const tabbable = isPressed || (!pressedButtonValue && isFirstButton);
 
-  const actualSize = size || contextSize;
+  // map group size to button size when button is rendered within a group.
+  const GROUP_SIZE_TO_BUTTON_SIZE = {
+    small: "extraSmall",
+    medium: "small",
+    large: "medium",
+  } as const;
+
+  const mapGroupSizeToButtonSize = (groupSize: "small" | "medium" | "large") =>
+    GROUP_SIZE_TO_BUTTON_SIZE[groupSize];
+
+  const displaySize = contextSize
+    ? mapGroupSizeToButtonSize(contextSize)
+    : size;
   const iconOnly = (buttonIcon && !children) || isIconOnly(children);
 
   invariant(
@@ -102,8 +112,8 @@ export const ButtonToggle = ({
   );
 
   invariant(
-    !(iconOnly && actualSize === "small"),
-    "Cannot render an icon-only button in small size.",
+    !(iconOnly && displaySize === "extraSmall"),
+    "Cannot render an icon-only button in small size group.",
   );
 
   return (
@@ -116,7 +126,7 @@ export const ButtonToggle = ({
       aria-pressed={!!isPressed}
       disabled={disabled || isDisabled}
       id={inputGuid.current}
-      $size={actualSize}
+      $size={displaySize}
       $active={!!isPressed}
       $iconOnly={iconOnly}
       $fullWidth={fullWidth}
@@ -125,12 +135,12 @@ export const ButtonToggle = ({
       onBlur={onBlur}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
-      {...(tabbable ? { tabIndex: 0 } : { tabIndex: -1 })}
+      {...(isInGroup && { tabIndex: tabbable ? 0 : -1 })}
       ref={callbackRef}
       {...rest}
       {...tagComponent(dataComponent || "button-toggle", rest)}
     >
-      {buttonIcon && actualSize !== "small" && (
+      {buttonIcon && displaySize !== "extraSmall" && (
         <Icon aria-hidden type={buttonIcon} />
       )}
       {children}

--- a/src/components/button-toggle/button-toggle.component.tsx
+++ b/src/components/button-toggle/button-toggle.component.tsx
@@ -1,8 +1,8 @@
-import React, { useRef } from "react";
+import React, { useRef, useContext } from "react";
 import invariant from "invariant";
 import StyledButtonToggle from "./button-toggle.style";
 import guid from "../../__internal__/utils/helpers/guid";
-import { useButtonToggleGroupContext } from "./button-toggle-group/__internal__/button-toggle-group.context";
+import ButtonToggleGroupContext from "./button-toggle-group/__internal__/button-toggle-group.context";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 import Icon, { IconType } from "../icon";
 import isIconOnly from "../button/__next__/__internal__/utils/is-icon-only";
@@ -20,10 +20,7 @@ export interface ButtonToggleProps extends TagProps {
   onFocus?: (ev: React.FocusEvent<HTMLButtonElement>) => void;
   /** Callback triggered by click event on the button. */
   onClick?: (ev: React.MouseEvent<HTMLButtonElement>) => void;
-  /**
-   * Set the pressed state of the toggle button.
-   * @deprecated Please control the state of selected buttons through ButtonToggleGroup.
-   * */
+  /** Set the pressed state of the toggle button when used outside of a group. */
   pressed?: boolean;
   /** An optional string by which to identify the button in an onChange handler on the parent ButtonToggleGroup. */
   value?: string;
@@ -55,7 +52,7 @@ export const ButtonToggle = ({
   onFocus,
   onClick,
   pressed,
-  size,
+  size = "medium",
   value,
   "data-component": dataComponent,
   ...rest
@@ -74,7 +71,7 @@ export const ButtonToggle = ({
     hintTextId,
     size: contextSize,
     fullWidth,
-  } = useButtonToggleGroupContext();
+  } = useContext(ButtonToggleGroupContext);
 
   const callbackRef = (element: HTMLButtonElement | null) => {
     buttonRef.current = element;
@@ -89,11 +86,29 @@ export const ButtonToggle = ({
     onChange?.(ev, newValue);
   }
 
-  const isPressed = pressedButtonValue === value || pressed;
+  const isInGroup = !!onChange;
+  const isPressed = isInGroup ? pressedButtonValue === value : pressed;
   const isFirstButton = buttonRef.current === firstButton;
   const tabbable = isPressed || (!pressedButtonValue && isFirstButton);
+  const tabIndex = tabbable ? 0 : -1;
 
-  const actualSize = size || contextSize;
+  // map group size to button size when button is rendered within a group.
+  const mapGroupSizeToButtonSize = (
+    groupSize: "small" | "medium" | "large",
+  ) => {
+    switch (groupSize) {
+      case "small":
+        return "extraSmall";
+      case "medium":
+        return "small";
+      case "large":
+        return "medium";
+    }
+  };
+
+  const displaySize = contextSize
+    ? mapGroupSizeToButtonSize(contextSize)
+    : size;
   const iconOnly = (buttonIcon && !children) || isIconOnly(children);
 
   invariant(
@@ -102,8 +117,8 @@ export const ButtonToggle = ({
   );
 
   invariant(
-    !(iconOnly && actualSize === "small"),
-    "Cannot render an icon-only button in small size.",
+    !(iconOnly && contextSize === "small"),
+    "Cannot render an icon-only button in small size group.",
   );
 
   return (
@@ -116,7 +131,7 @@ export const ButtonToggle = ({
       aria-pressed={!!isPressed}
       disabled={disabled || isDisabled}
       id={inputGuid.current}
-      $size={actualSize}
+      $size={displaySize}
       $active={!!isPressed}
       $iconOnly={iconOnly}
       $fullWidth={fullWidth}
@@ -125,12 +140,12 @@ export const ButtonToggle = ({
       onBlur={onBlur}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
-      {...(tabbable ? { tabIndex: 0 } : { tabIndex: -1 })}
+      {...(isInGroup && { tabIndex: tabIndex })}
       ref={callbackRef}
       {...rest}
       {...tagComponent(dataComponent || "button-toggle", rest)}
     >
-      {buttonIcon && actualSize !== "small" && (
+      {buttonIcon && contextSize !== "small" && (
         <Icon aria-hidden type={buttonIcon} />
       )}
       {children}

--- a/src/components/button-toggle/button-toggle.mdx
+++ b/src/components/button-toggle/button-toggle.mdx
@@ -15,7 +15,7 @@ import * as ButtonToggleStories from "./button-toggle.stories";
   Product Design System component
 </a>
 
-Press one of the buttons to make selection. This component can be used when user has to make a choice between a small number of options.
+ Press one of the buttons to make a selection. This component can be used when the user has to make a choice between a small number of options.
 
 ## Contents
 
@@ -39,14 +39,14 @@ import {
 Pass `ButtonToggle` buttons as children of `ButtonToggleGroup` to render them in a group.
 Control the state of the selected values by making use of the `value` and `onChange` props available in `ButtonToggleGroup`.
 
-If using this component without a visible label, please ensure to provide and accessible label to the group using the `aria-label` prop.
+If using this component without a visible label, please ensure to provide an accessible label to the group using the `aria-label` prop.
 
 <Canvas of={ButtonToggleStories.Default} />
 
 ### With Label and Hint Text
 
 The `label` prop can be used to set a visible label for the group.
-To provide an additional hint text string, use the `hintText` prop.
+To provide an additional hint text string, use the `inputHint` prop.
 
 <Canvas of={ButtonToggleStories.WithLabelAndHint} />
 

--- a/src/components/button-toggle/button-toggle.mdx
+++ b/src/components/button-toggle/button-toggle.mdx
@@ -15,7 +15,7 @@ import * as ButtonToggleStories from "./button-toggle.stories";
   Product Design System component
 </a>
 
-Press one of the buttons to make selection. This component should be used when user has to make a choice between a small number of options.
+Press one of the buttons to make selection. This component can be used when user has to make a choice between a small number of options.
 
 ## Contents
 
@@ -34,21 +34,28 @@ import {
 
 ## Examples
 
-### Default
+### Grouped
 
-To use this component, pass the `ButtonToggle` buttons as children of `ButtonToggleGroup`. 
-Control the state of the selected values by making use of the `value` and `onChange` props provided. 
+Pass `ButtonToggle` buttons as children of `ButtonToggleGroup` to render them in a group.
+Control the state of the selected values by making use of the `value` and `onChange` props available in `ButtonToggleGroup`.
 
-If using this component without a visible label, please ensure to provide and accessible label using `aria-label`.
+If using this component without a visible label, please ensure to provide and accessible label to the group using the `aria-label` prop.
 
 <Canvas of={ButtonToggleStories.Default} />
 
 ### With Label and Hint Text
 
-The `label` prop can be used to set a visible label for the component.
+The `label` prop can be used to set a visible label for the group.
 To provide an additional hint text string, use the `hintText` prop.
 
 <Canvas of={ButtonToggleStories.WithLabelAndHint} />
+
+### Single
+
+`ButtonToggle` can be used individually to act as a switch to turn something on and off. 
+Control the state of the button using the `pressed` prop available.
+
+<Canvas of={ButtonToggleStories.Single} />
 
 ### With Icons
 
@@ -69,22 +76,37 @@ See our [Loader documentation](../?path=/docs/loader--docs) for more information
 
 ### Sizes
 
-The component can be rendered in three different sizes: `"small"`, `"medium"` (default) and `"large"`. 
-This can be changed by passing the `size` prop to `ButtonToggleGroup`.
+#### Grouped
 
-**Note:** Do not pass icons when using the `"small"` size, please limit the content of the buttons to only text. 
+The size of a group can be changed by passing the `size` prop to `ButtonToggleGroup`. Available sizes are `"small"`, `"medium"` (default) and `"large"`.
 
-<Canvas of={ButtonToggleStories.Sizes} />
+**Note:** Do not make use of icons when using the `"small"` size, please limit the content of the buttons to only text. 
+
+<Canvas of={ButtonToggleStories.SizesGrouped} />
+
+#### Single
+
+The size of a button can be changed by passing the `size` prop to `ButtonToggle`. Available sizes are `"small"`, `"medium"` (default) and `"large"`.
+
+**Note:** This will only be applied when `ButtonToggle` is used in isolation, if used within a group this prop will have no effect.
+
+<Canvas of={ButtonToggleStories.SizesSingle} />
 
 ### Icon Only
 
-`ButtonToggle` can be rendered as an icon-only button, when only `Icon` children are passed.
-This should only be done using sizes `"medium"` or `"large"`. 
+`ButtonToggle` can be rendered as an icon-only button when only `Icon` children are passed.
 
 Please ensure to provide accessible names using `aria-label` to any buttons with no visible label.
 
-<Canvas of={ButtonToggleStories.IconOnly} />
+#### Grouped
 
+**Note:** Do not make use of icons when using the `"small"` size, icon-only groups are only available in sizes `"medium"` or `"large"`. 
+
+<Canvas of={ButtonToggleStories.IconOnlyGrouped} />
+
+#### Single
+
+<Canvas of={ButtonToggleStories.IconOnlySingle} />
 
 ### Allow Deselect
 

--- a/src/components/button-toggle/button-toggle.mdx
+++ b/src/components/button-toggle/button-toggle.mdx
@@ -15,7 +15,7 @@ import * as ButtonToggleStories from "./button-toggle.stories";
   Product Design System component
 </a>
 
-Press one of the buttons to make selection. This component should be used when user has to make a choice between a small number of options.
+ Press one of the buttons to make a selection. This component can be used when the user has to make a choice between a small number of options.
 
 ## Contents
 
@@ -34,21 +34,28 @@ import {
 
 ## Examples
 
-### Default
+### Grouped
 
-To use this component, pass the `ButtonToggle` buttons as children of `ButtonToggleGroup`. 
-Control the state of the selected values by making use of the `value` and `onChange` props provided. 
+Pass `ButtonToggle` buttons as children of `ButtonToggleGroup` to render them in a group.
+Control the state of the selected values by making use of the `value` and `onChange` props available in `ButtonToggleGroup`.
 
-If using this component without a visible label, please ensure to provide and accessible label using `aria-label`.
+If using this component without a visible label, please ensure to provide an accessible label to the group using the `aria-label` prop.
 
 <Canvas of={ButtonToggleStories.Default} />
 
 ### With Label and Hint Text
 
-The `label` prop can be used to set a visible label for the component.
-To provide an additional hint text string, use the `hintText` prop.
+The `label` prop can be used to set a visible label for the group.
+To provide an additional hint text string, use the `inputHint` prop.
 
 <Canvas of={ButtonToggleStories.WithLabelAndHint} />
+
+### Single
+
+`ButtonToggle` can be used individually to act as a switch to turn something on and off. 
+Control the state of the button using the `pressed` prop available.
+
+<Canvas of={ButtonToggleStories.Single} />
 
 ### With Icons
 
@@ -69,22 +76,37 @@ See our [Loader documentation](../?path=/docs/loader--docs) for more information
 
 ### Sizes
 
-The component can be rendered in three different sizes: `"small"`, `"medium"` (default) and `"large"`. 
-This can be changed by passing the `size` prop to `ButtonToggleGroup`.
+#### Grouped
 
-**Note:** Do not pass icons when using the `"small"` size, please limit the content of the buttons to only text. 
+The size of a group can be changed by passing the `size` prop to `ButtonToggleGroup`. Available sizes are `"small"`, `"medium"` (default) and `"large"`.
 
-<Canvas of={ButtonToggleStories.Sizes} />
+**Note:** Do not make use of icons when using the `"small"` size, please limit the content of the buttons to only text. 
+
+<Canvas of={ButtonToggleStories.SizesGrouped} />
+
+#### Single
+
+The size of a button can be changed by passing the `size` prop to `ButtonToggle`. Available sizes are `"small"`, `"medium"` (default) and `"large"`.
+
+**Note:** This will only be applied when `ButtonToggle` is used in isolation, if used within a group this prop will have no effect.
+
+<Canvas of={ButtonToggleStories.SizesSingle} />
 
 ### Icon Only
 
-`ButtonToggle` can be rendered as an icon-only button, when only `Icon` children are passed.
-This should only be done using sizes `"medium"` or `"large"`. 
+`ButtonToggle` can be rendered as an icon-only button when only `Icon` children are passed.
 
 Please ensure to provide accessible names using `aria-label` to any buttons with no visible label.
 
-<Canvas of={ButtonToggleStories.IconOnly} />
+#### Grouped
 
+**Note:** Do not make use of icons when using the `"small"` size, icon-only groups are only available in sizes `"medium"` or `"large"`. 
+
+<Canvas of={ButtonToggleStories.IconOnlyGrouped} />
+
+#### Single
+
+<Canvas of={ButtonToggleStories.IconOnlySingle} />
 
 ### Allow Deselect
 

--- a/src/components/button-toggle/button-toggle.stories.tsx
+++ b/src/components/button-toggle/button-toggle.stories.tsx
@@ -4,6 +4,7 @@ import generateStyledSystemProps from "../../../.storybook/utils/styled-system-p
 import { ButtonToggle, ButtonToggleGroup, ButtonToggleGroupProps } from ".";
 import Icon from "../icon";
 import { Loader } from "../loader/__next__/loader.component";
+import Box from "../box";
 
 const styledSystemProps = generateStyledSystemProps({
   margin: true,
@@ -76,6 +77,21 @@ export const WithLabelAndHint: Story = {
     value: "with-label-2",
   },
 };
+
+export const Single: Story = () => {
+  const [isPressed, setIsPressed] = useState(true);
+
+  const handleClick = () => {
+    setIsPressed(!isPressed);
+  };
+
+  return (
+    <ButtonToggle pressed={isPressed} onClick={handleClick}>
+      ButtonToggle
+    </ButtonToggle>
+  );
+};
+Single.storyName = "Single";
 
 export const WithIcon: Story = ({ ...args }: ButtonToggleGroupProps) => {
   const [leftValue, setLeftValue] = useState("icon-left-1");
@@ -168,7 +184,7 @@ export const Loading: Story = ({ ...args }: ButtonToggleGroupProps) => {
 };
 Loading.storyName = "Loading";
 
-export const Sizes: Story = ({ ...args }: ButtonToggleGroupProps) => {
+export const SizesGrouped: Story = ({ ...args }: ButtonToggleGroupProps) => {
   const [valueSmall, setValueSmall] = useState("small-2");
   const [valueMedium, setValueMedium] = useState("medium-2");
   const [valueLarge, setValueLarge] = useState("large-2");
@@ -199,7 +215,7 @@ export const Sizes: Story = ({ ...args }: ButtonToggleGroupProps) => {
       <ButtonToggleGroup
         {...args}
         id="small"
-        label="Small"
+        label="Small ButtonToggleGroup"
         value={valueSmall}
         onChange={handleOnChangeSmall}
         size="small"
@@ -213,7 +229,7 @@ export const Sizes: Story = ({ ...args }: ButtonToggleGroupProps) => {
       <ButtonToggleGroup
         {...args}
         id="medium"
-        label="Medium"
+        label="Medium ButtonToggleGroup"
         value={valueMedium}
         onChange={handleOnChangeMedium}
         size="medium"
@@ -236,7 +252,7 @@ export const Sizes: Story = ({ ...args }: ButtonToggleGroupProps) => {
       <ButtonToggleGroup
         {...args}
         id="large"
-        label="Large"
+        label="Large ButtonToggleGroup"
         value={valueLarge}
         onChange={handleOnChangeLarge}
         size="large"
@@ -257,9 +273,54 @@ export const Sizes: Story = ({ ...args }: ButtonToggleGroupProps) => {
     </>
   );
 };
-Sizes.storyName = "Sizes";
+SizesGrouped.storyName = "Sizes - Grouped";
 
-export const IconOnly: Story = ({ ...args }: ButtonToggleGroupProps) => {
+export const SizesSingle: Story = () => {
+  const [isPressedSmall, setIsPressedSmall] = useState(true);
+  const [isPressedMedium, setIsPressedMedium] = useState(true);
+  const [isPressedLarge, setIsPressedLarge] = useState(true);
+
+  const handleClickSmall = () => {
+    setIsPressedSmall(!isPressedSmall);
+  };
+
+  const handleClickMedium = () => {
+    setIsPressedMedium(!isPressedMedium);
+  };
+
+  const handleClickLarge = () => {
+    setIsPressedLarge(!isPressedLarge);
+  };
+
+  return (
+    <Box display="flex" justifyContent="space-around">
+      <ButtonToggle
+        pressed={isPressedSmall}
+        onClick={handleClickSmall}
+        size="small"
+      >
+        <Icon aria-hidden type="placeholder" /> Small ButtonToggle
+      </ButtonToggle>
+      <ButtonToggle
+        pressed={isPressedMedium}
+        onClick={handleClickMedium}
+        size="medium"
+      >
+        <Icon aria-hidden type="placeholder" /> Medium ButtonToggle
+      </ButtonToggle>
+      <ButtonToggle
+        pressed={isPressedLarge}
+        onClick={handleClickLarge}
+        size="large"
+      >
+        <Icon aria-hidden type="placeholder" /> Large ButtonToggle
+      </ButtonToggle>
+    </Box>
+  );
+};
+SizesSingle.storyName = "Sizes - Single";
+
+export const IconOnlyGrouped: Story = ({ ...args }: ButtonToggleGroupProps) => {
   const [valueMedium, setValueMedium] = useState("medium-2");
   const [valueLarge, setValueLarge] = useState("large-2");
 
@@ -320,7 +381,52 @@ export const IconOnly: Story = ({ ...args }: ButtonToggleGroupProps) => {
     </>
   );
 };
-IconOnly.storyName = "Icon Only";
+IconOnlyGrouped.storyName = "Icon Only - Grouped";
+
+export const IconOnlySingle: Story = () => {
+  const [isPressedSmall, setIsPressedSmall] = useState(true);
+  const [isPressedMedium, setIsPressedMedium] = useState(true);
+  const [isPressedLarge, setIsPressedLarge] = useState(true);
+
+  const handleClickSmall = () => {
+    setIsPressedSmall(!isPressedSmall);
+  };
+
+  const handleClickMedium = () => {
+    setIsPressedMedium(!isPressedMedium);
+  };
+
+  const handleClickLarge = () => {
+    setIsPressedLarge(!isPressedLarge);
+  };
+
+  return (
+    <Box display="flex" justifyContent="space-around">
+      <ButtonToggle
+        pressed={isPressedSmall}
+        onClick={handleClickSmall}
+        size="small"
+      >
+        <Icon ariaLabel="Placeholder 1" type="placeholder" />
+      </ButtonToggle>
+      <ButtonToggle
+        pressed={isPressedMedium}
+        onClick={handleClickMedium}
+        size="medium"
+      >
+        <Icon ariaLabel="Placeholder 2" type="placeholder" />
+      </ButtonToggle>
+      <ButtonToggle
+        pressed={isPressedLarge}
+        onClick={handleClickLarge}
+        size="large"
+      >
+        <Icon ariaLabel="Placeholder 3" type="placeholder" />
+      </ButtonToggle>
+    </Box>
+  );
+};
+IconOnlySingle.storyName = "Icon Only - Single";
 
 export const AllowDeselect: Story = {
   ...Default,

--- a/src/components/button-toggle/button-toggle.style.ts
+++ b/src/components/button-toggle/button-toggle.style.ts
@@ -3,32 +3,32 @@ import styled, { css } from "styled-components";
 import applyBaseTheme from "../../style/themes/apply-base-theme";
 import addFocusStyling from "../../style/utils/add-focus-styling";
 
-// these sizes refer to buttons used within the group
-// TODO: update sizes to map group size and also support single button sizes - FE-7662
 const sizeMap = {
-  // extra-small button
-  small: {
+  extraSmall: {
     size: "var(--global-size-xs)",
     padding: "var(--global-space-comp-2-xs) var(--global-space-comp-s)",
     borderRadius: "12px",
   },
-  // small button
-  medium: {
+  small: {
     size: "var(--global-size-s)",
     padding: "var(--global-space-comp-xs) var(--global-space-comp-m)",
     borderRadius: "var(--global-radius-action-l)",
   },
-  // medium button
-  large: {
+  medium: {
     size: "var(--global-size-m)",
     padding: "var(--global-space-comp-s) var(--global-space-comp-l)",
     borderRadius: "var(--global-radius-action-xl)",
+  },
+  large: {
+    size: "var(--global-size-l)",
+    padding: "var(--global-space-comp-s) var(--global-space-comp-l)",
+    borderRadius: "var(--global-radius-action-2-xl)",
   },
 };
 
 interface StyledButtonToggleProps {
   disabled?: boolean;
-  $size: "small" | "medium" | "large";
+  $size: "extraSmall" | "small" | "medium" | "large";
   $active?: boolean;
   $iconOnly?: boolean;
   $fullWidth?: boolean;

--- a/src/components/button-toggle/button-toggle.style.ts
+++ b/src/components/button-toggle/button-toggle.style.ts
@@ -5,21 +5,25 @@ import addFocusStyling from "../../style/utils/add-focus-styling";
 
 const sizeMap = {
   extraSmall: {
+    font: "var(--global-font-static-comp-medium-s)",
     size: "var(--global-size-xs)",
     padding: "var(--global-space-comp-2-xs) var(--global-space-comp-s)",
     borderRadius: "12px",
   },
   small: {
+    font: "var(--global-font-static-comp-medium-s)",
     size: "var(--global-size-s)",
     padding: "var(--global-space-comp-xs) var(--global-space-comp-m)",
     borderRadius: "var(--global-radius-action-l)",
   },
   medium: {
+    font: "var(--global-font-static-comp-medium-m)",
     size: "var(--global-size-m)",
     padding: "var(--global-space-comp-s) var(--global-space-comp-l)",
     borderRadius: "var(--global-radius-action-xl)",
   },
   large: {
+    font: "var(--global-font-static-comp-medium-l)",
     size: "var(--global-size-l)",
     padding: "var(--global-space-comp-s) var(--global-space-comp-l)",
     borderRadius: "var(--global-radius-action-2-xl)",
@@ -68,7 +72,7 @@ const StyledButtonToggle = styled.button.attrs(
     background-color: transparent;
 
     color: var(--button-typical-toggle-label-default);
-    font: var(--global-font-static-comp-medium-m);
+    font: ${sizeMap[$size].font};
     text-align: center;
 
     ${$active &&

--- a/src/components/button-toggle/button-toggle.style.ts
+++ b/src/components/button-toggle/button-toggle.style.ts
@@ -3,32 +3,36 @@ import styled, { css } from "styled-components";
 import applyBaseTheme from "../../style/themes/apply-base-theme";
 import addFocusStyling from "../../style/utils/add-focus-styling";
 
-// these sizes refer to buttons used within the group
-// TODO: update sizes to map group size and also support single button sizes - FE-7662
 const sizeMap = {
-  // extra-small button
-  small: {
+  extraSmall: {
+    font: "var(--global-font-static-comp-medium-s)",
     size: "var(--global-size-xs)",
     padding: "var(--global-space-comp-2-xs) var(--global-space-comp-s)",
     borderRadius: "12px",
   },
-  // small button
-  medium: {
+  small: {
+    font: "var(--global-font-static-comp-medium-s)",
     size: "var(--global-size-s)",
     padding: "var(--global-space-comp-xs) var(--global-space-comp-m)",
     borderRadius: "var(--global-radius-action-l)",
   },
-  // medium button
-  large: {
+  medium: {
+    font: "var(--global-font-static-comp-medium-m)",
     size: "var(--global-size-m)",
     padding: "var(--global-space-comp-s) var(--global-space-comp-l)",
     borderRadius: "var(--global-radius-action-xl)",
+  },
+  large: {
+    font: "var(--global-font-static-comp-medium-l)",
+    size: "var(--global-size-l)",
+    padding: "var(--global-space-comp-s) var(--global-space-comp-l)",
+    borderRadius: "var(--global-radius-action-2-xl)",
   },
 };
 
 interface StyledButtonToggleProps {
   disabled?: boolean;
-  $size: "small" | "medium" | "large";
+  $size: "extraSmall" | "small" | "medium" | "large";
   $active?: boolean;
   $iconOnly?: boolean;
   $fullWidth?: boolean;
@@ -68,7 +72,7 @@ const StyledButtonToggle = styled.button.attrs(
     background-color: transparent;
 
     color: var(--button-typical-toggle-label-default);
-    font: var(--global-font-static-comp-medium-m);
+    font: ${sizeMap[$size].font};
     text-align: center;
 
     ${$active &&

--- a/src/components/button-toggle/button-toggle.test.tsx
+++ b/src/components/button-toggle/button-toggle.test.tsx
@@ -2,32 +2,11 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ButtonToggleGroup, ButtonToggle } from ".";
-import Logger from "../../__internal__/utils/logger";
-
-test("logs warning if not used within ButtonToggleGroup", () => {
-  const loggerErrorSpy = jest
-    .spyOn(Logger, "error")
-    .mockImplementation(() => {});
-
-  render(<ButtonToggle>Button</ButtonToggle>);
-
-  expect(loggerErrorSpy).toHaveBeenCalledWith(
-    expect.stringContaining(
-      "Carbon ButtonToggleGroup: Context not found. Have you wrapped your Carbon subcomponents properly? See stack trace for more details.",
-    ),
-  );
-
-  loggerErrorSpy.mockRestore();
-});
 
 test("should call `onClick` when the button is clicked", async () => {
   const onClick = jest.fn();
   const user = userEvent.setup();
-  render(
-    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
-      <ButtonToggle onClick={onClick}>Button</ButtonToggle>
-    </ButtonToggleGroup>,
-  );
+  render(<ButtonToggle onClick={onClick}>Button</ButtonToggle>);
 
   await user.click(screen.getByRole("button"));
   expect(onClick).toHaveBeenCalledTimes(1);
@@ -36,11 +15,7 @@ test("should call `onClick` when the button is clicked", async () => {
 test("should call `onFocus` when the button is focused", async () => {
   const onFocus = jest.fn();
   const user = userEvent.setup();
-  render(
-    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
-      <ButtonToggle onFocus={onFocus}>Button</ButtonToggle>
-    </ButtonToggleGroup>,
-  );
+  render(<ButtonToggle onFocus={onFocus}>Button</ButtonToggle>);
 
   await user.click(screen.getByRole("button"));
   expect(onFocus).toHaveBeenCalledTimes(1);
@@ -49,11 +24,7 @@ test("should call `onFocus` when the button is focused", async () => {
 test("should call `onBlur` when the button is blurred", async () => {
   const onBlur = jest.fn();
   const user = userEvent.setup();
-  render(
-    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
-      <ButtonToggle onBlur={onBlur}>Button</ButtonToggle>
-    </ButtonToggleGroup>,
-  );
+  render(<ButtonToggle onBlur={onBlur}>Button</ButtonToggle>);
 
   await user.click(screen.getByRole("button"));
   await user.tab();
@@ -61,11 +32,7 @@ test("should call `onBlur` when the button is blurred", async () => {
 });
 
 test("should render disabled button with expected styles", () => {
-  render(
-    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
-      <ButtonToggle disabled>Button</ButtonToggle>
-    </ButtonToggleGroup>,
-  );
+  render(<ButtonToggle disabled>Button</ButtonToggle>);
 
   expect(screen.getByRole("button")).toBeDisabled();
   expect(screen.getByRole("button")).toHaveStyle({ cursor: "not-allowed" });
@@ -74,13 +41,7 @@ test("should render disabled button with expected styles", () => {
 test("should throw an error when neither children or a `buttonIcon` is provided", () => {
   const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
 
-  expect(() =>
-    render(
-      <ButtonToggleGroup id="test" value="" onChange={() => {}}>
-        <ButtonToggle />
-      </ButtonToggleGroup>,
-    ),
-  ).toThrow(
+  expect(() => render(<ButtonToggle />)).toThrow(
     "Either prop `buttonIcon` must be defined, or this node must have children",
   );
 
@@ -88,11 +49,7 @@ test("should throw an error when neither children or a `buttonIcon` is provided"
 });
 
 test("should render with aria-label attribute", () => {
-  render(
-    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
-      <ButtonToggle aria-label="test-label">Button</ButtonToggle>
-    </ButtonToggleGroup>,
-  );
+  render(<ButtonToggle aria-label="test-label">Button</ButtonToggle>);
 
   expect(screen.getByRole("button")).toHaveAccessibleName("test-label");
 });
@@ -101,16 +58,14 @@ test("should render with aria-labelledby attribute", () => {
   render(
     <>
       <span id="test-id">Test Label</span>
-      <ButtonToggleGroup id="test" value="" onChange={() => {}}>
-        <ButtonToggle aria-labelledby="test-id">Button</ButtonToggle>
-      </ButtonToggleGroup>
+      <ButtonToggle aria-labelledby="test-id">Button</ButtonToggle>
     </>,
   );
 
   expect(screen.getByRole("button")).toHaveAccessibleName("Test Label");
 });
 
-test("should render with aria-pressed true when the button is selected", () => {
+test("should render with aria-pressed true when the button is selected within a group", () => {
   render(
     <ButtonToggleGroup id="test" value="test-value" onChange={() => {}}>
       <ButtonToggle value="test-value">Button</ButtonToggle>
@@ -120,70 +75,73 @@ test("should render with aria-pressed true when the button is selected", () => {
   expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
 });
 
-test("should render with aria-pressed false when the button is not selected", () => {
-  render(
-    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
-      <ButtonToggle pressed={false}>Button</ButtonToggle>
-    </ButtonToggleGroup>,
-  );
-
-  expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
-});
-
-test("should render with provided data- tags", () => {
-  render(
-    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
-      <ButtonToggle data-element="test-element" data-role="test-role">
-        Button
-      </ButtonToggle>
-    </ButtonToggleGroup>,
-  );
-
-  expect(screen.getByTestId("test-role")).toHaveAttribute(
-    "data-element",
-    "test-element",
-  );
-});
-
-test("should render with value attribute", () => {
+test("should render with aria-pressed false when the button is not selected within a group", () => {
   render(
     <ButtonToggleGroup id="test" value="" onChange={() => {}}>
       <ButtonToggle value="test-value">Button</ButtonToggle>
     </ButtonToggleGroup>,
   );
 
+  expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+});
+
+test("should render with aria-pressed true when `pressed` is true", () => {
+  render(<ButtonToggle pressed>Single Button</ButtonToggle>);
+
+  expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+});
+
+test("should render with aria-pressed false when `pressed` is false", () => {
+  render(<ButtonToggle pressed={false}>Single Button</ButtonToggle>);
+
+  expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+});
+
+test("should render with provided data- tags", () => {
+  render(
+    <ButtonToggle data-element="test-element" data-role="test-role">
+      Button
+    </ButtonToggle>,
+  );
+
+  expect(screen.getByRole("button")).toHaveAttribute(
+    "data-element",
+    "test-element",
+  );
+  expect(screen.getByRole("button")).toHaveAttribute("data-role", "test-role");
+});
+
+test("should render with value attribute", () => {
+  render(<ButtonToggle value="test-value">Button</ButtonToggle>);
+
   expect(screen.getByRole("button")).toHaveValue("test-value");
 });
 
 test("should render button with text content", () => {
-  render(
-    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
-      <ButtonToggle>Test Button Text</ButtonToggle>
-    </ButtonToggleGroup>,
-  );
+  render(<ButtonToggle>Test Button Text</ButtonToggle>);
 
   expect(screen.getByRole("button")).toHaveTextContent("Test Button Text");
 });
 
+test("should not render with tabindex when not in a group", () => {
+  render(<ButtonToggle pressed={false}>Single Button</ButtonToggle>);
+
+  expect(screen.getByRole("button")).not.toHaveAttribute("tabindex");
+});
+
 test("should render with provided `buttonIcon`", () => {
-  render(
-    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
-      <ButtonToggle buttonIcon="placeholder" />
-    </ButtonToggleGroup>,
-  );
+  render(<ButtonToggle buttonIcon="placeholder" />);
 
   expect(screen.getByTestId("icon")).toBeVisible();
   expect(screen.getByTestId("icon")).toHaveAttribute("type", "placeholder");
 });
 
 // coverage
-test("should render button with expected styles when selected button is disabled", () => {
+test("should render button with expected styles when pressed button is disabled", () => {
   render(
-    <ButtonToggleGroup id="test" value="test-value" onChange={() => {}}>
-      <ButtonToggle value="test-value" disabled>
-        Button
-      </ButtonToggle>
-    </ButtonToggleGroup>,
+    <ButtonToggle pressed disabled>
+      Button
+    </ButtonToggle>,
   );
 
   expect(screen.getByRole("button")).toHaveStyleRule(
@@ -192,13 +150,51 @@ test("should render button with expected styles when selected button is disabled
   );
 });
 
-// coverage
-test("should render with expected styles when `size` prop is set", () => {
+test("should render extra-small button when rendered in small group", () => {
   render(
-    <ButtonToggleGroup id="test" value="" onChange={() => {}}>
-      <ButtonToggle value="test-value" size="large">
-        Button
-      </ButtonToggle>
+    <ButtonToggleGroup
+      id="test"
+      value="test-value"
+      onChange={() => {}}
+      size="small"
+    >
+      <ButtonToggle value="">Button</ButtonToggle>
+    </ButtonToggleGroup>,
+  );
+
+  expect(screen.getByRole("button")).toHaveStyleRule(
+    "height",
+    "var(--global-size-xs)",
+  );
+});
+
+test("should render small button when rendered in medium group", () => {
+  render(
+    <ButtonToggleGroup
+      id="test"
+      value="test-value"
+      onChange={() => {}}
+      size="medium"
+    >
+      <ButtonToggle value="">Button</ButtonToggle>
+    </ButtonToggleGroup>,
+  );
+
+  expect(screen.getByRole("button")).toHaveStyleRule(
+    "height",
+    "var(--global-size-s)",
+  );
+});
+
+test("should render medium button when rendered in large group", () => {
+  render(
+    <ButtonToggleGroup
+      id="test"
+      value="test-value"
+      onChange={() => {}}
+      size="large"
+    >
+      <ButtonToggle value="">Button</ButtonToggle>
     </ButtonToggleGroup>,
   );
 


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Add support to render a single `ButtonToggle`  outside of a group.

- Updates button sizes to match Button component and maps group sizes to render correct button size. 
<img width="834" height="71" alt="image" src="https://github.com/user-attachments/assets/e4220b52-ed3a-419d-a004-7e9ae2735215" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

`ButtonToggle` does not support rendering a single button outside a group.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
