### PR TITLE
test(vertical-menu): refine testing suite

### DIFF
--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.pw.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.pw.tsx
@@ -10,10 +10,7 @@ import {
   WithSiblingControl,
 } from "./components.test-pw";
 
-import {
-  assertCssValueIsApproximately,
-  checkAccessibility,
-} from "../../../../playwright/support/helper";
+import { checkAccessibility } from "../../../../playwright/support/helper";
 import {
   responsiveVerticalMenuLauncher,
   responsiveVerticalMenuWrapper,
@@ -24,60 +21,6 @@ import {
 } from "../../../../playwright/components/vertical-menu/responsive-vertical-menu";
 
 test.describe("functional tests", () => {
-  [
-    [200, 200],
-    [350, 350],
-    [632, 375],
-  ].forEach(([requestedWidth, actualWidth]) => {
-    test(`should render with width of ${actualWidth}px when ${requestedWidth}px is requested`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <ResponsiveVerticalMenuDefaultComponent
-          width={`${requestedWidth}px`}
-        />,
-      );
-      await expect(responsiveVerticalMenuLauncher(page)).toBeVisible();
-      await responsiveVerticalMenuLauncher(page).click();
-      expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
-      expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
-
-      await assertCssValueIsApproximately(
-        responsiveVerticalMenuPrimary(page),
-        "width",
-        actualWidth,
-      );
-    });
-  });
-
-  (
-    [
-      ["30%", 230],
-      ["45%", 345],
-      ["95%", 729],
-    ] as const
-  ).forEach(([height, heightInPx]) => {
-    test(`should render with height of ${height}`, async ({ mount, page }) => {
-      await mount(<ResponsiveVerticalMenuDefaultComponent height={height} />);
-
-      await expect(responsiveVerticalMenuLauncher(page)).toBeVisible();
-      await responsiveVerticalMenuLauncher(page).click();
-      expect(responsiveVerticalMenuWrapper(page)).toBeDefined();
-      expect(responsiveVerticalMenuPrimary(page)).toBeDefined();
-
-      await expect(responsiveVerticalMenuPrimary(page)).toHaveAttribute(
-        "height",
-        height,
-      );
-      await assertCssValueIsApproximately(
-        responsiveVerticalMenuPrimary(page),
-        "height",
-        heightInPx,
-      );
-    });
-  });
-
   test(`menu text is aligned regardless of icon presence`, async ({
     mount,
     page,

--- a/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.stories.tsx
+++ b/src/components/vertical-menu/responsive-vertical-menu/responsive-vertical-menu.stories.tsx
@@ -1,7 +1,6 @@
 import React, { useRef } from "react";
 import { Meta, StoryObj } from "@storybook/react-vite";
 
-import allModes from "../../../../.storybook/modes";
 import isChromatic from "../../../../.storybook/isChromatic";
 
 import {
@@ -23,9 +22,7 @@ const meta: Meta<typeof ResponsiveVerticalMenu> = {
   component: ResponsiveVerticalMenu,
   parameters: {
     themeProvider: { chromatic: { theme: "sage" } },
-    modes: {
-      desktop: allModes.chromatic,
-    },
+    chromatic: { disableSnapshot: true },
   },
   decorators: [
     (Story, { viewMode }) => (
@@ -132,7 +129,6 @@ export const ProgrammaticFocus: Story = () => {
   );
 };
 ProgrammaticFocus.storyName = "Focusing Launch Button Programmatically";
-ProgrammaticFocus.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithDivider: Story = () => {
   return (
@@ -372,9 +368,6 @@ export const ItemWithOnClickHandler: Story = () => {
   );
 };
 ItemWithOnClickHandler.storyName = "Item With OnClick Handler";
-ItemWithOnClickHandler.parameters = {
-  chromatic: { disableSnapshot: true },
-};
 
 export const ItemWithCustomLabel: Story = () => {
   return (
@@ -398,6 +391,3 @@ export const ItemWithCustomLabel: Story = () => {
   );
 };
 ItemWithCustomLabel.storyName = "Item With Custom Label";
-ItemWithCustomLabel.parameters = {
-  chromatic: { disableSnapshot: true },
-};

--- a/src/components/vertical-menu/vertical-menu.pw.tsx
+++ b/src/components/vertical-menu/vertical-menu.pw.tsx
@@ -2,240 +2,21 @@ import React from "react";
 import { test, expect } from "../../../playwright/helpers/base-test";
 import {
   VerticalMenuDefaultComponent,
-  VerticalMenuItemCustom,
-  VerticalMenuTriggerCustom,
-  VerticalMenuItemCustomHref,
   VerticalMenuFullScreenCustom,
   VerticalMenuFullScreenCustomWithDialog,
   VerticalMenuFullScreenBackgroundScrollTest,
-  ClosedVerticalMenuFullScreenWithButtons,
-  CustomComponent,
-  Adornment,
-  CustomItemPadding,
-  CustomItemHeight,
 } from "./components.test-pw";
-import VerticalMenuTrigger from "./vertical-menu-trigger/vertical-menu-trigger.component";
 import {
   assertCssValueIsApproximately,
   checkAccessibility,
   waitForAnimationEnd,
 } from "../../../playwright/support/helper";
 import {
-  verticalMenuComponent,
   verticalMenuItem,
   verticalMenuTrigger,
   verticalMenuFullScreen,
 } from "../../../playwright/components/vertical-menu";
 import { closeIconButton } from "../../../playwright/components/index";
-import { CHARACTERS } from "../../../playwright/support/constants";
-
-const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
-const testData = CHARACTERS.STANDARD;
-const keysToTrigger = ["Space", "Enter"] as const;
-
-test.describe("should render Vertical Menu component", () => {
-  test(`should render with aria-label prop set to playwright-standard`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <VerticalMenuDefaultComponent aria-label={CHARACTERS.STANDARD} />,
-    );
-
-    await expect(verticalMenuComponent(page)).toHaveAttribute(
-      "aria-label",
-      CHARACTERS.STANDARD,
-    );
-  });
-
-  test(`should render with aria-labelledby prop set to playwright-standard`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <VerticalMenuDefaultComponent aria-labelledby={CHARACTERS.STANDARD} />,
-    );
-
-    await expect(verticalMenuComponent(page)).toHaveAttribute(
-      "aria-labelledby",
-      CHARACTERS.STANDARD,
-    );
-  });
-
-  [200, 350, 632].forEach((width) => {
-    test(`should render with width of ${width}`, async ({ mount, page }) => {
-      await mount(<VerticalMenuDefaultComponent width={`${width}px`} />);
-
-      await assertCssValueIsApproximately(
-        verticalMenuComponent(page),
-        "width",
-        width,
-      );
-    });
-  });
-
-  (
-    [
-      ["30%", 230],
-      ["45%", 345],
-      ["95%", 729],
-    ] as const
-  ).forEach(([height, heightInPx]) => {
-    test(`should render with height if ${height}`, async ({ mount, page }) => {
-      await mount(<VerticalMenuDefaultComponent height={height} />);
-
-      await expect(verticalMenuComponent(page)).toHaveAttribute(
-        "height",
-        height,
-      );
-      await assertCssValueIsApproximately(
-        verticalMenuComponent(page),
-        "height",
-        heightInPx,
-      );
-    });
-  });
-
-  specialCharacters.forEach((title) => {
-    test(`should render with ${title} as title`, async ({ mount, page }) => {
-      await mount(<VerticalMenuItemCustom title={title} />);
-
-      await expect(verticalMenuItem(page).locator("span").nth(1)).toHaveText(
-        title,
-      );
-    });
-  });
-
-  test(`should render with adornment prop`, async ({ mount, page }) => {
-    await mount(<VerticalMenuItemCustom />);
-
-    const pill1 = verticalMenuItem(page).nth(0).locator("div > span");
-    await expect(pill1).toHaveAttribute("data-component", "pill");
-    await expect(pill1).toBeVisible();
-
-    await verticalMenuItem(page).first().click();
-
-    const pill2 = verticalMenuItem(page).nth(1).locator("div > span");
-    await expect(pill2).toHaveAttribute("data-component", "pill");
-    await expect(pill2).toBeVisible();
-    await expect(pill1).toHaveCount(0);
-
-    await verticalMenuItem(page).first().click();
-    await expect(pill1).toHaveAttribute("data-component", "pill");
-    await expect(pill1).toBeVisible();
-    await expect(pill2).toHaveCount(0);
-  });
-
-  test(`should render with iconType prop`, async ({ mount, page }) => {
-    await mount(<VerticalMenuItemCustom iconType="filter" />);
-
-    const filter = verticalMenuItem(page).first().locator("span").first();
-
-    await expect(filter).toHaveAttribute("data-element", "filter");
-    await expect(filter).toBeVisible();
-  });
-
-  test(`should render with active prop`, async ({ mount, page }) => {
-    await mount(<VerticalMenuItemCustom />);
-
-    const backgroundColor = await page.evaluate(() => {
-      const menuItem = document.querySelector(
-        `[data-component="vertical-menu-item"]`,
-      );
-      if (!menuItem) {
-        return null;
-      }
-      const beforePseudoElement = window.getComputedStyle(menuItem, "::before");
-      return beforePseudoElement ? beforePseudoElement.backgroundColor : null;
-    });
-
-    expect(backgroundColor).toBe("rgba(255, 255, 255, 0.3)");
-  });
-
-  ["27px", "59px", "77px"].forEach((height) => {
-    test(`should render with height of ${height}`, async ({ mount, page }) => {
-      await mount(<VerticalMenuItemCustom height={height} />);
-
-      await expect(verticalMenuItem(page)).toHaveCSS("min-height", height);
-    });
-  });
-
-  test(`should render active component with expected border radius styling`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<VerticalMenuItemCustom active />);
-
-    const borderRadius = await page.evaluate(() => {
-      const menuItem = document.querySelector(
-        `[data-component="vertical-menu-item"]`,
-      );
-      if (!menuItem) {
-        return null;
-      }
-      const beforePseudoElement = window.getComputedStyle(menuItem, "::before");
-      return beforePseudoElement ? beforePseudoElement.borderRadius : null;
-    });
-
-    expect(borderRadius).toBe("8px");
-  });
-
-  test(`should render without href prop`, async ({ mount, page }) => {
-    await mount(<VerticalMenuItemCustomHref />);
-
-    await verticalMenuItem(page).click();
-
-    await expect(
-      verticalMenuItem(page).nth(1).locator("..").locator("div").first(),
-    ).toBeVisible();
-  });
-
-  test(`should render with href prop`, async ({ mount, page }) => {
-    await mount(<VerticalMenuItemCustomHref href={testData} />);
-
-    await verticalMenuItem(page).click();
-
-    await expect(
-      verticalMenuItem(page).nth(1).locator("..").locator("a").first(),
-    ).toBeVisible();
-  });
-
-  test(`should render Vertical Menu Item with href prop in Vertical Menu`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<CustomComponent />);
-
-    const item = verticalMenuComponent(page).locator("li").locator("a");
-
-    await expect(item).toHaveAttribute("href", "/item-1");
-    await expect(item).toBeVisible();
-  });
-
-  [true, false].forEach((open) => {
-    test(`should render defaultOpen prop set to ${open}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<VerticalMenuItemCustom defaultOpen={open} />);
-
-      const menuItem1 = verticalMenuItem(page)
-        .locator("span")
-        .filter({ hasText: "ChildItem 1" });
-      const menuItem2 = verticalMenuItem(page)
-        .locator("span")
-        .filter({ hasText: "ChildItem 2" });
-
-      if (open) {
-        await expect(menuItem1).toBeVisible();
-        await expect(menuItem2).toBeVisible();
-      } else {
-        await expect(menuItem1).toHaveCount(0);
-        await expect(menuItem2).toHaveCount(0);
-      }
-    });
-  });
-});
 
 test.describe("with beforeEach for VerticalMenuFullScreen", () => {
   test.beforeEach(async ({ page }) => {
@@ -245,60 +26,23 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
     });
   });
 
-  test(`should render with aria-label prop set to playwright-standard`, async ({
+  test(`should render the VerticalMenuTrigger with a height of 40px when the viewport is reduced to trigger responsive mode`, async ({
     mount,
     page,
   }) => {
-    await mount(
-      <VerticalMenuFullScreenCustom aria-label={CHARACTERS.STANDARD} />,
-    );
-
-    await verticalMenuTrigger(page).click();
-
-    await expect(verticalMenuFullScreen(page)).toHaveAttribute(
-      "aria-label",
-      CHARACTERS.STANDARD,
-    );
-  });
-
-  test(`should render with aria-labelledby prop set to playwright-standard`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <VerticalMenuFullScreenCustom aria-labelledby={CHARACTERS.STANDARD} />,
-    );
-
-    await verticalMenuTrigger(page).click();
-
-    await expect(verticalMenuFullScreen(page)).toHaveAttribute(
-      "aria-labelledby",
-      CHARACTERS.STANDARD,
-    );
-  });
-
-  test(`should close the Vertical Menu Full Screen when escape key is pressed`, async ({
-    mount,
-    page,
-  }) => {
+    await page.setViewportSize({ width: 1300, height: 768 });
     await mount(<VerticalMenuFullScreenCustom />);
 
-    await verticalMenuTrigger(page).click();
-    const verticalMenu = verticalMenuFullScreen(page);
-    await verticalMenu.waitFor();
+    await expect(verticalMenuTrigger(page)).toBeHidden();
 
-    await page.keyboard.press("Escape");
+    await page.setViewportSize({ width: 599, height: 768 });
 
-    await expect(verticalMenu).toBeHidden();
-  });
-
-  test(`should render Vertical Menu Full Screen with isOpen prop`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<VerticalMenuFullScreenCustom isOpen />);
-
-    await expect(verticalMenuItem(page).first()).toBeVisible();
+    await expect(verticalMenuTrigger(page)).toBeVisible();
+    await assertCssValueIsApproximately(
+      verticalMenuTrigger(page),
+      "height",
+      40,
+    );
   });
 
   test("when a Vertical Menu Fullscreen is opened and then closed, the call to action element should be focused", async ({
@@ -337,22 +81,6 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
     await expect(item).toBeFocused();
   });
 
-  test(`should verify that Vertical Menu Fullscreen has no effect on the tab order when isOpen prop is false`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<ClosedVerticalMenuFullScreenWithButtons />);
-
-    await page.keyboard.press("Tab");
-    await expect(
-      page.getByRole("button").filter({ hasText: "Button 1" }),
-    ).toBeFocused();
-    await page.keyboard.press("Tab");
-    await expect(
-      page.getByRole("button").filter({ hasText: "Button 2" }),
-    ).toBeFocused();
-  });
-
   test(`should return focus to Vertical Menu Full Screen close button with tabbing`, async ({
     mount,
     page,
@@ -363,31 +91,6 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
     await verticalMenuFullScreen(page).locator("div").nth(0).click();
     await verticalMenuFullScreen(page).press("Tab");
     await expect(closeIconButton(page)).toBeFocused();
-  });
-
-  ["25px", "55px", "77px"].forEach((height) => {
-    test(`should render component trigger with height prop set to ${height}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<VerticalMenuTriggerCustom height={height} />);
-
-      const trigger = verticalMenuTrigger(page);
-
-      await expect(trigger).toHaveAttribute("height", height);
-      await expect(trigger).toHaveCSS("min-height", height);
-    });
-  });
-
-  test(`should render children prop set to playwright_test`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <VerticalMenuTrigger onClick={() => {}}>{testData}</VerticalMenuTrigger>,
-    );
-
-    await expect(verticalMenuTrigger(page)).toHaveText(testData);
   });
 
   test(`should navigate to the 3rd item using Tab key`, async ({
@@ -405,23 +108,6 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
     ).toBeFocused();
   });
 
-  test(`should navigate to the 5th item using Tab key`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<VerticalMenuDefaultComponent />);
-
-    await verticalMenuItem(page).first().focus();
-    await page.keyboard.press("Tab");
-    await page.keyboard.press("Tab");
-    await page.keyboard.press("Tab");
-    await page.keyboard.press("Tab");
-
-    await expect(
-      verticalMenuItem(page).filter({ hasText: "Item 5" }),
-    ).toBeFocused();
-  });
-
   test(`should navigate to the 4th item using Shift Tab key`, async ({
     mount,
     page,
@@ -435,63 +121,6 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
     await expect(
       verticalMenuItem(page).filter({ hasText: "Item 4" }),
     ).toBeFocused();
-  });
-
-  test(`should expand to item 3 using click`, async ({ mount, page }) => {
-    await mount(<VerticalMenuDefaultComponent />);
-
-    await verticalMenuItem(page).nth(2).click();
-
-    await expect(
-      verticalMenuItem(page).locator("span").filter({ hasText: "Active Item" }),
-    ).toBeVisible();
-  });
-
-  test(`should collapse to item 3 using click`, async ({ mount, page }) => {
-    await mount(<VerticalMenuDefaultComponent />);
-
-    await verticalMenuItem(page).nth(2).click();
-    await verticalMenuItem(page).nth(2).click();
-
-    await expect(
-      verticalMenuItem(page).locator("span").filter({ hasText: "Active Item" }),
-    ).toBeHidden();
-  });
-
-  (
-    [
-      ["expand", keysToTrigger[0], 1],
-      ["expand", keysToTrigger[1], 1],
-      ["collapse", keysToTrigger[0], 2],
-      ["collapse", keysToTrigger[1], 2],
-    ] as [string, "Space" | "Enter", number][]
-  ).forEach(([action, key, index]) => {
-    test(`should ${action} Item 2 using ${key} key`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<VerticalMenuDefaultComponent />);
-
-      for (let i = 0; i < index; i++) {
-        await verticalMenuItem(page).nth(2).focus();
-        await page.keyboard.press(key);
-      }
-
-      if (action === "expand") {
-        await expect(
-          verticalMenuItem(page)
-            .locator("span")
-            .filter({ hasText: "Active Item" }),
-        ).toBeVisible();
-      }
-      if (action === "collapse") {
-        await expect(
-          verticalMenuItem(page)
-            .locator("span")
-            .filter({ hasText: "Active Item" }),
-        ).toBeHidden();
-      }
-    });
   });
 
   test(`should navigate to the children element using Tab key`, async ({
@@ -608,42 +237,6 @@ test.describe("should check the accessibility tests", () => {
     await page.keyboard.press("Tab");
     await page.keyboard.press("Tab");
     await page.keyboard.press("Enter");
-
-    await checkAccessibility(page);
-  });
-
-  test(`should pass accessibility tests when active`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<VerticalMenuItemCustom active={(isOpen) => !isOpen} />);
-
-    await checkAccessibility(page);
-  });
-
-  test(`should pass accessibility tests with Adornment`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<Adornment />);
-
-    await checkAccessibility(page);
-  });
-
-  test(`should pass accessibility tests with CustomItemHeight`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<CustomItemHeight />);
-
-    await checkAccessibility(page);
-  });
-
-  test(`should pass accessibility tests with CustomItemPadding`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<CustomItemPadding />);
 
     await checkAccessibility(page);
   });

--- a/src/components/vertical-menu/vertical-menu.pw.tsx
+++ b/src/components/vertical-menu/vertical-menu.pw.tsx
@@ -2,240 +2,21 @@ import React from "react";
 import { test, expect } from "../../../playwright/helpers/base-test";
 import {
   VerticalMenuDefaultComponent,
-  VerticalMenuItemCustom,
-  VerticalMenuTriggerCustom,
-  VerticalMenuItemCustomHref,
   VerticalMenuFullScreenCustom,
   VerticalMenuFullScreenCustomWithDialog,
   VerticalMenuFullScreenBackgroundScrollTest,
-  ClosedVerticalMenuFullScreenWithButtons,
-  CustomComponent,
-  Adornment,
-  CustomItemPadding,
-  CustomItemHeight,
 } from "./components.test-pw";
-import VerticalMenuTrigger from "./vertical-menu-trigger/vertical-menu-trigger.component";
 import {
   assertCssValueIsApproximately,
   checkAccessibility,
   waitForAnimationEnd,
 } from "../../../playwright/support/helper";
 import {
-  verticalMenuComponent,
   verticalMenuItem,
   verticalMenuTrigger,
   verticalMenuFullScreen,
 } from "../../../playwright/components/vertical-menu";
 import { closeIconButton } from "../../../playwright/components/index";
-import { CHARACTERS } from "../../../playwright/support/constants";
-
-const specialCharacters = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
-const testData = CHARACTERS.STANDARD;
-const keysToTrigger = ["Space", "Enter"] as const;
-
-test.describe("should render Vertical Menu component", () => {
-  test(`should render with aria-label prop set to playwright-standard`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <VerticalMenuDefaultComponent aria-label={CHARACTERS.STANDARD} />,
-    );
-
-    await expect(verticalMenuComponent(page)).toHaveAttribute(
-      "aria-label",
-      CHARACTERS.STANDARD,
-    );
-  });
-
-  test(`should render with aria-labelledby prop set to playwright-standard`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <VerticalMenuDefaultComponent aria-labelledby={CHARACTERS.STANDARD} />,
-    );
-
-    await expect(verticalMenuComponent(page)).toHaveAttribute(
-      "aria-labelledby",
-      CHARACTERS.STANDARD,
-    );
-  });
-
-  [200, 350, 632].forEach((width) => {
-    test(`should render with width of ${width}`, async ({ mount, page }) => {
-      await mount(<VerticalMenuDefaultComponent width={`${width}px`} />);
-
-      await assertCssValueIsApproximately(
-        verticalMenuComponent(page),
-        "width",
-        width,
-      );
-    });
-  });
-
-  (
-    [
-      ["30%", 230],
-      ["45%", 345],
-      ["95%", 729],
-    ] as const
-  ).forEach(([height, heightInPx]) => {
-    test(`should render with height if ${height}`, async ({ mount, page }) => {
-      await mount(<VerticalMenuDefaultComponent height={height} />);
-
-      await expect(verticalMenuComponent(page)).toHaveAttribute(
-        "height",
-        height,
-      );
-      await assertCssValueIsApproximately(
-        verticalMenuComponent(page),
-        "height",
-        heightInPx,
-      );
-    });
-  });
-
-  specialCharacters.forEach((title) => {
-    test(`should render with ${title} as title`, async ({ mount, page }) => {
-      await mount(<VerticalMenuItemCustom title={title} />);
-
-      await expect(verticalMenuItem(page).locator("span").nth(1)).toHaveText(
-        title,
-      );
-    });
-  });
-
-  test(`should render with adornment prop`, async ({ mount, page }) => {
-    await mount(<VerticalMenuItemCustom />);
-
-    const pill1 = verticalMenuItem(page).nth(0).locator("div > span");
-    await expect(pill1).toHaveAttribute("data-component", "pill");
-    await expect(pill1).toBeVisible();
-
-    await verticalMenuItem(page).first().click();
-
-    const pill2 = verticalMenuItem(page).nth(1).locator("div > span");
-    await expect(pill2).toHaveAttribute("data-component", "pill");
-    await expect(pill2).toBeVisible();
-    await expect(pill1).toHaveCount(0);
-
-    await verticalMenuItem(page).first().click();
-    await expect(pill1).toHaveAttribute("data-component", "pill");
-    await expect(pill1).toBeVisible();
-    await expect(pill2).toHaveCount(0);
-  });
-
-  test(`should render with iconType prop`, async ({ mount, page }) => {
-    await mount(<VerticalMenuItemCustom iconType="filter" />);
-
-    const filter = verticalMenuItem(page).first().locator("span").first();
-
-    await expect(filter).toHaveAttribute("data-element", "filter");
-    await expect(filter).toBeVisible();
-  });
-
-  test(`should render with active prop`, async ({ mount, page }) => {
-    await mount(<VerticalMenuItemCustom />);
-
-    const backgroundColor = await page.evaluate(() => {
-      const menuItem = document.querySelector(
-        `[data-component="vertical-menu-item"]`,
-      );
-      if (!menuItem) {
-        return null;
-      }
-      const beforePseudoElement = window.getComputedStyle(menuItem, "::before");
-      return beforePseudoElement ? beforePseudoElement.backgroundColor : null;
-    });
-
-    expect(backgroundColor).toBe("rgba(255, 255, 255, 0.3)");
-  });
-
-  ["27px", "59px", "77px"].forEach((height) => {
-    test(`should render with height of ${height}`, async ({ mount, page }) => {
-      await mount(<VerticalMenuItemCustom height={height} />);
-
-      await expect(verticalMenuItem(page)).toHaveCSS("min-height", height);
-    });
-  });
-
-  test(`should render active component with expected border radius styling`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<VerticalMenuItemCustom active />);
-
-    const borderRadius = await page.evaluate(() => {
-      const menuItem = document.querySelector(
-        `[data-component="vertical-menu-item"]`,
-      );
-      if (!menuItem) {
-        return null;
-      }
-      const beforePseudoElement = window.getComputedStyle(menuItem, "::before");
-      return beforePseudoElement ? beforePseudoElement.borderRadius : null;
-    });
-
-    expect(borderRadius).toBe("8px");
-  });
-
-  test(`should render without href prop`, async ({ mount, page }) => {
-    await mount(<VerticalMenuItemCustomHref />);
-
-    await verticalMenuItem(page).click();
-
-    await expect(
-      verticalMenuItem(page).nth(1).locator("..").locator("div").first(),
-    ).toBeVisible();
-  });
-
-  test(`should render with href prop`, async ({ mount, page }) => {
-    await mount(<VerticalMenuItemCustomHref href={testData} />);
-
-    await verticalMenuItem(page).click();
-
-    await expect(
-      verticalMenuItem(page).nth(1).locator("..").locator("a").first(),
-    ).toBeVisible();
-  });
-
-  test(`should render Vertical Menu Item with href prop in Vertical Menu`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<CustomComponent />);
-
-    const item = verticalMenuComponent(page).locator("li").locator("a");
-
-    await expect(item).toHaveAttribute("href", "/item-1");
-    await expect(item).toBeVisible();
-  });
-
-  [true, false].forEach((open) => {
-    test(`should render defaultOpen prop set to ${open}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<VerticalMenuItemCustom defaultOpen={open} />);
-
-      const menuItem1 = verticalMenuItem(page)
-        .locator("span")
-        .filter({ hasText: "ChildItem 1" });
-      const menuItem2 = verticalMenuItem(page)
-        .locator("span")
-        .filter({ hasText: "ChildItem 2" });
-
-      if (open) {
-        await expect(menuItem1).toBeVisible();
-        await expect(menuItem2).toBeVisible();
-      } else {
-        await expect(menuItem1).toHaveCount(0);
-        await expect(menuItem2).toHaveCount(0);
-      }
-    });
-  });
-});
 
 test.describe("with beforeEach for VerticalMenuFullScreen", () => {
   test.beforeEach(async ({ page }) => {
@@ -245,60 +26,17 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
     });
   });
 
-  test(`should render with aria-label prop set to playwright-standard`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <VerticalMenuFullScreenCustom aria-label={CHARACTERS.STANDARD} />,
-    );
-
-    await verticalMenuTrigger(page).click();
-
-    await expect(verticalMenuFullScreen(page)).toHaveAttribute(
-      "aria-label",
-      CHARACTERS.STANDARD,
-    );
-  });
-
-  test(`should render with aria-labelledby prop set to playwright-standard`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <VerticalMenuFullScreenCustom aria-labelledby={CHARACTERS.STANDARD} />,
-    );
-
-    await verticalMenuTrigger(page).click();
-
-    await expect(verticalMenuFullScreen(page)).toHaveAttribute(
-      "aria-labelledby",
-      CHARACTERS.STANDARD,
-    );
-  });
-
-  test(`should close the Vertical Menu Full Screen when escape key is pressed`, async ({
+  test(`should render the VerticalMenuTrigger with a default height of 40px`, async ({
     mount,
     page,
   }) => {
     await mount(<VerticalMenuFullScreenCustom />);
 
-    await verticalMenuTrigger(page).click();
-    const verticalMenu = verticalMenuFullScreen(page);
-    await verticalMenu.waitFor();
-
-    await page.keyboard.press("Escape");
-
-    await expect(verticalMenu).toBeHidden();
-  });
-
-  test(`should render Vertical Menu Full Screen with isOpen prop`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<VerticalMenuFullScreenCustom isOpen />);
-
-    await expect(verticalMenuItem(page).first()).toBeVisible();
+    await assertCssValueIsApproximately(
+      verticalMenuTrigger(page),
+      "height",
+      40,
+    );
   });
 
   test("when a Vertical Menu Fullscreen is opened and then closed, the call to action element should be focused", async ({
@@ -337,22 +75,6 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
     await expect(item).toBeFocused();
   });
 
-  test(`should verify that Vertical Menu Fullscreen has no effect on the tab order when isOpen prop is false`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<ClosedVerticalMenuFullScreenWithButtons />);
-
-    await page.keyboard.press("Tab");
-    await expect(
-      page.getByRole("button").filter({ hasText: "Button 1" }),
-    ).toBeFocused();
-    await page.keyboard.press("Tab");
-    await expect(
-      page.getByRole("button").filter({ hasText: "Button 2" }),
-    ).toBeFocused();
-  });
-
   test(`should return focus to Vertical Menu Full Screen close button with tabbing`, async ({
     mount,
     page,
@@ -363,31 +85,6 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
     await verticalMenuFullScreen(page).locator("div").nth(0).click();
     await verticalMenuFullScreen(page).press("Tab");
     await expect(closeIconButton(page)).toBeFocused();
-  });
-
-  ["25px", "55px", "77px"].forEach((height) => {
-    test(`should render component trigger with height prop set to ${height}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<VerticalMenuTriggerCustom height={height} />);
-
-      const trigger = verticalMenuTrigger(page);
-
-      await expect(trigger).toHaveAttribute("height", height);
-      await expect(trigger).toHaveCSS("min-height", height);
-    });
-  });
-
-  test(`should render children prop set to playwright_test`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(
-      <VerticalMenuTrigger onClick={() => {}}>{testData}</VerticalMenuTrigger>,
-    );
-
-    await expect(verticalMenuTrigger(page)).toHaveText(testData);
   });
 
   test(`should navigate to the 3rd item using Tab key`, async ({
@@ -405,23 +102,6 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
     ).toBeFocused();
   });
 
-  test(`should navigate to the 5th item using Tab key`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<VerticalMenuDefaultComponent />);
-
-    await verticalMenuItem(page).first().focus();
-    await page.keyboard.press("Tab");
-    await page.keyboard.press("Tab");
-    await page.keyboard.press("Tab");
-    await page.keyboard.press("Tab");
-
-    await expect(
-      verticalMenuItem(page).filter({ hasText: "Item 5" }),
-    ).toBeFocused();
-  });
-
   test(`should navigate to the 4th item using Shift Tab key`, async ({
     mount,
     page,
@@ -435,63 +115,6 @@ test.describe("with beforeEach for VerticalMenuFullScreen", () => {
     await expect(
       verticalMenuItem(page).filter({ hasText: "Item 4" }),
     ).toBeFocused();
-  });
-
-  test(`should expand to item 3 using click`, async ({ mount, page }) => {
-    await mount(<VerticalMenuDefaultComponent />);
-
-    await verticalMenuItem(page).nth(2).click();
-
-    await expect(
-      verticalMenuItem(page).locator("span").filter({ hasText: "Active Item" }),
-    ).toBeVisible();
-  });
-
-  test(`should collapse to item 3 using click`, async ({ mount, page }) => {
-    await mount(<VerticalMenuDefaultComponent />);
-
-    await verticalMenuItem(page).nth(2).click();
-    await verticalMenuItem(page).nth(2).click();
-
-    await expect(
-      verticalMenuItem(page).locator("span").filter({ hasText: "Active Item" }),
-    ).toBeHidden();
-  });
-
-  (
-    [
-      ["expand", keysToTrigger[0], 1],
-      ["expand", keysToTrigger[1], 1],
-      ["collapse", keysToTrigger[0], 2],
-      ["collapse", keysToTrigger[1], 2],
-    ] as [string, "Space" | "Enter", number][]
-  ).forEach(([action, key, index]) => {
-    test(`should ${action} Item 2 using ${key} key`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<VerticalMenuDefaultComponent />);
-
-      for (let i = 0; i < index; i++) {
-        await verticalMenuItem(page).nth(2).focus();
-        await page.keyboard.press(key);
-      }
-
-      if (action === "expand") {
-        await expect(
-          verticalMenuItem(page)
-            .locator("span")
-            .filter({ hasText: "Active Item" }),
-        ).toBeVisible();
-      }
-      if (action === "collapse") {
-        await expect(
-          verticalMenuItem(page)
-            .locator("span")
-            .filter({ hasText: "Active Item" }),
-        ).toBeHidden();
-      }
-    });
   });
 
   test(`should navigate to the children element using Tab key`, async ({
@@ -608,42 +231,6 @@ test.describe("should check the accessibility tests", () => {
     await page.keyboard.press("Tab");
     await page.keyboard.press("Tab");
     await page.keyboard.press("Enter");
-
-    await checkAccessibility(page);
-  });
-
-  test(`should pass accessibility tests when active`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<VerticalMenuItemCustom active={(isOpen) => !isOpen} />);
-
-    await checkAccessibility(page);
-  });
-
-  test(`should pass accessibility tests with Adornment`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<Adornment />);
-
-    await checkAccessibility(page);
-  });
-
-  test(`should pass accessibility tests with CustomItemHeight`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<CustomItemHeight />);
-
-    await checkAccessibility(page);
-  });
-
-  test(`should pass accessibility tests with CustomItemPadding`, async ({
-    mount,
-    page,
-  }) => {
-    await mount(<CustomItemPadding />);
 
     await checkAccessibility(page);
   });


### PR DESCRIPTION
### Proposed behaviour

Removes a number of Playwright tests that duplicate either Jest or Chromatic ones for the Vertical Menu component

### Current behaviour

There are a number of tests that exist in different forms in all the testing suites we do(Jest, Playwright, Chromatic) which cause a prolonged time of execution for no additional value.

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

This should decrease the time of execution without compromising testing and coverage

### Testing instructions

Make sure the Playwright tests pass
