### PR TITLE
chore(ci): add additional guard to chromatic runs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -14,7 +14,7 @@ jobs:
       branch_name: ${{ fromJson(steps.get_pull.outputs.data).head.label }}
     steps:
       - id: get_pull
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3.x
         with:
           route: GET /repos/{owner}/{repo}/pulls/{pull_number}
           owner: ${{ github.event.repository.owner.login }}

--- a/.github/workflows/forked-ci.yml
+++ b/.github/workflows/forked-ci.yml
@@ -9,7 +9,7 @@ jobs:
   trigger-chromatic:
     runs-on: ubuntu-latest
     steps:
-      - uses: octokit/request-action@v2.x
+      - uses: octokit/request-action@v3.x
         id: dispatch_chromatic
         with:
           route: POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,12 +5,62 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  trigger-chromatic:
+  check-chromatic:
+    name: Check Chromatic
     # if not a fork or a draft
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check_approvals.outputs.should_run }}
     steps:
-      - uses: octokit/request-action@v2.x
+      - name: Check Approvals
+        id: check_approvals
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const REQUIRED_APPROVALS = 2;
+
+            const data = await github.graphql(
+              `query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {     
+                    latestReviews(first: 100) {
+                      nodes {
+                        state
+                        authorCanPushToRepository
+                      }
+                    }
+                  }
+                }
+              }`,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: context.payload.pull_request.number,
+              }
+            );
+
+            const pr = data.repository.pullRequest;
+            const approvals = pr.latestReviews.nodes.filter(
+              (review) =>
+                review.state === "APPROVED" && review.authorCanPushToRepository
+            ).length;
+            
+            if (approvals >= REQUIRED_APPROVALS) {
+              core.setOutput("should_run", "true");
+              return;
+            }
+
+            core.setOutput("should_run", "false");
+
+  trigger-chromatic:
+    name: Trigger Chromatic
+    needs: [check-chromatic]
+    if: ${{ needs.check-chromatic.outputs.should_run == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch Chromatic
+        uses: octokit/request-action@v3.x
         id: dispatch_chromatic
         with:
           route: POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->



### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Chromatic dispatch workflow is triggered when PR is not in draft. 

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
