### PR TITLE
test(textarea): refine testing suite

### DIFF
--- a/src/components/textarea/textarea-test.stories.tsx
+++ b/src/components/textarea/textarea-test.stories.tsx
@@ -175,6 +175,7 @@ export const Validation = () => {
       <Textarea
         label="Textarea"
         error="Error Message"
+        required
         mb={2}
         name="ta-error"
         value={state["ta-error"] || ""}

--- a/src/components/textarea/textarea.pw.tsx
+++ b/src/components/textarea/textarea.pw.tsx
@@ -1,28 +1,13 @@
-import { type TextareaProps } from "../textarea";
 import React from "react";
 import { test, expect } from "../../../playwright/helpers/base-test";
 
 import {
-  characterCount,
   getDataElementByValue,
-  getDataRoleByValue,
   getElement,
-  tooltipPreview,
   visuallyHiddenCharacterCount,
-  visuallyHiddenHint,
 } from "../../../playwright/components";
-import { ICON } from "../../../playwright/components/locators";
-import {
-  textarea,
-  textareaChildren,
-} from "../../../playwright/components/textarea";
-import { CHARACTERS, VALIDATION } from "../../../playwright/support/constants";
-import {
-  checkAccessibility,
-  verifyRequiredAsteriskForLabel,
-  waitForAnimationEnd,
-} from "../../../playwright/support/helper";
-import Box from "../box";
+import { textareaChildren } from "../../../playwright/components/textarea";
+import { checkAccessibility } from "../../../playwright/support/helper";
 import {
   AutoFocusExample,
   CharacterLimitExample,
@@ -48,354 +33,7 @@ import {
   ValidationStringPositionExample,
 } from "./components.test-pw";
 
-const testData = [CHARACTERS.DIACRITICS, CHARACTERS.SPECIALCHARACTERS];
-
 test.describe("Props tests for Textarea component", () => {
-  test("should render with data-element prop", async ({ mount, page }) => {
-    await mount(<TextareaComponent data-element={CHARACTERS.STANDARD} />);
-
-    await expect(
-      getDataElementByValue(page, CHARACTERS.STANDARD),
-    ).toHaveAttribute("data-element", CHARACTERS.STANDARD);
-  });
-
-  test("should render with data-role prop", async ({ mount, page }) => {
-    await mount(<TextareaComponent data-role={CHARACTERS.STANDARD} />);
-
-    await expect(getDataRoleByValue(page, CHARACTERS.STANDARD)).toHaveAttribute(
-      "data-role",
-      CHARACTERS.STANDARD,
-    );
-  });
-
-  test("should render with id prop", async ({ mount, page }) => {
-    await mount(<TextareaComponent id={CHARACTERS.STANDARD} />);
-
-    const textareaChildrenElement = textareaChildren(page);
-
-    await expect(textareaChildrenElement).toHaveId(CHARACTERS.STANDARD);
-  });
-
-  testData.forEach((label) => {
-    test(`should render with label prop set to ${label}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<TextareaComponent label={label} />);
-
-      const labelElement = getDataElementByValue(page, "label");
-
-      await expect(labelElement).toHaveText(label);
-    });
-  });
-
-  test("should render with labelInline prop", async ({ mount, page }) => {
-    await mount(<TextareaComponent labelInline />);
-
-    const labelElementParent = getDataElementByValue(page, "label").locator(
-      "..",
-    );
-
-    await expect(labelElementParent).toHaveCSS("justify-content", "flex-end");
-  });
-
-  (
-    [
-      ["left", "flex-start"],
-      ["right", "flex-end"],
-    ] as [TextareaProps["labelAlign"], string][]
-  ).forEach(([labelAlign, cssValue]) => {
-    test(`should render with labelAlign prop set to ${labelAlign}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<TextareaComponent labelInline labelAlign={labelAlign} />);
-
-      const labelElementParent = getDataElementByValue(page, "label").locator(
-        "..",
-      );
-
-      await expect(labelElementParent).toHaveCSS("justify-content", cssValue);
-    });
-  });
-
-  (
-    [
-      [1, "8px"],
-      [2, "16px"],
-    ] as [TextareaProps["labelSpacing"], string][]
-  ).forEach(([spacing, padding]) => {
-    test(`should render with labelSpacing prop set to ${spacing}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<TextareaComponent labelInline labelSpacing={spacing} />);
-
-      const labelElementParent = getDataElementByValue(page, "label").locator(
-        "..",
-      );
-
-      await expect(labelElementParent).toHaveCSS("padding-right", padding);
-    });
-  });
-
-  test("should render with required prop", async ({ mount, page }) => {
-    await mount(<TextareaComponent required />);
-
-    await verifyRequiredAsteriskForLabel(page);
-  });
-
-  (
-    [
-      [11, 11, "rgba(0, 0, 0, 0.55)"],
-      [11, 10, "rgb(219, 0, 78)"],
-    ] as const
-  ).forEach(([charactersUsed, limit, color]) => {
-    test(`should input ${charactersUsed} characters and warn if over character limit of ${limit} in Textarea`, async ({
-      mount,
-      page,
-    }) => {
-      const inputValue = "12345678901";
-      const underCharacters =
-        limit - charactersUsed === 1 ? "character" : "characters";
-      const overCharacters =
-        charactersUsed - limit === 1 ? "character" : "characters";
-      await mount(<TextareaComponent characterLimit={limit} />);
-
-      await textareaChildren(page).fill(inputValue);
-
-      await expect(characterCount(page)).toHaveText(
-        `${
-          charactersUsed - limit
-            ? `${charactersUsed - limit} ${overCharacters} too many`
-            : `${charactersUsed - limit} ${underCharacters} left`
-        }`,
-      );
-
-      await expect(characterCount(page)).toHaveCSS("color", color);
-
-      await expect(visuallyHiddenCharacterCount(page)).toHaveText(
-        `${
-          charactersUsed - limit
-            ? `${charactersUsed - limit} ${overCharacters} too many`
-            : `${charactersUsed - limit} ${underCharacters} left`
-        }`,
-      );
-    });
-  });
-
-  test("input hint should be rendered if a value is passed", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextareaComponent inputHint="foo" />);
-
-    await expect(getDataElementByValue(page, "input-hint")).toBeInViewport();
-  });
-
-  test("input hint should not be rendered if no value is passed", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextareaComponent inputHint="" />);
-
-    await expect(
-      getDataElementByValue(page, "input-hint"),
-    ).not.toBeInViewport();
-  });
-
-  test("character counter of 5 should be rendered", async ({ mount, page }) => {
-    await mount(<TextareaComponent characterLimit={5} />);
-
-    await expect(characterCount(page)).toBeInViewport();
-  });
-
-  test("character counter of undefined should not be rendered", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextareaComponent characterLimit={undefined} />);
-
-    await expect(characterCount(page)).not.toBeInViewport();
-  });
-
-  test("visually hidden character count of 5 should be rendered", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextareaComponent characterLimit={5} />);
-
-    const visuallyHiddenCharacterCountElement =
-      visuallyHiddenCharacterCount(page);
-
-    await expect(visuallyHiddenCharacterCountElement).toBeVisible();
-  });
-
-  test("visually hidden character count of undefined should not be rendered", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextareaComponent characterLimit={undefined} />);
-
-    const visuallyHiddenCharacterCountElement =
-      visuallyHiddenCharacterCount(page);
-
-    await expect(visuallyHiddenCharacterCountElement).toBeHidden();
-  });
-
-  test("visually hidden hint of 5 should be rendered", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextareaComponent characterLimit={5} />);
-
-    const visuallyHiddenHintElement = visuallyHiddenHint(page);
-
-    await expect(visuallyHiddenHintElement).toBeVisible();
-  });
-
-  test("visually hidden hint of undefined should not be rendered", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextareaComponent characterLimit={undefined} />);
-
-    const visuallyHiddenHintElement = visuallyHiddenHint(page);
-
-    await expect(visuallyHiddenHintElement).toBeHidden();
-  });
-
-  ["10%", "30%", "50%", "80%", "100%"].forEach((maxWidth) => {
-    test(`should check maxWidth as ${maxWidth} for TextArea component`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<TextareaComponent maxWidth={maxWidth} />);
-
-      const inputElementParentParent = getDataElementByValue(page, "input")
-        .locator("..")
-        .locator("..");
-
-      await expect(inputElementParentParent).toHaveCSS("max-width", maxWidth);
-    });
-  });
-
-  test("when maxWidth has no value it should render as 100%", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextareaComponent maxWidth="" />);
-
-    const inputElementParentParent = getDataElementByValue(page, "input")
-      .locator("..")
-      .locator("..");
-
-    await expect(inputElementParentParent).toHaveCSS("max-width", "100%");
-  });
-
-  test("should render with name prop", async ({ mount, page }) => {
-    await mount(<TextareaComponent name={CHARACTERS.STANDARD} />);
-
-    await expect(textareaChildren(page)).toHaveAttribute(
-      "name",
-      CHARACTERS.STANDARD,
-    );
-  });
-
-  test("should render with disabled prop", async ({ mount, page }) => {
-    await mount(<TextareaComponent disabled />);
-
-    const textareaChildrenElement = textareaChildren(page);
-
-    await expect(textareaChildrenElement).toBeDisabled();
-  });
-
-  test("should pass disabled state to the icon", async ({ mount, page }) => {
-    await mount(<TextareaComponent disabled inputIcon="bin" />);
-
-    const textareaIcon = textarea(page).locator(ICON);
-
-    await expect(textareaIcon).toBeVisible();
-    await expect(textareaIcon).toHaveAttribute("disabled", "");
-  });
-
-  testData.forEach((placeholder) => {
-    test(`should render with placeholder prop set to ${placeholder}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<TextareaComponent placeholder={placeholder} />);
-
-      await expect(textareaChildren(page)).toHaveAttribute(
-        "placeholder",
-        placeholder,
-      );
-    });
-  });
-
-  test("should render with autoFocus prop and correct styling", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextareaComponent autoFocus />);
-
-    const textareaChildrenElement = textareaChildren(page);
-    await expect(textareaChildrenElement).toBeFocused();
-
-    await expect(textarea(page)).toHaveCSS(
-      "box-shadow",
-      "rgb(0, 0, 0) 0px 0px 0px 2px, rgb(255, 181, 0) 0px 0px 0px 4px",
-    );
-  });
-
-  test("should render with readOnly prop", async ({ mount, page }) => {
-    await mount(<TextareaComponent readOnly />);
-
-    await expect(textareaChildren(page)).not.toBeEditable();
-  });
-
-  test("should render readOnly icon in a disabled state", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<TextareaComponent readOnly inputIcon="bin" />);
-
-    const textareaIcon = textarea(page).locator(ICON);
-    await expect(textareaIcon).toBeVisible();
-    await expect(textareaIcon).toHaveAttribute("disabled", "");
-  });
-
-  (
-    [
-      [VALIDATION.ERROR, "error", true],
-      [VALIDATION.WARNING, "warning", true],
-      [VALIDATION.INFO, "info", true],
-      ["rgb(117, 131, 143)", "error", false],
-      ["rgb(117, 131, 143)", "warning", false],
-      ["rgb(117, 131, 143)", "info", false],
-    ] as const
-  ).forEach(([borderColor, type, bool]) => {
-    test(`should verify component input border colour is ${borderColor} when validation is ${type} and boolean prop is ${bool}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <TextareaComponent
-          labelInline
-          labelAlign="right"
-          {...{
-            [type]: bool,
-          }}
-        />,
-      );
-
-      await expect(textarea(page)).toHaveCSS(
-        "border-bottom-color",
-        borderColor,
-      );
-    });
-  });
-
   (
     [
       ["flex", 399],
@@ -420,122 +58,16 @@ test.describe("Props tests for Textarea component", () => {
       await expect(labelParentParentElement).toHaveCSS("display", displayValue);
     });
   });
+});
 
-  (["add", "filter", "play"] as const).forEach((icon) => {
-    test(`should render with inputIcon prop set to ${icon}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<TextareaComponent inputIcon={icon} />);
+test("should render with autoFocus and textarea receives focus", async ({
+  mount,
+  page,
+}) => {
+  await mount(<TextareaComponent autoFocus />);
 
-      const iconElement = getElement(page, icon);
-
-      await expect(iconElement).toBeInViewport();
-    });
-  });
-
-  (["top", "bottom", "left", "right"] as const).forEach((position) => {
-    // TODO: Skipped due to flaky focus behaviour. To review in FE-6428
-    test.skip(`should render component with tooltip positioned to the ${position}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <Box m="250px">
-          <TextareaComponent
-            error={CHARACTERS.STANDARD}
-            tooltipPosition={position}
-          />
-        </Box>,
-      );
-
-      const errorIcon = getDataElementByValue(page, "error");
-      await errorIcon.hover();
-      const tooltipPreviewElement = tooltipPreview(page);
-      await waitForAnimationEnd(tooltipPreviewElement);
-
-      await expect(tooltipPreviewElement).toHaveText(CHARACTERS.STANDARD);
-      await expect(tooltipPreviewElement).toHaveAttribute(
-        "data-placement",
-        position,
-      );
-    });
-  });
-
-  (["left", "right"] as const).forEach((align) => {
-    test(`should render with align prop set to ${align}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<TextareaComponent align={align} />);
-
-      await expect(textareaChildren(page)).toHaveCSS("text-align", align);
-    });
-  });
-
-  testData.forEach((input) => {
-    test(`should update value correctly when user types ${input}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<TextareaComponent />);
-
-      const textareaChildrenElement = textareaChildren(page);
-      await textareaChildrenElement.fill(input);
-
-      await expect(textareaChildrenElement).toHaveText(input);
-    });
-  });
-
-  testData.forEach((value) => {
-    test(`should render with value prop set to ${value}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<TextareaComponent value={value} />);
-
-      await expect(textareaChildren(page)).toHaveText(value);
-    });
-  });
-
-  [5, 25, 100].forEach((rows) => {
-    test(`should render with rows prop set to ${rows}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<TextareaComponent rows={rows} />);
-
-      await expect(textareaChildren(page)).toHaveAttribute(
-        "rows",
-        String(rows),
-      );
-    });
-  });
-
-  (
-    [
-      [true, 100],
-      [false, 79],
-    ] as const
-  ).forEach(([expandableValue, height]) => {
-    test(`should verify is displayed with expandable set to ${expandableValue}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(<TextareaComponent expandable={expandableValue} />);
-
-      const textareaChildrenElement = textareaChildren(page);
-      await textareaChildrenElement.press("t");
-      await textareaChildrenElement.press("Enter");
-      await textareaChildrenElement.press("e");
-      await textareaChildrenElement.press("Enter");
-      await textareaChildrenElement.press("s");
-      await textareaChildrenElement.press("Enter");
-      await textareaChildrenElement.press("t");
-
-      await expect(textareaChildrenElement).toHaveCSS("height", `${height}px`);
-    });
-  });
+  const textareaChildrenElement = textareaChildren(page);
+  await expect(textareaChildrenElement).toBeFocused();
 });
 
 test(`should verify expandable Textarea shrinks back to original height when lines are removed`, async ({
@@ -567,47 +99,6 @@ test(`should verify expandable Textarea shrinks back to original height when lin
 });
 
 test.describe("Event tests for Textarea component", () => {
-  const inputValue = "1";
-
-  test("should call onChange callback when a type event is triggered", async ({
-    mount,
-    page,
-  }) => {
-    let callbackCount = 0;
-    await mount(
-      <TextareaComponent
-        onChange={() => {
-          callbackCount += 1;
-        }}
-      />,
-    );
-
-    const textareaChildrenElement = textareaChildren(page);
-    await textareaChildrenElement.fill(inputValue);
-
-    expect(callbackCount).toEqual(1);
-  });
-
-  test("should call onBlur callback when a blur event is triggered", async ({
-    mount,
-    page,
-  }) => {
-    let callbackCount = 0;
-    await mount(
-      <TextareaComponent
-        onBlur={() => {
-          callbackCount += 1;
-        }}
-      />,
-    );
-
-    const textareaChildrenElement = textareaChildren(page);
-    await textareaChildrenElement.click();
-    await textareaChildrenElement.blur();
-
-    expect(callbackCount).toEqual(1);
-  });
-
   test("should call onClick callback when a click event is triggered", async ({
     mount,
     page,
@@ -623,25 +114,6 @@ test.describe("Event tests for Textarea component", () => {
 
     const textareaChildrenElement = textareaChildren(page);
     await textareaChildrenElement.click();
-
-    expect(callbackCount).toEqual(1);
-  });
-
-  test("should call onFocus callback when a focus event is triggered", async ({
-    mount,
-    page,
-  }) => {
-    let callbackCount = 0;
-    await mount(
-      <TextareaComponent
-        onFocus={() => {
-          callbackCount += 1;
-        }}
-      />,
-    );
-
-    const textareaChildrenElement = textareaChildren(page);
-    await textareaChildrenElement.focus();
 
     expect(callbackCount).toEqual(1);
   });
@@ -863,41 +335,6 @@ test.describe("Accessibility tests for Textarea component", () => {
   });
 });
 
-test("should have the expected default border radius styling", async ({
-  mount,
-  page,
-}) => {
-  await mount(<TextareaComponent />);
-
-  const inputElementParent = getElement(page, "input").locator("..");
-
-  await expect(inputElementParent).toHaveCSS("border-radius", "8px");
-});
-
-test("should have the expected custom border radius styling", async ({
-  mount,
-  page,
-}) => {
-  await mount(<TextareaComponent borderRadius="borderRadius400" />);
-
-  const inputElementParent = getElement(page, "input").locator("..");
-
-  await expect(inputElementParent).toHaveCSS("border-radius", "32px");
-});
-
-test("should have the expected custom border radius styling when an array is passed", async ({
-  mount,
-  page,
-}) => {
-  await mount(
-    <TextareaComponent borderRadius={["borderRadius400", "borderRadius010"]} />,
-  );
-
-  const inputElementParent = getElement(page, "input").locator("..");
-
-  await expect(inputElementParent).toHaveCSS("border-radius", "32px 1px");
-});
-
 test("should not have borders when hideBorders prop is passed", async ({
   mount,
   page,
@@ -950,6 +387,7 @@ test("should set aria-live attribute on Character Count to `polite` when compone
   await expect(CharacterCountElement).toHaveAttribute("aria-live", "off");
 
   await textareaElement.focus();
+  await expect(textareaElement).toBeFocused();
   await textareaElement.fill("Foo");
 
   await expect(CharacterCountElement).toHaveAttribute("aria-live", "polite");

--- a/src/components/textarea/textarea.stories.tsx
+++ b/src/components/textarea/textarea.stories.tsx
@@ -32,6 +32,7 @@ export const DefaultStory: Story = () => {
   return <Textarea label="Textarea" value={state} onChange={setValue} />;
 };
 DefaultStory.storyName = "Default";
+DefaultStory.parameters = { chromatic: { disableSnapshot: true } };
 
 export const DisabledStory: Story = () => {
   const [value, setValue] = useState("");
@@ -70,6 +71,7 @@ export const LabelAlignStory: Story = () => {
   );
 };
 LabelAlignStory.storyName = "Label Align";
+LabelAlignStory.parameters = { chromatic: { disableSnapshot: true } };
 
 export const ReadOnlyStory: Story = () => {
   const [value, setValue] = useState("");
@@ -154,6 +156,9 @@ export const TranslationsCharacterLimitStory: Story = () => {
   );
 };
 TranslationsCharacterLimitStory.storyName = "Translations Character Limit";
+TranslationsCharacterLimitStory.parameters = {
+  chromatic: { disableSnapshot: true },
+};
 
 export const LabelInlineStory: Story = () => {
   const [value, setValue] = useState("");
@@ -167,6 +172,7 @@ export const LabelInlineStory: Story = () => {
   );
 };
 LabelInlineStory.storyName = "Label Inline";
+LabelInlineStory.parameters = { chromatic: { disableSnapshot: true } };
 
 export const CustomWidthStory: Story = () => {
   const [value, setValue] = useState("");
@@ -182,6 +188,7 @@ export const CustomWidthStory: Story = () => {
   );
 };
 CustomWidthStory.storyName = "Custom Width";
+CustomWidthStory.parameters = { chromatic: { disableSnapshot: true } };
 
 export const MaxWidthStory: Story = () => {
   const [value, setValue] = useState("");
@@ -195,6 +202,7 @@ export const MaxWidthStory: Story = () => {
   );
 };
 MaxWidthStory.storyName = "Max Width";
+MaxWidthStory.parameters = { chromatic: { disableSnapshot: true } };
 
 export const InputHintStory: Story = () => {
   const [value, setValue] = useState("");
@@ -208,6 +216,7 @@ export const InputHintStory: Story = () => {
   );
 };
 InputHintStory.storyName = "Input Hint";
+InputHintStory.parameters = { chromatic: { disableSnapshot: true } };
 
 export const LabelHelpStory: Story = () => {
   const [value, setValue] = useState("");
@@ -235,6 +244,7 @@ export const RequiredStory: Story = () => {
   );
 };
 RequiredStory.storyName = "Required";
+RequiredStory.parameters = { chromatic: { disableSnapshot: true } };
 
 export const IsOptionalStory: Story = () => {
   const [value, setValue] = useState("");
@@ -248,6 +258,7 @@ export const IsOptionalStory: Story = () => {
   );
 };
 IsOptionalStory.storyName = "isOptional";
+IsOptionalStory.parameters = { chromatic: { disableSnapshot: true } };
 
 export const BorderRadiusStory: Story = () => {
   const [stateOne, setStateOne] = useState("");

--- a/src/components/textarea/textarea.test.tsx
+++ b/src/components/textarea/textarea.test.tsx
@@ -65,6 +65,36 @@ test("should not render a placeholder if disabled", () => {
   expect(screen.getByRole("textbox")).toHaveAttribute("placeholder", "");
 });
 
+test("should render a placeholder when provided", () => {
+  render(<MockComponent placeholder="Enter text here" />);
+  expect(screen.getByRole("textbox")).toHaveAttribute(
+    "placeholder",
+    "Enter text here",
+  );
+});
+
+test("should apply maxWidth styling correctly", () => {
+  render(<MockComponent maxWidth="50%" />);
+  expect(screen.getByTestId("input-presentation-container")).toHaveStyle({
+    "max-width": "50%",
+  });
+});
+
+test("should call consumer onBlur callback when textarea is blurred", () => {
+  const onBlur = jest.fn();
+  render(<Textarea value="foo" onChange={jest.fn()} onBlur={onBlur} />);
+
+  fireEvent.blur(screen.getByRole("textbox"));
+
+  expect(onBlur).toHaveBeenCalledTimes(1);
+});
+
+test("should disable the textarea when disabled is true", () => {
+  render(<MockComponent disabled />);
+
+  expect(screen.getByRole("textbox")).toBeDisabled();
+});
+
 testStyledSystemMargin(
   (props) => <MockComponent data-role="textarea-wrapper" {...props} />,
   () => screen.getByTestId("textarea-wrapper"),


### PR DESCRIPTION
### Proposed behaviour

Removes a number of Playwright tests that duplicate either Jest or Chromatic ones for the Simple Color Picker component

### Current behaviour

There are a number of tests that exist in different forms in all the testing suites we do(Jest, Playwright, Chromatic) which cause a prolonged time of execution for no additional value.

### Checklist

<!-- Each PR should include the following -->

- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

This should decrease the time of execution without compromising testing and coverage

### Testing instructions

Make sure the Playwright tests pass
