### PR TITLE
fix(loader): use inverse outer-arc token

### DIFF
--- a/skills/carbon-react/components/loader-next.md
+++ b/skills/carbon-react/components/loader-next.md
@@ -17,7 +17,7 @@ description: Carbon LoaderNext component props and usage examples.
 | --- | --- | --- | --- | --- | --- |
 | animationTime | number \| undefined | No |  | Specify a custom animation time for the loader |  |
 | hasMotion | boolean \| undefined | No |  | If set to `false` all motion will be suspended | true |
-| inverse | boolean \| undefined | No |  | Toggle the inverse color scheme | false |
+| inverse | boolean \| undefined | No |  | Toggle the inverse color scheme |  |
 | isError | boolean \| undefined | No |  | Enable the error state for the ring loader when it is tracked | false |
 | isSuccess | boolean \| undefined | No |  | Enable the success state for the ring loader when it is tracked | false |
 | isTracked | boolean \| undefined | No |  | If set to `true` the animation type will become tracked, this is used specifically for when wait times are predictable | false |

--- a/src/components/button/__next__/button-test.stories.tsx
+++ b/src/components/button/__next__/button-test.stories.tsx
@@ -6,6 +6,7 @@ import Textbox from "../../textbox";
 import { action } from "storybook/actions";
 import Typography from "../../typography";
 import Icon from "../../icon";
+import { Loader } from "../../loader/__next__/loader.component";
 import DefaultDecorator from "../../../../.storybook/utils/default-decorator";
 
 const meta: Meta<typeof Button> = {
@@ -932,6 +933,49 @@ export const InverseVariants: Story = () => {
 InverseVariants.storyName = "Inverse Variants";
 InverseVariants.parameters = {
   chromatic: { disableSnapshot: true },
+};
+
+export const Loading: Story = () => {
+  return (
+    <Box display="flex" flexDirection="column" gap={2}>
+      <Button variantType="primary">
+        <Loader
+          variant="inline"
+          loaderType="ring"
+          size="extra-small"
+          hasMotion={false}
+        />
+      </Button>
+      <Button variantType="secondary">
+        <Loader
+          variant="inline"
+          loaderType="ring"
+          size="extra-small"
+          hasMotion={false}
+        />
+      </Button>
+      <Button variantType="tertiary">
+        <Loader
+          variant="inline"
+          loaderType="ring"
+          size="extra-small"
+          hasMotion={false}
+        />
+      </Button>
+      <Button variantType="subtle">
+        <Loader
+          variant="inline"
+          loaderType="ring"
+          size="extra-small"
+          hasMotion={false}
+        />
+      </Button>
+    </Box>
+  );
+};
+Loading.storyName = "Loading";
+Loading.parameters = {
+  chromatic: { disableSnapshot: false },
 };
 
 const FocusAndHoverStateButtons = () => (

--- a/src/components/button/__next__/button.component.tsx
+++ b/src/components/button/__next__/button.component.tsx
@@ -279,7 +279,12 @@ export const Button = forwardRef<ButtonRef, ButtonProps>(
         {...rest}
       >
         <StyledContentContainer data-role="button-child-container">
-          <ButtonContext.Provider value={{ isInsideButton: true }}>
+          <ButtonContext.Provider
+            value={{
+              isInsideButton: true,
+              isColouredSurface: computedVariantType === "primary",
+            }}
+          >
             {renderChildren()}
           </ButtonContext.Provider>
         </StyledContentContainer>

--- a/src/components/button/__next__/button.context.ts
+++ b/src/components/button/__next__/button.context.ts
@@ -2,6 +2,7 @@ import React from "react";
 
 export interface ButtonContextProps {
   isInsideButton?: boolean;
+  isColouredSurface?: boolean;
 }
 
 export default React.createContext<ButtonContextProps>({});

--- a/src/components/button/button.component.tsx
+++ b/src/components/button/button.component.tsx
@@ -333,7 +333,12 @@ const Button = React.forwardRef<
         {...(href && { href })}
         ref={setRefs}
       >
-        <ButtonContext.Provider value={{ isInsideButton: true }}>
+        <ButtonContext.Provider
+          value={{
+            isInsideButton: true,
+            isColouredSurface: buttonType === "primary",
+          }}
+        >
           {renderChildren({
             iconType,
             iconPosition,

--- a/src/components/loader/__next__/loader.component.tsx
+++ b/src/components/loader/__next__/loader.component.tsx
@@ -62,7 +62,7 @@ export const Loader = ({
   loaderType = "standalone",
   size,
   variant,
-  inverse = false,
+  inverse,
   isSuccess = false,
   isError = false,
   ...rest
@@ -73,7 +73,8 @@ export const Loader = ({
     "screen and (prefers-reduced-motion: no-preference)",
   );
 
-  const { isInsideButton } = useContext(ButtonContext);
+  const { isInsideButton, isColouredSurface } = useContext(ButtonContext);
+  const resolvedInverse = inverse ?? !!isColouredSurface;
   const loaderTypeValue = isInsideButton ? "ring" : loaderType;
 
   const loaderContent = (() => {
@@ -82,7 +83,7 @@ export const Loader = ({
         return StarsLoader({ loaderLabel, showLabel, loaderType });
       case "ring":
         return RingLoader({
-          inverse,
+          inverse: resolvedInverse,
           size,
           variant,
           hasMotion,
@@ -98,7 +99,7 @@ export const Loader = ({
         return StandaloneLoader({
           size,
           variant,
-          inverse,
+          inverse: resolvedInverse,
           loaderLabel,
           showLabel,
           loaderType,
@@ -118,7 +119,7 @@ export const Loader = ({
       {allowMotion ? (
         loaderContent
       ) : (
-        <StyledLabel inverse={inverse}>
+        <StyledLabel inverse={resolvedInverse}>
           {loaderLabel || l.loader.loading()}
         </StyledLabel>
       )}

--- a/src/components/loader/__next__/loader.test.tsx
+++ b/src/components/loader/__next__/loader.test.tsx
@@ -123,6 +123,20 @@ test("when the user disallows animations, alternative loading text is rendered w
   );
 });
 
+test("when the user disallows animations and loader is inside a primary `Button`, alternative loading text is rendered with inverse colour", () => {
+  mockUseMediaQuery.mockReturnValueOnce(false);
+  render(
+    <Button buttonType="primary" onClick={() => {}}>
+      <Loader />
+    </Button>,
+  );
+
+  expect(screen.getByText("Loading...")).toHaveStyleRule(
+    "color",
+    "var(--progress-inverse-label-alt)",
+  );
+});
+
 test("when the user disallows animations or their preference cannot be determined, alternative loading text is rendered", () => {
   mockUseMediaQuery.mockReturnValueOnce(undefined);
   render(<Loader />);
@@ -379,6 +393,34 @@ test("renders correctly with the expected background color when `loaderType` is 
   expect(screen.getByRole("presentation")).toHaveStyleRule(
     "stroke",
     "var(--progress-loader-inverse-bg-default)",
+    { modifier: "circle[data-role='outer-arc']" },
+  );
+});
+
+test("uses inverse outer arc token when ring loader is rendered inside a primary `Button`", () => {
+  render(
+    <Button buttonType="primary" onClick={() => {}}>
+      <Loader loaderType="ring" variant="inline" size="extra-small" showLabel />
+    </Button>,
+  );
+
+  expect(screen.getByRole("presentation")).toHaveStyleRule(
+    "stroke",
+    "var(--progress-loader-inverse-bg-default)",
+    { modifier: "circle[data-role='outer-arc']" },
+  );
+});
+
+test("keeps default outer arc token when ring loader is rendered inside a secondary `Button`", () => {
+  render(
+    <Button buttonType="secondary" onClick={() => {}}>
+      <Loader loaderType="ring" variant="inline" size="extra-small" showLabel />
+    </Button>,
+  );
+
+  expect(screen.getByRole("presentation")).toHaveStyleRule(
+    "stroke",
+    "var(--progress-loader-bg-default)",
     { modifier: "circle[data-role='outer-arc']" },
   );
 });


### PR DESCRIPTION
### Proposed behaviour

A Loader inside a coloured button (primary/destructive-primary) uses its inverse scheme, rendering the outer-arc with var(--progress-loader-inverse-bg-default) (#FFFFFF1A) per the design spec. Secondary/tertiary buttons keep the default track, and an explicit inverse prop still takes precedence.

### Current behaviour

A ring Loader inside a filled/coloured button (e.g. primary) renders its outer-arc with var(--progress-loader-bg-default) (#E8EAEC), the on-light track colour so on the button loading story the arc is a low-contrast grey against the coloured button background.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
