### PR TITLE
feat(dialog): add dialog header component - FE-7750

### DIFF
--- a/skills/carbon-react/components/alert.md
+++ b/skills/carbon-react/components/alert.md
@@ -36,7 +36,6 @@ description: Carbon Alert component props and usage examples.
 | greyBackground | boolean \| undefined | No |  |  |  | Change the background color of the content to grey |  |
 | headerChildren | React.ReactNode | No |  |  |  | Container for components to be displayed in the header |  |
 | height | string \| undefined | No |  |  |  | Allows developers to specify a specific height for the dialog. |  |
-| help | string \| undefined | No |  |  |  | Adds Help tooltip to Header |  |
 | onCancel | ((ev: React.KeyboardEvent<HTMLElement> \| KeyboardEvent \| React.MouseEvent<HTMLButtonElement>) => void) \| undefined | No |  |  |  | A custom close event handler |  |
 | restoreFocusOnClose | boolean \| undefined | No |  |  |  | Enables the automatic restoration of focus to the element that invoked the modal when the modal is closed. |  |
 | role | string \| undefined | No |  |  |  | The ARIA role to be applied to the Dialog container |  |
@@ -54,6 +53,7 @@ description: Carbon Alert component props and usage examples.
 | disableClose | boolean \| undefined | No |  | Yes | Use `showCloseIcon={false}` instead. |  |  |
 | disableContentPadding | boolean \| undefined | No |  | Yes | Use `contentPadding` instead. |  |  |
 | fullscreen | boolean \| undefined | No |  | Yes | Use `size="fullscreen"` instead. |  |  |
+| help | string \| undefined | No |  | Yes | This prop no longer has any effect and will be removed in a future release. | Adds Help tooltip to Header. |  |
 | highlightVariant | string \| undefined | No |  | Yes | Use `gradientKeyLine` instead. |  |  |
 | pagesStyling | boolean \| undefined | No |  | Yes | PagesStyling is now deprecated and will be removed in a future release |  |  |
 

--- a/skills/carbon-react/components/dialog.md
+++ b/skills/carbon-react/components/dialog.md
@@ -34,7 +34,6 @@ description: Carbon Dialog component props and usage examples.
 | greyBackground | boolean \| undefined | No |  |  |  | Change the background color of the content to grey |  |
 | headerChildren | React.ReactNode | No |  |  |  | Container for components to be displayed in the header |  |
 | height | string \| undefined | No |  |  |  | Allows developers to specify a specific height for the dialog. |  |
-| help | string \| undefined | No |  |  |  | Adds Help tooltip to Header |  |
 | onCancel | ((ev: React.KeyboardEvent<HTMLElement> \| KeyboardEvent \| React.MouseEvent<HTMLButtonElement>) => void) \| undefined | No |  |  |  | A custom close event handler |  |
 | restoreFocusOnClose | boolean \| undefined | No |  |  |  | Enables the automatic restoration of focus to the element that invoked the modal when the modal is closed. |  |
 | role | string \| undefined | No |  |  |  | The ARIA role to be applied to the Dialog container |  |
@@ -52,6 +51,7 @@ description: Carbon Dialog component props and usage examples.
 | disableClose | boolean \| undefined | No |  | Yes | Use `showCloseIcon={false}` instead. |  |  |
 | disableContentPadding | boolean \| undefined | No |  | Yes | Use `contentPadding` instead. |  |  |
 | fullscreen | boolean \| undefined | No |  | Yes | Use `size="fullscreen"` instead. |  |  |
+| help | string \| undefined | No |  | Yes | This prop no longer has any effect and will be removed in a future release. | Adds Help tooltip to Header. |  |
 | highlightVariant | string \| undefined | No |  | Yes | Use `gradientKeyLine` instead. |  |  |
 | pagesStyling | boolean \| undefined | No |  | Yes | PagesStyling is now deprecated and will be removed in a future release |  |  |
 
@@ -1022,6 +1022,261 @@ function WithHeaderChildrenRender({
 ```
 
 
+### WithStatusHeaderSubtle
+
+**Args**
+
+```tsx
+{
+    open: isChromatic(),
+    size: "medium",
+  }
+```
+
+**Render**
+
+```tsx
+function WithStatusHeaderSubtleRender({
+    onCancel,
+    ...args
+  }: Partial<DialogProps>) {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(args.open || false);
+
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <Dialog
+          {...args}
+          open={open}
+          onCancel={(ev) => {
+            onCancel?.(ev);
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          title={
+            <DialogHeadingStatus
+              title="Information: Please review the details below"
+              subtitle="This is an informational message"
+              status="subtle"
+            />
+          }
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </Dialog>
+      </>
+    );
+  }
+```
+
+
+### WithStatusHeaderPositive
+
+**Args**
+
+```tsx
+{
+    open: isChromatic(),
+    size: "medium",
+  }
+```
+
+**Render**
+
+```tsx
+function WithStatusHeaderPositiveRender({
+    onCancel,
+    ...args
+  }: Partial<DialogProps>) {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(args.open || false);
+
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <Dialog
+          {...args}
+          open={open}
+          onCancel={(ev) => {
+            onCancel?.(ev);
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          title={
+            <DialogHeadingStatus
+              title="Success: Your changes have been saved"
+              subtitle="All data has been successfully updated"
+              status="positive"
+            />
+          }
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </Dialog>
+      </>
+    );
+  }
+```
+
+
+### WithStatusHeaderNegative
+
+**Args**
+
+```tsx
+{
+    open: isChromatic(),
+    size: "medium",
+  }
+```
+
+**Render**
+
+```tsx
+function WithStatusHeaderNegativeRender({
+    onCancel,
+    ...args
+  }: Partial<DialogProps>) {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(args.open || false);
+
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <Dialog
+          {...args}
+          open={open}
+          onCancel={(ev) => {
+            onCancel?.(ev);
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          title={
+            <DialogHeadingStatus
+              title="Error: Unable to complete the action"
+              subtitle="Please check your input and try again"
+              status="negative"
+            />
+          }
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </Dialog>
+      </>
+    );
+  }
+```
+
+
+### WithStatusHeaderCaution
+
+**Args**
+
+```tsx
+{
+    open: isChromatic(),
+    size: "medium",
+  }
+```
+
+**Render**
+
+```tsx
+function WithStatusHeaderCautionRender({
+    onCancel,
+    ...args
+  }: Partial<DialogProps>) {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(args.open || false);
+
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <Dialog
+          {...args}
+          open={open}
+          onCancel={(ev) => {
+            onCancel?.(ev);
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          title={
+            <DialogHeadingStatus
+              title="Warning: This action cannot be undone"
+              subtitle="Please confirm before proceeding"
+              status="caution"
+            />
+          }
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </Dialog>
+      </>
+    );
+  }
+```
+
+
+### WithStatusHeaderInfo
+
+**Args**
+
+```tsx
+{
+    open: isChromatic(),
+    size: "medium",
+  }
+```
+
+**Render**
+
+```tsx
+function WithStatusHeaderInfoRender({
+    onCancel,
+    ...args
+  }: Partial<DialogProps>) {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(args.open || false);
+
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <Dialog
+          {...args}
+          open={open}
+          onCancel={(ev) => {
+            onCancel?.(ev);
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          title={
+            <DialogHeadingStatus
+              title="New feature available"
+              subtitle="Learn about the latest updates"
+              status="info"
+            />
+          }
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </Dialog>
+      </>
+    );
+  }
+```
+
+
 ### MDX Example 1
 
 **Args**
@@ -1105,6 +1360,41 @@ Use the `headerChildren` prop to render additional content — such as action bu
 
 <Canvas of={DialogStories.WithHeaderChildren} />
 
+### With status header
+
+Use the `DialogHeader` component (exported from Dialog) to render a status-styled header with an icon before the title. This is commonly used to indicate the status or severity of the dialog content. The icon is automatically marked as `aria-hidden="true"` since it's decorative - the status should be conveyed through the title text itself for accessibility.
+
+`DialogHeader` automatically generates IDs for its title and subtitle elements, which the Dialog component detects and uses for proper ARIA labeling. No additional `aria-label` or `aria-labelledby` props are needed:
+```
+
+
+### MDX Example 2
+
+**Args**
+
+```tsx
+#### Available status variants
+
+**Subtle** - For informational dialogs
+
+<Canvas of={DialogStories.WithStatusHeaderSubtle} />
+
+**Positive** - For success or confirmation dialogs
+
+<Canvas of={DialogStories.WithStatusHeaderPositive} />
+
+**Negative** - For error or critical dialogs
+
+<Canvas of={DialogStories.WithStatusHeaderNegative} />
+
+**Caution** - For warning dialogs
+
+<Canvas of={DialogStories.WithStatusHeaderCaution} />
+
+**Info** - For general information dialogs
+
+<Canvas of={DialogStories.WithStatusHeaderInfo} />
+
 ### Gradient keyline
 
 Setting `gradientKeyLine` adds a decorative gradient keyline below the dialog header.
@@ -1142,7 +1432,7 @@ To achieve this, forward a custom ref handle to the `Dialog` component using the
 ```
 
 
-### MDX Example 2
+### MDX Example 3
 
 **Args**
 

--- a/src/components/dialog/__internal__/__next__/components-test.pw.tsx
+++ b/src/components/dialog/__internal__/__next__/components-test.pw.tsx
@@ -1,7 +1,10 @@
 import React, { useRef, useState } from "react";
 import Textbox from "../../../textbox";
 import Button from "../../../button";
-import Dialog, { withDialogHeader, DialogProps } from "./dialog.component";
+import Dialog, { type DialogProps } from "./dialog.component";
+import DialogHeadingStatus, {
+  DialogHeadingStatusProps,
+} from "./dialog-header/dialog-header.component";
 
 export const DialogComponent = (props: Partial<DialogProps>) => {
   const [isOpen, setIsOpen] = useState(true);
@@ -54,41 +57,47 @@ export const DialogFullscreen = (props: Partial<DialogProps>) => {
   );
 };
 
-const DialogWithHeadingVariant = withDialogHeader(Dialog);
-
 export const DialogWithHeadingVariantPositive = (
-  props: Partial<DialogProps>,
+  props: Partial<DialogProps & DialogHeadingStatusProps>,
 ) => {
   return (
-    <DialogWithHeadingVariant
+    <Dialog
       open
-      title="Dialog with positive icon"
-      subtitle="Subheading"
-      statusIcon="positive"
+      title={
+        <DialogHeadingStatus
+          title="Dialog with positive icon"
+          subtitle="Subheading"
+          status="positive"
+        />
+      }
       onCancel={() => {}}
       {...props}
     >
       <Textbox onChange={() => {}} label="Textbox1" value="Textbox1" />
       <Textbox onChange={() => {}} label="Textbox2" value="Textbox2" />
       <Textbox onChange={() => {}} label="Textbox3" value="Textbox3" />
-    </DialogWithHeadingVariant>
+    </Dialog>
   );
 };
 
 export const DialogWithHeadingVariantSubtle = (props: Partial<DialogProps>) => {
   return (
-    <DialogWithHeadingVariant
+    <Dialog
       open
-      title="Dialog with subtle icon"
-      subtitle="Subheading"
-      statusIcon="subtle"
+      title={
+        <DialogHeadingStatus
+          title="Dialog with subtle icon"
+          subtitle="Subheading"
+          status="subtle"
+        />
+      }
       onCancel={() => {}}
       {...props}
     >
       <Textbox onChange={() => {}} label="Textbox1" value="Textbox1" />
       <Textbox onChange={() => {}} label="Textbox2" value="Textbox2" />
       <Textbox onChange={() => {}} label="Textbox3" value="Textbox3" />
-    </DialogWithHeadingVariant>
+    </Dialog>
   );
 };
 
@@ -96,18 +105,22 @@ export const DialogWithHeadingVariantNegative = (
   props: Partial<DialogProps>,
 ) => {
   return (
-    <DialogWithHeadingVariant
+    <Dialog
       open
-      title="Dialog with negative icon"
-      subtitle="Subheading"
-      statusIcon="negative"
+      title={
+        <DialogHeadingStatus
+          title="Dialog with negative icon"
+          subtitle="Subheading"
+          status="negative"
+        />
+      }
       onCancel={() => {}}
       {...props}
     >
       <Textbox onChange={() => {}} label="Textbox1" value="Textbox1" />
       <Textbox onChange={() => {}} label="Textbox2" value="Textbox2" />
       <Textbox onChange={() => {}} label="Textbox3" value="Textbox3" />
-    </DialogWithHeadingVariant>
+    </Dialog>
   );
 };
 
@@ -115,34 +128,59 @@ export const DialogWithHeadingVariantCaution = (
   props: Partial<DialogProps>,
 ) => {
   return (
-    <DialogWithHeadingVariant
+    <Dialog
       open
-      title="Dialog with caution icon"
-      subtitle="Subheading"
-      statusIcon="caution"
+      title={
+        <DialogHeadingStatus
+          title="Dialog with caution icon"
+          subtitle="Subheading"
+          status="caution"
+        />
+      }
       onCancel={() => {}}
       {...props}
     >
       <Textbox onChange={() => {}} label="Textbox1" value="Textbox1" />
       <Textbox onChange={() => {}} label="Textbox2" value="Textbox2" />
       <Textbox onChange={() => {}} label="Textbox3" value="Textbox3" />
-    </DialogWithHeadingVariant>
+    </Dialog>
   );
 };
 
 export const DialogWithHeadingVariantInfo = (props: Partial<DialogProps>) => {
   return (
-    <DialogWithHeadingVariant
+    <Dialog
       open
-      title="Dialog with info icon"
-      subtitle="Subheading"
-      statusIcon="info"
+      title={
+        <DialogHeadingStatus
+          title="Dialog with info icon"
+          subtitle="Subheading"
+          status="info"
+        />
+      }
       onCancel={() => {}}
       {...props}
     >
       <Textbox onChange={() => {}} label="Textbox1" value="Textbox1" />
       <Textbox onChange={() => {}} label="Textbox2" value="Textbox2" />
       <Textbox onChange={() => {}} label="Textbox3" value="Textbox3" />
-    </DialogWithHeadingVariant>
+    </Dialog>
+  );
+};
+
+export const DialogWithHeadingNoSubtitle = (props: Partial<DialogProps>) => {
+  return (
+    <Dialog
+      open
+      title={
+        <DialogHeadingStatus title="Dialog with info icon" status="info" />
+      }
+      onCancel={() => {}}
+      {...props}
+    >
+      <Textbox onChange={() => {}} label="Textbox1" value="Textbox1" />
+      <Textbox onChange={() => {}} label="Textbox2" value="Textbox2" />
+      <Textbox onChange={() => {}} label="Textbox3" value="Textbox3" />
+    </Dialog>
   );
 };

--- a/src/components/dialog/__internal__/__next__/dialog-header/dialog-header.component.tsx
+++ b/src/components/dialog/__internal__/__next__/dialog-header/dialog-header.component.tsx
@@ -1,11 +1,16 @@
-import React, { forwardRef, useRef } from "react";
-import { DialogProps, DialogHandle } from "../dialog.component";
+import React, { forwardRef, useRef, useContext } from "react";
 import { StyledSubtitle } from "../dialog.style";
 import Box from "../../../../box";
 import Icon, { IconColor } from "../../../../icon";
 import { IconType } from "../../../../icon/icon-type";
 import Typography from "../../../../typography";
 import createGuid from "../../../../../__internal__/utils/helpers/guid";
+
+/** @internal Context for passing IDs from Dialog to DialogHeader */
+export const DialogHeadingStatusContext = React.createContext<{
+  titleId?: string;
+  subtitleId?: string;
+} | null>(null);
 
 /** Allowed status variants for the dialog heading icon. */
 export type DialogHeadingStatus =
@@ -15,7 +20,6 @@ export type DialogHeadingStatus =
   | "caution"
   | "info";
 
-/** Map each status to its icon type and colour token. */
 const STATUS_CONFIG: Record<
   DialogHeadingStatus,
   { iconType: IconType; color: IconColor }
@@ -42,136 +46,68 @@ const STATUS_CONFIG: Record<
   },
 };
 
-// Define the extra props the HOC injects
-interface WithCustomHeadingProps {
-  /** Custom heading renderer — receives the original title and subtitle */
-  renderHeading?: (
-    title: React.ReactNode,
-    subtitle: React.ReactNode,
-  ) => React.ReactNode;
-  /** Renders a status icon to the left of the title */
-  statusIcon?: DialogHeadingStatus;
+export interface DialogHeadingStatusProps {
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  status: DialogHeadingStatus;
 }
 
-type EnhancedDialogProps = Omit<DialogProps, "title" | "subtitle"> &
-  WithCustomHeadingProps & {
-    title?: React.ReactNode;
-    subtitle?: React.ReactNode;
-  };
+interface DialogHeadingStatusComponent
+  extends React.ForwardRefExoticComponent<
+    DialogHeadingStatusProps & React.RefAttributes<HTMLDivElement>
+  > {
+  $$carbonDialogHeadingStatus?: boolean;
+}
 
-function withDialogHeader(
-  WrappedDialog: React.ForwardRefExoticComponent<
-    DialogProps & React.RefAttributes<DialogHandle>
-  >,
-) {
-  const Enhanced = forwardRef<DialogHandle, EnhancedDialogProps>(
-    (
-      {
-        renderHeading,
-        statusIcon,
-        title,
-        subtitle,
-        "aria-labelledby": propAriaLabelledBy,
-        "aria-describedby": propAriaDescribedBy,
-        "aria-label": propAriaLabel,
-        ...rest
-      },
-      ref,
-    ) => {
-      const statusTitleId = useRef(createGuid()).current;
-      const statusSubtitleId = useRef(createGuid()).current;
+const DialogHeadingStatus: DialogHeadingStatusComponent = forwardRef<
+  HTMLDivElement,
+  DialogHeadingStatusProps
+>(({ title, subtitle, status }, ref) => {
+  const { iconType, color } = STATUS_CONFIG[status];
+  const context = useContext(DialogHeadingStatusContext);
 
-      let resolvedTitle: React.ReactNode = title;
-      let passSubtitle = true;
-      let ariaLabelledBy: string | undefined = propAriaLabelledBy;
-      let ariaDescribedBy: string | undefined = propAriaDescribedBy;
-      let ariaLabel: string | undefined = propAriaLabel;
+  // Always call hooks unconditionally at the top level
+  const generatedTitleId = useRef(context?.titleId || createGuid()).current;
+  const generatedSubtitleId = useRef(createGuid()).current;
 
-      if (renderHeading) {
-        resolvedTitle = renderHeading(title, subtitle);
-        passSubtitle = false;
+  // Use context IDs if available, otherwise use generated ones
+  const titleId = context?.titleId || generatedTitleId;
+  const subtitleId = context?.subtitleId || generatedSubtitleId;
 
-        // istanbul ignore next: This is a dev-time warning to encourage accessibility best practices.
-        if (!propAriaLabelledBy && !propAriaLabel) {
-          // eslint-disable-next-line no-console
-          console.warn(
-            "Dialog withDialogHeader: When using `renderHeading`, you must provide " +
-              "`aria-labelledby` or `aria-label` so the dialog has an accessible name.",
-          );
-        }
-      } else if (statusIcon) {
-        const { iconType, color } = STATUS_CONFIG[statusIcon];
-
-        resolvedTitle = (
-          <Box
-            data-role="status-heading"
-            display="flex"
-            flexWrap="wrap"
-            alignItems="center"
-          >
-            <Icon
-              type={iconType}
-              color={color}
-              fontSize="medium"
-              aria-hidden={true}
-              ml="-4px"
-            />
-            <Typography
-              variant="h1"
-              ml="var(--global-space-comp-L, 16px)"
-              data-element="dialog-title"
-              id={statusTitleId}
-            >
-              {title}
-            </Typography>
-            {subtitle && (
-              <StyledSubtitle
-                data-element="subtitle"
-                data-role="subtitle"
-                id={statusSubtitleId}
-                mb="0"
-              >
-                {subtitle}
-              </StyledSubtitle>
-            )}
-          </Box>
-        );
-        passSubtitle = false;
-
-        // Point aria-labelledby at the id we generated (only when consumer didn't provide one)
-        ariaLabelledBy ??= statusTitleId;
-        // Also set aria-label as a belt-and-suspenders fallback
-        // (aria-labelledby takes precedence when both are present,
-        // but aria-label alone satisfies axe if the id ref fails)
-        // istanbul ignore else
-        if (typeof title === "string") {
-          ariaLabel = ariaLabel ?? title;
-        }
-        if (subtitle) {
-          ariaDescribedBy ??= statusSubtitleId;
-        }
-      }
-
-      return (
-        <WrappedDialog
-          {...rest}
-          title={resolvedTitle}
-          {...(passSubtitle ? { subtitle } : {})}
-          aria-labelledby={ariaLabelledBy}
-          aria-describedby={ariaDescribedBy}
-          aria-label={ariaLabel}
-          ref={ref}
-        />
-      );
-    },
+  return (
+    <Box
+      ref={ref}
+      data-role="status-heading"
+      display="flex"
+      flexWrap="wrap"
+      alignItems="center"
+    >
+      <Icon type={iconType} color={color} size="medium" aria-hidden ml="-4px" />
+      <Typography
+        variant="h1"
+        ml="var(--global-space-comp-l)"
+        data-element="dialog-title"
+        id={titleId}
+      >
+        {title}
+      </Typography>
+      {subtitle && (
+        <StyledSubtitle
+          data-element="subtitle"
+          data-role="subtitle"
+          id={subtitleId}
+          mb="0"
+        >
+          {subtitle}
+        </StyledSubtitle>
+      )}
+    </Box>
   );
+});
 
-  Enhanced.displayName = `withDialogHeader(${
-    WrappedDialog.displayName || WrappedDialog.name || "Component"
-  })`;
+DialogHeadingStatus.displayName = "DialogHeadingStatus";
 
-  return Enhanced;
-}
+// Static marker to identify this component even when wrapped in memo/styled-components
+DialogHeadingStatus.$$carbonDialogHeadingStatus = true;
 
-export default withDialogHeader;
-export type { EnhancedDialogProps };
+export default DialogHeadingStatus;

--- a/src/components/dialog/__internal__/__next__/dialog-header/dialog-header.test.tsx
+++ b/src/components/dialog/__internal__/__next__/dialog-header/dialog-header.test.tsx
@@ -1,10 +1,8 @@
-import React, { createRef, forwardRef } from "react";
+import React, { createRef } from "react";
 import { render, screen, within } from "@testing-library/react";
 
-import Dialog, { DialogHandle, DialogProps } from "../dialog.component";
-import withDialogHeader from "./dialog-header.component";
-
-const DialogWithHeadingVariant = withDialogHeader(Dialog);
+import Dialog from "../dialog.component";
+import DialogHeadingStatus from "./dialog-header.component";
 
 beforeEach(() => {
   jest.useFakeTimers();
@@ -15,227 +13,108 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
-describe("withDialogHeader", () => {
-  describe("without renderHeading", () => {
-    test("renders the default title as a heading", () => {
-      render(<DialogWithHeadingVariant open title="Default Title" />);
-
-      const dialog = screen.getByRole("dialog", { name: /Default Title/i });
-      const heading = within(dialog).getByRole("heading", {
-        level: 1,
-        name: /Default Title/i,
-      });
-
-      expect(heading).toBeVisible();
-    });
-
-    test("renders the default subtitle", () => {
+describe("DialogHeader", () => {
+  test.each([
+    ["subtle", "info"],
+    ["positive", "tick_circle"],
+    ["negative", "error"],
+    ["caution", "warning"],
+    ["info", "info"],
+  ] as const)(
+    "renders the %s status icon with the correct icon type",
+    (status, expectedIconType) => {
       render(
-        <DialogWithHeadingVariant
-          open
-          title="My Title"
-          subtitle="My Subtitle"
-        />,
-      );
-
-      const dialog = screen.getByRole("dialog", {
-        description: /My Subtitle/i,
-      });
-
-      expect(dialog).toHaveTextContent("My Subtitle");
-    });
-  });
-
-  describe("with renderHeading", () => {
-    test("calls renderHeading with the title and subtitle", () => {
-      const renderHeading = jest.fn(
-        (title: React.ReactNode, subtitle: React.ReactNode) => (
-          <div data-role="custom-heading">
-            <h1>{title}</h1>
-            <p>{subtitle}</p>
-          </div>
-        ),
-      );
-
-      render(
-        <DialogWithHeadingVariant
-          open
-          title="Custom Title"
-          subtitle="Custom Subtitle"
-          renderHeading={renderHeading}
-        />,
-      );
-
-      expect(renderHeading).toHaveBeenCalledWith(
-        "Custom Title",
-        "Custom Subtitle",
-      );
-    });
-
-    test("renders the custom heading output", () => {
-      render(
-        <DialogWithHeadingVariant
-          open
-          title="Custom Title"
-          subtitle="Custom Subtitle"
-          renderHeading={(title, subtitle) => (
-            <div data-role="custom-heading">
-              <h1>{title}</h1>
-              <p>{subtitle}</p>
-            </div>
-          )}
-        />,
-      );
-
-      const customHeading = screen.getByTestId("custom-heading");
-      expect(customHeading).toBeVisible();
-      expect(
-        within(customHeading).getByRole("heading", {
-          level: 1,
-          name: /Custom Title/i,
-        }),
-      ).toBeVisible();
-      expect(customHeading).toHaveTextContent("Custom Subtitle");
-    });
-
-    test("does not render subtitle separately when renderHeading is provided", () => {
-      render(
-        <DialogWithHeadingVariant
-          open
-          title="Title"
-          subtitle="Subtitle"
-          renderHeading={(title) => <h1>{title}</h1>}
-        />,
-      );
-
-      expect(
-        screen.queryByTestId("subtitle") ??
-          screen.queryByText("Subtitle", {
-            selector: '[data-element="subtitle"]',
-          }),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  describe("ref forwarding", () => {
-    test("forwards the ref to the underlying Dialog", () => {
-      const ref = createRef<DialogHandle>();
-
-      render(<DialogWithHeadingVariant open title="Ref Test" ref={ref} />);
-
-      expect(ref.current).not.toBeNull();
-      expect(ref.current).toHaveProperty("focus");
-    });
-  });
-
-  describe("with statusIcon", () => {
-    test.each([
-      ["subtle", "info"],
-      ["positive", "tick_circle"],
-      ["negative", "error"],
-      ["caution", "warning"],
-      ["info", "info"],
-    ] as const)(
-      "renders the %s status icon with the correct icon type",
-      (status, expectedIconType) => {
-        render(
-          <DialogWithHeadingVariant
-            open
-            title={`${status} Title`}
-            subtitle="Subheading"
-            statusIcon={status}
-          />,
-        );
-
-        const statusHeading = screen.getByTestId("status-heading");
-        expect(statusHeading).toBeVisible();
-
-        const icon = within(statusHeading).getByTestId("icon");
-        expect(icon).toHaveAttribute("type", expectedIconType);
-      },
-    );
-
-    test("renders the title text inside the status heading", () => {
-      render(
-        <DialogWithHeadingVariant
-          open
-          title="Dialog title with positive icon"
-          statusIcon="positive"
-        />,
-      );
-
-      const statusHeading = screen.getByTestId("status-heading");
-      expect(
-        within(statusHeading).getByRole("heading", {
-          level: 1,
-          name: /Dialog title with positive icon/i,
-        }),
-      ).toBeVisible();
-    });
-
-    test("renders the subtitle inside the status heading", () => {
-      render(
-        <DialogWithHeadingVariant
-          open
-          title="Title"
+        <DialogHeadingStatus
+          title={`${status} Title`}
           subtitle="Subheading"
-          statusIcon="negative"
+          status={status}
         />,
-      );
-
-      const statusHeading = screen.getByTestId("status-heading");
-      expect(within(statusHeading).getByText("Subheading")).toBeVisible();
-    });
-
-    test("does not render subtitle separately from the status heading", () => {
-      render(
-        <DialogWithHeadingVariant
-          open
-          title="Title"
-          subtitle="Subheading"
-          statusIcon="caution"
-        />,
-      );
-
-      // Subtitle should only appear inside the status heading, not as a
-      // separate element rendered by the base Dialog
-      const subtitleElements = screen.getAllByText("Subheading");
-      expect(subtitleElements).toHaveLength(1);
-
-      const statusHeading = screen.getByTestId("status-heading");
-      expect(within(statusHeading).getByText("Subheading")).toBeVisible();
-    });
-
-    test("renders without subtitle when subtitle is not provided", () => {
-      render(
-        <DialogWithHeadingVariant open title="Title Only" statusIcon="info" />,
       );
 
       const statusHeading = screen.getByTestId("status-heading");
       expect(statusHeading).toBeVisible();
-      expect(
-        within(statusHeading).queryByTestId("subtitle"),
-      ).not.toBeInTheDocument();
-    });
+
+      const icon = within(statusHeading).getByTestId("icon");
+      expect(icon).toHaveAttribute("type", expectedIconType);
+    },
+  );
+
+  test("renders the title text inside the status heading", () => {
+    render(
+      <DialogHeadingStatus
+        title="Dialog title with positive icon"
+        status="positive"
+      />,
+    );
+
+    const statusHeading = screen.getByTestId("status-heading");
+    expect(
+      within(statusHeading).getByRole("heading", {
+        level: 1,
+        name: /Dialog title with positive icon/i,
+      }),
+    ).toBeVisible();
   });
 
-  describe("displayName", () => {
-    test("sets the correct displayName", () => {
-      expect(DialogWithHeadingVariant.displayName).toBe(
-        "withDialogHeader(Dialog)",
-      );
-    });
+  test("renders the subtitle inside the status heading", () => {
+    render(
+      <DialogHeadingStatus
+        title="Title"
+        subtitle="Subheading"
+        status="negative"
+      />,
+    );
 
-    test("falls back to 'Component' when displayName is not set", () => {
-      const AnonymousDialog = forwardRef<DialogHandle, DialogProps>(
-        (props, ref) => <Dialog {...props} ref={ref} />,
-      );
-      delete (AnonymousDialog as unknown as Record<string, unknown>)
-        .displayName;
+    const statusHeading = screen.getByTestId("status-heading");
+    expect(within(statusHeading).getByText("Subheading")).toBeVisible();
+  });
 
-      const Wrapped = withDialogHeader(AnonymousDialog as typeof Dialog);
+  test("renders without subtitle when subtitle is not provided", () => {
+    render(<DialogHeadingStatus title="Title Only" status="info" />);
 
-      expect(Wrapped.displayName).toBe("withDialogHeader(Component)");
-    });
+    const statusHeading = screen.getByTestId("status-heading");
+    expect(statusHeading).toBeVisible();
+    expect(
+      within(statusHeading).queryByTestId("subtitle"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("forwards ref to the container element", () => {
+    const ref = createRef<HTMLDivElement>();
+
+    render(<DialogHeadingStatus title="Title" status="positive" ref={ref} />);
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe("DIV");
+  });
+
+  test("works when passed as title prop to Dialog", () => {
+    render(
+      <Dialog
+        open
+        title={
+          <DialogHeadingStatus
+            title="Dialog with status"
+            subtitle="Subtitle text"
+            status="positive"
+          />
+        }
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    const statusHeading = within(dialog).getByTestId("status-heading");
+    expect(statusHeading).toBeVisible();
+    expect(
+      within(statusHeading).getByRole("heading", {
+        level: 1,
+        name: /Dialog with status/i,
+      }),
+    ).toBeVisible();
+    expect(within(statusHeading).getByText("Subtitle text")).toBeVisible();
+  });
+
+  test("displayName is set correctly", () => {
+    expect(DialogHeadingStatus.displayName).toBe("DialogHeadingStatus");
   });
 });

--- a/src/components/dialog/__internal__/__next__/dialog-test.stories.tsx
+++ b/src/components/dialog/__internal__/__next__/dialog-test.stories.tsx
@@ -8,9 +8,8 @@ import Button from "../../../button/__next__/";
 import Typography from "../../../typography";
 import Textbox from "../../../textbox";
 
-import Dialog, { withDialogHeader } from "./dialog.component";
-
-const DialogWithHeadingVariant = withDialogHeader(Dialog);
+import Dialog from "./dialog.component";
+import DialogHeader from "./dialog-header/dialog-header.component";
 
 const meta: Meta<typeof Dialog> = {
   title: "Dialog/Test",
@@ -124,82 +123,102 @@ export const SizeFullScreen: Story = {
   ),
 };
 
-export const HeadingSubtle: StoryObj<typeof DialogWithHeadingVariant> = {
+export const HeadingSubtle: StoryObj<typeof Dialog> = {
   name: "Heading Subtle",
   render: () => (
-    <DialogWithHeadingVariant
+    <Dialog
       open
-      title="Dialog with subtle icon"
-      subtitle="Subheading"
-      statusIcon="subtle"
+      title={
+        <DialogHeader
+          title="Dialog with subtle icon"
+          subtitle="Subheading"
+          status="subtle"
+        />
+      }
       onCancel={() => {}}
       footer={<Buttons />}
     >
       {dialogContent}
-    </DialogWithHeadingVariant>
+    </Dialog>
   ),
 };
 
-export const HeadingPositive: StoryObj<typeof DialogWithHeadingVariant> = {
+export const HeadingPositive: StoryObj<typeof Dialog> = {
   name: "Heading Positive",
   render: () => (
-    <DialogWithHeadingVariant
+    <Dialog
       open
-      title="Dialog with positive icon"
-      subtitle="Subheading"
-      statusIcon="positive"
+      title={
+        <DialogHeader
+          title="Dialog with positive icon"
+          subtitle="Subheading"
+          status="positive"
+        />
+      }
       onCancel={() => {}}
       footer={<Buttons />}
     >
       {dialogContent}
-    </DialogWithHeadingVariant>
+    </Dialog>
   ),
 };
 
-export const HeadingNegative: StoryObj<typeof DialogWithHeadingVariant> = {
+export const HeadingNegative: StoryObj<typeof Dialog> = {
   name: "Heading Negative",
   render: () => (
-    <DialogWithHeadingVariant
+    <Dialog
       open
-      title="Dialog with negative icon"
-      subtitle="Subheading"
-      statusIcon="negative"
+      title={
+        <DialogHeader
+          title="Dialog with negative icon"
+          subtitle="Subheading"
+          status="negative"
+        />
+      }
       onCancel={() => {}}
       footer={<Buttons />}
     >
       {dialogContent}
-    </DialogWithHeadingVariant>
+    </Dialog>
   ),
 };
 
-export const HeadingCaution: StoryObj<typeof DialogWithHeadingVariant> = {
+export const HeadingCaution: StoryObj<typeof Dialog> = {
   name: "Heading Caution",
   render: () => (
-    <DialogWithHeadingVariant
+    <Dialog
       open
-      title="Dialog with caution icon"
-      subtitle="Subheading"
-      statusIcon="caution"
+      title={
+        <DialogHeader
+          title="Dialog with caution icon"
+          subtitle="Subheading"
+          status="caution"
+        />
+      }
       onCancel={() => {}}
       footer={<Buttons />}
     >
       {dialogContent}
-    </DialogWithHeadingVariant>
+    </Dialog>
   ),
 };
 
-export const HeadingInfo: StoryObj<typeof DialogWithHeadingVariant> = {
+export const HeadingInfo: StoryObj<typeof Dialog> = {
   name: "Heading Info",
   render: () => (
-    <DialogWithHeadingVariant
+    <Dialog
       open
-      title="Dialog with info icon"
-      subtitle="Subheading"
-      statusIcon="info"
+      title={
+        <DialogHeader
+          title="Dialog with info icon"
+          subtitle="Subheading"
+          status="info"
+        />
+      }
       onCancel={() => {}}
       footer={<Buttons />}
     >
       {dialogContent}
-    </DialogWithHeadingVariant>
+    </Dialog>
   ),
 };

--- a/src/components/dialog/__internal__/__next__/dialog.component.tsx
+++ b/src/components/dialog/__internal__/__next__/dialog.component.tsx
@@ -14,13 +14,17 @@ import {
   StyledSubtitle,
 } from "./dialog.style";
 
-import { StyledHeaderHelp } from "../../../heading/heading.style";
+import DialogHeadingStatus, {
+  DialogHeadingStatusContext,
+} from "./dialog-header/dialog-header.component";
+
+import Button from "../../../button/__next__";
 import Icon from "../../../icon";
 import Typography from "../../../typography";
 import Modal, { ModalProps } from "../../../../__internal__/modal";
+import FullScreenHeading from "../../../../__internal__/full-screen-heading";
 
 import FocusTrap from "../../../../__internal__/focus-trap";
-import FullScreenHeading from "../../../../__internal__/full-screen-heading";
 import createGuid from "../../../../__internal__/utils/helpers/guid";
 import tagComponent, {
   TagProps,
@@ -28,9 +32,9 @@ import tagComponent, {
 
 import useLocale from "../../../../hooks/__internal__/useLocale";
 import useModalAria from "../../../../hooks/__internal__/useModalAria/useModalAria";
-import Button from "../../../button/__next__";
 
 import { Size, ContentPaddingInterface } from "./dialog.config";
+import isDialogHeadingStatusComponent from "./utils";
 
 export type { Size, ContentPaddingInterface };
 
@@ -92,7 +96,10 @@ export interface DialogProps extends ModalProps, TagProps {
   headerChildren?: React.ReactNode;
   /** Allows developers to specify a specific height for the dialog. */
   height?: string;
-  /** Adds Help tooltip to Header */
+  /**
+   * Adds Help tooltip to Header.
+   * @deprecated This prop no longer has any effect and will be removed in a future release.
+   */
   help?: string;
   /** Adds a gradient keyline to the dialog header */
   gradientKeyLine?: boolean;
@@ -209,6 +216,24 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
       [],
     );
 
+    // Check if title is a DialogHeader component
+    const isDialogHeader = React.useMemo(() => {
+      if (!title || !React.isValidElement(title)) {
+        return false;
+      }
+
+      // Check direct type match
+      if (title.type === DialogHeadingStatus) {
+        return true;
+      }
+
+      return isDialogHeadingStatusComponent(title.type);
+    }, [title]);
+
+    const isValidDialogHeader =
+      isDialogHeader &&
+      React.isValidElement<{ subtitle?: React.ReactNode }>(title);
+
     const closeIcon = showCloseIcon && onCancel && (
       <Button
         aria-label={locale.dialog.ariaLabels.close()}
@@ -224,52 +249,61 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
     );
 
     const dialogTitle = () => {
-      const renderTitle = (
+      // Helper to render subtitle
+      const renderSubtitle = () => {
+        if (!subtitle) return null;
+        return (
+          <StyledSubtitle
+            as="div"
+            data-element="subtitle"
+            data-role="subtitle"
+            id={subtitleId}
+          >
+            {subtitle}
+          </StyledSubtitle>
+        );
+      };
+
+      // Render title content based on type and props
+      const renderTitleContent = () => {
+        // Non-string title renders as-is
+        if (typeof title !== "string") {
+          return title;
+        }
+
+        // String title only
+        return (
+          <Typography
+            wordWrap="break-word"
+            wordBreak="normal"
+            variant="h1"
+            data-element="dialog-title"
+            id={titleId}
+          >
+            {title}
+          </Typography>
+        );
+      };
+
+      const titleContent = (
         <div data-element="dialog-title-container">
-          {typeof title === "string" ? (
-            <>
-              {help ? (
-                <div data-element="dialog-title-help-wrapper">
-                  <Typography
-                    wordWrap="break-word"
-                    wordBreak="normal"
-                    variant="h1"
-                    marginRight="16px"
-                    data-element="dialog-title"
-                    id={titleId}
-                  >
-                    {title}
-                  </Typography>
-                  <StyledHeaderHelp data-element="help" tooltipPosition="right">
-                    {help}
-                  </StyledHeaderHelp>
-                </div>
-              ) : (
-                <Typography
-                  wordWrap="break-word"
-                  wordBreak="normal"
-                  variant="h1"
-                  data-element="dialog-title"
-                  id={titleId}
-                >
-                  {title}
-                </Typography>
-              )}
-            </>
-          ) : (
-            title
-          )}
-          {subtitle && (
-            <StyledSubtitle
-              as="div"
-              data-element="subtitle"
-              data-role="subtitle"
-              id={subtitleId}
-            >
-              {subtitle}
-            </StyledSubtitle>
-          )}
+          {renderTitleContent()}
+          {renderSubtitle()}
         </div>
+      );
+
+      // Wrap in context provider if title is DialogHeader
+      const renderTitle = isDialogHeader ? (
+        <DialogHeadingStatusContext.Provider
+          value={{
+            titleId,
+            subtitleId,
+          }}
+        >
+          {titleContent}
+        </DialogHeadingStatusContext.Provider>
+      ) : (
+        titleContent
       );
 
       return isFullScreen ? (
@@ -317,10 +351,15 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
 
     const ariaProps = {
       "aria-describedby":
-        subtitle && typeof subtitle === "string" ? subtitleId : ariaDescribedBy,
+        (isValidDialogHeader && title.props.subtitle) ||
+        (subtitle && typeof subtitle === "string")
+          ? subtitleId
+          : ariaDescribedBy,
       "aria-label": ariaLabel,
       "aria-labelledby":
-        title && typeof title === "string" ? titleId : ariaLabelledBy,
+        isValidDialogHeader || (title && typeof title === "string")
+          ? titleId
+          : ariaLabelledBy,
     };
 
     return (
@@ -399,8 +438,6 @@ Dialog.displayName = "Dialog";
 
 export default Dialog;
 
-export { default as withDialogHeader } from "./dialog-header/dialog-header.component";
-export type {
-  EnhancedDialogProps,
-  DialogHeadingStatus,
-} from "./dialog-header/dialog-header.component";
+export { default as DialogHeader } from "./dialog-header/dialog-header.component";
+export { default as DialogHeadingStatus } from "./dialog-header/dialog-header.component";
+export type { DialogHeadingStatusProps } from "./dialog-header/dialog-header.component";

--- a/src/components/dialog/__internal__/__next__/dialog.pw.tsx
+++ b/src/components/dialog/__internal__/__next__/dialog.pw.tsx
@@ -9,6 +9,7 @@ import {
   DialogWithHeadingVariantPositive,
   DialogWithHeadingVariantSubtle,
   DialogWithHeadingVariantInfo,
+  DialogWithHeadingNoSubtitle,
 } from "./components-test.pw";
 import { checkAccessibility } from "../../../../../playwright/support/helper";
 
@@ -129,6 +130,14 @@ test.describe("Dialog component", () => {
       page,
     }) => {
       await mount(<DialogWithHeadingVariantInfo />);
+      await checkAccessibility(page, page.getByRole("dialog"));
+    });
+
+    test("should check accessibility with header variant without subtitle", async ({
+      mount,
+      page,
+    }) => {
+      await mount(<DialogWithHeadingNoSubtitle />);
       await checkAccessibility(page, page.getByRole("dialog"));
     });
   });

--- a/src/components/dialog/__internal__/__next__/dialog.style.ts
+++ b/src/components/dialog/__internal__/__next__/dialog.style.ts
@@ -266,11 +266,6 @@ const StyledDialogTitle = styled.div<StyledDialogTitleProps>`
 
   ${({ showCloseIcon }) => showCloseIcon && "padding-right: 85px"};
 
-  [data-element="dialog-title-help-wrapper"] {
-    display: inline-flex;
-    align-items: baseline;
-  }
-
   [data-element="dialog-title-container"] {
     [data-element="dialog-title"] {
       color: var(--container-standard-txt-default, rgba(0, 0, 0, 0.95));

--- a/src/components/dialog/__internal__/__next__/dialog.test.tsx
+++ b/src/components/dialog/__internal__/__next__/dialog.test.tsx
@@ -9,7 +9,7 @@ import {
 import userEvent from "@testing-library/user-event";
 
 import CarbonProvider from "../../../carbon-provider";
-import Dialog from ".";
+import Dialog, { DialogHeadingStatus, DialogHeadingStatusProps } from ".";
 import { DialogHandle, DialogProps } from "./dialog.component";
 import Form from "../../../form";
 import { DIALOG_SIZE_CONFIG } from "./dialog.config";
@@ -114,12 +114,122 @@ describe("Modal Dialog", () => {
     );
   });
 
-  test("help icon is displayed when help prop is passed", () => {
+  test("when DialogHeader is used with a subtitle, the subtitle ID is set for aria-describedby", () => {
+    render(
+      <Dialog
+        open
+        title={
+          <DialogHeadingStatus
+            title="Header with subtitle"
+            subtitle="This is a subtitle"
+            status="info"
+          />
+        }
+      />,
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAccessibleName("Header with subtitle");
+    expect(dialog).toHaveAccessibleDescription("This is a subtitle");
+  });
+
+  test("when DialogHeader is used without a subtitle, aria-describedby is not set by DialogHeader", () => {
+    render(
+      <Dialog
+        open
+        title={
+          <DialogHeadingStatus title="Header without subtitle" status="info" />
+        }
+      />,
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAccessibleName("Header without subtitle");
+    // Dialog should not have an accessible description from DialogHeader
+    expect(dialog).not.toHaveAttribute("aria-describedby");
+  });
+
+  test("when DialogHeader is wrapped in React.memo, it is still detected correctly", () => {
+    const MemoizedDialogHeader = React.memo(DialogHeadingStatus);
+    render(
+      <Dialog
+        open
+        title={
+          <MemoizedDialogHeader
+            title="Memoized Header"
+            subtitle="This is a subtitle"
+            status="positive"
+          />
+        }
+      />,
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAccessibleName("Memoized Header");
+    expect(dialog).toHaveAccessibleDescription("This is a subtitle");
+  });
+
+  test("when DialogHeader is wrapped with marker directly on wrapper, it is detected correctly", () => {
+    // Simulate styled-components or similar wrapper with marker copied to wrapper
+    const StyledWrapper = (props: DialogHeadingStatusProps) => {
+      return <DialogHeadingStatus {...props} />;
+    };
+    // Set marker directly on the wrapper (not nested in a type property)
+    (
+      StyledWrapper as React.FC<DialogHeadingStatusProps> & {
+        $$carbonDialogHeadingStatus: boolean;
+      }
+    ).$$carbonDialogHeadingStatus = true;
+
+    render(
+      <Dialog
+        open
+        title={
+          <StyledWrapper
+            title="Styled Header"
+            subtitle="Styled subtitle"
+            status="positive"
+          />
+        }
+      />,
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAccessibleName("Styled Header");
+    expect(dialog).toHaveAccessibleDescription("Styled subtitle");
+  });
+
+  test("when DialogHeader is wrapped in a custom HOC, it is still detected correctly", () => {
+    // Custom HOC that creates a wrapper without the marker directly on it
+    const CustomWrapper = (props: DialogHeadingStatusProps) => {
+      return <DialogHeadingStatus {...props} />;
+    };
+    // Simulate a wrapper structure where the marker is on a nested type property
+    (
+      CustomWrapper as React.FC<DialogHeadingStatusProps> & {
+        type: typeof DialogHeadingStatus;
+      }
+    ).type = DialogHeadingStatus;
+
+    render(
+      <Dialog
+        open
+        title={
+          <CustomWrapper
+            title="Wrapped Header"
+            subtitle="This is a subtitle"
+            status="info"
+          />
+        }
+      />,
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAccessibleName("Wrapped Header");
+    expect(dialog).toHaveAccessibleDescription("This is a subtitle");
+  });
+
+  test("help icon is not displayed when deprecated help prop is passed", () => {
     render(<Dialog open title="My dialog" help="Help text" />);
 
-    const help = screen.getByLabelText("help");
+    const help = screen.queryByLabelText("help");
 
-    expect(help).toBeVisible();
+    expect(help).not.toBeInTheDocument();
   });
 
   test("close button is displayed when onCancel prop is passed", () => {

--- a/src/components/dialog/__internal__/__next__/index.ts
+++ b/src/components/dialog/__internal__/__next__/index.ts
@@ -1,2 +1,4 @@
 export { default } from "./dialog.component";
 export type { DialogProps } from "./dialog.component";
+export { DialogHeader, DialogHeadingStatus } from "./dialog.component";
+export type { DialogHeadingStatusProps } from "./dialog.component";

--- a/src/components/dialog/__internal__/__next__/utils.ts
+++ b/src/components/dialog/__internal__/__next__/utils.ts
@@ -1,0 +1,15 @@
+const canHaveProperties = (value: unknown): value is object =>
+  value !== null && (typeof value === "object" || typeof value === "function");
+
+const hasDialogHeadingStatusMarker = (value: unknown) =>
+  canHaveProperties(value) &&
+  "$$carbonDialogHeadingStatus" in value &&
+  value.$$carbonDialogHeadingStatus;
+
+export const isDialogHeadingStatusComponent = (componentType: unknown) =>
+  hasDialogHeadingStatusMarker(componentType) ||
+  (canHaveProperties(componentType) &&
+    "type" in componentType &&
+    hasDialogHeadingStatusMarker(componentType.type));
+
+export default isDialogHeadingStatusComponent;

--- a/src/components/dialog/dialog.component.tsx
+++ b/src/components/dialog/dialog.component.tsx
@@ -140,3 +140,9 @@ export const Dialog = forwardRef<DialogHandle, DialogProps>(
 Dialog.displayName = "Dialog";
 export default Dialog;
 export type { DialogHandle, ContentPaddingInterface };
+
+export {
+  DialogHeader,
+  DialogHeadingStatus,
+} from "./__internal__/__next__/dialog.component";
+export type { DialogHeadingStatusProps } from "./__internal__/__next__/dialog.component";

--- a/src/components/dialog/dialog.mdx
+++ b/src/components/dialog/dialog.mdx
@@ -111,6 +111,51 @@ Use the `headerChildren` prop to render additional content — such as action bu
 
 <Canvas of={DialogStories.WithHeaderChildren} />
 
+### With status header
+
+Use the `DialogHeader` component (exported from Dialog) to render a status-styled header with an icon before the title. This is commonly used to indicate the status or severity of the dialog content. The icon is automatically marked as `aria-hidden="true"` since it's decorative - the status should be conveyed through the title text itself for accessibility.
+
+`DialogHeader` automatically generates IDs for its title and subtitle elements, which the Dialog component detects and uses for proper ARIA labeling. No additional `aria-label` or `aria-labelledby` props are needed:
+
+```tsx
+import Dialog, { DialogHeader } from "carbon-react/lib/components/dialog";
+
+<Dialog
+  open
+  title={
+    <DialogHeader
+      title="Dialog with status"
+      subtitle="Subheading"
+      status="positive"
+    />
+  }
+>
+  {/* Dialog content */}
+</Dialog>;
+```
+
+#### Available status variants
+
+**Subtle** - For informational dialogs
+
+<Canvas of={DialogStories.WithStatusHeaderSubtle} />
+
+**Positive** - For success or confirmation dialogs
+
+<Canvas of={DialogStories.WithStatusHeaderPositive} />
+
+**Negative** - For error or critical dialogs
+
+<Canvas of={DialogStories.WithStatusHeaderNegative} />
+
+**Caution** - For warning dialogs
+
+<Canvas of={DialogStories.WithStatusHeaderCaution} />
+
+**Info** - For general information dialogs
+
+<Canvas of={DialogStories.WithStatusHeaderInfo} />
+
 ### Gradient keyline
 
 Setting `gradientKeyLine` adds a decorative gradient keyline below the dialog header.

--- a/src/components/dialog/dialog.pw.tsx
+++ b/src/components/dialog/dialog.pw.tsx
@@ -32,7 +32,6 @@ import {
 import {
   getDataElementByValue,
   portal,
-  tooltipPreview,
   backgroundUILocator,
 } from "../../../playwright/components";
 
@@ -74,7 +73,7 @@ test.describe("Dialog component", () => {
       });
     });
 
-    test("when help prop is provided, hovering over the rendered help icon displays help text", async ({
+    test("when deprecated help prop is provided, help icon is not rendered", async ({
       mount,
       page,
     }) => {
@@ -83,9 +82,7 @@ test.describe("Dialog component", () => {
       );
 
       const helpIcon = page.getByLabel("help");
-      await helpIcon.hover();
-
-      await expect(page.getByRole("tooltip")).toHaveText("Some help text");
+      await expect(helpIcon).toBeHidden();
     });
 
     test("when Dialog is opened, the first focusable element should be focused", async ({
@@ -325,7 +322,7 @@ test.describe("Dialog component", () => {
       await checkAccessibility(page);
     });
 
-    test("WithHelp story should pass accessibility checks", async ({
+    test("WithHelp story should pass accessibility checks (help prop is deprecated and ignored)", async ({
       mount,
       page,
     }) => {
@@ -338,10 +335,9 @@ test.describe("Dialog component", () => {
 
       await checkAccessibility(page);
 
+      // Verify help icon is not rendered since prop is deprecated
       const helpIcon = page.getByLabel("help");
-      await helpIcon.hover();
-
-      await checkAccessibility(page);
+      await expect(helpIcon).toBeHidden();
     });
 
     test("LoadingContent story should pass accessibility checks", async ({
@@ -668,7 +664,10 @@ test.describe("Fullscreen Dialog component", () => {
       await expect(dialogFullScreen).toBeHidden();
     });
 
-    test("should render component with help text", async ({ mount, page }) => {
+    test("should not render help icon when deprecated help prop is provided", async ({
+      mount,
+      page,
+    }) => {
       await mount(
         <FullScreenDialogComponent
           title="Sample Dialog"
@@ -677,8 +676,7 @@ test.describe("Fullscreen Dialog component", () => {
       );
 
       const helpIcon = getDataElementByValue(page, "question");
-      await helpIcon.hover();
-      await expect(tooltipPreview(page)).toHaveText("Some help text");
+      await expect(helpIcon).toBeHidden();
     });
 
     test("should render component with first input and button as focusableSelectors", async ({
@@ -730,7 +728,10 @@ test.describe("Fullscreen Dialog component", () => {
       );
     });
 
-    test("should check accessibility with help", async ({ mount, page }) => {
+    test("should check accessibility (WithHelp story uses deprecated prop)", async ({
+      mount,
+      page,
+    }) => {
       await mount(<WithHelp />);
 
       const openButton = page

--- a/src/components/dialog/dialog.stories.tsx
+++ b/src/components/dialog/dialog.stories.tsx
@@ -14,7 +14,7 @@ import Toast from "../toast";
 import Message from "../message";
 
 import type { DialogProps } from ".";
-import Dialog from ".";
+import Dialog, { DialogHeadingStatus } from ".";
 
 const meta: Meta<typeof Dialog> = {
   title: "Dialog",
@@ -946,5 +946,220 @@ export const WithContentPaddingCustom: Story = {
   args: {
     ...DefaultStory.args,
     contentPadding: { py: 5, px: 8 },
+  },
+};
+
+export const WithStatusHeaderSubtle: Story = {
+  name: "With Status Header - Subtle",
+  args: {
+    open: isChromatic(),
+    size: "medium",
+  },
+  parameters: { chromatic: { disableSnapshot: true } },
+  render: function WithStatusHeaderSubtleRender({
+    onCancel,
+    ...args
+  }: Partial<DialogProps>) {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(args.open || false);
+
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <Dialog
+          {...args}
+          open={open}
+          onCancel={(ev) => {
+            onCancel?.(ev);
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          title={
+            <DialogHeadingStatus
+              title="Information: Please review the details below"
+              subtitle="This is an informational message"
+              status="subtle"
+            />
+          }
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </Dialog>
+      </>
+    );
+  },
+};
+
+export const WithStatusHeaderPositive: Story = {
+  name: "With Status Header - Positive",
+  args: {
+    open: isChromatic(),
+    size: "medium",
+  },
+  parameters: { chromatic: { disableSnapshot: true } },
+  render: function WithStatusHeaderPositiveRender({
+    onCancel,
+    ...args
+  }: Partial<DialogProps>) {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(args.open || false);
+
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <Dialog
+          {...args}
+          open={open}
+          onCancel={(ev) => {
+            onCancel?.(ev);
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          title={
+            <DialogHeadingStatus
+              title="Success: Your changes have been saved"
+              subtitle="All data has been successfully updated"
+              status="positive"
+            />
+          }
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </Dialog>
+      </>
+    );
+  },
+};
+
+export const WithStatusHeaderNegative: Story = {
+  name: "With Status Header - Negative",
+  args: {
+    open: isChromatic(),
+    size: "medium",
+  },
+  parameters: { chromatic: { disableSnapshot: true } },
+  render: function WithStatusHeaderNegativeRender({
+    onCancel,
+    ...args
+  }: Partial<DialogProps>) {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(args.open || false);
+
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <Dialog
+          {...args}
+          open={open}
+          onCancel={(ev) => {
+            onCancel?.(ev);
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          title={
+            <DialogHeadingStatus
+              title="Error: Unable to complete the action"
+              subtitle="Please check your input and try again"
+              status="negative"
+            />
+          }
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </Dialog>
+      </>
+    );
+  },
+};
+
+export const WithStatusHeaderCaution: Story = {
+  name: "With Status Header - Caution",
+  args: {
+    open: isChromatic(),
+    size: "medium",
+  },
+  parameters: { chromatic: { disableSnapshot: true } },
+  render: function WithStatusHeaderCautionRender({
+    onCancel,
+    ...args
+  }: Partial<DialogProps>) {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(args.open || false);
+
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <Dialog
+          {...args}
+          open={open}
+          onCancel={(ev) => {
+            onCancel?.(ev);
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          title={
+            <DialogHeadingStatus
+              title="Warning: This action cannot be undone"
+              subtitle="Please confirm before proceeding"
+              status="caution"
+            />
+          }
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </Dialog>
+      </>
+    );
+  },
+};
+
+export const WithStatusHeaderInfo: Story = {
+  name: "With Status Header - Info",
+  args: {
+    open: isChromatic(),
+    size: "medium",
+  },
+  parameters: { chromatic: { disableSnapshot: true } },
+  render: function WithStatusHeaderInfoRender({
+    onCancel,
+    ...args
+  }: Partial<DialogProps>) {
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(args.open || false);
+
+    return (
+      <>
+        <Button ref={buttonRef} onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+        <Dialog
+          {...args}
+          open={open}
+          onCancel={(ev) => {
+            onCancel?.(ev);
+            setOpen(false);
+            setTimeout(() => buttonRef.current?.focus(), 0);
+          }}
+          title={
+            <DialogHeadingStatus
+              title="New feature available"
+              subtitle="Learn about the latest updates"
+              status="info"
+            />
+          }
+          footer={<Buttons />}
+        >
+          {dialogContent}
+        </Dialog>
+      </>
+    );
   },
 };

--- a/src/components/dialog/dialog.test.tsx
+++ b/src/components/dialog/dialog.test.tsx
@@ -136,12 +136,12 @@ describe("Modal Dialog", () => {
     );
   });
 
-  test("help icon is displayed when help prop is passed", () => {
+  test("help icon is not displayed when deprecated help prop is passed", () => {
     render(<Dialog open title="My dialog" help="Help text" />);
 
-    const help = screen.getByLabelText("help");
+    const help = screen.queryByLabelText("help");
 
-    expect(help).toBeVisible();
+    expect(help).not.toBeInTheDocument();
   });
 
   test("close button is displayed when onCancel prop is passed", () => {

--- a/src/components/dialog/index.ts
+++ b/src/components/dialog/index.ts
@@ -1,3 +1,5 @@
 export { default } from "./dialog.component";
 export type { DialogProps, DialogHandle } from "./dialog.component";
 export type { DialogSizes } from "./dialog.config";
+export { DialogHeader, DialogHeadingStatus } from "./dialog.component";
+export type { DialogHeadingStatusProps } from "./dialog.component";


### PR DESCRIPTION
### Proposed behaviour

Refactor the HOC for heading variants. 

### Current behaviour

Currently we have a HOC for generating heading variants but this is overkill for what we need.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

N/A

### Testing instructions

There should be no visual or functional regressions with the heading variants of Dialog.
There should also be no regression associated with Dialog in general too.