### PR TITLE
chore(stories): resolve React warnings for keys and DOM prop forwarding

### DIFF
--- a/skills/carbon-react/components/portrait.md
+++ b/skills/carbon-react/components/portrait.md
@@ -377,7 +377,7 @@ description: Carbon Portrait component props and usage examples.
           value={variant}
         >
           {availableVariants.map(({ label, value }) => (
-            <Option text={label} value={value} />
+            <Option key={value} text={label} value={value} />
           ))}
         </Select>
       </Box>

--- a/src/components/file-input/file-input-test.stories.tsx
+++ b/src/components/file-input/file-input-test.stories.tsx
@@ -67,16 +67,23 @@ export const AllStatuses = (args: Partial<FileInputProps>) => {
       message: "oops, that's not right",
     },
   ];
-  return statuses.map((status) => (
-    <FileInput
-      my={20}
-      label="test"
-      inputHint="hint"
-      uploadStatus={status}
-      onChange={() => {}}
-      {...args}
-    />
-  ));
+  return statuses.map((status, index) => {
+    const statusType = Array.isArray(status)
+      ? "multiple"
+      : (status?.status ?? "none");
+
+    return (
+      <FileInput
+        key={`status-${statusType}-${index}`}
+        my={20}
+        label="test"
+        inputHint="hint"
+        uploadStatus={status}
+        onChange={() => {}}
+        {...args}
+      />
+    );
+  });
 };
 
 export const LongFilenameStatus = (args: Partial<FileInputProps>) => {

--- a/src/components/form/form.component.tsx
+++ b/src/components/form/form.component.tsx
@@ -120,7 +120,7 @@ export const Form = ({
           $hasFooterChildren={!!footerChildren}
           $stickyFooter={stickyFooter}
           {...(stickyFooter && { $stickyFooterVariant: stickyFooterVariant })}
-          disableStickyOnSmallScreen={disableStickyOnSmallScreen}
+          $disableStickyOnSmallScreen={disableStickyOnSmallScreen}
           $buttonAlignment={buttonAlignment}
           $fullWidthButtons={fullWidthButtons}
           {...footerPadding}

--- a/src/components/form/form.style.ts
+++ b/src/components/form/form.style.ts
@@ -52,7 +52,7 @@ interface StyledFormFooterProps {
   $stickyFooterVariant?: "light" | "grey";
   $fullWidthButtons?: boolean;
   $buttonAlignment?: FormButtonAlignment;
-  disableStickyOnSmallScreen?: boolean;
+  $disableStickyOnSmallScreen?: boolean;
 }
 
 export const StyledFormFooter = styled.div.attrs(
@@ -104,8 +104,8 @@ export const StyledFormFooter = styled.div.attrs(
 
   ${padding}
 
-  ${({ disableStickyOnSmallScreen }) =>
-    disableStickyOnSmallScreen &&
+  ${({ $disableStickyOnSmallScreen }) =>
+    $disableStickyOnSmallScreen &&
     css`
       @media screen and (max-width: 600px) {
         position: static;

--- a/src/components/menu/menu-test.stories.tsx
+++ b/src/components/menu/menu-test.stories.tsx
@@ -379,7 +379,7 @@ MenuFullScreenKeysTest.storyName = "Menu Fullscreen with dynamic submenus";
 export const MenuWithSubmenuCustomPadding = () => (
   <>
     {[0, "5px", 1, 2, "17px", 3, 4, 5, 6, 7, 8].map((padding) => (
-      <Menu>
+      <Menu key={`menu-padding-${padding}`}>
         <MenuItem px={padding} href="#">
           Item One
         </MenuItem>

--- a/src/components/password/password.component.tsx
+++ b/src/components/password/password.component.tsx
@@ -20,10 +20,13 @@ export const Password = ({
   id,
   disabled,
   forceObscurity = false,
+  characterLimit,
   inputIcon,
   size,
   ...rest
 }: PasswordProps) => {
+  void characterLimit;
+
   const internalInputId = useRef(id || guid());
   const l = useLocale();
 

--- a/src/components/portrait/portrait.stories.tsx
+++ b/src/components/portrait/portrait.stories.tsx
@@ -294,7 +294,7 @@ export const Variants: Story = () => {
           value={variant}
         >
           {availableVariants.map(({ label, value }) => (
-            <Option text={label} value={value} />
+            <Option key={value} text={label} value={value} />
           ))}
         </Select>
       </Box>

--- a/src/components/tile/tile-test.stories.tsx
+++ b/src/components/tile/tile-test.stories.tsx
@@ -65,25 +65,26 @@ export const DefaultStory = ({
   ...args
 }: TileProps & TileStoryProps) => {
   const contentOneProps = {
-    key: "one",
     children: contentOneChildren,
     width: contentOneWidth,
   };
   const contentTwoProps = {
-    key: "two",
     children: contentTwoChildren,
     width: contentTwoWidth,
   };
   const contentThreeProps = {
-    key: "three",
     children: contentThreeChildren,
     width: contentThreeWidth,
   };
   const tileContent = [
-    contentOneProps.children ? <TileContent {...contentOneProps} /> : undefined,
-    contentTwoProps.children ? <TileContent {...contentTwoProps} /> : undefined,
+    contentOneProps.children ? (
+      <TileContent key="one" {...contentOneProps} />
+    ) : undefined,
+    contentTwoProps.children ? (
+      <TileContent key="two" {...contentTwoProps} />
+    ) : undefined,
     contentThreeProps.children ? (
-      <TileContent {...contentThreeProps} />
+      <TileContent key="three" {...contentThreeProps} />
     ) : undefined,
   ];
   return (


### PR DESCRIPTION
### Proposed behaviour

Stories render without those warnings by adding stable keys, passing key directly, and using transient styled props for non-DOM attributes.

### Current behaviour

 Storybook stories show React warnings due to missing list keys, key being spread into JSX, and style-only props leaking to DOM.

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [x] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
