### PR TITLE
fix(sidebar): remove scroll content from tab order in firefox

### DIFF
--- a/src/components/sidebar/sidebar.component.tsx
+++ b/src/components/sidebar/sidebar.component.tsx
@@ -218,6 +218,7 @@ export const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
         <StyledSidebarContent
           data-element="sidebar-content"
           data-role="sidebar-content"
+          tabIndex={-1}
           {...filterStyledSystemPaddingProps(rest)}
         >
           <SidebarContext.Provider value={{ isInSidebar: true }}>


### PR DESCRIPTION
### Proposed behaviour

When tabbing trough a scrollable Sidebar in Firefox, focus should move from the close button to the first focusable element within the Sidebar content. 
The scrollable content wrapper should not be included in the sequential tab order, while the interactive elements inside it should remain focusable.

https://github.com/user-attachments/assets/d871b590-2c42-4898-92ca-8f4d70771788


### Current behaviour

When tabbing trough the Sidebar 'With scroll' story in firefox, focus moves from the close button to the scrollable Sidebar content before reaching the first scrollable element which causes content area to be highlighted.

https://github.com/user-attachments/assets/ccde8b20-8171-431d-b3c5-bd214832272f

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

### Testing instructions
