### PR TITLE
chore(button): use DS background token for contrast

### DIFF
--- a/src/components/button/__next__/button-test.stories.tsx
+++ b/src/components/button/__next__/button-test.stories.tsx
@@ -144,7 +144,7 @@ export const AllSizesVariantsTypes: Story = () => {
             flexDirection="column"
             gap={1}
             p={1}
-            backgroundColor="#DDDDDD"
+            backgroundColor="var(--mode-color-generic-bg-nought)"
           >
             <h3>Typical/Default</h3>
             <Box
@@ -438,7 +438,7 @@ export const AllSizesVariantsTypes: Story = () => {
             flexDirection="column"
             gap={1}
             p={1}
-            backgroundColor="#DDDDDD"
+            backgroundColor="var(--mode-color-generic-bg-nought)"
           >
             <h3>Typical/Default</h3>
             <Box
@@ -670,7 +670,7 @@ export const AllSizesVariantsTypes: Story = () => {
             flexDirection="column"
             gap={1}
             p={1}
-            backgroundColor="#DDDDDD"
+            backgroundColor="var(--mode-color-generic-bg-nought)"
           >
             <h3>Typical/Default</h3>
             <Box


### PR DESCRIPTION
### Proposed behaviour

In Button/Test -> AllSizesVariantsTypes, some button groups (including secondary destructive examples) are rendered on hardcoded grey backgrounds (#DDDDDD). This can produce contrast failures and does not represent an official DS background token.
<img width="1395" height="953" alt="image" src="https://github.com/user-attachments/assets/9be51c42-da3e-4b43-9b65-671557e2bab6" />
<img width="1443" height="956" alt="image" src="https://github.com/user-attachments/assets/48932985-18ac-462c-8eb4-55c600772737" />

### Current behaviour


Use Design System background tokens in the story (e.g. var(--mode-color-generic-bg-nought)) instead of hardcoded greys, so contrast checks run against approved DS colors and reflect intended design usage.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
