### PR TITLE
fix(tabs): ensure focused tab is fully visible

### DIFF
--- a/src/components/tabs/__next__/tabs-interaction.stories.tsx
+++ b/src/components/tabs/__next__/tabs-interaction.stories.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, expect } from "storybook/test";
+
+import { Tabs, Tab, TabList, TabPanel } from ".";
+import Box from "../../box";
+import Typography from "../../typography";
+
+import { allowInteractions } from "../../../../.storybook/interaction-toggle/reduced-motion";
+
+const meta: Meta<typeof Tabs> = {
+  title: "Tabs/Interactions",
+  component: Tabs,
+  parameters: {
+    themeProvider: { chromatic: { theme: "sage" } },
+  },
+  decorators: [
+    (StoryToRender) => (
+      <Box backgroundColor="var(--container-standard-bg-alt)" p={3}>
+        <StoryToRender />
+      </Box>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tabs>;
+
+const tabCount = 10;
+export const ScrollToFocus: Story = {
+  render: (args) => (
+    <Tabs {...args}>
+      <TabList ariaLabel="Sample Tabs">
+        {Array.from({ length: tabCount }, (_, index) => (
+          <Tab
+            key={`tab-${index + 1}--overflow`}
+            id={`tab-${index + 1}--overflow`}
+            controls={`tab-panel-${index + 1}--overflow`}
+            label={`Tab ${index + 1}`}
+          />
+        ))}
+      </TabList>
+      {Array.from({ length: tabCount }, (_, index) => (
+        <TabPanel
+          key={`tab-panel-${index + 1}--overflow`}
+          id={`tab-panel-${index + 1}--overflow`}
+          tabId={`tab-${index + 1}--overflow`}
+        >
+          <Typography>{`Content ${index + 1}`}</Typography>
+        </TabPanel>
+      ))}
+    </Tabs>
+  ),
+  play: async ({ canvas }) => {
+    if (!allowInteractions()) {
+      return;
+    }
+
+    await userEvent.click(canvas.getByRole("tab", { name: "Tab 1" }));
+    await userEvent.keyboard("{ArrowRight}");
+    await userEvent.keyboard("{ArrowRight}");
+
+    expect(canvas.getByRole("tab", { name: "Tab 3" })).toHaveFocus();
+  },
+  parameters: {
+    chromatic: { viewports: [320] },
+  },
+  globals: {
+    viewport: { value: "mobile" },
+  },
+};

--- a/src/components/tabs/__next__/tabs.component.tsx
+++ b/src/components/tabs/__next__/tabs.component.tsx
@@ -107,6 +107,10 @@ export const Tab = ({
     if (focusIndex === id) {
       const tabElement = document.getElementById(id);
       tabElement?.focus();
+      tabElement?.scrollIntoView({
+        block: "nearest",
+        inline: "center",
+      });
     }
   }, [focusIndex, id, setCurrentTabId]);
 
@@ -477,6 +481,7 @@ export const TabList = forwardRef<TabsHandle, TabListProps>(
             aria-label={ariaLabel}
             id={`tablist-${idTabList.current}`}
             onKeyDown={handleKeyDown}
+            onScroll={updateUI}
             $orientation={orientation}
             $scrollRequired={scrollRequired}
             ref={tabListRef}

--- a/src/components/tabs/__next__/tabs.style.ts
+++ b/src/components/tabs/__next__/tabs.style.ts
@@ -101,7 +101,7 @@ export const StyledScrollButton = styled.button<{
   border-bottom: 2px solid var(--tab-border-active-alt);
   top: 6px;
   position: relative;
-  z-index: 1;
+  z-index: 2;
 `;
 
 // Again, can't be easily tested in Jest owing to lack of an actual DOM

--- a/src/components/tabs/__next__/tabs.test.tsx
+++ b/src/components/tabs/__next__/tabs.test.tsx
@@ -33,6 +33,11 @@ const TestComponent = ({ ...args }) => {
   );
 };
 
+beforeEach(() => {
+  // scrollIntoView is not implemented in jsdom but hasn't been marked as such
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
 test("shows a warning when slots are used with a non-string label", () => {
   const jestWarnSpy = jest.spyOn(console, "warn").mockImplementation();
   const slotContent = <Icon type="blocked_square" />;

--- a/src/components/tabs/tabs.test.tsx
+++ b/src/components/tabs/tabs.test.tsx
@@ -5,6 +5,11 @@ import { Tabs, Tab } from ".";
 import Logger from "../../__internal__/utils/logger";
 import DrawerSidebarContext from "../drawer/__internal__/drawer-sidebar.context";
 
+beforeEach(() => {
+  // scrollIntoView is not implemented in jsdom but hasn't been marked as such
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
 test("calls Logger.warn twice when the Tabs and Tab components are rendered", () => {
   const loggerSpy = jest.spyOn(Logger, "warn");
 


### PR DESCRIPTION
fix #8093 #7570

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

When horizontal scrolling is present and using keyboard navigation:
- Focused `Tab` is fully visible. 
- Left scroll button renders when navigating through the tablist. 
<img width="408" height="111" alt="image" src="https://github.com/user-attachments/assets/ea40de4f-e5d8-4f12-872e-d4763b6eff46" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

When horizontal scrolling is present and using keyboard navigation:
- Focused `Tab` is obscured. 
- Left scroll button does not render when navigating through the tablist. 
<img width="406" height="108" alt="image" src="https://github.com/user-attachments/assets/680cb14a-7a07-4a59-aa78-db7bb52fc01e" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
