### PR TITLE
docs(storybook): create deprecated props section in arg tables

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -25,6 +25,18 @@ type DocgenComponent = {
   };
 };
 
+type ArgTypeTable = {
+  category?: string;
+  subcategory?: string;
+  jsDocTags?: Record<string, unknown>;
+} & Record<string, unknown>;
+
+type EnhancedArgType = {
+  table?: ArgTypeTable;
+} & Record<string, unknown>;
+
+const DEPRECATED_PROPS_CATEGORY = "Deprecated Props";
+
 // Temporary workaround for Storybook docs not rendering JSDoc @deprecated tag text
 // from extracted argTypes in this repo's current Storybook version line.
 // Applied to both the main story's argTypes (via argTypesEnhancers) and each
@@ -49,14 +61,19 @@ const applyDeprecatedJsDocTags = <T extends Record<string, unknown>>(
       return acc;
     }
 
-    const typedArgType = argType as {
-      table?: { jsDocTags?: Record<string, unknown> } & Record<string, unknown>;
-    };
+    const typedArgType = argType as EnhancedArgType;
+    const existingCategory = typedArgType.table?.category;
+    const shouldMoveExistingCategoryToSubcategory =
+      existingCategory && existingCategory !== DEPRECATED_PROPS_CATEGORY;
 
     (acc as Record<string, unknown>)[argName] = {
       ...typedArgType,
       table: {
         ...typedArgType.table,
+        category: DEPRECATED_PROPS_CATEGORY,
+        subcategory: shouldMoveExistingCategoryToSubcategory
+          ? existingCategory
+          : typedArgType.table?.subcategory,
         jsDocTags: {
           ...typedArgType.table?.jsDocTags,
           deprecated: deprecationMessage,


### PR DESCRIPTION
### Proposed behaviour

Seperate out the main props from the deprecated props

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

Deprecated props are jumbled in with the main props which can be quite overwhelming to consumers

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Storybook added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
