### PR TITLE
feat(anchor-navigation): align with fusion ds FE-7264

### DIFF
--- a/skills/carbon-react/components/anchor-navigation-item.md
+++ b/skills/carbon-react/components/anchor-navigation-item.md
@@ -17,7 +17,7 @@ description: Carbon AnchorNavigationItem component props and usage examples.
 | --- | --- | --- | --- | --- | --- |
 | children | React.ReactNode | No |  | Children elements |  |
 | href | string \| undefined | No |  | href to be passed to the anchor element, can be linked with id passed to the scrollable section |  |
-| isSelected | boolean \| undefined | No |  | Indicates if component is selected |  |
+| isSelected | boolean \| undefined | No |  | Indicates if a component is selected |  |
 | onClick | ((ev: React.MouseEvent<HTMLAnchorElement>) => void) \| undefined | No |  | onClick handler |  |
 | onKeyDown | ((ev: React.KeyboardEvent<HTMLAnchorElement>) => void) \| undefined | No |  | OnKeyDown handler |  |
 | tabIndex | number \| undefined | No |  | tabIndex passed to the anchor element |  |

--- a/skills/carbon-react/components/anchor-navigation.md
+++ b/skills/carbon-react/components/anchor-navigation.md
@@ -19,6 +19,8 @@ description: Carbon AnchorNavigation component props and usage examples.
 | stickyNavigation | React.ReactNode | No |  | The AnchorNavigationItems components to be rendered in the sticky navigation. It is important to maintain proper structure. List of AnchorNavigationItems has to be wrapped in React.Fragment |  |
 | data-element | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
 | data-role | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
+| aria-label | string \| undefined | No |  | Defines a string value that labels the current element. |  |
+| aria-labelledby | string \| undefined | No |  | Identifies the element (or elements) that labels the current element. |  |
 
 ## Examples
 ### Default

--- a/src/components/anchor-navigation/anchor-navigation-item/anchor-navigation-item.component.tsx
+++ b/src/components/anchor-navigation/anchor-navigation-item/anchor-navigation-item.component.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Typography from "../../typography";
 import StyledNavigationItem from "./anchor-navigation-item.style";
 
 export interface AnchorNavigationItemProps {
@@ -6,7 +7,7 @@ export interface AnchorNavigationItemProps {
   target?: React.RefObject<HTMLElement>;
   /** href to be passed to the anchor element, can be linked with id passed to the scrollable section */
   href?: string;
-  /** Indicates if component is selected */
+  /** Indicates if a component is selected */
   isSelected?: boolean;
   /** onClick handler */
   onClick?: (ev: React.MouseEvent<HTMLAnchorElement>) => void;
@@ -21,18 +22,12 @@ export interface AnchorNavigationItemProps {
 const AnchorNavigationItem = React.forwardRef<
   HTMLAnchorElement,
   AnchorNavigationItemProps
->(
-  (
-    {
-      children,
-      onKeyDown,
-      onClick,
-      href,
-      tabIndex,
-      isSelected,
-    }: AnchorNavigationItemProps,
-    ref,
-  ) => (
+>(({ target: _target, ...props }: AnchorNavigationItemProps, ref) => {
+  // `target` is consumed by AnchorNavigation via child.props.target to scroll
+  // to the target section; it is intentionally omitted from this component.
+  const { children, onKeyDown, onClick, href, tabIndex, isSelected } = props;
+
+  return (
     <StyledNavigationItem isSelected={isSelected}>
       <a
         onKeyDown={onKeyDown}
@@ -40,13 +35,25 @@ const AnchorNavigationItem = React.forwardRef<
         tabIndex={tabIndex}
         ref={ref}
         href={href}
+        aria-current={isSelected ? "location" : undefined}
         data-element="anchor-navigation-item"
       >
-        {children}
+        <span
+          aria-hidden="true"
+          data-element="anchor-navigation-item-indicator"
+          data-role="anchor-navigation-item-indicator"
+        />
+        <Typography
+          as="span"
+          data-element="anchor-navigation-item-label"
+          mb={0}
+        >
+          {children}
+        </Typography>
       </a>
     </StyledNavigationItem>
-  ),
-);
+  );
+});
 
 AnchorNavigationItem.displayName = "AnchorNavigationItem";
 export default AnchorNavigationItem;

--- a/src/components/anchor-navigation/anchor-navigation-item/anchor-navigation-item.style.ts
+++ b/src/components/anchor-navigation/anchor-navigation-item/anchor-navigation-item.style.ts
@@ -9,35 +9,72 @@ const StyledNavigationItem = styled.li<StyledNavigationItemProps>`
   width: 100%;
 
   a {
+    --anchor-navigation-item-border-width: var(--global-size-6-xs);
+
+    align-content: center;
+    border-inline-start: var(--anchor-navigation-item-border-width) solid
+      var(--tab-border-default);
     cursor: pointer;
-    display: block;
+    display: grid;
+    grid-template-columns: var(--global-space-comp-l) minmax(0, 1fr);
     text-decoration: none;
-    color: var(--colorsUtilityYin090);
-    background-color: transparent;
-    border-left: var(--sizing050) solid var(--colorsActionMinor100);
-    font-weight: 500;
-    padding: 12px 24px;
-    border-top-right-radius: var(--borderRadius100);
-    border-bottom-right-radius: var(--borderRadius100);
+    color: var(--tab-label-default);
+    background-color: var(--tab-bg-default);
+    box-sizing: border-box;
+    min-height: var(--global-size-m);
+    padding-block: var(--global-space-comp-s);
+    padding-inline-end: var(--global-space-comp-l);
+    position: relative;
+    border-top-right-radius: var(--global-radius-container-m);
+    border-bottom-right-radius: var(--global-radius-container-m);
+
+    [data-element="anchor-navigation-item-indicator"] {
+      align-self: stretch;
+      background-color: transparent;
+      grid-column: 1;
+      grid-row: 1;
+      justify-self: start;
+      margin-inline-start: calc(
+        -1 * var(--anchor-navigation-item-border-width)
+      );
+      width: var(--global-size-6-xs);
+    }
+
+    [data-element="anchor-navigation-item-label"] {
+      color: inherit;
+      font: var(--global-font-static-comp-medium-m);
+      grid-column: 2;
+      grid-row: 1;
+      min-width: 0;
+    }
 
     &:focus {
       ${addFocusStyling()}
-      position: relative;
+      z-index: 1;
     }
 
     &:hover {
       ${({ isSelected }) =>
         !isSelected &&
         css`
-          background-color: var(--colorsActionMinor100);
+          background-color: var(--tab-bg-hover);
+          border-inline-start-color: var(--tab-border-hover);
+          color: var(--tab-label-hover);
         `};
     }
 
     ${({ isSelected }) =>
       isSelected &&
       css`
-        background-color: var(--colorsActionMajorYang100);
-        border-left-color: var(--colorsActionMajor500);
+        background-color: var(--tab-bg-active);
+        border-inline-start-color: var(--tab-border-active-alt);
+        color: var(--tab-label-active);
+
+        [data-element="anchor-navigation-item-indicator"] {
+          background-color: var(--tab-border-active);
+          border-radius: var(--global-radius-action-m);
+          width: var(--global-size-5-xs);
+        }
       `}
   }
 `;

--- a/src/components/anchor-navigation/anchor-navigation.component.tsx
+++ b/src/components/anchor-navigation/anchor-navigation.component.tsx
@@ -1,4 +1,5 @@
 import React, {
+  type AriaAttributes,
   useState,
   useRef,
   useEffect,
@@ -13,6 +14,7 @@ import { defaultFocusableSelectors } from "../../__internal__/focus-trap/focus-t
 import Event from "../../__internal__/utils/helpers/events";
 import {
   StyledAnchorNavigation,
+  StyledNavigationWrapper,
   StyledNavigation,
   StyledContent,
 } from "./anchor-navigation.style";
@@ -20,7 +22,9 @@ import AnchorNavigationItem, {
   AnchorNavigationItemProps,
 } from "./anchor-navigation-item/anchor-navigation-item.component";
 
-export interface AnchorNavigationProps extends TagProps {
+export interface AnchorNavigationProps
+  extends TagProps,
+    Pick<AriaAttributes, "aria-label" | "aria-labelledby"> {
   /** Child elements */
   children?: React.ReactNode;
   /** The AnchorNavigationItems components to be rendered in the sticky navigation.
@@ -32,9 +36,33 @@ export interface AnchorNavigationProps extends TagProps {
 const SECTION_VISIBILITY_OFFSET = 200;
 const SCROLL_THROTTLE = 100;
 
+const flattenNavigationChildren = (
+  children: React.ReactNode,
+): React.ReactElement[] => {
+  const result: React.ReactElement[] = [];
+
+  React.Children.forEach(children, (child) => {
+    if (!React.isValidElement(child)) return;
+
+    if (child.type === React.Fragment) {
+      const fragment = child as React.ReactElement<{
+        children?: React.ReactNode;
+      }>;
+      result.push(...flattenNavigationChildren(fragment.props.children));
+      return;
+    }
+
+    result.push(child);
+  });
+
+  return result;
+};
+
 const AnchorNavigation = ({
   children,
   stickyNavigation,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledby,
   "data-element": dataElement,
   "data-role": dataRole,
 }: AnchorNavigationProps): JSX.Element => {
@@ -44,19 +72,21 @@ const AnchorNavigation = ({
     "`stickyNavigation` prop in `AnchorNavigation` should be a React Fragment.",
   );
 
+  const navigationChildren = useMemo(
+    () => flattenNavigationChildren(stickyNavigation.props.children),
+    [stickyNavigation],
+  );
+
   const hasCorrectItemStructure = useMemo(() => {
-    const incorrectChild = React.Children.toArray(
-      stickyNavigation.props.children,
-    ).find((child: React.ReactNode) => {
+    const incorrectChild = navigationChildren.find((child) => {
       return (
-        !React.isValidElement(child) ||
         (child.type as React.FunctionComponent).displayName !==
-          "AnchorNavigationItem"
+        "AnchorNavigationItem"
       );
     });
 
     return !incorrectChild;
-  }, [stickyNavigation]);
+  }, [navigationChildren]);
 
   invariant(
     hasCorrectItemStructure,
@@ -65,16 +95,17 @@ const AnchorNavigation = ({
 
   const [selectedIndex, setSelectedIndex] = useState(0);
 
-  const sectionRefs = useRef<React.RefObject<HTMLElement>[]>(
-    React.Children.map(
-      stickyNavigation.props.children,
+  const sectionRefs = useRef<(React.RefObject<HTMLElement> | undefined)[]>([]);
+  // Keep the targets in sync when conditional navigation items are added,
+  // removed or reordered after the initial render.
+  sectionRefs.current = navigationChildren.map(
+    (child) =>
       (
-        child: React.ReactElement<
+        child as React.ReactElement<
           AnchorNavigationItemProps,
           typeof AnchorNavigationItem
-        >,
-      ) => child.props.target,
-    ),
+        >
+      ).props.target,
   );
 
   const contentRef = useRef<HTMLDivElement>(null);
@@ -91,28 +122,28 @@ const AnchorNavigation = ({
     if (navigationRef.current === null) return;
 
     const offsetsWithIndexes = sectionRefs.current
-      .map(({ current }, index) => [
+      .map((sectionRef, index) => [
         index,
-        current?.getBoundingClientRect().top,
+        sectionRef?.current?.getBoundingClientRect().top,
       ])
       .filter(
         (offsetWithIndex): offsetWithIndex is [number, number] =>
           offsetWithIndex[1] !== undefined,
       );
 
+    if (offsetsWithIndexes.length === 0) return;
+
     const { top: navTopOffset } = navigationRef.current.getBoundingClientRect();
 
-    const indexOfSmallestNegativeTopOffset = offsetsWithIndexes.reduce(
-      (currentTopIndex, offsetWithIndex) => {
-        const [index, offset] = offsetWithIndex;
+    const [indexOfSmallestNegativeTopOffset] = offsetsWithIndexes.reduce(
+      (currentTop, offsetWithIndex) => {
+        const [, offset] = offsetWithIndex;
 
         if (offset - SECTION_VISIBILITY_OFFSET > navTopOffset)
-          return currentTopIndex;
-        return offset > offsetsWithIndexes[currentTopIndex][1]
-          ? index
-          : currentTopIndex;
+          return currentTop;
+        return offset > currentTop[1] ? offsetWithIndex : currentTop;
       },
-      offsetsWithIndexes[0][0],
+      offsetsWithIndexes[0],
     );
 
     setSelectedIndex(indexOfSmallestNegativeTopOffset);
@@ -141,30 +172,29 @@ const AnchorNavigation = ({
     return () => window.removeEventListener("scroll", scrollHandler, true);
   }, [scrollHandler]);
 
-  const focusSection = (section: HTMLElement) => {
-    if (!section.matches(defaultFocusableSelectors)) {
-      section.setAttribute("tabindex", "-1");
+  const focusSectionHeading = (section: HTMLElement) => {
+    const heading = section.querySelector<HTMLElement>(
+      "h1, h2, h3, h4, h5, h6",
+    );
+    const focusTarget = heading ?? section;
+
+    if (!focusTarget.matches(defaultFocusableSelectors)) {
+      focusTarget.setAttribute("tabindex", "-1");
     }
 
-    section.focus({ preventScroll: true });
+    if (!focusTarget.dataset.carbonAnchornavRef) {
+      focusTarget.dataset.carbonAnchornavRef = "true";
+    }
+
+    focusTarget.focus({ preventScroll: true });
   };
 
   const scrollToSection = (index: number): void => {
-    const sectionToScroll = sectionRefs.current[index].current;
+    const sectionToScroll = sectionRefs.current[index]?.current;
 
-    // istanbul ignore if
-    // function is called only after component is rendered, so ref cannot hold a null value
-    if (sectionToScroll === null) return;
+    if (!sectionToScroll) return;
 
-    // ensure section has the appropriate element to remove the default focus styles.
-    // Can ignore else branch because there's no harm in setting this to "true" twice (it can't hold any other value),
-    // but it's probably more efficient not to.
-    // istanbul ignore else
-    if (!sectionToScroll.dataset.carbonAnchornavRef) {
-      sectionToScroll.dataset.carbonAnchornavRef = "true";
-    }
-
-    focusSection(sectionToScroll);
+    focusSectionHeading(sectionToScroll);
 
     // workaround due to preventScroll focus method option on firefox not working consistently
     window.setTimeout(() => {
@@ -202,21 +232,29 @@ const AnchorNavigation = ({
       data-element={dataElement}
       data-role={dataRole}
     >
-      <StyledNavigation
-        ref={navigationRef}
-        data-element="anchor-sticky-navigation"
+      <StyledNavigationWrapper
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledby}
       >
-        {React.Children.map(stickyNavigation.props.children, (child, index) =>
-          React.cloneElement(child, {
-            href: child.props.href || "#", // need to pass an href to ensure the link is tabbable by default
-            isSelected: index === selectedIndex,
-            onClick: (event: React.MouseEvent<HTMLAnchorElement>) =>
-              handleClick(event, index),
-            onKeyDown: (event: React.KeyboardEvent<HTMLAnchorElement>) =>
-              handleKeyDown(event, index),
-          }),
-        )}
-      </StyledNavigation>
+        {/* role="list" is explicit to restore list semantics in VoiceOver when list-style: none is applied */}
+        <StyledNavigation
+          ref={navigationRef}
+          role="list"
+          data-element="anchor-sticky-navigation"
+        >
+          {navigationChildren.map((child, index) =>
+            React.cloneElement(child, {
+              key: child.key ?? index,
+              href: child.props.href || "#", // need to pass an href to ensure the link is tabbable by default
+              isSelected: index === selectedIndex,
+              onClick: (event: React.MouseEvent<HTMLAnchorElement>) =>
+                handleClick(event, index),
+              onKeyDown: (event: React.KeyboardEvent<HTMLAnchorElement>) =>
+                handleKeyDown(event, index),
+            }),
+          )}
+        </StyledNavigation>
+      </StyledNavigationWrapper>
       <StyledContent>{children}</StyledContent>
     </StyledAnchorNavigation>
   );

--- a/src/components/anchor-navigation/anchor-navigation.pw.tsx
+++ b/src/components/anchor-navigation/anchor-navigation.pw.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { test } from "../../../playwright/helpers/base-test";
+import { expect, test } from "../../../playwright/helpers/base-test";
 
 import {
   AnchorNavigationComponent,
@@ -28,4 +28,65 @@ test.describe("Accessibility tests for Anchor Navigation component", () => {
 
     await checkAccessibility(page, page.locator(DIALOG_FULL_SCREEN));
   });
+});
+
+test("active indicator matches single- and multiline label heights", async ({
+  mount,
+  page,
+}) => {
+  await mount(<AnchorNavigationComponent />);
+
+  const firstLink = page.getByRole("link", { name: "First" });
+  const firstLabel = firstLink.locator(
+    '[data-element="anchor-navigation-item-label"]',
+  );
+  const firstIndicator = firstLink.locator(
+    '[data-element="anchor-navigation-item-indicator"]',
+  );
+
+  const firstLabelHeight = await firstLabel.evaluate(
+    (element) => element.getBoundingClientRect().height,
+  );
+  const firstIndicatorHeight = await firstIndicator.evaluate(
+    (element) => element.getBoundingClientRect().height,
+  );
+  const firstLinkHeight = await firstLink.evaluate(
+    (element) => element.getBoundingClientRect().height,
+  );
+
+  // Link must be at least as tall as its label (min-height token); avoid hardcoding the resolved px value.
+  expect(firstLinkHeight).toBeGreaterThanOrEqual(firstLabelHeight);
+  expect(firstIndicatorHeight).toBe(firstLabelHeight);
+
+  const multilineLink = page.getByRole("link", {
+    name: "Navigation item with very long label",
+  });
+  await multilineLink.click();
+
+  const multilineLabelHeight = await multilineLink
+    .locator('[data-element="anchor-navigation-item-label"]')
+    .evaluate((element) => element.getBoundingClientRect().height);
+  const multilineIndicatorHeight = await multilineLink
+    .locator('[data-element="anchor-navigation-item-indicator"]')
+    .evaluate((element) => element.getBoundingClientRect().height);
+
+  expect(multilineLabelHeight).toBeGreaterThan(firstLabelHeight);
+  expect(multilineIndicatorHeight).toBe(multilineLabelHeight);
+});
+
+test("uses the responsive sticky offset", async ({ mount, page }) => {
+  await page.setViewportSize({ width: 599, height: 768 });
+  await mount(<AnchorNavigationComponent />);
+
+  const navigation = page.getByRole("navigation");
+  const getTop = () =>
+    navigation.evaluate((element) => parseFloat(getComputedStyle(element).top));
+
+  // Capture the narrow-viewport offset first, then assert the wide-viewport
+  // offset is larger — avoiding hardcoded resolved token values.
+  const narrowTop = await getTop();
+
+  await page.setViewportSize({ width: 600, height: 768 });
+
+  await expect.poll(getTop).toBeGreaterThan(narrowTop);
 });

--- a/src/components/anchor-navigation/anchor-navigation.style.ts
+++ b/src/components/anchor-navigation/anchor-navigation.style.ts
@@ -6,22 +6,34 @@ const StyledAnchorNavigation = styled.div`
   width: 100%;
 `;
 
-const StyledNavigation = styled.ul`
+const StyledNavigationWrapper = styled.nav`
   position: sticky;
-  top: 32px;
+  top: var(--global-space-layout-2-xs);
+  max-width: 240px;
+
+  @media screen and (min-width: 600px) {
+    top: var(--global-space-layout-xs);
+  }
+`;
+
+const StyledNavigation = styled.ul`
   list-style: none;
   margin: 0;
   padding: 0;
-  max-width: 240px;
 `;
 
 const StyledContent = styled.div`
   flex: 1;
-  margin-left: 32px;
+  margin-left: var(--global-space-layout-s);
 
   [data-carbon-anchornav-ref="true"]:focus {
     outline: none;
   }
 `;
 
-export { StyledAnchorNavigation, StyledNavigation, StyledContent };
+export {
+  StyledAnchorNavigation,
+  StyledNavigationWrapper,
+  StyledNavigation,
+  StyledContent,
+};

--- a/src/components/anchor-navigation/anchor-navigation.test.tsx
+++ b/src/components/anchor-navigation/anchor-navigation.test.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Textbox from "../textbox";
@@ -9,6 +9,15 @@ import {
   AnchorSectionDivider,
 } from ".";
 
+/** Returns the <li> nav item whose link has the given accessible name. */
+const getNavItem = (name: string): HTMLElement => {
+  const match = screen
+    .getAllByRole("listitem")
+    .find((item) => within(item).queryByRole("link", { name }) !== null);
+  if (!match) throw new Error(`Nav item with link name "${name}" not found`);
+  return match;
+};
+
 const MockComponent = () => {
   const ref1 = useRef<HTMLDivElement>(null);
   const ref2 = useRef<HTMLDivElement>(null);
@@ -16,6 +25,7 @@ const MockComponent = () => {
 
   return (
     <AnchorNavigation
+      aria-label="page sections"
       stickyNavigation={
         <>
           <AnchorNavigationItem target={ref1}>First</AnchorNavigationItem>
@@ -74,16 +84,27 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-test("has proper data attributes applied to elements", () => {
+test("has proper data attributes applied to root element and navigation landmark", () => {
   render(<MockComponent />);
+  const navigation = screen.getByRole("navigation", {
+    name: "page sections",
+  });
+  expect(navigation).toHaveAttribute("aria-label", "page sections");
+  // data-component is on the outer wrapper div, not on the <nav> landmark
   expect(screen.getByTestId("test-component")).toHaveAttribute(
     "data-component",
     "anchor-navigation",
   );
+  expect(navigation).not.toContainElement(
+    screen.getByRole("heading", { name: "First section" }),
+  );
+  expect(navigation).toContainElement(screen.getByRole("list"));
   expect(screen.getByRole("list")).toHaveAttribute(
     "data-element",
     "anchor-sticky-navigation",
   );
+  // role="list" is explicit to restore VoiceOver list semantics when list-style: none is applied
+  expect(screen.getByRole("list")).toHaveAttribute("role", "list");
 
   const anchorNavigationLinks = screen.getAllByRole("link");
   anchorNavigationLinks.forEach((anchor) => {
@@ -91,7 +112,53 @@ test("has proper data attributes applied to elements", () => {
   });
 });
 
-test("when navigation item is clicked, the item is selected and the section container is focused", async () => {
+test("renders nav without aria-label when aria-label prop is not provided", () => {
+  const ref = React.createRef<HTMLDivElement>();
+  render(
+    <AnchorNavigation
+      stickyNavigation={
+        <>
+          <AnchorNavigationItem target={ref}>Item</AnchorNavigationItem>
+        </>
+      }
+    />,
+  );
+  expect(screen.getByRole("navigation")).not.toHaveAttribute("aria-label");
+});
+
+test("applies aria-labelledby to the navigation landmark", () => {
+  const ref = React.createRef<HTMLDivElement>();
+  render(
+    <>
+      <h2 id="nav-heading">Page sections</h2>
+      <AnchorNavigation
+        aria-labelledby="nav-heading"
+        stickyNavigation={
+          <>
+            <AnchorNavigationItem target={ref}>Item</AnchorNavigationItem>
+          </>
+        }
+      />
+    </>,
+  );
+  expect(
+    screen.getByRole("navigation", { name: "Page sections" }),
+  ).toHaveAttribute("aria-labelledby", "nav-heading");
+});
+
+test("marks the selected link as the current location", () => {
+  render(<MockComponent />);
+
+  expect(screen.getByRole("link", { name: "First" })).toHaveAttribute(
+    "aria-current",
+    "location",
+  );
+  expect(screen.getByRole("link", { name: "Second" })).not.toHaveAttribute(
+    "aria-current",
+  );
+});
+
+test("when navigation item is clicked, the item is selected and the section heading is focused", async () => {
   render(<MockComponent />);
 
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -104,21 +171,33 @@ test("when navigation item is clicked, the item is selected and the section cont
   // toHaveStyle still passes even with incorrect styles when used with CSS variables
   // (see https://github.com/testing-library/jest-dom/issues/461 - the variables seem to be
   // treated by js-dom as "invalid values" as explained in the first reply) - so using toHaveStyleRule instead
-  const selectedItem = screen.getAllByRole("listitem")[1];
+  const selectedItem = getNavItem("Second");
   expect(selectedItem).toHaveStyleRule(
     "background-color",
-    "var(--colorsActionMajorYang100)",
+    "var(--tab-bg-active)",
     { modifier: "& a" },
   );
   expect(selectedItem).toHaveStyleRule(
-    "border-left-color",
-    "var(--colorsActionMajor500)",
-    { modifier: "& a" },
+    "background-color",
+    "var(--tab-border-active)",
+    {
+      modifier: '& a [data-element="anchor-navigation-item-indicator"]',
+    },
   );
-  expect(screen.getByTestId("section-2")).toHaveFocus();
+  expect(screen.getByRole("link", { name: "First" })).not.toHaveAttribute(
+    "aria-current",
+  );
+  expect(screen.getByRole("link", { name: "Second" })).toHaveAttribute(
+    "aria-current",
+    "location",
+  );
+  const heading = screen.getByRole("heading", { name: "Second section" });
+  expect(heading).toHaveFocus();
+  expect(heading).toHaveAttribute("data-carbon-anchornav-ref", "true");
+  expect(heading).toHaveAttribute("tabindex", "-1");
 });
 
-test("when Enter is pressed on a navigation item, the item is selected and the section container is focused", async () => {
+test("when Enter is pressed on a navigation item, the item is selected and the section heading is focused", async () => {
   render(<MockComponent />);
 
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -130,21 +209,30 @@ test("when Enter is pressed on a navigation item, the item is selected and the s
     jest.advanceTimersByTime(10);
   });
 
-  const selectedItem = screen.getAllByRole("listitem")[1];
+  const selectedItem = getNavItem("Second");
   expect(selectedItem).toHaveStyleRule(
     "background-color",
-    "var(--colorsActionMajorYang100)",
+    "var(--tab-bg-active)",
     { modifier: "& a" },
   );
   expect(selectedItem).toHaveStyleRule(
-    "border-left-color",
-    "var(--colorsActionMajor500)",
-    { modifier: "& a" },
+    "background-color",
+    "var(--tab-border-active)",
+    {
+      modifier: '& a [data-element="anchor-navigation-item-indicator"]',
+    },
   );
-  expect(screen.getByTestId("section-2")).toHaveFocus();
+  expect(screen.getByRole("link", { name: "First" })).not.toHaveAttribute(
+    "aria-current",
+  );
+  expect(screen.getByRole("link", { name: "Second" })).toHaveAttribute(
+    "aria-current",
+    "location",
+  );
+  expect(screen.getByRole("heading", { name: "Second section" })).toHaveFocus();
 });
 
-test("does not alter the tabindex of the container if it was already focusable", async () => {
+test("does not alter the tabindex of the container when moving focus to its heading", async () => {
   render(<MockComponent />);
 
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -156,6 +244,7 @@ test("does not alter the tabindex of the container if it was already focusable",
   });
 
   expect(screen.getByTestId("section-1")).toHaveAttribute("tabindex", "0");
+  expect(screen.getByRole("heading", { name: "First section" })).toHaveFocus();
 });
 
 test("does nothing if a key other than tab or enter is pressed", async () => {
@@ -169,16 +258,18 @@ test("does nothing if a key other than tab or enter is pressed", async () => {
     jest.advanceTimersByTime(10);
   });
 
-  const originallySelectedItem = screen.getAllByRole("listitem")[0];
+  const originallySelectedItem = getNavItem("First");
   expect(originallySelectedItem).toHaveStyleRule(
     "background-color",
-    "var(--colorsActionMajorYang100)",
+    "var(--tab-bg-active)",
     { modifier: "& a" },
   );
   expect(originallySelectedItem).toHaveStyleRule(
-    "border-left-color",
-    "var(--colorsActionMajor500)",
-    { modifier: "& a" },
+    "background-color",
+    "var(--tab-border-active)",
+    {
+      modifier: '& a [data-element="anchor-navigation-item-indicator"]',
+    },
   );
 });
 
@@ -220,19 +311,260 @@ test.each([
       jest.advanceTimersByTime(10);
     });
 
-    const selectedItem = screen.getAllByRole("listitem")[selectedAnchorIndex];
+    const itemLabels = [
+      "First",
+      "Second",
+      "The slightly longer than expected third navigation item",
+    ];
+    const selectedItem = getNavItem(itemLabels[selectedAnchorIndex]);
     expect(selectedItem).toHaveStyleRule(
       "background-color",
-      "var(--colorsActionMajorYang100)",
+      "var(--tab-bg-active)",
       { modifier: "& a" },
     );
     expect(selectedItem).toHaveStyleRule(
-      "border-left-color",
-      "var(--colorsActionMajor500)",
-      { modifier: "& a" },
+      "background-color",
+      "var(--tab-border-active)",
+      {
+        modifier: '& a [data-element="anchor-navigation-item-indicator"]',
+      },
     );
   },
 );
+
+test("focuses the section itself when it has no heading, and does not alter tabindex when already focusable", async () => {
+  const ref = React.createRef<HTMLDivElement>();
+  render(
+    <AnchorNavigation
+      stickyNavigation={
+        <>
+          <AnchorNavigationItem target={ref}>Section</AnchorNavigationItem>
+        </>
+      }
+    >
+      {/* section has tabIndex, so it's already focusable; no heading child */}
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
+      <div ref={ref} tabIndex={0} data-role="headingless-section" />
+    </AnchorNavigation>,
+  );
+
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  await user.click(screen.getByRole("link", { name: "Section" }));
+  act(() => {
+    jest.advanceTimersByTime(10);
+  });
+
+  // Section itself is the focus target (no heading found → null branch of ??)
+  // It already matches focusable selectors (tabIndex=0) → tabindex NOT overwritten (false branch of if)
+  const section = screen.getByTestId("headingless-section");
+  expect(section).toHaveFocus();
+  expect(section).toHaveAttribute("tabindex", "0");
+});
+
+test("does not set data-carbon-anchornav-ref when it is already present (second click of same item)", async () => {
+  render(<MockComponent />);
+
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  // First click — sets the attribute
+  await user.click(screen.getByRole("link", { name: "Second" }));
+  act(() => {
+    jest.advanceTimersByTime(10);
+  });
+
+  const heading = screen.getByRole("heading", { name: "Second section" });
+  expect(heading).toHaveAttribute("data-carbon-anchornav-ref", "true");
+
+  // Second click of the same item — attribute already present (false branch of if)
+  await user.click(screen.getByRole("link", { name: "Second" }));
+  act(() => {
+    jest.advanceTimersByTime(10);
+  });
+
+  expect(heading).toHaveAttribute("data-carbon-anchornav-ref", "true");
+  expect(heading).toHaveFocus();
+});
+
+test("supports conditional items and items inside nested fragments", async () => {
+  const firstRef = React.createRef<HTMLDivElement>();
+  const secondRef = React.createRef<HTMLDivElement>();
+  const showConditionalItem = false;
+
+  render(
+    <AnchorNavigation
+      stickyNavigation={
+        <>
+          {showConditionalItem && (
+            <AnchorNavigationItem target={firstRef}>
+              Hidden
+            </AnchorNavigationItem>
+          )}
+          <>
+            <AnchorNavigationItem target={firstRef} key="first">
+              First
+            </AnchorNavigationItem>
+            <>
+              <AnchorNavigationItem target={secondRef} key="second">
+                Second
+              </AnchorNavigationItem>
+            </>
+          </>
+        </>
+      }
+    >
+      <div ref={firstRef}>
+        <h2>First section</h2>
+      </div>
+      <div ref={secondRef}>
+        <h2>Second section</h2>
+      </div>
+    </AnchorNavigation>,
+  );
+
+  expect(
+    screen.queryByRole("link", { name: "Hidden" }),
+  ).not.toBeInTheDocument();
+  expect(screen.getAllByRole("link")).toHaveLength(2);
+
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  await user.click(screen.getByRole("link", { name: "Second" }));
+  act(() => {
+    jest.advanceTimersByTime(10);
+  });
+
+  expect(screen.getByRole("heading", { name: "Second section" })).toHaveFocus();
+});
+
+test("keeps item indexes aligned with targets when conditional items change", async () => {
+  const firstRef = React.createRef<HTMLDivElement>();
+  const secondRef = React.createRef<HTMLDivElement>();
+
+  const Navigation = ({ showFirst }: { showFirst: boolean }) => (
+    <AnchorNavigation
+      stickyNavigation={
+        <>
+          {showFirst && (
+            <AnchorNavigationItem target={firstRef} key="first">
+              First
+            </AnchorNavigationItem>
+          )}
+          <AnchorNavigationItem target={secondRef} key="second">
+            Second
+          </AnchorNavigationItem>
+        </>
+      }
+    >
+      <div ref={firstRef}>
+        <h2>First section</h2>
+      </div>
+      <div ref={secondRef}>
+        <h2>Second section</h2>
+      </div>
+    </AnchorNavigation>
+  );
+
+  const { rerender } = render(<Navigation showFirst />);
+  rerender(<Navigation showFirst={false} />);
+
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  await user.click(screen.getByRole("link", { name: "Second" }));
+  act(() => {
+    jest.advanceTimersByTime(10);
+  });
+
+  expect(screen.getByRole("heading", { name: "Second section" })).toHaveFocus();
+});
+
+test("selects the correct item when preceding items have no targets", () => {
+  const firstRef = React.createRef<HTMLDivElement>();
+  const fourthRef = React.createRef<HTMLDivElement>();
+  const fifthRef = React.createRef<HTMLDivElement>();
+
+  render(
+    <AnchorNavigation
+      stickyNavigation={
+        <>
+          <AnchorNavigationItem target={firstRef}>First</AnchorNavigationItem>
+          <AnchorNavigationItem>Second without target</AnchorNavigationItem>
+          <AnchorNavigationItem>Third without target</AnchorNavigationItem>
+          <AnchorNavigationItem target={fourthRef}>Fourth</AnchorNavigationItem>
+          <AnchorNavigationItem target={fifthRef}>Fifth</AnchorNavigationItem>
+        </>
+      }
+    >
+      <div ref={firstRef}>First section</div>
+      <div ref={fourthRef}>Fourth section</div>
+      <div ref={fifthRef}>Fifth section</div>
+    </AnchorNavigation>,
+  );
+
+  [firstRef, fourthRef, fifthRef].forEach((sectionRef, index) => {
+    jest
+      .spyOn(sectionRef.current as HTMLDivElement, "getBoundingClientRect")
+      .mockReturnValue({ top: 100 + index * 50 } as DOMRect);
+  });
+  jest
+    .spyOn(screen.getByRole("list"), "getBoundingClientRect")
+    .mockReturnValue({ top: 200 } as DOMRect);
+
+  act(() => {
+    window.dispatchEvent(new Event("scroll"));
+  });
+
+  expect(screen.getByRole("link", { name: "Fifth" })).toHaveAttribute(
+    "aria-current",
+    "location",
+  );
+});
+
+test("does not change the selected item on scroll when no items have targets", () => {
+  render(
+    <AnchorNavigation
+      stickyNavigation={
+        <>
+          <AnchorNavigationItem>First</AnchorNavigationItem>
+          <AnchorNavigationItem>Second</AnchorNavigationItem>
+        </>
+      }
+    />,
+  );
+
+  act(() => {
+    window.dispatchEvent(new Event("scroll"));
+  });
+
+  expect(screen.getByRole("link", { name: "First" })).toHaveAttribute(
+    "aria-current",
+    "location",
+  );
+});
+
+test("does not select or scroll to an item without a target", async () => {
+  render(
+    <AnchorNavigation
+      stickyNavigation={
+        <>
+          <AnchorNavigationItem>First</AnchorNavigationItem>
+          <AnchorNavigationItem>Second</AnchorNavigationItem>
+        </>
+      }
+    />,
+  );
+
+  (Element.prototype.scrollIntoView as jest.Mock).mockClear();
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  await user.click(screen.getByRole("link", { name: "Second" }));
+
+  expect(screen.getByRole("link", { name: "First" })).toHaveAttribute(
+    "aria-current",
+    "location",
+  );
+  expect(screen.getByRole("link", { name: "Second" })).not.toHaveAttribute(
+    "aria-current",
+  );
+  expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+});
 
 test("cleans up event listeners after unmounting", () => {
   const { unmount } = render(<MockComponent />);
@@ -298,39 +630,107 @@ describe("validates incorrect stickyNavigation prop content", () => {
 test("renders not selected navigation item with proper background when hovered", async () => {
   render(<MockComponent />);
 
-  expect(screen.getAllByRole("listitem")[1]).toHaveStyleRule(
+  const unselectedItem = getNavItem("Second");
+  expect(unselectedItem).toHaveStyleRule(
     "background-color",
-    "var(--colorsActionMinor100)",
+    "var(--tab-bg-hover)",
     { modifier: "& a:hover" },
   );
+  expect(unselectedItem).toHaveStyleRule(
+    "border-inline-start-color",
+    "var(--tab-border-hover)",
+    { modifier: "& a:hover" },
+  );
+  expect(unselectedItem).toHaveStyleRule("color", "var(--tab-label-hover)", {
+    modifier: "& a:hover",
+  });
 });
 
-test("renders selected navigation item with proper background when hovered", async () => {
+test("renders default navigation item with proper background and label colors", () => {
   render(<MockComponent />);
 
-  expect(screen.getAllByRole("listitem")[0]).not.toHaveStyleRule(
+  const defaultItem = getNavItem("Second");
+  expect(defaultItem).toHaveStyleRule(
     "background-color",
-    undefined,
-    {
-      modifier: "& a:hover",
-    },
+    "var(--tab-bg-default)",
+    { modifier: "& a" },
+  );
+  expect(defaultItem).toHaveStyleRule("color", "var(--tab-label-default)", {
+    modifier: "& a",
+  });
+});
+
+test("keeps selected navigation item active styling when hovered", async () => {
+  render(<MockComponent />);
+
+  const selectedItem = getNavItem("First");
+  expect(selectedItem).not.toHaveStyleRule(
+    "background-color",
+    "var(--tab-bg-hover)",
+    { modifier: "& a:hover" },
+  );
+  expect(selectedItem).not.toHaveStyleRule("color", "var(--tab-label-hover)", {
+    modifier: "& a:hover",
+  });
+  expect(selectedItem).toHaveStyleRule(
+    "background-color",
+    "var(--tab-bg-active)",
+    { modifier: "& a" },
   );
 });
 
-test("has the expected border radius styling on the navigation items", () => {
+test("renders navigation item with proper focus styling", () => {
   render(<MockComponent />);
 
-  const anchorNavigationItems = screen.getAllByRole("listitem");
-  anchorNavigationItems.forEach((item) => {
-    expect(item).toHaveStyleRule(
-      "border-top-right-radius",
-      "var(--borderRadius100)",
-      { modifier: "& a" },
-    );
-    expect(item).toHaveStyleRule(
-      "border-bottom-right-radius",
-      "var(--borderRadius100)",
-      { modifier: "& a" },
-    );
+  const defaultItem = getNavItem("Second");
+  expect(defaultItem).toHaveStyleRule(
+    "box-shadow",
+    "var(--focus-shadow-default)",
+    { modifier: "& a:focus" },
+  );
+  expect(defaultItem).toHaveStyleRule("outline", "transparent 3px solid", {
+    modifier: "& a:focus",
+  });
+  expect(defaultItem).toHaveStyleRule("z-index", "1", {
+    modifier: "& a:focus",
+  });
+});
+
+test("has the expected active item indicator styling", () => {
+  render(<MockComponent />);
+
+  const selectedItem = getNavItem("First");
+  expect(selectedItem).toHaveStyleRule("min-height", "var(--global-size-m)", {
+    modifier: "& a",
+  });
+  expect(selectedItem).toHaveStyleRule(
+    "border-inline-start",
+    "var(--anchor-navigation-item-border-width) solid var(--tab-border-default)",
+    { modifier: "& a" },
+  );
+  expect(selectedItem).toHaveStyleRule(
+    "border-inline-start-color",
+    "var(--tab-border-active-alt)",
+    { modifier: "& a" },
+  );
+  expect(selectedItem).toHaveStyleRule(
+    "background-color",
+    "var(--tab-border-active)",
+    {
+      modifier: '& a [data-element="anchor-navigation-item-indicator"]',
+    },
+  );
+  expect(selectedItem).toHaveStyleRule("width", "var(--global-size-5-xs)", {
+    modifier: '& a [data-element="anchor-navigation-item-indicator"]',
+  });
+
+  const indicator = within(selectedItem).getByTestId(
+    "anchor-navigation-item-indicator",
+  );
+  expect(indicator).toHaveAttribute("aria-hidden", "true");
+  expect(indicator).not.toHaveAttribute("tabindex");
+
+  expect(selectedItem).toHaveStyleRule("color", "var(--tab-label-active)", {
+    modifier: "& a",
   });
 });


### PR DESCRIPTION
### Proposed behaviour

Aligns `Anchor Navigation `component component with fusion DS designs:

- uses design tokens;
- accessibility matches design notes
- 

### Current behaviour

Not aligned with fusion DS.

### Checklist

- [X] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context


### Testing instructions

<img width="873" height="316" alt="Screenshot 2026-07-29 at 12 15 57" src="https://github.com/user-attachments/assets/5059cb18-8800-49b2-9b49-fe181c5234b9" />

<img width="778" height="461" alt="Screenshot 2026-07-29 at 12 02 56" src="https://github.com/user-attachments/assets/550450c3-94db-4305-b7dc-f22c76a7da52" />



