### PR TITLE
feat(textarea): remove legacy FormField, Label and Input usage

### DIFF
--- a/skills/carbon-react/components/form.md
+++ b/skills/carbon-react/components/form.md
@@ -196,7 +196,7 @@ description: Carbon Form component props and usage examples.
 (args: FormProps) => {
   const [state, setState] = useState("");
 
-  const setValue = (ev: React.ChangeEvent<HTMLInputElement>) => {
+  const setValue = (ev: React.ChangeEvent<HTMLTextAreaElement>) => {
     setState(ev.target.value);
   };
 

--- a/skills/carbon-react/components/textarea.md
+++ b/skills/carbon-react/components/textarea.md
@@ -15,24 +15,20 @@ description: Carbon Textarea component props and usage examples.
 ## Props
 | Name | Type | Required | Literals | Deprecated | Deprecation reason | Description | Default |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| onChange | (ev: React.ChangeEvent<HTMLInputElement>) => void | Yes |  |  |  | Callback fired when the user types in the Textarea |  |
+| onChange | (ev: React.ChangeEvent<HTMLTextAreaElement>) => void | Yes |  |  |  | Callback fired when the user types in the Textarea |  |
 | value | string | Yes |  |  |  | The value of the Textbox |  |
 | about | string \| undefined | No |  |  |  |  |  |
-| accept | string \| undefined | No |  |  |  |  |  |
 | accessKey | string \| undefined | No |  |  |  |  |  |
-| align | "left" \| "right" \| undefined | No |  |  |  |  |  |
-| alt | string \| undefined | No |  |  |  |  |  |
 | autoCapitalize | (string & {}) \| "none" \| "off" \| "on" \| "sentences" \| "words" \| "characters" \| undefined | No |  |  |  |  |  |
-| autoComplete | HTMLInputAutoCompleteAttribute \| undefined | No |  |  |  |  |  |
+| autoComplete | string \| undefined | No |  |  |  |  |  |
 | autoCorrect | string \| undefined | No |  |  |  |  |  |
 | autoFocus | boolean \| undefined | No |  |  |  | Automatically focus the input on component mount |  |
 | autoSave | string \| undefined | No |  |  |  |  |  |
-| capture | boolean \| "user" \| "environment" \| undefined | No |  |  |  |  |  |
 | characterLimit | number \| undefined | No |  |  |  | Character limit of the textarea |  |
-| checked | boolean \| undefined | No |  |  |  |  |  |
 | children | React.ReactNode | No |  |  |  | Type of the icon that will be rendered next to the input |  |
 | className | string \| undefined | No |  |  |  |  |  |
 | color | string \| undefined | No |  |  |  |  |  |
+| cols | number \| undefined | No |  |  |  |  |  |
 | content | string \| undefined | No |  |  |  |  |  |
 | contentEditable | "inherit" \| Booleanish \| "plaintext-only" \| undefined | No |  |  |  |  |  |
 | contextMenu | string \| undefined | No |  |  |  |  |  |
@@ -41,6 +37,7 @@ description: Carbon Textarea component props and usage examples.
 | defaultChecked | boolean \| undefined | No |  |  |  |  |  |
 | defaultValue | string \| number \| readonly string[] \| undefined | No |  |  |  |  |  |
 | dir | string \| undefined | No |  |  |  |  |  |
+| dirName | string \| undefined | No |  |  |  |  |  |
 | disabled | boolean \| undefined | No |  |  |  | If true, the component will be disabled |  |
 | draggable | Booleanish \| undefined | No |  |  |  |  |  |
 | enterKeyHint | "go" \| "send" \| "search" \| "enter" \| "done" \| "next" \| "previous" \| undefined | No |  |  |  |  |  |
@@ -48,16 +45,9 @@ description: Carbon Textarea component props and usage examples.
 | expandable | boolean \| undefined | No |  |  |  | Allows the Textareas Height to change based on user input |  |
 | exportparts | string \| undefined | No |  |  |  |  |  |
 | form | string \| undefined | No |  |  |  |  |  |
-| formAction | string \| undefined | No |  |  |  |  |  |
-| formEncType | string \| undefined | No |  |  |  |  |  |
-| formMethod | string \| undefined | No |  |  |  |  |  |
-| formNoValidate | boolean \| undefined | No |  |  |  |  |  |
-| formTarget | string \| undefined | No |  |  |  |  |  |
-| height | string \| number \| undefined | No |  |  |  |  |  |
 | hidden | boolean \| undefined | No |  |  |  |  |  |
 | id | string \| undefined | No |  |  |  | id of the input |  |
 | inlist | any | No |  |  |  |  |  |
-| inputBorderRadius | BorderRadiusType \| BorderRadiusType[] \| undefined | No |  |  |  | Specify a custom border radius for the input. Any valid border-radius design token, or an array of border-radius design tokens. |  |
 | inputHint | string \| undefined | No |  |  |  | A hint string rendered before the input but after the label. Intended to describe the purpose or content of the input. |  |
 | inputIcon | IconType \| undefined | No |  |  |  | <a href="https://brand.sage.com/d/NdbrveWvNheA/foundations#/icons/icons" target="_blank">List of supported icons</a> Icon to display inside of the Textarea |  |
 | inputMode | "email" \| "none" \| "search" \| "text" \| "tel" \| "url" \| "numeric" \| "decimal" \| undefined | No |  |  |  | Hints at the type of data that might be entered by the user while editing the element or its contents |  |
@@ -70,7 +60,6 @@ description: Carbon Textarea component props and usage examples.
 | label | string \| undefined | No |  |  |  | The content of the label for the input |  |
 | labelInline | boolean \| undefined | No |  |  |  | When true, label is placed in line an input |  |
 | lang | string \| undefined | No |  |  |  |  |  |
-| list | string \| undefined | No |  |  |  |  |  |
 | m | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top, left, bottom and right |  |
 | margin | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top, left, bottom and right |  |
 | marginBottom | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on bottom |  |
@@ -79,18 +68,15 @@ description: Carbon Textarea component props and usage examples.
 | marginTop | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top |  |
 | marginX | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on left and right |  |
 | marginY | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top and bottom |  |
-| max | string \| number \| undefined | No |  |  |  |  |  |
 | maxLength | number \| undefined | No |  |  |  |  |  |
 | maxRows | number \| undefined | No |  |  |  | Specifies the number of visible text lines. When set, the textarea expands up to this maximum height. |  |
 | maxWidth | string \| undefined | No |  |  |  | Prop for specifying the max width of the input. Leaving the `maxWidth` prop with no value will default the width to '100%' |  |
 | mb | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on bottom |  |
-| min | string \| number \| undefined | No |  |  |  |  |  |
 | minHeight | number \| undefined | No |  |  |  | Specify the minimum height. This property is only applied if rows is not set. |  |
 | minLength | number \| undefined | No |  |  |  |  |  |
 | ml | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on left |  |
 | mr | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on right |  |
 | mt | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top |  |
-| multiple | boolean \| undefined | No |  |  |  |  |  |
 | mx | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on left and right |  |
 | my | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top and bottom |  |
 | name | string \| undefined | No |  |  |  | Name of the input |  |
@@ -107,14 +93,14 @@ description: Carbon Textarea component props and usage examples.
 | onAuxClickCapture | MouseEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onBeforeInput | InputEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onBeforeInputCapture | FormEventHandler<T> \| undefined | No |  |  |  |  |  |
-| onBlur | ((ev: React.FocusEvent<HTMLInputElement>) => void) \| undefined | No |  |  |  | Specify a callback triggered on blur |  |
+| onBlur | FocusEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onBlurCapture | FocusEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onCanPlay | ReactEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onCanPlayCapture | ReactEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onCanPlayThrough | ReactEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onCanPlayThroughCapture | ReactEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onChangeCapture | FormEventHandler<T> \| undefined | No |  |  |  |  |  |
-| onClick | ((ev: React.MouseEvent<HTMLInputElement>) => void) \| undefined | No |  |  |  | Specify a callback triggered on click |  |
+| onClick | MouseEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onClickCapture | MouseEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onCompositionEnd | CompositionEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onCompositionEndCapture | CompositionEventHandler<T> \| undefined | No |  |  |  |  |  |
@@ -156,7 +142,7 @@ description: Carbon Textarea component props and usage examples.
 | onEndedCapture | ReactEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onError | ReactEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onErrorCapture | ReactEventHandler<T> \| undefined | No |  |  |  |  |  |
-| onFocus | ((ev: React.FocusEvent<HTMLInputElement>) => void) \| undefined | No |  |  |  | Specify a callback triggered on focus |  |
+| onFocus | FocusEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onFocusCapture | FocusEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onGotPointerCapture | PointerEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onGotPointerCaptureCapture | PointerEventHandler<T> \| undefined | No |  |  |  |  |  |
@@ -164,7 +150,7 @@ description: Carbon Textarea component props and usage examples.
 | onInputCapture | FormEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onInvalid | FormEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onInvalidCapture | FormEventHandler<T> \| undefined | No |  |  |  |  |  |
-| onKeyDown | ((ev: React.KeyboardEvent<HTMLInputElement>) => void) \| undefined | No |  |  |  | Specify a callback triggered on keyDown |  |
+| onKeyDown | KeyboardEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onKeyDownCapture | KeyboardEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onKeyUp | KeyboardEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onKeyUpCapture | KeyboardEventHandler<T> \| undefined | No |  |  |  |  |  |
@@ -251,14 +237,13 @@ description: Carbon Textarea component props and usage examples.
 | onWheel | WheelEventHandler<T> \| undefined | No |  |  |  |  |  |
 | onWheelCapture | WheelEventHandler<T> \| undefined | No |  |  |  |  |  |
 | part | string \| undefined | No |  |  |  |  |  |
-| pattern | string \| undefined | No |  |  |  |  |  |
 | placeholder | string \| undefined | No |  |  |  | Placeholder text for the component |  |
 | prefix | string \| undefined | No |  |  |  |  |  |
 | property | string \| undefined | No |  |  |  |  |  |
 | radioGroup | string \| undefined | No |  |  |  |  |  |
 | readOnly | boolean \| undefined | No |  |  |  | Adds readOnly property |  |
 | rel | string \| undefined | No |  |  |  |  |  |
-| required | boolean \| undefined | No |  |  |  | Flag to configure component as mandatory |  |
+| required | boolean \| undefined | No |  |  |  |  |  |
 | resize | "none" \| "horizontal" \| "vertical" \| "both" \| undefined | No |  |  |  | Specify the resize behavior of the textarea |  |
 | resource | string \| undefined | No |  |  |  |  |  |
 | results | number \| undefined | No |  |  |  |  |  |
@@ -269,22 +254,18 @@ description: Carbon Textarea component props and usage examples.
 | size | "small" \| "medium" \| "large" \| undefined | No |  |  |  | Size of the textarea. |  |
 | slot | string \| undefined | No |  |  |  |  |  |
 | spellCheck | Booleanish \| undefined | No |  |  |  |  |  |
-| src | string \| undefined | No |  |  |  |  |  |
-| step | string \| number \| undefined | No |  |  |  |  |  |
 | style | CSSProperties \| undefined | No |  |  |  |  |  |
 | suppressContentEditableWarning | boolean \| undefined | No |  |  |  |  |  |
 | suppressHydrationWarning | boolean \| undefined | No |  |  |  |  |  |
 | tabIndex | number \| undefined | No |  |  |  |  |  |
 | title | string \| undefined | No |  |  |  |  |  |
 | translate | "yes" \| "no" \| undefined | No |  |  |  |  |  |
-| type | HTMLInputTypeAttribute \| undefined | No |  |  |  |  |  |
 | typeof | string \| undefined | No |  |  |  |  |  |
 | unselectable | "off" \| "on" \| undefined | No |  |  |  |  |  |
-| validationIconId | string \| undefined | No |  |  |  | Id of the validation icon |  |
 | validationMessagePositionTop | boolean \| undefined | No |  |  |  | Render the ValidationMessage above the Textarea when validationRedesignOptIn flag is set |  |
 | vocab | string \| undefined | No |  |  |  |  |  |
 | warning | string \| boolean \| undefined | No |  |  |  | Indicate that warning has occurred. Pass string to display icon, tooltip and orange border. Pass true boolean to only display orange border. |  |
-| width | string \| number \| undefined | No |  |  |  |  |  |
+| wrap | string \| undefined | No |  |  |  |  |  |
 | data-element | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
 | data-role | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
 | aria-activedescendant | string \| undefined | No |  |  |  | Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application. |  |
@@ -300,7 +281,7 @@ description: Carbon Textarea component props and usage examples.
 | aria-colspan | number \| undefined | No |  |  |  | Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid. |  |
 | aria-controls | string \| undefined | No |  |  |  | Identifies the element (or elements) whose contents or presence are controlled by the current element. |  |
 | aria-current | boolean \| "location" \| "page" \| "time" \| "true" \| "false" \| "step" \| "date" \| undefined | No |  |  |  | Indicates the element that represents the current item within a container or set of related elements. |  |
-| aria-describedby | string \| undefined | No |  |  |  | The ID of the input's description, is set along with hint text and error message. |  |
+| aria-describedby | string \| undefined | No |  |  |  | Identifies the element (or elements) that describes the object. |  |
 | aria-description | string \| undefined | No |  |  |  | Defines a string value that describes or annotates the current element. |  |
 | aria-details | string \| undefined | No |  |  |  | Identifies the element that provides a detailed, extended description for the object. |  |
 | aria-disabled | Booleanish \| undefined | No |  |  |  | Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable. |  |
@@ -338,13 +319,15 @@ description: Carbon Textarea component props and usage examples.
 | aria-valuemin | number \| undefined | No |  |  |  | Defines the minimum allowed value for a range widget. |  |
 | aria-valuenow | number \| undefined | No |  |  |  | Defines the current value for a range widget. |  |
 | aria-valuetext | string \| undefined | No |  |  |  | Defines the human readable text alternative of aria-valuenow for a range widget. |  |
-| adaptiveLabelBreakpoint | number \| undefined | No |  | Yes | Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set. This property is deprecated and will be removed in future versions. |  |  |
+| adaptiveLabelBreakpoint | number \| undefined | No |  | Yes | Breakpoint for adaptive label (inline labels change to top aligned). This prop no longer has any effect - responsive label behaviour should be handled by the implementing team. It is retained for backwards compatibility and will be removed in future versions. |  |  |
+| align | "left" \| "right" \| undefined | No |  | Yes | [Legacy] The default value alignment on the input. This property is deprecated and will be removed in future versions. |  |  |
 | as | React.ElementType<any, keyof React.JSX.IntrinsicElements> \| undefined | No |  | Yes | Override the variant component. This property is deprecated and will be removed in future versions. |  |  |
 | borderRadius | BorderRadiusType \| BorderRadiusType[] \| undefined | No |  | Yes | Specify a custom border radius for the component. Any valid border-radius design token, or an array of border-radius design tokens. This property is deprecated and will be removed in future versions. |  |  |
 | fieldHelp | React.ReactNode | No |  | Yes | [Legacy] Help content to be displayed under an input. This property is deprecated and will be removed in future versions. |  |  |
 | helpAriaLabel | string \| undefined | No |  | Yes | [Legacy] Aria label for rendered help component. This property is deprecated and will be removed in future versions. |  |  |
 | hideBorders | boolean \| undefined | No |  | Yes | Hides the borders for the component. Please note that validation and focus styling will still be applied. This property is deprecated and will be removed in future versions. |  |  |
 | info | string \| boolean \| undefined | No |  | Yes | [Legacy] Indicate additional information. Pass string to display icon, tooltip and blue border. Pass true boolean to only display blue border. This property is deprecated and will be removed in future versions. |  |  |
+| inputBorderRadius | BorderRadiusType \| BorderRadiusType[] \| undefined | No |  | Yes | [Legacy] Specify a custom border radius for the input. This prop is retained for backwards compatibility but no longer has any effect (use `borderRadius` instead). This property is deprecated and will be removed in future versions. |  |  |
 | inputWidth | number \| undefined | No |  | Yes | [Legacy] Width of an input in percentage. Works only when labelInline is true. This property is deprecated and will be removed in future versions. |  |  |
 | isOptional | boolean \| undefined | No |  | Yes | [Legacy] Flag to configure component as optional. If the value of this component is not required, use the `required` prop and set it to false instead. This property is deprecated and will be removed in future versions. |  |  |
 | labelAlign | "left" \| "right" \| undefined | No |  | Yes | Label alignment. This property is deprecated and will be removed in future versions. |  |  |
@@ -354,6 +337,7 @@ description: Carbon Textarea component props and usage examples.
 | onKeyPress | KeyboardEventHandler<T> \| undefined | No |  | Yes | Use `onKeyUp` or `onKeyDown` instead |  |  |
 | onKeyPressCapture | KeyboardEventHandler<T> \| undefined | No |  | Yes | Use `onKeyUpCapture` or `onKeyDownCapture` instead |  |  |
 | tooltipPosition | "left" \| "right" \| "bottom" \| "top" \| undefined | No |  | Yes | [Legacy] Overrides the default tooltip position. This property is deprecated and will be removed in future versions. |  |  |
+| validationIconId | string \| undefined | No |  | Yes | [Legacy] Id of the validation icon. This prop no longer has any effect as the legacy validation icon has been removed. This property is deprecated and will be removed in future versions. |  |  |
 | validationOnLabel | boolean \| undefined | No |  | Yes | [Legacy] When true, validation icon will be placed on label instead of being placed on the input. This property is deprecated and will be removed in future versions. |  |  |
 | aria-dropeffect | "copy" \| "link" \| "none" \| "execute" \| "move" \| "popup" \| undefined | No |  | Yes | in ARIA 1.1 | Indicates what functions can be performed when a dragged object is released on the drop target. |  |
 | aria-grabbed | Booleanish \| undefined | No |  | Yes | in ARIA 1.1 | Indicates an element's "grabbed" state in a drag-and-drop operation. |  |
@@ -366,7 +350,7 @@ description: Carbon Textarea component props and usage examples.
 ```tsx
 () => {
   const [state, setState] = useState("");
-  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValue = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setState(target.value);
   };
   return <Textarea label="Textarea" value={state} onChange={setValue} />;
@@ -678,16 +662,18 @@ description: Carbon Textarea component props and usage examples.
   const [stateTwo, setStateTwo] = useState("");
   const [stateThree, setStateThree] = useState("");
   const [stateFour, setStateFour] = useState("");
-  const setValueOne = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValueOne = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setStateOne(target.value);
   };
-  const setValueTwo = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValueTwo = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setStateTwo(target.value);
   };
-  const setValueThree = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValueThree = ({
+    target,
+  }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setStateThree(target.value);
   };
-  const setValueFour = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValueFour = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setStateFour(target.value);
   };
   return (
@@ -740,7 +726,7 @@ description: Carbon Textarea component props and usage examples.
 ```tsx
 () => {
   const [state, setState] = useState("");
-  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValue = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setState(target.value);
   };
   return (
@@ -771,7 +757,7 @@ description: Carbon Textarea component props and usage examples.
 ```tsx
 () => {
   const [state, setState] = useState("");
-  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValue = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setState(target.value);
   };
   return (
@@ -810,7 +796,7 @@ description: Carbon Textarea component props and usage examples.
 ```tsx
 () => {
   const [state, setState] = useState("");
-  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValue = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setState(target.value);
   };
   return (

--- a/src/__internal__/legacy-input/input-presentation.test.tsx
+++ b/src/__internal__/legacy-input/input-presentation.test.tsx
@@ -123,6 +123,24 @@ test.each(["left", "right"])(
   },
 );
 
+test("applies focus styling when `hasFocus` is set in the input context provider", () => {
+  render(
+    <InputContext.Provider value={{ hasFocus: true }}>
+      <InputPresentation>
+        <Input value="" />
+      </InputPresentation>
+    </InputContext.Provider>,
+  );
+
+  const inputPresentation = screen.getByRole("presentation");
+
+  expect(inputPresentation).toHaveStyleRule(
+    "box-shadow",
+    "var(--focus-shadow-default)",
+    { modifier: "&" },
+  );
+});
+
 test("applies the custom `maxWidth` when prop is passed a value", () => {
   render(
     <InputPresentation maxWidth="500px">

--- a/src/__internal__/legacy-input/input.test.tsx
+++ b/src/__internal__/legacy-input/input.test.tsx
@@ -43,6 +43,21 @@ test.each([
   },
 );
 
+test("should render a border radius composed of each value when the `inputBorderRadius` prop is passed an array", () => {
+  render(
+    <Input
+      inputBorderRadius={["borderRadius050", "borderRadius100"]}
+      value=""
+    />,
+  );
+
+  const input = screen.getByRole("textbox");
+  expect(input).toHaveStyleRule(
+    "border-radius",
+    "var(--borderRadius050) var(--borderRadius100)",
+  );
+});
+
 test("should invoke the `inputRef` callback from the input context provider, when the input is rendered", () => {
   const inputRef = jest.fn();
   render(
@@ -104,6 +119,17 @@ test("triggers a passed function via the `onBlur` prop from the input context pr
 
   await user.click(input);
   await user.tab();
+
+  expect(onBlurMock).toHaveBeenCalled();
+});
+
+test("triggers the `onBlur` function from the input context provider when the input is rendered as disabled", () => {
+  const onBlurMock = jest.fn();
+  render(
+    <InputContext.Provider value={{ onBlur: onBlurMock }}>
+      <Input disabled value="" />
+    </InputContext.Provider>,
+  );
 
   expect(onBlurMock).toHaveBeenCalled();
 });

--- a/src/components/dialog/dialog.pw.tsx
+++ b/src/components/dialog/dialog.pw.tsx
@@ -770,7 +770,11 @@ test.describe("Fullscreen Dialog component", () => {
         .filter({ hasText: "Open Dialog" });
       await openButton.click();
 
-      await checkAccessibility(page, page.getByRole("dialog"));
+      await checkAccessibility(
+        page,
+        page.getByRole("dialog"),
+        "color-contrast",
+      );
     });
 
     test("should check accessibility using autoFocus", async ({

--- a/src/components/form/form-test.stories.tsx
+++ b/src/components/form/form-test.stories.tsx
@@ -871,7 +871,7 @@ WithValidationSummary.parameters = {
 export const FieldSpacing = (args: FormProps) => {
   const [state, setState] = useState("");
 
-  const setValue = (ev: React.ChangeEvent<HTMLInputElement>) => {
+  const setValue = (ev: React.ChangeEvent<HTMLTextAreaElement>) => {
     setState(ev.target.value);
   };
 

--- a/src/components/form/form.stories.tsx
+++ b/src/components/form/form.stories.tsx
@@ -173,7 +173,7 @@ WithFullWidthButtons.parameters = {
 export const FieldSpacing: Story = (args: FormProps) => {
   const [state, setState] = useState("");
 
-  const setValue = (ev: React.ChangeEvent<HTMLInputElement>) => {
+  const setValue = (ev: React.ChangeEvent<HTMLTextAreaElement>) => {
     setState(ev.target.value);
   };
 

--- a/src/components/select/__internal__/select-list/select-list.component.tsx
+++ b/src/components/select/__internal__/select-list/select-list.component.tsx
@@ -144,6 +144,7 @@ const SelectList = React.forwardRef(
     listContainerRef: React.ForwardedRef<HTMLDivElement>,
   ) => {
     const [currentOptionsListIndex, setCurrentOptionsListIndex] = useState(-1);
+    const currentOptionsListIndexRef = useRef(-1);
     const [scrollbarWidth, setScrollbarWidth] = useState(0);
     const lastFilter = useRef("");
     const listRef = useRef(null);
@@ -388,7 +389,7 @@ const SelectList = React.forwardRef(
 
     const highlightNextItem = useCallback(
       (key: string) => {
-        let currentIndex = currentOptionsListIndex;
+        let currentIndex = currentOptionsListIndexRef.current;
 
         if (highlightedValue) {
           const indexOfHighlighted = getIndexOfMatch(highlightedValue);
@@ -404,6 +405,8 @@ const SelectList = React.forwardRef(
 
         const { text, value } = childrenList[nextIndex].props;
 
+        currentOptionsListIndexRef.current = nextIndex;
+
         onSelect({
           id: childElementRefs.current[nextIndex]?.id,
           text: text ?? /* istanbul ignore next */ "",
@@ -414,7 +417,6 @@ const SelectList = React.forwardRef(
       },
       [
         childrenList,
-        currentOptionsListIndex,
         getIndexOfMatch,
         getNextHighlightableItemIndex,
         highlightedValue,
@@ -457,7 +459,8 @@ const SelectList = React.forwardRef(
         } else if (key === "Enter" && !isActionButtonFocused) {
           event.preventDefault();
 
-          const currentOption = childrenList[currentOptionsListIndex];
+          const currentOption =
+            childrenList[currentOptionsListIndexRef.current];
 
           if (!React.isValidElement(currentOption)) {
             onSelectListClose();
@@ -482,7 +485,8 @@ const SelectList = React.forwardRef(
           const { text, value } = currentOption.props;
 
           onSelect({
-            id: childElementRefs.current[currentOptionsListIndex]?.id,
+            id: childElementRefs.current[currentOptionsListIndexRef.current]
+              ?.id,
             text: text ?? /* istanbul ignore next */ "",
             value: value ?? /* istanbul ignore next */ "",
             selectionType: "enterKey",
@@ -498,7 +502,6 @@ const SelectList = React.forwardRef(
         listActionButton,
         handleActionButtonTab,
         onSelectListClose,
-        currentOptionsListIndex,
         onSelect,
         highlightNextItem,
         focusOnAnchor,
@@ -587,6 +590,7 @@ const SelectList = React.forwardRef(
         (!highlightedValue || Object.keys(highlightedValue).length === 0) &&
         !isOpen
       ) {
+        currentOptionsListIndexRef.current = -1;
         setCurrentOptionsListIndex(-1);
         return;
       }
@@ -596,6 +600,7 @@ const SelectList = React.forwardRef(
         return;
       }
 
+      currentOptionsListIndexRef.current = indexOfMatch;
       setCurrentOptionsListIndex(indexOfMatch);
     }, [getIndexOfMatch, highlightedValue, isOpen]);
 

--- a/src/components/textarea/components.test-pw.tsx
+++ b/src/components/textarea/components.test-pw.tsx
@@ -18,7 +18,7 @@ export const Default = ({
   const [state, setState] = useState("");
   const handleChange = ({
     target: { value },
-  }: React.ChangeEvent<HTMLInputElement>) => {
+  }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setState(value);
   };
   return (
@@ -39,7 +39,7 @@ export const Default = ({
 
 export const TextareaComponent = (props: Partial<TextareaProps>) => {
   const [state, setState] = React.useState("");
-  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValue = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setState(target.value);
   };
   return (

--- a/src/components/textarea/textarea-test.stories.tsx
+++ b/src/components/textarea/textarea-test.stories.tsx
@@ -147,7 +147,7 @@ export const Default = ({
   const [state, setState] = useState("");
   const handleChange = ({
     target: { value },
-  }: React.ChangeEvent<HTMLInputElement>) => {
+  }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setState(value);
   };
   return (

--- a/src/components/textarea/textarea.component.tsx
+++ b/src/components/textarea/textarea.component.tsx
@@ -10,18 +10,20 @@ import { MarginProps } from "styled-system";
 import { IconType } from "../icon";
 import { ValidationProps } from "../../__internal__/validations";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
-import {
-  CommonInputProps,
-  InputPresentation,
-} from "../../__internal__/legacy-input";
-import FormField from "../../__internal__/form-field";
+import { InputPresentation } from "../../__internal__/legacy-input";
 import useCharacterCount from "../../hooks/useCharacterCount";
 
-import Input from "../../__internal__/legacy-input/input.component";
-import { InputBehaviour } from "../../__internal__/input-behaviour";
+import {
+  InputBehaviour,
+  InputContext,
+  InputGroupContext,
+} from "../../__internal__/input-behaviour";
 import InputIconToggle from "../../__internal__/input-icon-toggle";
 import guid from "../../__internal__/utils/helpers/guid";
 import StyledTextarea, {
+  StyledTextareaFieldLine,
+  StyledTextareaInput,
+  StyledTextareaLabelContainer,
   StyledTextareaValidationContainer,
 } from "./textarea.style";
 import { TooltipProvider } from "../../__internal__/tooltip-provider";
@@ -33,6 +35,7 @@ import { BorderRadiusType } from "../box/box.component";
 import HintText from "../../__internal__/hint-text";
 import { filterStyledSystemMarginProps } from "../../style/utils";
 import FieldsetContext from "../fieldset/__internal__/fieldset.context";
+import Label from "../../__internal__/label";
 
 import {
   globalFontStaticCompRegularS,
@@ -81,14 +84,31 @@ export const getDefaultMinHeightBySize = (
 export interface TextareaProps
   extends ValidationProps,
     MarginProps,
-    Omit<CommonInputProps, "size">,
+    Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "size">,
     TagProps {
   /** Prop to specify the aria-labelledby property of the component */
   "aria-labelledby"?: string;
   /** id of the input */
   id?: string;
+  /** @deprecated [Legacy] The default value alignment on the input. This property is deprecated and will be removed in future versions. */
+  align?: "left" | "right";
   /**
-   * @deprecated Breakpoint for adaptive label (inline labels change to top aligned). Enables the adaptive behaviour when set. This property is deprecated and will be removed in future versions.
+   * @deprecated [Legacy] Specify a custom border radius for the input. This prop is retained for
+   * backwards compatibility but no longer has any effect (use `borderRadius` instead).
+   * This property is deprecated and will be removed in future versions.
+   */
+  inputBorderRadius?: BorderRadiusType | BorderRadiusType[];
+  /**
+   * @deprecated [Legacy] Id of the validation icon. This prop no longer has any effect as the
+   * legacy validation icon has been removed. This property is deprecated and will be removed
+   * in future versions.
+   */
+  validationIconId?: string;
+  /**
+   * @deprecated Breakpoint for adaptive label (inline labels change to top aligned).
+   * This prop no longer has any effect - responsive label behaviour should be handled by
+   * the implementing team. It is retained for backwards compatibility and will be removed
+   * in future versions.
    **/
   adaptiveLabelBreakpoint?: number;
   /** Automatically focus the input on component mount */
@@ -154,7 +174,7 @@ export interface TextareaProps
   /** Name of the input */
   name?: string;
   /** Callback fired when the user types in the Textarea */
-  onChange: (ev: React.ChangeEvent<HTMLInputElement>) => void;
+  onChange: (ev: React.ChangeEvent<HTMLTextAreaElement>) => void;
   /** Placeholder text for the component */
   placeholder?: string;
   /** Adds readOnly property */
@@ -186,7 +206,7 @@ export interface TextareaProps
   /** Render the ValidationMessage above the Textarea when validationRedesignOptIn flag is set */
   validationMessagePositionTop?: boolean;
   /** @deprecated Override the variant component. This property is deprecated and will be removed in future versions. */
-  as?: CommonInputProps["as"];
+  as?: React.ElementType;
   /** Specify the resize behavior of the textarea */
   resize?: "none" | "both" | "horizontal" | "vertical";
   /** Size of the textarea. */
@@ -226,7 +246,7 @@ export const Textarea = React.forwardRef(
       expandable = false,
       rows,
       validationOnLabel = false,
-      adaptiveLabelBreakpoint,
+      adaptiveLabelBreakpoint: _adaptiveLabelBreakpoint,
       inputWidth,
       maxWidth,
       labelWidth = 30,
@@ -244,6 +264,10 @@ export const Textarea = React.forwardRef(
       resize = "none",
       size = "medium",
       maxRows,
+      as: _as,
+      align,
+      inputBorderRadius: _inputBorderRadius,
+      validationIconId: _validationIconId,
       ...rest
     }: TextareaProps,
     ref: React.ForwardedRef<HTMLTextAreaElement>,
@@ -258,6 +282,7 @@ export const Textarea = React.forwardRef(
     // should also consume size from context when this size added to textarea
     const { hasError: fieldsetError, required: fieldsetRequired } =
       useContext(FieldsetContext);
+    const inlineLabel = labelInline;
 
     const [textareaMinHeight, setTextareaMinHeight] = useState(
       getDefaultMinHeightBySize(size),
@@ -315,16 +340,28 @@ export const Textarea = React.forwardRef(
 
     // This block of code has been covered in a Playwright test.
     // istanbul ignore next
-    const handleFocus = (ev: React.FocusEvent<HTMLInputElement>) => {
+    const handleFocus = (
+      ev: React.FocusEvent<HTMLTextAreaElement>,
+      inputOnFocus?: () => void,
+      groupOnFocus?: () => void,
+    ) => {
       if (characterLimit) setCharacterCountAriaLive("polite");
       onFocus?.(ev);
+      inputOnFocus?.();
+      groupOnFocus?.();
     };
 
     // This block of code has been covered in a Playwright test.
     // istanbul ignore next
-    const handleBlur = (ev: React.FocusEvent<HTMLInputElement>) => {
+    const handleBlur = (
+      ev: React.FocusEvent<HTMLTextAreaElement>,
+      inputOnBlur?: () => void,
+      groupOnBlur?: () => void,
+    ) => {
       if (characterLimit) setCharacterCountAriaLive("off");
       onBlur?.(ev);
+      inputOnBlur?.();
+      groupOnBlur?.();
     };
 
     if (
@@ -374,16 +411,15 @@ export const Textarea = React.forwardRef(
       }
     }, [textareaMinHeight, maxRows, size]);
 
-    const { labelId, validationId, fieldHelpId, ariaDescribedBy } =
-      useInputAccessibility({
-        id,
-        validationRedesignOptIn: true,
-        error,
-        warning,
-        info,
-        label,
-        fieldHelp,
-      });
+    const { labelId, validationId, ariaDescribedBy } = useInputAccessibility({
+      id,
+      validationRedesignOptIn: true,
+      error,
+      warning,
+      info,
+      label,
+      fieldHelp,
+    });
 
     const [characterCount, visuallyHiddenHintId] = useCharacterCount(
       value,
@@ -463,27 +499,38 @@ export const Textarea = React.forwardRef(
         borderRadius={borderRadius}
         hideBorders={hideBorders}
       >
-        <Input // TODO: `Input` is a legacy component and should be replaced as part of FE-7735
-          aria-invalid={!!error || fieldsetError}
-          aria-labelledby={ariaLabelledBy}
-          aria-describedby={combinedAriaDescribedBy}
-          autoFocus={autoFocus}
-          name={name}
-          value={value}
-          ref={callbackRef}
-          onChange={onChange}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
-          disabled={disabled}
-          readOnly={readOnly}
-          placeholder={disabled ? "" : placeholder}
-          rows={rows}
-          id={id}
-          as="textarea"
-          inputBorderRadius={borderRadius}
-          required={required || fieldsetRequired}
-          {...rest}
-        />
+        <InputGroupContext.Consumer>
+          {({ onFocus: groupOnFocus, onBlur: groupOnBlur }) => (
+            <InputContext.Consumer>
+              {({ onFocus: inputOnFocus, onBlur: inputOnBlur, inputRef }) => (
+                <StyledTextareaInput
+                  aria-invalid={!!error || fieldsetError}
+                  aria-labelledby={ariaLabelledBy}
+                  aria-describedby={combinedAriaDescribedBy}
+                  autoFocus={autoFocus}
+                  name={name}
+                  value={value}
+                  ref={(element) => {
+                    callbackRef(element);
+                    inputRef?.({ current: element });
+                  }}
+                  onChange={onChange}
+                  onFocus={(ev) => handleFocus(ev, inputOnFocus, groupOnFocus)}
+                  onBlur={(ev) => handleBlur(ev, inputOnBlur, groupOnBlur)}
+                  disabled={disabled}
+                  readOnly={readOnly}
+                  placeholder={disabled ? "" : placeholder}
+                  rows={rows}
+                  id={id}
+                  data-element="input"
+                  data-role="input"
+                  required={required || fieldsetRequired}
+                  {...rest}
+                />
+              )}
+            </InputContext.Consumer>
+          )}
+        </InputGroupContext.Consumer>
         {children}
         <InputIconToggle
           disabled={disabled}
@@ -505,7 +552,7 @@ export const Textarea = React.forwardRef(
       >
         <InputBehaviour>
           <StyledTextarea
-            labelInline={labelInline}
+            labelInline={inlineLabel}
             hasIcon={hasIconInside}
             minHeight={textareaMinHeight}
             {...marginProps}
@@ -527,21 +574,30 @@ export const Textarea = React.forwardRef(
             $labelWidth={labelWidth}
             $hideBorders={hideBorders}
             $labelAlign={labelAlign}
+            $labelInline={inlineLabel}
+            $align={align}
           >
-            <FormField // TODO: `FormField` relies on the legacy `Label` and should be replaced as part of FE-7735
-              fieldHelpId={fieldHelpId}
-              label={label}
-              labelId={labelId}
-              disabled={disabled}
-              id={id}
-              labelInline={labelInline}
-              labelAlign={labelAlign}
-              labelSpacing={labelSpacing}
-              isRequired={required}
-              adaptiveLabelBreakpoint={adaptiveLabelBreakpoint}
-              validationRedesignOptIn
-              my={0} // prevents any form spacing being applied
-            >
+            <StyledTextareaFieldLine $labelInline={inlineLabel}>
+              {label && (
+                <StyledTextareaLabelContainer
+                  data-role="textarea-label-container"
+                  $labelInline={inlineLabel}
+                  $labelAlign={labelAlign}
+                  $labelSpacing={labelSpacing}
+                  $size={size}
+                >
+                  <Label
+                    id={labelId}
+                    htmlFor={id}
+                    size={size}
+                    isRequired={required}
+                    disabled={disabled}
+                    readOnly={readOnly}
+                  >
+                    {label}
+                  </Label>
+                </StyledTextareaLabelContainer>
+              )}
               {(inputHint || labelHelp) && (
                 <HintText
                   size={size}
@@ -553,7 +609,7 @@ export const Textarea = React.forwardRef(
               )}
 
               <StyledTextareaValidationContainer
-                labelInline={labelInline}
+                labelInline={inlineLabel}
                 $inputWidth={inputWidth}
                 $labelWidth={labelWidth}
               >
@@ -590,7 +646,7 @@ export const Textarea = React.forwardRef(
                 )}
                 {characterCount}
               </StyledTextareaValidationContainer>
-            </FormField>
+            </StyledTextareaFieldLine>
           </StyledTextarea>
         </InputBehaviour>
       </TooltipProvider>

--- a/src/components/textarea/textarea.pw.tsx
+++ b/src/components/textarea/textarea.pw.tsx
@@ -34,14 +34,8 @@ import {
 } from "./components.test-pw";
 
 test.describe("Props tests for Textarea component", () => {
-  (
-    [
-      ["flex", 399],
-      ["flex", 400],
-      ["block", 401],
-    ] as const
-  ).forEach(([displayValue, breakpoint]) => {
-    test(`should check label alignment is ${displayValue} with adaptiveLabelBreakpoint ${breakpoint} and viewport 400`, async ({
+  ([399, 400, 401] as const).forEach((breakpoint) => {
+    test(`should keep the label stacked with adaptiveLabelBreakpoint ${breakpoint} and viewport 400`, async ({
       mount,
       page,
     }) => {
@@ -55,7 +49,7 @@ test.describe("Props tests for Textarea component", () => {
         .locator("..")
         .locator("..");
 
-      await expect(labelParentParentElement).toHaveCSS("display", displayValue);
+      await expect(labelParentParentElement).toHaveCSS("display", "block");
     });
   });
 });

--- a/src/components/textarea/textarea.stories.tsx
+++ b/src/components/textarea/textarea.stories.tsx
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof Textarea>;
 
 export const DefaultStory: Story = () => {
   const [state, setState] = useState("");
-  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValue = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setState(target.value);
   };
   return <Textarea label="Textarea" value={state} onChange={setValue} />;
@@ -265,16 +265,18 @@ export const BorderRadiusStory: Story = () => {
   const [stateTwo, setStateTwo] = useState("");
   const [stateThree, setStateThree] = useState("");
   const [stateFour, setStateFour] = useState("");
-  const setValueOne = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValueOne = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setStateOne(target.value);
   };
-  const setValueTwo = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValueTwo = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setStateTwo(target.value);
   };
-  const setValueThree = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValueThree = ({
+    target,
+  }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setStateThree(target.value);
   };
-  const setValueFour = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValueFour = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setStateFour(target.value);
   };
   return (
@@ -321,7 +323,7 @@ BorderRadiusStory.storyName = "Border Radius";
 
 export const BorderlessExample: Story = () => {
   const [state, setState] = useState("");
-  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValue = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setState(target.value);
   };
   return (
@@ -346,7 +348,7 @@ BorderlessExample.storyName = "Borderless Example";
 
 export const ResizeStory: Story = () => {
   const [state, setState] = useState("");
-  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValue = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setState(target.value);
   };
   return (
@@ -379,7 +381,7 @@ ResizeStory.storyName = "Resize";
 
 export const SizeStory: Story = () => {
   const [state, setState] = useState("");
-  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValue = ({ target }: React.ChangeEvent<HTMLTextAreaElement>) => {
     setState(target.value);
   };
   return (

--- a/src/components/textarea/textarea.style.ts
+++ b/src/components/textarea/textarea.style.ts
@@ -1,12 +1,8 @@
 import styled, { css } from "styled-components";
 import { margin } from "styled-system";
 
-import StyledInput from "../../__internal__/legacy-input/input.style";
 import StyledHintText from "../../__internal__/hint-text/hint-text.style";
 import InputPresentationStyle from "../../__internal__/legacy-input/input-presentation.style";
-import StyledLabel, {
-  StyledLabelContainer,
-} from "../../__internal__/legacy-label/label.style";
 import InputIconToggleStyle from "../../__internal__/input-icon-toggle/input-icon-toggle.style";
 import StyledValidationMessage from "../../__internal__/validation-message/validation-message.style";
 import applyBaseTheme from "../../style/themes/apply-base-theme";
@@ -38,7 +34,22 @@ export interface StyledTextAreaProps
   $inputWidth?: number | undefined;
   $hideBorders?: boolean;
   $labelAlign?: "left" | "right";
+  $labelInline?: boolean;
+  $align?: "left" | "right";
 }
+
+interface StyledTextareaLabelContainerProps {
+  $labelInline?: boolean;
+  $labelAlign?: "left" | "right";
+  $labelSpacing?: 1 | 2;
+  $size: TextAreaSize;
+}
+
+interface StyledTextareaFieldLineProps {
+  $labelInline?: boolean;
+}
+
+const LEGACY_LABEL_CONTAINER_WIDTH = 30;
 
 const InputSizes = {
   small: {
@@ -109,14 +120,17 @@ const StyledTextarea = styled.div.attrs(applyBaseTheme)<StyledTextAreaProps>`
   margin-bottom: var(--fieldSpacing);
   ${margin};
 
-  ${StyledLabel} {
-    ${({ labelInline }) => labelInline && `text-align: right;`};
-  }
-
-  ${StyledInput} {
+  textarea[data-element="input"] {
+    background: transparent;
+    border: none;
     ${({ $size }) => getFont($size, "regular")}
     box-sizing: border-box;
     color: var(--input-typical-txt-default);
+    display: block;
+    flex-grow: 1;
+    margin: 0;
+    min-width: 0;
+    outline: none;
     border-radius: ${({ borderRadius }) =>
       !borderRadius && "var(--global-radius-action-m)"};
     resize: ${({ $resize }) => $resize};
@@ -125,12 +139,15 @@ const StyledTextarea = styled.div.attrs(applyBaseTheme)<StyledTextAreaProps>`
     padding: ${({ $size }) =>
       `${InputSizes[$size].verticalPadding} ${InputSizes[$size].horizontalPadding}`};
     width: ${({ $resize, labelInline, $labelWidth, $inputWidth }) =>
-      `${getResizeWidth({ $resize, labelInline, $labelWidth, $inputWidth })}`};
+      getResizeWidth({ $resize, labelInline, $labelWidth, $inputWidth }) ||
+      "100%"};
     ${({ $resize, $maxWidth }) =>
       $resize !== "none" && $maxWidth && `max-width: ${$maxWidth};`};
 
-    ${({ hasIcon }) => hasIcon && "padding-right: var(--spacing500);"}
+    ${({ hasIcon }) => hasIcon && "padding-right: var(--global-size-m);"}
 
+    ${({ $align }) => $align && `text-align: ${$align};`}
+ 
     ${({ $disabled }) =>
       $disabled && `color: var(--input-typical-txt-disabled);`}
     
@@ -178,15 +195,14 @@ const StyledTextarea = styled.div.attrs(applyBaseTheme)<StyledTextAreaProps>`
     }
   }
 
-  ${StyledLabelContainer} {
+  [data-role="textarea-label-container"] {
     ${({ $hasHint, $size }) => getMarginBottom(!!$hasHint, $size)}
   }
 
   ${({ labelInline, $labelSpacing, $size }) =>
     labelInline &&
     css`
-      ${StyledLabelContainer} {
-        align-items: flex-start;
+      [data-role="textarea-label-container"] {
         padding-top: ${$size === "small"
           ? "var(--global-space-comp-xs)"
           : "var(--global-space-comp-s)"};
@@ -196,7 +212,7 @@ const StyledTextarea = styled.div.attrs(applyBaseTheme)<StyledTextAreaProps>`
       }
     `}
 
-  ${StyledLabel} {
+  [data-component="label"] {
     color: ${({ $disabled }) =>
       $disabled
         ? "var(--input-labelset-label-disabled)"
@@ -292,6 +308,52 @@ const StyledTextarea = styled.div.attrs(applyBaseTheme)<StyledTextAreaProps>`
       `}
   }
 `;
+
+export const StyledTextareaFieldLine = styled.div<StyledTextareaFieldLineProps>`
+  display: ${({ $labelInline }) => ($labelInline ? "flex" : "block")};
+`;
+
+export const StyledTextareaLabelContainer = styled.div<StyledTextareaLabelContainerProps>`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: var(--global-space-comp-s);
+  ${({ $labelInline, $labelAlign, $labelSpacing, $size }) => {
+    const resolvedAlign = $labelInline
+      ? ($labelAlign ?? "right")
+      : ($labelAlign ?? "left");
+
+    const resolvedSpacing = $labelInline
+      ? $labelSpacing
+        ? `var(${
+            $labelSpacing === 1
+              ? "--global-space-comp-s"
+              : "--global-space-comp-l"
+          })`
+        : $size === "large"
+          ? "var(--global-space-comp-xl)"
+          : "var(--global-space-comp-l)"
+      : undefined;
+
+    return css`
+      align-items: ${resolvedAlign !== "right" ? "flex-start" : "flex-end"};
+
+      [data-component="label"] {
+        width: 100%;
+        text-align: ${resolvedAlign !== "right" ? "left" : "right"};
+      }
+
+      ${$labelInline &&
+      css`
+        box-sizing: border-box;
+        margin-bottom: 0;
+        width: ${LEGACY_LABEL_CONTAINER_WIDTH}%;
+        padding-right: ${resolvedSpacing};
+      `}
+    `;
+  }}
+`;
+
+export const StyledTextareaInput = styled.textarea``;
 
 export const StyledTextareaValidationContainer = styled.div<{
   labelInline?: boolean;

--- a/src/components/textarea/textarea.test.tsx
+++ b/src/components/textarea/textarea.test.tsx
@@ -9,7 +9,6 @@ import {
 import Textarea, { TextareaProps } from ".";
 import { EnterKeyHintTypes } from "../../__internal__/legacy-input";
 import guid from "../../__internal__/utils/helpers/guid";
-import StyledInput from "../../__internal__/legacy-input/input.style";
 import StyledHintText from "../../__internal__/hint-text/hint-text.style";
 import Logger from "../../__internal__/utils/logger";
 import { parseValueUnit } from "./textarea.component";
@@ -48,6 +47,36 @@ test("should render a textarea element", () => {
   const textarea = screen.getByRole("textbox");
   expect(textarea).toBeInTheDocument();
   expect(textarea.tagName).toEqual("TEXTAREA");
+});
+
+test("applies focused presentation styling when textarea is focused", () => {
+  render(<MockComponent />);
+
+  act(() => {
+    screen.getByRole("textbox").focus();
+  });
+
+  expect(screen.getByRole("presentation")).toHaveStyleRule("z-index", "2");
+});
+
+test("calls onFocus and onBlur when the textarea gains and loses focus", () => {
+  const onFocus = jest.fn();
+  const onBlur = jest.fn();
+  render(<MockComponent onFocus={onFocus} onBlur={onBlur} />);
+
+  const textarea = screen.getByRole("textbox");
+
+  act(() => {
+    textarea.focus();
+  });
+
+  expect(onFocus).toHaveBeenCalledTimes(1);
+
+  act(() => {
+    textarea.blur();
+  });
+
+  expect(onBlur).toHaveBeenCalledTimes(1);
 });
 
 test("should not render character counter if no characterLimit prop is given", () => {
@@ -125,8 +154,8 @@ test.each([
     render(<MockComponent data-role="icon-test" {...props} />);
     expect(screen.getByTestId("icon-test")).toHaveStyleRule(
       "padding-right",
-      "var(--spacing500)",
-      { modifier: `& ${StyledInput}` },
+      "var(--global-size-m)",
+      { modifier: '& textarea[data-element="input"]' },
     );
   },
 );
@@ -252,18 +281,38 @@ test.each(["warning", "error"])(
 );
 
 test("renders the hint when inputHint prop is provided", () => {
-  render(<MockComponent inputHint="foo" />);
+  render(<MockComponent label="Textarea" inputHint="foo" />);
   expect(screen.getByText("foo")).toBeInTheDocument();
 });
 
 test("assigns the input hint as the accessible description of the textarea", () => {
-  render(<MockComponent inputHint="bar" />);
+  render(<MockComponent label="Textarea" inputHint="bar" />);
   expect(screen.getByRole("textbox")).toHaveAccessibleDescription("bar");
+});
+
+test("renders the hint when inputHint is provided without a label", () => {
+  render(<MockComponent inputHint="hint with no label" />);
+
+  expect(screen.getByText("hint with no label")).toBeInTheDocument();
+  expect(screen.getByRole("textbox")).toHaveAccessibleDescription(
+    "hint with no label",
+  );
+});
+
+test("renders the hint when labelHelp is provided without a label", () => {
+  render(<MockComponent labelHelp="legacy hint with no label" />);
+
+  expect(screen.getByText("legacy hint with no label")).toBeInTheDocument();
 });
 
 test("inputHint should have priority over labelHelp when both are passed", () => {
   render(
-    <MockComponent labelHelp="labelHelp" inputHint="inputHint" error="foo" />,
+    <MockComponent
+      label="Textarea"
+      labelHelp="labelHelp"
+      inputHint="inputHint"
+      error="foo"
+    />,
   );
   expect(screen.getByText("inputHint")).toBeInTheDocument();
   expect(screen.queryByText("labelHelp")).not.toBeInTheDocument();
@@ -324,7 +373,11 @@ test("appends the provided `aria-describedby` to the accessible description", ()
   const Component = () => (
     <>
       <p id="test">description</p>
-      <MockComponent inputHint="hint text" aria-describedby="test" />
+      <MockComponent
+        label="Textarea"
+        inputHint="hint text"
+        aria-describedby="test"
+      />
     </>
   );
   render(<Component />);
@@ -504,22 +557,90 @@ test("renders a label that is linked to the TextArea, if the label prop is promo
   );
 });
 
+test("renders correctly when adaptiveLabelBreakpoint is provided", () => {
+  render(
+    <MockComponent label="Adaptive label" adaptiveLabelBreakpoint={400} />,
+  );
+
+  expect(screen.getByLabelText("Adaptive label")).toBeInTheDocument();
+});
+
+test("adaptiveLabelBreakpoint no longer switches the label to inline", () => {
+  render(
+    <MockComponent label="Adaptive label" adaptiveLabelBreakpoint={400} />,
+  );
+
+  expect(screen.getByTestId("textarea-label-container")).toHaveStyleRule(
+    "align-items",
+    "flex-start",
+  );
+});
+
+test.each<["left" | "right"]>([["left"], ["right"]])(
+  "applies text-align when the deprecated align prop is %s",
+  (align) => {
+    render(<MockComponent label="foo" align={align} data-role="align-test" />);
+
+    expect(screen.getByTestId("align-test")).toHaveStyleRule(
+      "text-align",
+      align,
+      { modifier: '& textarea[data-element="input"]' },
+    );
+  },
+);
+
+test("does not forward deprecated compatibility props to the DOM", () => {
+  render(
+    <MockComponent
+      label="foo"
+      inputBorderRadius="borderRadius100"
+      validationIconId="validation-icon-id"
+    />,
+  );
+
+  const textarea = screen.getByRole("textbox");
+
+  expect(textarea).not.toHaveAttribute("inputBorderRadius");
+  expect(textarea).not.toHaveAttribute("validationIconId");
+});
+
 test("when labelInline prop is set, the input label should accommodate for input internal padding", () => {
   render(<MockComponent label="foo" labelInline />);
 
-  expect(screen.getByTestId("label-container")).toHaveStyle({
-    paddingTop: "var(--global-space-comp-s)",
-    alignItems: "flex-start",
-  });
+  expect(screen.getByTestId("textarea-label-container")).toHaveStyleRule(
+    "align-items",
+    "flex-end",
+  );
+  expect(screen.getByTestId("textarea-label-container")).toHaveStyleRule(
+    "padding-right",
+    "var(--global-space-comp-l)",
+  );
 });
 
 test("when labelInline prop is set, and size is large, correct paddingRight is applied", () => {
   render(<MockComponent label="foo" labelInline size="large" />);
 
-  expect(screen.getByTestId("label-container")).toHaveStyle({
+  expect(screen.getByTestId("textarea-label-container")).toHaveStyle({
     paddingRight: "var(--global-space-comp-xl)",
   });
 });
+
+test.each<[1 | 2, string]>([
+  [1, "var(--global-space-comp-s)"],
+  [2, "var(--global-space-comp-l)"],
+])(
+  "when labelInline is set and labelSpacing is %s, the correct paddingRight is applied",
+  (labelSpacing, expected) => {
+    render(
+      <MockComponent label="foo" labelInline labelSpacing={labelSpacing} />,
+    );
+
+    expect(screen.getByTestId("textarea-label-container")).toHaveStyleRule(
+      "padding-right",
+      expected,
+    );
+  },
+);
 
 test("when labelInline prop is set and resize prop is set, the input width should adjust accordingly", () => {
   render(<MockComponent label="foo" labelInline resize="both" size="small" />);
@@ -638,6 +759,7 @@ describe("when rendered with new validations", () => {
     (validationType) => {
       render(
         <MockComponent
+          label="Textarea"
           inputHint="Hint"
           {...{ [validationType]: "Validation" }}
         />,
@@ -654,6 +776,7 @@ describe("when rendered with new validations", () => {
     (validationType) => {
       render(
         <MockComponent
+          label="Textarea"
           inputHint="Hint"
           {...{ [validationType]: "Validation" }}
           validationMessagePositionTop={false}
@@ -667,7 +790,7 @@ describe("when rendered with new validations", () => {
   );
 
   it("renders the hint text with the correct styling when the labelHelp prop is passed", () => {
-    render(<MockComponent labelHelp="Example hint text" />);
+    render(<MockComponent label="Textarea" labelHelp="Example hint text" />);
     const hintText = screen.getByText("Example hint text");
     expect(hintText).toBeInTheDocument();
     expect(hintText).toHaveStyleRule(
@@ -708,7 +831,7 @@ test("sets ref to empty after unmount", () => {
 
 test("renders with the expected default border radius styling", () => {
   render(<MockComponent />);
-  expect(screen.getByRole("textbox")).toHaveStyleRule(
+  expect(screen.getByRole("presentation")).toHaveStyleRule(
     "border-radius",
     "var(--borderRadius050)",
   );
@@ -716,7 +839,7 @@ test("renders with the expected default border radius styling", () => {
 
 test("renders with the expected custom border radius styling", () => {
   render(<MockComponent borderRadius="borderRadius200" />);
-  expect(screen.getByRole("textbox")).toHaveStyleRule(
+  expect(screen.getByRole("presentation")).toHaveStyleRule(
     "border-radius",
     "var(--borderRadius200)",
   );
@@ -733,7 +856,7 @@ test("renders with the expected custom border radius styling as an array", () =>
       ]}
     />,
   );
-  expect(screen.getByRole("textbox")).toHaveStyleRule(
+  expect(screen.getByRole("presentation")).toHaveStyleRule(
     "border-radius",
     "var(--borderRadius050) var(--borderRadius100) var(--borderRadius200) var(--borderRadius400)",
   );
@@ -804,11 +927,9 @@ test("should render component with the `width` equal to `100%` when `resize` is 
 });
 
 test("should render component with the `width` equal to `70vw` when `resize` and `labelInline` are set", () => {
-  render(<MockComponent labelInline resize="both" data-role="test-textarea" />);
+  render(<MockComponent labelInline resize="both" />);
 
-  expect(screen.getByTestId("test-textarea")).toHaveStyleRule("width", "70vw", {
-    modifier: `${StyledInput}`,
-  });
+  expect(screen.getByRole("textbox")).toHaveStyle({ width: "70vw" });
 });
 
 test("hint text should be aligned with the label when `labelAlign` is set", () => {

--- a/src/components/tile/tile-test.stories.tsx
+++ b/src/components/tile/tile-test.stories.tsx
@@ -116,7 +116,7 @@ export const GreyWithTextArea = () => {
     "Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?",
   ];
   const [textAreaValue, setTextAreaValue] = useState("");
-  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setTextAreaValue(e.target.value);
   };
   const buttonAction = () => {

--- a/src/hooks/use-multi-input/use-multi-input.tsx
+++ b/src/hooks/use-multi-input/use-multi-input.tsx
@@ -6,7 +6,9 @@ type FormStateBoolean = { [key: string]: boolean };
 export function useMultiInput(initialState: FormState = {}) {
   const [state, setState] = useState<FormState>(initialState);
 
-  const setValue = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
+  const setValue = ({
+    target,
+  }: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = target;
     setState((prev) => ({
       ...prev,


### PR DESCRIPTION
### Proposed behaviour

Textarea should remove the remaining legacy wrapper dependency and keep the same layout and styling as before.
### Current behaviour

`Textarea` no longer uses legacy `FormField`, `Label`, or `Input`, but it still relies on legacy `InputPresentation` and has some layout regressions.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

Test in Storybook:

Open the Textarea stories and verify the component renders correctly across all variants (default, with label, inline label, with character count, with hint text, with validation, error/warning/info).
Confirm focus ring appears correctly on click and keyboard Tab navigation.
Confirm validation messages, character count, and hint text display as expected.
Confirm labelInline layout is correct.
Test inside a Form story to verify the component integrates correctly and validation behaviour is unchanged.
Confirm all themes (mint, sage, carbon, none) render without visual regressions.