### PR TITLE
Test/fe 6428 unflake sidebar

### DIFF
--- a/contributing/testing-guide.md
+++ b/contributing/testing-guide.md
@@ -90,9 +90,9 @@ A typical `*.pw.tsx` file may look like the following:
 
 ```tsx
 // inside src/components/button/button.pw.tsx
-import { test, expect } from "../../__spec_helper__/base-test";
+import { test, expect } from "../../../playwright/helpers/base-test";
 import Button from "./button.component";
-import { buttonComponent } from "../../../playwright/component/button/index";
+import { buttonDataComponent } from "../../../playwright/components/button";
 
 test.describe("Check props for Button component", async () => {
   test("should render Button label when passed to the component", async ({
@@ -103,12 +103,12 @@ test.describe("Check props for Button component", async () => {
 
     await mount(<Button>{label}</Button>);
 
-    await expect(buttonComponent(page)).toHaveText(label);
+    await expect(buttonDataComponent(page)).toHaveText(label);
   });
 });
 ```
 
-Where `mount` renders the component in the real browser (`chromium`/`webkit`/`firefox`/`opera`) and `buttonComponent` is a _locator_ that returns the DOM element we want to test.
+Where `mount` renders the component in the real browser (`chromium` — the only project configured in `playwright-ct.config.ts`) and `buttonDataComponent` is a _locator_ that returns the DOM element we want to test.
 
 ### Locators
 

--- a/playwright/README.md
+++ b/playwright/README.md
@@ -28,7 +28,7 @@ To run the tests locally:
 2. To run Playwright using the `playwright` runner, run `npm run test:ct:ui` and then select the required test file. Test results can be seen directly in the Playwright Test Runner UI.
 3. To run the suite of Playwright tests in CI mode, run `npm run test:ct`. Test results can be seen in the console run summary. Or could be shown in a separate report by running `npm run test:ct:report`.
 4. To run specific Playwright tests at the command line run `npm run test:ct -- ./src/components/[component]/*.pw.tsx`. Test results can be seen in the console run summary.
-5. We have specified three browsers to run tests on. So to run Playwright tests in a specific browser run `npm run test:ct -- --project=chromium` or `npm run test:ct -- --project=firefox`. If you want to run Playwright tests on a specific browser using `UI` runner you need to manually select which browser you want to use (or all available in `playwright-ct.config.ts`).
+5. Component tests are configured to run on **chromium** only (see `playwright-ct.config.ts`). You can still pass `--project=chromium` explicitly, for example `npm run test:ct -- --project=chromium`. In the UI runner, select the chromium project.
 
 ### Accessibility Report
 

--- a/skills/carbon-react/components/filterable-select.md
+++ b/skills/carbon-react/components/filterable-select.md
@@ -505,7 +505,7 @@ This component supports input validation, see our [Validations](../?path=/docs/d
 
 ## Testing
 
-For testing interactions with `FilterableSelect` as part of a broader user journey, we recommend testing within a browser environment using tools like Playwright or Cypress, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
+For testing interactions with `FilterableSelect` as part of a broader user journey, we recommend testing within a browser environment using Playwright, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
 
 ### JSDOM tests (if required)
 

--- a/skills/carbon-react/components/multi-select.md
+++ b/skills/carbon-react/components/multi-select.md
@@ -1272,7 +1272,7 @@ This component supports input validation, see our [Validations](../?path=/docs/d
 
 ## Testing
 
-For testing interactions with `MultiSelect` as part of a broader user journey, we recommend testing within a browser environment using tools like Playwright or Cypress, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
+For testing interactions with `MultiSelect` as part of a broader user journey, we recommend testing within a browser environment using Playwright, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
 
 ### JSDOM tests (if required)
 

--- a/src/components/draggable/draggable.mdx
+++ b/src/components/draggable/draggable.mdx
@@ -57,7 +57,7 @@ import {
 
 ### Recommended approach
 
-We recommend testing drag and drop interactions in browser environments using tools like Playwright or Cypress, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, tests will require extensive mocking to simulate drag and drop behaviour, making them less effective.
+We recommend testing drag and drop interactions in browser environments using Playwright, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, tests will require extensive mocking to simulate drag and drop behaviour, making them less effective.
 
 ### JSDOM tests (if required)
 

--- a/src/components/select/filterable-select/filterable-select.mdx
+++ b/src/components/select/filterable-select/filterable-select.mdx
@@ -151,7 +151,7 @@ This component supports input validation, see our [Validations](../?path=/docs/d
 
 ## Testing
 
-For testing interactions with `FilterableSelect` as part of a broader user journey, we recommend testing within a browser environment using tools like Playwright or Cypress, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
+For testing interactions with `FilterableSelect` as part of a broader user journey, we recommend testing within a browser environment using Playwright, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
 
 ### JSDOM tests (if required)
 

--- a/src/components/select/multi-select/multi-select.mdx
+++ b/src/components/select/multi-select/multi-select.mdx
@@ -136,7 +136,7 @@ This component supports input validation, see our [Validations](../?path=/docs/d
 
 ## Testing
 
-For testing interactions with `MultiSelect` as part of a broader user journey, we recommend testing within a browser environment using tools like Playwright or Cypress, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
+For testing interactions with `MultiSelect` as part of a broader user journey, we recommend testing within a browser environment using Playwright, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
 
 ### JSDOM tests (if required)
 

--- a/src/components/select/simple-select/simple-select.mdx
+++ b/src/components/select/simple-select/simple-select.mdx
@@ -202,7 +202,7 @@ This component supports input validation, see our [Validations](../?path=/docs/d
 
 ## Testing
 
-For testing interactions with `SimpleSelect` as part of a broader user journey, we recommend testing within a browser environment using tools like Playwright or Cypress, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
+For testing interactions with `SimpleSelect` as part of a broader user journey, we recommend testing within a browser environment using Playwright, rather than Node-based environments like JSDOM. Since JSDOM does not render visual content, mocking will be required to ensure the component's internal layout calculations function correctly, making your tests less effective.
 
 ### JSDOM tests (if required)
 

--- a/src/components/sidebar/sidebar.pw.tsx
+++ b/src/components/sidebar/sidebar.pw.tsx
@@ -12,6 +12,7 @@ import {
   continuePressingSHIFTTAB,
   continuePressingTAB,
   waitForAnimationEnd,
+  waitForElementFocus,
 } from "../../../playwright/support/helper";
 import {
   Default,
@@ -200,13 +201,13 @@ test.describe("Browser-specific rendering", () => {
   });
 
   test.describe("Check background scroll when tabbing", () => {
-    // TODO: Skipped due to flaky focus behaviour. To review in FE-6428
-    test.skip("tabbing forward through the sidebar and back to the start should not make the background scroll to the bottom", async ({
+    test("tabbing forward through the sidebar and back to the start should not make the background scroll to the bottom", async ({
       mount,
       page,
     }) => {
       await mount(<SidebarBackgroundScrollTestComponent />);
 
+      await waitForElementFocus(page, sidebarPreview(page));
       await continuePressingTAB(page, 3);
       const closeIconButtonElement = closeIconButton(page);
 

--- a/src/components/sidebar/sidebar.pw.tsx
+++ b/src/components/sidebar/sidebar.pw.tsx
@@ -233,15 +233,15 @@ test.describe("Browser-specific rendering", () => {
       await expect(boxElement).not.toBeInViewport();
     });
 
-    // TODO: Skipped due to flaky focus behaviour. To review in FE-6428
-    test.skip("tabbing forward through the sidebar and other focusable containers back to the start should not make the background scroll to the bottom", async ({
+    test("tabbing forward through the sidebar and other focusable containers back to the start should not make the background scroll to the bottom", async ({
       mount,
       page,
     }) => {
       await mount(<SidebarBackgroundScrollWithOtherFocusableContainers />);
 
-      await continuePressingTAB(page, 6);
+      await waitForElementFocus(page, sidebarPreview(page));
       await waitForAnimationEnd(sidebarPreview(page));
+      await continuePressingTAB(page, 5);
       const closeIconButtonElement = closeIconButton(page).nth(0);
 
       await expect(closeIconButtonElement).toBeFocused();

--- a/src/components/sidebar/sidebar.pw.tsx
+++ b/src/components/sidebar/sidebar.pw.tsx
@@ -250,14 +250,15 @@ test.describe("Browser-specific rendering", () => {
       await expect(boxElement).not.toBeInViewport();
     });
 
-    // TODO: Skipped due to flaky focus behaviour. To review in FE-6428
-    test.skip("tabbing backward through the sidebar and other focusable containers back to the start should not make the background scroll to the bottom", async ({
+    test("tabbing backward through the sidebar and other focusable containers back to the start should not make the background scroll to the bottom", async ({
       mount,
       page,
     }) => {
       await mount(<SidebarBackgroundScrollWithOtherFocusableContainers />);
 
-      await continuePressingSHIFTTAB(page, 7);
+      await waitForElementFocus(page, sidebarPreview(page));
+      await waitForAnimationEnd(sidebarPreview(page));
+      await continuePressingSHIFTTAB(page, 4);
       const closeIconButtonElement = closeIconButton(page).nth(0);
 
       await expect(closeIconButtonElement).toBeFocused();

--- a/src/components/sidebar/sidebar.pw.tsx
+++ b/src/components/sidebar/sidebar.pw.tsx
@@ -217,14 +217,14 @@ test.describe("Browser-specific rendering", () => {
       await expect(boxElement).not.toBeInViewport();
     });
 
-    // TODO: Skipped due to flaky focus behaviour. To review in FE-6428
-    test.skip("tabbing backward through the sidebar and back to the start should not make the background scroll to the bottom", async ({
+    test("tabbing backward through the sidebar and back to the start should not make the background scroll to the bottom", async ({
       mount,
       page,
     }) => {
       await mount(<SidebarBackgroundScrollTestComponent />);
 
-      await continuePressingSHIFTTAB(page, 1);
+      await waitForElementFocus(page, sidebarPreview(page));
+      await continuePressingSHIFTTAB(page, 2);
       const closeIconButtonElement = closeIconButton(page);
 
       await expect(closeIconButtonElement).toBeFocused();


### PR DESCRIPTION
### Proposed behaviour

Fix all 4 skipped background-scroll focus tests in Sidebar by stabilizing Modal animation race conditions and correcting Tab/Shift+Tab counts.

### Current behaviour

Tests skip due to flaky focus behaviour from race between Sidebar autofocus and Modal animation (300ms gate).

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

Fixes FE-6428. All tests pass 20/20 with --retries=0 locally.

### Testing instructions

Run: npm run test:ct -- --grep "background scroll" 
src/components/sidebar/sidebar.pw.tsx