### PR TITLE
docs(flat-table): update sticky headers test to use inputs in sub-rows

### DIFF
--- a/src/components/flat-table/flat-table-test.stories.tsx
+++ b/src/components/flat-table/flat-table-test.stories.tsx
@@ -936,6 +936,7 @@ FlatTableThemes.storyName = "Themes";
 
 export const FlatTableWithStickyHeadAndFooter = () => {
   const [state, setState] = useState(["2016-10-01", "2016-10-30"]);
+  const [subRowDate, setSubRowDate] = useState("2019-04-04");
   const handleChange = (ev: DateRangeChangeEvent) => {
     const newValue = [
       ev.target.value[0].formattedValue,
@@ -1230,8 +1231,21 @@ export const FlatTableWithStickyHeadAndFooter = () => {
                         <FlatTableRow key="sub-row-1">
                           <FlatTableCell>Child one</FlatTableCell>
                           <FlatTableCell>York</FlatTableCell>
-                          <FlatTableCell>Single</FlatTableCell>
-                          <FlatTableCell>2</FlatTableCell>
+                          <FlatTableCell>
+                            <DateRange
+                              startLabel="From"
+                              endLabel="To"
+                              value={state}
+                              onChange={handleChange}
+                            />
+                          </FlatTableCell>
+                          <FlatTableCell>
+                            <MultiActionButton text="Multi Action Button">
+                              <Button>Button 1</Button>
+                              <Button>Button 2</Button>
+                              <Button>Button 3</Button>
+                            </MultiActionButton>
+                          </FlatTableCell>
                           <FlatTableCell>
                             <ActionPopover>
                               <ActionPopoverItem
@@ -1249,14 +1263,44 @@ export const FlatTableWithStickyHeadAndFooter = () => {
                               </ActionPopoverItem>
                             </ActionPopover>
                           </FlatTableCell>
-                          <FlatTableCell>date</FlatTableCell>
-                          <FlatTableCell>split button</FlatTableCell>
+                          <FlatTableCell>
+                            <DateInput
+                              label=""
+                              name={`child-one-date-${key}`}
+                              inputWidth={110}
+                              value={subRowDate}
+                              onChange={(ev) =>
+                                setSubRowDate(ev.target.value.formattedValue)
+                              }
+                              disablePortal
+                            />
+                          </FlatTableCell>
+                          <FlatTableCell>
+                            <SplitButton text="Split button">
+                              <Button href="#">Button 1</Button>
+                              <Button>Button 2</Button>
+                              <Button>Button 3</Button>
+                            </SplitButton>
+                          </FlatTableCell>
                         </FlatTableRow>,
                         <FlatTableRow key="sub-row-2">
                           <FlatTableCell>Child two</FlatTableCell>
                           <FlatTableCell>Edinburgh</FlatTableCell>
-                          <FlatTableCell>Single</FlatTableCell>
-                          <FlatTableCell>1</FlatTableCell>
+                          <FlatTableCell>
+                            <DateRange
+                              startLabel="From"
+                              endLabel="To"
+                              value={state}
+                              onChange={handleChange}
+                            />
+                          </FlatTableCell>
+                          <FlatTableCell>
+                            <MultiActionButton text="Multi Action Button">
+                              <Button>Button 1</Button>
+                              <Button>Button 2</Button>
+                              <Button>Button 3</Button>
+                            </MultiActionButton>
+                          </FlatTableCell>
                           <FlatTableCell>
                             <ActionPopover>
                               <ActionPopoverItem
@@ -1274,8 +1318,25 @@ export const FlatTableWithStickyHeadAndFooter = () => {
                               </ActionPopoverItem>
                             </ActionPopover>
                           </FlatTableCell>
-                          <FlatTableCell>date</FlatTableCell>
-                          <FlatTableCell>split button</FlatTableCell>
+                          <FlatTableCell>
+                            <DateInput
+                              label=""
+                              name={`child-two-date-${key}`}
+                              inputWidth={110}
+                              value={subRowDate}
+                              onChange={(ev) =>
+                                setSubRowDate(ev.target.value.formattedValue)
+                              }
+                              disablePortal
+                            />
+                          </FlatTableCell>
+                          <FlatTableCell>
+                            <SplitButton text="Split button">
+                              <Button href="#">Button 1</Button>
+                              <Button>Button 2</Button>
+                              <Button>Button 3</Button>
+                            </SplitButton>
+                          </FlatTableCell>
                         </FlatTableRow>,
                       ]}
                     >
@@ -1326,7 +1387,7 @@ export const FlatTableWithStickyHeadAndFooter = () => {
                           error=""
                           fieldHelp=""
                           helpAriaLabel=""
-                          inputWidth={70}
+                          inputWidth={110}
                           label=""
                           labelHelp=""
                           labelWidth={30}


### PR DESCRIPTION
### Proposed behaviour

Story refactor should add real date inputs to expandable sub-rows, exposing an existing keyboard navigation issue.

### Current behaviour

Arrow navigation issue is not reproducible without interactive inputs in expandable sub-rows.

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [X] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [X] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

Issue should be fixed in FE-7714

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
