### PR TITLE
fix(texteditor): correctly apply bold/italic when inside styled span

### DIFF
--- a/src/components/text-editor/__internal__/__nodes__/styled-span.node.test.tsx
+++ b/src/components/text-editor/__internal__/__nodes__/styled-span.node.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "lexical";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { createHeadlessEditor } from "@lexical/headless";
+import { $generateNodesFromDOM } from "@lexical/html";
 import {
   StyledSpanNode,
   $createStyledSpanNode,
@@ -292,6 +293,108 @@ describe("StyledSpanNode", () => {
         expect(domElement.style.fontWeight).toBe("700");
       });
     });
+
+    test("should create DOM with effective bold weight and italic style", () => {
+      editor?.update(() => {
+        const node = new StyledSpanNode(
+          "Formatted Text",
+          "400",
+          "14px",
+          "21px",
+        );
+        node.toggleFormat("bold");
+        node.toggleFormat("italic");
+        const config = staticConfig;
+
+        const domElement = node.createDOM(config);
+
+        // eslint-disable-next-line jest-dom/prefer-to-have-style
+        expect(domElement.style.fontWeight).toBe("700");
+        // eslint-disable-next-line jest-dom/prefer-to-have-style
+        expect(domElement.style.fontStyle).toBe("italic");
+      });
+    });
+
+    test("should update DOM when italic format is toggled on", () => {
+      editor?.update(() => {
+        const prevNode = new StyledSpanNode(
+          "Italic Toggle",
+          "400",
+          "14px",
+          "21px",
+        );
+        const currentNode = new StyledSpanNode(
+          "Italic Toggle",
+          "400",
+          "14px",
+          "21px",
+        );
+        currentNode.toggleFormat("italic");
+        const config = staticConfig;
+
+        const domElement = document.createElement("span");
+        domElement.style.fontStyle = "";
+
+        const wasUpdated = currentNode.updateDOM(prevNode, domElement, config);
+
+        expect(wasUpdated).toBe(true);
+        // eslint-disable-next-line jest-dom/prefer-to-have-style
+        expect(domElement.style.fontStyle).toBe("italic");
+      });
+    });
+
+    test("should update DOM when italic format is toggled off", () => {
+      editor?.update(() => {
+        const prevNode = new StyledSpanNode(
+          "Italic Toggle",
+          "400",
+          "14px",
+          "21px",
+        );
+        prevNode.toggleFormat("italic");
+        const currentNode = new StyledSpanNode(
+          "Italic Toggle",
+          "400",
+          "14px",
+          "21px",
+        );
+        const config = staticConfig;
+
+        const domElement = document.createElement("span");
+        domElement.style.fontStyle = "italic";
+
+        const wasUpdated = currentNode.updateDOM(prevNode, domElement, config);
+
+        expect(wasUpdated).toBe(true);
+        // eslint-disable-next-line jest-dom/prefer-to-have-style
+        expect(domElement.style.fontStyle).toBe("");
+      });
+    });
+
+    test("should evaluate bold ternary branches for both previous and current nodes", () => {
+      editor?.update(() => {
+        const prevNode = new StyledSpanNode(
+          "Bold Branch",
+          "400",
+          "14px",
+          "21px",
+        );
+        prevNode.toggleFormat("bold");
+        const currentNode = new StyledSpanNode(
+          "Bold Branch",
+          "400",
+          "14px",
+          "21px",
+        );
+        currentNode.toggleFormat("bold");
+        const config = staticConfig;
+
+        const domElement = document.createElement("span");
+        const wasUpdated = currentNode.updateDOM(prevNode, domElement, config);
+
+        expect(wasUpdated).toBe(false);
+      });
+    });
   });
 
   describe("DOM export and import", () => {
@@ -335,6 +438,31 @@ describe("StyledSpanNode", () => {
         expect(htmlElement.querySelector("strong span")).toHaveTextContent(
           "Combined Export Test",
         );
+      });
+    });
+
+    test("should export effective inline styles when formatted", () => {
+      editor?.update(() => {
+        const node = new StyledSpanNode(
+          "Formatted Export",
+          "400",
+          "14px",
+          "21px",
+        );
+        node.toggleFormat("bold");
+        node.toggleFormat("italic");
+
+        const { element } = node.exportDOM();
+        const htmlElement = element as HTMLElement;
+
+        // eslint-disable-next-line testing-library/no-node-access
+        const span = htmlElement.querySelector("span") as HTMLElement;
+
+        expect(span).toBeTruthy();
+        // eslint-disable-next-line jest-dom/prefer-to-have-style
+        expect(span.style.fontWeight).toBe("700");
+        // eslint-disable-next-line jest-dom/prefer-to-have-style
+        expect(span.style.fontStyle).toBe("italic");
       });
     });
 
@@ -383,6 +511,64 @@ describe("StyledSpanNode", () => {
         expect(node.getFontWeight()).toBe("400");
         expect(node.getFontSize()).toBe("14px");
         expect(node.getLineHeight()).toBe("21px");
+      });
+    });
+
+    test("should normalise imported bold weight to paragraph when typography does not match", () => {
+      editor?.update(() => {
+        const domElement = document.createElement("span");
+        domElement.textContent = "Bold looking paragraph";
+        domElement.style.fontWeight = "700";
+        domElement.style.fontSize = "14px";
+        domElement.style.lineHeight = "21px";
+
+        const importMap = StyledSpanNode.importDOM();
+        const conversionData = importMap?.span(domElement);
+        const node = conversionData?.conversion(document.createElement("span"))
+          ?.node as StyledSpanNode;
+
+        expect(node.getFontWeight()).toBe("400");
+        expect(node.getFontSize()).toBe("14px");
+        expect(node.getLineHeight()).toBe("21px");
+        expect(node.hasFormat("bold")).toBe(true);
+      });
+    });
+
+    test("should preserve bold format from parent strong while normalising span weight", () => {
+      editor?.update(() => {
+        const parser = new DOMParser();
+        const dom = parser.parseFromString(
+          '<p><strong><span style="font-weight: 700; font-size: 14px; line-height: 21px;">Bold import</span></strong></p>',
+          "text/html",
+        );
+
+        const nodes = $generateNodesFromDOM(editor as LexicalEditor, dom);
+        const paragraph = nodes[0] as ParagraphNode;
+        const styledNode = paragraph.getFirstChild();
+
+        expect($isStyledSpanNode(styledNode)).toBe(true);
+        expect((styledNode as StyledSpanNode).getFontWeight()).toBe("400");
+        expect((styledNode as StyledSpanNode).hasFormat("bold")).toBe(true);
+      });
+    });
+
+    test("should keep title typography weight without forcing bold format", () => {
+      editor?.update(() => {
+        const domElement = document.createElement("span");
+        domElement.textContent = "Title import";
+        domElement.style.fontWeight = "700";
+        domElement.style.fontSize = "24px";
+        domElement.style.lineHeight = "30px";
+
+        const importMap = StyledSpanNode.importDOM();
+        const conversionData = importMap?.span(domElement);
+        const node = conversionData?.conversion(document.createElement("span"))
+          ?.node as StyledSpanNode;
+
+        expect(node.getFontWeight()).toBe("700");
+        expect(node.getFontSize()).toBe("24px");
+        expect(node.getLineHeight()).toBe("30px");
+        expect(node.hasFormat("bold")).toBe(false);
       });
     });
   });

--- a/src/components/text-editor/__internal__/__nodes__/styled-span.node.ts
+++ b/src/components/text-editor/__internal__/__nodes__/styled-span.node.ts
@@ -152,12 +152,18 @@ export class StyledSpanNode extends TextNode {
 
   exportDOM(): DOMExportOutput {
     let element: HTMLElement = document.createElement("span");
-    element.style.fontWeight = this.__fontWeight;
+    const format = this.getFormat();
+
+    element.style.fontWeight = format & IS_BOLD ? "700" : this.__fontWeight;
     element.style.fontSize = this.__fontSize;
     element.style.lineHeight = this.__lineHeight;
+    if (format & IS_ITALIC) {
+      element.style.fontStyle = "italic";
+    }
+    if (format & IS_UNDERLINE) {
+      element.style.textDecoration = "underline";
+    }
     element.textContent = this.getTextContent();
-
-    const format = this.getFormat();
 
     if (format & IS_BOLD) {
       const strong = document.createElement("strong");
@@ -182,17 +188,40 @@ export class StyledSpanNode extends TextNode {
     return {
       span: (domNode: HTMLElement) => ({
         conversion: () => {
-          const fontWeight = domNode.style.fontWeight || "400";
+          let fontWeight = domNode.style.fontWeight || "400";
           const fontSize = domNode.style.fontSize || "14px";
           const lineHeight = domNode.style.lineHeight || "21px";
+          let shouldApplyBoldFormat = false;
+
+          // If font-weight is bold/700 but doesn't match a typography preset
+          // that genuinely uses 700 (e.g. title at 24px/30px), it was likely
+          // set by format (e.g. parent <strong>) so normalise to base weight.
+          if (fontWeight === "700" || fontWeight === "bold") {
+            const matchesTypography = Object.values(typographyMap).some(
+              (t) =>
+                t.weight === "700" &&
+                t.size === fontSize &&
+                t.lineHeight === lineHeight,
+            );
+            if (!matchesTypography) {
+              fontWeight = "400";
+              shouldApplyBoldFormat = !domNode.closest("strong, b");
+            }
+          }
+
+          const node = new StyledSpanNode(
+            domNode.textContent || "",
+            fontWeight,
+            fontSize,
+            lineHeight,
+          );
+
+          if (shouldApplyBoldFormat) {
+            node.toggleFormat("bold");
+          }
 
           return {
-            node: new StyledSpanNode(
-              domNode.textContent || "",
-              fontWeight,
-              fontSize,
-              lineHeight,
-            ),
+            node,
           };
         },
         priority: 1,
@@ -223,9 +252,13 @@ export class StyledSpanNode extends TextNode {
 
   createDOM(_config: EditorConfig): HTMLElement {
     const dom = super.createDOM(_config);
-    dom.style.fontWeight = this.__fontWeight;
+    const format = this.__format;
+    dom.style.fontWeight = format & IS_BOLD ? "700" : this.__fontWeight;
     dom.style.fontSize = this.__fontSize;
     dom.style.lineHeight = this.__lineHeight;
+    if (format & IS_ITALIC) {
+      dom.style.fontStyle = "italic";
+    }
     return dom;
   }
 
@@ -236,8 +269,13 @@ export class StyledSpanNode extends TextNode {
   ): boolean {
     let updated = super.updateDOM(prevNode as this, dom, config);
 
-    if (this.__fontWeight !== prevNode.__fontWeight) {
-      dom.style.fontWeight = this.__fontWeight;
+    const prevEffectiveWeight =
+      prevNode.__format & IS_BOLD ? "700" : prevNode.__fontWeight;
+    const nextEffectiveWeight =
+      this.__format & IS_BOLD ? "700" : this.__fontWeight;
+
+    if (nextEffectiveWeight !== prevEffectiveWeight) {
+      dom.style.fontWeight = nextEffectiveWeight;
       updated = true;
     }
     if (this.__fontSize !== prevNode.__fontSize) {
@@ -249,13 +287,13 @@ export class StyledSpanNode extends TextNode {
       updated = true;
     }
 
-    // Return true if the node was updated, false otherwise
-    // This is important for the editor to know if it needs to re-render the node
-    // If the text content or styles have changed, we return true
-    // If the text content is the same but styles have changed, we also return true
-    // If neither has changed, we return false
-    // This helps optimize rendering performance and ensures that the editor
-    // only re-renders nodes when necessary
+    const prevItalic = !!(prevNode.__format & IS_ITALIC);
+    const nextItalic = !!(this.__format & IS_ITALIC);
+    if (prevItalic !== nextItalic) {
+      dom.style.fontStyle = nextItalic ? "italic" : "";
+      updated = true;
+    }
+
     return updated;
   }
 


### PR DESCRIPTION
### Proposed behaviour

when bold/italic styling is applied to a default styled span within the text-editor, we now ensure that it's correctly serialised

fix #8056

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Current behaviour

bold/italic styling within a default styled span will break the seralised html output

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Unit tests added or updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
