### PR TITLE
feat(divider): align component with fusion DS

### DIFF
--- a/src/components/divider/divider.style.ts
+++ b/src/components/divider/divider.style.ts
@@ -13,16 +13,16 @@ type ColorMap = ({ variant, inverse }: ColorMapProps) => string;
 const colorMap: ColorMap = ({ variant, inverse }) => {
   if (variant === "prominent") {
     if (inverse) {
-      return "#6F6F6F";
+      return "var(--container-standard-inverse-border-alt)";
     }
 
-    return "#7C7C7C";
+    return "var(--container-standard-border-alt)";
   }
 
   if (inverse) {
-    return "#505050";
+    return "var(--container-standard-inverse-border-default)";
   }
-  return "#A0A0A0";
+  return "var(--container-standard-border-default)";
 };
 
 const StyledVerticalDividerWrapper = styled.div.attrs(
@@ -41,7 +41,7 @@ const StyledVerticalDivider = styled.div.attrs(applyBaseTheme)<
   Pick<DividerProps, "variant" | "inverse">
 >`
   height: 100%;
-  border-left: 1px solid
+  border-left: var(--global-borderwidth-xs) solid
     ${({ variant, inverse }) => colorMap({ variant, inverse })};
   display: inherit;
 `;
@@ -49,8 +49,8 @@ const StyledVerticalDivider = styled.div.attrs(applyBaseTheme)<
 const StyledHorizontalDivider = styled.hr.attrs(applyBaseTheme)<DividerProps>`
   ${margin}
   width: 100%;
-  border: 0;
-  height: 1px;
+  border-width: var(--global-borderwidth-none);
+  height: var(--global-borderwidth-xs);
   background-color: ${({ variant, inverse }) => colorMap({ variant, inverse })};
 `;
 

--- a/src/components/divider/divider.test.tsx
+++ b/src/components/divider/divider.test.tsx
@@ -105,43 +105,43 @@ describe("When type is set to 'vertical'", () => {
     expect(screen.getByTestId("bar")).toHaveAttribute("data-element", "baz");
   });
 
-  test("should render the 'typical' variant with the corect color", () => {
+  test("should render the 'typical' variant with the correct color", () => {
     render(<Divider h={200} variant="typical" inverse={false} />);
     const dividerContentElement = screen.getByTestId("divider-content");
 
     expect(dividerContentElement).toHaveStyleRule(
       "border-left",
-      "1px solid #A0A0A0",
+      "var(--global-borderwidth-xs) solid var(--container-standard-border-default)",
     );
   });
 
-  test("should render the 'typical' variant with the corect color when the 'inverse' prop is set", () => {
+  test("should render the 'typical' variant with the correct color when the 'inverse' prop is set", () => {
     render(<Divider h={200} variant="typical" inverse />);
     const dividerContentElement = screen.getByTestId("divider-content");
 
     expect(dividerContentElement).toHaveStyleRule(
       "border-left",
-      "1px solid #505050",
+      "var(--global-borderwidth-xs) solid var(--container-standard-inverse-border-default)",
     );
   });
 
-  test("should render the 'prominent' variant with the corect color", () => {
+  test("should render the 'prominent' variant with the correct color", () => {
     render(<Divider h={200} variant="prominent" inverse={false} />);
     const dividerContentElement = screen.getByTestId("divider-content");
 
     expect(dividerContentElement).toHaveStyleRule(
       "border-left",
-      "1px solid #7C7C7C",
+      "var(--global-borderwidth-xs) solid var(--container-standard-border-alt)",
     );
   });
 
-  test("should render the 'prominent' variant with the corect color when the 'inverse' prop is set", () => {
+  test("should render the 'prominent' variant with the correct color when the 'inverse' prop is set", () => {
     render(<Divider h={200} variant="prominent" inverse />);
     const dividerContentElement = screen.getByTestId("divider-content");
 
     expect(dividerContentElement).toHaveStyleRule(
       "border-left",
-      "1px solid #6F6F6F",
+      "var(--global-borderwidth-xs) solid var(--container-standard-inverse-border-alt)",
     );
   });
 });
@@ -159,7 +159,17 @@ describe("When type is set to 'horizontal'", () => {
     render(<Divider type="horizontal" inverse />);
     const hr = screen.getByTestId("divider");
 
-    expect(hr).toHaveStyleRule("background-color", "#505050");
+    expect(hr).toHaveStyleRule(
+      "background-color",
+      "var(--container-standard-inverse-border-default)",
+    );
+  });
+
+  test("should render with the correct height token", () => {
+    render(<Divider type="horizontal" />);
+    const hr = screen.getByTestId("divider");
+
+    expect(hr).toHaveStyleRule("height", "var(--global-borderwidth-xs)");
   });
 
   test("should apply the expected margin top", () => {


### PR DESCRIPTION
### Proposed behaviour

Use fusion design tokens for styling Divider

### Current behaviour

Styling is not aligned with design tokens

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [X] All themes are supported if required
- [X] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
