### PR TITLE
fix(dialog): honour contentPadding on fullscreen dialogs above 600px

### DIFF
--- a/src/components/dialog/__internal__/__next__/dialog.style.ts
+++ b/src/components/dialog/__internal__/__next__/dialog.style.ts
@@ -16,6 +16,7 @@ import {
   StyledFormFooter,
 } from "../../../form/form.style";
 import StyledFullScreenHeading from "../../../../__internal__/full-screen-heading/full-screen-heading.style";
+import { paddingPropertyNames } from "../../../../style/utils/filter-styled-system-padding-props";
 
 const dialogSizes = {
   small: DIALOG_SIZE_CONFIG.small.maxWidth,
@@ -81,6 +82,9 @@ const applyDefaultPadding = () => css`
   }
 `;
 
+const hasContentPadding = (props: PaddingProps) =>
+  paddingPropertyNames.some((key) => props[key] !== undefined);
+
 // istanbul ignore next
 const applyContentPadding =
   (disableContentPadding = false) =>
@@ -92,7 +96,7 @@ const applyContentPadding =
     }
 
     return css`
-      ${applyDefaultPadding()}
+      ${!hasContentPadding(props) && applyDefaultPadding()}
 
       ${paddingFn(props)}
     `;
@@ -372,7 +376,6 @@ const StyledDialog = styled.div<StyledDialogProps & ContentPaddingInterface>`
               min-width: ${DIALOG_MIN_WIDTH};
             }
           `}
-
           ${$size === "large" &&
           css`
             min-width: 850px;


### PR DESCRIPTION
### Proposed behaviour

The default padding is now skipped when a contentPadding prop is present, so the consumer's value (e.g. { p: 0 }) is honoured at all widths. Dialogs without contentPadding keep the existing default.

### Current behaviour

On `size="fullscreen" `dialogs, contentPadding is ignored above 600px. Fullscreen dialogs always apply a responsive default side padding regardless of whether contentPadding was set, `so contentPadding={{ p: 0 }}` only works below 600px.
solves https://github.com/Sage/carbon/issues/8103
### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
