### PR TITLE
fix: ensure popover components anchor within the same local tree as the trigger

### DIFF
--- a/skills/carbon-react/components/popover-container.md
+++ b/skills/carbon-react/components/popover-container.md
@@ -65,6 +65,7 @@ description: Carbon PopoverContainer component props and usage examples.
       >
         Contents
       </PopoverContainer>
+      <button type="button">Outside</button>
     </Box>
   );
 }

--- a/src/__internal__/popover/popover.component.tsx
+++ b/src/__internal__/popover/popover.component.tsx
@@ -157,8 +157,9 @@ const Popover = ({ disablePortal, portalTarget, ...props }: PopoverProps) => {
   }
 
   const target =
-    portalTarget ??
-    (isInModal && closestDialog ? closestDialog : document.body);
+    isInModal && closestDialog
+      ? closestDialog
+      : (portalTarget ?? document.body);
 
   return createPortal(
     <CarbonScopedTokensProvider

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -361,6 +361,7 @@ export const ActionPopover = forwardRef<
               placement={mappedPlacement}
               reference={buttonRef}
               disableBackgroundUI={isInFlatTable}
+              portalTarget={buttonRef.current}
             >
               <ActionPopoverMenu
                 data-component="action-popover"

--- a/src/components/action-popover/action-popover.test.tsx
+++ b/src/components/action-popover/action-popover.test.tsx
@@ -2444,3 +2444,19 @@ test("renders backdrop when opened inside FlatTable", async () => {
 
   expect(screen.getByTestId("popup-backdrop")).toBeVisible();
 });
+
+test("renders action popover menu under the action popover wrapper tree", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(
+    <ActionPopover data-role="anchor">
+      <ActionPopoverItem>Item 1</ActionPopoverItem>
+    </ActionPopover>,
+  );
+
+  await user.click(screen.getByRole("button"));
+  const menu = await screen.findByRole("list");
+  const anchor = screen.getByTestId("anchor");
+
+  expect(anchor).toContainElement(menu);
+});

--- a/src/components/popover-container/popover-container.component.tsx
+++ b/src/components/popover-container/popover-container.component.tsx
@@ -1,5 +1,8 @@
+/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 import React, {
   useCallback,
+  useLayoutEffect,
   useEffect,
   useRef,
   useState,
@@ -29,12 +32,13 @@ import useClickAwayListener from "../../hooks/__internal__/useClickAwayListener"
 import Events from "../../__internal__/utils/helpers/events";
 import FocusTrap from "../../__internal__/focus-trap";
 import ModalContext from "../../__internal__/modal/modal.context";
-import useFocusPortalContent from "../../hooks/__internal__/useFocusPortalContent";
+import useFocusPortalContent, {
+  nextElementToFocus,
+} from "../../hooks/__internal__/useFocusPortalContent";
 import tagComponent, {
   TagProps,
 } from "../../__internal__/utils/helpers/tags/tags";
 import { BoxProps } from "../box";
-import { defaultFocusableSelectors } from "../../__internal__/focus-trap/focus-trap-utils";
 import FlatTableContext from "../flat-table/__internal__/flat-table.context";
 import { useGlobalHeader } from "../global-header/__internal__/global-header.context";
 import MenuContext from "../menu/__internal__/menu.context";
@@ -90,6 +94,9 @@ export interface RenderCloseProps {
   "aria-label": string;
   closeButtonDataProps?: Pick<TagProps, "data-role" | "data-element">;
 }
+
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
 export const renderClose = ({
   "data-element": dataElement,
@@ -228,13 +235,15 @@ export const PopoverContainer = forwardRef<
 
     const closeButtonRef = useRef<HTMLButtonElement>(null);
     const openButtonRef = useRef<HTMLButtonElement>(null);
-    const popoverReference = useRef<HTMLDivElement>(null);
+    const [popoverReference, setPopoverReference] =
+      useState<HTMLDivElement | null>(null);
+    const [altTarget, setAltTarget] = useState<HTMLElement | null>(null);
     const guid = useRef(createGuid());
     const popoverContentNodeRef = useRef<HTMLDivElement>(null);
     const popoverContainerId = title
       ? `PopoverContainer_${guid.current}`
       : undefined;
-
+    const { inMenu } = useContext(MenuContext);
     const isOpen = isControlled ? open : isOpenInternal;
 
     const reduceMotion = !useMediaQuery(
@@ -267,11 +276,8 @@ export const PopoverContainer = forwardRef<
         if (!isControlled) setIsOpenInternal(false);
 
         onClose?.(ev);
-
-        /* istanbul ignore else */
-        if (isOpen) openButtonRef.current?.focus();
       },
-      [isControlled, isOpen, onClose],
+      [isControlled, onClose],
     );
 
     const handleEscKey = useCallback(
@@ -288,6 +294,7 @@ export const PopoverContainer = forwardRef<
 
         if (!eventIsFromSelectInput && isOpen && Events.isEscKey(ev)) {
           closePopover(ev);
+          openButtonRef.current?.focus({ preventScroll: true });
         }
       },
       [closePopover, isOpen],
@@ -322,6 +329,7 @@ export const PopoverContainer = forwardRef<
       e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>,
     ) => {
       closePopover(e);
+      openButtonRef.current?.focus({ preventScroll: true });
     };
 
     useFocusPortalContent(
@@ -329,41 +337,6 @@ export const PopoverContainer = forwardRef<
       shouldCoverButton ? undefined : openButtonRef,
       closePopover,
     );
-
-    const onFocusNextElement = useCallback(
-      (ev: React.FocusEvent<HTMLElement>) => {
-        const allFocusableElements: HTMLElement[] = Array.from(
-          document.querySelectorAll(defaultFocusableSelectors) ||
-            /* istanbul ignore next */ [],
-        );
-        const filteredElements = allFocusableElements.filter(
-          (el) => el === openButtonRef.current || Number(el.tabIndex) !== -1,
-        );
-
-        const openButtonRefIndex = filteredElements.indexOf(
-          openButtonRef.current as HTMLElement,
-        );
-
-        filteredElements[openButtonRefIndex + 1].focus();
-        closePopover(ev);
-      },
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [],
-    );
-
-    const handleFocusGuard = (
-      direction: "prev" | "next",
-      ev: React.FocusEvent<HTMLElement>,
-    ) => {
-      if (direction === "next" && onFocusNextElement) {
-        // Focus the next focusable element outside of the popover
-        onFocusNextElement(ev);
-        return;
-      }
-
-      // istanbul ignore else
-      if (direction === "prev") openButtonRef.current?.focus();
-    };
 
     const renderOpenComponentProps = {
       tabIndex: 0,
@@ -421,6 +394,7 @@ export const PopoverContainer = forwardRef<
         tabIndex={-1}
         disableAnimation={disableAnimation || reduceMotion}
         zIndex={isWithinGlobalHeader ? 10000 : 2000}
+        $inMenu={inMenu}
         {...filterStyledSystemPaddingProps(rest)}
       >
         <MenuContext.Provider value={{ inMenu: false }}>
@@ -449,21 +423,47 @@ export const PopoverContainer = forwardRef<
         </ModalContext.Provider>
       ) : (
         <>
-          <div
-            data-element="tab-guard-top"
-            // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-            tabIndex={0}
-            onFocus={(ev) => handleFocusGuard("prev", ev)}
-          />
           {popover()}
           <div
             data-element="tab-guard-bottom"
-            // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+            data-focus-guard
             tabIndex={0}
-            onFocus={(ev) => handleFocusGuard("next", ev)}
+            onFocus={(ev) => {
+              /* istanbul ignore else */
+              if (isOpen) {
+                closePopover(ev);
+                const { current: button } = openButtonRef;
+                const { current: container } = popoverContentNodeRef;
+
+                /* istanbul ignore else */
+                if (button && container) {
+                  const nextElement =
+                    nextElementToFocus(button, container) ?? button;
+                  (nextElement as HTMLElement).focus();
+                }
+              }
+            }}
           />
         </>
       );
+
+    useIsomorphicLayoutEffect(() => {
+      if (inMenu) {
+        const closestHeader = popoverReference?.closest(
+          "[data-component='global-header']",
+        ) as HTMLElement | null;
+        const closestMenu = popoverReference?.closest("[data-component='menu']")
+          ?.parentElement as HTMLElement | null;
+
+        setAltTarget(
+          closestHeader ?? closestMenu ?? /* istanbul ignore next */ null,
+        );
+      }
+    }, [inMenu, popoverReference]);
+
+    // if the popover is in a menu, we want to anchor the popover to the closest global header or menu,
+    // otherwise we will use the popover reference as the target
+    const popoverTarget = altTarget ?? popoverReference;
 
     return (
       <PopoverContainerWrapperStyle
@@ -471,7 +471,7 @@ export const PopoverContainer = forwardRef<
         hasFullWidth={hasFullWidth}
         {...tagComponent("popover-container", rest)}
       >
-        <div ref={popoverReference}>
+        <div ref={setPopoverReference}>
           {renderOpenComponent(renderOpenComponentProps)}
         </div>
         <CSSTransition
@@ -491,7 +491,7 @@ export const PopoverContainer = forwardRef<
           }
         >
           <Popover
-            reference={popoverReference}
+            reference={{ current: popoverReference }}
             placement={getPlacement()}
             popoverStrategy={
               disableAnimation || reduceMotion ? "fixed" : "absolute"
@@ -499,6 +499,7 @@ export const PopoverContainer = forwardRef<
             middleware={popoverMiddleware}
             childRefOverride={popoverContentNodeRef}
             disableBackgroundUI={isInFlatTable}
+            portalTarget={popoverTarget}
           >
             {childrenToRender()}
           </Popover>

--- a/src/components/popover-container/popover-container.server.test.tsx
+++ b/src/components/popover-container/popover-container.server.test.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { renderToString } from "react-dom/server";
+import PopoverContainer from "./popover-container.component";
+
+test("doesn't render popover-container in a server environment", () => {
+  const view = renderToString(
+    <PopoverContainer>
+      <>Hello world!</>
+    </PopoverContainer>,
+  );
+
+  expect(view).not.toContain("Hello world!");
+});

--- a/src/components/popover-container/popover-container.stories.tsx
+++ b/src/components/popover-container/popover-container.stories.tsx
@@ -60,6 +60,7 @@ export const Default: Story = () => {
       >
         Contents
       </PopoverContainer>
+      <button type="button">Outside</button>
     </Box>
   );
 };

--- a/src/components/popover-container/popover-container.style.ts
+++ b/src/components/popover-container/popover-container.style.ts
@@ -52,6 +52,7 @@ type PopoverContainerContentStyleProps = {
   zIndex?: number;
   $borderRadius?: BoxProps["borderRadius"];
   $popoverOffset?: number;
+  $inMenu?: boolean;
 };
 
 const PopoverContainerContentStyle = styled.div.attrs(
@@ -60,6 +61,13 @@ const PopoverContainerContentStyle = styled.div.attrs(
   ${padding}
 
   background: var(--colorsUtilityYang100);
+
+  ${({ $inMenu }) =>
+    $inMenu &&
+    css`
+      color: var(--page-content-txt-default);
+    `}
+
   ${({ $borderRadius = "borderRadius100" }) => {
     const radiusValues = $borderRadius.split(" ").filter(Boolean);
     return css`

--- a/src/components/popover-container/popover-container.test.tsx
+++ b/src/components/popover-container/popover-container.test.tsx
@@ -12,9 +12,19 @@ import { useGlobalHeader } from "../global-header/__internal__/global-header.con
 
 import Button from "../button";
 import RadioButton, { RadioButtonGroup } from "../radio-button";
+import GlobalHeader from "../global-header";
+import { Menu, MenuItem } from "../menu";
 
 jest.mock("../../hooks/useMediaQuery");
-jest.mock("../global-header/__internal__/global-header.context");
+jest.mock("../global-header/__internal__/global-header.context", () => {
+  const actual = jest.requireActual(
+    "../global-header/__internal__/global-header.context",
+  );
+  return {
+    ...actual,
+    useGlobalHeader: jest.fn(),
+  };
+});
 
 let mockedUseGlobalHeader: jest.MockedFunction<typeof useGlobalHeader>;
 
@@ -29,6 +39,32 @@ afterEach(() => {
   jest.runOnlyPendingTimers();
   jest.useRealTimers();
 });
+
+const PopoverInNavigation = ({ withNav = true }) => {
+  const [open, setOpen] = React.useState(false);
+
+  const children = (
+    <div data-role="menu-parent">
+      <Menu>
+        <MenuItem>
+          <PopoverContainer
+            onOpen={() => setOpen(true)}
+            onClose={() => setOpen(false)}
+            open={open}
+            renderOpenComponent={({ ref, onClick }) => (
+              <button aria-label="Notifications" ref={ref} onClick={onClick}>
+                open
+              </button>
+            )}
+          >
+            Content
+          </PopoverContainer>
+        </MenuItem>
+      </Menu>
+    </div>
+  );
+  return withNav ? <GlobalHeader>{children}</GlobalHeader> : children;
+};
 
 describe("open button", () => {
   it("renders open button", () => {
@@ -317,8 +353,11 @@ test("popup allows outside focus when shouldCoverButton prop is false", async ()
     </PopoverContainer>,
   );
 
-  await user.tab();
   const closeButton = screen.getByRole("button", { name: "close" });
+
+  await user.tab();
+  await user.tab();
+
   expect(closeButton).toHaveFocus();
 
   await user.tab();
@@ -672,6 +711,47 @@ describe("closing the popup", () => {
     expect(popup).toHaveClass("exit-done");
     mockedUseMediaQuery.mockReset();
   });
+
+  it("calls onClose once when tabbing off the last focusable element and parent does not update open state", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const onClose = jest.fn();
+
+    render(
+      <>
+        <PopoverContainer title="Title" open onClose={onClose}>
+          <button type="button">Inside</button>
+        </PopoverContainer>
+        <button type="button">Outside</button>
+      </>,
+    );
+
+    screen.getByRole("button", { name: "Inside" }).focus();
+    await user.tab();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "Outside" })).toHaveFocus();
+  });
+
+  it("closes and forwards focus when tabbing out of a popover with no focusable content", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    const onClose = jest.fn();
+    render(
+      <>
+        <PopoverContainer
+          open
+          onClose={onClose}
+          renderCloseComponent={() => <></>}
+        >
+          Just text
+        </PopoverContainer>
+        <button type="button">Outside</button>
+      </>,
+    );
+    screen.getByRole("dialog").focus();
+    await user.tab();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "Outside" })).toHaveFocus();
+  });
 });
 
 test("when content is navigated via keyboard, the next focusable item should be focused and popup closed", async () => {
@@ -862,4 +942,70 @@ test("should render with a z-index of 10000 if within global header", () => {
   expect(zIndex).toContain("10000");
 
   mockedUseGlobalHeader.mockReset();
+});
+
+test("renders popover content under the trigger tree instead of mounting to body root", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(
+    <div data-role="root">
+      <PopoverContainer>Content</PopoverContainer>
+    </div>,
+  );
+
+  const openButton = screen.getByRole("button");
+  await user.click(openButton);
+  const dialog = await screen.findByRole("dialog");
+  const expectedPortalTarget = screen.getByTestId("root");
+
+  expect(expectedPortalTarget).toContainElement(dialog);
+});
+
+test("renders popover content under the global header tree instead of mounting to body root", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(<PopoverInNavigation />);
+
+  const openButton = screen.getByRole("button", { name: "Notifications" });
+  await user.click(openButton);
+  const dialog = await screen.findByRole("dialog");
+  const expectedPortalTarget = screen.getByRole("navigation", {
+    name: "Global Header",
+  });
+
+  expect(expectedPortalTarget).toContainElement(dialog);
+});
+
+test("renders popover content under the menu tree instead of mounting to body root", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(<PopoverInNavigation withNav={false} />);
+
+  const openButton = screen.getByRole("button", { name: "Notifications" });
+  await user.click(openButton);
+  const dialog = await screen.findByRole("dialog");
+  const expectedPortalTarget = screen.getByTestId("menu-parent");
+
+  expect(expectedPortalTarget).toContainElement(dialog);
+});
+
+test("focuses the trigger when there's no other focusable elements and RadioButtonGroup is present", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(
+    <PopoverContainer>
+      <RadioButtonGroup name="bar" value="1" onChange={() => {}}>
+        <RadioButton value="1" label="radio 1" />
+        <RadioButton value="2" label="radio 2" />
+      </RadioButtonGroup>
+    </PopoverContainer>,
+  );
+
+  const openButton = screen.getByRole("button");
+  await user.click(openButton);
+  await user.tab(); // tab to close icon
+  await user.tab(); // tab to RadioButtonGroup
+  await user.tab();
+
+  expect(openButton).toHaveFocus();
 });

--- a/src/hooks/__internal__/useFocusPortalContent/index.ts
+++ b/src/hooks/__internal__/useFocusPortalContent/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./useFocusPortalContent";
+export { default, nextElementToFocus } from "./useFocusPortalContent";

--- a/src/hooks/__internal__/useFocusPortalContent/useFocusPortalContent.test.tsx
+++ b/src/hooks/__internal__/useFocusPortalContent/useFocusPortalContent.test.tsx
@@ -15,15 +15,15 @@ const MockComponent = ({ cb }: { cb: () => void }) => {
 
   return (
     <div>
+      <button type="button">Before target</button>
+      <button ref={setTarget} type="button">
+        Target
+      </button>
       <div ref={setContainer}>
         <button type="button">First</button>
         <button type="button">Middle</button>
         <button type="button">Last</button>
       </div>
-      <button type="button">Before target</button>
-      <button ref={setTarget} type="button">
-        Target
-      </button>
       <button type="button">After target</button>
     </div>
   );

--- a/src/hooks/__internal__/useFocusPortalContent/useFocusPortalContent.tsx
+++ b/src/hooks/__internal__/useFocusPortalContent/useFocusPortalContent.tsx
@@ -2,6 +2,26 @@ import { RefObject, useEffect } from "react";
 import Events from "../../../__internal__/utils/helpers/events";
 import { defaultFocusableSelectors } from "../../../__internal__/focus-trap/focus-trap-utils";
 
+export const nextElementToFocus = (
+  target: HTMLElement,
+  container: HTMLElement,
+) => {
+  const focusableElements: Element[] = Array.from(
+    document.querySelectorAll(defaultFocusableSelectors) ||
+      /* istanbul ignore next */ [],
+  ).filter(
+    (el) =>
+      Number((el as HTMLElement).tabIndex) !== -1 &&
+      !el.hasAttribute("data-focus-guard"),
+  );
+  const index = focusableElements.indexOf(target);
+  const nextElementOutsideContainer = focusableElements
+    .slice(index + 1)
+    .find((el) => !container.contains(el));
+
+  return nextElementOutsideContainer;
+};
+
 export default (
   container?: RefObject<HTMLElement>,
   target?: RefObject<HTMLElement>,
@@ -11,26 +31,12 @@ export default (
     const handleFocusPortalContent = (ev: KeyboardEvent) => {
       if (container?.current && target?.current) {
         const focusableElementsInContainer: HTMLElement[] = Array.from(
-          container.current?.querySelectorAll(defaultFocusableSelectors) ||
-            /* istanbul ignore next */ [],
+          container.current?.querySelectorAll(defaultFocusableSelectors),
         );
 
         const filteredFocusableElements = focusableElementsInContainer.filter(
           (el) => Number(el.tabIndex) !== -1,
         );
-
-        if (target?.current === document.activeElement) {
-          if (
-            Events.isTabKey(ev) &&
-            !Events.isShiftKey(ev) &&
-            filteredFocusableElements[0]
-          ) {
-            ev.preventDefault();
-            filteredFocusableElements[0]?.focus();
-          }
-
-          return;
-        }
 
         /* istanbul ignore if */
         if (!filteredFocusableElements.length) {
@@ -44,34 +50,17 @@ export default (
           filteredFocusableElements[0] === document.activeElement;
 
         if (Events.isTabKey(ev)) {
-          // last element focused inside portal navigate to next element in DOM after the target/ trigger element
+          // last element focused inside portal → move to the next element after the trigger
           if (lastElementFocused && !Events.isShiftKey(ev)) {
-            ev.preventDefault();
-
-            const allFocusableElements: HTMLElement[] = Array.from(
-              document.querySelectorAll(defaultFocusableSelectors) ||
-                /* istanbul ignore next */ [],
-            );
-            const filteredElements = allFocusableElements.filter(
-              (el) => el === target.current || Number(el.tabIndex) !== -1,
-            );
-            const nextIndex = filteredElements.indexOf(target.current) + 1;
-
             focusCallback?.(ev);
-            filteredElements[nextIndex]?.focus();
-
+            const next = nextElementToFocus(target.current, container.current);
+            ev.preventDefault();
+            ((next ?? target.current) as HTMLElement).focus();
             return;
           }
-          // first element focused inside portal navigate back to the target/ trigger element
+          // first element focused inside portal, shift+tab → back to the trigger
           if (firstElementFocused && Events.isShiftKey(ev)) {
-            ev.preventDefault();
-
             focusCallback?.(ev);
-
-            /* istanbul ignore else */
-            if (target.current !== document.activeElement) {
-              target.current?.focus();
-            }
           }
         }
       }


### PR DESCRIPTION
fix #7789

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Adds `portalTarget` to internal `Popover` component and ensures that `ActionPopover` and `PopoverContainer` utilise this to render the popover in the same local tree as the trigger/target element.
If they're rendered in a modal they will anchor within that local tree, if not they will anchor to the portalTarget or to the body as a fallback

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Portal/Popover based components anchor to the document.body if they're not rendered in a modal

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required
- [x] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
