### PR TITLE
fix(multi-select, simple-select): ensure correct prefix usage

### DIFF
--- a/src/__internal__/input/input-style-overrides.style.ts
+++ b/src/__internal__/input/input-style-overrides.style.ts
@@ -279,6 +279,11 @@ const mulitiSelectInputStyles = ($size?: string) => css`
         padding: var(--global-space-none) 48px var(--global-space-none)
           var(--global-space-comp-l);
       `}
+
+      span[data-element="textbox-prefix"] {
+        margin-left: var(--global-space-comp-none);
+        margin-right: var(--global-space-comp-m);
+      }
     }
   }
 `;
@@ -291,6 +296,11 @@ const simpleSelectStyles = css`
 
     input {
       cursor: pointer;
+    }
+
+    [data-element="textbox-prefix"] {
+      margin-left: var(--global-space-comp-none);
+      margin-right: var(--global-space-comp-m);
     }
   }
 `;

--- a/src/__internal__/input/input.component.tsx
+++ b/src/__internal__/input/input.component.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useContext } from "react";
 import InputContainer from "./input.style";
 import combineRefs from "../utils/helpers/combine-refs";
+import SelectTextboxContext from "../../components/select/__internal__/select-textbox/__internal__/select-textbox.context";
 
 export interface InputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "value" | "size"> {
@@ -102,6 +103,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ) => {
     const localRef = useRef<HTMLInputElement>(null);
     const combinedRef = combineRefs(ref, localRef);
+    const { selectType } = useContext(SelectTextboxContext);
 
     useEffect(() => {
       if (autoFocus) {
@@ -117,6 +119,12 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         }
       },
       [onFocus, type],
+    );
+
+    const prefixElement = (
+      <span id={prefixId} data-element="textbox-prefix">
+        {prefix}
+      </span>
     );
 
     return (
@@ -135,12 +143,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           role="presentation"
           className={`input-text-container ${disabled ? "disabled" : ""} ${readOnly ? "read-only" : ""}`}
         >
+          {prefix && selectType === "multi" && prefixElement}
           {leftChildren}
-          {prefix && (
-            <span id={prefixId} data-element="textbox-prefix">
-              {prefix}
-            </span>
-          )}
+          {prefix && selectType !== "multi" && prefixElement}
           <input
             ref={combinedRef}
             data-element="input"

--- a/src/__internal__/input/input.test.tsx
+++ b/src/__internal__/input/input.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import Input from ".";
 import InputIconToggle from "../input-icon-toggle";
+import SelectTextboxContext from "../../components/select/__internal__/select-textbox/__internal__/select-textbox.context";
 
 test("should render text input element with `type` of 'text' by default", () => {
   render(<Input value="" onChange={() => {}} />);
@@ -239,3 +240,24 @@ test("should render with prefix when `prefix` prop is provided", () => {
   const prefix = screen.getByText("$");
   expect(prefix).toBeVisible();
 });
+
+test.each(["multi", "filterable"] as const)(
+  "should include prefix in accessible description when select type is %s",
+  (selectType) => {
+    render(
+      <SelectTextboxContext.Provider
+        value={{ selectType, prefixId: "currency-prefix" }}
+      >
+        <Input
+          aria-describedby="currency-prefix"
+          prefix="$"
+          prefixId="currency-prefix"
+          value=""
+          onChange={() => {}}
+        />
+      </SelectTextboxContext.Provider>,
+    );
+
+    expect(screen.getByRole("textbox")).toHaveAccessibleDescription("$");
+  },
+);

--- a/src/components/select/__internal__/select-textbox/__internal__/select-textbox.context.ts
+++ b/src/components/select/__internal__/select-textbox/__internal__/select-textbox.context.ts
@@ -1,0 +1,8 @@
+import React from "react";
+
+interface SelectTextboxContextType {
+  prefixId?: string;
+  selectType?: "simple" | "filterable" | "multi";
+}
+
+export default React.createContext<SelectTextboxContextType>({});

--- a/src/components/select/__internal__/select-textbox/select-textbox.component.tsx
+++ b/src/components/select/__internal__/select-textbox/select-textbox.component.tsx
@@ -9,6 +9,8 @@ import Textbox, { CommonTextboxProps } from "../../../textbox";
 import useLocale from "../../../../hooks/__internal__/useLocale";
 import { ValidationProps } from "../../../../__internal__/validations";
 import combineRefs from "../../../../__internal__/utils/helpers/combine-refs";
+import SelectTextboxContext from "./__internal__/select-textbox.context";
+import guid from "../../../../__internal__/utils/helpers/guid";
 
 export interface FormInputPropTypes
   extends ValidationProps,
@@ -125,6 +127,7 @@ const SelectTextbox = React.forwardRef(
       activeDescendantId,
       onKeyDown,
       onChange,
+      prefix,
       ...restProps
     }: SelectTextboxProps,
     ref: React.ForwardedRef<HTMLInputElement>,
@@ -204,58 +207,77 @@ const SelectTextbox = React.forwardRef(
       .filter(Boolean)
       .join(" ");
 
+    const internalPrefixId = useRef(guid());
+    const contextPrefixId =
+      selectType === "simple" && prefix ? internalPrefixId.current : undefined;
+
     return (
-      <Textbox
-        aria-describedby={ariaDescribedBy}
-        aria-label={ariaLabel}
-        data-element={`${selectType ?? ""}-select-input`}
-        data-role="select-textbox"
-        inputIcon="dropdown"
-        autoComplete="off"
-        size={size}
-        formattedValue={formattedValue}
-        placeholder={shouldRenderInput ? placeholder : undefined}
-        {...inputAriaAttributes}
-        {...textboxProps}
-        className={classNames}
-        data-is-transparent={transparent}
-        data-is-open={isOpen}
-        // prevent uncontrolled warning being fired
-        onChange={onChange}
-        // ensure value is properly controlled
-        value={
-          hasStringValue ? (selectedValue as string | string[]) : undefined
-        }
-        // prevents any form spacing being applied
-        my={0}
-        leftChildren={
-          !shouldRenderInput ? (
-            <StyledSelectText
-              aria-hidden
-              aria-disabled={disabled || undefined}
-              data-element="select-text"
-              data-role="select-text"
-              $disabled={disabled}
-              $hasPlaceholder={showPlaceholder}
-              onClick={handleTextboxClick}
-              $readOnly={readOnly}
-              $size={size}
-              $transparent={transparent}
-              className={`select-text ${disabled ? "disabled" : ""} ${readOnly ? "read-only" : ""}`}
-              {...filteredRestProps}
-            >
-              <StyledSelectTextChildrenWrapper
-                $isDisabled={disabled}
+      <SelectTextboxContext.Provider
+        value={{ prefixId: contextPrefixId, selectType }}
+      >
+        <Textbox
+          aria-describedby={ariaDescribedBy}
+          aria-label={ariaLabel}
+          data-element={`${selectType ?? ""}-select-input`}
+          data-role="select-textbox"
+          inputIcon="dropdown"
+          autoComplete="off"
+          size={size}
+          formattedValue={formattedValue}
+          placeholder={shouldRenderInput ? placeholder : undefined}
+          {...inputAriaAttributes}
+          {...textboxProps}
+          className={classNames}
+          data-is-transparent={transparent}
+          data-is-open={isOpen}
+          // prevent uncontrolled warning being fired
+          onChange={onChange}
+          // ensure value is properly controlled
+          value={
+            hasStringValue ? (selectedValue as string | string[]) : undefined
+          }
+          // prevents any form spacing being applied
+          my={0}
+          {...(selectType !== "simple" && {
+            prefix,
+          })}
+          leftChildren={
+            !shouldRenderInput ? (
+              <StyledSelectText
+                aria-hidden
+                aria-disabled={disabled || undefined}
+                data-element="select-text"
+                data-role="select-text"
+                $disabled={disabled}
+                $hasPlaceholder={showPlaceholder}
+                onClick={handleTextboxClick}
                 $readOnly={readOnly}
+                $size={size}
+                $transparent={transparent}
+                className={`select-text ${disabled ? "disabled" : ""} ${readOnly ? "read-only" : ""}`}
+                {...filteredRestProps}
               >
-                {showPlaceholder ? placeholder : formattedValue}
-              </StyledSelectTextChildrenWrapper>
-            </StyledSelectText>
-          ) : (
-            leftChildren
-          )
-        }
-      />
+                {prefix && (
+                  <span
+                    id={internalPrefixId.current}
+                    data-element="textbox-prefix"
+                  >
+                    {prefix}
+                  </span>
+                )}
+                <StyledSelectTextChildrenWrapper
+                  $isDisabled={disabled}
+                  $readOnly={readOnly}
+                >
+                  {showPlaceholder ? placeholder : formattedValue}
+                </StyledSelectTextChildrenWrapper>
+              </StyledSelectText>
+            ) : (
+              leftChildren
+            )
+          }
+        />
+      </SelectTextboxContext.Provider>
     );
   },
 );

--- a/src/components/select/__internal__/select-textbox/select-textbox.style.ts
+++ b/src/components/select/__internal__/select-textbox/select-textbox.style.ts
@@ -31,11 +31,13 @@ const StyledSelectText = styled.span<StyledSelectTextProps>`
 
     ${$hasPlaceholder &&
     css`
-      color: ${$transparent
-        ? `var(--colorsUtilityYin100)`
-        : `var(--colorsUtilityYin055)`};
-      font-weight: ${$transparent ? 500 : "normal"};
-      user-select: none;
+      & > *:not([data-element="textbox-prefix"]) {
+        color: ${$transparent
+          ? `var(--colorsUtilityYin100)`
+          : `var(--colorsUtilityYin055)`};
+        font-weight: ${$transparent ? 500 : "normal"};
+        user-select: none;
+      }
     `}
 
     ${$disabled &&

--- a/src/components/select/__internal__/select-textbox/select-textbox.test.tsx
+++ b/src/components/select/__internal__/select-textbox/select-textbox.test.tsx
@@ -175,6 +175,20 @@ test("does not call onFocus callback when textbox is read only", () => {
 });
 
 describe("when selectType is 'simple'", () => {
+  it("includes the prefix in the combobox accessible description", () => {
+    render(
+      <ControlledSelectTextbox
+        selectType="simple"
+        label="Select Colour"
+        prefix="prefix"
+      />,
+    );
+
+    expect(
+      screen.getByRole("combobox", { name: /Select Colour/i }),
+    ).toHaveAccessibleDescription("prefix");
+  });
+
   it("applies correct styles when transparent", () => {
     render(
       <ControlledSelectTextbox

--- a/src/components/select/multi-select/multi-select-interaction.stories.tsx
+++ b/src/components/select/multi-select/multi-select-interaction.stories.tsx
@@ -103,6 +103,41 @@ export const HighlightedItem: Story = {
 };
 HighlightedItem.storyName = "Highlighted Item";
 
+export const Prefix: Story = {
+  render: () => (
+    <Box height={250}>
+      <ControlledMultiSelect
+        name="multi-prefix"
+        id="multi-prefix"
+        label="Multi Select"
+        prefix="prefix"
+        value={["2"]}
+      />
+    </Box>
+  ),
+  play: async ({ canvasElement }) => {
+    if (!allowInteractions()) {
+      return;
+    }
+
+    const canvas = within(canvasElement);
+    const select = canvas.getByRole("combobox", { name: /Multi Select/ });
+    await userEvent.click(select, { delay: 100 });
+
+    await expect(
+      within(document.body).getByRole("option", { name: "Amber" }),
+    ).toBeVisible();
+  },
+  decorators: [
+    (StoryToRender) => (
+      <DefaultDecorator>
+        <StoryToRender />
+      </DefaultDecorator>
+    ),
+  ],
+};
+Prefix.storyName = "Prefix";
+
 export const MultiColumnList: Story = {
   render: () => (
     <Box height={250}>

--- a/src/components/select/simple-select/simple-select-interaction.stories.tsx
+++ b/src/components/select/simple-select/simple-select-interaction.stories.tsx
@@ -162,6 +162,44 @@ export const HighlightedItem: Story = {
 
 HighlightedItem.storyName = "Highlighted Item";
 
+export const Prefix: Story = {
+  render: () => (
+    <Box height={250}>
+      <InteractiveComponent
+        onChange={() => {}}
+        name="simple-prefix"
+        id="simple-prefix"
+        label="Color"
+        prefix="prefix"
+      >
+        <Option text="Amber" value="1" />
+        <Option text="Black" value="2" />
+        <Option text="Blue" value="3" />
+      </InteractiveComponent>
+    </Box>
+  ),
+  play: async ({ canvasElement }) => {
+    if (!allowInteractions()) {
+      return;
+    }
+    const canvas = within(canvasElement);
+    const select = canvas.getByRole("combobox", { name: "Color" });
+    await userEvent.click(select, { delay: 100 });
+
+    await expect(
+      within(document.body).getByRole("option", { name: "Amber" }),
+    ).toBeVisible();
+  },
+  decorators: [
+    (StoryToRender) => (
+      <DefaultDecorator>
+        <StoryToRender />
+      </DefaultDecorator>
+    ),
+  ],
+};
+Prefix.storyName = "Prefix";
+
 /* Also demonstrates that falsy children are filtered out correctly */
 export const SelectedItemHover: Story = {
   render: () => (

--- a/src/components/textbox/__internal__/__next__/text-input.component.tsx
+++ b/src/components/textbox/__internal__/__next__/text-input.component.tsx
@@ -25,6 +25,7 @@ import useRegisterValidationToTabs from "../../../../hooks/__internal__/useRegis
 import combineRefs from "../../../../__internal__/utils/helpers/combine-refs";
 import FieldsetValidationContext from "../../../../__internal__/fieldset-validation-context";
 import FieldsetContext from "../../../fieldset/__internal__/fieldset.context";
+import selectTextboxContext from "../../../select/__internal__/select-textbox/__internal__/select-textbox.context";
 
 export interface TextInputProps
   extends Omit<ValidationProps, "info">,
@@ -172,7 +173,10 @@ export const TextInput = React.forwardRef(
     });
     const hintId = useRef(guid());
     const inputHintId = inputHint ? hintId.current : undefined;
-    const inputPrefixId = prefix ? `${uniqueId}-prefix` : undefined;
+    const { prefixId: contextPrefixId } = useContext(selectTextboxContext);
+    // If SelectTextbox provides a prefix id (from simple select currently), use that, otherwise generate one when a prefix is rendered by the input.
+    const inputPrefixId =
+      contextPrefixId || (prefix ? `${uniqueId}-prefix` : undefined);
 
     const {
       size: fieldsetSize,


### PR DESCRIPTION
fix #8060 

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

**Multi select with selected value**

<img width="244" height="206" alt="Screenshot 2026-07-15 at 16 13 01" src="https://github.com/user-attachments/assets/712b6c05-1c05-46ec-b5b7-2701d370ce1d" />

**Multi select with no selected value**

<img width="260" height="188" alt="Screenshot 2026-07-15 at 16 13 06" src="https://github.com/user-attachments/assets/a47d4100-5f6b-45e6-aacb-f2fb8440711f" />

**Simple select with selected value**

<img width="193" height="127" alt="Screenshot 2026-07-15 at 16 13 19" src="https://github.com/user-attachments/assets/e8981280-f529-4dab-a2f5-8a2ec452ac4c" />


**Simple select with no selected value**

<img width="263" height="233" alt="Screenshot 2026-07-15 at 16 13 15" src="https://github.com/user-attachments/assets/3b55c14d-560a-4e1c-8e9f-bb8eb7f6094a" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

**Multi select with selected value**

<img width="268" height="213" alt="Screenshot 2026-07-15 at 16 10 50" src="https://github.com/user-attachments/assets/0bbda4b1-10f4-4548-9c1b-f79c02e35fc7" />

**Multi select with no selected value**

<img width="247" height="231" alt="Screenshot 2026-07-15 at 16 10 56" src="https://github.com/user-attachments/assets/001b32d8-339e-4c2b-9ade-43eb79f54e13" />

**Simple select with selected value**

<img width="230" height="197" alt="Screenshot 2026-07-15 at 16 11 21" src="https://github.com/user-attachments/assets/d0ca1107-3846-4deb-b8fe-2e0ab5216c68" />

**Simple select with no selected value**

<img width="199" height="235" alt="Screenshot 2026-07-15 at 16 11 27" src="https://github.com/user-attachments/assets/3fc2a3a7-29a1-4a3f-b530-debcc709b2ee" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Check out the new added interactions stories for `SimpleSelect` and `MultiSelect`, both are just called `"Prefix"`
