### PR TITLE
fix(search): add validationMessagePositionTop to interface

### DIFF
--- a/skills/carbon-react/components/search.md
+++ b/skills/carbon-react/components/search.md
@@ -56,6 +56,7 @@ description: Carbon Search component props and usage examples.
 | searchButtonDataProps | TagProps \| undefined | No |  |  |  | Data tag prop bag for searchButton |  |
 | size | "small" \| "medium" \| "large" \| undefined | No |  |  |  | Size of an input |  |
 | triggerOnClear | boolean \| undefined | No |  |  |  | Sets whether the `onClick` action should be triggered when the Search cross icon is clicked. |  |
+| validationMessagePositionTop | boolean \| undefined | No |  |  |  | Render the ValidationMessage above the Textbox input when validationRedesignOptIn flag is set |  |
 | data-element | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
 | data-role | string \| undefined | No |  |  |  | Identifier used for testing purposes, applied to the root element of the component. |  |
 | aria-label | string \| undefined | No |  |  |  | Prop to specify the accessible name of the Search input. To be used when no visible label is provided |  |

--- a/src/components/search/search-test.stories.tsx
+++ b/src/components/search/search-test.stories.tsx
@@ -253,7 +253,7 @@ export const RegressionMatrix = () => (
         value="Default with label, input hint and error"
         label="Search"
         inputHint="Input hint"
-        error="Error message"
+        error="Error message above"
         aria-label="Default with label, input hint and error"
       />
     </Box>
@@ -265,7 +265,32 @@ export const RegressionMatrix = () => (
         inverse
         label="Search"
         inputHint="Input hint"
-        error="Error message"
+        error="Error message above"
+        aria-label="Inverse with label, input hint and error"
+      />
+    </Box>
+
+    <Box p={4}>
+      <Search
+        onChange={() => {}}
+        value="Default with label, input hint and error"
+        label="Search"
+        inputHint="Input hint"
+        error="Error message below"
+        validationMessagePositionTop={false}
+        aria-label="Default with label, input hint and error"
+      />
+    </Box>
+
+    <Box p={4} backgroundColor="#000000">
+      <Search
+        onChange={() => {}}
+        value="Inverse with label, input hint and error"
+        inverse
+        label="Search"
+        inputHint="Input hint"
+        error="Error message below"
+        validationMessagePositionTop={false}
         aria-label="Inverse with label, input hint and error"
       />
     </Box>

--- a/src/components/search/search.component.tsx
+++ b/src/components/search/search.component.tsx
@@ -56,6 +56,7 @@ export interface SearchEvent {
 
 export type SearchTextboxProps = Pick<
   CommonTextboxProps,
+  | "validationMessagePositionTop"
   | "tooltipPosition"
   | "name"
   | "id"
@@ -205,6 +206,7 @@ export const Search = React.forwardRef<SearchHandle, SearchProps>(
       searchWidth,
       maxWidth,
       tabIndex,
+      validationMessagePositionTop = true,
       tooltipPosition,
       warning,
       className,
@@ -397,6 +399,7 @@ export const Search = React.forwardRef<SearchHandle, SearchProps>(
       <TextInput
         {...rest}
         {...tagComponent("search", rest)}
+        validationMessagePositionTop={validationMessagePositionTop}
         className={classNames}
         id={id}
         name={name}


### PR DESCRIPTION
### Proposed behaviour

<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Adds `validationMessagePositionTop` to component interface and assigns the prop a default value of `true`. This means by default the validation message will render above the input; however, consumers can opt out of this by setting the prop to `false`.

### Current behaviour

<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Currently, `validationMessagePositionTop` is not part of the component interface and the component renders the validation message below the input by default. 

### Checklist

<!-- Each PR should include the following -->

- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Playwright automation tests added or updated if required
- [ ] Storybook added or updated if required
- [ ] Translations added or updated (including creating or amending translation keys table in storybook) if required
- [ ] Typescript `d.ts` file added or updated if required
- [ ] Related docs have been updated if required

#### QA

- [ ] Tested in provided StackBlitz sandbox/Storybook
- [ ] Add new Playwright test coverage if required
- [ ] Carbon implementation matches Design System/designs
- [ ] UI Tests GitHub check reviewed if required

### Additional context

<!-- Add any other context or links about the pull request here. -->

### Testing instructions

<!--
How can a reviewer test this PR?

If this PR addresses a pre-existing bug, please include a link to a sandbox that reproduces the original bug. A starter template has been provided to help you do this:
<https://stackblitz.com/fork/github/Parsium/carbon-starter>
-->
