### PR TITLE
build(playwright): prevent a11y report from running in ci

### DIFF
--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -25,10 +25,7 @@ export default defineConfig({
   maxFailures: process.env.CI ? 10 : undefined,
 
   reporter: process.env.CI
-    ? [
-        ["blob"],
-        [resolve(playwrightDir, "./support/accessibility-reporter.ts")],
-      ]
+    ? "blob"
     : [
         ["list"],
         ["html", { outputFolder: resolve(playwrightDir, "./test-report") }],


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Removes the a11y report from running in ci, as this is causing intermittent failures. The report will now only be available for local testing. 

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

A11y report is running in ci and causing intermittent failures.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
