### PR TITLE
fix(advanced-color-picker): generate valid html ids for colour inputs

### DIFF
--- a/skills/carbon-react/components/simple-color-picker.md
+++ b/skills/carbon-react/components/simple-color-picker.md
@@ -79,7 +79,7 @@ description: Carbon SimpleColorPicker component props and usage examples.
       value={state}
     >
       {colors.map(({ color, label }) => (
-        <SimpleColor value={color} key={color} aria-label={label} id={color} />
+        <SimpleColor value={color} key={color} aria-label={label} />
       ))}
     </SimpleColorPicker>
   );
@@ -111,13 +111,7 @@ description: Carbon SimpleColorPicker component props and usage examples.
         { color: "#0073C1", label: "blue" },
         { color: "#582C83", label: "purple" },
       ].map(({ color, label }) => (
-        <SimpleColor
-          value={color}
-          key={color}
-          aria-label={label}
-          id={color}
-          disabled
-        />
+        <SimpleColor value={color} key={color} aria-label={label} disabled />
       ))}
     </SimpleColorPicker>
   );
@@ -150,7 +144,7 @@ description: Carbon SimpleColorPicker component props and usage examples.
         { color: "#0073C1", label: "blue" },
         { color: "#582C83", label: "purple" },
       ].map(({ color, label }) => (
-        <SimpleColor value={color} key={color} aria-label={label} id={color} />
+        <SimpleColor value={color} key={color} aria-label={label} />
       ))}
     </SimpleColorPicker>
   );

--- a/src/components/advanced-color-picker/advanced-color-picker.component.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.component.tsx
@@ -20,6 +20,11 @@ export interface AdvancedColor {
   value: string;
 }
 
+const colorToId = (value: string) =>
+  `advanced-color-picker-color-${value
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")}`;
+
 export interface AdvancedColorPickerProps
   extends MarginProps,
     Pick<ModalProps, "restoreFocusOnClose">,
@@ -275,7 +280,7 @@ export const AdvancedColorPicker = ({
               value={value}
               key={value}
               aria-label={label}
-              id={value}
+              id={colorToId(value)}
               checked={value === selectedColor}
             />
           ))}

--- a/src/components/advanced-color-picker/advanced-color-picker.test.tsx
+++ b/src/components/advanced-color-picker/advanced-color-picker.test.tsx
@@ -97,6 +97,27 @@ test("the accessible description of the button includes the name of the currentl
   ).toHaveAccessibleDescription("Current colour assigned: orchid");
 });
 
+test("each color input has a unique id which is a valid CSS selector and reflects its color", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(<ControlledColorPicker />);
+  await user.click(screen.getByRole("button", { name: "Change colour" }));
+
+  const ids = screen.getAllByRole("radio").map((radio) => radio.id);
+
+  expect(new Set(ids).size).toBe(ids.length);
+  ids.forEach((id) => {
+    expect(id).toMatch(/^[A-Za-z][\w-]*$/);
+  });
+
+  expect(screen.getByRole("radio", { name: "white" }).id).toBe(
+    "advanced-color-picker-color-FFFFFF",
+  );
+  expect(screen.getByRole("radio", { name: "transparent" }).id).toBe(
+    "advanced-color-picker-color-transparent",
+  );
+});
+
 test.each([
   { value: "#FFFFFF", label: "white" },
   { value: "transparent", label: "transparent" },

--- a/src/components/simple-color-picker/components.test-pw.tsx
+++ b/src/components/simple-color-picker/components.test-pw.tsx
@@ -70,7 +70,7 @@ export const SimpleColorPickerCustom = ({
       {...props}
     >
       {colors.map(({ color, label }) => (
-        <SimpleColor value={color} key={color} aria-label={label} id={color} />
+        <SimpleColor value={color} key={color} aria-label={label} />
       ))}
     </SimpleColorPicker>
   );
@@ -94,7 +94,7 @@ export const SimpleColorCustom = ({
         value={state}
         key={colors[0].color}
         aria-label={colors[0].label}
-        id={colors[0].color}
+        id="simple-color-1"
         onChange={handleChange}
         {...props}
       />
@@ -102,7 +102,7 @@ export const SimpleColorCustom = ({
         value={state}
         key={colors[1].color}
         aria-label={colors[1].label}
-        id={colors[1].color}
+        id="simple-color-2"
         onChange={handleChange}
         {...props}
       />

--- a/src/components/simple-color-picker/simple-color-picker-test.stories.tsx
+++ b/src/components/simple-color-picker/simple-color-picker-test.stories.tsx
@@ -52,7 +52,6 @@ export const Default = ({
           value={color}
           key={color}
           aria-label={label}
-          id={color}
           defaultChecked={color === "#582C83"}
         />
       ))}
@@ -106,7 +105,7 @@ export const ValidationsStringComponent = () => {
           value={color}
           key={color}
           aria-label={label}
-          id={`${validationType}-${color}`}
+          id={`${validationType}-${label.replace(/\s+/g, "-")}`}
         />
       ))}
     </SimpleColorPicker>
@@ -143,7 +142,7 @@ export const ValidationsStringLabel = () => {
           value={color}
           key={color}
           aria-label={label}
-          id={`${validationType}-${color}`}
+          id={`${validationType}-${label.replace(/\s+/g, "-")}`}
         />
       ))}
     </SimpleColorPicker>
@@ -179,7 +178,7 @@ export const ValidationsBoolean = () => {
           value={color}
           key={color}
           aria-label={label}
-          id={`${validationType}-${color}`}
+          id={`${validationType}-${label.replace(/\s+/g, "-")}`}
         />
       ))}
     </SimpleColorPicker>
@@ -248,7 +247,7 @@ export const AllVariants = () => {
             value={color}
             key={color}
             aria-label={label}
-            id={`chr-default-${color}`}
+            id={`chr-default-${label.replace(/\s+/g, "-")}`}
           />
         ))}
       </SimpleColorPicker>
@@ -265,7 +264,7 @@ export const AllVariants = () => {
             value={color}
             key={color}
             aria-label={label}
-            id={`chr-disabled-${color}`}
+            id={`chr-disabled-${label.replace(/\s+/g, "-")}`}
             disabled
           />
         ))}
@@ -284,7 +283,7 @@ export const AllVariants = () => {
             value={color}
             key={color}
             aria-label={label}
-            id={`chr-required-${color}`}
+            id={`chr-required-${label.replace(/\s+/g, "-")}`}
           />
         ))}
       </SimpleColorPicker>
@@ -304,7 +303,7 @@ export const AllVariants = () => {
               value={color}
               key={color}
               aria-label={label}
-              id={`chr-${validationType}-${color}`}
+              id={`chr-${validationType}-${label.replace(/\s+/g, "-")}`}
             />
           ))}
         </SimpleColorPicker>
@@ -326,7 +325,7 @@ export const AllVariants = () => {
               value={color}
               key={color}
               aria-label={label}
-              id={`chr-legend-${validationType}-${color}`}
+              id={`chr-legend-${validationType}-${label.replace(/\s+/g, "-")}`}
             />
           ))}
         </SimpleColorPicker>
@@ -347,7 +346,7 @@ export const AllVariants = () => {
               value={color}
               key={color}
               aria-label={label}
-              id={`chr-bool-${validationType}-${color}`}
+              id={`chr-bool-${validationType}-${label.replace(/\s+/g, "-")}`}
             />
           ))}
         </SimpleColorPicker>

--- a/src/components/simple-color-picker/simple-color-picker.stories.tsx
+++ b/src/components/simple-color-picker/simple-color-picker.stories.tsx
@@ -50,7 +50,7 @@ export const Default: Story = () => {
       value={state}
     >
       {colors.map(({ color, label }) => (
-        <SimpleColor value={color} key={color} aria-label={label} id={color} />
+        <SimpleColor value={color} key={color} aria-label={label} />
       ))}
     </SimpleColorPicker>
   );
@@ -76,13 +76,7 @@ export const Disabled: Story = () => {
         { color: "#0073C1", label: "blue" },
         { color: "#582C83", label: "purple" },
       ].map(({ color, label }) => (
-        <SimpleColor
-          value={color}
-          key={color}
-          aria-label={label}
-          id={color}
-          disabled
-        />
+        <SimpleColor value={color} key={color} aria-label={label} disabled />
       ))}
     </SimpleColorPicker>
   );
@@ -109,7 +103,7 @@ export const Required: Story = () => {
         { color: "#0073C1", label: "blue" },
         { color: "#582C83", label: "purple" },
       ].map(({ color, label }) => (
-        <SimpleColor value={color} key={color} aria-label={label} id={color} />
+        <SimpleColor value={color} key={color} aria-label={label} />
       ))}
     </SimpleColorPicker>
   );


### PR DESCRIPTION
### Proposed behaviour

AdvancedColorPicker no longer passes each colour's CSS value as the id of its radio inputs. It omits id, so SimpleColor's existing `useRef(id || guid())` fallback generates one, valid since FE-7445 gave `guid()` a `carbon-` prefix. Same approach as FE-7445: let the central helper own the value instead of patching call sites.
The SimpleColorPicker stories and Playwright fixtures also stop passing the colour value as an id, so the docs no longer encourage the pattern.
No public API change, the id prop on SimpleColor is untouched and still honoured when supplied.
 

### Current behaviour

Both pickers take `{ value, label `} objects where value is a CSS colour, usually starting with #. AdvancedColorPicker passed it straight through as the input id, rendering id="#FFFFFF" — invalid HTML and unusable as a CSS selector. SimpleColorPicker produced the same invalid ids in its stories, because the examples passed id={color} themselves.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

In Storybook, open AdvancedColorPicker and SimpleColorPicker.
 
  1. Ids are valid: inspect a colour swatch. Its id is now advanced-color-picker-color-<colour> (e.g. …-FFFFFF,...-transparent), not #FFFFFF. All ids are unique.
  2. Still works: clicking swatches and Arrow-keys + Space still selects a colour; onChange fires.
  3. SimpleColorPicker stories: no example renders id="#…" anymore.
  4. Explicit id honoured: SimpleColor still uses an id you pass it (unchanged API).
