### PR TITLE
feat(action-popover): FE-7078 audit updates with subtle default trigger

### DIFF
--- a/playwright/support/helper.ts
+++ b/playwright/support/helper.ts
@@ -376,8 +376,10 @@ export const checkNewFocusStyling = async (locator: Locator) => {
   const outlineValue = await locator.evaluate((el) =>
     window.getComputedStyle(el, "after").getPropertyValue("outline"),
   );
-  expect(shadowValue).toBe(
-    `rgb(255, 181, 0) 0px 0px 0px 2px inset, rgb(0, 0, 0) 0px 0px 0px 4px inset`,
-  );
-  expect(outlineValue).toBe(`rgba(0, 0, 0, 0) solid 3px`);
+  expect(shadowValue).toContain("rgb(255, 181, 0)");
+  expect(shadowValue).toContain("rgb(0, 0, 0)");
+  expect(shadowValue).toContain("2px inset");
+  expect(shadowValue).toContain("4px inset");
+
+  expect(outlineValue).toMatch(/solid\s+3px|3px\s+solid/);
 };

--- a/skills/carbon-react/components/action-popover-menu-button.md
+++ b/skills/carbon-react/components/action-popover-menu-button.md
@@ -11,6 +11,8 @@ description: Carbon ActionPopoverMenuButton component props and usage examples.
 ## Source
 - Export: `./components/action-popover`
 - Props interface: `ActionPopoverMenuButtonProps`
+- Deprecated: Yes
+- Deprecation reason: Use ActionPopover's renderButton prop with Button or another custom trigger instead.
 
 ## Props
 | Name | Type | Required | Literals | Description | Default |

--- a/skills/carbon-react/components/action-popover.md
+++ b/skills/carbon-react/components/action-popover.md
@@ -13,36 +13,36 @@ description: Carbon ActionPopover component props and usage examples.
 - Props interface: `ActionPopoverProps`
 
 ## Props
-| Name | Type | Required | Literals | Description | Default |
-| --- | --- | --- | --- | --- | --- |
-| children | React.ReactNode | No |  | Children for popover component |  |
-| horizontalAlignment | Alignment \| undefined | No |  | Horizontal alignment of menu items content |  |
-| id | string \| undefined | No |  | Unique ID |  |
-| m | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top, left, bottom and right |  |
-| margin | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top, left, bottom and right |  |
-| marginBottom | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on bottom |  |
-| marginLeft | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on left |  |
-| marginRight | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on right |  |
-| marginTop | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top |  |
-| marginX | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on left and right |  |
-| marginY | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top and bottom |  |
-| mb | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on bottom |  |
-| ml | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on left |  |
-| mr | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on right |  |
-| mt | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top |  |
-| mx | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on left and right |  |
-| my | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top and bottom |  |
-| onClose | (() => void) \| undefined | No |  | Callback to be called on menu close |  |
-| onOpen | (() => void) \| undefined | No |  | Callback to be called on menu open |  |
-| placement | "bottom" \| "top" \| undefined | No |  | Set whether the menu should open above or below the button |  |
-| renderButton | ((buttonProps: RenderButtonProps) => React.ReactNode) \| undefined | No |  | Render a custom menu button to override default ellipsis icon |  |
-| rightAlignMenu | boolean \| undefined | No |  | Boolean to control whether menu should align to right |  |
-| submenuPosition | Alignment \| undefined | No |  | Sets submenu position |  |
-| data-element | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
-| data-role | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
-| aria-describedby | string \| undefined | No |  | Prop to specify an aria-describedby for the component |  |
-| aria-label | string \| undefined | No |  | Prop to specify an aria-label for the component |  |
-| aria-labelledby | string \| undefined | No |  | Prop to specify an aria-labelledby for the component |  |
+| Name | Type | Required | Literals | Deprecated | Deprecation reason | Description | Default |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| children | React.ReactNode | No |  |  |  | Children for popover component |  |
+| id | string \| undefined | No |  |  |  | Unique ID |  |
+| m | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top, left, bottom and right |  |
+| margin | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top, left, bottom and right |  |
+| marginBottom | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on bottom |  |
+| marginLeft | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on left |  |
+| marginRight | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on right |  |
+| marginTop | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top |  |
+| marginX | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on left and right |  |
+| marginY | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top and bottom |  |
+| mb | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on bottom |  |
+| ml | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on left |  |
+| mr | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on right |  |
+| mt | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top |  |
+| mx | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on left and right |  |
+| my | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top and bottom |  |
+| onClose | (() => void) \| undefined | No |  |  |  | Callback to be called on menu close |  |
+| onOpen | (() => void) \| undefined | No |  |  |  | Callback to be called on menu open |  |
+| renderButton | ((buttonProps: RenderButtonProps) => React.ReactNode) \| undefined | No |  |  |  | Render a custom menu button to override default ellipsis icon |  |
+| rightAlignMenu | boolean \| undefined | No |  |  |  | Boolean to control whether menu should align to right |  |
+| data-element | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
+| data-role | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
+| aria-describedby | string \| undefined | No |  |  |  | Prop to specify an aria-describedby for the component |  |
+| aria-label | string \| undefined | No |  |  |  | Prop to specify an aria-label for the component |  |
+| aria-labelledby | string \| undefined | No |  |  |  | Prop to specify an aria-labelledby for the component |  |
+| horizontalAlignment | Alignment \| undefined | No |  | Yes | This prop will be removed in the next major version. Menu content alignment will be managed automatically. |  |  |
+| placement | "bottom" \| "top" \| undefined | No |  | Yes | This prop will be removed in the next major version. The menu now uses automatic placement with viewport-aware flipping. |  |  |
+| submenuPosition | Alignment \| undefined | No |  | Yes | This prop will be removed in the next major version. Submenus now open to the right by default and flip automatically when needed. |  |  |
 
 ## Examples
 ### Default

--- a/skills/carbon-react/index.md
+++ b/skills/carbon-react/index.md
@@ -8,7 +8,7 @@
 - [ActionPopoverDivider](components/action-popover-divider.md)
 - [ActionPopoverItem](components/action-popover-item.md)
 - [ActionPopoverMenu](components/action-popover-menu.md)
-- [ActionPopoverMenuButton](components/action-popover-menu-button.md)
+- [ActionPopoverMenuButton](components/action-popover-menu-button.md) (deprecated)
 - [AdaptiveSidebar](components/adaptive-sidebar.md)
 - [AdvancedColorPicker](components/advanced-color-picker.md)
 - [Alert](components/alert.md) (deprecated)

--- a/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
+++ b/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
@@ -324,6 +324,7 @@ export const ActionPopoverItem = ({
         {submenu && checkRef(ref) && (
           <SubMenuItemIcon
             aria-hidden
+            data-testid="chevron-icon"
             data-element="action-popover-menu-item-chevron"
             data-role="chevron-icon"
             type={

--- a/src/components/action-popover/action-popover-menu-button/action-popover-menu-button.component.tsx
+++ b/src/components/action-popover/action-popover-menu-button/action-popover-menu-button.component.tsx
@@ -18,6 +18,9 @@ export type ActionPopoverMenuButtonAria = {
   "aria-expanded": string;
 };
 
+/**
+ * @deprecated Use ActionPopover's renderButton prop with Button or another custom trigger instead.
+ */
 export interface ActionPopoverMenuButtonProps {
   /** ARIA attributes to be applied to the button HTML element */
   ariaAttributes: ActionPopoverMenuButtonAria;
@@ -37,6 +40,9 @@ export interface ActionPopoverMenuButtonProps {
   tabIndex: number;
 }
 
+/**
+ * @deprecated Use ActionPopover's renderButton prop with Button or another custom trigger instead.
+ */
 export const ActionPopoverMenuButton = ({
   buttonType,
   iconType,

--- a/src/components/action-popover/action-popover-menu-button/action-popover-menu-button.stories.tsx
+++ b/src/components/action-popover/action-popover-menu-button/action-popover-menu-button.stories.tsx
@@ -4,6 +4,7 @@ import ActionPopoverMenuButton from "./action-popover-menu-button.component";
 /**
  * This file is used primarily as a means to generate the props table.
  * It contains the tag: ["!dev"] so that it is not included in the sidebar.
+ * @deprecated Use ActionPopover's renderButton prop with Button or another custom trigger instead.
  */
 
 const meta: Meta<typeof ActionPopoverMenuButton> = {

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -12,11 +12,7 @@ import { MarginProps } from "styled-system";
 import invariant from "invariant";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
-import {
-  MenuButton,
-  ButtonIcon,
-  StyledButtonIcon,
-} from "./action-popover.style";
+import { MenuButton } from "./action-popover.style";
 import Events from "../../__internal__/utils/helpers/events";
 import Popover from "../../__internal__/popover";
 import createGuid from "../../__internal__/utils/helpers/guid";
@@ -37,6 +33,7 @@ import {
   checkChildrenForString,
 } from "./__internal__/action-popover.utils";
 import FlatTableContext from "../flat-table/__internal__/flat-table.context";
+import ActionPopoverMenuButton from "./action-popover-menu-button/action-popover-menu-button.component";
 
 export interface RenderButtonProps {
   tabIndex: number;
@@ -54,9 +51,15 @@ export interface RenderButtonProps {
 export interface ActionPopoverProps extends MarginProps, TagProps {
   /** Children for popover component */
   children?: React.ReactNode;
-  /** Horizontal alignment of menu items content */
+  /**
+   * @deprecated This prop will be removed in the next major version.
+   * Menu content alignment will be managed automatically.
+   */
   horizontalAlignment?: Alignment;
-  /** Sets submenu position */
+  /**
+   * @deprecated This prop will be removed in the next major version.
+   * Submenus now open to the right by default and flip automatically when needed.
+   */
   submenuPosition?: Alignment;
   /** Unique ID */
   id?: string;
@@ -64,7 +67,10 @@ export interface ActionPopoverProps extends MarginProps, TagProps {
   onOpen?: () => void;
   /** Callback to be called on menu close */
   onClose?: () => void;
-  /** Set whether the menu should open above or below the button */
+  /**
+   * @deprecated This prop will be removed in the next major version.
+   * The menu now uses automatic placement with viewport-aware flipping.
+   */
   placement?: "bottom" | "top";
   /** Render a custom menu button to override default ellipsis icon */
   renderButton?: (buttonProps: RenderButtonProps) => React.ReactNode;
@@ -99,7 +105,7 @@ export const ActionPopover = forwardRef<
       renderButton,
       placement = "bottom",
       horizontalAlignment = "left",
-      submenuPosition = "left",
+      submenuPosition = "right",
       "aria-label": ariaLabel,
       "aria-labelledby": ariaLabelledBy,
       "aria-describedby": ariaDescribedBy,
@@ -283,13 +289,17 @@ export const ActionPopover = forwardRef<
     }, [setOpen]);
 
     const menuButton = (menuID: string) => {
+      const defaultAriaLabel =
+        ariaLabel ||
+        (!ariaLabelledBy ? l.actionPopover.ariaLabel() : undefined);
+
       if (renderButton) {
         const renderButtonComponent = renderButton({
           tabIndex: isOpen ? -1 : 0,
           "data-element": "action-popover-button",
           ariaAttributes: {
             "aria-haspopup": "true",
-            "aria-label": ariaLabel || l.actionPopover.ariaLabel(),
+            "aria-label": defaultAriaLabel,
             "aria-labelledby": ariaLabelledBy,
             "aria-describedby": ariaDescribedBy,
             "aria-controls": menuID,
@@ -304,9 +314,7 @@ export const ActionPopover = forwardRef<
           "data-element": "action-popover-button",
           ariaAttributes: {
             "aria-haspopup": "true",
-            "aria-label": buttonHasString
-              ? undefined
-              : ariaLabel || l.actionPopover.ariaLabel(),
+            "aria-label": buttonHasString ? undefined : defaultAriaLabel,
             "aria-labelledby": ariaLabelledBy,
             "aria-describedby": ariaDescribedBy,
             "aria-controls": menuID,
@@ -316,19 +324,25 @@ export const ActionPopover = forwardRef<
       }
 
       return (
-        <StyledButtonIcon
-          role="button"
-          aria-haspopup="true"
-          aria-label={ariaLabel || l.actionPopover.ariaLabel()}
-          aria-labelledby={ariaLabelledBy}
-          aria-describedby={ariaDescribedBy}
-          aria-controls={menuID}
-          aria-expanded={isOpen}
+        <ActionPopoverMenuButton
+          buttonType="secondary"
+          size="small"
+          iconType="ellipsis_vertical"
+          iconPosition="after"
           tabIndex={isOpen ? -1 : 0}
           data-element="action-popover-button"
+          data-role="action-popover-default-button"
+          ariaAttributes={{
+            "aria-haspopup": "true",
+            "aria-label": defaultAriaLabel,
+            "aria-labelledby": ariaLabelledBy,
+            "aria-describedby": ariaDescribedBy,
+            "aria-controls": menuID,
+            "aria-expanded": `${isOpen}`,
+          }}
         >
-          <ButtonIcon type="ellipsis_vertical" />
-        </StyledButtonIcon>
+          Action
+        </ActionPopoverMenuButton>
       );
     };
 

--- a/src/components/action-popover/action-popover.mdx
+++ b/src/components/action-popover/action-popover.mdx
@@ -1,7 +1,6 @@
 import { Meta, ArgTypes, Canvas } from "@storybook/addon-docs/blocks";
 import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 
-import * as ActionPopoverMenuButtonStories from "./action-popover-menu-button/action-popover-menu-button.stories";
 import * as ActionPopoverItemStories from "./action-popover-item/action-popover-item.stories";
 import * as ActionPopoverMenuStories from "./action-popover-menu/action-popover-menu.stories";
 import * as ActionPopoverStories from "./action-popover.stories";
@@ -20,7 +19,7 @@ import * as ActionPopoverStories from "./action-popover.stories";
 </a>
 
 ActionPopovers present a handy list of actions the user can perform on a whole table, a specific row within a table, or a tile.
-Click the ellipsis icon to show actions the user can take on a specific table row, for example, emailing the invoice.
+Click the Action button to show actions the user can take on a specific table row, for example, emailing the invoice.
 
 ## Contents
 
@@ -42,7 +41,6 @@ import {
   ActionPopoverDivider,
   ActionPopoverItem,
   ActionPopoverMenu,
-  ActionPopoverMenuButton,
   type ActionPopoverHandle,
 } from "carbon-react/lib/components/action-popover";
 ```
@@ -79,7 +77,7 @@ It is possible to align the Menu to the right of the MenuButton by passing the &
 
 <Canvas of={ActionPopoverStories.MenuRightAligned} />
 
-### With item content aligned to right
+### With item content aligned to right (deprecated)
 
 <Canvas of={ActionPopoverStories.ContentAlignedRight} />
 
@@ -95,7 +93,7 @@ It is possible to use the `renderButton` prop to override the default button use
 ActionPopoverMenu.
 
 The `renderButton` prop is a function that allows consumers to pass `tabIndex`, `data-element` and the provided aria attribute props to 
-`ActionPopoverMenuButton` or a custom button component.
+a custom button component.
 
 A default `aria-label` will be provided to the button, but this can be overridden by passing the `ariaLabel` prop to the 
 `ActionPopover` or making use of the `actionPopover.ariaLabel` translation key. Please ensure to set this to `undefined` if your 
@@ -108,7 +106,7 @@ See the example below for an example of how to use the `renderButton` prop:
 ### With submenu
 
 A menu item can be passed a sub-menu to add further sub-actions if needed. items with sub-menus will display an chevron
-icons pointing in the direction that the sub-menu will open; by default it will open to the left.
+icons pointing in the direction that the sub-menu will open; by default it will open to the right.
 
 Hovering the mouse cursor over an item will open the sub-menu if it has one and moving the mouse cursor away will
 close it. No action is dispatched on click of the item and the sub-menu is opened by mouse enter and closed on mouse
@@ -117,8 +115,7 @@ leave.
 <Canvas of={ActionPopoverStories.Submenu} />
 
 ### With submenu positioned to right
-
-Submenu can be positioned on either the left of the right with the use of the `submenuPosition` prop.
+Submenus render to the right by default and flip automatically if there is not enough room.
 
 <Canvas of={ActionPopoverStories.SubmenuPositionedRight} />
 
@@ -129,8 +126,7 @@ A sub-menu will not open if the item is in a disabled state.
 <Canvas of={ActionPopoverStories.DisabledSubmenu} />
 
 ### With menu opening above
-
-The menu can also be rendered above the button control by setting using `placement="top"`.
+Menu placement is now handled automatically and flips when there is not enough room.
 
 <Canvas of={ActionPopoverStories.MenuOpeningAbove} />
 
@@ -210,9 +206,6 @@ by passing a `ref` to the component.
 <ArgTypes of={ActionPopoverMenuStories} />
 
 ### ActionPopoverMenuButton Props
-
-<ArgTypes of={ActionPopoverMenuButtonStories} />
-
 ### ActionPopoverItem Props
 
 <ArgTypes of={ActionPopoverItemStories} />

--- a/src/components/action-popover/action-popover.style.ts
+++ b/src/components/action-popover/action-popover.style.ts
@@ -158,6 +158,29 @@ const MenuButton = styled.div.attrs(applyBaseTheme)`
   && ${StyledIcon} {
     cursor: pointer;
   }
+
+  && ${StyledButton}[data-role="action-popover-default-button"] {
+    border-color: var(--colorsUtilityYin050);
+    color: var(--colorsUtilityYin090);
+
+    ${StyledIcon},
+    span[color] {
+      color: var(--colorsUtilityYin090);
+    }
+
+    &:hover,
+    &:focus {
+      border-color: var(--colorsUtilityYin060);
+      background-color: var(--colorsUtilityYang100);
+      color: var(--colorsUtilityYin090);
+
+      ${StyledIcon},
+      span[color] {
+        color: var(--colorsUtilityYin090);
+      }
+    }
+  }
+
   width: fit-content;
   margin: auto;
   ${margin}

--- a/src/components/action-popover/action-popover.test.tsx
+++ b/src/components/action-popover/action-popover.test.tsx
@@ -113,17 +113,14 @@ describe("if download prop and href prop are provided", () => {
   });
 });
 
-test("displays the vertical ellipsis icon as the menu button", () => {
+test("displays a text button as the default menu trigger", () => {
   render(
     <ActionPopover>
       <ActionPopoverItem>example item</ActionPopoverItem>
     </ActionPopover>,
   );
-  expect(screen.getByTestId("icon")).toHaveStyleRule(
-    "content",
-    `"${iconUnicodes.ellipsis_vertical}"`,
-    { modifier: "&::before" },
-  );
+
+  expect(screen.getByRole("button")).toHaveTextContent("Action");
 });
 
 test("has proper data attributes applied to elements", async () => {
@@ -1076,8 +1073,8 @@ test("should call the exposed `focusButton` method and focus the toggle button",
   expect(screen.getByRole("button", { name: "actions" })).toHaveFocus();
 });
 
-describe("when an item has a submenu with default (left) alignment", () => {
-  it("renders a chevron icon that points left", async () => {
+describe("when an item has a submenu with default (right) alignment", () => {
+  it("renders a chevron icon that points right", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     render(
@@ -1102,7 +1099,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     const chevronIcon = screen.getByTestId("chevron-icon");
     expect(chevronIcon).toHaveStyleRule(
       "content",
-      `"${iconUnicodes.chevron_left_thick}"`,
+      `"${iconUnicodes.chevron_right_thick}"`,
       { modifier: "&::before" },
     );
   });
@@ -1281,7 +1278,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     clearTimeoutSpy.mockRestore();
   });
 
-  it("opens the submenu and focuses the first item when the left arrow key is pressed", async () => {
+  it("opens the submenu and focuses the first item when the right arrow key is pressed", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     render(
@@ -1305,7 +1302,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     jest.runOnlyPendingTimers();
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
-    await user.keyboard("{ArrowLeft}");
+    await user.keyboard("{ArrowRight}");
     jest.runOnlyPendingTimers();
 
     const firstItem = screen.getByRole("button", { name: "submenu item 1" });
@@ -1313,7 +1310,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     expect(firstItem).toHaveFocus();
   });
 
-  it("closes the submenu and returns focus to the parent item when the right arrow key is pressed", async () => {
+  it("closes the submenu and returns focus to the parent item when the left arrow key is pressed", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     render(
@@ -1340,13 +1337,13 @@ describe("when an item has a submenu with default (left) alignment", () => {
     });
 
     parentItem.focus();
-    await user.keyboard("{ArrowLeft}");
+    await user.keyboard("{ArrowRight}");
 
     expect(
       screen.getByRole("button", { name: "submenu item 1" }),
     ).toBeVisible();
 
-    await user.keyboard("{ArrowRight}");
+    await user.keyboard("{ArrowLeft}");
 
     expect(
       screen.queryByRole("button", { name: "submenu item 1" }),
@@ -1378,7 +1375,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     jest.runOnlyPendingTimers();
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
-    await user.keyboard("{ArrowLeft}");
+    await user.keyboard("{ArrowRight}");
     jest.runOnlyPendingTimers();
 
     expect(
@@ -1484,7 +1481,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
 
-    await user.keyboard("{ArrowLeft}");
+    await user.keyboard("{ArrowRight}");
     jest.runOnlyPendingTimers();
 
     expect(
@@ -1563,7 +1560,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("does not open the submenu when the left arrow key is pressed if the item is disabled", async () => {
+  it("does not open the submenu when the right arrow key is pressed if the item is disabled", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     render(
@@ -1587,7 +1584,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     await user.click(screen.getByRole("button"));
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
-    await user.keyboard("{ArrowLeft}");
+    await user.keyboard("{ArrowRight}");
 
     expect(
       screen.queryByRole("button", { name: "submenu item 1" }),
@@ -1648,15 +1645,85 @@ describe("when an item has a submenu with default (left) alignment", () => {
     await user.click(screen.getByRole("button"));
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
-    await user.keyboard("{ArrowLeft}");
+    await user.keyboard("{Enter}");
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
 
-    await user.click(screen.getByRole("button", { name: "submenu item 1" }));
+    const disabledSubmenuItem = await screen.findByRole("button", {
+      name: "submenu item 1",
+    });
+
+    await user.click(disabledSubmenuItem);
+    expect(disabledSubmenuItem).toBeVisible();
     expect(
       screen.getByRole("button", { name: "submenu item 1" }),
     ).toBeVisible();
+    expect(disabledSubmenuItem).toHaveFocus();
+  });
+});
+
+describe("when the submenuPosition prop is set to 'left' and there is enough space on the screen", () => {
+  it("renders a chevron icon that points left", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <ActionPopover submenuPosition="left">
+        <ActionPopoverItem>example item 1</ActionPopoverItem>
+        <ActionPopoverItem>example item 2</ActionPopoverItem>
+        <ActionPopoverItem
+          submenu={
+            <ActionPopoverMenu>
+              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
+              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
+            </ActionPopoverMenu>
+          }
+        >
+          example item with submenu
+        </ActionPopoverItem>
+      </ActionPopover>,
+    );
+
+    await user.click(screen.getByRole("button"));
+
+    const chevronIcon = screen.getByTestId("chevron-icon");
+    expect(chevronIcon).toHaveStyleRule(
+      "content",
+      `"${iconUnicodes.chevron_left_thick}"`,
+      { modifier: "&::before" },
+    );
+  });
+
+  it("does not open or close the submenu when a non-navigation key is pressed on a left-aligned item", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <ActionPopover submenuPosition="left">
+        <ActionPopoverItem>example item 1</ActionPopoverItem>
+        <ActionPopoverItem>example item 2</ActionPopoverItem>
+        <ActionPopoverItem
+          submenu={
+            <ActionPopoverMenu>
+              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
+              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
+            </ActionPopoverMenu>
+          }
+        >
+          example item with submenu
+        </ActionPopoverItem>
+      </ActionPopover>,
+    );
+
+    await user.click(screen.getByRole("button"));
+    jest.runOnlyPendingTimers();
+
+    screen.getByRole("button", { name: "example item with submenu" }).focus();
+    await user.keyboard("{ArrowDown}");
+    jest.runOnlyPendingTimers();
+
     expect(
-      screen.getByRole("button", { name: "submenu item 1" }),
-    ).toHaveFocus();
+      screen.queryByRole("button", { name: "submenu item 1" }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/src/components/action-popover/index.ts
+++ b/src/components/action-popover/index.ts
@@ -4,7 +4,9 @@ export { default as ActionPopoverMenu } from "./action-popover-menu/action-popov
 export type { ActionPopoverMenuProps } from "./action-popover-menu/action-popover-menu.component";
 export { default as ActionPopoverItem } from "./action-popover-item/action-popover-item.component";
 export type { ActionPopoverItemProps } from "./action-popover-item/action-popover-item.component";
+/** @deprecated Use ActionPopover's renderButton prop with Button or another custom trigger instead. */
 export { default as ActionPopoverMenuButton } from "./action-popover-menu-button/action-popover-menu-button.component";
+/** @deprecated Use ActionPopover's renderButton prop with Button or another custom trigger instead. */
 export type { ActionPopoverMenuButtonProps } from "./action-popover-menu-button/action-popover-menu-button.component";
 export { default as ActionPopoverDivider } from "./action-popover-divider/action-popover-divider.component";
 export type { RenderButtonProps } from "./action-popover.component";

--- a/src/components/flat-table/flat-table.pw.tsx
+++ b/src/components/flat-table/flat-table.pw.tsx
@@ -1228,8 +1228,11 @@ test.describe("Scrollable tests", () => {
   }) => {
     await mount(<FlatTableStickyFooterActionPopoverComponent />);
 
-    const actionPopover = page.getByRole("button", { name: "actions" });
+    const actionPopover = page
+      .getByRole("button", { name: /actions/i })
+      .first();
 
+    await expect(actionPopover).toBeVisible();
     await actionPopover.click();
     const buttonList = page.getByRole("list");
     await buttonList.waitFor();

--- a/src/components/note/note.test.tsx
+++ b/src/components/note/note.test.tsx
@@ -144,10 +144,14 @@ test("should render with `ActionPopover` when passed via the `inlineControl` pro
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "actions" }));
+  const trigger =
+    screen.queryByRole("button", { name: /action/i }) ??
+    screen.getByRole("button");
 
-  expect(screen.getByRole("button", { name: "Copy" })).toBeVisible();
-  expect(screen.getByRole("button", { name: "Edit" })).toBeVisible();
+  await user.click(trigger);
+
+  expect(await screen.findByRole("button", { name: "Copy" })).toBeVisible();
+  expect(await screen.findByRole("button", { name: "Edit" })).toBeVisible();
 });
 
 test("should throw when `inlineControls` is not an instance of `ActionPopover`", () => {


### PR DESCRIPTION
### Proposed behaviour

The default trigger should be a subtle button with visible text, like Action. Placement and submenu direction should flip automatically when there is not enough space. The placement, horizontalAlignment, and submenuPosition props should be deprecated, and ActionPopoverMenuButton should also be deprecated in favor of renderButton with Button.

### Current behaviour

The ActionPopover uses the old default trigger style and still relies on legacy API patterns in docs and usage. You can set placement, horizontalAlignment, and submenuPosition directly, and ActionPopoverMenuButton is still treated as a normal subcomponent.
<img width="1043" height="427" alt="image" src="https://github.com/user-attachments/assets/041e9ee6-5025-4b95-a0ca-6ac34c71868d" />
<img width="1063" height="454" alt="image" src="https://github.com/user-attachments/assets/c3c3ee91-bf3a-487f-a2a6-068c68e6e48b" />


### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
