### PR TITLE
fix(popover-container): render behind adaptive sidebar when it is a m…

### DIFF
--- a/src/components/popover-container/components.test-pw.tsx
+++ b/src/components/popover-container/components.test-pw.tsx
@@ -1,10 +1,30 @@
 import React, { useState } from "react";
 import Box from "../box";
 import { Select, Option } from "../select";
+import AdaptiveSidebar from "../adaptive-sidebar";
+import { GlobalHeaderProvider } from "../global-header/__internal__/global-header.context";
 import PopoverContainer from "./popover-container.component";
 
 export const Default = ({ title, open }: { title?: string; open: boolean }) => (
   <PopoverContainer title={title} open={open} />
+);
+
+export const PopoverContainerOverlappingAdaptiveSidebar = () => (
+  <Box height="100vh">
+    <GlobalHeaderProvider>
+      <PopoverContainer
+        title="notifications"
+        containerAriaLabel="notifications"
+        openButtonAriaLabel="open"
+        open
+      >
+        Notifications content
+      </PopoverContainer>
+    </GlobalHeaderProvider>
+    <AdaptiveSidebar open renderAsModal aria-label="sidebar">
+      Sidebar content
+    </AdaptiveSidebar>
+  </Box>
 );
 
 export const PopoverContainerWithSelect = () => {

--- a/src/components/popover-container/popover-container.pw.tsx
+++ b/src/components/popover-container/popover-container.pw.tsx
@@ -5,6 +5,7 @@ import {
   PopoverContainerWithSelect,
   Default,
   CoverButton,
+  PopoverContainerOverlappingAdaptiveSidebar,
 } from "../popover-container/components.test-pw";
 
 test.describe("Check props of Popover Container component", () => {
@@ -61,6 +62,23 @@ test.describe("Check props of Popover Container component", () => {
     await popoverContainer.press("Escape");
 
     await expect(popoverContainer).toBeHidden();
+  });
+
+  test("should render an adaptive sidebar above an overlapping open popover container when the sidebar is a modal", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<PopoverContainerOverlappingAdaptiveSidebar />);
+
+    const popoverZIndex = await page
+      .locator('[data-element="popover-container-content"]')
+      .evaluate((element) => parseInt(getComputedStyle(element).zIndex, 10));
+
+    const sidebarZIndex = await page
+      .locator('[data-role="adaptive-sidebar-modal-view"]')
+      .evaluate((element) => parseInt(getComputedStyle(element).zIndex, 10));
+
+    expect(sidebarZIndex).toBeGreaterThan(popoverZIndex);
   });
 
   test.describe("Accessibility tests", () => {

--- a/src/components/popover-container/popover-container.style.ts
+++ b/src/components/popover-container/popover-container.style.ts
@@ -71,7 +71,7 @@ const PopoverContainerContentStyle = styled.div.attrs(
   box-shadow: var(--boxShadow100);
   min-width: 300px;
   position: absolute;
-  z-index: ${({ zIndex }) => zIndex};
+  z-index: var(--adaptiveSidebarModalBackdrop, ${({ zIndex }) => zIndex});
 
   ${({ disableAnimation, $popoverOffset }) =>
     disableAnimation

--- a/src/components/popover-container/popover-container.test.tsx
+++ b/src/components/popover-container/popover-container.test.tsx
@@ -837,9 +837,12 @@ test("should render with a z-index of 2000 if not within global header", () => {
     </PopoverContainer>,
   );
 
-  expect(screen.getByRole("dialog")).toHaveStyle({
-    zIndex: "2000",
-  });
+  const zIndex = getComputedStyle(screen.getByRole("dialog")).getPropertyValue(
+    "z-index",
+  );
+
+  expect(zIndex).toContain("--adaptiveSidebarModalBackdrop");
+  expect(zIndex).toContain("2000");
 });
 
 test("should render with a z-index of 10000 if within global header", () => {
@@ -851,9 +854,12 @@ test("should render with a z-index of 10000 if within global header", () => {
     </PopoverContainer>,
   );
 
-  expect(screen.getByRole("dialog")).toHaveStyle({
-    zIndex: "10000",
-  });
+  const zIndex = getComputedStyle(screen.getByRole("dialog")).getPropertyValue(
+    "z-index",
+  );
+
+  expect(zIndex).toContain("--adaptiveSidebarModalBackdrop");
+  expect(zIndex).toContain("10000");
 
   mockedUseGlobalHeader.mockReset();
 });


### PR DESCRIPTION

### Proposed behaviour

  PopoverContainer now renders behind a modal AdaptiveSidebar. Normal usage (no modal sidebar) is unchanged.

### Current behaviour

  PopoverContainer renders above a modal AdaptiveSidebar, so when the screen shrinks and the sidebar becomes a modal, an open popover (e.g. anotifications panel) sits on top of it instead of behind it.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
