### PR TITLE
feat(sidebar): align with fusion ds

### DIFF
--- a/skills/carbon-react/components/sidebar.md
+++ b/skills/carbon-react/components/sidebar.md
@@ -13,49 +13,50 @@ description: Carbon Sidebar component props and usage examples.
 - Props interface: `SidebarProps`
 
 ## Props
-| Name | Type | Required | Literals | Description | Default |
-| --- | --- | --- | --- | --- | --- |
-| open | boolean | Yes |  | Sets the open state of the modal |  |
-| children | React.ReactNode | No |  | Modal content |  |
-| closeButtonDataProps | Pick<TagProps, "data-element" \| "data-role"> \| undefined | No |  | Data tag prop bag for close Button |  |
-| disableAutoFocus | boolean \| undefined | No |  |  |  |
-| disableEscKey | boolean \| undefined | No |  | Determines if the Esc Key closes the modal |  |
-| enableBackgroundUI | boolean \| undefined | No |  | Set this prop to false to hide the translucent background when the dialog is open. |  |
-| focusableContainers | React.RefObject<HTMLElement>[] \| undefined | No |  | an optional array of refs to containers whose content should also be reachable by tabbing from the sidebar |  |
-| focusableSelectors | string \| undefined | No |  | Optional selector to identify the focusable elements, if not provided a default selector is used |  |
-| focusFirstElement | React.MutableRefObject<HTMLElement \| null> \| undefined | No |  | Optional reference to an element meant to be focused on open |  |
-| header | React.ReactNode | No |  | Node that will be used as sidebar header. |  |
-| headerPadding | PaddingProps | No |  | Padding to be set on the Sidebar header |  |
-| headerVariant | "dark" \| "light" \| undefined | No |  | Header background variant for the sidebar. |  |
-| onCancel | ((ev: React.KeyboardEvent<HTMLElement> \| KeyboardEvent \| React.MouseEvent<HTMLElement>) => void) \| undefined | No |  | A custom close event handler |  |
-| p | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Padding on top, left, bottom and right |  |
-| padding | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Padding on top, left, bottom and right |  |
-| paddingBottom | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Padding on bottom |  |
-| paddingLeft | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Padding on left |  |
-| paddingRight | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Padding on right |  |
-| paddingTop | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Padding on top |  |
-| paddingX | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Padding on left and right |  |
-| paddingY | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Padding on top and bottom |  |
-| pb | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Padding on bottom |  |
-| pl | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Padding on left |  |
-| position | "left" \| "right" \| undefined | No |  | Sets the position of sidebar, either left or right. |  |
-| pr | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Padding on right |  |
-| pt | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Padding on top |  |
-| px | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Padding on left and right |  |
-| py | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | Padding on top and bottom |  |
-| restoreFocusOnClose | boolean \| undefined | No |  | Enables the automatic restoration of focus to the element that invoked the modal when the modal is closed. |  |
-| role | string \| undefined | No |  | The ARIA role to be applied to the component container |  |
-| size | "small" \| "medium" \| "large" \| "extra-small" \| "medium-small" \| "medium-large" \| "extra-large" \| undefined | No |  | Sets the size of the sidebar when open. |  |
-| subHeader | React.ReactNode | No |  | Node that will be used as sidebar subheader. |  |
-| subHeaderPadding | PaddingProps | No |  | Padding to be set on the Sidebar subheader |  |
-| topModalOverride | boolean \| undefined | No |  | Manually override the internal modal stacking order to set this as top |  |
-| width | ResponsiveValue<TVal, ThemeType> \| undefined | No |  | The width utility parses a component's `width` prop and converts it into a CSS width declaration. - Numbers from 0-1 are converted to percentage widths. - Numbers greater than 1 are converted to pixel values. - String values are passed as raw CSS values. - And arrays are converted to responsive width styles. |  |
-| widthAnimation | boolean \| undefined | No |  | Enables width animation when the sidebar width changes. |  |
-| data-element | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
-| data-role | string \| undefined | No |  | Identifier used for testing purposes, applied to the root element of the component. |  |
-| aria-describedby | string \| undefined | No |  | Prop to specify the aria-describedby property of the component |  |
-| aria-label | string \| undefined | No |  | Prop to specify the aria-label of the component. To be used only when the header prop is not defined, and the component is not labelled by any internal element. |  |
-| aria-labelledby | string \| undefined | No |  | Prop to specify the aria-labelledby property of the component To be used when the header prop is a custom React Node, or the component is labelled by an internal element other than the header. |  |
+| Name | Type | Required | Literals | Deprecated | Deprecation reason | Description | Default |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| open | boolean | Yes |  |  |  | Sets the open state of the modal |  |
+| children | React.ReactNode | No |  |  |  | Modal content |  |
+| closeButtonDataProps | Pick<TagProps, "data-element" \| "data-role"> \| undefined | No |  |  |  | Data tag prop bag for close Button |  |
+| disableAutoFocus | boolean \| undefined | No |  |  |  |  |  |
+| disableEscKey | boolean \| undefined | No |  |  |  | Determines if the Esc Key closes the modal |  |
+| enableBackgroundUI | boolean \| undefined | No |  |  |  | Set this prop to false to hide the translucent background when the dialog is open. |  |
+| focusableContainers | React.RefObject<HTMLElement>[] \| undefined | No |  |  |  | an optional array of refs to containers whose content should also be reachable by tabbing from the sidebar |  |
+| focusableSelectors | string \| undefined | No |  |  |  | Optional selector to identify the focusable elements, if not provided a default selector is used |  |
+| focusFirstElement | React.MutableRefObject<HTMLElement \| null> \| undefined | No |  |  |  | Optional reference to an element meant to be focused on open |  |
+| gradientKeyLine | boolean \| undefined | No |  |  |  | Adds the Carbon AI gradient keyline to the header. |  |
+| header | React.ReactNode | No |  |  |  | Node that will be used as sidebar header. |  |
+| headerPadding | PaddingProps | No |  |  |  | Padding to be set on the Sidebar header |  |
+| headerVariant | "typical" \| "dark" \| "light" \| "inverse" \| undefined | No |  |  |  | Header background variant for the sidebar. `light` and `dark` are deprecated aliases - use `typical` and `inverse` instead. |  |
+| onCancel | ((ev: React.KeyboardEvent<HTMLElement> \| KeyboardEvent \| React.MouseEvent<HTMLElement>) => void) \| undefined | No |  |  |  | A custom close event handler |  |
+| p | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on top, left, bottom and right |  |
+| padding | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on top, left, bottom and right |  |
+| paddingBottom | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on bottom |  |
+| paddingLeft | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on left |  |
+| paddingRight | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on right |  |
+| paddingTop | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on top |  |
+| paddingX | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on left and right |  |
+| paddingY | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on top and bottom |  |
+| pb | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on bottom |  |
+| pl | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on left |  |
+| pr | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on right |  |
+| pt | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on top |  |
+| px | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on left and right |  |
+| py | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | Padding on top and bottom |  |
+| restoreFocusOnClose | boolean \| undefined | No |  |  |  | Enables the automatic restoration of focus to the element that invoked the modal when the modal is closed. |  |
+| role | string \| undefined | No |  |  |  | The ARIA role to be applied to the component container |  |
+| subHeader | React.ReactNode | No |  |  |  | Node that will be used as sidebar subheader. |  |
+| subHeaderPadding | PaddingProps | No |  |  |  | Padding to be set on the Sidebar subheader |  |
+| topModalOverride | boolean \| undefined | No |  |  |  | Manually override the internal modal stacking order to set this as top |  |
+| width | ResponsiveValue<TVal, ThemeType> \| undefined | No |  |  |  | The width utility parses a component's `width` prop and converts it into a CSS width declaration. - Numbers from 0-1 are converted to percentage widths. - Numbers greater than 1 are converted to pixel values. - String values are passed as raw CSS values. - And arrays are converted to responsive width styles. |  |
+| widthAnimation | boolean \| undefined | No |  |  |  | Enables width animation when the sidebar width changes. |  |
+| data-element | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
+| data-role | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
+| aria-describedby | string \| undefined | No |  |  |  | Prop to specify the aria-describedby property of the component |  |
+| aria-label | string \| undefined | No |  |  |  | Provides an explicit accessible name for the component, overriding the automatic association with the header. |  |
+| aria-labelledby | string \| undefined | No |  |  |  | Identifies the element that provides an explicit accessible name for the component, overriding the automatic association with the header. |  |
+| position | "left" \| "right" \| undefined | No |  | Yes | This prop will be removed in a future release. Sidebar will always be positioned on the right. Update the layout to support a right-positioned Sidebar if it is set to left, otherwise remove the prop. |  |  |
+| size | "small" \| "medium" \| "large" \| "extra-small" \| "medium-small" \| "medium-large" \| "extra-large" \| undefined | No |  | Yes | Use `width` to customise the Sidebar width. |  |  |
 
 ## Examples
 ### Default
@@ -94,6 +95,37 @@ description: Carbon Sidebar component props and usage examples.
 ```
 
 
+### Responsive Behavior
+
+**Render**
+
+```tsx
+() => {
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
+
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
+      <Sidebar
+        open={isOpen}
+        onCancel={() => setIsOpen(false)}
+        header="Responsive sidebar"
+      >
+        <Form
+          leftSideButtons={<Button buttonType="tertiary">Cancel</Button>}
+          saveButton={<Button buttonType="primary">Save</Button>}
+          stickyFooter
+          onSubmit={(event) => event.preventDefault()}
+        >
+          <Box height="1000px">Long content</Box>
+        </Form>
+      </Sidebar>
+    </>
+  );
+}
+```
+
+
 ### With Restore Focus On Close
 
 **Render**
@@ -118,10 +150,10 @@ description: Carbon Sidebar component props and usage examples.
       {showMessage && (
         <Message
           ref={messageRef}
-          variant="error"
+          variant="info"
           onDismiss={() => setShowMessage(false)}
         >
-          Some custom message
+          Sidebar closed; focus moved to this message.
         </Message>
       )}
       <Sidebar
@@ -155,10 +187,35 @@ description: Carbon Sidebar component props and usage examples.
 ```tsx
 () => {
   const [isOpen, setIsOpen] = useState(defaultOpenState);
+  const [contentPadding, setContentPadding] = useState<"none" | "large">(
+    "large",
+  );
+
   return (
     <>
-      <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
-      <Sidebar open={isOpen} onCancel={() => setIsOpen(false)} p={0}>
+      <Button
+        onClick={() => {
+          setContentPadding("none");
+          setIsOpen(true);
+        }}
+      >
+        Open with no padding
+      </Button>
+      <Button
+        ml={2}
+        onClick={() => {
+          setContentPadding("large");
+          setIsOpen(true);
+        }}
+      >
+        Open with 32px padding
+      </Button>
+      <Sidebar
+        aria-label="Sidebar with custom content padding"
+        open={isOpen}
+        onCancel={() => setIsOpen(false)}
+        p={contentPadding === "none" ? 0 : "var(--global-space-comp-2-xl)"}
+      >
         <Box mb={2}>
           <Button buttonType="primary">Test</Button>
           <Button buttonType="secondary" ml={2}>
@@ -186,7 +243,7 @@ description: Carbon Sidebar component props and usage examples.
       <Sidebar
         open={isOpen}
         onCancel={() => setIsOpen(false)}
-        header={<Typography variant="h3">Sidebar header</Typography>}
+        header="Sidebar header"
       >
         <Box mb={2}>
           <Button buttonType="primary">Test</Button>
@@ -215,7 +272,7 @@ description: Carbon Sidebar component props and usage examples.
       <Sidebar
         open={isOpen}
         onCancel={() => setIsOpen(false)}
-        header={<Typography variant="h3">Sidebar header</Typography>}
+        header="Sidebar header"
         subHeader={
           <Button iconType="chevron_left_thick" buttonType="tertiary">
             Action
@@ -236,7 +293,7 @@ description: Carbon Sidebar component props and usage examples.
 ```
 
 
-### With Dark Header
+### With Inverse Header
 
 **Render**
 
@@ -244,23 +301,14 @@ description: Carbon Sidebar component props and usage examples.
 () => {
   const [isOpen, setIsOpen] = useState(defaultOpenState);
 
-  const headerNode = (
-    <Box display="flex" alignItems="center" gap="8px">
-      <Icon type="chat" inverse />
-      <Typography variant="h2" inverse>
-        Sidebar header
-      </Typography>
-    </Box>
-  );
-
   return (
     <>
       <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
       <Sidebar
         open={isOpen}
         onCancel={() => setIsOpen(false)}
-        header={headerNode}
-        headerVariant="dark"
+        header="Sidebar header"
+        headerVariant="inverse"
       >
         <Box mb={2}>
           <Button buttonType="primary">Test</Button>
@@ -268,6 +316,31 @@ description: Carbon Sidebar component props and usage examples.
             Last
           </Button>
         </Box>
+        Main Content
+      </Sidebar>
+    </>
+  );
+}
+```
+
+
+### With Gradient Keyline
+
+**Render**
+
+```tsx
+() => {
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
+
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
+      <Sidebar
+        open={isOpen}
+        onCancel={() => setIsOpen(false)}
+        header="Sidebar header"
+        gradientKeyLine
+      >
         Main Content
       </Sidebar>
     </>
@@ -289,7 +362,7 @@ description: Carbon Sidebar component props and usage examples.
       <Sidebar
         open={isOpen}
         onCancel={() => setIsOpen(false)}
-        header={<Typography variant="h3">Sidebar header</Typography>}
+        header="Sidebar header"
       >
         <Box mb={2}>
           <Button buttonType="primary">Test</Button>
@@ -320,7 +393,7 @@ description: Carbon Sidebar component props and usage examples.
         position="left"
         open={isOpen}
         onCancel={() => setIsOpen(false)}
-        header={<Typography variant="h3">Sidebar Header</Typography>}
+        header="Sidebar Header"
       >
         <Form
           rightSideButtons={<Button>Action button</Button>}
@@ -414,7 +487,7 @@ description: Carbon Sidebar component props and usage examples.
       <Sidebar
         open={isSidebarOpen}
         onCancel={() => setIsSidebarOpen(false)}
-        header={<Typography variant="h3">Sidebar header</Typography>}
+        header="Sidebar header"
         focusableContainers={[toast1Ref, toast2Ref]}
       >
         <Form
@@ -435,16 +508,14 @@ description: Carbon Sidebar component props and usage examples.
           <Textbox label="First Name" value="" onChange={() => {}} />
           <Textbox label="Middle Name" onChange={() => {}} value="" />
           <Textbox label="Surname" onChange={() => {}} value="" />
-          <Button onClick={() => setIsToast1Open(true)}>
-            Show first toast
-          </Button>
-          <Button
-            ml={2}
-            buttonType="primary"
-            onClick={() => setIsToast2Open(true)}
-          >
-            Show second toast
-          </Button>
+          <Box display="flex" gap={2}>
+            <Button onClick={() => setIsToast1Open(true)}>
+              Show first toast
+            </Button>
+            <Button buttonType="primary" onClick={() => setIsToast2Open(true)}>
+              Show second toast
+            </Button>
+          </Box>
         </Form>
       </Sidebar>
       <Toast
@@ -484,7 +555,7 @@ description: Carbon Sidebar component props and usage examples.
         open={isOpen}
         onCancel={() => setIsOpen(false)}
         width="25%"
-        header={<Typography variant="h3">Sidebar</Typography>}
+        header="Sidebar"
       >
         <Box
           mb={2}
@@ -506,7 +577,7 @@ description: Carbon Sidebar component props and usage examples.
 ```
 
 
-### With Header and Footer Padding
+### Custom Header and Content Padding
 
 **Render**
 
@@ -517,20 +588,18 @@ description: Carbon Sidebar component props and usage examples.
     <>
       <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
       <Sidebar
-        aria-label="sidebar"
-        position="left"
         open={isOpen}
         onCancel={() => setIsOpen(false)}
-        header={<Typography variant="h3">Sidebar Header</Typography>}
-        p={2}
-        headerPadding={{ p: 2 }}
+        header="Sidebar Header — 16px padding"
+        p="var(--global-space-comp-2-xl)"
+        headerPadding={{ p: "var(--global-space-comp-l)" }}
       >
         <Form
           rightSideButtons={<Button>Action button</Button>}
           stickyFooter
           buttonAlignment="right"
-          footerPadding={{ p: 2 }}
         >
+          <Box mb={2}>Content padding: 32px (--global-space-comp-2-xl).</Box>
           <Typography variant="p">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed lectus
             massa, suscipit vitae pellentesque quis, facilisis non ante.

--- a/src/components/sidebar/__internal__/sidebar-header/sidebar-header.component.tsx
+++ b/src/components/sidebar/__internal__/sidebar-header/sidebar-header.component.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { PaddingProps } from "styled-system";
+import Typography from "../../../typography";
 import StyledSidebarHeader, {
+  StyledSidebarHeaderDivider,
   StyledSidebarSubHeader,
 } from "./sidebar-header.style";
 
@@ -9,10 +11,12 @@ export interface SidebarHeaderProps extends PaddingProps {
   children?: React.ReactNode;
   /** A custom id. */
   id: string;
-  /** Close icon button to be rendered */
-  closeIcon?: React.ReactNode;
+  /** Close button to be rendered. */
+  closeButton?: React.ReactNode;
   /** Header background variant for the sidebar. */
-  headerVariant?: "light" | "dark";
+  headerVariant?: "typical" | "inverse" | "light" | "dark";
+  /** Adds the Carbon AI gradient keyline to the header. */
+  gradientKeyLine?: boolean;
 }
 
 export interface SidebarSubHeaderProps extends PaddingProps {
@@ -25,32 +29,45 @@ export interface SidebarSubHeaderProps extends PaddingProps {
 const SidebarHeader = ({
   children,
   id,
-  closeIcon,
+  closeButton,
   headerVariant,
+  gradientKeyLine,
   ...rest
 }: SidebarHeaderProps) => (
   <StyledSidebarHeader
-    hasClose={!!closeIcon}
+    $hasCloseButton={!!closeButton}
     data-component="sidebar-header"
     data-role="sidebar-header"
-    p="27px 32px 32px"
-    headerVariant={headerVariant}
+    $headerVariant={headerVariant}
+    $gradientKeyLine={gradientKeyLine}
     {...rest}
   >
     <div data-element="sidebar-heading" id={id}>
-      {children}
+      {typeof children === "string" ? (
+        <Typography
+          as="h1"
+          data-element="sidebar-title"
+          variant="h2"
+          wordBreak="normal"
+          wordWrap="break-word"
+        >
+          {children}
+        </Typography>
+      ) : (
+        children
+      )}
     </div>
-    {closeIcon}
+    {closeButton}
+    <StyledSidebarHeaderDivider
+      aria-hidden="true"
+      data-element="sidebar-header-divider"
+      $gradientKeyLine={gradientKeyLine}
+    />
   </StyledSidebarHeader>
 );
 
 const SidebarSubHeader = ({ children, id, ...rest }: SidebarSubHeaderProps) => (
-  <StyledSidebarSubHeader
-    data-component="sidebar-subheader"
-    p="var(--sizing100) var(--sizing400)"
-    id={id}
-    {...rest}
-  >
+  <StyledSidebarSubHeader data-component="sidebar-subheader" id={id} {...rest}>
     {children}
   </StyledSidebarSubHeader>
 );

--- a/src/components/sidebar/__internal__/sidebar-header/sidebar-header.style.ts
+++ b/src/components/sidebar/__internal__/sidebar-header/sidebar-header.style.ts
@@ -5,49 +5,108 @@ import StyledIconButton from "../../../icon-button/icon-button.style";
 import StyledIcon from "../../../icon/icon.style";
 
 const StyledSidebarHeader = styled.div.attrs(applyBaseTheme)<{
-  hasClose?: boolean;
-  headerVariant?: "light" | "dark";
+  $hasCloseButton?: boolean;
+  $headerVariant?: "typical" | "inverse" | "light" | "dark";
+  $gradientKeyLine?: boolean;
 }>`
-  background-color: ${({ headerVariant }) =>
-    headerVariant === "light"
-      ? "var(--colorsUtilityYang100)"
-      : "var(--colorsUtilityYin100)"};
-  box-shadow: inset 0 -1px 0 0 var(--colorsUtilityMajor100);
+  ${({ $headerVariant }) => {
+    const inverse = $headerVariant === "inverse" || $headerVariant === "dark";
+
+    return css`
+      background-color: ${inverse
+        ? "var(--container-standard-inverse-bg-default)"
+        : "var(--container-standard-bg-default)"};
+      color: ${inverse
+        ? "var(--container-standard-inverse-txt-default)"
+        : "var(--container-standard-txt-default)"};
+      position: relative;
+    `;
+  }}
   box-sizing: border-box;
+  flex: 0 0 auto;
+  min-height: calc((2 * var(--global-space-comp-xl)) + var(--global-size-s));
   width: 100%;
-  color: var(--colorsActionMinorYin090);
   transition: all 0.2s ease;
+  padding: var(--global-space-comp-xl);
   ${padding}
-  ${({ hasClose, headerVariant }) =>
-    hasClose &&
+  ${({ $hasCloseButton, $headerVariant }) =>
+    $hasCloseButton &&
     css`
       display: flex;
       justify-content: space-between;
-      gap: var(--spacing200);
+      gap: var(--global-space-comp-l);
       > ${StyledIconButton}:first-of-type {
-        ${headerVariant === "dark" &&
+        ${($headerVariant === "inverse" || $headerVariant === "dark") &&
         css`
           ${StyledIcon} {
-            color: var(--colorsUtilityYang080);
+            color: var(--container-standard-inverse-txt-default);
+          }
+
+          &:is(:hover, :active, :focus) ${StyledIcon} {
+            color: var(--container-standard-inverse-txt-default);
+          }
+
+          &:disabled ${StyledIcon} {
+            color: var(--container-standard-inverse-txt-alt);
           }
         `}
         align-self: flex-start;
+        border-radius: var(--global-radius-action-circle);
+        flex: 0 0 auto;
+        height: var(--global-size-s);
+        min-width: var(--global-size-s);
+        width: var(--global-size-s);
+
+        ${StyledIcon} {
+          height: var(--global-size-2-xs);
+          width: var(--global-size-2-xs);
+        }
       }
     `}
   div[data-element="sidebar-heading"] {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: var(--global-space-comp-xs);
+    min-width: 0;
     width: 100%;
+
+    [data-element="sidebar-title"] {
+      color: inherit;
+    }
   }
+`;
+
+const StyledSidebarHeaderDivider = styled.hr.attrs(applyBaseTheme)<{
+  $gradientKeyLine?: boolean;
+}>`
+  background: ${({ $gradientKeyLine }) =>
+    $gradientKeyLine
+      ? "var(--container-standard-border-ai-h)"
+      : "var(--container-standard-border-default)"};
+  border: var(--global-borderwidth-none);
+  bottom: 0;
+  height: ${({ $gradientKeyLine }) =>
+    $gradientKeyLine
+      ? "var(--global-borderwidth-s)"
+      : "var(--global-borderwidth-xs)"};
+  left: 0;
+  margin: 0;
+  position: absolute;
+  right: 0;
 `;
 
 const StyledSidebarSubHeader = styled.div.attrs(applyBaseTheme)`
   box-sizing: border-box;
   width: 100%;
-  color: var(--colorsActionMinorYin090);
-  background-color: var(--colorsUtilityMajor050);
-  border-bottom: 1px solid var(--colorsUtilityMajor075);
+  color: var(--container-standard-txt-default);
+  background-color: var(--container-standard-bg-alt);
+  border-bottom: var(--global-borderwidth-xs) solid
+    var(--container-standard-border-default);
+  padding: var(--global-space-comp-s) var(--global-space-comp-2-xl);
   ${padding}
   transition: all 0.2s ease;
 `;
 
 export default StyledSidebarHeader;
-export { StyledSidebarSubHeader };
+export { StyledSidebarHeaderDivider, StyledSidebarSubHeader };

--- a/src/components/sidebar/components.test-pw.tsx
+++ b/src/components/sidebar/components.test-pw.tsx
@@ -1,19 +1,19 @@
 import React, { useState, useRef } from "react";
 
-import Typography from "../../../src/components/typography";
+import Typography from "../typography";
 import Button from "../button";
 import Sidebar, { SidebarProps } from ".";
 import Box from "../box";
+import Form from "../form";
 import Toast from "../toast";
 import Textbox from "../textbox";
 
-export const Default = ({
+export const ControlledSidebar = ({
   open = true,
   restoreFocusOnClose,
   onCancel: onCancelProp,
-}: {
-  open?: boolean;
-  restoreFocusOnClose?: boolean;
+  ...props
+}: Partial<SidebarProps> & {
   onCancel?: () => void;
 }) => {
   const [isOpen, setIsOpen] = useState(open);
@@ -29,6 +29,7 @@ export const Default = ({
         open={isOpen}
         onCancel={handleCancel}
         restoreFocusOnClose={restoreFocusOnClose}
+        {...props}
       >
         <Box mb={2}>
           <Button buttonType="primary">Test</Button>
@@ -42,7 +43,7 @@ export const Default = ({
   );
 };
 
-export const DefaultNested = () => {
+export const NestedSidebars = () => {
   const [isFirstSidebarOpen, setIsFirstSidebarOpen] = useState(false);
   const [isNestedSidebarOpen, setIsNestedSidebarOpen] = useState(false);
   return (
@@ -73,34 +74,7 @@ export const DefaultNested = () => {
   );
 };
 
-export const SidebarComponentWithOnCancel = (props: Partial<SidebarProps>) => {
-  const [isOpen, setIsOpen] = useState(true);
-  const handleOnCancel = () => {
-    setIsOpen(false);
-  };
-  return (
-    <>
-      <Sidebar
-        aria-label="sidebar"
-        open={isOpen}
-        position="right"
-        size="medium"
-        onCancel={handleOnCancel}
-        {...props}
-      >
-        <Box mb={2}>
-          <Button buttonType="primary">Test</Button>
-          <Button buttonType="secondary" ml={2}>
-            Last
-          </Button>
-        </Box>
-        <Box mb="3000px">Main content</Box>
-      </Sidebar>
-    </>
-  );
-};
-
-export const SidebarBackgroundScrollTestComponent = () => {
+export const SidebarWithBackgroundScrollTarget = () => {
   const [value, setValue] = useState("");
 
   return (
@@ -126,7 +100,7 @@ export const SidebarBackgroundScrollTestComponent = () => {
   );
 };
 
-export const SidebarBackgroundScrollWithOtherFocusableContainers = () => {
+export const SidebarWithBackgroundScrollTargetAndFocusableContainers = () => {
   const toast1Ref = useRef(null);
   const toast2Ref = useRef(null);
   const [value, setValue] = useState("");
@@ -164,10 +138,10 @@ export const SidebarBackgroundScrollWithOtherFocusableContainers = () => {
   );
 };
 
-export const SidebarComponentFocusable = (props: Partial<SidebarProps>) => {
-  const [setIsDialogOpen] = React.useState(false);
-  const [isToastOpen, setIsToastOpen] = React.useState(false);
-  const toastRef = React.useRef(null);
+export const SidebarWithFocusableContainer = (props: Partial<SidebarProps>) => {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true);
+  const [isToastOpen, setIsToastOpen] = useState(false);
+  const toastRef = useRef(null);
   const CUSTOM_SELECTOR = "button, .focusable-container input";
   const [value, setValue] = useState("");
   const [value2, setValue2] = useState("");
@@ -175,8 +149,8 @@ export const SidebarComponentFocusable = (props: Partial<SidebarProps>) => {
   return (
     <>
       <Sidebar
-        open
-        onCancel={() => setIsDialogOpen}
+        open={isSidebarOpen}
+        onCancel={() => setIsSidebarOpen(false)}
         header={<Typography variant="h3">Sidebar header</Typography>}
         focusableContainers={[toastRef]}
         focusableSelectors={CUSTOM_SELECTOR}
@@ -220,3 +194,26 @@ export const SidebarComponentFocusable = (props: Partial<SidebarProps>) => {
     </>
   );
 };
+
+export const SidebarWithStickyForm = () => (
+  <Sidebar open onCancel={() => {}} header="Sidebar with sticky footer">
+    <Form
+      saveButton={<Button buttonType="primary">Save</Button>}
+      stickyFooter
+      onSubmit={(event) => event.preventDefault()}
+    >
+      <Box height="1200px">Long content</Box>
+    </Form>
+  </Sidebar>
+);
+
+export const SidebarWithTallStickyFormFooter = () => (
+  <Sidebar open onCancel={() => {}} header="Sidebar with tall sticky footer">
+    <Form
+      footerChildren={<Box height="128px">Footer content</Box>}
+      stickyFooter
+    >
+      content
+    </Form>
+  </Sidebar>
+);

--- a/src/components/sidebar/sidebar-test.stories.tsx
+++ b/src/components/sidebar/sidebar-test.stories.tsx
@@ -5,7 +5,6 @@ import isChromatic from "../../../.storybook/isChromatic";
 import allModes from "../../../.storybook/modes";
 
 import Box from "../box";
-import Icon from "../icon";
 import Button from "../button";
 import Form from "../form";
 import Sidebar, { SidebarProps } from ".";
@@ -93,6 +92,19 @@ const meta: Meta<typeof Sidebar> = {
 
 export default meta;
 
+const InteractiveSidebar = ({ children, ...props }: Partial<SidebarProps>) => {
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
+      <Sidebar {...props} open={isOpen} onCancel={() => setIsOpen(false)}>
+        {children}
+      </Sidebar>
+    </>
+  );
+};
+
 export const Default = (args: Partial<SidebarProps>) => {
   const [isOpen, setIsOpen] = useState(true);
   const onCancel = () => {
@@ -118,8 +130,6 @@ export const Default = (args: Partial<SidebarProps>) => {
 
 Default.storyName = "default";
 Default.args = {
-  position: "right",
-  size: "medium",
   enableBackgroundUI: false,
   disableEscKey: false,
 };
@@ -131,12 +141,7 @@ Default.parameters = {
 
 export const WithStickyForm: StoryObj<typeof Sidebar> = {
   render: (args) => (
-    <Sidebar
-      {...args}
-      header={<Typography variant="h3">With sticky form</Typography>}
-      open
-      onCancel={() => {}}
-    >
+    <InteractiveSidebar {...args} header="With sticky form">
       <Form
         fieldSpacing={2}
         leftSideButtons={<Button buttonType="tertiary">Cancel</Button>}
@@ -152,18 +157,13 @@ export const WithStickyForm: StoryObj<typeof Sidebar> = {
         <Textbox label="Textbox" value="" onChange={() => {}} />
         <Textbox label="Textbox" value="" onChange={() => {}} />
       </Form>
-    </Sidebar>
+    </InteractiveSidebar>
   ),
 };
 
 export const WithForm: StoryObj<typeof Sidebar> = {
   render: (args) => (
-    <Sidebar
-      {...args}
-      header={<Typography variant="h3">With form</Typography>}
-      open
-      onCancel={() => {}}
-    >
+    <InteractiveSidebar {...args} header="With form">
       <Form
         fieldSpacing={2}
         leftSideButtons={<Button buttonType="tertiary">Cancel</Button>}
@@ -178,7 +178,7 @@ export const WithForm: StoryObj<typeof Sidebar> = {
         <Textbox label="Textbox" value="" onChange={() => {}} />
         <Textbox label="Textbox" value="" onChange={() => {}} />
       </Form>
-    </Sidebar>
+    </InteractiveSidebar>
   ),
 };
 WithForm.parameters = { chromatic: { disableSnapshot: true } };
@@ -236,15 +236,7 @@ export const WithStepFlow: StoryObj<typeof Sidebar> = {
   },
 };
 
-export const DarkHeaderExampleImplementation = () => {
-  const headerNode = (
-    <Box display="flex" alignItems="center" gap="8px">
-      <Icon type="chat" inverse />
-      <Typography variant="h2" inverse>
-        Sidebar header
-      </Typography>
-    </Box>
-  );
+export const InverseHeaderExampleImplementation = () => {
   const footerNode = (
     <Box>
       <Typography>
@@ -258,40 +250,35 @@ export const DarkHeaderExampleImplementation = () => {
   );
 
   return (
-    <Sidebar
-      header={headerNode}
-      headerVariant="dark"
+    <InteractiveSidebar
+      header="Sidebar header"
+      headerVariant="inverse"
       subHeader={
         <Button iconType="chevron_left_thick" buttonType="tertiary">
           Action
         </Button>
       }
-      open
-      onCancel={() => {}}
     >
       <Form
         stickyFooterVariant="grey"
         footerChildren={footerNode}
         stickyFooter
       />
-    </Sidebar>
+    </InteractiveSidebar>
   );
 };
 
 export const WithLongHeader = () => {
-  const headerNode = (
-    <Typography variant="h2">
-      Really long header that should not overlap with the close button
-    </Typography>
-  );
-
   return (
-    <Sidebar header={headerNode} open onCancel={() => {}} width="460px">
+    <InteractiveSidebar
+      header="Really long header that should not overlap with the close button"
+      width="460px"
+    >
       Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint iure
       assumenda recusandae veniam deleniti adipisci dicta exercitationem
       delectus atque, quidem, eaque facilis dignissimos rem, minus cupiditate ad
       sed dolorem minima?
-    </Sidebar>
+    </InteractiveSidebar>
   );
 };
 
@@ -307,19 +294,17 @@ const DynamicWidthAfterMountComponent = (args: Partial<SidebarProps>) => {
   }, []);
 
   return (
-    <Sidebar
+    <InteractiveSidebar
       {...args}
       aria-label="sidebar"
-      header={<Typography variant="h2">Dynamic width after mount</Typography>}
-      open
-      onCancel={() => {}}
+      header="Dynamic width after mount"
       width={width}
     >
       <Typography variant="p">
         This story updates the sidebar width a little bit after the initial
         mount.
       </Typography>
-    </Sidebar>
+    </InteractiveSidebar>
   );
 };
 

--- a/src/components/sidebar/sidebar.component.tsx
+++ b/src/components/sidebar/sidebar.component.tsx
@@ -1,8 +1,12 @@
 import React, { useCallback, useRef, RefObject } from "react";
 import { PaddingProps, WidthProps } from "styled-system";
 
-import Modal, { ModalProps } from "../../__internal__/modal";
-import { StyledSidebar, StyledSidebarContent } from "./sidebar.style";
+import type { ModalProps } from "../../__internal__/modal";
+import {
+  StyledSidebar,
+  StyledSidebarContent,
+  StyledSidebarModal,
+} from "./sidebar.style";
 import IconButton from "../icon-button";
 import Icon from "../icon";
 import FocusTrap from "../../__internal__/focus-trap";
@@ -10,7 +14,9 @@ import SidebarHeader, { SidebarSubHeader } from "./__internal__/sidebar-header";
 import createGuid from "../../__internal__/utils/helpers/guid";
 import useLocale from "../../hooks/__internal__/useLocale";
 import { filterStyledSystemPaddingProps } from "../../style/utils";
-import tagComponent, { TagProps } from "../../__internal__/utils/helpers/tags";
+import tagComponent, {
+  type TagProps,
+} from "../../__internal__/utils/helpers/tags";
 import useModalAria from "../../hooks/__internal__/useModalAria/useModalAria";
 import SidebarContext from "./__internal__/sidebar.context";
 import useMediaQuery from "../../hooks/useMediaQuery";
@@ -23,14 +29,13 @@ export interface SidebarProps
   /** Prop to specify the aria-describedby property of the component */
   "aria-describedby"?: string;
   /**
-   * Prop to specify the aria-label of the component.
-   * To be used only when the header prop is not defined, and the component is not labelled by any internal element.
+   * Provides an explicit accessible name for the component, overriding the
+   * automatic association with the header.
    */
   "aria-label"?: string;
   /**
-   * Prop to specify the aria-labelledby property of the component
-   * To be used when the header prop is a custom React Node,
-   * or the component is labelled by an internal element other than the header.
+   * Identifies the element that provides an explicit accessible name for the
+   * component, overriding the automatic association with the header.
    */
   "aria-labelledby"?: string;
   /** Modal content */
@@ -59,8 +64,13 @@ export interface SidebarProps
   header?: React.ReactNode;
   /** Node that will be used as sidebar subheader. */
   subHeader?: React.ReactNode;
-  /** Header background variant for the sidebar. */
-  headerVariant?: "light" | "dark";
+  /**
+   * Header background variant for the sidebar.
+   * `light` and `dark` are deprecated aliases - use `typical` and `inverse` instead.
+   */
+  headerVariant?: "typical" | "inverse" | "light" | "dark";
+  /** Adds the Carbon AI gradient keyline to the header. */
+  gradientKeyLine?: boolean;
   /** A custom close event handler */
   onCancel?: (
     ev:
@@ -70,11 +80,15 @@ export interface SidebarProps
   ) => void;
   /** Sets the open state of the modal */
   open: boolean;
-  /** Sets the position of sidebar, either left or right. */
+  /** @deprecated This prop will be removed in a future release.
+   * Sidebar will always be positioned on the right.
+   * Update the layout to support a right-positioned Sidebar if it is set to
+   * left, otherwise remove the prop.
+   * */
   position?: "left" | "right";
   /** The ARIA role to be applied to the component container */
   role?: string;
-  /** Sets the size of the sidebar when open. */
+  /** @deprecated Use `width` to customise the Sidebar width. */
   size?:
     | "extra-small"
     | "small"
@@ -118,10 +132,11 @@ export const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
       disableEscKey = false,
       enableBackgroundUI = false,
       header,
-      headerVariant = "light",
+      headerVariant = "typical",
+      gradientKeyLine = false,
       subHeader,
       position = "right",
-      size = "medium",
+      size,
       children,
       onCancel,
       role = "dialog",
@@ -163,7 +178,7 @@ export const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
 
     const isTopModal = useModalAria(sidebarRef, hidden);
 
-    const closeIcon = () => {
+    const renderCloseButton = () => {
       if (!onCancel) return null;
       return (
         <IconButton
@@ -179,13 +194,19 @@ export const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
       );
     };
 
+    const closeButton = renderCloseButton();
+    const hasHeader = Boolean(header);
+    const hasSubHeader = Boolean(subHeader);
+
     const sidebar = (
       <StyledSidebar
         aria-modal={!enableBackgroundUI && isTopModal}
-        aria-describedby={!ariaDescribedBy ? subHeaderId : ariaDescribedBy}
+        aria-describedby={
+          !ariaDescribedBy && hasSubHeader ? subHeaderId : ariaDescribedBy
+        }
         aria-label={ariaLabel}
         aria-labelledby={
-          !ariaLabelledBy && !ariaLabel ? headerId : ariaLabelledBy
+          ariaLabelledBy || (!ariaLabel && hasHeader ? headerId : undefined)
         }
         data-component="sidebar"
         data-element={dataElement}
@@ -193,28 +214,28 @@ export const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
         ref={setRefs}
         position={position}
         size={size}
-        onCancel={onCancel}
         role={role}
         width={width}
         widthAnimation={widthAnimation && allowMotion}
         className={className}
       >
-        {header && (
+        {hasHeader && (
           <SidebarHeader
             headerVariant={headerVariant}
-            closeIcon={closeIcon()}
+            gradientKeyLine={gradientKeyLine}
+            closeButton={closeButton}
             {...headerPadding}
             id={headerId}
           >
             {header}
           </SidebarHeader>
         )}
-        {subHeader && (
+        {hasSubHeader && (
           <SidebarSubHeader {...subHeaderPadding} id={subHeaderId}>
             {subHeader}
           </SidebarSubHeader>
         )}
-        {!header && closeIcon()}
+        {!hasHeader && closeButton}
         <StyledSidebarContent
           data-element="sidebar-content"
           data-role="sidebar-content"
@@ -229,7 +250,7 @@ export const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
     );
 
     return (
-      <Modal
+      <StyledSidebarModal
         open={open}
         onCancel={onCancel}
         disableEscKey={disableEscKey}
@@ -252,7 +273,7 @@ export const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
             {sidebar}
           </FocusTrap>
         )}
-      </Modal>
+      </StyledSidebarModal>
     );
   },
 );

--- a/src/components/sidebar/sidebar.mdx
+++ b/src/components/sidebar/sidebar.mdx
@@ -30,7 +30,9 @@ import * as SidebarStories from "./sidebar.stories.tsx";
 import Sidebar from "carbon-react/lib/components/sidebar";
 ```
 
-- Sidebar is positioned on the right hand screen of the window by default. To position the sidebar on the left hand side pass `position='left'` to the component.
+- Sidebar is positioned on the right and uses a fluid `30vw` width with a `288px` minimum by default. At 768px and below it occupies the full viewport width without a dimmer, and its content regions scroll together.
+
+- The `position` and preset `size` props are deprecated. Existing explicit values remain supported during migration; use `width` for desktop width customisation.
 
 - The background behind the sidebar is disabled by default. To allow the user to interact with all the UI pass `enableBackgroundUI={ true }` to the component
 
@@ -48,6 +50,12 @@ to ensure behaviour is consistent across all browsers.
 
 <Canvas of={SidebarStories.DefaultStory} />
 
+### Responsive behavior
+
+Above 768px, the Sidebar uses its desktop width and keeps a sticky footer visible while the content scrolls (see [Quick Start](#quick-start) for the full-viewport behaviour at 768px and below).
+
+<Canvas of={SidebarStories.ResponsiveBehavior} />
+
 ### Preventing focus from being restored when Sidebar closes
 
 When the `restoreFocusOnClose` prop is `false`, focus will not be restored to the element that was focused before the `Sidebar` was opened.
@@ -61,11 +69,21 @@ Focus can instead be programmatically applied to another element if appropriate.
 
 ### With header
 
+String headers are rendered as an `h1`. String and custom React node headers are automatically associated with the dialog. Use `aria-labelledby` or `aria-label` to provide an explicit accessible name instead.
+
 <Canvas of={SidebarStories.WithHeader} />
 
-### With dark header
+### With inverse header
 
-<Canvas of={SidebarStories.WithDarkHeader} />
+Use `headerVariant="inverse"` for the dark treatment. The legacy `dark` and `light` values remain supported as deprecated aliases for `inverse` and `typical`.
+
+<Canvas of={SidebarStories.WithInverseHeader} />
+
+### With gradient keyline
+
+Setting `gradientKeyLine` adds the Carbon AI gradient keyline without changing the header's accessible name.
+
+<Canvas of={SidebarStories.WithGradientKeyLine} />
 
 ### With header and subheader
 
@@ -92,13 +110,15 @@ This may occasionally be useful with things like Toasts where they persist on th
 ### Custom width
 
 It is possible to set a custom width for the `Sidebar` via the `width` [prop](#props).
-Setting this prop will override the preset width value defined via the `size` prop.
+The custom width applies above 768px and cannot reduce the rendered width below 288px.
 
 <Canvas of={SidebarStories.CustomWidth} />
 
-### With header and footer padding overridden
+### Custom header and content padding
 
-<Canvas of={SidebarStories.WithHeaderAndFooterPadding} />
+The header and content padding can be customized independently. Form footers retain their own component styling.
+
+<Canvas of={SidebarStories.CustomHeaderAndContentPadding} />
 
 ### Top modal override
 

--- a/src/components/sidebar/sidebar.pw.tsx
+++ b/src/components/sidebar/sidebar.pw.tsx
@@ -7,26 +7,27 @@ import {
 } from "../../../playwright/components";
 import { sidebarPreview } from "../../../playwright/components/sidebar";
 import {
-  assertCssValueIsApproximately,
   checkAccessibility,
   continuePressingSHIFTTAB,
   continuePressingTAB,
   waitForAnimationEnd,
 } from "../../../playwright/support/helper";
 import {
-  Default,
-  DefaultNested,
-  SidebarBackgroundScrollTestComponent,
-  SidebarBackgroundScrollWithOtherFocusableContainers,
-  SidebarComponentFocusable,
+  ControlledSidebar,
+  NestedSidebars,
+  SidebarWithBackgroundScrollTarget,
+  SidebarWithBackgroundScrollTargetAndFocusableContainers,
+  SidebarWithFocusableContainer,
+  SidebarWithStickyForm,
+  SidebarWithTallStickyFormFooter,
 } from "./components.test-pw";
 
 test.describe("Focus management and interaction tests for Sidebar component", () => {
-  test("should render component with focusableContainers", async ({
+  test("allows an additional focusable container to remain interactive", async ({
     mount,
     page,
   }) => {
-    await mount(<SidebarComponentFocusable />);
+    await mount(<SidebarWithFocusableContainer />);
 
     const toastElement = getComponent(page, "toast");
 
@@ -45,11 +46,11 @@ test.describe("Focus management and interaction tests for Sidebar component", ()
     await expect(toastElement).toBeHidden();
   });
 
-  test("should render component with first input and button as focusableSelectors", async ({
+  test("uses focusableSelectors to skip excluded inputs during tab navigation", async ({
     mount,
     page,
   }) => {
-    await mount(<SidebarComponentFocusable />);
+    await mount(<SidebarWithFocusableContainer />);
 
     const sidebarPreviewElement = sidebarPreview(page);
     await sidebarPreviewElement.press("Tab");
@@ -69,11 +70,11 @@ test.describe("Focus management and interaction tests for Sidebar component", ()
     await expect(openToastElement).toBeFocused();
   });
 
-  test("should return focus to the Toast within component after non-focusable content has been selected", async ({
+  test("includes the Toast close button in the tab order", async ({
     mount,
     page,
   }) => {
-    await mount(<SidebarComponentFocusable />);
+    await mount(<SidebarWithFocusableContainer />);
 
     const toastElement = getComponent(page, "toast");
 
@@ -94,7 +95,7 @@ test.describe("Focus management and interaction tests for Sidebar component", ()
     mount,
     page,
   }) => {
-    await mount(<Default open={false} />);
+    await mount(<ControlledSidebar open={false} />);
 
     const button = page.getByRole("button").filter({ hasText: "Open sidebar" });
     const sidebar = sidebarPreview(page);
@@ -113,7 +114,7 @@ test.describe("Focus management and interaction tests for Sidebar component", ()
     mount,
     page,
   }) => {
-    await mount(<Default />);
+    await mount(<ControlledSidebar />);
 
     const sidebar = sidebarPreview(page);
     await expect(sidebar).toBeVisible();
@@ -130,11 +131,11 @@ test.describe("Focus management and interaction tests for Sidebar component", ()
     await expect(button).toBeFocused();
   });
 
-  test("when nested Sidebar's are opened/closed their respective call to action elements should be focused correctly", async ({
+  test("when nested Sidebars are opened and closed, focus returns to their respective call-to-action elements", async ({
     mount,
     page,
   }) => {
-    await mount(<DefaultNested />);
+    await mount(<NestedSidebars />);
 
     const firstButton = page
       .getByRole("button")
@@ -166,7 +167,7 @@ test.describe("Focus management and interaction tests for Sidebar component", ()
     mount,
     page,
   }) => {
-    await mount(<Default open={false} restoreFocusOnClose={false} />);
+    await mount(<ControlledSidebar open={false} restoreFocusOnClose={false} />);
 
     const button = page.getByRole("button").filter({ hasText: "Open sidebar" });
     const sidebar = sidebarPreview(page);
@@ -183,20 +184,104 @@ test.describe("Focus management and interaction tests for Sidebar component", ()
 });
 
 test.describe("Browser-specific rendering", () => {
-  test("check component has correctly styling when zoom is 400%", async ({
+  test("uses the fluid right-positioned desktop presentation above 768px", async ({
     mount,
     page,
   }) => {
-    await mount(<Default />);
+    await page.setViewportSize({ width: 1000, height: 800 });
+    await mount(<ControlledSidebar />);
 
-    // 4.0 zoom is equal to 400%
-    await page.evaluate("document.body.style.zoom=4.0");
+    const sidebar = sidebarPreview(page);
+    await expect(sidebar).toHaveCSS("width", "300px");
+    await expect(sidebar).toHaveCSS("min-width", "288px");
+    await expect(sidebar).toHaveCSS("right", "0px");
+    await expect(sidebar).toHaveCSS("border-radius", "24px 0px 0px 24px");
+    await expect(sidebar).toHaveCSS("overflow", "hidden");
+    await expect(getDataElementByValue(page, "modal-background")).toBeVisible();
+  });
 
-    await assertCssValueIsApproximately(
-      sidebarPreview(page),
-      "max-width",
-      1366,
-    );
+  test("uses the 288px desktop minimum width immediately above 768px", async ({
+    mount,
+    page,
+  }) => {
+    await page.setViewportSize({ width: 769, height: 800 });
+    await mount(<ControlledSidebar />);
+
+    const sidebar = sidebarPreview(page);
+    await expect(sidebar).toHaveCSS("width", "288px");
+    await expect(sidebar).toHaveCSS("right", "0px");
+    await expect(sidebar).toHaveCSS("border-radius", "24px 0px 0px 24px");
+    await expect(getDataElementByValue(page, "modal-background")).toBeVisible();
+  });
+
+  test("caps an oversized legacy preset width to the viewport", async ({
+    mount,
+    page,
+  }) => {
+    await page.setViewportSize({ width: 769, height: 800 });
+    await mount(<ControlledSidebar size="extra-large" />);
+
+    await expect(sidebarPreview(page)).toHaveCSS("width", "769px");
+  });
+
+  test("caps an oversized custom width to the viewport", async ({
+    mount,
+    page,
+  }) => {
+    await page.setViewportSize({ width: 769, height: 800 });
+    await mount(<ControlledSidebar width="1000px" />);
+
+    await expect(sidebarPreview(page)).toHaveCSS("width", "769px");
+  });
+
+  test("uses the fullscreen presentation without a dimmer at 768px", async ({
+    mount,
+    page,
+  }) => {
+    await page.setViewportSize({ width: 768, height: 800 });
+    await mount(<ControlledSidebar width="400px" />);
+
+    const sidebar = sidebarPreview(page);
+    await expect(sidebar).toHaveCSS("width", "768px");
+    await expect(sidebar).toHaveCSS("border-radius", "0px");
+    await expect(sidebar).toHaveCSS("overflow-y", "auto");
+    await expect(getDataElementByValue(page, "modal-background")).toBeHidden();
+    await expect(sidebar).toHaveAttribute("aria-modal", "true");
+  });
+
+  test("makes a sticky footer part of the whole Sidebar scroll at 768px", async ({
+    mount,
+    page,
+  }) => {
+    await page.setViewportSize({ width: 769, height: 800 });
+    await mount(<SidebarWithStickyForm />);
+
+    const sidebar = sidebarPreview(page);
+    const footer = page.getByTestId("form-footer");
+    await expect(footer).toHaveCSS("position", "sticky");
+
+    await page.setViewportSize({ width: 768, height: 800 });
+    await expect(footer).toHaveCSS("position", "static");
+    await expect(sidebar).toHaveCSS("overflow-y", "auto");
+    await expect
+      .poll(() =>
+        sidebar.evaluate(
+          (element) => element.scrollHeight > element.clientHeight,
+        ),
+      )
+      .toBe(true);
+  });
+
+  test("does not constrain custom sticky footer height", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<SidebarWithTallStickyFormFooter />);
+
+    const footer = page.getByTestId("form-footer");
+    await expect
+      .poll(() => footer.evaluate((element) => element.clientHeight))
+      .toBeGreaterThanOrEqual(128);
   });
 
   test.describe("Check background scroll when tabbing", () => {
@@ -205,7 +290,7 @@ test.describe("Browser-specific rendering", () => {
       mount,
       page,
     }) => {
-      await mount(<SidebarBackgroundScrollTestComponent />);
+      await mount(<SidebarWithBackgroundScrollTarget />);
 
       await continuePressingTAB(page, 3);
       const closeIconButtonElement = closeIconButton(page);
@@ -221,7 +306,7 @@ test.describe("Browser-specific rendering", () => {
       mount,
       page,
     }) => {
-      await mount(<SidebarBackgroundScrollTestComponent />);
+      await mount(<SidebarWithBackgroundScrollTarget />);
 
       await continuePressingSHIFTTAB(page, 1);
       const closeIconButtonElement = closeIconButton(page);
@@ -237,7 +322,7 @@ test.describe("Browser-specific rendering", () => {
       mount,
       page,
     }) => {
-      await mount(<SidebarBackgroundScrollWithOtherFocusableContainers />);
+      await mount(<SidebarWithBackgroundScrollTargetAndFocusableContainers />);
 
       await continuePressingTAB(page, 6);
       await waitForAnimationEnd(sidebarPreview(page));
@@ -254,7 +339,7 @@ test.describe("Browser-specific rendering", () => {
       mount,
       page,
     }) => {
-      await mount(<SidebarBackgroundScrollWithOtherFocusableContainers />);
+      await mount(<SidebarWithBackgroundScrollTargetAndFocusableContainers />);
 
       await continuePressingSHIFTTAB(page, 7);
       const closeIconButtonElement = closeIconButton(page).nth(0);
@@ -272,7 +357,7 @@ test.describe("Accessibility tests for Sidebar component", () => {
     mount,
     page,
   }) => {
-    await mount(<Default />);
+    await mount(<ControlledSidebar />);
 
     await checkAccessibility(page);
   });

--- a/src/components/sidebar/sidebar.stories.tsx
+++ b/src/components/sidebar/sidebar.stories.tsx
@@ -15,7 +15,6 @@ import Confirm from "../confirm";
 import Message from "../message";
 
 import Sidebar from ".";
-import Icon from "../icon";
 
 const styledSystemProps = generateStyledSystemProps({
   padding: true,
@@ -85,7 +84,45 @@ export const DefaultStory: Story = () => {
   );
 };
 DefaultStory.storyName = "Default";
-DefaultStory.parameters = { chromatic: { disableSnapshot: true } };
+
+export const ResponsiveBehavior: Story = () => {
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
+
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
+      <Sidebar
+        open={isOpen}
+        onCancel={() => setIsOpen(false)}
+        header="Responsive sidebar"
+      >
+        <Form
+          leftSideButtons={<Button buttonType="tertiary">Cancel</Button>}
+          saveButton={<Button buttonType="primary">Save</Button>}
+          stickyFooter
+          onSubmit={(event) => event.preventDefault()}
+        >
+          <Box height="1000px">Long content</Box>
+        </Form>
+      </Sidebar>
+    </>
+  );
+};
+ResponsiveBehavior.storyName = "Responsive Behavior";
+ResponsiveBehavior.parameters = {
+  chromatic: {
+    modes: {
+      aboveBreakpoint: {
+        ...allModes.chromatic,
+        viewport: { ...allModes.chromatic.viewport, width: 769 },
+      },
+      atBreakpoint: {
+        ...allModes.chromatic,
+        viewport: { ...allModes.chromatic.viewport, width: 768 },
+      },
+    },
+  },
+};
 
 export const RestoreFocusOnCloseStory: Story = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -106,10 +143,10 @@ export const RestoreFocusOnCloseStory: Story = () => {
       {showMessage && (
         <Message
           ref={messageRef}
-          variant="error"
+          variant="info"
           onDismiss={() => setShowMessage(false)}
         >
-          Some custom message
+          Sidebar closed; focus moved to this message.
         </Message>
       )}
       <Sidebar
@@ -138,10 +175,35 @@ RestoreFocusOnCloseStory.parameters = { chromatic: { disableSnapshot: true } };
 
 export const CustomPaddingAroundContent: Story = () => {
   const [isOpen, setIsOpen] = useState(defaultOpenState);
+  const [contentPadding, setContentPadding] = useState<"none" | "large">(
+    "large",
+  );
+
   return (
     <>
-      <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
-      <Sidebar open={isOpen} onCancel={() => setIsOpen(false)} p={0}>
+      <Button
+        onClick={() => {
+          setContentPadding("none");
+          setIsOpen(true);
+        }}
+      >
+        Open with no padding
+      </Button>
+      <Button
+        ml={2}
+        onClick={() => {
+          setContentPadding("large");
+          setIsOpen(true);
+        }}
+      >
+        Open with 32px padding
+      </Button>
+      <Sidebar
+        aria-label="Sidebar with custom content padding"
+        open={isOpen}
+        onCancel={() => setIsOpen(false)}
+        p={contentPadding === "none" ? 0 : "var(--global-space-comp-2-xl)"}
+      >
         <Box mb={2}>
           <Button buttonType="primary">Test</Button>
           <Button buttonType="secondary" ml={2}>
@@ -163,7 +225,7 @@ export const WithHeader: Story = () => {
       <Sidebar
         open={isOpen}
         onCancel={() => setIsOpen(false)}
-        header={<Typography variant="h3">Sidebar header</Typography>}
+        header="Sidebar header"
       >
         <Box mb={2}>
           <Button buttonType="primary">Test</Button>
@@ -177,7 +239,6 @@ export const WithHeader: Story = () => {
   );
 };
 WithHeader.storyName = "With Header";
-WithHeader.parameters = { chromatic: { disableSnapshot: true } };
 
 export const WithHeaderAndSubheader: Story = () => {
   const [isOpen, setIsOpen] = useState(defaultOpenState);
@@ -187,7 +248,7 @@ export const WithHeaderAndSubheader: Story = () => {
       <Sidebar
         open={isOpen}
         onCancel={() => setIsOpen(false)}
-        header={<Typography variant="h3">Sidebar header</Typography>}
+        header="Sidebar header"
         subHeader={
           <Button iconType="chevron_left_thick" buttonType="tertiary">
             Action
@@ -207,17 +268,8 @@ export const WithHeaderAndSubheader: Story = () => {
 };
 WithHeaderAndSubheader.storyName = "With Header And Subheader";
 
-export const WithDarkHeader: Story = () => {
+export const WithInverseHeader: Story = () => {
   const [isOpen, setIsOpen] = useState(defaultOpenState);
-
-  const headerNode = (
-    <Box display="flex" alignItems="center" gap="8px">
-      <Icon type="chat" inverse />
-      <Typography variant="h2" inverse>
-        Sidebar header
-      </Typography>
-    </Box>
-  );
 
   return (
     <>
@@ -225,8 +277,8 @@ export const WithDarkHeader: Story = () => {
       <Sidebar
         open={isOpen}
         onCancel={() => setIsOpen(false)}
-        header={headerNode}
-        headerVariant="dark"
+        header="Sidebar header"
+        headerVariant="inverse"
       >
         <Box mb={2}>
           <Button buttonType="primary">Test</Button>
@@ -239,7 +291,26 @@ export const WithDarkHeader: Story = () => {
     </>
   );
 };
-WithDarkHeader.storyName = "With Dark Header";
+WithInverseHeader.storyName = "With Inverse Header";
+
+export const WithGradientKeyLine: Story = () => {
+  const [isOpen, setIsOpen] = useState(defaultOpenState);
+
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
+      <Sidebar
+        open={isOpen}
+        onCancel={() => setIsOpen(false)}
+        header="Sidebar header"
+        gradientKeyLine
+      >
+        Main Content
+      </Sidebar>
+    </>
+  );
+};
+WithGradientKeyLine.storyName = "With Gradient Keyline";
 
 export const WithScroll: Story = () => {
   const [isOpen, setIsOpen] = useState(defaultOpenState);
@@ -249,7 +320,7 @@ export const WithScroll: Story = () => {
       <Sidebar
         open={isOpen}
         onCancel={() => setIsOpen(false)}
-        header={<Typography variant="h3">Sidebar header</Typography>}
+        header="Sidebar header"
       >
         <Box mb={2}>
           <Button buttonType="primary">Test</Button>
@@ -275,7 +346,7 @@ export const WithTypography: Story = () => {
         position="left"
         open={isOpen}
         onCancel={() => setIsOpen(false)}
-        header={<Typography variant="h3">Sidebar Header</Typography>}
+        header="Sidebar Header"
       >
         <Form
           rightSideButtons={<Button>Action button</Button>}
@@ -363,7 +434,7 @@ export const OtherFocusableContainers: Story = () => {
       <Sidebar
         open={isSidebarOpen}
         onCancel={() => setIsSidebarOpen(false)}
-        header={<Typography variant="h3">Sidebar header</Typography>}
+        header="Sidebar header"
         focusableContainers={[toast1Ref, toast2Ref]}
       >
         <Form
@@ -384,16 +455,14 @@ export const OtherFocusableContainers: Story = () => {
           <Textbox label="First Name" value="" onChange={() => {}} />
           <Textbox label="Middle Name" onChange={() => {}} value="" />
           <Textbox label="Surname" onChange={() => {}} value="" />
-          <Button onClick={() => setIsToast1Open(true)}>
-            Show first toast
-          </Button>
-          <Button
-            ml={2}
-            buttonType="primary"
-            onClick={() => setIsToast2Open(true)}
-          >
-            Show second toast
-          </Button>
+          <Box display="flex" gap={2}>
+            <Button onClick={() => setIsToast1Open(true)}>
+              Show first toast
+            </Button>
+            <Button buttonType="primary" onClick={() => setIsToast2Open(true)}>
+              Show second toast
+            </Button>
+          </Box>
         </Form>
       </Sidebar>
       <Toast
@@ -428,7 +497,7 @@ export const CustomWidth: Story = () => {
         open={isOpen}
         onCancel={() => setIsOpen(false)}
         width="25%"
-        header={<Typography variant="h3">Sidebar</Typography>}
+        header="Sidebar"
       >
         <Box
           mb={2}
@@ -449,26 +518,24 @@ export const CustomWidth: Story = () => {
 };
 CustomWidth.storyName = "Custom Width";
 
-export const WithHeaderAndFooterPadding: Story = () => {
+export const CustomHeaderAndContentPadding: Story = () => {
   const [isOpen, setIsOpen] = useState(defaultOpenState);
   return (
     <>
       <Button onClick={() => setIsOpen(true)}>Open sidebar</Button>
       <Sidebar
-        aria-label="sidebar"
-        position="left"
         open={isOpen}
         onCancel={() => setIsOpen(false)}
-        header={<Typography variant="h3">Sidebar Header</Typography>}
-        p={2}
-        headerPadding={{ p: 2 }}
+        header="Sidebar Header — 16px padding"
+        p="var(--global-space-comp-2-xl)"
+        headerPadding={{ p: "var(--global-space-comp-l)" }}
       >
         <Form
           rightSideButtons={<Button>Action button</Button>}
           stickyFooter
           buttonAlignment="right"
-          footerPadding={{ p: 2 }}
         >
+          <Box mb={2}>Content padding: 32px (--global-space-comp-2-xl).</Box>
           <Typography variant="p">
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed lectus
             massa, suscipit vitae pellentesque quis, facilisis non ante.
@@ -489,7 +556,7 @@ export const WithHeaderAndFooterPadding: Story = () => {
     </>
   );
 };
-WithHeaderAndFooterPadding.storyName = "With Header and Footer Padding";
+CustomHeaderAndContentPadding.storyName = "Custom Header and Content Padding";
 
 export const TopModalOverride: Story = () => {
   const [isOpenAll, setIsOpenAll] = useState(defaultOpenState);

--- a/src/components/sidebar/sidebar.style.ts
+++ b/src/components/sidebar/sidebar.style.ts
@@ -5,13 +5,21 @@ import computeSizing from "../../style/utils/element-sizing";
 import { SidebarProps } from "./sidebar.component";
 import applyBaseTheme from "../../style/themes/apply-base-theme";
 import StyledIconButton from "../icon-button/icon-button.style";
+import StyledIcon from "../icon/icon.style";
 
 import { SIDEBAR_SIZES_CSS } from "./sidebar.config";
-import { StyledForm, StyledFormContent } from "../form/form.style";
+import {
+  StyledForm,
+  StyledFormContent,
+  StyledFormFooter,
+} from "../form/form.style";
+import Modal from "../../__internal__/modal";
+
+const smallScreenBreakpoint = "768px";
 
 type StyledSidebarProps = Pick<
   SidebarProps,
-  "onCancel" | "position" | "size" | "width" | "widthAnimation"
+  "position" | "size" | "width" | "widthAnimation"
 >;
 
 const StyledSidebar = styled.div.attrs(applyBaseTheme)<StyledSidebarProps>`
@@ -20,9 +28,11 @@ const StyledSidebar = styled.div.attrs(applyBaseTheme)<StyledSidebarProps>`
     outline: none;
   }
 
-  ${({ onCancel, position, size, theme, width, widthAnimation }) => css`
-    background: var(--colorsUtilityYang100);
-    border-radius: 1px;
+  ${({ position, size, theme, width, widthAnimation }) => css`
+    background: var(--container-standard-bg-default);
+    border-radius: ${position === "left"
+      ? "var(--global-radius-none) var(--global-radius-container-xl) var(--global-radius-container-xl) var(--global-radius-none)"
+      : "var(--global-radius-container-xl) var(--global-radius-none) var(--global-radius-none) var(--global-radius-container-xl)"};
     bottom: 0;
     position: fixed;
     display: flex;
@@ -30,13 +40,18 @@ const StyledSidebar = styled.div.attrs(applyBaseTheme)<StyledSidebarProps>`
     top: 0;
     z-index: ${theme.zIndex.fullScreenModal};
     max-width: 100vw;
+    overflow: hidden;
 
-    ${!width &&
-    size &&
+    ${(!size || width) &&
     css`
-      width: ${SIDEBAR_SIZES_CSS[size]};
+      min-width: 288px;
     `}
-    ${width && computeSizing({ width })}
+
+    ${width
+      ? computeSizing({ width })
+      : css`
+          width: ${size ? SIDEBAR_SIZES_CSS[size] : "30vw"};
+        `}
 
     ${widthAnimation &&
     css`
@@ -45,19 +60,33 @@ const StyledSidebar = styled.div.attrs(applyBaseTheme)<StyledSidebarProps>`
 
     ${position &&
     css`
-      box-shadow: var(--boxShadow300);
+      box-shadow: var(--global-depth-lvl3);
       ${position}: 0;
     `}
 
-    ${onCancel &&
-    css`
-      > ${StyledIconButton}:first-of-type {
-        position: absolute;
-        z-index: 1;
-        right: 25px;
-        top: 25px;
+    > ${StyledIconButton}:first-of-type {
+      border-radius: var(--global-radius-action-circle);
+      height: var(--global-size-s);
+      min-width: var(--global-size-s);
+      position: absolute;
+      right: var(--global-space-comp-xl);
+      top: var(--global-space-comp-xl);
+      width: var(--global-size-s);
+      z-index: 1;
+
+      ${StyledIcon} {
+        height: var(--global-size-2-xs);
+        width: var(--global-size-2-xs);
       }
-    `}
+    }
+
+    @media screen and (max-width: ${smallScreenBreakpoint}) {
+      border-radius: var(--global-radius-none);
+      height: 100%;
+      min-width: 100%;
+      overflow-y: auto;
+      width: 100%;
+    }
   `}
 `;
 
@@ -67,7 +96,9 @@ const StyledSidebarContent = styled.div<PaddingProps>`
   overflow-y: auto;
   flex-grow: 1;
 
-  padding: var(--spacing300) var(--spacing400) var(--spacing400);
+  color: var(--container-standard-txt-default);
+  font: var(--global-font-static-body-regular-m);
+  padding: var(--global-space-comp-xl);
   ${paddingFn}
 
   &:has(${StyledForm}.sticky) {
@@ -78,11 +109,54 @@ const StyledSidebarContent = styled.div<PaddingProps>`
 
     ${StyledForm}.sticky {
       ${StyledFormContent} {
-        padding: var(--spacing300) var(--spacing400) var(--spacing400);
+        padding: var(--global-space-comp-xl);
         ${paddingFn}
+      }
+
+      ${StyledFormFooter} {
+        background: var(--container-standard-bg-default);
+        border-top: var(--global-borderwidth-xs) solid
+          var(--container-standard-border-default);
+        gap: var(--global-space-layout-2-xs);
+        padding: var(--global-space-comp-l) var(--global-space-comp-xl);
+      }
+    }
+  }
+
+  @media screen and (max-width: ${smallScreenBreakpoint}) {
+    flex-grow: 0;
+    overflow-y: visible;
+
+    &:has(${StyledForm}.sticky) {
+      overflow-y: visible;
+
+      ${StyledForm}.sticky {
+        height: auto;
+
+        ${StyledFormContent} {
+          overflow-y: visible;
+        }
+
+        ${StyledFormFooter} {
+          box-shadow: none;
+          position: static;
+        }
       }
     }
   }
 `;
 
-export { StyledSidebar, StyledSidebarContent };
+const StyledSidebarModal = styled(Modal)`
+  @media screen and (max-width: ${smallScreenBreakpoint}) {
+    [data-element="modal-background"] {
+      display: none;
+    }
+  }
+`;
+
+export {
+  StyledSidebar,
+  StyledSidebarContent,
+  StyledSidebarModal,
+  smallScreenBreakpoint,
+};

--- a/src/components/sidebar/sidebar.test.tsx
+++ b/src/components/sidebar/sidebar.test.tsx
@@ -69,6 +69,14 @@ test("renders with header when prop is provided", () => {
   ).toBeVisible();
 });
 
+test("renders a string header as a semantic heading", () => {
+  render(<Sidebar open header="My sidebar" />);
+
+  expect(
+    screen.getByRole("heading", { level: 1, name: "My sidebar" }),
+  ).toBeVisible();
+});
+
 test("renders with a subheader when the `subHeader` prop is provided", () => {
   render(<Sidebar open subHeader={<h2>My subheader</h2>} />);
 
@@ -77,7 +85,19 @@ test("renders with a subheader when the `subHeader` prop is provided", () => {
   ).toBeVisible();
 });
 
-test("sidebar uses header prop as accessible name when an HTML element is provided as header", () => {
+test("sidebar uses aria-labelledby to associate a custom header", () => {
+  render(
+    <Sidebar
+      open
+      aria-labelledby="my-sidebar-heading"
+      header={<h1 id="my-sidebar-heading">My sidebar</h1>}
+    />,
+  );
+
+  expect(screen.getByRole("dialog")).toHaveAccessibleName("My sidebar");
+});
+
+test("sidebar uses a custom header as its accessible name", () => {
   render(<Sidebar open header={<h1>My sidebar</h1>} />);
 
   expect(screen.getByRole("dialog")).toHaveAccessibleName("My sidebar");
@@ -352,8 +372,73 @@ test("ensures correct background color is applied", () => {
   const sidebarContent = screen.getByRole("dialog");
   expect(sidebarContent).toHaveStyleRule(
     "background",
-    "var(--colorsUtilityYang100)",
+    "var(--container-standard-bg-default)",
   );
+});
+
+test("uses the fluid desktop width and minimum width by default", () => {
+  render(<Sidebar open aria-label="My sidebar" />);
+
+  const sidebar = screen.getByRole("dialog");
+  expect(sidebar).toHaveStyleRule("width", "30vw");
+  expect(sidebar).toHaveStyleRule("min-width", "288px");
+  expect(sidebar).toHaveStyleRule("max-width", "100vw");
+  expect(sidebar).toHaveStyleRule("right", "0");
+  expect(sidebar).toHaveStyleRule("box-shadow", "var(--global-depth-lvl3)");
+  expect(sidebar).toHaveStyleRule("overflow", "hidden");
+});
+
+test("rounds the exposed right corners for legacy left positioning", () => {
+  render(<Sidebar open aria-label="My sidebar" position="left" />);
+
+  expect(screen.getByRole("dialog")).toHaveStyleRule(
+    "border-radius",
+    "var(--global-radius-none) var(--global-radius-container-xl) var(--global-radius-container-xl) var(--global-radius-none)",
+  );
+});
+
+test("retains explicitly supplied legacy size values", () => {
+  render(<Sidebar open aria-label="My sidebar" size="extra-small" />);
+
+  const sidebar = screen.getByRole("dialog");
+  expect(sidebar).toHaveStyleRule("width", "214px");
+  expect(sidebar).not.toHaveStyleRule("min-width", "288px");
+});
+
+test("uses custom width with a 288px minimum on desktop", () => {
+  render(<Sidebar open aria-label="My sidebar" width="200px" />);
+
+  const sidebar = screen.getByRole("dialog");
+  expect(sidebar).toHaveStyleRule("width", "200px");
+  expect(sidebar).toHaveStyleRule("min-width", "288px");
+  expect(sidebar).toHaveStyleRule("max-width", "100vw");
+});
+
+test("applies the full-width, square, scrollable small-screen styles", () => {
+  render(<Sidebar open aria-label="My sidebar" width="400px" />);
+
+  const sidebar = screen.getByRole("dialog");
+  const media = "screen and (max-width: 768px)";
+  expect(sidebar).toHaveStyleRule("width", "100%", { media });
+  expect(sidebar).toHaveStyleRule("min-width", "100%", { media });
+  expect(sidebar).toHaveStyleRule(
+    "border-radius",
+    "var(--global-radius-none)",
+    {
+      media,
+    },
+  );
+  expect(sidebar).toHaveStyleRule("overflow-y", "auto", { media });
+});
+
+test("retains modal semantics when responsive dimmer styling is enabled", () => {
+  render(
+    <CarbonProvider>
+      <Sidebar open aria-label="My sidebar" />
+    </CarbonProvider>,
+  );
+
+  expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
 });
 
 test("applies a width transition when `widthAnimation` is true and motion is allowed", () => {
@@ -404,29 +489,113 @@ testStyledSystemPadding(
 );
 
 // for coverage - the `headerVariant` prop will be captured by Chromatic`
-test('renders with correct styles when `headerVariant` is "light"', () => {
-  render(<Sidebar open header="foo" headerVariant="light" />);
+test.each(["typical", "light"] as const)(
+  'renders with typical styles when `headerVariant` is "%s"',
+  (headerVariant) => {
+    render(<Sidebar open header="foo" headerVariant={headerVariant} />);
 
-  const sidebarHeader = screen.getByTestId("sidebar-header");
+    const sidebarHeader = screen.getByTestId("sidebar-header");
 
-  expect(sidebarHeader).toHaveStyle({
-    "background-color": "var(--colorsUtilityYang100)",
+    expect(sidebarHeader).toHaveStyle({
+      "background-color": "var(--container-standard-bg-default)",
+    });
+  },
+);
+
+// for coverage - the `headerVariant` prop will be captured by Chromatic`
+test.each(["inverse", "dark"] as const)(
+  'renders with inverse styles when `headerVariant` is "%s"',
+  (headerVariant) => {
+    render(
+      <Sidebar
+        open
+        header="foo"
+        headerVariant={headerVariant}
+        onCancel={() => {}}
+      />,
+    );
+
+    const sidebarHeader = screen.getByTestId("sidebar-header");
+    const closeIcon = screen.getByTestId("icon");
+
+    expect(sidebarHeader).toHaveStyle(
+      "background-color: var(--container-standard-inverse-bg-default)",
+    );
+    expect(closeIcon).toHaveStyle(
+      "color: var(--container-standard-inverse-txt-default)",
+    );
+  },
+);
+
+test("renders an AI gradient keyline on the header", () => {
+  render(<Sidebar open header="My sidebar" gradientKeyLine />);
+
+  const divider = screen.getByRole("separator", { hidden: true });
+
+  expect(divider).toHaveAttribute("aria-hidden", "true");
+  expect(divider).toHaveStyleRule(
+    "background",
+    "var(--container-standard-border-ai-h)",
+  );
+  expect(divider).toHaveStyleRule("height", "var(--global-borderwidth-s)");
+  expect(screen.getByRole("dialog")).toHaveAccessibleName("My sidebar");
+});
+
+test("renders the standard header divider", () => {
+  render(<Sidebar open header="My sidebar" />);
+
+  const divider = screen.getByRole("separator", { hidden: true });
+
+  expect(divider).toHaveStyleRule(
+    "background",
+    "var(--container-standard-border-default)",
+  );
+  expect(divider).toHaveStyleRule("height", "var(--global-borderwidth-xs)");
+});
+
+test("applies the tokenized header layout and typography", () => {
+  render(<Sidebar open header="My sidebar" onCancel={() => {}} />);
+
+  const header = screen.getByTestId("sidebar-header");
+
+  expect(header).toHaveStyleRule("padding", "var(--global-space-comp-xl)");
+  expect(header).toHaveStyleRule(
+    "min-height",
+    "calc((2 * var(--global-space-comp-xl)) + var(--global-size-s))",
+  );
+  expect(header).toHaveStyleRule("gap", "var(--global-space-comp-l)");
+  expect(screen.getByRole("heading", { name: "My sidebar" })).toHaveStyleRule(
+    "font",
+    "var(--global-font-static-heading-m)",
+  );
+  expect(header).toHaveStyleRule("gap", "var(--global-space-comp-xs)", {
+    modifier: 'div[data-element="sidebar-heading"]',
+  });
+  expect(header).toHaveStyleRule("flex", "1 1 auto", {
+    modifier: 'div[data-element="sidebar-heading"]',
+  });
+  expect(header).toHaveStyleRule("min-width", "0", {
+    modifier: 'div[data-element="sidebar-heading"]',
   });
 });
 
-// for coverage - the `headerVariant` prop will be captured by Chromatic`
-test('renders with correct styles when `headerVariant` is "dark"', () => {
+test("applies tokenized content spacing and typography", () => {
   render(
-    <Sidebar open header="foo" headerVariant="dark" onCancel={() => {}} />,
+    <Sidebar open aria-label="My sidebar">
+      Content
+    </Sidebar>,
   );
 
-  const sidebarHeader = screen.getByTestId("sidebar-header");
-  const closeIcon = screen.getByTestId("icon");
-
-  expect(sidebarHeader).toHaveStyle(
-    "background-color: var(--colorsUtilityYin100)",
+  const content = screen.getByTestId("sidebar-content");
+  expect(content).toHaveStyleRule("padding", "var(--global-space-comp-xl)");
+  expect(content).toHaveStyleRule(
+    "font",
+    "var(--global-font-static-body-regular-m)",
   );
-  expect(closeIcon).toHaveStyle("color: var(--colorsUtilityYang080)");
+  expect(content).toHaveStyleRule(
+    "color",
+    "var(--container-standard-txt-default)",
+  );
 });
 
 test("close button has correct data-* props, when the closeButtonDataProps prop is passed", () => {


### PR DESCRIPTION
### Proposed behaviour

Updated Sidebar follows the latest responsive and visual design:
- Use a fluid `30vw` desktop width with a `288px` minimum.
- Cap explicit preset and custom widths at the viewport width.
- Render Sidebar full-width with square corners at `768px` and below.
- Hide the modal dimmer at `768px` and below.
- Allow the complete mobile Sidebar, including form footers, to scroll as one region.
- Use Fusion design tokens for backgrounds, borders, spacing, typography, depth.
- Render string headers as semantic `h1` elements and automatically associate string and custom-node headers with the dialog.
- Add `typical` and `inverse` header variants while retaining `light` and `dark` as deprecated aliases.
- Add the optional `gradientKeyLine` header treatment.
- Deprecate `position` and preset `size` props while retaining explicit legacy values.

BREAKING CHANGE: Sidebars without an explicit size or width now use a fluid 30vw width with a 288px minimum instead of the 514px medium width. At 768px and below, Sidebars fill the viewport and hide the modal dimmer.

### Current behaviour

Sidebar currently:
- Defaults to the fixed `medium` width of 514px.
- Uses legacy colour, spacing, border, shadow, and sizing tokens.
- Retains its desktop presentation on small screens.
- Uses `light` and `dark` header variants.
- Requires consumers to construct their own semantic header content.
- Does not support the optional AI gradient keyline treatment.

### Checklist

<!-- Each PR should include the following -->

- [X] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [X] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [X] Unit tests added or updated if required
- [X] Playwright automation tests added or updated if required
- [X] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [X] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [X] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

1. Open the default Sidebar at a viewport wider than 768px.
  - Confirm its width is `30vw`, with a 288px minimum.
  - Confirm it is positioned on the right with rounded exposed corners.
2. Set the viewport to 769px.
  - Confirm the default Sidebar remains 288px wide.
  - Confirm `size=“extra-large”` and oversized custom widths are capped at the viewport width.
3. Set the viewport to 768px or narrower.
  - Confirm the Sidebar fills the viewport.
  - Confirm its corners are square and the modal dimmer is hidden.
  - Confirm long content and a form footer scroll together.
4. Provide a string header.
  - Confirm it renders as an `h1` and supplies the dialog’s accessible name.
5. Provide a custom React-node header.
  - Confirm it supplies the dialog’s accessible name automatically.
  - Confirm explicit `aria-label` and `aria-labelledby` values still override the generated association.
6. Check `headerVariant=“typical”` and `headerVariant=“inverse”`.
  - Confirm deprecated `light` and `dark` values retain their equivalent treatments.
7. Enable `gradientKeyLine`.
  - Confirm the AI gradient divider appears without changing the accessible name.
8. Open the Top Modal Override story.
  - Confirm the Sidebar remains the active top modal when other dialogs are mounted after it.
  
  
  
<img width="379" height="718" alt="Screenshot 2026-08-23 at 21 25 05" src="https://github.com/user-attachments/assets/30a3ab9f-fa2c-43d7-a666-6d18bf456c49" />

<img width="384" height="732" alt="Screenshot 2026-08-23 at 21 26 14" src="https://github.com/user-attachments/assets/4e9fdb03-a22a-4f6b-8ff8-6d0a0ab7cc13" />

<img width="410" height="728" alt="Screenshot 2026-08-23 at 21 26 41" src="https://github.com/user-attachments/assets/65197752-a452-41df-864a-b0480025a492" />

<img width="398" height="738" alt="Screenshot 2026-08-23 at 21 27 15" src="https://github.com/user-attachments/assets/9fef8a82-14c6-4cb9-9242-fb6e4a775bb8" />
