### PR TITLE
fix(dialog): ensure that heading variants are importable and documented - FE-7750

### DIFF
--- a/skills/carbon-react/components/dialog.md
+++ b/skills/carbon-react/components/dialog.md
@@ -1025,6 +1025,166 @@ function WithHeaderChildrenRender({
 ```
 
 
+### HeadingSubtle
+
+**Render**
+
+```tsx
+function HeadingSubtleRender() {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(defaultOpenState);
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <DialogWithHeadingVariant
+          open={open}
+          title="Dialog with subtle icon"
+          subtitle="Subheading"
+          statusIcon="subtle"
+          onCancel={() => {
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </DialogWithHeadingVariant>
+      </>
+    );
+  }
+```
+
+
+### HeadingPositive
+
+**Render**
+
+```tsx
+function HeadingPositiveRender() {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(defaultOpenState);
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <DialogWithHeadingVariant
+          open={open}
+          title="Dialog with positive icon"
+          subtitle="Subheading"
+          statusIcon="positive"
+          onCancel={() => {
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </DialogWithHeadingVariant>
+      </>
+    );
+  }
+```
+
+
+### HeadingNegative
+
+**Render**
+
+```tsx
+function HeadingNegativeRender() {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(defaultOpenState);
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <DialogWithHeadingVariant
+          open={open}
+          title="Dialog with negative icon"
+          subtitle="Subheading"
+          statusIcon="negative"
+          onCancel={() => {
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </DialogWithHeadingVariant>
+      </>
+    );
+  }
+```
+
+
+### HeadingCaution
+
+**Render**
+
+```tsx
+function HeadingCautionRender() {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(defaultOpenState);
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <DialogWithHeadingVariant
+          open={open}
+          title="Dialog with caution icon"
+          subtitle="Subheading"
+          statusIcon="caution"
+          onCancel={() => {
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </DialogWithHeadingVariant>
+      </>
+    );
+  }
+```
+
+
+### HeadingInfo
+
+**Render**
+
+```tsx
+function HeadingInfoRender() {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(defaultOpenState);
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <DialogWithHeadingVariant
+          open={open}
+          title="Dialog with info icon"
+          subtitle="Subheading"
+          statusIcon="info"
+          onCancel={() => {
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </DialogWithHeadingVariant>
+      </>
+    );
+  }
+```
+
+
 ### MDX Example 1
 
 **Args**
@@ -1114,6 +1274,37 @@ Setting `gradientKeyLine` adds a decorative gradient keyline below the dialog he
 
 <Canvas of={DialogStories.GradientKeyLine} />
 
+## Header variations
+
+The `withDialogHeader` Higher Order Component (HOC) enhances the Dialog with a styled header and status icon. Wrap the Dialog component with `withDialogHeader` to create a variant that accepts a `statusIcon` prop for displaying contextual icons.
+```
+
+
+### MDX Example 2
+
+**Args**
+
+```tsx
+### Subtle
+
+<Canvas of={DialogStories.HeadingSubtle} />
+
+### Positive
+
+<Canvas of={DialogStories.HeadingPositive} />
+
+### Negative
+
+<Canvas of={DialogStories.HeadingNegative} />
+
+### Caution
+
+<Canvas of={DialogStories.HeadingCaution} />
+
+### Info
+
+<Canvas of={DialogStories.HeadingInfo} />
+
 ### Overriding content padding
 
 Use the `contentPadding` prop to override the default padding applied to the dialog content area.
@@ -1145,7 +1336,7 @@ To achieve this, forward a custom ref handle to the `Dialog` component using the
 ```
 
 
-### MDX Example 2
+### MDX Example 3
 
 **Args**
 

--- a/src/components/dialog/__internal__/__next__/dialog-header/dialog-header.component.tsx
+++ b/src/components/dialog/__internal__/__next__/dialog-header/dialog-header.component.tsx
@@ -174,4 +174,4 @@ function withDialogHeader(
 }
 
 export default withDialogHeader;
-export type { EnhancedDialogProps };
+export type { EnhancedDialogProps, WithCustomHeadingProps };

--- a/src/components/dialog/__internal__/__next__/dialog.component.tsx
+++ b/src/components/dialog/__internal__/__next__/dialog.component.tsx
@@ -403,4 +403,5 @@ export { default as withDialogHeader } from "./dialog-header/dialog-header.compo
 export type {
   EnhancedDialogProps,
   DialogHeadingStatus,
+  WithCustomHeadingProps,
 } from "./dialog-header/dialog-header.component";

--- a/src/components/dialog/dialog.component.tsx
+++ b/src/components/dialog/dialog.component.tsx
@@ -5,7 +5,10 @@ import type {
   ContentPaddingInterface,
   Size,
 } from "./__internal__/__next__/dialog.component";
-import { Dialog as NextDialog } from "./__internal__/__next__/dialog.component";
+import {
+  Dialog as NextDialog,
+  withDialogHeader as nextWithDialogHeader,
+} from "./__internal__/__next__/dialog.component";
 import Logger from "../../__internal__/utils/logger";
 import type { DialogSizes } from "./dialog.config";
 
@@ -140,3 +143,21 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
 Dialog.displayName = "Dialog";
 export default Dialog;
 export type { DialogHandle, ContentPaddingInterface };
+
+// Re-export dialog header types
+export type {
+  EnhancedDialogProps,
+  DialogHeadingStatus,
+  WithCustomHeadingProps,
+} from "./__internal__/__next__/dialog.component";
+
+export const withDialogHeader = (
+  WrappedDialog: React.ForwardRefExoticComponent<
+    DialogProps & React.RefAttributes<DialogHandle>
+  >,
+) =>
+  nextWithDialogHeader(
+    WrappedDialog as React.ForwardRefExoticComponent<
+      NextDialogProps & React.RefAttributes<DialogHandle>
+    >,
+  );

--- a/src/components/dialog/dialog.mdx
+++ b/src/components/dialog/dialog.mdx
@@ -117,6 +117,38 @@ Setting `gradientKeyLine` adds a decorative gradient keyline below the dialog he
 
 <Canvas of={DialogStories.GradientKeyLine} />
 
+## Header variations
+
+The `withDialogHeader` Higher Order Component (HOC) enhances the Dialog with a styled header and status icon. Wrap the Dialog component with `withDialogHeader` to create a variant that accepts a `statusIcon` prop for displaying contextual icons.
+
+```jsx
+// For dialogs with status icons in the header
+import Dialog, { withDialogHeader } from "carbon-react/lib/components/dialog";
+
+// Creates a new component that wraps the Dialog component with the `withDialogHeader` HOC
+const DialogWithHeadingVariant = withDialogHeader(Dialog);
+```
+
+### Subtle
+
+<Canvas of={DialogStories.HeadingSubtle} />
+
+### Positive
+
+<Canvas of={DialogStories.HeadingPositive} />
+
+### Negative
+
+<Canvas of={DialogStories.HeadingNegative} />
+
+### Caution
+
+<Canvas of={DialogStories.HeadingCaution} />
+
+### Info
+
+<Canvas of={DialogStories.HeadingInfo} />
+
 ### Overriding content padding
 
 Use the `contentPadding` prop to override the default padding applied to the dialog content area.

--- a/src/components/dialog/dialog.stories.tsx
+++ b/src/components/dialog/dialog.stories.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from "react";
+import Dialog, { withDialogHeader } from ".";
 import { Meta, StoryObj } from "@storybook/react-vite";
 
 import isChromatic from "../../../.storybook/isChromatic";
@@ -14,7 +15,8 @@ import Toast from "../toast";
 import Message from "../message";
 
 import type { DialogProps } from ".";
-import Dialog from ".";
+
+const DialogWithHeadingVariant = withDialogHeader(Dialog);
 
 const meta: Meta<typeof Dialog> = {
   title: "Dialog",
@@ -946,5 +948,145 @@ export const WithContentPaddingCustom: Story = {
   args: {
     ...DefaultStory.args,
     contentPadding: { py: 5, px: 8 },
+  },
+};
+
+export const HeadingSubtle: StoryObj<typeof DialogWithHeadingVariant> = {
+  name: "Heading with Subtle Status Icon",
+  render: function HeadingSubtleRender() {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(defaultOpenState);
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <DialogWithHeadingVariant
+          open={open}
+          title="Dialog with subtle icon"
+          subtitle="Subheading"
+          statusIcon="subtle"
+          onCancel={() => {
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </DialogWithHeadingVariant>
+      </>
+    );
+  },
+};
+
+export const HeadingPositive: StoryObj<typeof DialogWithHeadingVariant> = {
+  name: "Heading with Positive Status Icon",
+  render: function HeadingPositiveRender() {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(defaultOpenState);
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <DialogWithHeadingVariant
+          open={open}
+          title="Dialog with positive icon"
+          subtitle="Subheading"
+          statusIcon="positive"
+          onCancel={() => {
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </DialogWithHeadingVariant>
+      </>
+    );
+  },
+};
+
+export const HeadingNegative: StoryObj<typeof DialogWithHeadingVariant> = {
+  name: "Heading with Negative Status Icon",
+  render: function HeadingNegativeRender() {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(defaultOpenState);
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <DialogWithHeadingVariant
+          open={open}
+          title="Dialog with negative icon"
+          subtitle="Subheading"
+          statusIcon="negative"
+          onCancel={() => {
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </DialogWithHeadingVariant>
+      </>
+    );
+  },
+};
+
+export const HeadingCaution: StoryObj<typeof DialogWithHeadingVariant> = {
+  name: "Heading with Caution Status Icon",
+  render: function HeadingCautionRender() {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(defaultOpenState);
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <DialogWithHeadingVariant
+          open={open}
+          title="Dialog with caution icon"
+          subtitle="Subheading"
+          statusIcon="caution"
+          onCancel={() => {
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </DialogWithHeadingVariant>
+      </>
+    );
+  },
+};
+
+export const HeadingInfo: StoryObj<typeof DialogWithHeadingVariant> = {
+  name: "Heading with Info Status Icon",
+  render: function HeadingInfoRender() {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(defaultOpenState);
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <DialogWithHeadingVariant
+          open={open}
+          title="Dialog with info icon"
+          subtitle="Subheading"
+          statusIcon="info"
+          onCancel={() => {
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </DialogWithHeadingVariant>
+      </>
+    );
   },
 };

--- a/src/components/dialog/dialog.test.tsx
+++ b/src/components/dialog/dialog.test.tsx
@@ -9,7 +9,7 @@ import {
 import userEvent from "@testing-library/user-event";
 
 import CarbonProvider from "../carbon-provider";
-import Dialog, { DialogHandle, DialogProps } from ".";
+import Dialog, { DialogHandle, DialogProps, withDialogHeader } from ".";
 import Logger from "../../__internal__/utils/logger";
 
 beforeEach(() => {
@@ -580,4 +580,34 @@ test("removes content padding when disableContentPadding is true", () => {
     "padding",
     "0px",
   );
+});
+
+describe("withDialogHeader HOC", () => {
+  test("wraps Dialog component and renders with custom heading", () => {
+    const DialogWithCustomHeading = withDialogHeader(Dialog);
+
+    render(
+      <DialogWithCustomHeading
+        open
+        title="Custom Title"
+        subtitle="Custom Subtitle"
+        renderHeading={(title, subtitle) => (
+          <div data-role="custom-heading">
+            <h1>{title}</h1>
+            <p>{subtitle}</p>
+          </div>
+        )}
+      />,
+    );
+
+    const customHeading = screen.getByTestId("custom-heading");
+    expect(customHeading).toBeVisible();
+    expect(
+      within(customHeading).getByRole("heading", {
+        level: 1,
+        name: /Custom Title/i,
+      }),
+    ).toBeVisible();
+    expect(customHeading).toHaveTextContent("Custom Subtitle");
+  });
 });

--- a/src/components/dialog/index.ts
+++ b/src/components/dialog/index.ts
@@ -1,3 +1,9 @@
 export { default } from "./dialog.component";
 export type { DialogProps, DialogHandle } from "./dialog.component";
 export type { DialogSizes } from "./dialog.config";
+export {
+  withDialogHeader,
+  type EnhancedDialogProps,
+  type DialogHeadingStatus,
+  type WithCustomHeadingProps,
+} from "./dialog.component";


### PR DESCRIPTION
### Proposed behaviour

- Document the Dialog with heading variants HOC.
- Ensure that `withDialogHeading` HOC can be imported from the `Dialog` file path, rather than directly from the `internal/__next__` folder.

### Current behaviour

- HOC not documented publicly. 
- The HOC has to be imported directly from the `internal/__next__` folder, which isn't ideal.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

There should be documented examples for the Dialog with heading variants in Storybook.