### PR TITLE
docs: align Playwright testing docs after Cypress removal

### DIFF
--- a/contributing/testing-guide.md
+++ b/contributing/testing-guide.md
@@ -90,9 +90,9 @@ A typical `*.pw.tsx` file may look like the following:
 
 ```tsx
 // inside src/components/button/button.pw.tsx
-import { test, expect } from "../../__spec_helper__/base-test";
+import { test, expect } from "../../../playwright/helpers/base-test";
 import Button from "./button.component";
-import { buttonComponent } from "../../../playwright/component/button/index";
+import { buttonDataComponent } from "../../../playwright/components/button";
 
 test.describe("Check props for Button component", async () => {
   test("should render Button label when passed to the component", async ({
@@ -103,12 +103,12 @@ test.describe("Check props for Button component", async () => {
 
     await mount(<Button>{label}</Button>);
 
-    await expect(buttonComponent(page)).toHaveText(label);
+    await expect(buttonDataComponent(page)).toHaveText(label);
   });
 });
 ```
 
-Where `mount` renders the component in the real browser (`chromium`/`webkit`/`firefox`/`opera`) and `buttonComponent` is a _locator_ that returns the DOM element we want to test.
+Where `mount` renders the component in the real browser (`chromium` — the only project configured in `playwright-ct.config.ts`) and `buttonDataComponent` is a _locator_ that returns the DOM element we want to test.
 
 ### Locators
 

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -28,7 +28,7 @@ To run the tests locally:
 2. To run Playwright using the `playwright` runner, run `npm run test:ct:ui` and then select the required test file. Test results can be seen directly in the Playwright Test Runner UI.
 3. To run the suite of Playwright tests in CI mode, run `npm run test:ct`. Test results can be seen in the console run summary. Or could be shown in a separate report by running `npm run test:ct:report`.
 4. To run specific Playwright tests at the command line run `npm run test:ct -- ./src/components/[component]/*.pw.tsx`. Test results can be seen in the console run summary.
-5. We have specified three browsers to run tests on. So to run Playwright tests in a specific browser run `npm run test:ct -- --project=chromium` or `npm run test:ct -- --project=firefox`. If you want to run Playwright tests on a specific browser using `UI` runner you need to manually select which browser you want to use (or all available in `playwright-ct.config.ts`).
+5. Component tests are configured to run on **chromium** only (see `playwright-ct.config.ts`). You can still pass `--project=chromium` explicitly, for example `npm run test:ct -- --project=chromium`. In the UI runner, select the chromium project.
 
 ### Accessibility Report
 

--- a/skills/carbon-react/components/filterable-select.md
+++ b/skills/carbon-react/components/filterable-select.md
@@ -505,7 +505,7 @@ This component supports input validation, see our [Validations](../?path=/docs/d
 
 ## Testing
 
-For testing interactions with `FilterableSelect` as part of a broader user journey, we recommend testing within a browser environment using tools like Playwright or Cypress, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
+For testing interactions with `FilterableSelect` as part of a broader user journey, we recommend testing within a browser environment using Playwright, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
 
 ### JSDOM tests (if required)
 

--- a/skills/carbon-react/components/multi-select.md
+++ b/skills/carbon-react/components/multi-select.md
@@ -1272,7 +1272,7 @@ This component supports input validation, see our [Validations](../?path=/docs/d
 
 ## Testing
 
-For testing interactions with `MultiSelect` as part of a broader user journey, we recommend testing within a browser environment using tools like Playwright or Cypress, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
+For testing interactions with `MultiSelect` as part of a broader user journey, we recommend testing within a browser environment using Playwright, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
 
 ### JSDOM tests (if required)
 

--- a/src/components/draggable/draggable.mdx
+++ b/src/components/draggable/draggable.mdx
@@ -57,7 +57,7 @@ import {
 
 ### Recommended approach
 
-We recommend testing drag and drop interactions in browser environments using tools like Playwright or Cypress, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, tests will require extensive mocking to simulate drag and drop behaviour, making them less effective.
+We recommend testing drag and drop interactions in browser environments using Playwright, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, tests will require extensive mocking to simulate drag and drop behaviour, making them less effective.
 
 ### JSDOM tests (if required)
 

--- a/src/components/select/filterable-select/filterable-select.mdx
+++ b/src/components/select/filterable-select/filterable-select.mdx
@@ -151,7 +151,7 @@ This component supports input validation, see our [Validations](../?path=/docs/d
 
 ## Testing
 
-For testing interactions with `FilterableSelect` as part of a broader user journey, we recommend testing within a browser environment using tools like Playwright or Cypress, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
+For testing interactions with `FilterableSelect` as part of a broader user journey, we recommend testing within a browser environment using Playwright, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
 
 ### JSDOM tests (if required)
 

--- a/src/components/select/multi-select/multi-select.mdx
+++ b/src/components/select/multi-select/multi-select.mdx
@@ -136,7 +136,7 @@ This component supports input validation, see our [Validations](../?path=/docs/d
 
 ## Testing
 
-For testing interactions with `MultiSelect` as part of a broader user journey, we recommend testing within a browser environment using tools like Playwright or Cypress, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
+For testing interactions with `MultiSelect` as part of a broader user journey, we recommend testing within a browser environment using Playwright, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
 
 ### JSDOM tests (if required)
 

--- a/src/components/select/simple-select/simple-select.mdx
+++ b/src/components/select/simple-select/simple-select.mdx
@@ -202,7 +202,7 @@ This component supports input validation, see our [Validations](../?path=/docs/d
 
 ## Testing
 
-For testing interactions with `SimpleSelect` as part of a broader user journey, we recommend testing within a browser environment using tools like Playwright or Cypress, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
+For testing interactions with `SimpleSelect` as part of a broader user journey, we recommend testing within a browser environment using Playwright, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
 
 ### JSDOM tests (if required)
 


### PR DESCRIPTION
### Proposed behaviour

Fix stale Playwright import paths and chromium-only guidance in contributor docs. Remove deprecated Cypress mentions from MDX files.

### Current behaviour

Docs reference old Cypress testing patterns and incorrect import paths after Cypress → Playwright migration.

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [x] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

Align docs after Cypress → Playwright migration completion.

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
