### PR TITLE
fix: ensure popovers are not clipped by parent overflows

### DIFF
--- a/src/__internal__/popover/popover.component.tsx
+++ b/src/__internal__/popover/popover.component.tsx
@@ -4,6 +4,7 @@ import React, {
   useRef,
   RefObject,
   useEffect,
+  useState,
 } from "react";
 import { createPortal } from "react-dom";
 import { flip, Placement, Middleware } from "@floating-ui/dom";
@@ -125,7 +126,7 @@ const Popover = ({ disablePortal, portalTarget, ...props }: PopoverProps) => {
   const { wrapperId } = useContext(TokensWrapperContext);
   const closestDialog =
     props.reference.current?.closest<HTMLElement>("[role='dialog']");
-  const [mode, setMode] = React.useState<string | undefined>();
+  const [mode, setMode] = useState<string | undefined>();
 
   useEffect(() => {
     const wrapper = props.reference.current?.closest("[data-carbon-theme]");
@@ -145,7 +146,10 @@ const Popover = ({ disablePortal, portalTarget, ...props }: PopoverProps) => {
       attributeFilter: ["data-carbon-theme"],
     });
 
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      setMode(undefined);
+    };
   }, [props.reference]);
 
   if (disablePortal) {

--- a/src/components/action-popover/action-popover-test.stories.tsx
+++ b/src/components/action-popover/action-popover-test.stories.tsx
@@ -18,6 +18,8 @@ import {
   FlatTableCell,
 } from "../flat-table";
 import Box from "../box";
+import { FlexTileCell, FlexTileContainer, Tile } from "../tile";
+import Typography from "../typography";
 
 export default {
   title: "Action Popover/Test",
@@ -29,6 +31,7 @@ export default {
     "WithoutDefaultAriaLabel",
     "ActionPopoverClick",
     "ActionPopoverSubmenuClick",
+    "TestParentOverflow",
   ],
   parameters: {
     info: { disable: true },
@@ -905,5 +908,64 @@ export const WithoutDefaultAriaLabel = () => {
         </ActionPopoverItem>
       </ActionPopover>
     </Box>
+  );
+};
+
+export const TestParentOverflow = () => {
+  return (
+    <Tile my={1} py={0}>
+      <FlexTileContainer>
+        <FlexTileCell flexBasis="80px" flexGrow={0} py={1}>
+          <Box>
+            <Box alignItems="center" display="flex" minHeight="48px">
+              <Typography mb={0}>Foo</Typography>
+              <Typography variant="b" wordBreak="break-word">
+                Bar
+              </Typography>
+            </Box>
+          </Box>
+        </FlexTileCell>
+        <FlexTileCell flexBasis="80px" flexGrow={0} py={1}>
+          <Box>
+            <Box alignItems="center" display="flex" minHeight="48px">
+              <Typography mb={0}>Foo</Typography>
+              <Typography variant="b" wordBreak="break-word">
+                Bar
+              </Typography>
+            </Box>
+          </Box>
+        </FlexTileCell>
+        <FlexTileCell flexBasis="80px" flexGrow={0} py={1}>
+          <Box>
+            <Box alignItems="center" display="flex" minHeight="48px">
+              <Typography mb={0}>Foo</Typography>
+              <Typography variant="b" wordBreak="break-word">
+                Bar
+              </Typography>
+            </Box>
+          </Box>
+        </FlexTileCell>
+        <FlexTileCell flexBasis="160px" flexGrow={1} justifyContent="flex-end">
+          <Box>
+            <Box alignItems="center" display="flex" minHeight="48px">
+              <ActionPopover id="action" mr={1}>
+                <ActionPopoverItem onClick={() => {}}>
+                  Action 1
+                </ActionPopoverItem>
+                <ActionPopoverItem onClick={() => {}}>
+                  Action 2
+                </ActionPopoverItem>
+                <ActionPopoverItem onClick={() => {}}>
+                  Action 3
+                </ActionPopoverItem>
+                <ActionPopoverItem onClick={() => {}}>
+                  Action 4
+                </ActionPopoverItem>
+              </ActionPopover>
+            </Box>
+          </Box>
+        </FlexTileCell>
+      </FlexTileContainer>
+    </Tile>
   );
 };

--- a/src/components/action-popover/action-popover.component.tsx
+++ b/src/components/action-popover/action-popover.component.tsx
@@ -336,6 +336,21 @@ export const ActionPopover = forwardRef<
 
     const parentID = id || `ActionPopoverButton_${guid}`;
     const menuID = `ActionPopoverMenu_${guid}`;
+    const [popoverTarget, setPopoverTarget] = useState<HTMLElement | null>(
+      null,
+    );
+
+    useEffect(() => {
+      setPopoverTarget(
+        (buttonRef.current?.closest<HTMLElement>(
+          "[data-component='tokens-wrapper']",
+        ) as HTMLElement) || buttonRef.current,
+      );
+
+      return () => {
+        setPopoverTarget(null);
+      };
+    }, []);
 
     return (
       <MenuButton
@@ -361,7 +376,7 @@ export const ActionPopover = forwardRef<
               placement={mappedPlacement}
               reference={buttonRef}
               disableBackgroundUI={isInFlatTable}
-              portalTarget={buttonRef.current}
+              portalTarget={popoverTarget}
             >
               <ActionPopoverMenu
                 data-component="action-popover"

--- a/src/components/action-popover/action-popover.test.tsx
+++ b/src/components/action-popover/action-popover.test.tsx
@@ -23,6 +23,7 @@ import {
 } from "../flat-table";
 import iconUnicodes from "../icon/icon-unicodes";
 import guid from "../../__internal__/utils/helpers/guid";
+import TokensWrapper from "../tokens-wrapper";
 
 jest.mock("../../__internal__/utils/helpers/guid");
 (guid as jest.MockedFunction<typeof guid>).mockImplementation(
@@ -2459,4 +2460,27 @@ test("renders action popover menu under the action popover wrapper tree", async 
   const anchor = screen.getByTestId("anchor");
 
   expect(anchor).toContainElement(menu);
+});
+
+test("uses the TokensWrapper as the popover portal target when present", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(
+    <TokensWrapper>
+      <ActionPopover>
+        <ActionPopoverItem>Item 1</ActionPopoverItem>
+      </ActionPopover>
+    </TokensWrapper>,
+  );
+
+  await user.click(screen.getByRole("button"));
+  await screen.findByRole("list");
+
+  const tokensWrapper = screen.getByTestId("tokens-wrapper");
+  const portalProvider = screen.getByTestId(
+    "carbon-portal-scoped-tokens-provider",
+  );
+
+  // eslint-disable-next-line testing-library/no-node-access
+  expect(portalProvider.parentElement).toBe(tokensWrapper);
 });

--- a/src/components/popover-container/popover-container.component.tsx
+++ b/src/components/popover-container/popover-container.component.tsx
@@ -398,7 +398,20 @@ export const PopoverContainer = forwardRef<
         {...filterStyledSystemPaddingProps(rest)}
       >
         <MenuContext.Provider value={{ inMenu: false }}>
-          <PopoverContainerHeaderStyle>
+          <PopoverContainerHeaderStyle
+            onKeyDown={(e) => {
+              if (
+                !shouldCoverButton &&
+                e.key === "Tab" &&
+                e.shiftKey &&
+                closeButtonRef.current === document.activeElement
+              ) {
+                e.preventDefault();
+                closePopover(e);
+                openButtonRef.current?.focus();
+              }
+            }}
+          >
             {title && (
               <PopoverContainerTitleStyle
                 id={popoverContainerId}
@@ -448,21 +461,29 @@ export const PopoverContainer = forwardRef<
       );
 
     useIsomorphicLayoutEffect(() => {
-      if (inMenu) {
-        const closestHeader = popoverReference?.closest(
-          "[data-component='global-header']",
-        ) as HTMLElement | null;
-        const closestMenu = popoverReference?.closest("[data-component='menu']")
-          ?.parentElement as HTMLElement | null;
+      const closestHeader = inMenu
+        ? (popoverReference?.closest(
+            "[data-component='global-header']",
+          ) as HTMLElement | null)
+        : null;
+      const closestMenu = inMenu
+        ? (popoverReference?.closest("[data-component='menu']")
+            ?.parentElement as HTMLElement | null)
+        : null;
+      const tokensWrapper = popoverReference?.closest(
+        "[data-component='tokens-wrapper']",
+      ) as HTMLElement | null;
 
-        setAltTarget(
-          closestHeader ?? closestMenu ?? /* istanbul ignore next */ null,
-        );
-      }
+      setAltTarget(
+        closestHeader ??
+          closestMenu ??
+          tokensWrapper ??
+          /* istanbul ignore next */ null,
+      );
     }, [inMenu, popoverReference]);
 
-    // if the popover is in a menu, we want to anchor the popover to the closest global header or menu,
-    // otherwise we will use the popover reference as the target
+    // Prefer the closest global header or menu, then a tokens wrapper, before
+    // falling back to the popover reference itself.
     const popoverTarget = altTarget ?? popoverReference;
 
     return (

--- a/src/components/popover-container/popover-container.test.tsx
+++ b/src/components/popover-container/popover-container.test.tsx
@@ -14,6 +14,7 @@ import Button from "../button";
 import RadioButton, { RadioButtonGroup } from "../radio-button";
 import GlobalHeader from "../global-header";
 import { Menu, MenuItem } from "../menu";
+import TokensWrapper from "../tokens-wrapper";
 
 jest.mock("../../hooks/useMediaQuery");
 jest.mock("../global-header/__internal__/global-header.context", () => {
@@ -959,6 +960,27 @@ test("renders popover content under the trigger tree instead of mounting to body
   const expectedPortalTarget = screen.getByTestId("root");
 
   expect(expectedPortalTarget).toContainElement(dialog);
+});
+
+test("uses the TokensWrapper as the popover portal target when present", async () => {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+  render(
+    <TokensWrapper>
+      <PopoverContainer>Content</PopoverContainer>
+    </TokensWrapper>,
+  );
+
+  await user.click(screen.getByRole("button"));
+  await screen.findByRole("dialog");
+
+  const tokensWrapper = screen.getByTestId("tokens-wrapper");
+  const portalProvider = screen.getByTestId(
+    "carbon-portal-scoped-tokens-provider",
+  );
+
+  // eslint-disable-next-line testing-library/no-node-access
+  expect(portalProvider.parentElement).toBe(tokensWrapper);
 });
 
 test("renders popover content under the global header tree instead of mounting to body root", async () => {


### PR DESCRIPTION
fix #8148

### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Popover based components will now anchor to the TokensWrapper if one is found in the DOM. If not it will fallback to rendering as a sibling of the trigger element and then document.body after that.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->
Popovers anchor as siblings of the trigger element, meaning they are subject to being clipped by parent overflow

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [x] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
Worth testing `action-popover-test--test-parent-overflow` to ensure the parent overflow is no longer clipping the popover