### PR TITLE
feat(file-input): introduce multiple file uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5613,9 +5613,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5633,9 +5630,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5653,9 +5647,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5673,9 +5664,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5693,9 +5681,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5713,9 +5698,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5733,9 +5715,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5753,9 +5732,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6021,9 +5997,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6038,9 +6011,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6055,9 +6025,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6072,9 +6039,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6089,9 +6053,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6106,9 +6067,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6123,9 +6081,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6140,9 +6095,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/skills/carbon-react/components/file-input.md
+++ b/skills/carbon-react/components/file-input.md
@@ -40,6 +40,7 @@ description: Carbon FileInput component props and usage examples.
 | ml | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on left |  |
 | mr | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on right |  |
 | mt | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top |  |
+| multiple | boolean \| undefined | No |  | Flag to allow multiple file selection. |  |
 | mx | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on left and right |  |
 | my | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top and bottom |  |
 | name | string \| undefined | No |  | Name of the input |  |
@@ -433,6 +434,129 @@ description: Carbon FileInput component props and usage examples.
         onAction: () => {},
       }}
       onChange={() => {}}
+    />
+  );
+}
+```
+
+
+### Multiple Files
+
+**Render**
+
+```tsx
+() => {
+  return (
+    <FileInput label="Multiple file selection" multiple onChange={() => {}} />
+  );
+}
+```
+
+
+### Multiple Files (Upload Status)
+
+**Render**
+
+```tsx
+() => {
+  return (
+    <FileInput
+      label="Multiple uploaded files"
+      multiple
+      uploadStatus={[
+        {
+          status: "completed",
+          filename: "file-one.txt",
+          href: "#",
+          onAction: () => {},
+        },
+        {
+          status: "completed",
+          filename: "file-two.pdf",
+          href: "#",
+          onAction: () => {},
+        },
+      ]}
+      onChange={() => {}}
+    />
+  );
+}
+```
+
+
+### Multiple Files (Interactive)
+
+**Render**
+
+```tsx
+() => {
+  const [files, setFiles] = useState<FileUploadStatusProps[]>([]);
+  const onChange = (fileList: FileList) => {
+    const newFiles = Array.from(fileList).map((file) => ({
+      status: "uploading" as const,
+      filename: file.name,
+      progress: 0,
+      message: "0% uploaded",
+      onAction: () => removeFile(file.name),
+    }));
+
+    // append new session files (don't overwrite existing ones)
+    setFiles((prev) => [...prev, ...newFiles]);
+
+    // simulate upload progression per file
+    newFiles.forEach((file) => {
+      let progress = 0;
+
+      const interval = setInterval(() => {
+        progress += Math.random() * 25;
+
+        if (progress >= 100) {
+          clearInterval(interval);
+
+          setFiles((prev) =>
+            prev.map((f) =>
+              f.filename === file.filename
+                ? {
+                    ...f,
+                    status: "completed",
+                    progress: undefined,
+                    message: "File uploaded",
+                    href: "#",
+                    onAction: () => removeFile(file.filename),
+                  }
+                : f,
+            ),
+          );
+          return;
+        }
+
+        setFiles((prev) =>
+          prev.map((f) =>
+            f.filename === file.filename
+              ? {
+                  ...f,
+                  status: "uploading",
+                  progress,
+                  message: `${Math.round(progress)}% uploaded`,
+                  onAction: () => removeFile(file.filename),
+                }
+              : f,
+          ),
+        );
+      }, 300);
+    });
+  };
+
+  const removeFile = (filename: string) => {
+    setFiles((prev) => prev.filter((f) => f.filename !== filename));
+  };
+
+  return (
+    <FileInput
+      label="Multiple file upload (interactive)"
+      multiple
+      uploadStatus={files}
+      onChange={onChange}
     />
   );
 }

--- a/src/components/file-input/file-input.component.tsx
+++ b/src/components/file-input/file-input.component.tsx
@@ -50,6 +50,8 @@ export interface FileInputProps
   minHeight?: string;
   /** A valid CSS string for the min-width CSS property. */
   minWidth?: string;
+  /** Flag to allow multiple file selection. */
+  multiple?: boolean;
   /** onChange event handler. Accepts a list of all files currently entered to the input. */
   onChange: (files: FileList) => void;
   /** used to control how to display the progress of uploaded file(s) within the component */
@@ -77,6 +79,7 @@ export const FileInput = React.forwardRef(
       maxWidth,
       minHeight,
       minWidth = "280px",
+      multiple = false,
       name,
       onChange,
       required,
@@ -87,8 +90,16 @@ export const FileInput = React.forwardRef(
     ref: React.ForwardedRef<HTMLInputElement>,
   ) => {
     const locale = useLocale();
-    const textOnButton = buttonText || locale.fileInput.selectFile();
-    const mainText = dragAndDropText || locale.fileInput.dragAndDrop();
+    const textOnButton =
+      buttonText ||
+      (multiple
+        ? locale.fileInput?.selectFile_multiple?.()
+        : locale.fileInput.selectFile());
+    const mainText =
+      dragAndDropText ||
+      (multiple
+        ? locale.fileInput?.dragAndDrop_multiple?.()
+        : locale.fileInput.dragAndDrop());
 
     const sizeProps = {
       maxHeight: maxHeight || undefined,
@@ -199,6 +210,7 @@ export const FileInput = React.forwardRef(
             aria-invalid={!!error}
             id={uniqueId}
             ref={internalCallbackRef}
+            multiple={multiple}
             name={uniqueName}
             onChange={onInputChange}
             type="file"
@@ -249,17 +261,18 @@ export const FileInput = React.forwardRef(
           validationRedesignOptIn // do not support old-style validation for File Input component
           {...filterStyledSystemMarginProps(rest)}
         >
-          {filesUploaded.length === 0
-            ? input
-            : filesUploaded.map((props) => (
-                <StyledFileInputPresentation
-                  hasUploadStatus
-                  {...sizeProps}
-                  key={props.filename}
-                >
-                  <FileUploadStatus {...props} />
-                </StyledFileInputPresentation>
-              ))}
+          {(multiple || filesUploaded.length === 0) && input}
+          {filesUploaded.length > 0 &&
+            filesUploaded.map((props) => (
+              <StyledFileInputPresentation
+                hasUploadStatus
+                isPartOfMultiUpload={multiple}
+                {...sizeProps}
+                key={props.filename}
+              >
+                <FileUploadStatus {...props} />
+              </StyledFileInputPresentation>
+            ))}
         </FormField>
       </InputBehaviour>
     );

--- a/src/components/file-input/file-input.mdx
+++ b/src/components/file-input/file-input.mdx
@@ -147,6 +147,38 @@ than a [ProgressTracker](../?path=/docs/progress-tracker--docs) as it does when 
 
 <Canvas of={FileInputStories.UploadStatusNoProgress} />
 
+### Multiple file upload support
+
+The `multiple` prop enables selection of more than one file in a single interaction.
+
+The file input remains visible after files have been selected. This allows users to continue including additional files in a single session, rather than replacing the existing selection.
+
+Each selected file is displayed as an individual upload entry beneath the input, with its own upload status managed independently via the `uploadStatus` prop.
+
+When using `multiple`, the `uploadStatus` prop should be an array where each item represents one file.
+
+This means:
+- Each file must be represented by its own `FileUploadStatusProps` object
+- You are responsible for tracking and updating state per file (progress, success, error, removal)
+
+#### Basic usage
+
+<Canvas of={FileInputStories.MultipleFiles} />
+
+#### Multiple files with upload status
+
+When `multiple` is enabled, `uploadStatus` should be an array of `FileUploadStatusProps`, where each entry maps to a single file.
+
+<Canvas of={FileInputStories.MultipleFilesUploadStatus} />
+
+#### Interactive example
+
+This example demonstrates a more realistic workflow where files can be added in multiple sessions, uploaded independently, and removed individually.
+
+Each file progresses independently, simulating how real-world upload systems handle concurrent uploads and state updates.
+
+<Canvas of={FileInputStories.MultipleFilesInteractive} />
+
 ## Validation States
 
 This component supports input validation, see our [Validations](../?path=/docs/documentation-validations--docs) documentation page for more information.

--- a/src/components/file-input/file-input.stories.tsx
+++ b/src/components/file-input/file-input.stories.tsx
@@ -354,3 +354,115 @@ export const UploadStatusNoProgress: Story = () => {
   );
 };
 UploadStatusNoProgress.storyName = "Upload Status (No Progress)";
+
+export const MultipleFiles: Story = () => {
+  return (
+    <FileInput label="Multiple file selection" multiple onChange={() => {}} />
+  );
+};
+MultipleFiles.storyName = "Multiple Files";
+
+export const MultipleFilesUploadStatus: Story = () => {
+  return (
+    <FileInput
+      label="Multiple uploaded files"
+      multiple
+      uploadStatus={[
+        {
+          status: "completed",
+          filename: "file-one.txt",
+          href: "#",
+          onAction: () => {},
+        },
+        {
+          status: "completed",
+          filename: "file-two.pdf",
+          href: "#",
+          onAction: () => {},
+        },
+      ]}
+      onChange={() => {}}
+    />
+  );
+};
+MultipleFilesUploadStatus.storyName = "Multiple Files (Upload Status)";
+MultipleFilesUploadStatus.parameters = {
+  chromatic: { disableSnapshot: false },
+};
+
+export const MultipleFilesInteractive: Story = () => {
+  const [files, setFiles] = useState<FileUploadStatusProps[]>([]);
+  const onChange = (fileList: FileList) => {
+    const newFiles = Array.from(fileList).map((file) => ({
+      status: "uploading" as const,
+      filename: file.name,
+      progress: 0,
+      message: "0% uploaded",
+      onAction: () => removeFile(file.name),
+    }));
+
+    // append new session files (don't overwrite existing ones)
+    setFiles((prev) => [...prev, ...newFiles]);
+
+    // simulate upload progression per file
+    newFiles.forEach((file) => {
+      let progress = 0;
+
+      const interval = setInterval(() => {
+        progress += Math.random() * 25;
+
+        if (progress >= 100) {
+          clearInterval(interval);
+
+          setFiles((prev) =>
+            prev.map((f) =>
+              f.filename === file.filename
+                ? {
+                    ...f,
+                    status: "completed",
+                    progress: undefined,
+                    message: "File uploaded",
+                    href: "#",
+                    onAction: () => removeFile(file.filename),
+                  }
+                : f,
+            ),
+          );
+          return;
+        }
+
+        setFiles((prev) =>
+          prev.map((f) =>
+            f.filename === file.filename
+              ? {
+                  ...f,
+                  status: "uploading",
+                  progress,
+                  message: `${Math.round(progress)}% uploaded`,
+                  onAction: () => removeFile(file.filename),
+                }
+              : f,
+          ),
+        );
+      }, 300);
+    });
+  };
+
+  const removeFile = (filename: string) => {
+    setFiles((prev) => prev.filter((f) => f.filename !== filename));
+  };
+
+  return (
+    <FileInput
+      label="Multiple file upload (interactive)"
+      multiple
+      uploadStatus={files}
+      onChange={onChange}
+    />
+  );
+};
+
+MultipleFilesInteractive.storyName = "Multiple Files (Interactive)";
+MultipleFilesInteractive.parameters = {
+  chromatic: { disableSnapshot: false },
+};

--- a/src/components/file-input/file-input.style.tsx
+++ b/src/components/file-input/file-input.style.tsx
@@ -24,10 +24,18 @@ interface StyledFileInputPresentationProps
   minHeight?: string;
   minWidth?: string;
   isVertical?: boolean;
+  isPartOfMultiUpload?: boolean;
 }
 
 export const StyledFileInputPresentation = styled.div<StyledFileInputPresentationProps>`
-  ${({ hasUploadStatus, minWidth, minHeight, maxWidth, maxHeight }) => css`
+  ${({
+    hasUploadStatus,
+    minWidth,
+    minHeight,
+    maxWidth,
+    maxHeight,
+    isPartOfMultiUpload,
+  }) => css`
     min-width: ${minWidth};
     min-height: ${minHeight};
     max-width: ${maxWidth};
@@ -36,6 +44,11 @@ export const StyledFileInputPresentation = styled.div<StyledFileInputPresentatio
       padding: 11px; /* not 12px to account for 1px border */
       max-height: ${maxHeight};
       box-sizing: border-box;
+    `}
+    ${hasUploadStatus &&
+    isPartOfMultiUpload &&
+    css`
+      margin-top: 8px;
     `}
   `}
 

--- a/src/components/file-input/file-input.test.tsx
+++ b/src/components/file-input/file-input.test.tsx
@@ -192,6 +192,28 @@ describe("interactions", () => {
     expect(onChange.mock.calls[0][0][0]).toBe(file);
   });
 
+  it("with multiple - uploading multiple files via the hidden input calls onChange prop with all files as argument", async () => {
+    const user = userEvent.setup();
+    const file1 = new File(["file one"], "one.txt", {
+      type: "text/plain",
+    });
+    const file2 = new File(["file two"], "two.txt", {
+      type: "text/plain",
+    });
+    const onChange = jest.fn();
+
+    render(<FileInput label="file input" multiple onChange={onChange} />);
+
+    const hiddenInput = screen.getByLabelText("file input");
+
+    await user.upload(hiddenInput, [file1, file2]);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toHaveLength(2);
+    expect(onChange.mock.calls[0][0][0]).toBe(file1);
+    expect(onChange.mock.calls[0][0][1]).toBe(file2);
+  });
+
   // note: these style changes on dragging are better tested with Playwright (and will be too). The tests are here as
   // well in order to achieve coverage - because that's still better than just putting istanbul ignore everywhere.
   it("dragging a file onto the page causes the border style of the input area to change", () => {
@@ -297,6 +319,25 @@ describe("interactions", () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0][0][0]).toBe(file);
+  });
+
+  it("with multiple - dragging multiple files over the input area calls onChange prop with the dragged files as argument", () => {
+    const file1 = new File(["file one"], "one.txt", { type: "text/plain" });
+    const file2 = new File(["file two"], "two.txt", { type: "text/plain" });
+    const onChange = jest.fn();
+
+    render(<FileInput label="file input" multiple onChange={onChange} />);
+
+    const inputArea = screen.getByTestId("file-input-presentation");
+
+    fireEvent.drop(inputArea, {
+      dataTransfer: { files: [file1, file2] },
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toHaveLength(2);
+    expect(onChange.mock.calls[0][0][0]).toBe(file1);
+    expect(onChange.mock.calls[0][0][1]).toBe(file2);
   });
 });
 
@@ -412,5 +453,33 @@ describe("with uploadStatus prop set", () => {
       "border",
       "var(--borderWidth200) solid var(--colorsSemanticNegative500)",
     );
+  });
+
+  it("when multiple upload statuses are provided, multiple file entries are rendered", () => {
+    render(
+      <FileInput
+        label="file input"
+        multiple
+        uploadStatus={[
+          {
+            status: "completed",
+            filename: "file-one.txt",
+            href: "#",
+            onAction: () => {},
+          },
+          {
+            status: "completed",
+            filename: "file-two.txt",
+            href: "#",
+            onAction: () => {},
+          },
+        ]}
+        onChange={() => {}}
+      />,
+    );
+
+    const statusItems = screen.getAllByTestId("file-upload-status");
+
+    expect(statusItems).toHaveLength(2);
   });
 });

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -90,7 +90,9 @@ const enGB: Locale = {
   },
   fileInput: {
     dragAndDrop: () => "or drag and drop your file",
+    dragAndDrop_multiple: () => "or drag and drop your files",
     selectFile: () => "Select file",
+    selectFile_multiple: () => "Select files",
     fileUploadStatus: () => "File upload status",
     actions: {
       cancel: () => "Cancel upload",

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -64,7 +64,9 @@ interface Locale {
   };
   fileInput: {
     dragAndDrop: () => string;
+    dragAndDrop_multiple?: () => string;
     selectFile: () => string;
+    selectFile_multiple?: () => string;
     fileUploadStatus: () => string;
     actions: {
       cancel: () => string;


### PR DESCRIPTION
### Proposed behaviour


<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

This PR enhances the existing `FileInput` component to support multiple file uploads. Multiple file upload functionality can be activated via the _optional_ `multiple` boolean prop, which is defaulted to `false`.

When `multiple` is enabled, each uploaded file is represented by its own `FileUploadStatusProps` object, allowing consumers to independently track progress, success, error, and removal states for each file.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Prior to this PR, the `FileInput` component only supported single file upload. Once a file had been successfully uploaded, the file input section would be replaced with a status section which would display the file name, status and a way to remove the file. Removing the file would display the file input section again in place.

This functionality still exists for the `FileInput` component, but the new prop `multiple` allows more than one file to be uploaded. A list of file status components for each uploaded file appears below the file input section, which remains visible for further file uploads if necessary.

<img width="298" height="311" alt="Screenshot 2026-06-18 at 13 37 39" src="https://github.com/user-attachments/assets/23dd45a9-4d94-43d6-bbc0-6132b2a40212" />


### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
