### PR TITLE
docs(dialog): add FocusingADifferentFirstElement story

### DIFF
--- a/src/components/dialog/dialog.mdx
+++ b/src/components/dialog/dialog.mdx
@@ -162,6 +162,8 @@ The handle exposes the `focus()` method of the Dialog's root DOM node:
 dialogHandle.current?.focus();
 ```
 
+<Canvas of={DialogStories.FocusingADifferentFirstElement} />
+
 ### Allowing other elements to be focused
 
 Use `focusableContainers` to allow elements outside the dialog's DOM subtree — such as Toast notifications — to be reachable with the keyboard while the dialog is open.


### PR DESCRIPTION
### Proposed behaviour

The "Overriding the first focused element" section renders the FocusingADifferentFirstElement story via a <Canvas> block, allowing users to interact with both the focusFirstElement ref approach and the disableAutoFocus + autoFocus approach directly from the docs page.

### Current behaviour

The "Overriding the first focused element" section in the Dialog docs page contains only explanatory text and code snippets — the interactive FocusingADifferentFirstElement story is not rendered there.

<img width="1125" height="621" alt="image" src="https://github.com/user-attachments/assets/a710688a-b388-4c41-bbbb-8a125d6f4503" />
<img width="1184" height="807" alt="image" src="https://github.com/user-attachments/assets/90086d4d-881e-489d-af59-afae3355fbd5" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
