### PR TITLE
fix(menu): hide MenuDivider list item from accessibility tree

### DIFF
--- a/src/components/menu/menu-divider/menu-divider.component.tsx
+++ b/src/components/menu/menu-divider/menu-divider.component.tsx
@@ -15,7 +15,11 @@ const MenuDivider = React.forwardRef<HTMLDivElement, MenuDividerProps>(
     const { menuType } = useStrictMenuContext();
 
     return (
-      <StyledMenuItem inSubmenu>
+      <StyledMenuItem
+        inSubmenu
+        aria-hidden="true"
+        data-role="divider-container"
+      >
         <StyledDivider
           size={size}
           {...tagComponent("menu-divider", rest)}

--- a/src/components/menu/menu-divider/menu-divider.test.tsx
+++ b/src/components/menu/menu-divider/menu-divider.test.tsx
@@ -138,3 +138,16 @@ test("should have the expected 'data-' attributes", () => {
   expect(screen.getByTestId("divider")).toHaveAttribute("data-element", "foo");
   expect(screen.getByTestId("divider")).toHaveAttribute("data-role", "divider");
 });
+
+test("should have aria-hidden='true' on the list item", () => {
+  render(
+    <Menu>
+      <MenuDivider data-role="divider" />
+    </Menu>,
+  );
+
+  expect(screen.getByTestId("divider-container")).toHaveAttribute(
+    "aria-hidden",
+    "true",
+  );
+});


### PR DESCRIPTION
### Proposed behaviour

When navigating a menu with a submenu using VoiceOver, the MenuDivider should not be included in the accessible item count. Screen readers announce the correct item count, e.g. "3 of 4", matching the number of actual navigable menu items.

### Current behaviour

Screen readers count the decorative separator as a menu item in a menu with submenu. VoiceOver announces incorrect totals, e.g. "3 of 5" in a submenu that visually has only 4 navigable items.

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

### Testing instructions
