### PR TITLE
refactor(text-editor): use ButtonToggle for formatting controls

### DIFF
--- a/skills/carbon-react/components/button-toggle.md
+++ b/skills/carbon-react/components/button-toggle.md
@@ -19,6 +19,7 @@ description: Carbon ButtonToggle component props and usage examples.
 | buttonIcon | IconType \| undefined | No |  |  |  | Icon rendered within the button. Will not be rendered if size is small. |  |
 | children | React.ReactNode | No |  |  |  | Content to display within the button. |  |
 | disabled | boolean \| undefined | No |  |  |  | Disable the ButtonToggle. |  |
+| id | string \| undefined | No |  |  |  | Override the auto-generated id on the button element. |  |
 | onBlur | ((ev: React.FocusEvent<HTMLButtonElement>) => void) \| undefined | No |  |  |  | Callback triggered by blur event on the button. |  |
 | onClick | ((ev: React.MouseEvent<HTMLButtonElement>) => void) \| undefined | No |  |  |  | Callback triggered by click event on the button. |  |
 | onFocus | ((ev: React.FocusEvent<HTMLButtonElement>) => void) \| undefined | No |  |  |  | Callback triggered by focus event on the button. |  |

--- a/src/components/button-toggle/button-toggle.component.tsx
+++ b/src/components/button-toggle/button-toggle.component.tsx
@@ -14,6 +14,14 @@ export interface ButtonToggleProps extends TagProps {
   "aria-labelledby"?: string;
   /** Content to display within the button. */
   children?: React.ReactNode;
+  /**
+   * @private
+   * @internal
+   * @ignore
+   * Additional class name to merge with the component's own class. */
+  className?: string;
+  /** Override the auto-generated id on the button element. */
+  id?: string;
   /** Callback triggered by blur event on the button. */
   onBlur?: (ev: React.FocusEvent<HTMLButtonElement>) => void;
   /** Callback triggered by focus event on the button. */
@@ -47,7 +55,9 @@ export const ButtonToggle = ({
   buttonIcon,
   buttonIconSize,
   children,
+  className,
   disabled,
+  id,
   onBlur,
   onFocus,
   onClick,
@@ -118,14 +128,12 @@ export const ButtonToggle = ({
 
   return (
     <StyledButtonToggle
-      className="button-toggle"
       data-button-toggle-internal
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
       aria-describedby={hintTextId}
       aria-pressed={!!isPressed}
       disabled={disabled || isDisabled}
-      id={inputGuid.current}
       $size={displaySize}
       $active={!!isPressed}
       $iconOnly={iconOnly}
@@ -139,6 +147,8 @@ export const ButtonToggle = ({
       ref={callbackRef}
       {...rest}
       {...tagComponent(dataComponent || "button-toggle", rest)}
+      className={["button-toggle", className].filter(Boolean).join(" ")}
+      id={id ?? inputGuid.current}
     >
       {buttonIcon && displaySize !== "extraSmall" && (
         <Icon aria-hidden type={buttonIcon} />

--- a/src/components/text-editor/__internal__/__ui__/Toolbar/buttons/bold.component.tsx
+++ b/src/components/text-editor/__internal__/__ui__/Toolbar/buttons/bold.component.tsx
@@ -2,61 +2,54 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import { FORMAT_TEXT_COMMAND } from "lexical";
 import React from "react";
 
-import { FormattingButton } from "../toolbar.style";
+import ToolbarButtonToggle from "../toolbar-button.component";
 
 import useLocale from "../../../../../../hooks/__internal__/useLocale";
 import { TEXT_EDITOR_ACTION_TYPES } from "../../../__utils__/constants";
 import { FormattingButtonProps } from "../../../__utils__/interfaces.types";
 
 // The `BoldButton` component is a button that applies bold formatting to the selected text in the editor.
-const BoldButton = React.forwardRef<HTMLButtonElement, FormattingButtonProps>(
-  (
-    {
-      isActive,
-      isFirstButton = false,
-      namespace,
-      size = "medium",
-    }: FormattingButtonProps,
-    ref,
-  ) => {
-    // Get the editor instance
-    const [editor] = useLexicalComposerContext();
-    // Get the locale to enable translations
-    const locale = useLocale();
+const BoldButton = ({
+  isActive,
+  isFirstButton = false,
+  namespace,
+  size = "medium",
+}: FormattingButtonProps) => {
+  // Get the editor instance
+  const [editor] = useLexicalComposerContext();
+  // Get the locale to enable translations
+  const locale = useLocale();
 
-    // When the button is clicked, dispatch the `FORMAT_TEXT_COMMAND` with the `Bold` action
-    const handleClick = () => {
-      const isEditable = editor.isEditable();
+  // When the button is clicked, dispatch the `FORMAT_TEXT_COMMAND` with the `Bold` action
+  const handleClick = () => {
+    const isEditable = editor.isEditable();
 
-      /* istanbul ignore else */
-      if (isEditable) {
-        editor.dispatchCommand(
-          FORMAT_TEXT_COMMAND,
-          TEXT_EDITOR_ACTION_TYPES.Bold,
-        );
+    /* istanbul ignore else */
+    if (isEditable) {
+      editor.dispatchCommand(
+        FORMAT_TEXT_COMMAND,
+        TEXT_EDITOR_ACTION_TYPES.Bold,
+      );
+    }
+  };
+
+  return (
+    <ToolbarButtonToggle
+      type="button"
+      size={size}
+      aria-label={locale.textEditor.boldAria()}
+      onClick={handleClick}
+      buttonIcon="bold"
+      onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) =>
+        e.preventDefault()
       }
-    };
-
-    return (
-      <FormattingButton
-        size={size}
-        aria-label={locale.textEditor.boldAria()}
-        onClick={() => handleClick()}
-        iconType="bold"
-        onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) =>
-          e.preventDefault()
-        }
-        buttonType={isActive ? "primary" : "tertiary"}
-        isActive={isActive}
-        aria-pressed={isActive}
-        id={`${namespace}-bold-button`}
-        data-role={`${namespace}-bold-button`}
-        tabIndex={isFirstButton ? 0 : -1}
-        className="toolbar-button"
-        ref={ref}
-      />
-    );
-  },
-);
+      pressed={isActive}
+      id={`${namespace}-bold-button`}
+      data-role={`${namespace}-bold-button`}
+      tabIndex={isFirstButton ? 0 : -1}
+      className="toolbar-button"
+    />
+  );
+};
 
 export default BoldButton;

--- a/src/components/text-editor/__internal__/__ui__/Toolbar/buttons/hyperlink.component.tsx
+++ b/src/components/text-editor/__internal__/__ui__/Toolbar/buttons/hyperlink.component.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { FormattingButton } from "../toolbar.style";
+import { StyledToolbarButton } from "../toolbar.style";
 
 import useLocale from "../../../../../../hooks/__internal__/useLocale";
 import { FormattingButtonProps } from "../../../__utils__/interfaces.types";
@@ -12,42 +12,32 @@ type HyperlinkButtonProps = Pick<
   setDialogOpen: (open: boolean) => void;
 };
 
-const HyperlinkButton = React.forwardRef<
-  HTMLButtonElement,
-  HyperlinkButtonProps
->(
-  (
-    {
-      isFirstButton,
-      namespace,
-      size = "medium",
-      setDialogOpen,
-    }: HyperlinkButtonProps,
-    ref,
-  ) => {
-    // Get the locale to enable translations
-    const locale = useLocale();
+const HyperlinkButton = ({
+  isFirstButton,
+  namespace,
+  size = "medium",
+  setDialogOpen,
+}: HyperlinkButtonProps) => {
+  // Get the locale to enable translations
+  const locale = useLocale();
 
-    return (
-      <FormattingButton
-        size={size}
-        aria-label={locale.textEditor.hyperlink.buttonAria()}
-        onClick={() => {
-          setDialogOpen(true);
-        }}
-        onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) =>
-          e.preventDefault()
-        }
-        iconType="link_on"
-        buttonType={"tertiary"}
-        data-role={`${namespace}-hyperlink-button`}
-        id={`${namespace}-hyperlink-button`}
-        tabIndex={isFirstButton ? 0 : -1}
-        className="toolbar-button"
-        ref={ref}
-      />
-    );
-  },
-);
+  return (
+    <StyledToolbarButton
+      size={size}
+      aria-label={locale.textEditor.hyperlink.buttonAria()}
+      type="button"
+      onClick={() => {
+        setDialogOpen(true);
+      }}
+      onMouseDown={(e) => e.preventDefault()}
+      iconType="link_on"
+      variantType="tertiary"
+      data-role={`${namespace}-hyperlink-button`}
+      id={`${namespace}-hyperlink-button`}
+      tabIndex={isFirstButton ? 0 : -1}
+      className="toolbar-button"
+    />
+  );
+};
 
 export default HyperlinkButton;

--- a/src/components/text-editor/__internal__/__ui__/Toolbar/buttons/italic.component.tsx
+++ b/src/components/text-editor/__internal__/__ui__/Toolbar/buttons/italic.component.tsx
@@ -2,60 +2,53 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import { FORMAT_TEXT_COMMAND } from "lexical";
 import React from "react";
 
-import { FormattingButton } from "../toolbar.style";
+import ToolbarButtonToggle from "../toolbar-button.component";
 import useLocale from "../../../../../../hooks/__internal__/useLocale";
 import { FormattingButtonProps } from "../../../__utils__/interfaces.types";
 import { TEXT_EDITOR_ACTION_TYPES } from "../../../__utils__/constants";
 
 // The `ItalicButton` component is a button that applies italic formatting to the selected text in the editor.
-const ItalicButton = React.forwardRef<HTMLButtonElement, FormattingButtonProps>(
-  (
-    {
-      isActive,
-      isFirstButton = false,
-      namespace,
-      size = "medium",
-    }: FormattingButtonProps,
-    ref,
-  ) => {
-    // Get the editor instance
-    const [editor] = useLexicalComposerContext();
-    // Get the locale to enable translations
-    const locale = useLocale();
+const ItalicButton = ({
+  isActive,
+  isFirstButton = false,
+  namespace,
+  size = "medium",
+}: FormattingButtonProps) => {
+  // Get the editor instance
+  const [editor] = useLexicalComposerContext();
+  // Get the locale to enable translations
+  const locale = useLocale();
 
-    // When the button is clicked, dispatch the `FORMAT_TEXT_COMMAND` with the `Italic` action
-    const handleClick = () => {
-      const isEditable = editor.isEditable();
+  // When the button is clicked, dispatch the `FORMAT_TEXT_COMMAND` with the `Italic` action
+  const handleClick = () => {
+    const isEditable = editor.isEditable();
 
-      /* istanbul ignore else */
-      if (isEditable) {
-        editor.dispatchCommand(
-          FORMAT_TEXT_COMMAND,
-          TEXT_EDITOR_ACTION_TYPES.Italic,
-        );
+    /* istanbul ignore else */
+    if (isEditable) {
+      editor.dispatchCommand(
+        FORMAT_TEXT_COMMAND,
+        TEXT_EDITOR_ACTION_TYPES.Italic,
+      );
+    }
+  };
+
+  return (
+    <ToolbarButtonToggle
+      type="button"
+      size={size}
+      aria-label={locale.textEditor.italicAria()}
+      onClick={handleClick}
+      onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) =>
+        e.preventDefault()
       }
-    };
-
-    return (
-      <FormattingButton
-        size={size}
-        aria-label={locale.textEditor.italicAria()}
-        onClick={() => handleClick()}
-        onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) =>
-          e.preventDefault()
-        }
-        iconType="italic"
-        buttonType={isActive ? "primary" : "tertiary"}
-        isActive={isActive}
-        aria-pressed={isActive}
-        data-role={`${namespace}-italic-button`}
-        id={`${namespace}-italic-button`}
-        tabIndex={isFirstButton ? 0 : -1}
-        className="toolbar-button"
-        ref={ref}
-      />
-    );
-  },
-);
+      buttonIcon="italic"
+      pressed={isActive}
+      data-role={`${namespace}-italic-button`}
+      id={`${namespace}-italic-button`}
+      tabIndex={isFirstButton ? 0 : -1}
+      className="toolbar-button"
+    />
+  );
+};
 
 export default ItalicButton;

--- a/src/components/text-editor/__internal__/__ui__/Toolbar/buttons/list.component.tsx
+++ b/src/components/text-editor/__internal__/__ui__/Toolbar/buttons/list.component.tsx
@@ -25,7 +25,7 @@ import {
 
 import React, { useCallback, useEffect, useState } from "react";
 
-import { FormattingButton } from "../toolbar.style";
+import ToolbarButtonToggle from "../toolbar-button.component";
 import useLocale from "../../../../../../hooks/__internal__/useLocale";
 import { TEXT_EDITOR_ACTION_TYPES } from "../../../__utils__/constants";
 
@@ -362,7 +362,8 @@ const ListControls = ({
   return (
     <>
       {showUL && (
-        <FormattingButton
+        <ToolbarButtonToggle
+          type="button"
           size={size}
           aria-label={locale.textEditor.unorderedListAria()}
           onClick={() =>
@@ -371,10 +372,8 @@ const ListControls = ({
           onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) =>
             e.preventDefault()
           }
-          iconType="bullet_list_dotted"
-          buttonType={isULActive ? "primary" : "tertiary"}
-          isActive={isULActive}
-          aria-pressed={isULActive}
+          buttonIcon="bullet_list_dotted"
+          pressed={isULActive}
           data-role={`${namespace}-unordered-list-button`}
           id={`${namespace}-unordered-list-button`}
           tabIndex={ulIsFirstButton ? 0 : -1}
@@ -382,7 +381,8 @@ const ListControls = ({
         />
       )}
       {showOL && (
-        <FormattingButton
+        <ToolbarButtonToggle
+          type="button"
           size={size}
           aria-label={locale.textEditor.orderedListAria()}
           onClick={() =>
@@ -391,10 +391,8 @@ const ListControls = ({
           onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) =>
             e.preventDefault()
           }
-          iconType="bullet_list_numbers"
-          buttonType={isOLActive ? "primary" : "tertiary"}
-          isActive={isOLActive}
-          aria-pressed={isOLActive}
+          buttonIcon="bullet_list_numbers"
+          pressed={isOLActive}
           data-role={`${namespace}-ordered-list-button`}
           id={`${namespace}-ordered-list-button`}
           tabIndex={olIsFirstButton ? 0 : -1}

--- a/src/components/text-editor/__internal__/__ui__/Toolbar/buttons/underline.component.tsx
+++ b/src/components/text-editor/__internal__/__ui__/Toolbar/buttons/underline.component.tsx
@@ -2,63 +2,53 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import { FORMAT_TEXT_COMMAND } from "lexical";
 import React from "react";
 
-import { FormattingButton } from "../toolbar.style";
+import ToolbarButtonToggle from "../toolbar-button.component";
 import useLocale from "../../../../../../hooks/__internal__/useLocale";
 import { FormattingButtonProps } from "../../../__utils__/interfaces.types";
 import { TEXT_EDITOR_ACTION_TYPES } from "../../../__utils__/constants";
 
 // The `UnderlineButton` component is a button that applies underline formatting to the selected text in the editor.
-const UnderlineButton = React.forwardRef<
-  HTMLButtonElement,
-  FormattingButtonProps
->(
-  (
-    {
-      isActive,
-      isFirstButton = false,
-      namespace,
-      size = "medium",
-    }: FormattingButtonProps,
-    ref,
-  ) => {
-    // Get the editor instance
-    const [editor] = useLexicalComposerContext();
-    // Get the locale to enable translations
-    const locale = useLocale();
+const UnderlineButton = ({
+  isActive,
+  isFirstButton = false,
+  namespace,
+  size = "medium",
+}: FormattingButtonProps) => {
+  // Get the editor instance
+  const [editor] = useLexicalComposerContext();
+  // Get the locale to enable translations
+  const locale = useLocale();
 
-    // When the button is clicked, dispatch the `FORMAT_TEXT_COMMAND` with the `Underline` action
-    const handleClick = () => {
-      const isEditable = editor.isEditable();
+  // When the button is clicked, dispatch the `FORMAT_TEXT_COMMAND` with the `Underline` action
+  const handleClick = () => {
+    const isEditable = editor.isEditable();
 
-      /* istanbul ignore else */
-      if (isEditable) {
-        editor.dispatchCommand(
-          FORMAT_TEXT_COMMAND,
-          TEXT_EDITOR_ACTION_TYPES.Underline,
-        );
+    /* istanbul ignore else */
+    if (isEditable) {
+      editor.dispatchCommand(
+        FORMAT_TEXT_COMMAND,
+        TEXT_EDITOR_ACTION_TYPES.Underline,
+      );
+    }
+  };
+
+  return (
+    <ToolbarButtonToggle
+      type="button"
+      size={size}
+      aria-label={locale.textEditor.underlineAria()}
+      onClick={handleClick}
+      buttonIcon="underline"
+      onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) =>
+        e.preventDefault()
       }
-    };
-
-    return (
-      <FormattingButton
-        size={size}
-        aria-label={locale.textEditor.underlineAria()}
-        onClick={() => handleClick()}
-        iconType="underline"
-        onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) =>
-          e.preventDefault()
-        }
-        buttonType={isActive ? "primary" : "tertiary"}
-        isActive={isActive}
-        aria-pressed={isActive}
-        data-role={`${namespace}-underline-button`}
-        id={`${namespace}-underline-button`}
-        tabIndex={isFirstButton ? 0 : -1}
-        className="toolbar-button"
-        ref={ref}
-      />
-    );
-  },
-);
+      pressed={isActive}
+      data-role={`${namespace}-underline-button`}
+      id={`${namespace}-underline-button`}
+      tabIndex={isFirstButton ? 0 : -1}
+      className="toolbar-button"
+    />
+  );
+};
 
 export default UnderlineButton;

--- a/src/components/text-editor/__internal__/__ui__/Toolbar/toolbar-button.component.tsx
+++ b/src/components/text-editor/__internal__/__ui__/Toolbar/toolbar-button.component.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import { ButtonToggle, ButtonToggleProps } from "../../../../button-toggle";
+
+type ToolbarNativeButtonProps = Pick<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "onMouseDown" | "tabIndex" | "type"
+>;
+
+// Widens ButtonToggleProps with native button attributes needed in the toolbar context
+// (onMouseDown, tabIndex, type) without exposing them on ButtonToggle's public API.
+type ToolbarButtonToggleProps = ButtonToggleProps & ToolbarNativeButtonProps;
+
+const ToolbarButtonToggle = ({
+  onClick,
+  ...props
+}: ToolbarButtonToggleProps) => {
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.currentTarget.focus({ preventScroll: true });
+    onClick?.(event);
+  };
+
+  return <ButtonToggle {...props} onClick={handleClick} />;
+};
+
+export default ToolbarButtonToggle;

--- a/src/components/text-editor/__internal__/__ui__/Toolbar/toolbar.style.ts
+++ b/src/components/text-editor/__internal__/__ui__/Toolbar/toolbar.style.ts
@@ -2,9 +2,8 @@ import styled, { css } from "styled-components";
 
 import Button, { ButtonProps } from "../../../../button/__next__";
 
-interface FormattingButtonProps extends ButtonProps {
+interface StyledToolbarButtonProps extends ButtonProps {
   tabIndex?: number;
-  isActive?: boolean;
   onMouseDown?: React.MouseEventHandler<HTMLButtonElement>;
   size: "small" | "medium" | "large";
 }
@@ -66,8 +65,7 @@ const CommandButtons = styled.div`
   gap: var(--global-space-comp-s);
 `;
 
-// TODO: replace this with ButtonToggle
-const FormattingButton = styled(Button)<FormattingButtonProps>`
+const StyledToolbarButton = styled(Button)<StyledToolbarButtonProps>`
   border: none;
   color: var(--button-typical-toggle-label-default);
 
@@ -80,18 +78,11 @@ const FormattingButton = styled(Button)<FormattingButtonProps>`
     min-width: ${sizeMap[size].buttonSize};
     min-height: ${sizeMap[size].buttonSize};
   `}
-
-  ${({ isActive }) =>
-    isActive &&
-    css`
-      background-color: var(--button-typical-toggle-bg-active);
-      color: var(--button-typical-toggle-label-active);
-    `}
 `;
 
 export {
   StyledToolbar,
   StyledToolbarWrapper,
   CommandButtons,
-  FormattingButton,
+  StyledToolbarButton,
 };


### PR DESCRIPTION
### Proposed behaviour

Formatting Controls in TextEditor rendered via ButtonToggle

### Current behaviour

Formatting Controls in TextEditor are not rendered via ButtonToggle

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
