### PR TITLE
fix(menu-item): bump style specificity for submenu padding (FE-7694)

### DIFF
--- a/src/components/menu/menu-item/menu-item.style.ts
+++ b/src/components/menu/menu-item/menu-item.style.ts
@@ -271,14 +271,14 @@ const StyledMenuItemWrapper = styled.a.attrs(applyBaseTheme).attrs({
     css`
       ${hasSubmenu || maxWidth
         ? css`
-            > a,
-            > button {
+            & > a,
+            & > button {
               padding: 11px 16px ${hasSubmenu && maxWidth ? "12px" : "10px"};
             }
           `
         : css`
-            > a,
-            > button {
+            & > a,
+            & > button {
               padding: 11px 16px;
             }
           `}


### PR DESCRIPTION
fixes #7983

### Proposed behaviour

Bump style rule specificity to ensure submenu items have the correct padding when the consuming app uses multiple Carbon versions:

<img width="368" height="209" alt="Screenshot 2026-06-22 at 10 12 22" src="https://github.com/user-attachments/assets/aafec8cf-03ec-466d-b852-5e680b1b40c9" />



>[!IMPORTANT]
>**This is a temporary fix to unblock certain consumers from upgrading Carbon.**
>
>A long-term fix to update the Carbon's compilation process is being reviewed. This would ensure all CSS class names generated for Carbon's styled components are properly name-spaced based on the Carbon version, to prevent further collisions between different versions.

### Current behaviour

WHEN two Carbon versions are rendered on the same page
AND one install is <v159.3.1 and the other is >=v159.3.1
THEN the padding of `MenuItem` imported from one install is overridden by a `Link` styling rule from the other Carbon install.

<img width="368" height="209" alt="Screenshot 2026-06-22 at 10 11 51" src="https://github.com/user-attachments/assets/e163e20c-a18b-44f3-a95a-6509ac819bea" />


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [x] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [x] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

### Testing instructions

