### PR TITLE
fix(simple-select): add inputMode none to input

### DIFF
--- a/src/components/select/__internal__/select-textbox/select-textbox.component.tsx
+++ b/src/components/select/__internal__/select-textbox/select-textbox.component.tsx
@@ -221,6 +221,7 @@ const SelectTextbox = React.forwardRef(
           data-element={`${selectType ?? ""}-select-input`}
           data-role="select-textbox"
           inputIcon="dropdown"
+          {...(selectType === "simple" && { inputMode: "none" })}
           autoComplete="off"
           size={size}
           formattedValue={formattedValue}

--- a/src/components/select/__internal__/select-textbox/select-textbox.test.tsx
+++ b/src/components/select/__internal__/select-textbox/select-textbox.test.tsx
@@ -253,9 +253,21 @@ describe("when selectType is 'simple'", () => {
   });
 });
 
+test("sets inputmode='none' on the combobox when selectType is 'simple'", () => {
+  render(<ControlledSelectTextbox selectType="simple" />);
+
+  expect(screen.getByRole("combobox")).toHaveAttribute("inputmode", "none");
+});
+
 describe.each(["filterable", "multi"] as const)(
   "when input is rendered as part of %s select",
   (selectType) => {
+    it("does not set inputmode='none' on the combobox", () => {
+      render(<ControlledSelectTextbox selectType={selectType} />);
+
+      expect(screen.getByRole("combobox")).not.toHaveAttribute("inputmode");
+    });
+
     it("does not render the `select-text` overlay", () => {
       render(
         <ControlledSelectTextbox


### PR DESCRIPTION
fix #7786

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

adds `inputMode` none to the input to ensure mobile browsers treat the input as non-editable. This avoids imposed browser behaviours like a persistent keyboard overlay

<img width="1320" height="2868" alt="IMG_4677" src="https://github.com/user-attachments/assets/f3ac123a-5e74-43f1-9dfb-f71e89ffb1a1" />

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, `inputMode` none is not present on the input to ensure mobile browsers treat the input as non-editable. This imposes browser behaviours like a persistent keyboard overlay

<img width="1320" height="2868" alt="IMG_4678" src="https://github.com/user-attachments/assets/86c2bba2-e395-4982-a911-44e8f65abc58" />

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->

Inspect the DOM and navigate the `<input ...` element included within the `SimpleSelect` component on master and this branch. On master there will be no `inputmode="none"` attribute, however, on this branch the attribute will be observable. 

Then if possible repeat the same steps but disregard DOM inspection on a mobile device, on master there should be a keyboard overlay which cannot be dismissed. On this branch there will be no keyboard overlay. 