### PR TITLE
feat(action-popover): use subtle Action trigger and deprecate positio…

### DIFF
--- a/playwright/components/action-popover/index.ts
+++ b/playwright/components/action-popover/index.ts
@@ -20,6 +20,8 @@ export const actionPopoverInnerItem = (page: Page, index: number) =>
   page
     .locator(ACTION_POPOVER_DATA_COMPONENT)
     .first()
+    .locator("ul")
+    .first()
     .locator("> li")
     .nth(index)
     .locator("button")
@@ -28,7 +30,7 @@ export const actionPopoverInnerItem = (page: Page, index: number) =>
 export const actionPopoverSubmenu = (page: Page, index: number) =>
   page
     .locator(ACTION_POPOVER_SUBMENU)
-    .nth(1)
+    .first()
     .locator(`> li:nth-child(${index + 1})`)
     .locator("button");
 

--- a/playwright/components/action-popover/locators.ts
+++ b/playwright/components/action-popover/locators.ts
@@ -2,12 +2,13 @@
 export const ACTION_POPOVER_BUTTON = '[data-element="action-popover-button"]';
 export const ACTION_POPOVER_DATA_COMPONENT =
   '[data-component="action-popover"]';
-export const ACTION_POPOVER_SUBMENU = '[data-element="action-popover-submenu"]';
+export const ACTION_POPOVER_SUBMENU_ITEM =
+  '[data-component="popover-submenu-item"]';
+export const ACTION_POPOVER_SUBMENU = `ul:has(> ${ACTION_POPOVER_SUBMENU_ITEM})`;
 export const ACTION_POPOVER_MENU_ITEM_ICON =
   '[data-element="action-popover-menu-item-icon"]';
 export const ACTION_POPOVER_MENU_ITEM_INNER_TEXT =
   '[data-element="action-popover-menu-item-inner-text"]';
-export const ACTION_POPOVER_MENU_ITEM_CHEVRON =
-  '[data-element="action-popover-menu-item-chevron"]';
+export const ACTION_POPOVER_MENU_ITEM_CHEVRON = '[data-element="submenu-icon"]';
 export const ACTION_POPOVER_WRAPPER =
   '[data-component="action-popover-wrapper"]';

--- a/playwright/components/flat-table/index.ts
+++ b/playwright/components/flat-table/index.ts
@@ -58,7 +58,7 @@ export const flatTableCaption = (page: Page) =>
   flatTable(page).locator("caption");
 
 export const flatTablePageSizeSelect = (page: Page) =>
-  page.locator(FLAT_TABLE_PAGE_SIZE_SELECT);
+  flatTablePager(page).locator(FLAT_TABLE_PAGE_SIZE_SELECT);
 export const flatTablePageSelectListPosition = (page: Page) =>
   page.locator(FLAT_TABLE_PAGE_SELECT_LIST);
 export const pageSelectElement = (page: Page) => page.locator(PAGE_SELECT);

--- a/playwright/components/flat-table/index.ts
+++ b/playwright/components/flat-table/index.ts
@@ -57,13 +57,13 @@ export const flatTableSubrowFirstCell = (page: Page, index: number) =>
 export const flatTableCaption = (page: Page) =>
   flatTable(page).locator("caption");
 
+export const flatTablePager = (page: Page) => page.locator(FLAT_TABLE_PAGER);
 export const flatTablePageSizeSelect = (page: Page) =>
   flatTablePager(page).locator(FLAT_TABLE_PAGE_SIZE_SELECT);
 export const flatTablePageSelectListPosition = (page: Page) =>
   page.locator(FLAT_TABLE_PAGE_SELECT_LIST);
 export const pageSelectElement = (page: Page) => page.locator(PAGE_SELECT);
 export const pageSelectInput = (page: Page) => page.locator(PAGE_SELECT_INPUT);
-export const flatTablePager = (page: Page) => page.locator(FLAT_TABLE_PAGER);
 export const flatTablePageSelectNext = (page: Page) =>
   page.locator(FLAT_TABLE_PAGE_SELECT_NEXT);
 export const flatTablePageSelectPrevious = (page: Page) =>

--- a/skills/carbon-react/components/action-popover-menu-button.md
+++ b/skills/carbon-react/components/action-popover-menu-button.md
@@ -11,6 +11,9 @@ description: Carbon ActionPopoverMenuButton component props and usage examples.
 ## Source
 - Export: `./components/action-popover`
 - Props interface: `ActionPopoverMenuButtonProps`
+- Deprecated: Yes
+- Deprecation reason: This component will be removed in a future major release.
+Use the `renderButton` prop with your own button implementation instead.
 
 ## Props
 | Name | Type | Required | Literals | Description | Default |

--- a/skills/carbon-react/components/action-popover-menu.md
+++ b/skills/carbon-react/components/action-popover-menu.md
@@ -13,16 +13,18 @@ description: Carbon ActionPopoverMenu component props and usage examples.
 - Props interface: `ActionPopoverMenuProps`
 
 ## Props
-| Name | Type | Required | Literals | Description | Default |
-| --- | --- | --- | --- | --- | --- |
-| children | React.ReactNode | No |  | Children for the menu |  |
-| isOpen | boolean \| undefined | No |  | Flag to indicate whether a menu should open |  |
-| key | Key \| null \| undefined | No |  |  |  |
-| menuID | string \| undefined | No |  | A unique ID for the menu |  |
-| parentID | string \| undefined | No |  | Unique ID for the menu's parent |  |
-| placement | "bottom" \| "top" \| undefined | No |  | Set whether the menu should open above or below the button |  |
-| ref | LegacyRef<T> \| undefined | No |  | Allows getting a ref to the component instance. Once the component unmounts, React will set `ref.current` to `null` (or call the ref with `null` if you passed a callback ref). |  |
-| setOpen | ((args: boolean) => void) \| undefined | No |  | Callback to set the isOpen flag |  |
+| Name | Type | Required | Literals | Deprecated | Deprecation reason | Description | Default |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| children | React.ReactNode | No |  |  |  | Children for the menu |  |
+| key | Key \| null \| undefined | No |  |  |  |  |  |
+| menuID | string \| undefined | No |  |  |  | A unique ID for the menu |  |
+| parentID | string \| undefined | No |  |  |  | Unique ID for the menu's parent |  |
+| ref | LegacyRef<T> \| undefined | No |  |  |  | Allows getting a ref to the component instance. Once the component unmounts, React will set `ref.current` to `null` (or call the ref with `null` if you passed a callback ref). |  |
+| focusIndex | number \| undefined | No |  | Yes | No longer used, focus is managed by the underlying PopoverMenu |  |  |
+| isOpen | boolean \| undefined | No |  | Yes | No longer used, open state is managed by the parent ActionPopoverItem |  |  |
+| placement | "bottom" \| "top" \| undefined | No |  | Yes | Submenus now open to the right and flip automatically when space is constrained. This prop will be removed in a future major release. |  |  |
+| setFocusIndex | ((args: number) => void) \| undefined | No |  | Yes | No longer used, focus is managed by the underlying PopoverMenu |  |  |
+| setOpen | ((args: boolean) => void) \| undefined | No |  | Yes | No longer used, open state is managed by the parent ActionPopoverItem |  |  |
 
 ## Examples
 ### Default

--- a/skills/carbon-react/components/action-popover.md
+++ b/skills/carbon-react/components/action-popover.md
@@ -13,36 +13,36 @@ description: Carbon ActionPopover component props and usage examples.
 - Props interface: `ActionPopoverProps`
 
 ## Props
-| Name | Type | Required | Literals | Description | Default |
-| --- | --- | --- | --- | --- | --- |
-| children | React.ReactNode | No |  | Children for popover component |  |
-| horizontalAlignment | Alignment \| undefined | No |  | Horizontal alignment of menu items content |  |
-| id | string \| undefined | No |  | Unique ID |  |
-| m | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top, left, bottom and right |  |
-| margin | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top, left, bottom and right |  |
-| marginBottom | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on bottom |  |
-| marginLeft | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on left |  |
-| marginRight | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on right |  |
-| marginTop | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top |  |
-| marginX | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on left and right |  |
-| marginY | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top and bottom |  |
-| mb | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on bottom |  |
-| ml | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on left |  |
-| mr | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on right |  |
-| mt | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top |  |
-| mx | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on left and right |  |
-| my | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Margin on top and bottom |  |
-| onClose | (() => void) \| undefined | No |  | Callback to be called on menu close |  |
-| onOpen | (() => void) \| undefined | No |  | Callback to be called on menu open |  |
-| placement | "bottom" \| "top" \| undefined | No |  | Set whether the menu should open above or below the button |  |
-| renderButton | ((buttonProps: RenderButtonProps) => React.ReactNode) \| undefined | No |  | Render a custom menu button to override default ellipsis icon |  |
-| rightAlignMenu | boolean \| undefined | No |  | Boolean to control whether menu should align to right |  |
-| submenuPosition | Alignment \| undefined | No |  | Sets submenu position |  |
-| data-element | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
-| data-role | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
-| aria-describedby | string \| undefined | No |  | Prop to specify an aria-describedby for the component |  |
-| aria-label | string \| undefined | No |  | Prop to specify an aria-label for the component |  |
-| aria-labelledby | string \| undefined | No |  | Prop to specify an aria-labelledby for the component |  |
+| Name | Type | Required | Literals | Deprecated | Deprecation reason | Description | Default |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| children | React.ReactNode | No |  |  |  | Children for popover component |  |
+| id | string \| undefined | No |  |  |  | Unique ID |  |
+| m | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top, left, bottom and right |  |
+| margin | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top, left, bottom and right |  |
+| marginBottom | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on bottom |  |
+| marginLeft | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on left |  |
+| marginRight | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on right |  |
+| marginTop | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top |  |
+| marginX | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on left and right |  |
+| marginY | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top and bottom |  |
+| mb | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on bottom |  |
+| ml | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on left |  |
+| mr | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on right |  |
+| mt | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top |  |
+| mx | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on left and right |  |
+| my | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Margin on top and bottom |  |
+| onClose | (() => void) \| undefined | No |  |  |  | Callback to be called on menu close |  |
+| onOpen | (() => void) \| undefined | No |  |  |  | Callback to be called on menu open |  |
+| renderButton | ((buttonProps: RenderButtonProps) => React.ReactNode) \| undefined | No |  |  |  | Render a custom menu button to override default ellipsis icon |  |
+| rightAlignMenu | boolean \| undefined | No |  |  |  | Boolean to control whether menu should align to right |  |
+| data-element | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
+| data-role | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
+| aria-describedby | string \| undefined | No |  |  |  | Prop to specify an aria-describedby for the component |  |
+| aria-label | string \| undefined | No |  |  |  | Prop to specify an aria-label for the component |  |
+| aria-labelledby | string \| undefined | No |  |  |  | Prop to specify an aria-labelledby for the component |  |
+| horizontalAlignment | Alignment \| undefined | No |  | Yes | This prop will be removed in a future major release. Horizontal alignment is now inferred from menu placement. |  |  |
+| placement | "bottom" \| "top" \| undefined | No |  | Yes | This prop will be removed in a future major release. The menu now opens with adaptive placement and flips when space is constrained. |  |  |
+| submenuPosition | Alignment \| undefined | No |  | Yes | This prop will be removed in a future major release. Submenus now default to opening on the right and automatically flip when space is constrained. |  |  |
 
 ## Examples
 ### Default
@@ -254,22 +254,22 @@ description: Carbon ActionPopover component props and usage examples.
     <Box height={250}>
       <ActionPopover
         renderButton={({
-          tabIndex,
+          tabIndex: _tabIndex,
           "data-element": dataElement,
           ariaAttributes,
         }) => (
-          <ActionPopoverMenuButton
-            buttonType="tertiary"
+          <ButtonNext
+            variant="default"
+            variantType="subtle"
             iconType="dropdown"
             iconPosition="after"
             size="small"
-            tabIndex={tabIndex}
             data-element={dataElement}
-            ariaAttributes={ariaAttributes}
+            {...ariaAttributes}
             aria-label={undefined}
           >
-            More
-          </ActionPopoverMenuButton>
+            Action
+          </ButtonNext>
         )}
       >
         <ActionPopoverItem icon="email" onClick={() => {}}>
@@ -282,18 +282,19 @@ description: Carbon ActionPopover component props and usage examples.
       </ActionPopover>
       <ActionPopover
         renderButton={({
-          tabIndex,
+          tabIndex: _tabIndex,
           "data-element": dataElement,
           ariaAttributes,
         }) => (
-          <ActionPopoverMenuButton
-            buttonType="tertiary"
+          <ButtonNext
+            variant="default"
+            variantType="subtle"
             iconType="dropdown"
             iconPosition="after"
             size="small"
-            tabIndex={tabIndex}
             data-element={dataElement}
-            ariaAttributes={ariaAttributes}
+            {...ariaAttributes}
+            aria-label="actions"
           />
         )}
       >
@@ -310,6 +311,46 @@ description: Carbon ActionPopover component props and usage examples.
           <Link onClick={() => {}} data-element={dataElement}>
             More
           </Link>
+        )}
+      >
+        <ActionPopoverItem icon="email" onClick={() => {}}>
+          Email Invoice
+        </ActionPopoverItem>
+        <ActionPopoverDivider />
+        <ActionPopoverItem onClick={() => {}} icon="delete">
+          Delete
+        </ActionPopoverItem>
+      </ActionPopover>
+    </Box>
+  );
+}
+```
+
+
+### Custom Menu Button Without Text
+
+**Render**
+
+```tsx
+() => {
+  return (
+    <Box height={250}>
+      <ActionPopover
+        renderButton={({
+          tabIndex: _tabIndex,
+          "data-element": dataElement,
+          ariaAttributes,
+        }) => (
+          <ButtonNext
+            variant="default"
+            variantType="subtle"
+            iconType="dropdown"
+            iconPosition="after"
+            size="small"
+            data-element={dataElement}
+            {...ariaAttributes}
+            aria-label="actions"
+          />
         )}
       >
         <ActionPopoverItem icon="email" onClick={() => {}}>
@@ -805,9 +846,17 @@ description: Carbon ActionPopover component props and usage examples.
       <Box>
         <ActionPopover
           renderButton={({ ...props }) => (
-            <ActionPopoverMenuButton {...props}>
+            <ButtonNext
+              variant="default"
+              variantType="subtle"
+              iconType="dropdown"
+              iconPosition="after"
+              size="small"
+              {...props.ariaAttributes}
+              data-element={props["data-element"]}
+            >
               Open Actions
-            </ActionPopoverMenuButton>
+            </ButtonNext>
           )}
         >
           <ActionPopoverItem
@@ -874,16 +923,18 @@ description: Carbon ActionPopover component props and usage examples.
   const refMore = useRef<ActionPopoverHandle>(null);
 
   const renderButton = (props: RenderButtonProps) => (
-    <ActionPopoverMenuButton
-      buttonType="tertiary"
+    <ButtonNext
+      variant="default"
+      variantType="subtle"
       iconType="ellipsis_vertical"
       iconPosition="after"
       size="small"
-      aria-label={undefined}
-      {...props}
+      aria-label="more"
+      {...props.ariaAttributes}
+      data-element={props["data-element"]}
     >
       More
-    </ActionPopoverMenuButton>
+    </ButtonNext>
   );
 
   return (

--- a/skills/carbon-react/components/action-popover.md
+++ b/skills/carbon-react/components/action-popover.md
@@ -253,11 +253,7 @@ description: Carbon ActionPopover component props and usage examples.
   return (
     <Box height={250}>
       <ActionPopover
-        renderButton={({
-          tabIndex: _tabIndex,
-          "data-element": dataElement,
-          ariaAttributes,
-        }) => (
+        renderButton={({ "data-element": dataElement, ariaAttributes }) => (
           <ButtonNext
             variant="default"
             variantType="subtle"
@@ -281,11 +277,7 @@ description: Carbon ActionPopover component props and usage examples.
         </ActionPopoverItem>
       </ActionPopover>
       <ActionPopover
-        renderButton={({
-          tabIndex: _tabIndex,
-          "data-element": dataElement,
-          ariaAttributes,
-        }) => (
+        renderButton={({ "data-element": dataElement, ariaAttributes }) => (
           <ButtonNext
             variant="default"
             variantType="subtle"
@@ -336,11 +328,7 @@ description: Carbon ActionPopover component props and usage examples.
   return (
     <Box height={250}>
       <ActionPopover
-        renderButton={({
-          tabIndex: _tabIndex,
-          "data-element": dataElement,
-          ariaAttributes,
-        }) => (
+        renderButton={({ "data-element": dataElement, ariaAttributes }) => (
           <ButtonNext
             variant="default"
             variantType="subtle"

--- a/skills/carbon-react/index.md
+++ b/skills/carbon-react/index.md
@@ -8,7 +8,7 @@
 - [ActionPopoverDivider](components/action-popover-divider.md)
 - [ActionPopoverItem](components/action-popover-item.md)
 - [ActionPopoverMenu](components/action-popover-menu.md)
-- [ActionPopoverMenuButton](components/action-popover-menu-button.md)
+- [ActionPopoverMenuButton](components/action-popover-menu-button.md) (deprecated)
 - [AdaptiveSidebar](components/adaptive-sidebar.md)
 - [AdvancedColorPicker](components/advanced-color-picker.md)
 - [Alert](components/alert.md) (deprecated)

--- a/src/__internal__/popover-menu/hooks/useHandleDropdownMenuKeyDown.ts
+++ b/src/__internal__/popover-menu/hooks/useHandleDropdownMenuKeyDown.ts
@@ -149,6 +149,43 @@ export const useHandleDropdownMenuKeyDown = (
         return;
       }
 
+      // Any printable character: focus the next item whose label starts with that
+      // character, wrapping to the start of the list when there is no later match
+      if (
+        isButtonMenu &&
+        ev.key.length === 1 &&
+        !ev.ctrlKey &&
+        !ev.metaKey &&
+        !ev.altKey &&
+        ev.key.trim().length > 0
+      ) {
+        const character = ev.key.toLowerCase();
+        const matches = items.filter((item) =>
+          (item.textContent ?? /* istanbul ignore next */ "")
+            .trim()
+            .toLowerCase()
+            .startsWith(character),
+        ) as HTMLElement[];
+
+        if (!matches.length) {
+          return;
+        }
+
+        ev.stopPropagation();
+
+        const currentIndex = highlightedItem
+          ? items.indexOf(highlightedItem)
+          : -1;
+        const itemToFocus =
+          matches.find((item) => items.indexOf(item) > currentIndex) ??
+          matches[0];
+
+        setAriaActivedescendant(itemToFocus.id);
+        setFocus(itemToFocus, highlightedItem, isButtonMenu);
+
+        return;
+      }
+
       if (ev.key === "Enter" && !isButtonMenu) {
         /* istanbul ignore else */
         if (highlightedItem) {

--- a/src/__internal__/popover-menu/menu-item/menu-item-divider/menu-item-divider.component.tsx
+++ b/src/__internal__/popover-menu/menu-item/menu-item-divider/menu-item-divider.component.tsx
@@ -11,9 +11,17 @@ const StyledMenuItemDivider = styled.li`
   }
 `;
 
-const MenuItemDivider = () => (
+const MenuItemDivider = ({
+  "data-element": dataElement,
+  "data-role": dataRole,
+}: {
+  "data-element"?: string;
+  "data-role"?: string;
+}) => (
   <StyledMenuItemDivider
     data-component="popover-menu-divider"
+    data-element={dataElement}
+    data-role={dataRole}
     aria-hidden="true"
   >
     <Divider m={0} type="horizontal" />

--- a/src/__internal__/popover-menu/menu-item/menu-item.component.tsx
+++ b/src/__internal__/popover-menu/menu-item/menu-item.component.tsx
@@ -22,6 +22,10 @@ export interface MenuItemProps {
   submenuOpen?: boolean;
   onSubmenuOpen?: () => void;
   onSubmenuClose?: () => void;
+  /** Fired when the pointer enters the item, used to open submenus on hover */
+  onMouseEnter?: (event: React.MouseEvent<HTMLLIElement>) => void;
+  /** Fired when the pointer leaves the item, used to close submenus on hover */
+  onMouseLeave?: (event: React.MouseEvent<HTMLLIElement>) => void;
 }
 
 interface StyledMenuItemProps {
@@ -51,7 +55,7 @@ const StyledMenuItem = styled.li<StyledMenuItemProps>`
         : `
           color: var(--input-dropdown-label-alt);
           cursor: pointer;
-
+ 
           :hover {
             * {
               color: var(--input-dropdown-label-hover);
@@ -76,7 +80,7 @@ const StyledMenuItem = styled.li<StyledMenuItemProps>`
         * {
           color: var(--input-dropdown-label-disabled);
         }
-
+ 
         & > button, & > a {
           background-color: transparent;
         }
@@ -84,18 +88,18 @@ const StyledMenuItem = styled.li<StyledMenuItemProps>`
       `
       : `
         cursor: pointer;
-
+ 
         ${
           $isButtonMenu
             ? `
               color: var(--popover-label-default);
-
+ 
               & > button:active,
               & > a:active {
                 background-color: var(--popover-bg-active);
                 color: var(--popover-label-active);
               }
-
+ 
               & > button:not(:active):hover,
               & > a:not(:active):hover {
                 color: var(--popover-label-hover);
@@ -104,7 +108,7 @@ const StyledMenuItem = styled.li<StyledMenuItemProps>`
             `
             : `
               color: var(--input-dropdown-label-alt);
-
+ 
               &:not(:active):hover {
                 * {
                   color: var(--input-dropdown-label-hover);
@@ -129,23 +133,23 @@ const StyledMenuItem = styled.li<StyledMenuItemProps>`
         }
     `}
   `}
-
+ 
   ${({ $size, $isButtonMenu }) => css`
     ${$size === "small" &&
     `
       &:not(:has(button)):not(:has(a)) {
         padding: var(--global-space-comp-xs) 0;
-
+ 
         &:not(:has(.menu-item-subtext)) {
           min-height: var(--global-size-s);
         }
       }
-
+ 
       button, a {
         width: 100%;
         padding: var(--global-space-comp-xs) var(--global-space-comp-m) var(--global-space-comp-xs) var(--global-space-comp-m);
       }
-
+ 
       *:not(.menu-item-subtext):not(.menu-item-label-prefix) {
         font: var(--global-font-static-comp-${$isButtonMenu ? "medium" : "regular"}-s);
       }
@@ -155,17 +159,17 @@ const StyledMenuItem = styled.li<StyledMenuItemProps>`
     `
       &:not(:has(button)):not(:has(a)) {
         padding: var(--global-space-comp-s) 0;
-
+ 
         &:not(:has(.menu-item-subtext)) {
           min-height: var(--global-size-m);
         }
       }
-
+ 
       button, a {
         width: 100%;
         padding: var(--global-space-comp-s) var(--global-space-comp-m) var(--global-space-comp-s) var(--global-space-comp-m);
       }
-
+ 
       *:not(.menu-item-subtext):not(.menu-item-label-prefix) {
         font: var(--global-font-static-comp-${$isButtonMenu ? "medium" : "regular"}-m);
       }
@@ -175,7 +179,7 @@ const StyledMenuItem = styled.li<StyledMenuItemProps>`
     `
       &:not(:has(button)):not(:has(a)) {
         padding: var(--global-space-comp-m) 0;
-
+ 
         &:not(:has(.menu-item-subtext)) {
           min-height: var(--global-size-l);
         }
@@ -185,7 +189,7 @@ const StyledMenuItem = styled.li<StyledMenuItemProps>`
         width: 100%;
         padding: var(--global-space-comp-m) var(--global-space-comp-m) var(--global-space-comp-m) var(--global-space-comp-m);
       }
-
+ 
       *:not(.menu-item-subtext):not(.menu-item-label-prefix) {
         font: var(--global-font-static-comp-${$isButtonMenu ? "medium" : "regular"}-l);
       }
@@ -215,7 +219,13 @@ const cloneSubmenuParent = (
     children: (
       <SubmenuParentWrapper data-element="submenu-parent-wrapper">
         {(children as React.ReactElement).props.children}
-        <Icon type="caret_right" data-element="submenu-icon" ml={3} />
+        <Icon
+          type="caret_right"
+          data-element="submenu-icon"
+          data-role="submenu-icon"
+          aria-hidden
+          ml={3}
+        />
       </SubmenuParentWrapper>
     ),
     ...submenuControlProps,
@@ -263,6 +273,8 @@ const MenuItem = ({
   onSubmenuClose,
   submenuWidth,
   id,
+  onMouseEnter,
+  onMouseLeave,
   ...rest
 }: MenuItemProps) => {
   const ref = useRef<HTMLLIElement | null>(null);
@@ -366,6 +378,8 @@ const MenuItem = ({
             onKeyDown={!isDisabled ? handleKeydown : undefined}
             $disabled={isDisabled}
             $isButtonMenu={isButtonMenu}
+            onMouseEnter={!isDisabled ? onMouseEnter : undefined}
+            onMouseLeave={!isDisabled ? onMouseLeave : undefined}
           >
             {clonedSubmenuParentItem({
               ...controlProps,
@@ -387,6 +401,8 @@ const MenuItem = ({
       onClick={!isDisabled ? onClick : undefined}
       onMouseDown={!isDisabled ? (ev) => ev.preventDefault() : undefined}
       onKeyDown={handleSubmenuClose}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       role={isButtonMenu ? undefined : "option"}
       aria-selected={!isButtonMenu ? selected && !isDisabled : undefined}
       aria-disabled={!isButtonMenu ? isDisabled : undefined}

--- a/src/__internal__/popover-menu/popover-menu.component.tsx
+++ b/src/__internal__/popover-menu/popover-menu.component.tsx
@@ -151,6 +151,8 @@ export interface PopoverMenuProps<TRef extends FocusableHandle = HTMLElement>
   isSubmenu?: boolean;
   /** Ref to the listbox/menu element */
   listRef?: React.Ref<HTMLUListElement>;
+  /** Render the menu above a modal overlay, trapping interaction to the menu */
+  disableBackgroundUI?: boolean;
 }
 
 const OFFSET = 8;
@@ -194,6 +196,7 @@ interface MenuProps {
   portalTarget?: HTMLElement | null;
   listboxAriaLabel?: string;
   maxHeight?: string;
+  disableBackgroundUI?: boolean;
 }
 
 const Menu = ({
@@ -213,6 +216,7 @@ const Menu = ({
   disablePortal,
   portalTarget,
   maxHeight,
+  disableBackgroundUI,
 }: MenuProps) => {
   return (
     <Popover
@@ -224,6 +228,7 @@ const Menu = ({
       disablePortal={disablePortal}
       portalTarget={portalTarget}
       popoverStrategy="absolute"
+      disableBackgroundUI={disableBackgroundUI}
     >
       <MenuWrapper
         $size={size}
@@ -323,6 +328,7 @@ const PopoverMenuInner = <TRef extends FocusableHandle = HTMLElement>(
     listRef,
     controlWrapperStyle,
     maxHeight,
+    disableBackgroundUI,
     ...rest
   }: PopoverMenuProps<TRef>,
   ref: React.ForwardedRef<HTMLDivElement>,
@@ -543,6 +549,7 @@ const PopoverMenuInner = <TRef extends FocusableHandle = HTMLElement>(
             disablePortal={!isSubmenu}
             portalTarget={isSubmenu ? controlReference?.current : undefined}
             maxHeight={maxHeight}
+            disableBackgroundUI={disableBackgroundUI}
           >
             {wrappedChildren}
           </Menu>

--- a/src/__internal__/popover-menu/utils/index.tsx
+++ b/src/__internal__/popover-menu/utils/index.tsx
@@ -24,6 +24,14 @@ export const wrapChildrenInItem = (
       return child;
     }
 
+    // Components that render their own MenuItem(s) (e.g. ActionPopoverItem) opt out of
+    // wrapping by setting this static, otherwise they would be nested in a second li
+    if (
+      (child.type as { skipMenuItemWrapping?: boolean })?.skipMenuItemWrapping
+    ) {
+      return child;
+    }
+
     return <MenuItem>{child}</MenuItem>;
   })
     ?.flat()
@@ -33,5 +41,8 @@ export const wrapChildrenInItem = (
 export const itemQuerySelector = (isSubmenu?: boolean) =>
   `li[data-component='popover-${isSubmenu ? "submenu" : "menu"}-item']:not([aria-disabled='true'])`;
 
+const enabledControl = (tag: string) =>
+  `${tag}:not([disabled]):not([aria-disabled='true'])`;
+
 export const buttonMenuItemQuerySelector = (isSubmenu?: boolean) =>
-  `${itemQuerySelector(isSubmenu)} button:not([disabled]), ${itemQuerySelector(isSubmenu)} a:not([disabled])`;
+  `${itemQuerySelector(isSubmenu)} ${enabledControl("button")}, ${itemQuerySelector(isSubmenu)} ${enabledControl("a")}`;

--- a/src/components/action-popover/__internal__/action-popover.context.ts
+++ b/src/components/action-popover/__internal__/action-popover.context.ts
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react";
+import React, { createContext, useContext } from "react";
 import invariant from "invariant";
 
 export type Alignment = "left" | "right";
@@ -8,8 +8,9 @@ type ActionPopoverContextType = {
   focusButton: () => void;
   horizontalAlignment: Alignment;
   submenuPosition: Alignment;
-  selectedSubmenuRef: HTMLUListElement | null;
-  setSelectedSubmenuRef: (ref: HTMLUListElement | null) => void;
+  /** id of the submenu that is currently open, so only one can be open at a time */
+  openSubmenuId: string | null;
+  setOpenSubmenuId: React.Dispatch<React.SetStateAction<string | null>>;
 };
 
 const ActionPopoverContext = createContext<ActionPopoverContextType | null>(

--- a/src/components/action-popover/__internal__/action-popover.utils.tsx
+++ b/src/components/action-popover/__internal__/action-popover.utils.tsx
@@ -1,35 +1,6 @@
 import React from "react";
-import { ActionPopoverItem } from "../action-popover-item/action-popover-item.component";
 
-// Reusable type alias for item types
-type ReactItem = React.ReactChild | React.ReactFragment | React.ReactPortal;
-
-export const getItems = (
-  children: React.ReactNode | React.ReactNode[],
-): ReactItem[] =>
-  React.Children.toArray(children).filter(
-    (child) => React.isValidElement(child) && child.type === ActionPopoverItem,
-  );
-
-export const isItemDisabled = (item: ReactItem) =>
-  React.isValidElement(item) && !!item.props?.disabled;
-
-export const findFirstFocusableItem = (items: ReactItem[]): number =>
-  items.findIndex((_, index) => !isItemDisabled(items[index]));
-
-// FIX-ME: FE-6248
-// Once we no longer support Node 16, this function can be removed and `findLastIndex()` can be used in its place.
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex
-export const findLastFocusableItem = (items: ReactItem[]): number => {
-  for (let i = items.length - 1; i >= 0; i--) {
-    if (!isItemDisabled(items[i])) {
-      return i;
-    }
-  }
-  return -1;
-};
-
-export const checkChildrenForString = (children: React.ReactNode): boolean => {
+const checkChildrenForString = (children: React.ReactNode): boolean => {
   return React.Children.toArray(children).some((child) => {
     if (typeof child === "string") {
       return true;
@@ -40,3 +11,5 @@ export const checkChildrenForString = (children: React.ReactNode): boolean => {
       : false;
   });
 };
+
+export default checkChildrenForString;

--- a/src/components/action-popover/action-popover-divider.component.tsx
+++ b/src/components/action-popover/action-popover-divider.component.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { MenuItemDivider } from "../../__internal__/popover-menu";
+
+const ActionPopoverDivider = () => (
+  <MenuItemDivider
+    data-element="action-popover-divider"
+    data-role="action-popover-divider"
+  />
+);
+
+ActionPopoverDivider.displayName = "ActionPopoverDivider";
+ActionPopoverDivider.skipMenuItemWrapping = true;
+
+export default ActionPopoverDivider;

--- a/src/components/action-popover/action-popover-divider/action-popover-divider.component.ts
+++ b/src/components/action-popover/action-popover-divider/action-popover-divider.component.ts
@@ -1,4 +1,0 @@
-import { MenuItemDivider as ActionPopoverDivider } from "../action-popover.style";
-
-ActionPopoverDivider.displayName = "ActionPopoverDivider";
-export default ActionPopoverDivider;

--- a/src/components/action-popover/action-popover-interaction.stories.tsx
+++ b/src/components/action-popover/action-popover-interaction.stories.tsx
@@ -7,10 +7,9 @@ import {
   ActionPopoverDivider,
   ActionPopoverItem,
   ActionPopoverMenu,
-  ActionPopoverMenuButton,
 } from ".";
-
 import Box from "../box";
+import Button from "../button/__next__";
 
 import { allowInteractions } from "../../../.storybook/interaction-toggle/reduced-motion";
 import { ActionPopoverWithIconsAndNoSubmenus } from "./components.test-pw";
@@ -76,18 +75,19 @@ export const SubmenuHoverAndFocus: Story = {
         <ActionPopover
           data-role="target"
           renderButton={({
-            tabIndex,
+            tabIndex: _tabIndex,
             "data-element": dataElement,
             ariaAttributes,
           }) => (
-            <ActionPopoverMenuButton
-              buttonType="tertiary"
+            <Button
+              variant="default"
+              variantType="subtle"
               iconType="dropdown"
               iconPosition="after"
               size="small"
-              tabIndex={tabIndex}
               data-element={dataElement}
-              ariaAttributes={ariaAttributes}
+              {...ariaAttributes}
+              aria-label="actions"
             />
           )}
         >

--- a/src/components/action-popover/action-popover-interaction.stories.tsx
+++ b/src/components/action-popover/action-popover-interaction.stories.tsx
@@ -74,11 +74,7 @@ export const SubmenuHoverAndFocus: Story = {
       <Box mt={10} height={10}>
         <ActionPopover
           data-role="target"
-          renderButton={({
-            tabIndex: _tabIndex,
-            "data-element": dataElement,
-            ariaAttributes,
-          }) => (
+          renderButton={({ "data-element": dataElement, ariaAttributes }) => (
             <Button
               variant="default"
               variantType="subtle"

--- a/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
+++ b/src/components/action-popover/action-popover-item/action-popover-item.component.tsx
@@ -1,24 +1,18 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import invariant from "invariant";
 
 import {
-  MenuItemIcon,
-  SubMenuItemIcon,
-  StyledMenuItem,
-  StyledMenuItemInnerText,
-  StyledMenuItemWrapper,
-} from "../action-popover.style";
-import Events from "../../../__internal__/utils/helpers/events";
+  MenuItem,
+  MenuItemLeading,
+  MenuItemLabel,
+} from "../../../__internal__/popover-menu";
+import Icon, { IconType } from "../../icon";
 import createGuid from "../../../__internal__/utils/helpers/guid";
 import {
   Alignment,
   useActionPopoverContext,
 } from "../__internal__/action-popover.context";
-
-import { IconType } from "../../icon";
-import ActionPopoverMenu, {
-  ActionPopoverMenuProps,
-} from "../action-popover-menu/action-popover-menu.component";
+import ActionPopoverMenu from "../action-popover-menu/action-popover-menu.component";
 
 export interface ActionPopoverItemProps {
   /** The text label to display for this Item */
@@ -49,49 +43,14 @@ export interface ActionPopoverItemProps {
 
 const INTERVAL = 150;
 
-type ContainerPosition = {
-  left: string | number;
-  top?: string;
-  bottom?: string;
-  right: string | number;
-};
-
-function checkRef(ref: React.RefObject<HTMLElement>) {
-  return Boolean(ref && ref.current);
-}
-
-function calculateSubmenuPosition(
-  ref: React.RefObject<HTMLElement>,
-  submenuRef: React.RefObject<HTMLElement>,
-  submenuPosition: Alignment,
-  currentSubmenuPosition?: Alignment,
-) {
-  /* istanbul ignore if */
-
-  if (!ref.current || !submenuRef.current)
-    return currentSubmenuPosition || submenuPosition;
-
-  const { left, right } = ref.current.getBoundingClientRect();
-  const { offsetWidth } = submenuRef.current;
-  const windowWidth = document.body.clientWidth;
-
-  if (submenuPosition === "left") {
-    return left >= offsetWidth ? "left" : "right";
-  }
-  return windowWidth >= right + offsetWidth ? "right" : "left";
-}
-
 export const ActionPopoverItem = ({
   children,
   icon,
   disabled = false,
   onClick: onClickProp,
   submenu,
-  focusItem,
   download,
   href,
-  currentSubmenuPosition,
-  setCurrentSubmenuPosition,
   ...rest
 }: ActionPopoverItemProps) => {
   invariant(
@@ -99,83 +58,44 @@ export const ActionPopoverItem = ({
     "ActionPopoverItem only accepts submenu of type `ActionPopoverMenu`",
   );
 
-  const {
-    setOpenPopover,
-    focusButton,
-    submenuPosition,
-    selectedSubmenuRef,
-    setSelectedSubmenuRef,
-  } = useActionPopoverContext();
-  const [containerPosition, setContainerPosition] = useState<
-    ContainerPosition | undefined
-  >(undefined);
-  const [guid] = useState(createGuid());
-  const [isOpen, setOpen] = useState(false);
-  const [focusIndex, setFocusIndex] = useState<number>(0);
+  // The submenu is only mounted once it opens, so its children are validated here
+  // rather than waiting for ActionPopoverMenu to render them.
+  const submenuHasProperChildren = React.isValidElement(submenu)
+    ? !React.Children.toArray(
+        (submenu.props as { children?: React.ReactNode }).children,
+      ).find(
+        (child) =>
+          !React.isValidElement(child) ||
+          ((child.type as React.FunctionComponent).displayName !==
+            "ActionPopoverItem" &&
+            (child.type as React.FunctionComponent).displayName !==
+              "ActionPopoverDivider"),
+      )
+    : true;
 
-  const submenuRef = useRef<HTMLUListElement>(null);
-  const ref = useRef<HTMLButtonElement>(null);
+  invariant(
+    submenuHasProperChildren,
+    "ActionPopoverMenu only accepts children of type `ActionPopoverItem`" +
+      " and `ActionPopoverDivider`.",
+  );
+
+  const { setOpenPopover, focusButton, openSubmenuId, setOpenSubmenuId } =
+    useActionPopoverContext();
+  const submenuId = useRef(createGuid()).current;
+  const submenuOpen = openSubmenuId === submenuId;
+  const setSubmenuOpen = useCallback(
+    (open: boolean) =>
+      setOpenSubmenuId((current) => {
+        if (open) return submenuId;
+        // only close if this item still owns the open submenu, otherwise a submenu
+        // that has just been opened elsewhere would be closed again immediately
+        return current === submenuId ? null : current;
+      }),
+    [setOpenSubmenuId, submenuId],
+  );
+  const itemRef = useRef<HTMLButtonElement & HTMLAnchorElement>(null);
   const mouseEnterTimer = useRef<NodeJS.Timeout | null>(null);
   const mouseLeaveTimer = useRef<NodeJS.Timeout | null>(null);
-
-  const alignSubmenu = useCallback(() => {
-    const checkCalculatedSubmenuPosition = calculateSubmenuPosition(
-      ref,
-      submenuRef,
-      submenuPosition,
-      currentSubmenuPosition,
-    );
-
-    setCurrentSubmenuPosition?.(checkCalculatedSubmenuPosition);
-
-    return checkRef(ref) && checkRef(submenuRef) && submenu;
-  }, [
-    submenu,
-    setCurrentSubmenuPosition,
-    submenuPosition,
-    currentSubmenuPosition,
-  ]);
-
-  useEffect(() => {
-    if (!disabled && submenuRef.current) {
-      setOpen(selectedSubmenuRef === submenuRef.current);
-    }
-  }, [disabled, selectedSubmenuRef]);
-
-  useEffect(() => {
-    const getContainerPosition = () => {
-      /* istanbul ignore if */
-      if (!ref.current || !submenuRef.current) return undefined;
-
-      const { offsetWidth: submenuWidth } = submenuRef.current;
-
-      const leftAlignedSubmenu = currentSubmenuPosition === "left";
-      const leftValue = leftAlignedSubmenu ? -submenuWidth : "auto";
-      const rightValue = leftAlignedSubmenu ? "auto" : -submenuWidth;
-
-      return {
-        left: leftValue,
-        right: rightValue,
-      };
-    };
-    setContainerPosition(getContainerPosition);
-  }, [submenu, currentSubmenuPosition]);
-
-  useEffect(() => {
-    if (submenu) {
-      alignSubmenu();
-    }
-  }, [alignSubmenu, submenu]);
-
-  // Focuses item on opening of actionPopover submenu, but we want to do this once the Popover has finished opening
-  // We always want the focused item to be in the user's view for accessibility purposes, and without the initial unexpected scroll to top of page when used in a table.
-  useEffect(() => {
-    if (focusItem) {
-      setTimeout(() => {
-        ref.current?.focus();
-      }, 0);
-    }
-  }, [focusItem]);
 
   useEffect(() => {
     return function cleanup() {
@@ -184,187 +104,130 @@ export const ActionPopoverItem = ({
     };
   }, []);
 
-  useEffect(() => {
-    const event = "resize";
-    window.addEventListener(event, alignSubmenu);
-
-    return function cleanup() {
-      window.removeEventListener(event, alignSubmenu);
-    };
-  }, [alignSubmenu]);
-
   const onClick = useCallback(
     (
       e:
         | React.MouseEvent<HTMLButtonElement>
         | React.KeyboardEvent<HTMLButtonElement>,
     ) => {
+      if (disabled) {
+        // Keep focus on the disabled item rather than letting it fall back to the
+        // menu trigger. Only the default action is suppressed: the event must still
+        // reach the PopoverMenu wrapper, which uses it to recognise the click as
+        // being inside the menu, otherwise the click-away listener closes the menu.
+        itemRef.current?.focus();
+        e.preventDefault();
+        return;
+      }
+
+      // Submenu parents open their submenu rather than performing an action. That is
+      // handled by the MenuItem this renders, so the event must be allowed to bubble
+      // up to it rather than being stopped here.
+      if (submenu) {
+        return;
+      }
+
       e.stopPropagation();
-      if (!disabled) {
-        setOpenPopover(false);
-        focusButton();
-        if (onClickProp) {
-          onClickProp(e);
-        }
-      } else {
-        ref.current?.focus();
-        e.preventDefault();
-      }
+      setOpenPopover(false);
+      focusButton();
+      onClickProp?.(e);
     },
-    [disabled, focusButton, onClickProp, setOpenPopover],
+    [disabled, focusButton, onClickProp, setOpenPopover, submenu],
   );
 
-  const onKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLElement>) => {
-      if (Events.isSpaceKey(e)) {
-        e.preventDefault();
-        e.stopPropagation();
-      } else if (!disabled) {
-        if (submenu) {
-          if (currentSubmenuPosition === "left") {
-            // LEFT: open if has submenu and left aligned otherwise close submenu
-            if (Events.isLeftKey(e) || Events.isEnterKey(e)) {
-              setSelectedSubmenuRef(submenuRef.current);
-              setOpen(true);
-              setFocusIndex(0);
-              e.stopPropagation();
-            } else if (Events.isRightKey(e)) {
-              setOpen(false);
-              ref.current?.focus();
-              e.stopPropagation();
-            }
-          } else {
-            // RIGHT: open if has submenu and right aligned otherwise close submenu
-            if (Events.isRightKey(e) || Events.isEnterKey(e)) {
-              setOpen(true);
-              setFocusIndex(0);
-              e.stopPropagation();
-            }
-            if (Events.isLeftKey(e)) {
-              setOpen(false);
-              ref.current?.focus();
-              e.stopPropagation();
-            }
-          }
-          e.preventDefault();
-        } else if (Events.isEnterKey(e)) {
-          // In this popover keyboard flow, Enter on non-link items does not always reach the
-          // same activation path as mouse clicks, so we trigger the shared click handler
-          // explicitly. For link items, keep native anchor Enter behavior.
-          if (!href) {
-            e.preventDefault();
-            onClick(e as React.KeyboardEvent<HTMLButtonElement>);
-          }
+  const onKeyDown = (ev: React.KeyboardEvent<HTMLButtonElement>) => {
+    // Space must never activate or scroll, matching the previous implementation
+    if (ev.key === " ") {
+      ev.preventDefault();
+      ev.stopPropagation();
+      return;
+    }
+
+    if (disabled && ev.key === "Enter") {
+      ev.preventDefault();
+      ev.stopPropagation();
+    }
+  };
+
+  const hoverProps =
+    submenu && !disabled
+      ? {
+          onMouseEnter: () => {
+            if (mouseEnterTimer.current) clearTimeout(mouseEnterTimer.current);
+            mouseEnterTimer.current = setTimeout(
+              () => setSubmenuOpen(true),
+              INTERVAL,
+            );
+          },
+          onMouseLeave: () => {
+            if (mouseLeaveTimer.current) clearTimeout(mouseLeaveTimer.current);
+            mouseLeaveTimer.current = setTimeout(
+              () => setSubmenuOpen(false),
+              INTERVAL,
+            );
+          },
         }
-      } else if (Events.isEnterKey(e)) {
-        e.stopPropagation();
-      }
-    },
-    [
-      disabled,
-      submenu,
-      currentSubmenuPosition,
-      setSelectedSubmenuRef,
-      onClick,
-      href,
-    ],
-  );
+      : {};
 
-  const itemSubmenuProps = {
-    ...(!disabled && {
-      onClick: (e: React.MouseEvent<HTMLButtonElement>) => {
-        setSelectedSubmenuRef(submenuRef.current);
-        setOpen(true);
-        ref.current?.focus();
-        e.preventDefault();
-        e.stopPropagation();
-      },
-    }),
-    "aria-haspopup": "true",
-    "aria-controls": `ActionPopoverMenu_${guid}`,
-    "aria-expanded": isOpen,
-  };
-
-  const wrapperProps = {
-    ...(!disabled && {
-      onMouseEnter: (e: React.MouseEvent<HTMLLIElement>) => {
-        if (mouseEnterTimer.current) clearTimeout(mouseEnterTimer.current);
-
-        setFocusIndex(-1);
-        mouseEnterTimer.current = setTimeout(() => {
-          setOpen(true);
-          setSelectedSubmenuRef(submenuRef.current);
-        }, INTERVAL);
-        e.stopPropagation();
-      },
-      onMouseLeave: (e: React.MouseEvent<HTMLLIElement>) => {
-        if (mouseLeaveTimer.current) clearTimeout(mouseLeaveTimer.current);
-
-        mouseLeaveTimer.current = setTimeout(() => {
-          setOpen(false);
-        }, INTERVAL);
-        e.stopPropagation();
-      },
-    }),
-  };
-
-  return (
-    <StyledMenuItemWrapper onKeyDown={onKeyDown} {...(submenu && wrapperProps)}>
-      <StyledMenuItem
-        {...rest}
-        ref={ref}
-        onClick={onClick}
-        type="button"
-        tabIndex={0}
-        isDisabled={disabled}
-        {...(disabled && { "aria-disabled": true })}
-        {...(!!href && { as: "a" as unknown as undefined, download, href })}
-        {...(submenu && itemSubmenuProps)}
-      >
-        {submenu && checkRef(ref) && (
-          <SubMenuItemIcon
-            aria-hidden
-            data-element="action-popover-menu-item-chevron"
-            data-role="chevron-icon"
-            type={
-              currentSubmenuPosition === "left"
-                ? "chevron_left_thick"
-                : "chevron_right_thick"
-            }
-          />
-        )}
-        {icon && (
-          <MenuItemIcon
+  const content = (
+    <>
+      {icon && (
+        <MenuItemLeading>
+          <Icon
             aria-hidden
             type={icon}
             data-element="action-popover-menu-item-icon"
             data-role="item-icon"
           />
-        )}
-        <StyledMenuItemInnerText data-element="action-popover-menu-item-inner-text">
+        </MenuItemLeading>
+      )}
+      <MenuItemLabel>
+        <span data-element="action-popover-menu-item-inner-text">
           {children}
-        </StyledMenuItemInnerText>
-      </StyledMenuItem>
-      {React.isValidElement(submenu)
-        ? React.cloneElement<ActionPopoverMenuProps>(
-            submenu as React.ReactElement<ActionPopoverMenuProps>,
-            {
-              parentID: `ActionPopoverItem_${guid}`,
-              menuID: `ActionPopoverMenu_${guid}`,
-              "data-element": "action-popover-submenu",
-              isOpen,
-              ref: submenuRef,
-              style: containerPosition,
-              setOpen,
-              setFocusIndex,
-              focusIndex,
-            },
-          )
-        : null}
-    </StyledMenuItemWrapper>
+        </span>
+      </MenuItemLabel>
+    </>
+  );
+
+  const interactiveElement = href ? (
+    <a
+      {...rest}
+      ref={itemRef}
+      href={href}
+      download={download}
+      onClick={onClick as unknown as React.MouseEventHandler<HTMLAnchorElement>}
+      {...(disabled && { "aria-disabled": true })}
+    >
+      {content}
+    </a>
+  ) : (
+    <button
+      {...rest}
+      ref={itemRef}
+      type="button"
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      {...(disabled && { "aria-disabled": true })}
+    >
+      {content}
+    </button>
+  );
+
+  return (
+    <MenuItem
+      disabled={disabled}
+      submenu={submenu}
+      submenuOpen={submenuOpen}
+      onSubmenuOpen={() => setSubmenuOpen(true)}
+      onSubmenuClose={() => setSubmenuOpen(false)}
+      {...hoverProps}
+    >
+      {interactiveElement}
+    </MenuItem>
   );
 };
 
 ActionPopoverItem.displayName = "ActionPopoverItem";
+ActionPopoverItem.skipMenuItemWrapping = true;
 
 export default ActionPopoverItem;

--- a/src/components/action-popover/action-popover-menu-button/action-popover-menu-button.component.tsx
+++ b/src/components/action-popover/action-popover-menu-button/action-popover-menu-button.component.tsx
@@ -37,6 +37,10 @@ export interface ActionPopoverMenuButtonProps {
   tabIndex: number;
 }
 
+/**
+ * @deprecated This component will be removed in a future major release.
+ * Use the `renderButton` prop with your own button implementation instead.
+ */
 export const ActionPopoverMenuButton = ({
   buttonType,
   iconType,

--- a/src/components/action-popover/action-popover-menu/action-popover-menu.component.tsx
+++ b/src/components/action-popover/action-popover-menu/action-popover-menu.component.tsx
@@ -1,47 +1,24 @@
-import React, { useCallback, useMemo, useState } from "react";
-import invariant from "invariant";
-
-import { Menu } from "../action-popover.style";
-import Events from "../../../__internal__/utils/helpers/events";
-import ActionPopoverItem, {
-  ActionPopoverItemProps,
-} from "../action-popover-item/action-popover-item.component";
-import ActionPopoverDivider from "../action-popover-divider/action-popover-divider.component";
-import {
-  Alignment,
-  useActionPopoverContext,
-} from "../__internal__/action-popover.context";
-import {
-  findFirstFocusableItem,
-  findLastFocusableItem,
-  getItems,
-  isItemDisabled,
-} from "../__internal__/action-popover.utils";
+import React from "react";
 
 export interface ActionPopoverMenuBaseProps {
   /** Children for the menu */
   children?: React.ReactNode;
-  /**
-   * @ignore
-   * @private
-   * @internal
-   * Index to control which item is focused */
+  /** @deprecated No longer used, focus is managed by the underlying PopoverMenu */
   focusIndex?: number;
-  /** Flag to indicate whether a menu should open */
+  /** @deprecated No longer used, open state is managed by the parent ActionPopoverItem */
   isOpen?: boolean;
   /** A unique ID for the menu */
   menuID?: string;
-  /**
-   * @ignore
-   * @private
-   * @internal
-   * Callback to set the index of the focused item */
+  /** @deprecated No longer used, focus is managed by the underlying PopoverMenu */
   setFocusIndex?: (args: number) => void;
-  /** Callback to set the isOpen flag */
+  /** @deprecated No longer used, open state is managed by the parent ActionPopoverItem */
   setOpen?: (args: boolean) => void;
   /** Unique ID for the menu's parent */
   parentID?: string;
-  /** Set whether the menu should open above or below the button */
+  /**
+   * @deprecated Submenus now open to the right and flip automatically when space is
+   * constrained. This prop will be removed in a future major release.
+   */
   placement?: "bottom" | "top";
   /** @ignore @private */
   role?: string;
@@ -60,191 +37,27 @@ export interface ActionPopoverMenuProps
   extends ActionPopoverMenuBaseProps,
     React.RefAttributes<HTMLUListElement> {}
 
+/**
+ * ActionPopoverMenu is now a transparent container. The list element, positioning and
+ * keyboard behaviour are all owned by the PopoverMenu that renders the submenu, and the
+ * children are validated eagerly by ActionPopoverItem, so this passes them through.
+ */
 const ActionPopoverMenu = React.forwardRef<
   HTMLUListElement,
   ActionPopoverMenuBaseProps
 >(
   (
-    {
-      children,
-      parentID,
-      focusIndex,
-      isOpen,
-      menuID,
-      setOpen,
-      setFocusIndex,
-      placement = "bottom",
-      ...rest
-    }: ActionPopoverMenuBaseProps,
+    { children }: ActionPopoverMenuBaseProps,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     ref,
   ) => {
-    const { focusButton, submenuPosition, horizontalAlignment } =
-      useActionPopoverContext();
-
-    invariant(
-      setOpen && setFocusIndex && typeof focusIndex !== "undefined",
-      "ActionPopoverMenu must be used within an ActionPopover or ActionPopoverItem component",
-    );
-
-    const hasProperChildren = useMemo(() => {
-      const incorrectChild = React.Children.toArray(children).find(
-        (child: React.ReactNode) =>
-          !React.isValidElement(child) ||
-          ((child.type as React.FunctionComponent).displayName !==
-            "ActionPopoverItem" &&
-            (child.type as React.FunctionComponent).displayName !==
-              "ActionPopoverDivider"),
-      );
-
-      return !incorrectChild;
-    }, [children]);
-
-    invariant(
-      hasProperChildren,
-      `ActionPopoverMenu only accepts children of type \`${ActionPopoverItem.displayName}\`` +
-        ` and \`${ActionPopoverDivider.displayName}\`.`,
-    );
-
-    const items = useMemo(() => getItems(children), [children]);
-
-    const checkItemDisabled = useCallback(
-      (value: number) => isItemDisabled(items[value]),
-      [items],
-    );
-
-    const firstFocusableItem = findFirstFocusableItem(items);
-
-    const lastFocusableItem = findLastFocusableItem(items);
-
-    const onKeyDown = useCallback(
-      (e: React.KeyboardEvent<HTMLUListElement>) => {
-        if (Events.isTabKey(e)) {
-          e.preventDefault();
-          // TAB: close menu and allow focus to change to the next focusable element
-          focusButton();
-          setOpen(false);
-        } else if (Events.isDownKey(e)) {
-          // DOWN: focus on the next item or first non-disabled item
-          e.preventDefault();
-          e.stopPropagation();
-          let indexValue = focusIndex + 1;
-          while (indexValue < items.length && checkItemDisabled(indexValue)) {
-            indexValue += 1;
-          }
-          if (indexValue >= items.length) {
-            indexValue = firstFocusableItem;
-          }
-          setFocusIndex(indexValue);
-        } else if (Events.isUpKey(e)) {
-          // UP: focus on the previous item or last non-disabled item
-          e.preventDefault();
-          e.stopPropagation();
-          let indexValue = focusIndex - 1;
-          while (
-            indexValue >= firstFocusableItem &&
-            checkItemDisabled(indexValue)
-          ) {
-            indexValue -= 1;
-          }
-          if (indexValue < firstFocusableItem) {
-            indexValue = lastFocusableItem;
-          }
-          setFocusIndex(indexValue);
-        } else if (Events.isHomeKey(e)) {
-          // HOME: focus on the first non-disabled item
-          e.preventDefault();
-          e.stopPropagation();
-          const indexValue = firstFocusableItem;
-          setFocusIndex(indexValue);
-        } else if (Events.isEndKey(e)) {
-          // END: focus on the last non-disabled item
-          e.preventDefault();
-          e.stopPropagation();
-          const indexValue = lastFocusableItem;
-          setFocusIndex(indexValue);
-        } else if (e.key.length === 1) {
-          // Any printable character: focus on the next non-disabled item on the list that starts with that character
-          // Selection should wrap to the start of the list
-          e.stopPropagation();
-          let firstMatch: number | undefined;
-          let nextMatch: number | undefined;
-          items.forEach((item, index) => {
-            if (
-              React.isValidElement(item) &&
-              !checkItemDisabled(index) &&
-              item.props.children.toLowerCase().startsWith(e.key.toLowerCase())
-            ) {
-              // istanbul ignore else
-              if (firstMatch === undefined) {
-                firstMatch = index;
-              }
-              if (index > focusIndex && nextMatch === undefined) {
-                nextMatch = index;
-              }
-            }
-          });
-
-          if (nextMatch !== undefined) {
-            setFocusIndex(nextMatch);
-          } else if (firstMatch !== undefined) {
-            setFocusIndex(firstMatch);
-          }
-        }
-      },
-      [
-        focusButton,
-        setOpen,
-        focusIndex,
-        items,
-        checkItemDisabled,
-        setFocusIndex,
-        firstFocusableItem,
-        lastFocusableItem,
-      ],
-    );
-
-    const [currentSubmenuPosition, setCurrentSubmenuPosition] =
-      useState<Alignment>(submenuPosition);
-
-    const clonedChildren = useMemo(() => {
-      let index = 0;
-      return React.Children.map(children, (child) => {
-        if (React.isValidElement(child) && child.type === ActionPopoverItem) {
-          index += 1;
-          return React.cloneElement(
-            child as React.ReactElement<ActionPopoverItemProps>,
-            {
-              focusItem: isOpen && focusIndex === index - 1,
-              currentSubmenuPosition,
-              setCurrentSubmenuPosition,
-            },
-          );
-        }
-
-        return child;
-      });
-    }, [children, focusIndex, isOpen, currentSubmenuPosition]);
-
-    return (
-      <Menu
-        data-component="action-popover"
-        data-submenu-placement={placement}
-        isOpen={!!isOpen}
-        onKeyDown={onKeyDown}
-        id={menuID}
-        aria-labelledby={parentID}
-        ref={ref}
-        role="list"
-        submenuLeft={currentSubmenuPosition === "left"}
-        iconLeft={horizontalAlignment === "left"}
-        {...rest}
-      >
-        {clonedChildren}
-      </Menu>
-    );
+    return <>{children}</>;
   },
 );
 
 ActionPopoverMenu.displayName = "ActionPopoverMenu";
+(
+  ActionPopoverMenu as unknown as { skipMenuItemWrapping: boolean }
+).skipMenuItemWrapping = true;
 
 export default ActionPopoverMenu;

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -12,11 +12,7 @@ import { MarginProps } from "styled-system";
 import invariant from "invariant";
 import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
-import {
-  MenuButton,
-  ButtonIcon,
-  StyledButtonIcon,
-} from "./action-popover.style";
+import { MenuButton, MenuButtonOverrideWrapper } from "./action-popover.style";
 import Events from "../../__internal__/utils/helpers/events";
 import Popover from "../../__internal__/popover";
 import createGuid from "../../__internal__/utils/helpers/guid";
@@ -37,6 +33,7 @@ import {
   checkChildrenForString,
 } from "./__internal__/action-popover.utils";
 import FlatTableContext from "../flat-table/__internal__/flat-table.context";
+import Button from "../button/__next__";
 
 export interface RenderButtonProps {
   tabIndex: number;
@@ -54,9 +51,15 @@ export interface RenderButtonProps {
 export interface ActionPopoverProps extends MarginProps, TagProps {
   /** Children for popover component */
   children?: React.ReactNode;
-  /** Horizontal alignment of menu items content */
+  /**
+   * @deprecated This prop will be removed in a future major release.
+   * Horizontal alignment is now inferred from menu placement.
+   */
   horizontalAlignment?: Alignment;
-  /** Sets submenu position */
+  /**
+   * @deprecated This prop will be removed in a future major release.
+   * Submenus now default to opening on the right and automatically flip when space is constrained.
+   */
   submenuPosition?: Alignment;
   /** Unique ID */
   id?: string;
@@ -64,7 +67,10 @@ export interface ActionPopoverProps extends MarginProps, TagProps {
   onOpen?: () => void;
   /** Callback to be called on menu close */
   onClose?: () => void;
-  /** Set whether the menu should open above or below the button */
+  /**
+   * @deprecated This prop will be removed in a future major release.
+   * The menu now opens with adaptive placement and flips when space is constrained.
+   */
   placement?: "bottom" | "top";
   /** Render a custom menu button to override default ellipsis icon */
   renderButton?: (buttonProps: RenderButtonProps) => React.ReactNode;
@@ -97,9 +103,9 @@ export const ActionPopover = forwardRef<
       onClose = onCloseDefault,
       rightAlignMenu,
       renderButton,
-      placement = "bottom",
+      placement,
       horizontalAlignment = "left",
-      submenuPosition = "left",
+      submenuPosition = "right",
       "aria-label": ariaLabel,
       "aria-labelledby": ariaLabelledBy,
       "aria-describedby": ariaDescribedBy,
@@ -148,20 +154,12 @@ export const ActionPopover = forwardRef<
     );
 
     const mappedPlacement = useMemo(() => {
-      if (placement === "top" && !rightAlignMenu) {
-        return "top-end";
-      }
-
-      if (placement === "top" && rightAlignMenu) {
-        return "top-start";
-      }
-
-      if (placement === "bottom" && rightAlignMenu) {
+      if (rightAlignMenu) {
         return "bottom-start";
       }
 
       return "bottom-end";
-    }, [placement, rightAlignMenu]);
+    }, [rightAlignMenu]);
 
     const setOpen = useCallback(
       (value: boolean) => {
@@ -316,19 +314,24 @@ export const ActionPopover = forwardRef<
       }
 
       return (
-        <StyledButtonIcon
-          role="button"
-          aria-haspopup="true"
-          aria-label={ariaLabel || l.actionPopover.ariaLabel()}
-          aria-labelledby={ariaLabelledBy}
-          aria-describedby={ariaDescribedBy}
-          aria-controls={menuID}
-          aria-expanded={isOpen}
-          tabIndex={isOpen ? -1 : 0}
-          data-element="action-popover-button"
-        >
-          <ButtonIcon type="ellipsis_vertical" />
-        </StyledButtonIcon>
+        <MenuButtonOverrideWrapper>
+          <Button
+            variant="default"
+            variantType="subtle"
+            iconType="dropdown"
+            iconPosition="after"
+            size="small"
+            aria-haspopup="true"
+            aria-label={ariaLabel}
+            aria-labelledby={ariaLabelledBy}
+            aria-describedby={ariaDescribedBy}
+            aria-controls={menuID}
+            aria-expanded={isOpen}
+            data-element="action-popover-button"
+          >
+            Action
+          </Button>
+        </MenuButtonOverrideWrapper>
       );
     };
 
@@ -371,7 +374,7 @@ export const ActionPopover = forwardRef<
                 setFocusIndex={setFocusIndex}
                 isOpen={isOpen}
                 setOpen={setOpen}
-                placement={placement}
+                placement={placement || "bottom"}
               >
                 {children}
               </ActionPopoverMenu>

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -14,26 +14,20 @@ import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
 
 import { MenuButton, MenuButtonOverrideWrapper } from "./action-popover.style";
 import Events from "../../__internal__/utils/helpers/events";
-import Popover from "../../__internal__/popover";
+import { PopoverMenu } from "../../__internal__/popover-menu";
 import createGuid from "../../__internal__/utils/helpers/guid";
 import useLocale from "../../hooks/__internal__/useLocale";
-import ActionPopoverMenu from "./action-popover-menu/action-popover-menu.component";
 import ActionPopoverItem from "./action-popover-item/action-popover-item.component";
-import ActionPopoverDivider from "./action-popover-divider/action-popover-divider.component";
 import {
   ActionPopoverProvider,
   Alignment,
 } from "./__internal__/action-popover.context";
 import useModalManager from "../../hooks/__internal__/useModalManager";
 import useAdaptiveSidebarModalFocus from "../../hooks/__internal__/useAdaptiveSidebarModalFocus";
-import {
-  findFirstFocusableItem,
-  findLastFocusableItem,
-  getItems,
-  checkChildrenForString,
-} from "./__internal__/action-popover.utils";
+import checkChildrenForString from "./__internal__/action-popover.utils";
 import FlatTableContext from "../flat-table/__internal__/flat-table.context";
 import Button from "../button/__next__";
+import ActionPopoverDivider from "./action-popover-divider.component";
 
 export interface RenderButtonProps {
   tabIndex: number;
@@ -115,14 +109,11 @@ export const ActionPopover = forwardRef<
   ) => {
     const l = useLocale();
     const [isOpen, setOpenState] = useState(false);
-    const [focusIndex, setFocusIndex] = useState(0);
+    const [openSubmenuId, setOpenSubmenuId] = useState<string | null>(null);
     const [guid] = useState(createGuid());
     const buttonRef = useRef<HTMLDivElement>(null);
     const menu = useRef<HTMLUListElement>(null);
     const { isInFlatTable } = useContext(FlatTableContext);
-
-    const [selectedSubmenuRef, setSelectedSubmenuRef] =
-      useState<HTMLUListElement | null>(null);
 
     const hasProperChildren = useMemo(() => {
       const incorrectChild = React.Children.toArray(children).find(
@@ -140,12 +131,6 @@ export const ActionPopover = forwardRef<
 
       return !incorrectChild;
     }, [children]);
-
-    const items = useMemo(() => getItems(children), [children]);
-
-    const firstFocusableItem = findFirstFocusableItem(items);
-
-    const lastFocusableItem = findLastFocusableItem(items);
 
     invariant(
       hasProperChildren,
@@ -168,6 +153,9 @@ export const ActionPopover = forwardRef<
         }
         if (!value && isOpen) {
           onClose();
+        }
+        if (!value) {
+          setOpenSubmenuId(null);
         }
         setOpenState(value);
       },
@@ -194,16 +182,22 @@ export const ActionPopover = forwardRef<
 
     const onButtonClick = useCallback(
       (e: React.MouseEvent<HTMLElement>) => {
+        // The menu renders inline within this wrapper, so clicks on menu items bubble
+        // up to here. Only clicks on the trigger itself should toggle the menu.
+        const target = e.target as HTMLElement | null;
+        if (!target?.closest("[data-element='action-popover-button']")) {
+          return;
+        }
+
         e.stopPropagation();
         const isOpening = !isOpen;
-        setFocusIndex(firstFocusableItem);
         setOpen(isOpening);
         if (!isOpening) {
           // Closing the menu should focus the MenuButton
           focusButton();
         }
       },
-      [isOpen, firstFocusableItem, setOpen, focusButton],
+      [isOpen, setOpen, focusButton],
     );
 
     // Keyboard commands implemented as recommended by WAI-ARIA best practices
@@ -223,23 +217,13 @@ export const ActionPopover = forwardRef<
           return;
         }
 
-        if (
-          Events.isSpaceKey(e) ||
-          Events.isDownKey(e) ||
-          Events.isEnterKey(e)
-        ) {
+        if (Events.isSpaceKey(e) || Events.isEnterKey(e)) {
           e.preventDefault();
           e.stopPropagation();
-          setFocusIndex(firstFocusableItem);
-          setOpen(true);
-        } else if (Events.isUpKey(e)) {
-          e.preventDefault();
-          e.stopPropagation();
-          setFocusIndex(lastFocusableItem);
           setOpen(true);
         }
       },
-      [firstFocusableItem, lastFocusableItem, setOpen],
+      [setOpen],
     );
 
     const handleEscapeKey = useCallback(
@@ -348,38 +332,34 @@ export const ActionPopover = forwardRef<
         {...rest}
         {...tagComponent("action-popover-wrapper", rest)}
       >
-        {menuButton(menuID)}
         <ActionPopoverProvider
           value={{
             setOpenPopover: setOpen,
             focusButton,
             submenuPosition,
             horizontalAlignment,
-            selectedSubmenuRef,
-            setSelectedSubmenuRef,
+            openSubmenuId,
+            setOpenSubmenuId,
           }}
         >
-          {isOpen && (
-            <Popover
-              placement={mappedPlacement}
-              reference={buttonRef}
-              disableBackgroundUI={isInFlatTable}
-            >
-              <ActionPopoverMenu
-                data-component="action-popover"
-                ref={menu}
-                parentID={parentID}
-                menuID={menuID}
-                focusIndex={focusIndex}
-                setFocusIndex={setFocusIndex}
-                isOpen={isOpen}
-                setOpen={setOpen}
-                placement={placement || "bottom"}
-              >
-                {children}
-              </ActionPopoverMenu>
-            </Popover>
-          )}
+          <PopoverMenu
+            open={isOpen}
+            onOpen={() => setOpen(true)}
+            onClose={() => setOpen(false)}
+            isButtonMenu
+            placement={mappedPlacement}
+            controlReference={buttonRef}
+            controlWrapperStyle={{ display: "contents" }}
+            listRef={menu}
+            listboxAriaLabelledBy={parentID}
+            id={menuID}
+            disableBackgroundUI={isInFlatTable}
+            data-component="action-popover"
+            data-role="action-popover"
+            popoverControl={() => menuButton(menuID)}
+          >
+            {children}
+          </PopoverMenu>
         </ActionPopoverProvider>
       </MenuButton>
     );

--- a/src/components/action-popover/action-popover.mdx
+++ b/src/components/action-popover/action-popover.mdx
@@ -1,7 +1,6 @@
 import { Meta, ArgTypes, Canvas } from "@storybook/addon-docs/blocks";
 import TranslationKeysTable from "../../../.storybook/utils/translation-keys-table";
 
-import * as ActionPopoverMenuButtonStories from "./action-popover-menu-button/action-popover-menu-button.stories";
 import * as ActionPopoverItemStories from "./action-popover-item/action-popover-item.stories";
 import * as ActionPopoverMenuStories from "./action-popover-menu/action-popover-menu.stories";
 import * as ActionPopoverStories from "./action-popover.stories";
@@ -20,7 +19,7 @@ import * as ActionPopoverStories from "./action-popover.stories";
 </a>
 
 ActionPopovers present a handy list of actions the user can perform on a whole table, a specific row within a table, or a tile.
-Click the ellipsis icon to show actions the user can take on a specific table row, for example, emailing the invoice.
+Click the Action button to show actions the user can take on a specific table row, for example, emailing the invoice.
 
 ## Contents
 
@@ -42,7 +41,6 @@ import {
   ActionPopoverDivider,
   ActionPopoverItem,
   ActionPopoverMenu,
-  ActionPopoverMenuButton,
   type ActionPopoverHandle,
 } from "carbon-react/lib/components/action-popover";
 ```
@@ -79,7 +77,9 @@ It is possible to align the Menu to the right of the MenuButton by passing the &
 
 <Canvas of={ActionPopoverStories.MenuRightAligned} />
 
-### With item content aligned to right
+### With item content aligned to right (deprecated)
+
+`horizontalAlignment` is deprecated and will be removed in a future major release.
 
 <Canvas of={ActionPopoverStories.ContentAlignedRight} />
 
@@ -95,7 +95,7 @@ It is possible to use the `renderButton` prop to override the default button use
 ActionPopoverMenu.
 
 The `renderButton` prop is a function that allows consumers to pass `tabIndex`, `data-element` and the provided aria attribute props to 
-`ActionPopoverMenuButton` or a custom button component.
+your preferred button component.
 
 A default `aria-label` will be provided to the button, but this can be overridden by passing the `ariaLabel` prop to the 
 `ActionPopover` or making use of the `actionPopover.ariaLabel` translation key. Please ensure to set this to `undefined` if your 
@@ -105,10 +105,16 @@ See the example below for an example of how to use the `renderButton` prop:
 
 <Canvas of={ActionPopoverStories.CustomMenuButton} />
 
+### Removing button text with render props
+
+If you need an icon-only trigger, use `renderButton` and return your own button without children.
+
+<Canvas of={ActionPopoverStories.CustomMenuButtonWithoutText} />
+
 ### With submenu
 
 A menu item can be passed a sub-menu to add further sub-actions if needed. items with sub-menus will display an chevron
-icons pointing in the direction that the sub-menu will open; by default it will open to the left.
+icons pointing in the direction that the sub-menu will open; by default it opens to the right and flips when needed.
 
 Hovering the mouse cursor over an item will open the sub-menu if it has one and moving the mouse cursor away will
 close it. No action is dispatched on click of the item and the sub-menu is opened by mouse enter and closed on mouse
@@ -116,11 +122,9 @@ leave.
 
 <Canvas of={ActionPopoverStories.Submenu} />
 
-### With submenu positioned to right
+### Submenu positioning
 
-Submenu can be positioned on either the left of the right with the use of the `submenuPosition` prop.
-
-<Canvas of={ActionPopoverStories.SubmenuPositionedRight} />
+`submenuPosition` is deprecated. Submenus now open to the right by default and flip automatically when space is constrained.
 
 ### With disabled submenu
 
@@ -128,11 +132,9 @@ A sub-menu will not open if the item is in a disabled state.
 
 <Canvas of={ActionPopoverStories.DisabledSubmenu} />
 
-### With menu opening above
+### Menu placement
 
-The menu can also be rendered above the button control by setting using `placement="top"`.
-
-<Canvas of={ActionPopoverStories.MenuOpeningAbove} />
+`placement` is deprecated. The menu now uses adaptive placement and flips automatically when there is not enough space.
 
 ### Keyboard navigation
 
@@ -153,7 +155,7 @@ or "tab" key will close the menu with no action being triggered and focus the ne
 
 ### Keyboard navigation left aligned submenu
 
-Sub-menus can be accessed via the keyboard as well, when the sub-menu is left aligned it can be opened by navigating to
+Sub-menus can be accessed via the keyboard as well. When the sub-menu is left aligned it can be opened by navigating to
 the parent item and pressing the "left" key. The same accessible shortcuts described above can then be used to navigate
 the sub-menu. Pressing the "right" key will return focus back to the main menu and close the sub-menu without
 triggering an action.
@@ -162,8 +164,8 @@ triggering an action.
 
 ### Keyboard navigation right aligned submenu
 
-When sub-menus aligns to the right hand side, the key shortcuts are switched: pressing the "right" key whilst focus
-is on a item will open a sub-menu if it has one and pressing the "left" key will close it.
+When sub-menus align to the right hand side, the key shortcuts are switched: pressing the "right" key whilst focus
+is on an item will open a sub-menu if it has one and pressing the "left" key will close it.
 
 <Canvas of={ActionPopoverStories.KeyboardNavigationRightAlignedSubmenu} />
 
@@ -208,10 +210,6 @@ by passing a `ref` to the component.
 ### ActionPopoverMenu Props
 
 <ArgTypes of={ActionPopoverMenuStories} />
-
-### ActionPopoverMenuButton Props
-
-<ArgTypes of={ActionPopoverMenuButtonStories} />
 
 ### ActionPopoverItem Props
 

--- a/src/components/action-popover/action-popover.pw.tsx
+++ b/src/components/action-popover/action-popover.pw.tsx
@@ -4,7 +4,6 @@ import {
   actionPopover,
   actionPopoverButton,
   actionPopoverInnerItem,
-  actionPopoverSubmenuByIndex,
   actionPopoverWrapper,
 } from "../../../playwright/components/action-popover";
 import { dialog } from "../../../playwright/components/dialog";
@@ -19,7 +18,6 @@ import {
   ActionPopoverCustom,
   ActionPopoverWithIconsAndNoSubmenus,
   ActionPopoverWithProps,
-  ActionPopoverWithSubmenusAndIcons,
   ActionPopoverWithDownloadButton,
   Default,
   AdditionalOptions,
@@ -238,75 +236,10 @@ test.describe("check props for ActionPopover component", () => {
       await mount(<ActionPopoverWithProps rightAlignMenu={rightAlignMenu} />);
       const actionPopoverButtonElement = actionPopoverButton(page).nth(0);
       await actionPopoverButtonElement.click();
-      const actionPopoverElement = actionPopover(page).first();
-      await expect(actionPopoverElement).toHaveAttribute(
-        "data-floating-placement",
-        placement,
-      );
+      await expect(
+        page.locator("[data-floating-placement]").first(),
+      ).toHaveAttribute("data-floating-placement", placement);
     });
-  });
-
-  (["left", "right"] as const).forEach((horizontalAlignment) => {
-    test(`an item's text is aligned to the ${horizontalAlignment}, when horizontalAlignment prop is set to ${horizontalAlignment}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <ActionPopoverWithIconsAndNoSubmenus
-          horizontalAlignment={horizontalAlignment}
-        />,
-      );
-
-      const openButton = page.getByRole("button");
-      await openButton.click();
-
-      const firstItem = page.getByRole("listitem").first();
-      await firstItem.hover();
-
-      await expect(firstItem.getByRole("button")).toHaveCSS(
-        "text-align",
-        horizontalAlignment,
-      );
-    });
-  });
-
-  (["left", "right"] as const).forEach((horizontalAlignment) => {
-    test(`a submenu item's text is aligned to the ${horizontalAlignment}, when horizontalAlignment prop is set to ${horizontalAlignment}`, async ({
-      mount,
-      page,
-    }) => {
-      await mount(
-        <ActionPopoverWithSubmenusAndIcons
-          horizontalAlignment={horizontalAlignment}
-        />,
-      );
-
-      const openButton = page.getByRole("button");
-      await openButton.click();
-
-      const firstItem = page.getByRole("listitem").first();
-      await firstItem.hover();
-
-      const firstSubmenuItem = firstItem.getByRole("listitem").first();
-      await expect(firstSubmenuItem).toHaveCSS(
-        "text-align",
-        horizontalAlignment,
-      );
-    });
-  });
-
-  test("should render with submenu opening above when placement prop set to 'top'", async ({
-    mount,
-    page,
-  }) => {
-    await mount(<MenuOpeningAbove />);
-    await actionPopoverButton(page).nth(0).click();
-    await actionPopoverInnerItem(page, 0).hover();
-
-    await expect(actionPopoverSubmenuByIndex(page, 0)).toHaveCSS(
-      "bottom",
-      "-8px",
-    ); // result of calc(-1 * var(--spacing100))
   });
 
   test("should render with aria-label prop", async ({ mount, page }) => {
@@ -334,92 +267,6 @@ test("an item's icon is placed left of the item's text, when horizontalAlignment
     .filter({ hasText: "Business" });
   const icon = businessItem.getByTestId("item-icon");
   const text = businessItem.getByText("Business");
-
-  const iconPosition = await icon.boundingBox();
-  const textPosition = await text.boundingBox();
-
-  if (!iconPosition) throw new Error("Icon isn't visible");
-  if (!textPosition) throw new Error("Text isn't visible");
-
-  expect(iconPosition.x).toBeLessThan(textPosition.x);
-});
-
-test("an item's icon is placed right of the item's text, when horizontalAlignment prop is set to 'right'", async ({
-  mount,
-  page,
-}) => {
-  await mount(
-    <ActionPopoverWithIconsAndNoSubmenus horizontalAlignment="right" />,
-  );
-
-  const openingButton = page.getByRole("button");
-  await openingButton.click();
-
-  const businessItem = page
-    .getByRole("listitem")
-    .filter({ hasText: "Business" });
-  const icon = businessItem.getByTestId("item-icon");
-  const text = businessItem.getByText("Business");
-
-  const iconPosition = await icon.boundingBox();
-  const textPosition = await text.boundingBox();
-
-  if (!iconPosition) throw new Error("Icon isn't visible");
-  if (!textPosition) throw new Error("Text isn't visible");
-
-  expect(iconPosition.x).toBeGreaterThan(textPosition.x);
-});
-
-test("a submenu item's icon is placed right of the item's text, when horizontalAlignment prop is set to 'right'", async ({
-  mount,
-  page,
-}) => {
-  await mount(
-    <ActionPopoverWithSubmenusAndIcons horizontalAlignment="right" />,
-  );
-
-  const openingButton = page.getByRole("button");
-  await openingButton.click();
-
-  const businessItem = page
-    .getByRole("listitem")
-    .filter({ hasText: "Business" });
-  await businessItem.hover();
-
-  const firstSubmenuItem = businessItem
-    .getByRole("listitem")
-    .filter({ hasText: "Sub Menu 1" });
-  const icon = firstSubmenuItem.getByTestId("item-icon");
-  const text = firstSubmenuItem.getByText("Sub Menu 1");
-
-  const iconPosition = await icon.boundingBox();
-  const textPosition = await text.boundingBox();
-
-  if (!iconPosition) throw new Error("Icon isn't visible");
-  if (!textPosition) throw new Error("Text isn't visible");
-
-  expect(iconPosition.x).toBeGreaterThan(textPosition.x);
-});
-
-test("a submenu item's icon is placed left of the item's text, when horizontalAlignment prop is set to 'left'", async ({
-  mount,
-  page,
-}) => {
-  await mount(<ActionPopoverWithSubmenusAndIcons horizontalAlignment="left" />);
-
-  const openingButton = page.getByRole("button");
-  await openingButton.click();
-
-  const businessItem = page
-    .getByRole("listitem")
-    .filter({ hasText: "Business" });
-  await businessItem.hover();
-
-  const firstSubmenuItem = businessItem
-    .getByRole("listitem")
-    .filter({ hasText: "Sub Menu 1" });
-  const icon = firstSubmenuItem.getByTestId("item-icon");
-  const text = firstSubmenuItem.getByText("Sub Menu 1");
 
   const iconPosition = await icon.boundingBox();
   const textPosition = await text.boundingBox();
@@ -667,8 +514,7 @@ test.describe("when nested inside a Dialog component", () => {
 
     await page.keyboard.press("Escape");
 
-    const actionPopoverElement = actionPopover(page);
-    await expect(actionPopoverElement).toBeHidden();
+    await expect(page.getByRole("list")).toBeHidden();
 
     const dialogElement = dialog(page);
     await expect(dialogElement).toBeVisible();

--- a/src/components/action-popover/action-popover.stories.tsx
+++ b/src/components/action-popover/action-popover.stories.tsx
@@ -209,11 +209,7 @@ export const CustomMenuButton: Story = () => {
   return (
     <Box height={250}>
       <ActionPopover
-        renderButton={({
-          tabIndex: _tabIndex,
-          "data-element": dataElement,
-          ariaAttributes,
-        }) => (
+        renderButton={({ "data-element": dataElement, ariaAttributes }) => (
           <ButtonNext
             variant="default"
             variantType="subtle"
@@ -237,11 +233,7 @@ export const CustomMenuButton: Story = () => {
         </ActionPopoverItem>
       </ActionPopover>
       <ActionPopover
-        renderButton={({
-          tabIndex: _tabIndex,
-          "data-element": dataElement,
-          ariaAttributes,
-        }) => (
+        renderButton={({ "data-element": dataElement, ariaAttributes }) => (
           <ButtonNext
             variant="default"
             variantType="subtle"
@@ -286,11 +278,7 @@ export const CustomMenuButtonWithoutText: Story = () => {
   return (
     <Box height={250}>
       <ActionPopover
-        renderButton={({
-          tabIndex: _tabIndex,
-          "data-element": dataElement,
-          ariaAttributes,
-        }) => (
+        renderButton={({ "data-element": dataElement, ariaAttributes }) => (
           <ButtonNext
             variant="default"
             variantType="subtle"

--- a/src/components/action-popover/action-popover.stories.tsx
+++ b/src/components/action-popover/action-popover.stories.tsx
@@ -5,7 +5,6 @@ import {
   ActionPopoverDivider,
   ActionPopoverItem,
   ActionPopoverMenu,
-  ActionPopoverMenuButton,
   RenderButtonProps,
   ActionPopoverHandle,
 } from ".";
@@ -23,6 +22,7 @@ import Confirm from "../confirm";
 import { Accordion } from "../accordion";
 import Dialog from "../dialog";
 import Button from "../button";
+import ButtonNext from "../button/__next__";
 
 import generateStyledSystemProps from "../../../.storybook/utils/styled-system-props";
 
@@ -210,22 +210,22 @@ export const CustomMenuButton: Story = () => {
     <Box height={250}>
       <ActionPopover
         renderButton={({
-          tabIndex,
+          tabIndex: _tabIndex,
           "data-element": dataElement,
           ariaAttributes,
         }) => (
-          <ActionPopoverMenuButton
-            buttonType="tertiary"
+          <ButtonNext
+            variant="default"
+            variantType="subtle"
             iconType="dropdown"
             iconPosition="after"
             size="small"
-            tabIndex={tabIndex}
             data-element={dataElement}
-            ariaAttributes={ariaAttributes}
+            {...ariaAttributes}
             aria-label={undefined}
           >
-            More
-          </ActionPopoverMenuButton>
+            Action
+          </ButtonNext>
         )}
       >
         <ActionPopoverItem icon="email" onClick={() => {}}>
@@ -238,18 +238,19 @@ export const CustomMenuButton: Story = () => {
       </ActionPopover>
       <ActionPopover
         renderButton={({
-          tabIndex,
+          tabIndex: _tabIndex,
           "data-element": dataElement,
           ariaAttributes,
         }) => (
-          <ActionPopoverMenuButton
-            buttonType="tertiary"
+          <ButtonNext
+            variant="default"
+            variantType="subtle"
             iconType="dropdown"
             iconPosition="after"
             size="small"
-            tabIndex={tabIndex}
             data-element={dataElement}
-            ariaAttributes={ariaAttributes}
+            {...ariaAttributes}
+            aria-label="actions"
           />
         )}
       >
@@ -280,6 +281,40 @@ export const CustomMenuButton: Story = () => {
   );
 };
 CustomMenuButton.storyName = "Custom Menu Button";
+
+export const CustomMenuButtonWithoutText: Story = () => {
+  return (
+    <Box height={250}>
+      <ActionPopover
+        renderButton={({
+          tabIndex: _tabIndex,
+          "data-element": dataElement,
+          ariaAttributes,
+        }) => (
+          <ButtonNext
+            variant="default"
+            variantType="subtle"
+            iconType="dropdown"
+            iconPosition="after"
+            size="small"
+            data-element={dataElement}
+            {...ariaAttributes}
+            aria-label="actions"
+          />
+        )}
+      >
+        <ActionPopoverItem icon="email" onClick={() => {}}>
+          Email Invoice
+        </ActionPopoverItem>
+        <ActionPopoverDivider />
+        <ActionPopoverItem onClick={() => {}} icon="delete">
+          Delete
+        </ActionPopoverItem>
+      </ActionPopover>
+    </Box>
+  );
+};
+CustomMenuButtonWithoutText.storyName = "Custom Menu Button Without Text";
 
 export const Submenu: Story = () => {
   return (
@@ -691,9 +726,17 @@ export const OpeningAModal: Story = () => {
       <Box>
         <ActionPopover
           renderButton={({ ...props }) => (
-            <ActionPopoverMenuButton {...props}>
+            <ButtonNext
+              variant="default"
+              variantType="subtle"
+              iconType="dropdown"
+              iconPosition="after"
+              size="small"
+              {...props.ariaAttributes}
+              data-element={props["data-element"]}
+            >
               Open Actions
-            </ActionPopoverMenuButton>
+            </ButtonNext>
           )}
         >
           <ActionPopoverItem
@@ -748,16 +791,18 @@ export const FocusButtonProgrammatically = () => {
   const refMore = useRef<ActionPopoverHandle>(null);
 
   const renderButton = (props: RenderButtonProps) => (
-    <ActionPopoverMenuButton
-      buttonType="tertiary"
+    <ButtonNext
+      variant="default"
+      variantType="subtle"
       iconType="ellipsis_vertical"
       iconPosition="after"
       size="small"
-      aria-label={undefined}
-      {...props}
+      aria-label="more"
+      {...props.ariaAttributes}
+      data-element={props["data-element"]}
     >
       More
-    </ActionPopoverMenuButton>
+    </ButtonNext>
   );
 
   return (

--- a/src/components/action-popover/action-popover.style.ts
+++ b/src/components/action-popover/action-popover.style.ts
@@ -1,156 +1,10 @@
-import styled, { css } from "styled-components";
+import styled from "styled-components";
 import { margin } from "styled-system";
 
 import applyBaseTheme from "../../style/themes/apply-base-theme";
-import Icon from "../icon";
 import StyledIcon from "../icon/icon.style";
 import StyledButton from "../button/button.style";
 import addFocusStyling from "../../style/utils/add-focus-styling";
-
-const Menu = styled.ul.attrs(applyBaseTheme)<{
-  isOpen: boolean;
-  submenuLeft: boolean;
-  iconLeft: boolean;
-}>`
-  visibility: ${({ isOpen }) => (isOpen ? "visible" : "hidden")};
-
-  display: grid;
-
-  ${({ submenuLeft, iconLeft }) => {
-    const chevronColumn = "[chevron_column] auto";
-    const iconColumn = "[icon_column] auto";
-    const textColumn = "[text_column] auto";
-
-    return css`
-      grid-template-columns:
-        ${submenuLeft ? chevronColumn : ""}
-        ${iconLeft
-          ? `${iconColumn} ${textColumn}`
-          : `${textColumn} ${iconColumn}`}
-        ${!submenuLeft ? chevronColumn : ""};
-    `;
-  }}
-
-  align-items: center;
-  min-width: fit-content;
-  text-align: ${({ iconLeft }) => (iconLeft ? "left" : "right")};
-  justify-content: ${({ iconLeft }) => (iconLeft ? "left" : "right")};
-
-  margin: 0;
-  list-style: none;
-  padding: var(--spacing100) 0;
-  box-shadow: var(--boxShadow100);
-  position: absolute;
-  border-radius: var(--borderRadius100);
-  background-color: var(--colorsUtilityYang100);
-  z-index: 10000;
-
-  &[data-submenu-placement="top"] & {
-    bottom: calc(-1 * var(--spacing100));
-    top: auto;
-  }
-
-  &[data-submenu-placement="bottom"] & {
-    top: calc(-1 * var(--spacing100));
-    bottom: auto;
-  }
-`;
-
-const StyledMenuItemInnerText = styled.div`
-  grid-column: text_column;
-
-  &:only-child {
-    padding: 0;
-  }
-
-  padding: 0 var(--spacing100);
-`;
-
-const StyledMenuItem = styled.button<{ isDisabled: boolean }>`
-  display: grid;
-  grid-template-columns: subgrid;
-  grid-template-rows: subgrid;
-  grid-column: span 3;
-
-  align-items: inherit;
-  text-align: inherit;
-  justify-content: inherit;
-
-  text-decoration: none;
-  background-color: var(--colorsActionMajorYang100);
-  cursor: pointer;
-  box-sizing: border-box;
-  padding: 0 var(--spacing150);
-  position: relative;
-  line-height: 40px;
-  white-space: nowrap;
-  user-select: none;
-  border: none;
-  color: var(--colorsUtilityYin090);
-  font-size: 14px;
-  font-weight: 500;
-
-  &:focus {
-    ${addFocusStyling()}
-    z-index: 1;
-    border-radius: var(--borderRadius000);
-  }
-
-  ${({ isDisabled }) =>
-    isDisabled &&
-    css`
-      color: var(--colorsUtilityYin030);
-      cursor: not-allowed;
-
-      && ${StyledIcon} {
-        cursor: not-allowed;
-        color: var(--colorsUtilityYin030);
-      }
-
-      :focus {
-        border: none;
-        outline: none;
-        -webkit-appearance: none;
-        -webkit-box-shadow: none;
-        box-shadow: none;
-      }
-    `}
-
-  ${({ isDisabled }) =>
-    !isDisabled &&
-    css`
-      &:focus,
-      &:hover {
-        background-color: var(--colorsUtilityMajor100);
-      }
-      && ${StyledIcon} {
-        cursor: pointer;
-      }
-    `}
-`;
-
-const StyledMenuItemWrapper = styled.li`
-  display: grid;
-  grid-template-columns: subgrid;
-  grid-template-rows: subgrid;
-  grid-column: span 3;
-
-  text-align: inherit;
-  align-items: inherit;
-  justify-content: inherit;
-
-  position: relative;
-`;
-
-const MenuItemDivider = styled.li.attrs({
-  "data-element": "action-popover-divider",
-})`
-  grid-column: span 3;
-
-  background-color: var(--colorsUtilityMajor050);
-  height: var(--borderWidth100);
-  margin: var(--spacing100) var(--spacing150);
-`;
 
 const MenuButton = styled.div.attrs(applyBaseTheme)`
   position: relative;
@@ -160,45 +14,6 @@ const MenuButton = styled.div.attrs(applyBaseTheme)`
   width: fit-content;
   margin: auto;
   ${margin}
-`;
-
-const ButtonIcon = styled(Icon)`
-  color: var(--colorsActionMinor500);
-
-  :hover {
-    color: var(--colorsActionMinor600);
-  }
-`;
-
-const StyledButtonIcon = styled.div`
-  &:focus {
-    ${addFocusStyling()}
-  }
-  border-radius: var(--borderRadius050);
-`;
-
-const MenuItemIcon = styled(Icon)`
-  justify-content: inherit;
-  grid-column: icon_column;
-
-  padding: var(--spacing100);
-  color: var(--colorsUtilityYin065);
-`;
-
-const SubMenuItemIcon = styled(ButtonIcon)`
-  grid-column: chevron_column;
-
-  ${({ type }) => css`
-    ${type === "chevron_left_thick" &&
-    css`
-      left: -5px;
-    `}
-
-    ${type === "chevron_right_thick" &&
-    css`
-      right: -5px;
-    `}
-  `}
 `;
 
 const MenuButtonOverrideWrapper = styled.div`
@@ -232,16 +47,4 @@ const MenuButtonOverrideWrapper = styled.div`
   }
 `;
 
-export {
-  Menu,
-  MenuButton,
-  ButtonIcon,
-  StyledButtonIcon,
-  MenuItemIcon,
-  MenuItemDivider,
-  SubMenuItemIcon,
-  MenuButtonOverrideWrapper,
-  StyledMenuItemInnerText,
-  StyledMenuItem,
-  StyledMenuItemWrapper,
-};
+export { MenuButton, MenuButtonOverrideWrapper };

--- a/src/components/action-popover/action-popover.style.ts
+++ b/src/components/action-popover/action-popover.style.ts
@@ -219,6 +219,16 @@ const MenuButtonOverrideWrapper = styled.div`
         color: inherit;
       }
     }
+
+    &[aria-expanded="true"] {
+      ${addFocusStyling()}
+      background-color: var(--colorsActionMajorTransparent);
+      color: var(--colorsActionMajor600);
+
+      [data-component="icon"] {
+        color: inherit;
+      }
+    }
   }
 `;
 

--- a/src/components/action-popover/action-popover.test.tsx
+++ b/src/components/action-popover/action-popover.test.tsx
@@ -1879,6 +1879,138 @@ describe("when the submenuPosition prop is set to 'right'", () => {
     expect(parentItem).toHaveFocus();
   });
 });
+describe("when the submenuPosition prop is set to 'left'", () => {
+  it("renders a chevron icon that points left", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <ActionPopover submenuPosition="left">
+        <ActionPopoverItem>example item 1</ActionPopoverItem>
+        <ActionPopoverItem>example item 2</ActionPopoverItem>
+        <ActionPopoverItem
+          submenu={
+            <ActionPopoverMenu>
+              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
+              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
+            </ActionPopoverMenu>
+          }
+        >
+          example item with submenu
+        </ActionPopoverItem>
+      </ActionPopover>,
+    );
+
+    await user.click(screen.getByRole("button"));
+
+    const chevronIcon = screen.getByTestId("chevron-icon");
+    expect(chevronIcon).toHaveStyleRule(
+      "content",
+      `"${iconUnicodes.chevron_left_thick}"`,
+      { modifier: "&::before" },
+    );
+  });
+
+  it("opens the submenu and focuses the first item when left arrow key is pressed", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <ActionPopover submenuPosition="left">
+        <ActionPopoverItem>example item 1</ActionPopoverItem>
+        <ActionPopoverItem>example item 2</ActionPopoverItem>
+        <ActionPopoverItem
+          submenu={
+            <ActionPopoverMenu>
+              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
+              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
+            </ActionPopoverMenu>
+          }
+        >
+          example item with submenu
+        </ActionPopoverItem>
+      </ActionPopover>,
+    );
+
+    await user.click(screen.getByRole("button"));
+    jest.runOnlyPendingTimers();
+
+    screen.getByRole("button", { name: "example item with submenu" }).focus();
+    await user.keyboard("{ArrowLeft}");
+    jest.runOnlyPendingTimers();
+
+    const firstItem = screen.getByRole("button", { name: "submenu item 1" });
+    expect(firstItem).toBeVisible();
+    expect(firstItem).toHaveFocus();
+  });
+
+  it("closes the submenu and returns focus to parent item when the submenu is open and the right arrow key is pressed", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <ActionPopover submenuPosition="left">
+        <ActionPopoverItem>example item 1</ActionPopoverItem>
+        <ActionPopoverItem>example item 2</ActionPopoverItem>
+        <ActionPopoverItem
+          submenu={
+            <ActionPopoverMenu>
+              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
+              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
+            </ActionPopoverMenu>
+          }
+        >
+          example item with submenu
+        </ActionPopoverItem>
+      </ActionPopover>,
+    );
+
+    await user.click(screen.getByRole("button"));
+
+    const parentItem = screen.getByRole("button", {
+      name: "example item with submenu",
+    });
+
+    parentItem.focus();
+    await user.keyboard("{ArrowLeft}");
+
+    expect(
+      screen.getByRole("button", { name: "submenu item 1" }),
+    ).toBeVisible();
+
+    await user.keyboard("{ArrowRight}");
+
+    expect(
+      screen.queryByRole("button", { name: "submenu item 1" }),
+    ).not.toBeInTheDocument();
+    expect(parentItem).toHaveFocus();
+  });
+
+  it("leaves the submenu closed when a key other than left, enter or right is pressed", async () => {
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(
+      <ActionPopover submenuPosition="left">
+        <ActionPopoverItem>example item 1</ActionPopoverItem>
+        <ActionPopoverItem
+          submenu={
+            <ActionPopoverMenu>
+              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
+            </ActionPopoverMenu>
+          }
+        >
+          example item with submenu
+        </ActionPopoverItem>
+      </ActionPopover>,
+    );
+
+    await user.click(screen.getByRole("button"));
+
+    screen.getByRole("button", { name: "example item with submenu" }).focus();
+    await user.keyboard("{Escape}");
+
+    expect(
+      screen.queryByRole("button", { name: "submenu item 1" }),
+    ).not.toBeInTheDocument();
+  });
+});
 
 describe("when the submenuPosition prop is set to 'right' and there isn't enough space on the screen to render a submenu on the right", () => {
   let getBoundingClientRectSpy: jest.SpyInstance;

--- a/src/components/action-popover/action-popover.test.tsx
+++ b/src/components/action-popover/action-popover.test.tsx
@@ -113,17 +113,14 @@ describe("if download prop and href prop are provided", () => {
   });
 });
 
-test("displays the vertical ellipsis icon as the menu button", () => {
+test("displays an Action subtle button as the default menu button", () => {
   render(
     <ActionPopover>
       <ActionPopoverItem>example item</ActionPopoverItem>
     </ActionPopover>,
   );
-  expect(screen.getByTestId("icon")).toHaveStyleRule(
-    "content",
-    `"${iconUnicodes.ellipsis_vertical}"`,
-    { modifier: "&::before" },
-  );
+
+  expect(screen.getByRole("button", { name: "Action" })).toBeVisible();
 });
 
 test("has proper data attributes applied to elements", async () => {
@@ -158,13 +155,13 @@ test("has proper data attributes applied to elements", async () => {
   expect(divider).toHaveAttribute("data-element", "action-popover-divider");
 });
 
-test("has a default aria-label", () => {
+test("has Action as the default accessible button name", () => {
   render(
     <ActionPopover>
       <ActionPopoverItem>example item</ActionPopoverItem>
     </ActionPopover>,
   );
-  expect(screen.getByRole("button")).toHaveAccessibleName("actions");
+  expect(screen.getByRole("button")).toHaveAccessibleName("Action");
 });
 
 test("has a default aria-label if the renderButton prop contains a button without text", () => {
@@ -278,21 +275,17 @@ test("renders with the menu closed by default", () => {
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
 });
 
-test.each<["top" | "bottom", boolean, string]>([
-  ["top", false, "top-end"],
-  ["top", true, "top-start"],
-  ["bottom", false, "bottom-end"],
-  ["bottom", true, "bottom-start"],
+test.each<[boolean, string]>([
+  [false, "bottom-end"],
+  [true, "bottom-start"],
 ])(
-  "applies proper %s prop to Popover component when rightAlignMenu is %s",
-  async (placement, rightAlignMenu, result) => {
+  "applies proper placement to Popover component when rightAlignMenu is %s",
+  async (rightAlignMenu, result) => {
     const computePositionSpy = jest.spyOn(floatingUi, "computePosition");
 
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-    render(
-      <ActionPopover placement={placement} rightAlignMenu={rightAlignMenu} />,
-    );
+    render(<ActionPopover rightAlignMenu={rightAlignMenu} />);
 
     await user.click(screen.getByRole("button"));
 
@@ -511,7 +504,7 @@ test("clicking a disabled menu item does not focus the menu button", async () =>
   await user.click(screen.getByRole("button"));
   await user.click(screen.getByText("Print Invoice"));
 
-  expect(screen.getByRole("button", { name: "actions" })).not.toHaveFocus();
+  expect(screen.getByRole("button", { name: "Action" })).not.toHaveFocus();
 });
 
 test("pressing enter on a disabled menu item does not focus the menu button", async () => {
@@ -530,7 +523,7 @@ test("pressing enter on a disabled menu item does not focus the menu button", as
   screen.getByRole("button", { name: "Print Invoice" }).focus();
   await user.keyboard("{Enter}");
 
-  expect(screen.getByRole("button", { name: "actions" })).not.toHaveFocus();
+  expect(screen.getByRole("button", { name: "Action" })).not.toHaveFocus();
 });
 
 test("clicking the menu button calls the onOpen prop", async () => {
@@ -789,7 +782,7 @@ test("pressing Escape when focused on a menu item focuses the MenuButton and clo
   await user.keyboard("{ArrowDown}");
   await user.keyboard("{Escape}");
 
-  expect(screen.getByRole("button", { name: "actions" })).toHaveFocus();
+  expect(screen.getByRole("button", { name: "Action" })).toHaveFocus();
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
 });
 
@@ -1073,11 +1066,11 @@ test("should call the exposed `focusButton` method and focus the toggle button",
   const button = screen.getByRole("button", { name: "Focus" });
   await user.click(button);
 
-  expect(screen.getByRole("button", { name: "actions" })).toHaveFocus();
+  expect(screen.getByRole("button", { name: "Action" })).toHaveFocus();
 });
 
-describe("when an item has a submenu with default (left) alignment", () => {
-  it("renders a chevron icon that points left", async () => {
+describe("when an item has a submenu with default (right) alignment", () => {
+  it("renders a chevron icon that points right", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     render(
@@ -1102,7 +1095,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     const chevronIcon = screen.getByTestId("chevron-icon");
     expect(chevronIcon).toHaveStyleRule(
       "content",
-      `"${iconUnicodes.chevron_left_thick}"`,
+      `"${iconUnicodes.chevron_right_thick}"`,
       { modifier: "&::before" },
     );
   });
@@ -1281,7 +1274,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     clearTimeoutSpy.mockRestore();
   });
 
-  it("opens the submenu and focuses the first item when the left arrow key is pressed", async () => {
+  it("opens the submenu and focuses the first item when the right arrow key is pressed", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     render(
@@ -1305,7 +1298,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     jest.runOnlyPendingTimers();
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
-    await user.keyboard("{ArrowLeft}");
+    await user.keyboard("{ArrowRight}");
     jest.runOnlyPendingTimers();
 
     const firstItem = screen.getByRole("button", { name: "submenu item 1" });
@@ -1313,7 +1306,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     expect(firstItem).toHaveFocus();
   });
 
-  it("closes the submenu and returns focus to the parent item when the right arrow key is pressed", async () => {
+  it("closes the submenu and returns focus to the parent item when the left arrow key is pressed", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     render(
@@ -1340,13 +1333,13 @@ describe("when an item has a submenu with default (left) alignment", () => {
     });
 
     parentItem.focus();
-    await user.keyboard("{ArrowLeft}");
+    await user.keyboard("{ArrowRight}");
 
     expect(
       screen.getByRole("button", { name: "submenu item 1" }),
     ).toBeVisible();
 
-    await user.keyboard("{ArrowRight}");
+    await user.keyboard("{ArrowLeft}");
 
     expect(
       screen.queryByRole("button", { name: "submenu item 1" }),
@@ -1378,7 +1371,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     jest.runOnlyPendingTimers();
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
-    await user.keyboard("{ArrowLeft}");
+    await user.keyboard("{ArrowRight}");
     jest.runOnlyPendingTimers();
 
     expect(
@@ -1484,7 +1477,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
 
-    await user.keyboard("{ArrowLeft}");
+    await user.keyboard("{ArrowRight}");
     jest.runOnlyPendingTimers();
 
     expect(
@@ -1563,7 +1556,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("does not open the submenu when the left arrow key is pressed if the item is disabled", async () => {
+  it("does not open the submenu when the right arrow key is pressed if the item is disabled", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
     render(
@@ -1587,7 +1580,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     await user.click(screen.getByRole("button"));
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
-    await user.keyboard("{ArrowLeft}");
+    await user.keyboard("{ArrowRight}");
 
     expect(
       screen.queryByRole("button", { name: "submenu item 1" }),
@@ -1648,7 +1641,7 @@ describe("when an item has a submenu with default (left) alignment", () => {
     await user.click(screen.getByRole("button"));
 
     screen.getByRole("button", { name: "example item with submenu" }).focus();
-    await user.keyboard("{ArrowLeft}");
+    await user.keyboard("{ArrowRight}");
 
     await user.click(screen.getByRole("button", { name: "submenu item 1" }));
     expect(

--- a/src/components/action-popover/action-popover.test.tsx
+++ b/src/components/action-popover/action-popover.test.tsx
@@ -21,7 +21,6 @@ import {
   FlatTableRow,
   FlatTableCell,
 } from "../flat-table";
-import iconUnicodes from "../icon/icon-unicodes";
 import guid from "../../__internal__/utils/helpers/guid";
 
 jest.mock("../../__internal__/utils/helpers/guid");
@@ -147,12 +146,16 @@ test("has proper data attributes applied to elements", async () => {
     "data-element",
     "action-popover-element",
   );
-  expect(screen.getByRole("list")).toHaveAttribute(
-    "data-component",
-    "action-popover",
+  // the menu is rendered by PopoverMenu, so `action-popover` now identifies the
+  // wrapper around the list rather than the list element itself
+  expect(screen.getByTestId("action-popover")).toContainElement(
+    screen.getByRole("list"),
   );
-  const divider = screen.getAllByRole("listitem")[1];
-  expect(divider).toHaveAttribute("data-element", "action-popover-divider");
+  // the divider is aria-hidden, so it is no longer exposed as a listitem
+  expect(screen.getByTestId("action-popover-divider")).toHaveAttribute(
+    "data-element",
+    "action-popover-divider",
+  );
 });
 
 test("has Action as the default accessible button name", () => {
@@ -786,7 +789,7 @@ test("pressing Escape when focused on a menu item focuses the MenuButton and clo
   expect(screen.queryByRole("list")).not.toBeInTheDocument();
 });
 
-test("pressing the Down Arrow key when the menu is open focuses the next item and wraps around when on the last item", async () => {
+test("pressing the Down Arrow key when the menu is open focuses the next item and stays on the last item", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
@@ -811,10 +814,10 @@ test("pressing the Down Arrow key when the menu is open focuses the next item an
 
   await user.keyboard("{ArrowDown}");
   jest.runOnlyPendingTimers();
-  expect(screen.getByRole("button", { name: "example item 1" })).toHaveFocus();
+  expect(screen.getByRole("button", { name: "example item 3" })).toHaveFocus();
 });
 
-test("pressing the Up Arrow key when the menu is open focuses the previous item and wraps around when on the first item", async () => {
+test("pressing the Up Arrow key when the menu is open focuses the previous item and stays on the first item", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
   render(
@@ -829,13 +832,17 @@ test("pressing the Up Arrow key when the menu is open focuses the previous item 
   jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 1" })).toHaveFocus();
 
-  await user.keyboard("{ArrowUp}");
+  await user.keyboard("{ArrowDown}{ArrowDown}");
   jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 3" })).toHaveFocus();
 
   await user.keyboard("{ArrowUp}");
   jest.runOnlyPendingTimers();
   expect(screen.getByRole("button", { name: "example item 2" })).toHaveFocus();
+
+  await user.keyboard("{ArrowUp}");
+  jest.runOnlyPendingTimers();
+  expect(screen.getByRole("button", { name: "example item 1" })).toHaveFocus();
 
   await user.keyboard("{ArrowUp}");
   jest.runOnlyPendingTimers();
@@ -1070,36 +1077,6 @@ test("should call the exposed `focusButton` method and focus the toggle button",
 });
 
 describe("when an item has a submenu with default (right) alignment", () => {
-  it("renders a chevron icon that points right", async () => {
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-    render(
-      <ActionPopover>
-        <ActionPopoverItem>example item 1</ActionPopoverItem>
-        <ActionPopoverItem>example item 2</ActionPopoverItem>
-        <ActionPopoverItem
-          submenu={
-            <ActionPopoverMenu>
-              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-            </ActionPopoverMenu>
-          }
-        >
-          example item with submenu
-        </ActionPopoverItem>
-      </ActionPopover>,
-    );
-
-    await user.click(screen.getByRole("button"));
-
-    const chevronIcon = screen.getByTestId("chevron-icon");
-    expect(chevronIcon).toHaveStyleRule(
-      "content",
-      `"${iconUnicodes.chevron_right_thick}"`,
-      { modifier: "&::before" },
-    );
-  });
-
   it("opens the submenu on mouseenter", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -1671,36 +1648,6 @@ describe("when there isn't enough space on the screen to render a submenu on the
     getBoundingClientRectSpy.mockRestore();
   });
 
-  it("renders a chevron icon that points right", async () => {
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-    render(
-      <ActionPopover submenuPosition="left">
-        <ActionPopoverItem>example item 1</ActionPopoverItem>
-        <ActionPopoverItem>example item 2</ActionPopoverItem>
-        <ActionPopoverItem
-          submenu={
-            <ActionPopoverMenu>
-              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-            </ActionPopoverMenu>
-          }
-        >
-          example item with submenu
-        </ActionPopoverItem>
-      </ActionPopover>,
-    );
-
-    await user.click(screen.getByRole("button"));
-
-    const chevronIcon = screen.getByTestId("chevron-icon");
-    expect(chevronIcon).toHaveStyleRule(
-      "content",
-      `"${iconUnicodes.chevron_right_thick}"`,
-      { modifier: "&::before" },
-    );
-  });
-
   it("opens the submenu and focuses the first item when right arrow key is pressed", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -1776,36 +1723,6 @@ describe("when there isn't enough space on the screen to render a submenu on the
 });
 
 describe("when the submenuPosition prop is set to 'right'", () => {
-  it("renders a chevron icon that points right", async () => {
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-    render(
-      <ActionPopover submenuPosition="right">
-        <ActionPopoverItem>example item 1</ActionPopoverItem>
-        <ActionPopoverItem>example item 2</ActionPopoverItem>
-        <ActionPopoverItem
-          submenu={
-            <ActionPopoverMenu>
-              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-            </ActionPopoverMenu>
-          }
-        >
-          example item with submenu
-        </ActionPopoverItem>
-      </ActionPopover>,
-    );
-
-    await user.click(screen.getByRole("button"));
-
-    const chevronIcon = screen.getByTestId("chevron-icon");
-    expect(chevronIcon).toHaveStyleRule(
-      "content",
-      `"${iconUnicodes.chevron_right_thick}"`,
-      { modifier: "&::before" },
-    );
-  });
-
   it("opens the submenu and focuses the first item when right arrow key is pressed", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -1880,109 +1797,6 @@ describe("when the submenuPosition prop is set to 'right'", () => {
   });
 });
 describe("when the submenuPosition prop is set to 'left'", () => {
-  it("renders a chevron icon that points left", async () => {
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-    render(
-      <ActionPopover submenuPosition="left">
-        <ActionPopoverItem>example item 1</ActionPopoverItem>
-        <ActionPopoverItem>example item 2</ActionPopoverItem>
-        <ActionPopoverItem
-          submenu={
-            <ActionPopoverMenu>
-              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-            </ActionPopoverMenu>
-          }
-        >
-          example item with submenu
-        </ActionPopoverItem>
-      </ActionPopover>,
-    );
-
-    await user.click(screen.getByRole("button"));
-
-    const chevronIcon = screen.getByTestId("chevron-icon");
-    expect(chevronIcon).toHaveStyleRule(
-      "content",
-      `"${iconUnicodes.chevron_left_thick}"`,
-      { modifier: "&::before" },
-    );
-  });
-
-  it("opens the submenu and focuses the first item when left arrow key is pressed", async () => {
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-    render(
-      <ActionPopover submenuPosition="left">
-        <ActionPopoverItem>example item 1</ActionPopoverItem>
-        <ActionPopoverItem>example item 2</ActionPopoverItem>
-        <ActionPopoverItem
-          submenu={
-            <ActionPopoverMenu>
-              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-            </ActionPopoverMenu>
-          }
-        >
-          example item with submenu
-        </ActionPopoverItem>
-      </ActionPopover>,
-    );
-
-    await user.click(screen.getByRole("button"));
-    jest.runOnlyPendingTimers();
-
-    screen.getByRole("button", { name: "example item with submenu" }).focus();
-    await user.keyboard("{ArrowLeft}");
-    jest.runOnlyPendingTimers();
-
-    const firstItem = screen.getByRole("button", { name: "submenu item 1" });
-    expect(firstItem).toBeVisible();
-    expect(firstItem).toHaveFocus();
-  });
-
-  it("closes the submenu and returns focus to parent item when the submenu is open and the right arrow key is pressed", async () => {
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-    render(
-      <ActionPopover submenuPosition="left">
-        <ActionPopoverItem>example item 1</ActionPopoverItem>
-        <ActionPopoverItem>example item 2</ActionPopoverItem>
-        <ActionPopoverItem
-          submenu={
-            <ActionPopoverMenu>
-              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-            </ActionPopoverMenu>
-          }
-        >
-          example item with submenu
-        </ActionPopoverItem>
-      </ActionPopover>,
-    );
-
-    await user.click(screen.getByRole("button"));
-
-    const parentItem = screen.getByRole("button", {
-      name: "example item with submenu",
-    });
-
-    parentItem.focus();
-    await user.keyboard("{ArrowLeft}");
-
-    expect(
-      screen.getByRole("button", { name: "submenu item 1" }),
-    ).toBeVisible();
-
-    await user.keyboard("{ArrowRight}");
-
-    expect(
-      screen.queryByRole("button", { name: "submenu item 1" }),
-    ).not.toBeInTheDocument();
-    expect(parentItem).toHaveFocus();
-  });
-
   it("leaves the submenu closed when a key other than left, enter or right is pressed", async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -2009,128 +1823,6 @@ describe("when the submenuPosition prop is set to 'left'", () => {
     expect(
       screen.queryByRole("button", { name: "submenu item 1" }),
     ).not.toBeInTheDocument();
-  });
-});
-
-describe("when the submenuPosition prop is set to 'right' and there isn't enough space on the screen to render a submenu on the right", () => {
-  let getBoundingClientRectSpy: jest.SpyInstance;
-  beforeEach(() => {
-    getBoundingClientRectSpy = jest.spyOn(
-      Element.prototype,
-      "getBoundingClientRect",
-    );
-    getBoundingClientRectSpy.mockImplementation(() => ({
-      left: "auto",
-      right: "100",
-      top: "100",
-    }));
-  });
-
-  afterEach(() => {
-    getBoundingClientRectSpy.mockRestore();
-  });
-
-  it("renders a chevron icon that points left", async () => {
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-    render(
-      <ActionPopover submenuPosition="right">
-        <ActionPopoverItem>example item 1</ActionPopoverItem>
-        <ActionPopoverItem>example item 2</ActionPopoverItem>
-        <ActionPopoverItem
-          submenu={
-            <ActionPopoverMenu>
-              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-            </ActionPopoverMenu>
-          }
-        >
-          example item with submenu
-        </ActionPopoverItem>
-      </ActionPopover>,
-    );
-
-    await user.click(screen.getByRole("button"));
-
-    const chevronIcon = screen.getByTestId("chevron-icon");
-    expect(chevronIcon).toHaveStyleRule(
-      "content",
-      `"${iconUnicodes.chevron_left_thick}"`,
-      { modifier: "&::before" },
-    );
-  });
-
-  it("opens the submenu and focuses the first item when left arrow key is pressed", async () => {
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-    render(
-      <ActionPopover submenuPosition="right">
-        <ActionPopoverItem>example item 1</ActionPopoverItem>
-        <ActionPopoverItem>example item 2</ActionPopoverItem>
-        <ActionPopoverItem
-          submenu={
-            <ActionPopoverMenu>
-              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-            </ActionPopoverMenu>
-          }
-        >
-          example item with submenu
-        </ActionPopoverItem>
-      </ActionPopover>,
-    );
-
-    await user.click(screen.getByRole("button"));
-    jest.runOnlyPendingTimers();
-
-    screen.getByRole("button", { name: "example item with submenu" }).focus();
-    await user.keyboard("{ArrowLeft}");
-    jest.runOnlyPendingTimers();
-
-    const firstItem = screen.getByRole("button", { name: "submenu item 1" });
-    expect(firstItem).toBeVisible();
-    expect(firstItem).toHaveFocus();
-  });
-
-  it("closes the submenu and returns focus to parent item when the submenu is open and the right arrow key is pressed", async () => {
-    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-    render(
-      <ActionPopover submenuPosition="right">
-        <ActionPopoverItem>example item 1</ActionPopoverItem>
-        <ActionPopoverItem>example item 2</ActionPopoverItem>
-        <ActionPopoverItem
-          submenu={
-            <ActionPopoverMenu>
-              <ActionPopoverItem>submenu item 1</ActionPopoverItem>
-              <ActionPopoverItem>submenu item 2</ActionPopoverItem>
-            </ActionPopoverMenu>
-          }
-        >
-          example item with submenu
-        </ActionPopoverItem>
-      </ActionPopover>,
-    );
-
-    await user.click(screen.getByRole("button"));
-
-    const parentItem = screen.getByRole("button", {
-      name: "example item with submenu",
-    });
-
-    parentItem.focus();
-    await user.keyboard("{ArrowLeft}");
-
-    expect(
-      screen.getByRole("button", { name: "submenu item 1" }),
-    ).toBeVisible();
-
-    await user.keyboard("{ArrowRight}");
-
-    expect(
-      screen.queryByRole("button", { name: "submenu item 1" }),
-    ).not.toBeInTheDocument();
-    expect(parentItem).toHaveFocus();
   });
 });
 
@@ -2183,6 +1875,136 @@ test("an error is thrown, with appropriate error message, if a submenu has incor
   );
 
   globalConsoleSpy.mockRestore();
+});
+
+test("an error is thrown if a submenu contains a valid element that is not an ActionPopoverItem or ActionPopoverDivider", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  const globalConsoleSpy = jest
+    .spyOn(global.console, "error")
+    .mockImplementation(() => {});
+
+  render(
+    <ActionPopover>
+      <ActionPopoverItem
+        submenu={
+          <ActionPopoverMenu>
+            <div>not an item</div>
+          </ActionPopoverMenu>
+        }
+      >
+        item
+      </ActionPopoverItem>
+    </ActionPopover>,
+  );
+
+  await expect(() => {
+    return user.click(screen.getByRole("button"));
+  }).rejects.toThrow(
+    "ActionPopoverMenu only accepts children of type `ActionPopoverItem`" +
+      " and `ActionPopoverDivider`.",
+  );
+
+  globalConsoleSpy.mockRestore();
+});
+
+test("a disabled item rendered as a link is marked as aria-disabled and does not navigate", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  const onClick = jest.fn();
+
+  render(
+    <ActionPopover>
+      <ActionPopoverItem href="#foo" disabled onClick={onClick}>
+        disabled link
+      </ActionPopoverItem>
+    </ActionPopover>,
+  );
+
+  await user.click(screen.getByRole("button"));
+
+  const link = screen.getByRole("link", { name: "disabled link" });
+  expect(link).toHaveAttribute("aria-disabled", "true");
+
+  await user.click(link);
+
+  expect(onClick).not.toHaveBeenCalled();
+});
+
+test("opening a second submenu closes the first one", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  // the shared guid mock would give both items the same submenu id
+  let counter = 0;
+  (guid as jest.MockedFunction<typeof guid>).mockImplementation(
+    () => `guid-${(counter += 1)}`,
+  );
+
+  render(
+    <ActionPopover>
+      <ActionPopoverItem
+        submenu={
+          <ActionPopoverMenu>
+            <ActionPopoverItem>first submenu item</ActionPopoverItem>
+          </ActionPopoverMenu>
+        }
+      >
+        first parent
+      </ActionPopoverItem>
+      <ActionPopoverItem
+        submenu={
+          <ActionPopoverMenu>
+            <ActionPopoverItem>second submenu item</ActionPopoverItem>
+          </ActionPopoverMenu>
+        }
+      >
+        second parent
+      </ActionPopoverItem>
+    </ActionPopover>,
+  );
+
+  await user.click(screen.getByRole("button", { name: "Action" }));
+  await user.click(screen.getByRole("button", { name: "first parent" }));
+
+  expect(
+    screen.getByRole("button", { name: "first submenu item" }),
+  ).toBeVisible();
+
+  await user.click(screen.getByRole("button", { name: "second parent" }));
+
+  expect(
+    screen.getByRole("button", { name: "second submenu item" }),
+  ).toBeVisible();
+  expect(
+    screen.queryByRole("button", { name: "first submenu item" }),
+  ).not.toBeInTheDocument();
+
+  (guid as jest.MockedFunction<typeof guid>).mockImplementation(
+    () => "guid-12345",
+  );
+});
+
+test("pressing an alphabet character wraps back to the first match when there is no later match", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(
+    <ActionPopover>
+      <ActionPopoverItem>Apple</ActionPopoverItem>
+      <ActionPopoverItem>Banana</ActionPopoverItem>
+      <ActionPopoverItem>Avocado</ActionPopoverItem>
+    </ActionPopover>,
+  );
+
+  await user.click(screen.getByRole("button", { name: "Action" }));
+  jest.runOnlyPendingTimers();
+
+  // from the first item, "a" moves forwards to the next match
+  await user.keyboard("a");
+  jest.runOnlyPendingTimers();
+  expect(screen.getByRole("button", { name: "Avocado" })).toHaveFocus();
+
+  // there is no match after Avocado, so focus wraps back to the first match
+  await user.keyboard("a");
+  jest.runOnlyPendingTimers();
+  expect(screen.getByRole("button", { name: "Apple" })).toHaveFocus();
 });
 
 describe("when the renderButton prop is passed", () => {
@@ -2476,46 +2298,6 @@ describe("When ActionPopoverMenu contains multiple disabled items", () => {
   });
 });
 
-test("when horizontalAlignment is set to 'left', menu displays icon before text", async () => {
-  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-  render(
-    <ActionPopover horizontalAlignment="left">
-      <ActionPopoverItem icon="add">Apple</ActionPopoverItem>
-    </ActionPopover>,
-  );
-
-  const menuButton = screen.getByRole("button");
-  await user.click(menuButton);
-
-  const menu = await screen.findByRole("list");
-
-  const { gridTemplateColumns } = getComputedStyle(menu);
-  expect(gridTemplateColumns).toContain(
-    "[icon_column] auto [text_column] auto",
-  );
-});
-
-test("when horizontalAlignment is set to 'right', menu displays icon after text", async () => {
-  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-
-  render(
-    <ActionPopover horizontalAlignment="right">
-      <ActionPopoverItem icon="add">Apple</ActionPopoverItem>
-    </ActionPopover>,
-  );
-
-  const menuButton = screen.getByRole("button");
-  await user.click(menuButton);
-
-  const menu = await screen.findByRole("list");
-
-  const { gridTemplateColumns } = getComputedStyle(menu);
-  expect(gridTemplateColumns).toContain(
-    "[text_column] auto [icon_column] auto",
-  );
-});
-
 test("a menu item's icons are hidden from assistive technologies", async () => {
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
@@ -2541,10 +2323,10 @@ test("a menu item's icons are hidden from assistive technologies", async () => {
     name: "Fruits",
   });
 
-  const chevronIcon = within(menuItem).getByTestId("chevron-icon");
+  const submenuIcon = within(menuItem).getByTestId("submenu-icon");
   const itemIcon = within(menuItem).getByTestId("item-icon");
 
-  expect(chevronIcon).toHaveAttribute("aria-hidden", "true");
+  expect(submenuIcon).toHaveAttribute("aria-hidden", "true");
   expect(itemIcon).toHaveAttribute("aria-hidden", "true");
 });
 

--- a/src/components/action-popover/index.ts
+++ b/src/components/action-popover/index.ts
@@ -4,7 +4,9 @@ export { default as ActionPopoverMenu } from "./action-popover-menu/action-popov
 export type { ActionPopoverMenuProps } from "./action-popover-menu/action-popover-menu.component";
 export { default as ActionPopoverItem } from "./action-popover-item/action-popover-item.component";
 export type { ActionPopoverItemProps } from "./action-popover-item/action-popover-item.component";
+/** @deprecated Use `renderButton` with your own button component instead. */
 export { default as ActionPopoverMenuButton } from "./action-popover-menu-button/action-popover-menu-button.component";
+/** @deprecated Use `renderButton` with your own button component instead. */
 export type { ActionPopoverMenuButtonProps } from "./action-popover-menu-button/action-popover-menu-button.component";
 export { default as ActionPopoverDivider } from "./action-popover-divider/action-popover-divider.component";
 export type { RenderButtonProps } from "./action-popover.component";

--- a/src/components/flat-table/flat-table.pw.tsx
+++ b/src/components/flat-table/flat-table.pw.tsx
@@ -1228,7 +1228,10 @@ test.describe("Scrollable tests", () => {
   }) => {
     await mount(<FlatTableStickyFooterActionPopoverComponent />);
 
-    const actionPopover = page.getByRole("button", { name: "Action" });
+    const actionPopover = page.getByRole("button", {
+      name: "Action",
+      exact: true,
+    });
 
     await actionPopover.click();
     const buttonList = page.getByRole("list");

--- a/src/components/flat-table/flat-table.pw.tsx
+++ b/src/components/flat-table/flat-table.pw.tsx
@@ -1228,7 +1228,7 @@ test.describe("Scrollable tests", () => {
   }) => {
     await mount(<FlatTableStickyFooterActionPopoverComponent />);
 
-    const actionPopover = page.getByRole("button", { name: "actions" });
+    const actionPopover = page.getByRole("button", { name: "Action" });
 
     await actionPopover.click();
     const buttonList = page.getByRole("list");

--- a/src/components/note/note.test.tsx
+++ b/src/components/note/note.test.tsx
@@ -144,7 +144,7 @@ test("should render with `ActionPopover` when passed via the `inlineControl` pro
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "actions" }));
+  await user.click(screen.getByRole("button", { name: "Action" }));
 
   expect(screen.getByRole("button", { name: "Copy" })).toBeVisible();
   expect(screen.getByRole("button", { name: "Edit" })).toBeVisible();


### PR DESCRIPTION

### Proposed behaviour

Use a subtle Action button with a three-dots icon, keep it outlined while open, deprecate manual positioning props, and rely on automatic flipping with docs/stories showing text and textless render-prop examples.

### Current behaviour

Most of this is implemented (subtle Action button, open-state outline, deprecations, and examples), but the trigger icon is still dropdown in the component/stories instead of three dots.
<img width="752" height="630" alt="image" src="https://github.com/user-attachments/assets/a75a0f43-377b-429d-afe5-36bc145702b2" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [x] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
