### PR TITLE
fix(textbox): support input type and pattern props

### DIFF
--- a/skills/carbon-react/components/date-input.md
+++ b/skills/carbon-react/components/date-input.md
@@ -279,6 +279,7 @@ description: Carbon DateInput component props and usage examples.
 | tabIndex | number \| undefined | No |  |  |  |  |  |
 | title | string \| undefined | No |  |  |  |  |  |
 | translate | "yes" \| "no" \| undefined | No |  |  |  |  |  |
+| type | HTMLInputTypeAttribute \| undefined | No |  |  |  |  |  |
 | typeof | string \| undefined | No |  |  |  |  |  |
 | unselectable | "off" \| "on" \| undefined | No |  |  |  |  |  |
 | validationIconId | string \| undefined | No |  |  |  | Id of the validation icon |  |

--- a/skills/carbon-react/components/decimal.md
+++ b/skills/carbon-react/components/decimal.md
@@ -287,6 +287,7 @@ description: Carbon Decimal component props and usage examples.
 | tabIndex | number \| undefined | No |  |  |  |  |  |
 | title | string \| undefined | No |  |  |  |  |  |
 | translate | "yes" \| "no" \| undefined | No |  |  |  |  |  |
+| type | HTMLInputTypeAttribute \| undefined | No |  |  |  |  |  |
 | typeof | string \| undefined | No |  |  |  |  |  |
 | unselectable | "off" \| "on" \| undefined | No |  |  |  |  |  |
 | validationIconId | string \| undefined | No |  |  |  | Id of the validation icon |  |

--- a/skills/carbon-react/components/filterable-select.md
+++ b/skills/carbon-react/components/filterable-select.md
@@ -302,6 +302,7 @@ description: Carbon FilterableSelect component props and usage examples.
 | title | string \| undefined | No |  |  |  |  |  |
 | tooltipPosition | "left" \| "right" \| "bottom" \| "top" \| undefined | No |  |  |  | [Legacy] Overrides the default tooltip position |  |
 | translate | "yes" \| "no" \| undefined | No |  |  |  |  |  |
+| type | HTMLInputTypeAttribute \| undefined | No |  |  |  |  |  |
 | typeof | string \| undefined | No |  |  |  |  |  |
 | unselectable | "off" \| "on" \| undefined | No |  |  |  |  |  |
 | validationIconId | string \| undefined | No |  |  |  | Id of the validation icon |  |

--- a/skills/carbon-react/components/grouped-character.md
+++ b/skills/carbon-react/components/grouped-character.md
@@ -284,6 +284,7 @@ description: Carbon GroupedCharacter component props and usage examples.
 | tabIndex | number \| undefined | No |  |  |  |  |  |
 | title | string \| undefined | No |  |  |  |  |  |
 | translate | "yes" \| "no" \| undefined | No |  |  |  |  |  |
+| type | HTMLInputTypeAttribute \| undefined | No |  |  |  |  |  |
 | typeof | string \| undefined | No |  |  |  |  |  |
 | unselectable | "off" \| "on" \| undefined | No |  |  |  |  |  |
 | validationIconId | string \| undefined | No |  |  |  | Id of the validation icon |  |

--- a/skills/carbon-react/components/multi-select.md
+++ b/skills/carbon-react/components/multi-select.md
@@ -299,6 +299,7 @@ description: Carbon MultiSelect component props and usage examples.
 | title | string \| undefined | No |  |  |  |  |  |
 | tooltipPosition | "left" \| "right" \| "bottom" \| "top" \| undefined | No |  |  |  | [Legacy] Overrides the default tooltip position |  |
 | translate | "yes" \| "no" \| undefined | No |  |  |  |  |  |
+| type | HTMLInputTypeAttribute \| undefined | No |  |  |  |  |  |
 | typeof | string \| undefined | No |  |  |  |  |  |
 | unselectable | "off" \| "on" \| undefined | No |  |  |  |  |  |
 | validationIconId | string \| undefined | No |  |  |  | Id of the validation icon |  |

--- a/skills/carbon-react/components/number.md
+++ b/skills/carbon-react/components/number.md
@@ -282,6 +282,7 @@ description: Carbon Number component props and usage examples.
 | tabIndex | number \| undefined | No |  |  |  |  |  |
 | title | string \| undefined | No |  |  |  |  |  |
 | translate | "yes" \| "no" \| undefined | No |  |  |  |  |  |
+| type | HTMLInputTypeAttribute \| undefined | No |  |  |  |  |  |
 | typeof | string \| undefined | No |  |  |  |  |  |
 | unselectable | "off" \| "on" \| undefined | No |  |  |  |  |  |
 | validationIconId | string \| undefined | No |  |  |  | Id of the validation icon |  |

--- a/skills/carbon-react/components/textarea.md
+++ b/skills/carbon-react/components/textarea.md
@@ -287,6 +287,7 @@ description: Carbon Textarea component props and usage examples.
 | title | string \| undefined | No |  |  |  |  |  |
 | tooltipPosition | "left" \| "right" \| "bottom" \| "top" \| undefined | No |  |  |  | [Legacy] Overrides the default tooltip position |  |
 | translate | "yes" \| "no" \| undefined | No |  |  |  |  |  |
+| type | HTMLInputTypeAttribute \| undefined | No |  |  |  |  |  |
 | typeof | string \| undefined | No |  |  |  |  |  |
 | unselectable | "off" \| "on" \| undefined | No |  |  |  |  |  |
 | validationIconId | string \| undefined | No |  |  |  | Id of the validation icon |  |

--- a/skills/carbon-react/components/textbox.md
+++ b/skills/carbon-react/components/textbox.md
@@ -280,6 +280,7 @@ description: Carbon Textbox component props and usage examples.
 | tabIndex | number \| undefined | No |  |  |  |  |  |
 | title | string \| undefined | No |  |  |  |  |  |
 | translate | "yes" \| "no" \| undefined | No |  |  |  |  |  |
+| type | HTMLInputTypeAttribute \| undefined | No |  |  |  |  |  |
 | typeof | string \| undefined | No |  |  |  |  |  |
 | unselectable | "off" \| "on" \| undefined | No |  |  |  |  |  |
 | validationIconId | string \| undefined | No |  |  |  | Id of the validation icon |  |

--- a/src/__internal__/legacy-input/input.component.tsx
+++ b/src/__internal__/legacy-input/input.component.tsx
@@ -13,7 +13,7 @@ export type EnterKeyHintTypes =
   | "send";
 
 export interface CommonInputProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type" | "value"> {
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "value"> {
   /* The default value alignment on the input */
   align?: "right" | "left";
   /** The ID of the input's description, is set along with hint text and error message. */

--- a/src/components/textbox/textbox.test.tsx
+++ b/src/components/textbox/textbox.test.tsx
@@ -110,6 +110,23 @@ test("accepts ref as a ref object", () => {
   expect(ref.current).toBe(screen.getByRole("textbox"));
 });
 
+test("forwards type and pattern to the input", () => {
+  render(
+    <Textbox
+      value="foo"
+      onChange={() => {}}
+      type="email"
+      pattern={".+@example\\.com"}
+    />,
+  );
+
+  expect(screen.getByRole("textbox")).toHaveAttribute("type", "email");
+  expect(screen.getByRole("textbox")).toHaveAttribute(
+    "pattern",
+    ".+@example\\.com",
+  );
+});
+
 test("accepts ref as a ref callback", () => {
   const ref = jest.fn();
   render(<Textbox value="foo" onChange={() => {}} ref={ref} />);


### PR DESCRIPTION
### Proposed behaviour

Allow Textbox inherit HTML `type ` prop and pass `type ` and `pattern ` to underlying input.

### Current behaviour

Textbox excludes the native HTML type prop from its props. Consumers can not specify input type, and TS shows the `type `does not exist in TextboxProps. This prevents from combining an input type with `pattern `attribute for validation.

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
