### PR TITLE
fix(pager): update pager aria-labels to support page numbers

### DIFF
--- a/src/components/pager/__internal__/pagination-navigation.component.tsx
+++ b/src/components/pager/__internal__/pagination-navigation.component.tsx
@@ -173,7 +173,7 @@ const PaginationNavigation = ({
           <StyledButtonWrapper $visible={showFirst}>
             <Button
               variantType="subtle"
-              aria-label={locale.pager.firstAriaLabel?.()}
+              aria-label={locale.pager.firstAriaLabel?.(totalPages)}
               size={size}
               onClick={handleFirstButtonClick}
             >
@@ -184,7 +184,10 @@ const PaginationNavigation = ({
         <StyledButtonWrapper $visible={showPrevious}>
           <Button
             variantType="subtle"
-            aria-label={locale.pager.previousAriaLabel?.()}
+            aria-label={locale.pager.previousAriaLabel?.(
+              currentPage - 1,
+              totalPages,
+            )}
             size={size}
             onClick={handlePreviousButtonClick}
             ref={previousRef}
@@ -195,7 +198,10 @@ const PaginationNavigation = ({
         <StyledButtonWrapper $visible={showNext}>
           <Button
             variantType="subtle"
-            aria-label={locale.pager.nextAriaLabel?.()}
+            aria-label={locale.pager.nextAriaLabel?.(
+              currentPage + 1,
+              totalPages,
+            )}
             size={size}
             onClick={handleNextButtonClick}
             ref={nextRef}
@@ -207,7 +213,7 @@ const PaginationNavigation = ({
           <StyledButtonWrapper $visible={showLast}>
             <Button
               variantType="subtle"
-              aria-label={locale.pager.lastAriaLabel?.()}
+              aria-label={locale.pager.lastAriaLabel?.(totalPages)}
               size={size}
               onClick={handleLastButtonClick}
             >

--- a/src/components/pager/pager.pw.tsx
+++ b/src/components/pager/pager.pw.tsx
@@ -10,9 +10,11 @@ test("should focus the 'previous' button when 'last' button is pressed and then 
 }) => {
   await mount(<PagerComponent />);
 
-  const lastButton = page.getByRole("button", { name: "Go to last page" });
+  const lastButton = page.getByRole("button", {
+    name: "Go to last page (page 10 of 10)",
+  });
   const previousButton = page.getByRole("button", {
-    name: "Go to previous page",
+    name: "Go to previous page (page 9 of 10)",
   });
 
   await lastButton.click();
@@ -26,9 +28,11 @@ test("should focus the 'previous' button when 'next' is pressed on the penultima
 }) => {
   await mount(<PagerComponent currentPage={9} />);
 
-  const nextButton = page.getByRole("button", { name: "Go to next page" });
+  const nextButton = page.getByRole("button", {
+    name: "Go to next page (page 10 of 10)",
+  });
   const previousButton = page.getByRole("button", {
-    name: "Go to previous page",
+    name: "Go to previous page (page 9 of 10)",
   });
 
   await nextButton.click();
@@ -42,9 +46,11 @@ test("should focus the 'next' button when 'previous' is pressed on the second pa
 }) => {
   await mount(<PagerComponent currentPage={2} />);
 
-  const nextButton = page.getByRole("button", { name: "Go to next page" });
+  const nextButton = page.getByRole("button", {
+    name: "Go to next page (page 2 of 10)",
+  });
   const previousButton = page.getByRole("button", {
-    name: "Go to previous page",
+    name: "Go to previous page (page 1 of 10)",
   });
 
   await previousButton.click();
@@ -58,8 +64,12 @@ test("should focus the 'next' button when 'first' is pressed and then hidden", a
 }) => {
   await mount(<PagerComponent currentPage={2} />);
 
-  const nextButton = page.getByRole("button", { name: "Go to next page" });
-  const firstButton = page.getByRole("button", { name: "Go to first page" });
+  const nextButton = page.getByRole("button", {
+    name: "Go to next page (page 2 of 10)",
+  });
+  const firstButton = page.getByRole("button", {
+    name: "Go to first page (page 1 of 10)",
+  });
 
   await firstButton.click();
 

--- a/src/components/pager/pager.test.tsx
+++ b/src/components/pager/pager.test.tsx
@@ -12,10 +12,12 @@ test("`next` and `last` buttons are not visible when on the last page", async ()
   render(<Pager onPagination={() => {}} totalRecords={100} currentPage={10} />);
 
   expect(
-    screen.queryByRole("button", { name: "Go to next page" }),
+    screen.queryByRole("button", {
+      name: "Go to next page (page 11 of 10)",
+    }),
   ).not.toBeInTheDocument();
   expect(
-    screen.queryByRole("button", { name: "Go to last page" }),
+    screen.queryByRole("button", { name: "Go to last page (page 10 of 10)" }),
   ).not.toBeInTheDocument();
 });
 
@@ -23,10 +25,12 @@ test("`previous` and `first` buttons are not visible when on the first page", as
   render(<Pager onPagination={() => {}} totalRecords={100} currentPage={1} />);
 
   expect(
-    screen.queryByRole("button", { name: "Go to previous page" }),
+    screen.queryByRole("button", {
+      name: "Go to previous page (page 0 of 10)",
+    }),
   ).not.toBeInTheDocument();
   expect(
-    screen.queryByRole("button", { name: "Go to first page" }),
+    screen.queryByRole("button", { name: "Go to first page (page 1 of 10)" }),
   ).not.toBeInTheDocument();
 });
 
@@ -64,7 +68,11 @@ test("calls the `onFirst` callback when the `First` button is clicked", async ()
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "Go to first page" }));
+  await user.click(
+    screen.getByRole("button", {
+      name: "Go to first page (page 1 of 10)",
+    }),
+  );
   expect(onFirst).toHaveBeenCalledTimes(1);
 });
 
@@ -80,7 +88,11 @@ test("calls the `onPrevious` callback when the `Previous` button is clicked", as
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "Go to previous page" }));
+  await user.click(
+    screen.getByRole("button", {
+      name: "Go to previous page (page 9 of 10)",
+    }),
+  );
   expect(onPrevious).toHaveBeenCalledTimes(1);
 });
 
@@ -96,7 +108,9 @@ test("calls the `onNext` callback when the `Next` button is clicked", async () =
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "Go to next page" }));
+  await user.click(
+    screen.getByRole("button", { name: "Go to next page (page 2 of 10)" }),
+  );
   expect(onNext).toHaveBeenCalledTimes(1);
 });
 
@@ -112,7 +126,11 @@ test("calls the `onLast` callback when the `Last` button is clicked", async () =
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "Go to last page" }));
+  await user.click(
+    screen.getByRole("button", {
+      name: "Go to last page (page 10 of 10)",
+    }),
+  );
   expect(onLast).toHaveBeenCalledTimes(1);
 });
 
@@ -192,7 +210,9 @@ test("clicking the `Next` button sets the current page to the next page", async 
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "Go to next page" }));
+  await user.click(
+    screen.getByRole("button", { name: "Go to next page (page 10 of 10)" }),
+  );
 
   expect(screen.getByRole("textbox", { name: "Page 10" })).toHaveValue("10");
 });
@@ -208,7 +228,11 @@ test("clicking the `Previous` button sets the current page to the previous page"
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "Go to previous page" }));
+  await user.click(
+    screen.getByRole("button", {
+      name: "Go to previous page (page 4 of 10)",
+    }),
+  );
 
   expect(screen.getByRole("textbox", { name: "Page 4" })).toHaveValue("4");
 });
@@ -224,7 +248,11 @@ test("clicking the `First` button sets the current page to the first page", asyn
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "Go to first page" }));
+  await user.click(
+    screen.getByRole("button", {
+      name: "Go to first page (page 1 of 10)",
+    }),
+  );
 
   expect(screen.getByRole("textbox", { name: "Page 1" })).toHaveValue("1");
 });
@@ -240,7 +268,11 @@ test("clicking the `Last` button sets the current page to the last page", async 
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "Go to last page" }));
+  await user.click(
+    screen.getByRole("button", {
+      name: "Go to last page (page 10 of 10)",
+    }),
+  );
 
   expect(screen.getByRole("textbox", { name: "Page 10" })).toHaveValue("10");
 });
@@ -256,15 +288,19 @@ test("does not render `First` and `Last` buttons when `showFirstAndLastButtons` 
   );
 
   expect(
-    screen.queryByRole("button", { name: "Go to first page" }),
+    screen.queryByRole("button", { name: "Go to first page (page 1 of 10)" }),
   ).not.toBeInTheDocument();
   expect(
-    screen.queryByRole("button", { name: "Go to last page" }),
+    screen.queryByRole("button", { name: "Go to last page (page 10 of 10)" }),
   ).not.toBeInTheDocument();
   expect(
-    screen.getByRole("button", { name: "Go to previous page" }),
+    screen.getByRole("button", {
+      name: "Go to previous page (page 4 of 10)",
+    }),
   ).toBeVisible();
-  expect(screen.getByRole("button", { name: "Go to next page" })).toBeVisible();
+  expect(
+    screen.getByRole("button", { name: "Go to next page (page 6 of 10)" }),
+  ).toBeVisible();
 });
 
 test("calls `onPagination` with `first` origin when the `First` button is clicked", async () => {
@@ -279,7 +315,9 @@ test("calls `onPagination` with `first` origin when the `First` button is clicke
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "Go to first page" }));
+  await user.click(
+    screen.getByRole("button", { name: "Go to first page (page 1 of 10)" }),
+  );
 
   expect(onPagination).toHaveBeenCalledWith(1, 10, "first");
 });
@@ -296,7 +334,11 @@ test("calls `onPagination` with `previous` origin when the `Previous` button is 
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "Go to previous page" }));
+  await user.click(
+    screen.getByRole("button", {
+      name: "Go to previous page (page 1 of 10)",
+    }),
+  );
 
   expect(onPagination).toHaveBeenCalledWith(1, 10, "previous");
 });
@@ -313,7 +355,9 @@ test("calls `onPagination` with `next` origin when the `Next` button is clicked"
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "Go to next page" }));
+  await user.click(
+    screen.getByRole("button", { name: "Go to next page (page 6 of 10)" }),
+  );
 
   expect(onPagination).toHaveBeenCalledWith(6, 10, "next");
 });
@@ -330,7 +374,11 @@ test("calls `onPagination` with `last` origin when the `Last` button is clicked"
     />,
   );
 
-  await user.click(screen.getByRole("button", { name: "Go to last page" }));
+  await user.click(
+    screen.getByRole("button", {
+      name: "Go to last page (page 10 of 10)",
+    }),
+  );
 
   expect(onPagination).toHaveBeenCalledWith(10, 10, "last");
 });

--- a/src/locales/en-gb.ts
+++ b/src/locales/en-gb.ts
@@ -144,10 +144,18 @@ const enGB: Locale = {
     },
   },
   pager: {
-    firstAriaLabel: () => "Go to first page",
-    lastAriaLabel: () => "Go to last page",
-    nextAriaLabel: () => "Go to next page",
-    previousAriaLabel: () => "Go to previous page",
+    firstAriaLabel: (totalPages: string | number) =>
+      `Go to first page (page 1 of ${totalPages})`,
+    lastAriaLabel: (totalPages: string | number) =>
+      `Go to last page (page ${totalPages} of ${totalPages})`,
+    nextAriaLabel: (
+      currentPage: number | string,
+      totalPages: number | string,
+    ) => `Go to next page (page ${currentPage} of ${totalPages})`,
+    previousAriaLabel: (
+      currentPage: number | string,
+      totalPages: number | string,
+    ) => `Go to previous page (page ${currentPage} of ${totalPages})`,
     pageX: (currentPage?: number | string) => `Page ${currentPage}`,
     ofTotalPages: (totalPages: number | string) => `of ${totalPages} pages`,
     itemsPerPage: () => "Items per page",

--- a/src/locales/locale.ts
+++ b/src/locales/locale.ts
@@ -135,10 +135,16 @@ interface Locale {
     pageX: (currentPage?: number | string) => string;
     ofTotalPages?: (totalPages: string | number) => string;
     itemsPerPage?: () => string;
-    firstAriaLabel?: () => string;
-    lastAriaLabel?: () => string;
-    nextAriaLabel?: () => string;
-    previousAriaLabel?: () => string;
+    firstAriaLabel?: (totalPages: string | number) => string;
+    lastAriaLabel?: (totalPages: string | number) => string;
+    nextAriaLabel?: (
+      currentPage: number | string,
+      totalPages: string | number,
+    ) => string;
+    previousAriaLabel?: (
+      currentPage: number | string,
+      totalPages: string | number,
+    ) => string;
   };
   password: {
     buttonLabelHide?: () => string;


### PR DESCRIPTION
### Proposed behaviour

Updating aria-label for all pager buttons to add context of page number

### Current behaviour

Buttons have no context of page number

### Checklist

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [x] Unit tests added or updated if required
- [x] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Testing instructions

Use pager with a screen reader and confirm all buttons provide accurate label for their relevant page behaviour.
