### PR TITLE
Switch: Fix uppercase labels to sentence case in all locales

### DIFF
--- a/src/components/switch/switch.test.tsx
+++ b/src/components/switch/switch.test.tsx
@@ -103,9 +103,9 @@ describe("Switch", () => {
   });
 
   describe("On/Off state text", () => {
-    it("renders OFF and ON text outside the track when not loading", () => {
+    it("renders Off and On text outside the track when not loading", () => {
       renderSwitch();
-      expect(screen.getByText(/^(ON|OFF)$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^(On|Off)$/i)).toBeInTheDocument();
     });
 
     it("uses locale text for On/Off labels", () => {
@@ -231,7 +231,7 @@ describe("Switch", () => {
   describe("loading state", () => {
     it("hides On/Off state text when loading", () => {
       renderSwitch({ loading: true });
-      expect(screen.queryByText(/^(ON|OFF)$/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/^(On|Off)$/i)).not.toBeInTheDocument();
     });
 
     it("renders a loader element when loading", () => {
@@ -250,8 +250,8 @@ describe("Switch", () => {
           locale={{
             locale: () => "en-US",
             switch: {
-              on: () => "ON",
-              off: () => "OFF",
+              on: () => "On",
+              off: () => "Off",
               processingLabel: () => "En cours...",
             },
           }}

--- a/src/locales/de-de.ts
+++ b/src/locales/de-de.ts
@@ -245,8 +245,8 @@ const deDE: Partial<Locale> = {
     closeIconAriaLabel: () => "Schließen",
   },
   switch: {
-    on: () => "EIN",
-    off: () => "AUS",
+    on: () => "Ein",
+    off: () => "Aus",
     processingLabel: () => "Verarbeitung",
   },
   tileSelect: {

--- a/src/locales/de-de.ts
+++ b/src/locales/de-de.ts
@@ -254,8 +254,8 @@ const deDE: Partial<Locale> = {
     closeIconAriaLabel: () => "Schließen",
   },
   switch: {
-    on: () => "EIN",
-    off: () => "AUS",
+    on: () => "Ein",
+    off: () => "Aus",
     processingLabel: () => "Verarbeitung",
   },
   tileSelect: {

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -259,8 +259,8 @@ const enGB: Locale = {
     closeIconAriaLabel: () => "Close",
   },
   switch: {
-    on: () => "ON",
-    off: () => "OFF",
+    on: () => "On",
+    off: () => "Off",
     processingLabel: () => "Processing...",
   },
   tileSelect: {

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -272,8 +272,8 @@ const enGB: Locale = {
     closeIconAriaLabel: () => "Close",
   },
   switch: {
-    on: () => "ON",
-    off: () => "OFF",
+    on: () => "On",
+    off: () => "Off",
     processingLabel: () => "Processing...",
   },
   tileSelect: {

--- a/src/locales/es-es.ts
+++ b/src/locales/es-es.ts
@@ -251,8 +251,8 @@ const esES: Partial<Locale> = {
     closeIconAriaLabel: () => "Cerrar",
   },
   switch: {
-    on: () => "SÍ",
-    off: () => "NO",
+    on: () => "Sí",
+    off: () => "No",
     processingLabel: () => "Procesando",
   },
   tileSelect: {

--- a/src/locales/es-es.ts
+++ b/src/locales/es-es.ts
@@ -261,8 +261,8 @@ const esES: Partial<Locale> = {
     closeIconAriaLabel: () => "Cerrar",
   },
   switch: {
-    on: () => "SÍ",
-    off: () => "NO",
+    on: () => "Sí",
+    off: () => "No",
     processingLabel: () => "Procesando",
   },
   tileSelect: {

--- a/src/locales/fr-ca.ts
+++ b/src/locales/fr-ca.ts
@@ -253,8 +253,8 @@ const frCA: Partial<Locale> = {
     closeIconAriaLabel: () => "Fermer",
   },
   switch: {
-    on: () => "OUI",
-    off: () => "NON",
+    on: () => "Oui",
+    off: () => "Non",
     processingLabel: () => "Traitement en cours",
   },
   tileSelect: {

--- a/src/locales/fr-ca.ts
+++ b/src/locales/fr-ca.ts
@@ -264,8 +264,8 @@ const frCA: Partial<Locale> = {
     closeIconAriaLabel: () => "Fermer",
   },
   switch: {
-    on: () => "OUI",
-    off: () => "NON",
+    on: () => "Oui",
+    off: () => "Non",
     processingLabel: () => "Traitement en cours",
   },
   tileSelect: {

--- a/src/locales/pt-pt.ts
+++ b/src/locales/pt-pt.ts
@@ -260,8 +260,8 @@ const ptPT: Partial<Locale> = {
     closeIconAriaLabel: () => "Fechar",
   },
   switch: {
-    on: () => "ON",
-    off: () => "OFF",
+    on: () => "On",
+    off: () => "Off",
     processingLabel: () => "A processar",
   },
   tileSelect: {

--- a/src/locales/pt-pt.ts
+++ b/src/locales/pt-pt.ts
@@ -270,8 +270,8 @@ const ptPT: Partial<Locale> = {
     closeIconAriaLabel: () => "Fechar",
   },
   switch: {
-    on: () => "ON",
-    off: () => "OFF",
+    on: () => "On",
+    off: () => "Off",
     processingLabel: () => "A processar",
   },
   tileSelect: {


### PR DESCRIPTION
### Proposed behaviour
Switch labels must be in Sentence case
<img width="196" height="109" alt="image" src="https://github.com/user-attachments/assets/6661f9da-b34e-46ce-adf3-5a8db66e9e5e" />

### Current behaviour
Switch labels are in UPPER CASE
<img width="208" height="123" alt="image" src="https://github.com/user-attachments/assets/5a36fbf0-5a1a-4840-845f-71da5a55eb98" />

### Checklist
<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [x] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
