### PR TITLE
chore(storybook): show deprecation props on sub components

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,6 @@
 import { Preview } from "@storybook/react-vite";
+import { parameters as defaultArgTypesParameters } from "@storybook/react/entry-preview-argtypes";
+import type { StrictArgTypes } from "storybook/internal/types";
 import { configure } from "storybook/test";
 
 import "../src/style/fonts.css";
@@ -25,50 +27,68 @@ type DocgenComponent = {
 
 // Temporary workaround for Storybook docs not rendering JSDoc @deprecated tag text
 // from extracted argTypes in this repo's current Storybook version line.
-const deprecatedJsDocArgTypesEnhancer = ((context) => {
-  const component = context.component as DocgenComponent | undefined;
-  const docgenProps = component?.__docgenInfo?.props;
+// Applied to both the main story's argTypes (via argTypesEnhancers) and each
+// subcomponent's argTypes (via a docs.extractArgTypes wrapper below) so the
+// "Deprecation Warning" chip appears in every ArgTypes tab.
+const applyDeprecatedJsDocTags = <T extends Record<string, unknown>>(
+  component: unknown,
+  argTypes: T,
+): T => {
+  const docgenProps = (component as DocgenComponent | undefined)?.__docgenInfo
+    ?.props;
 
-  if (!docgenProps) {
-    return context.argTypes;
+  if (!docgenProps || !argTypes) {
+    return argTypes;
   }
 
-  const nextArgTypes = Object.entries(context.argTypes).reduce(
-    (acc, [argName, argType]) => {
-      const deprecationMessage = docgenProps[argName]?.tags?.deprecated;
+  return Object.entries(argTypes).reduce((acc, [argName, argType]) => {
+    const deprecationMessage = docgenProps[argName]?.tags?.deprecated?.trim();
 
-      if (!deprecationMessage) {
-        acc[argName] = argType;
-        return acc;
-      }
-
-      const normalizedMessage = deprecationMessage.trim();
-
-      if (!normalizedMessage) {
-        acc[argName] = argType;
-        return acc;
-      }
-
-      const nextJsDocTags = {
-        ...(argType.table?.jsDocTags as Record<string, unknown> | undefined),
-        deprecated: normalizedMessage,
-      };
-
-      acc[argName] = {
-        ...argType,
-        table: {
-          ...argType.table,
-          jsDocTags: nextJsDocTags,
-        },
-      };
-
+    if (!deprecationMessage) {
+      (acc as Record<string, unknown>)[argName] = argType;
       return acc;
-    },
-    {} as typeof context.argTypes,
-  );
+    }
 
-  return nextArgTypes;
-}) satisfies NonNullable<Preview["argTypesEnhancers"]>[number];
+    const typedArgType = argType as {
+      table?: { jsDocTags?: Record<string, unknown> } & Record<string, unknown>;
+    };
+
+    (acc as Record<string, unknown>)[argName] = {
+      ...typedArgType,
+      table: {
+        ...typedArgType.table,
+        jsDocTags: {
+          ...typedArgType.table?.jsDocTags,
+          deprecated: deprecationMessage,
+        },
+      },
+    };
+
+    return acc;
+  }, {} as T);
+};
+
+const deprecatedJsDocArgTypesEnhancer = ((context) =>
+  applyDeprecatedJsDocTags(
+    context.component,
+    context.argTypes,
+  )) satisfies NonNullable<Preview["argTypesEnhancers"]>[number];
+
+// Storybook's ArgTypes docs block extracts subcomponent argTypes directly via
+// `parameters.docs.extractArgTypes(component)` and bypasses argTypesEnhancers,
+// so wrap the framework default to reapply the deprecation shim for subcomponents.
+type ExtractArgTypes = (component: unknown) => StrictArgTypes | null;
+const defaultExtractArgTypes = (
+  defaultArgTypesParameters as { docs?: { extractArgTypes?: ExtractArgTypes } }
+).docs?.extractArgTypes;
+
+const extractArgTypesWithDeprecatedJsDoc: ExtractArgTypes = (component) => {
+  const argTypes = defaultExtractArgTypes?.(component) ?? null;
+  if (!argTypes) {
+    return argTypes;
+  }
+  return applyDeprecatedJsDocTags(component, argTypes);
+};
 
 // Configure the testIdAttribute to look for data-role when querying elements using `getByTestId`.
 configure({ testIdAttribute: "data-role" });
@@ -82,7 +102,11 @@ const customViewports = {
 };
 
 const parameters = {
-  docs: { canvas: { layout: "padded" }, theme: sageStorybookTheme },
+  docs: {
+    canvas: { layout: "padded" },
+    theme: sageStorybookTheme,
+    extractArgTypes: extractArgTypesWithDeprecatedJsDoc,
+  },
   a11y: {
     // axe-core optionsParameter (https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter)
     options: {

--- a/.storybook/vite-env.d.ts
+++ b/.storybook/vite-env.d.ts
@@ -14,3 +14,14 @@ interface ImportMetaEnv {
   // add types of custom env variables here:
   readonly STORYBOOK_VIEW_MODE: "docs" | "story";
 }
+
+// Storybook does not ship a .d.ts for this subpath, but preview.ts imports the
+// default `extractArgTypes` from it to reuse the framework's docgen extraction.
+declare module "@storybook/react/entry-preview-argtypes" {
+  export const parameters: {
+    docs?: {
+      extractArgTypes?: (component: unknown) => Record<string, unknown> | null;
+    };
+  };
+  export const argTypesEnhancers: unknown[];
+}


### PR DESCRIPTION
### Proposed behaviour

- Update the shim to work with the sub components as well

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

- Sub component prop tables are not pulling through the jsdocs deprecation tag

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
