### PR TITLE
fix(tabs): remove gap in overflow layout

### DIFF
--- a/src/components/tabs/__next__/tabs.component.tsx
+++ b/src/components/tabs/__next__/tabs.component.tsx
@@ -478,6 +478,7 @@ export const TabList = forwardRef<TabsHandle, TabListProps>(
             id={`tablist-${idTabList.current}`}
             onKeyDown={handleKeyDown}
             $orientation={orientation}
+            $scrollRequired={scrollRequired}
             ref={tabListRef}
             role="tablist"
             tabIndex={-1}

--- a/src/components/tabs/__next__/tabs.style.ts
+++ b/src/components/tabs/__next__/tabs.style.ts
@@ -12,6 +12,7 @@ type Dimension = {
 };
 
 const VERTICAL_TAB_WIDTH = 200;
+export const TAB_LIST_FOCUS_PADDING = 6;
 
 const sizes: Record<string, Dimension> = {
   medium: {
@@ -34,6 +35,7 @@ const sizes: Record<string, Dimension> = {
 
 interface StyledTabListProps {
   $orientation: "horizontal" | "vertical";
+  $scrollRequired: boolean;
 }
 
 export const StyledTabPanel = styled.div`
@@ -42,10 +44,15 @@ export const StyledTabPanel = styled.div`
 
 export const StyledTabList = styled.div<StyledTabListProps>`
   display: flex;
-  ${({ $orientation }) => css`
+  ${({ $orientation, $scrollRequired }) => css`
     ${$orientation === "horizontal" &&
     css`
       margin-bottom: 8px;
+
+      ${$scrollRequired &&
+      css`
+        margin-inline: -${TAB_LIST_FOCUS_PADDING}px;
+      `}
     `}
 
     ${$orientation === "vertical" &&
@@ -56,7 +63,7 @@ export const StyledTabList = styled.div<StyledTabListProps>`
     `}
   `}
   width: 100%;
-  padding: 6px;
+  padding: ${TAB_LIST_FOCUS_PADDING}px;
   overflow-x: hidden;
 `;
 
@@ -94,6 +101,7 @@ export const StyledScrollButton = styled.button<{
   border-bottom: 2px solid var(--tab-border-active-alt);
   top: 6px;
   position: relative;
+  z-index: 1;
 `;
 
 // Again, can't be easily tested in Jest owing to lack of an actual DOM

--- a/src/components/tabs/__next__/tabs.test.tsx
+++ b/src/components/tabs/__next__/tabs.test.tsx
@@ -9,6 +9,7 @@ import { assertLoggerComponentMessage } from "../../../__spec_helper__/__interna
 import Textbox from "../../textbox";
 import { TabsHandle } from "./tabs.types";
 import Button from "../../button";
+import { StyledTabList, TAB_LIST_FOCUS_PADDING } from "./tabs.style";
 
 const TestComponent = ({ ...args }) => {
   return (
@@ -601,4 +602,30 @@ test("applies the `data-element` and `data-role` props to expected elements", ()
   expect(tabPanel1).toHaveAttribute("data-component", "tab-panel");
   expect(tabPanel1).toHaveAttribute("data-element", "tabpanel-foo");
   expect(tabPanel1).toHaveAttribute("data-role", "tabpanel-bar");
+});
+
+test("applies negative inline margin only when horizontal scrolling is required", () => {
+  render(
+    <StyledTabList $orientation="horizontal" $scrollRequired>
+      Scrollable tabs
+    </StyledTabList>,
+  );
+
+  expect(screen.getByText("Scrollable tabs")).toHaveStyleRule(
+    "margin-inline",
+    `-${TAB_LIST_FOCUS_PADDING}px`,
+  );
+});
+
+test("does not apply negative inline margin only when horizontal scrolling is not required", () => {
+  render(
+    <StyledTabList $orientation="horizontal" $scrollRequired={false}>
+      Non-scrollable tabs
+    </StyledTabList>,
+  );
+
+  expect(screen.getByText("Non-scrollable tabs")).not.toHaveStyleRule(
+    "margin-inline",
+    `-${TAB_LIST_FOCUS_PADDING}px`,
+  );
 });


### PR DESCRIPTION
### Proposed behaviour

The tab strip should use the full available horizontal space and align consistently with whichever navigation  controls are visible

### Current behaviour

The space is visible between the tab strip and the overflow navigation control, depending on the current scroll position.

### Checklist

- [X] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

Fixes #7992

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

<img width="781" height="239" alt="current" src="https://github.com/user-attachments/assets/19fc0949-d18e-4211-b008-bfce3def0196" />


<img width="837" height="254" alt="fixed" src="https://github.com/user-attachments/assets/515abc27-1a2f-4f9e-9702-0f25b5ab064a" />
